### PR TITLE
Add Windows support for "Require all software" during setup experience.

### DIFF
--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -37,6 +37,7 @@ const DEFAULT_CONFIG_MDM_MOCK: IMdmConfig = {
     apple_setup_assistant: null,
     apple_enable_release_device_manually: false,
     require_all_software_macos: false,
+    require_all_software_windows: false,
     lock_end_user_info: false,
   },
   macos_migration: {

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -82,6 +82,7 @@ export interface IMdmConfig {
     apple_enable_release_device_manually: boolean | null;
     macos_manual_agent_install: boolean | null;
     require_all_software_macos: boolean | null;
+    require_all_software_windows: boolean | null;
     lock_end_user_info: boolean | null;
     enable_create_local_admin_account?: boolean;
   };

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -66,6 +66,7 @@ export interface ITeam extends ITeamSummary {
       apple_enable_release_device_manually: boolean | null;
       macos_manual_agent_install: boolean | null;
       require_all_software_macos: boolean | null;
+      require_all_software_windows: boolean | null;
       lock_end_user_info: boolean | null;
       enable_create_local_admin_account?: boolean;
     };

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -160,28 +160,25 @@ const InstallSoftware = ({
         !appleMdmAndAbmEnabled;
 
       const turnOnAndroidMdm = platform === "android" && !isAndroidMdmEnabled;
-      const turnOnWindowsMdm = platform === "windows" && !isWindowsMdmEnabled;
 
-      const turnOnMdm = turnOnAppleMdm || turnOnAndroidMdm || turnOnWindowsMdm;
-
-      const isAndroidOrWindows =
-        platform === "android" || platform === "windows";
-
-      let mdmEmptyStateHeader = "Additional configuration required";
-      if (platform === "android") {
-        mdmEmptyStateHeader = "Turn on Android MDM";
-      } else if (platform === "windows") {
-        mdmEmptyStateHeader = "Turn on Windows MDM";
-      }
+      // Only Apple and Android setup experience require MDM. Windows admins can
+      // pre-stage setup-experience software without MDM, but the
+      // require_all_software_windows option does require Windows MDM to be on
+      // (gated at the checkbox level inside InstallSoftwareForm).
+      const turnOnMdm = turnOnAppleMdm || turnOnAndroidMdm;
 
       return (
         <SetupExperienceContentContainer>
           <PageDescription content="Install software on hosts that automatically enroll to Fleet." />
           {turnOnMdm ? (
             <EmptyState
-              header={mdmEmptyStateHeader}
+              header={
+                platform === "android"
+                  ? "Turn on Android MDM"
+                  : "Additional configuration required"
+              }
               info={
-                isAndroidOrWindows
+                platform === "android"
                   ? "Turn on MDM to install software during setup experience."
                   : "Turn on MDM and automatic enrollment to install software during setup experience."
               }
@@ -213,6 +210,7 @@ const InstallSoftware = ({
                   : globalConfig?.mdm?.setup_experience
                       ?.require_all_software_windows
               }
+              isWindowsMdmEnabled={!!isWindowsMdmEnabled}
               router={router}
               refetchSoftwareTitles={refetchSoftwareTitles}
             />

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -138,6 +138,7 @@ const InstallSoftware = ({
   );
 
   const isAndroidMdmEnabled = globalConfig?.mdm.android_enabled_and_configured;
+  const isWindowsMdmEnabled = globalConfig?.mdm.windows_enabled_and_configured;
 
   const isLoadingConfig = isLoadingGlobalConfig || isLoadingTeamConfig;
 
@@ -159,22 +160,28 @@ const InstallSoftware = ({
         !appleMdmAndAbmEnabled;
 
       const turnOnAndroidMdm = platform === "android" && !isAndroidMdmEnabled;
+      const turnOnWindowsMdm = platform === "windows" && !isWindowsMdmEnabled;
 
-      // Only Apple and Android setup experience require MDM
-      const turnOnMdm = turnOnAppleMdm || turnOnAndroidMdm;
+      const turnOnMdm = turnOnAppleMdm || turnOnAndroidMdm || turnOnWindowsMdm;
+
+      const isAndroidOrWindows =
+        platform === "android" || platform === "windows";
+
+      let mdmEmptyStateHeader = "Additional configuration required";
+      if (platform === "android") {
+        mdmEmptyStateHeader = "Turn on Android MDM";
+      } else if (platform === "windows") {
+        mdmEmptyStateHeader = "Turn on Windows MDM";
+      }
 
       return (
         <SetupExperienceContentContainer>
           <PageDescription content="Install software on hosts that automatically enroll to Fleet." />
           {turnOnMdm ? (
             <EmptyState
-              header={
-                platform === "android"
-                  ? "Turn on Android MDM"
-                  : "Additional configuration required"
-              }
+              header={mdmEmptyStateHeader}
               info={
-                platform === "android"
+                isAndroidOrWindows
                   ? "Turn on MDM to install software during setup experience."
                   : "Turn on MDM and automatic enrollment to install software during setup experience."
               }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -199,6 +199,13 @@ const InstallSoftware = ({
                   : globalConfig?.mdm?.setup_experience
                       ?.require_all_software_macos
               }
+              savedRequireAllSoftwareWindows={
+                currentTeamId
+                  ? teamConfig?.mdm?.setup_experience
+                      ?.require_all_software_windows
+                  : globalConfig?.mdm?.setup_experience
+                      ?.require_all_software_windows
+              }
               router={router}
               refetchSoftwareTitles={refetchSoftwareTitles}
             />

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
@@ -15,6 +15,10 @@ import InstallSoftwareForm from "./InstallSoftwareForm";
 const render = createCustomRenderer({ withBackendMock: true });
 
 describe("InstallSoftware", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("should render the expected message if there are no software titles to select from", () => {
     render(
       <InstallSoftwareForm
@@ -167,6 +171,7 @@ describe("InstallSoftware", () => {
     render(
       <InstallSoftwareForm
         savedRequireAllSoftwareWindows
+        isWindowsMdmEnabled
         currentTeamId={1}
         softwareTitles={[
           createMockSoftwareTitle({
@@ -220,8 +225,6 @@ describe("InstallSoftware", () => {
     await waitFor(() => {
       expect(updateRequireAllSoftwareWindowsSpy).toHaveBeenCalledWith(1, true);
     });
-
-    updateRequireAllSoftwareWindowsSpy.mockRestore();
   });
 
   it("disables the Windows checkbox when Windows MDM is not configured", async () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
@@ -8,6 +8,7 @@ import {
   createMockSoftwarePackage,
   createMockSoftwareTitle,
 } from "__mocks__/softwareMock";
+import mdmAPI from "services/entities/mdm";
 
 import InstallSoftwareForm from "./InstallSoftwareForm";
 
@@ -189,6 +190,37 @@ describe("InstallSoftware", () => {
       expect(checkbox).toBeVisible();
       expect(checkbox).toBeChecked();
     });
+  });
+
+  it("calls the Windows require-all API on Save when the Windows checkbox is toggled", async () => {
+    const updateRequireAllSoftwareWindowsSpy = jest
+      .spyOn(mdmAPI, "updateRequireAllSoftwareWindows")
+      .mockResolvedValue({});
+
+    const { user } = render(
+      <InstallSoftwareForm
+        savedRequireAllSoftwareWindows={false}
+        currentTeamId={1}
+        softwareTitles={[createMockSoftwareTitle()]}
+        hasManualAgentInstall={false}
+        platform="windows"
+        router={createMockRouter()}
+        refetchSoftwareTitles={noop}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /Cancel setup if software fails/,
+      })
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(updateRequireAllSoftwareWindowsSpy).toHaveBeenCalledWith(1, true);
+    });
+
+    updateRequireAllSoftwareWindowsSpy.mockRestore();
   });
 
   it("should disable adding software for macos with manual agent install", async () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
@@ -200,6 +200,7 @@ describe("InstallSoftware", () => {
     const { user } = render(
       <InstallSoftwareForm
         savedRequireAllSoftwareWindows={false}
+        isWindowsMdmEnabled
         currentTeamId={1}
         softwareTitles={[createMockSoftwareTitle()]}
         hasManualAgentInstall={false}
@@ -221,6 +222,26 @@ describe("InstallSoftware", () => {
     });
 
     updateRequireAllSoftwareWindowsSpy.mockRestore();
+  });
+
+  it("disables the Windows checkbox when Windows MDM is not configured", async () => {
+    render(
+      <InstallSoftwareForm
+        savedRequireAllSoftwareWindows={false}
+        isWindowsMdmEnabled={false}
+        currentTeamId={1}
+        softwareTitles={[createMockSoftwareTitle()]}
+        hasManualAgentInstall={false}
+        platform="windows"
+        router={createMockRouter()}
+        refetchSoftwareTitles={noop}
+      />
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /Cancel setup if software fails/,
+    });
+    expect(checkbox).toHaveAttribute("aria-disabled", "true");
   });
 
   it("should disable adding software for macos with manual agent install", async () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tests.tsx
@@ -126,7 +126,7 @@ describe("InstallSoftware", () => {
     });
   });
 
-  it('should render the "Cancel setup if software install fails" form for macos platform', async () => {
+  it('should render the "Cancel setup if software fails" form for macos platform', async () => {
     render(
       <InstallSoftwareForm
         savedRequireAllSoftwareMacOS
@@ -155,7 +155,36 @@ describe("InstallSoftware", () => {
 
     await waitFor(() => {
       const checkbox = screen.getByRole("checkbox", {
-        name: /Cancel setup if software install fails/,
+        name: /Cancel setup if software fails/,
+      });
+      expect(checkbox).toBeVisible();
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it('should render the "Cancel setup if software fails" form for windows platform', async () => {
+    render(
+      <InstallSoftwareForm
+        savedRequireAllSoftwareWindows
+        currentTeamId={1}
+        softwareTitles={[
+          createMockSoftwareTitle({
+            software_package: createMockSoftwarePackage({
+              install_during_setup: true,
+            }),
+          }),
+          createMockSoftwareTitle(),
+        ]}
+        hasManualAgentInstall={false}
+        platform="windows"
+        router={createMockRouter()}
+        refetchSoftwareTitles={noop}
+      />
+    );
+
+    await waitFor(() => {
+      const checkbox = screen.getByRole("checkbox", {
+        name: /Cancel setup if software fails/,
       });
       expect(checkbox).toBeVisible();
       expect(checkbox).toBeChecked();

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
@@ -9,7 +9,6 @@ import { ISoftwareTitle } from "interfaces/software";
 import { INotification } from "interfaces/notification";
 
 import { NotificationContext } from "context/notification";
-import useGitOpsMode from "hooks/useGitOpsMode";
 import mdmAPI from "services/entities/mdm";
 
 import Button from "components/buttons/Button";
@@ -88,13 +87,12 @@ const InstallSoftwareForm = ({
   platform,
   savedRequireAllSoftwareMacOS,
   savedRequireAllSoftwareWindows,
-  isWindowsMdmEnabled = true,
+  isWindowsMdmEnabled = false,
   router,
   refetchSoftwareTitles,
 }: IInstallSoftwareFormProps) => {
   const noSoftwareUploaded = hasNoSoftwareUploaded(softwareTitles);
   const { renderFlash, renderMultiFlash } = useContext(NotificationContext);
-  const { gitOpsModeEnabled } = useGitOpsMode("software");
   const [requireAllSoftwareMacOS, setRequireAllSoftwareMacOS] = useState(
     savedRequireAllSoftwareMacOS ?? false
   );
@@ -287,34 +285,52 @@ const InstallSoftwareForm = ({
         />
         {platform === "macos" && (
           <div className={`${baseClass}__macos_options`}>
-            <Checkbox
-              disabled={gitOpsModeEnabled || manualAgentInstallBlockingSoftware}
-              value={requireAllSoftwareMacOS}
-              onChange={handleChangeRequireAllMacOS}
-            >
-              <TooltipWrapper tipContent="If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled.">
-                Cancel setup if software fails
-              </TooltipWrapper>
-            </Checkbox>
+            <GitOpsModeTooltipWrapper
+              tipOffset={6}
+              entityType="software"
+              renderChildren={(disableChildren) => (
+                <Checkbox
+                  disabled={
+                    disableChildren || manualAgentInstallBlockingSoftware
+                  }
+                  value={requireAllSoftwareMacOS}
+                  onChange={handleChangeRequireAllMacOS}
+                >
+                  <TooltipWrapper
+                    tipContent="If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled."
+                    disableTooltip={disableChildren}
+                  >
+                    Cancel setup if software fails
+                  </TooltipWrapper>
+                </Checkbox>
+              )}
+            />
           </div>
         )}
         {platform === "windows" && (
           <div className={`${baseClass}__windows_options`}>
-            <Checkbox
-              disabled={gitOpsModeEnabled || !isWindowsMdmEnabled}
-              value={requireAllSoftwareWindows}
-              onChange={handleChangeRequireAllWindows}
-            >
-              <TooltipWrapper
-                tipContent={
-                  isWindowsMdmEnabled
-                    ? "If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled."
-                    : "Turn on Windows MDM to use this option."
-                }
-              >
-                Cancel setup if software fails
-              </TooltipWrapper>
-            </Checkbox>
+            <GitOpsModeTooltipWrapper
+              tipOffset={6}
+              entityType="software"
+              renderChildren={(disableChildren) => (
+                <Checkbox
+                  disabled={disableChildren || !isWindowsMdmEnabled}
+                  value={requireAllSoftwareWindows}
+                  onChange={handleChangeRequireAllWindows}
+                >
+                  <TooltipWrapper
+                    tipContent={
+                      isWindowsMdmEnabled
+                        ? "If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled."
+                        : "Turn on Windows MDM to use this option."
+                    }
+                    disableTooltip={disableChildren}
+                  >
+                    Cancel setup if software fails
+                  </TooltipWrapper>
+                </Checkbox>
+              )}
+            />
           </div>
         )}
         <GitOpsModeTooltipWrapper

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
@@ -287,6 +287,7 @@ const InstallSoftwareForm = ({
           <div className={`${baseClass}__macos_options`}>
             <GitOpsModeTooltipWrapper
               tipOffset={6}
+              position="bottom-start"
               entityType="software"
               renderChildren={(disableChildren) => (
                 <Checkbox
@@ -311,6 +312,7 @@ const InstallSoftwareForm = ({
           <div className={`${baseClass}__windows_options`}>
             <GitOpsModeTooltipWrapper
               tipOffset={6}
+              position="bottom-start"
               entityType="software"
               renderChildren={(disableChildren) => (
                 <Checkbox

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
@@ -75,6 +75,7 @@ interface IInstallSoftwareFormProps {
   softwareTitles: ISoftwareTitle[] | null;
   platform: SetupExperiencePlatform;
   savedRequireAllSoftwareMacOS?: boolean | null;
+  savedRequireAllSoftwareWindows?: boolean | null;
   router: InjectedRouter;
   refetchSoftwareTitles: () => void;
 }
@@ -85,6 +86,7 @@ const InstallSoftwareForm = ({
   softwareTitles,
   platform,
   savedRequireAllSoftwareMacOS,
+  savedRequireAllSoftwareWindows,
   router,
   refetchSoftwareTitles,
 }: IInstallSoftwareFormProps) => {
@@ -94,6 +96,9 @@ const InstallSoftwareForm = ({
   const [requireAllSoftwareMacOS, setRequireAllSoftwareMacOS] = useState(
     savedRequireAllSoftwareMacOS ?? false
   );
+  const [requireAllSoftwareWindows, setRequireAllSoftwareWindows] = useState(
+    savedRequireAllSoftwareWindows ?? false
+  );
   const [isSaving, setIsSaving] = useState(false);
 
   const initialSelectedSoftware = useMemo(
@@ -101,12 +106,17 @@ const InstallSoftwareForm = ({
     [softwareTitles]
   );
 
-  // Track if the user changed the macOS checkbox since the last save.
+  // Track if the user changed the require-all checkbox since the last save.
   // We don't compare against props here to avoid races with parent refetch timing.
   const [touchedRequireAll, setTouchedRequireAll] = useState(false);
 
-  const handleChangeRequireAll = (value: boolean) => {
+  const handleChangeRequireAllMacOS = (value: boolean) => {
     setRequireAllSoftwareMacOS(value);
+    setTouchedRequireAll(true);
+  };
+
+  const handleChangeRequireAllWindows = (value: boolean) => {
+    setRequireAllSoftwareWindows(value);
     setTouchedRequireAll(true);
   };
 
@@ -136,7 +146,8 @@ const InstallSoftwareForm = ({
   );
 
   const shouldUpdateSoftware = isSoftwareSelectionDirty;
-  const shouldUpdateRequireAll = platform === "macos" && touchedRequireAll;
+  const shouldUpdateRequireAll =
+    (platform === "macos" || platform === "windows") && touchedRequireAll;
 
   const onClickSave = async (evt: React.FormEvent) => {
     evt.preventDefault();
@@ -170,13 +181,20 @@ const InstallSoftwareForm = ({
       }
     }
 
-    // 2. macOS “require all software” update
+    // 2. "require all software" update (macOS or Windows)
     if (shouldUpdateRequireAll) {
       try {
-        await mdmAPI.updateRequireAllSoftwareMacOS(
-          currentTeamId,
-          requireAllSoftwareMacOS
-        );
+        if (platform === "windows") {
+          await mdmAPI.updateRequireAllSoftwareWindows(
+            currentTeamId,
+            requireAllSoftwareWindows
+          );
+        } else {
+          await mdmAPI.updateRequireAllSoftwareMacOS(
+            currentTeamId,
+            requireAllSoftwareMacOS
+          );
+        }
         hadSuccess = true;
         setTouchedRequireAll(false);
       } catch (e) {
@@ -185,7 +203,7 @@ const InstallSoftwareForm = ({
           alertType: "error",
           isVisible: true,
           message:
-            "Couldn't update 'Cancel setup if software install fails'. Please try again.",
+            "Couldn't update 'Cancel setup if software fails'. Please try again.",
           persistOnPageChange: false,
         });
       }
@@ -270,10 +288,23 @@ const InstallSoftwareForm = ({
             <Checkbox
               disabled={gitOpsModeEnabled || manualAgentInstallBlockingSoftware}
               value={requireAllSoftwareMacOS}
-              onChange={handleChangeRequireAll}
+              onChange={handleChangeRequireAllMacOS}
             >
-              <TooltipWrapper tipContent="If any software fails, the end user won't be let through, and will see a prompt to contact their IT admin. Remaining software installs will be canceled.">
-                Cancel setup if software install fails
+              <TooltipWrapper tipContent="If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled.">
+                Cancel setup if software fails
+              </TooltipWrapper>
+            </Checkbox>
+          </div>
+        )}
+        {platform === "windows" && (
+          <div className={`${baseClass}__windows_options`}>
+            <Checkbox
+              disabled={gitOpsModeEnabled}
+              value={requireAllSoftwareWindows}
+              onChange={handleChangeRequireAllWindows}
+            >
+              <TooltipWrapper tipContent="If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled.">
+                Cancel setup if software fails
               </TooltipWrapper>
             </Checkbox>
           </div>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
@@ -76,6 +76,7 @@ interface IInstallSoftwareFormProps {
   platform: SetupExperiencePlatform;
   savedRequireAllSoftwareMacOS?: boolean | null;
   savedRequireAllSoftwareWindows?: boolean | null;
+  isWindowsMdmEnabled?: boolean;
   router: InjectedRouter;
   refetchSoftwareTitles: () => void;
 }
@@ -87,6 +88,7 @@ const InstallSoftwareForm = ({
   platform,
   savedRequireAllSoftwareMacOS,
   savedRequireAllSoftwareWindows,
+  isWindowsMdmEnabled = true,
   router,
   refetchSoftwareTitles,
 }: IInstallSoftwareFormProps) => {
@@ -299,11 +301,17 @@ const InstallSoftwareForm = ({
         {platform === "windows" && (
           <div className={`${baseClass}__windows_options`}>
             <Checkbox
-              disabled={gitOpsModeEnabled}
+              disabled={gitOpsModeEnabled || !isWindowsMdmEnabled}
               value={requireAllSoftwareWindows}
               onChange={handleChangeRequireAllWindows}
             >
-              <TooltipWrapper tipContent="If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled.">
+              <TooltipWrapper
+                tipContent={
+                  isWindowsMdmEnabled
+                    ? "If any software fails, the end user will be prompted to restart setup. Remaining software installs will be canceled."
+                    : "Turn on Windows MDM to use this option."
+                }
+              >
                 Cancel setup if software fails
               </TooltipWrapper>
             </Checkbox>

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -268,6 +268,14 @@ const mdmService = {
     });
   },
 
+  updateRequireAllSoftwareWindows: (teamId: number, isEnabled: boolean) => {
+    const { MDM_SETUP } = endpoints;
+    return sendRequest("PATCH", MDM_SETUP, {
+      fleet_id: teamId,
+      require_all_software_windows: isEnabled,
+    });
+  },
+
   updateSetupExperienceSettings: (updateData: IUpdateSetupExperienceBody) => {
     const { MDM_SETUP_EXPERIENCE } = endpoints;
     const body = {

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -261,16 +261,16 @@ const mdmService = {
   },
 
   updateRequireAllSoftwareMacOS: (teamId: number, isEnabled: boolean) => {
-    const { MDM_SETUP } = endpoints;
-    return sendRequest("PATCH", MDM_SETUP, {
+    const { MDM_SETUP_EXPERIENCE } = endpoints;
+    return sendRequest("PATCH", MDM_SETUP_EXPERIENCE, {
       fleet_id: teamId,
       require_all_software_macos: isEnabled,
     });
   },
 
   updateRequireAllSoftwareWindows: (teamId: number, isEnabled: boolean) => {
-    const { MDM_SETUP } = endpoints;
-    return sendRequest("PATCH", MDM_SETUP, {
+    const { MDM_SETUP_EXPERIENCE } = endpoints;
+    return sendRequest("PATCH", MDM_SETUP_EXPERIENCE, {
       fleet_id: teamId,
       require_all_software_windows: isEnabled,
     });


### PR DESCRIPTION
Added a checkbox for the setup experience page.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42854 

<img width="598" height="373" alt="image" src="https://github.com/user-attachments/assets/4842190f-f9f8-401f-a9e2-61c5755fb5be" />
---
<img width="444" height="377" alt="image" src="https://github.com/user-attachments/assets/e9da5e65-1b09-4b05-ab8c-a5099866704d" />
---
<img width="458" height="387" alt="image" src="https://github.com/user-attachments/assets/bf10b747-805b-4484-a90f-7700ba177098" />

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows support to the MDM setup experience so admins can require all software during Windows device setup, saved independently from macOS.

* **UI**
  * Checkbox label clarified to "Cancel setup if software fails".
  * Windows checkbox is disabled when Windows MDM is not configured and shows a contextual tooltip.

* **Tests**
  * Added tests covering Windows UI states and save behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->