### PR TITLE
Add activities for user actions on labels

### DIFF
--- a/changes/36976-activities-for-labels
+++ b/changes/36976-activities-for-labels
@@ -1,0 +1,1 @@
+* Added generation of activities when users create, edit, or delete labels (`created_label`, `edited_label`, and `deleted_label` respectively).

--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -2021,6 +2021,9 @@ func TestApplyLabels(t *testing.T) {
 			fleet.BuiltinLabelNameUbuntuLinux: ubuntuLabel,
 		}, nil
 	}
+	// Reset invocation flag — earlier sub-cases call LabelsByName as part of
+	// the regular-label apply flow (used for created/edited activity detection).
+	ds.LabelsByNameFuncInvoked = false
 
 	name = writeTmpYml(t, builtinLabelSpec)
 	_, err := RunAppNoChecks([]string{"apply", "-f", name})

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -167,6 +167,21 @@ func RunServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 	ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
 		return &fleet.TeamMDM{}, nil
 	}
+	// Default mocks used by ApplyLabelSpecs to detect created vs edited labels
+	// for activity emission. Tests can override these.
+	ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+		return map[string]*fleet.Label{}, nil
+	}
+	ds.LabelFunc = func(ctx context.Context, lid uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+		return &fleet.LabelWithTeamName{Label: fleet.Label{ID: lid}}, nil, nil
+	}
+	ds.LabelMembershipHostIDsFunc = func(ctx context.Context, labelID uint) ([]uint, error) {
+		return nil, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{ID: tid}, nil
+	}
+
 	var cachedDS fleet.Datastore
 	if len(opts) > 0 && opts[0].NoCacheDatastore {
 		cachedDS = ds

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"text/template"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
+
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl"
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl/testing_utils"
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/integrationtest"
@@ -31,6 +33,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	appleMdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	mock_pkg "github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/tokenpki"
 	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -58,6 +61,7 @@ type enterpriseIntegrationGitopsTestSuite struct {
 	integrationtest.WithServer
 	fleetCfg               config.FleetConfig
 	softwareTitleIconStore fleet.SoftwareTitleIconStore
+	activityMock           *mock_pkg.MockActivityService
 }
 
 func (s *enterpriseIntegrationGitopsTestSuite) SetupSuite() {
@@ -124,6 +128,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) SetupSuite() {
 		serverConfig.Logger = slog.New(slog.DiscardHandler)
 	}
 	users, server := service.RunServerForTestsWithDS(s.T(), s.DS, &serverConfig)
+	s.activityMock = serverConfig.ActivityMock
 	s.T().Setenv("FLEET_SERVER_ADDRESS", server.URL) // fleetctl always uses this env var in tests
 	s.Server = server
 	s.Users = users
@@ -3277,6 +3282,260 @@ func labelTeamIDResult(t *testing.T, s *enterpriseIntegrationGitopsTestSuite, ct
 		got[r.Name] = teamID
 	}
 	return got
+}
+
+// captureLabelActivities replaces the suite's activity mock with a recorder.
+// It returns a function that returns and resets the captured label activities.
+// Cleanup restores the previous NewActivityFunc.
+func (s *enterpriseIntegrationGitopsTestSuite) captureLabelActivities(t *testing.T) func() []activity_api.ActivityDetails {
+	t.Helper()
+	require.NotNil(t, s.activityMock, "activity mock should be wired up via TestServerOpts.ActivityMock")
+	prev := s.activityMock.NewActivityFunc
+	var (
+		mu       sync.Mutex
+		captured []activity_api.ActivityDetails
+	)
+	s.activityMock.NewActivityFunc = func(ctx context.Context, user *activity_api.User, a activity_api.ActivityDetails) error {
+		switch a.(type) {
+		case fleet.ActivityTypeCreatedLabel, fleet.ActivityTypeEditedLabel, fleet.ActivityTypeDeletedLabel:
+			mu.Lock()
+			captured = append(captured, a)
+			mu.Unlock()
+		}
+		if prev != nil {
+			return prev(ctx, user, a)
+		}
+		return nil
+	}
+	t.Cleanup(func() { s.activityMock.NewActivityFunc = prev })
+
+	return func() []activity_api.ActivityDetails {
+		mu.Lock()
+		defer mu.Unlock()
+		out := captured
+		captured = nil
+		return out
+	}
+}
+
+func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsLabelActivities() {
+	t := s.T()
+	ctx := context.Background()
+
+	user := s.createGitOpsUser(t)
+	fleetCfg := s.createFleetctlConfig(t, user)
+
+	teamName := uuid.NewString()
+	_, err := s.DS.NewTeam(ctx, &fleet.Team{Name: teamName})
+	require.NoError(t, err)
+
+	// Hosts to assign to the manual label in later phases.
+	for _, h := range []string{"label-act-host-1", "label-act-host-2"} {
+		_, err := s.DS.NewHost(ctx, &fleet.Host{
+			UUID:           h,
+			Hostname:       h,
+			Platform:       "linux",
+			HardwareSerial: h,
+		})
+		require.NoError(t, err)
+	}
+
+	globalFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	teamFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+
+	writeGlobal := func(body string) {
+		require.NoError(t, os.WriteFile(globalFile.Name(), []byte(`
+agent_options:
+controls:
+org_settings:
+  secrets:
+  - secret: test_secret
+policies:
+reports:
+labels:
+`+body), 0o644))
+	}
+	writeTeam := func(body string) {
+		require.NoError(t, os.WriteFile(teamFile.Name(), fmt.Appendf(nil, `
+controls:
+software:
+reports:
+policies:
+agent_options:
+name: %s
+settings:
+  secrets: [{"secret":"enroll_secret"}]
+labels:
+%s`, teamName, body), 0o644))
+	}
+	apply := func() {
+		s.assertRealRunOutput(t, fleetctl.RunAppForTest(t, []string{
+			"gitops", "--config", fleetCfg.Name(),
+			"-f", globalFile.Name(), "-f", teamFile.Name(),
+		}))
+	}
+
+	flush := s.captureLabelActivities(t)
+
+	// Phase 1: initial apply creates one global and one team label.
+	writeGlobal(`  - name: lbl-global
+    description: original-global
+    label_membership_type: dynamic
+    query: SELECT 1
+`)
+	writeTeam(`  - name: lbl-team
+    description: original-team
+    label_membership_type: dynamic
+    query: SELECT 2
+`)
+	apply()
+	got := flush()
+	require.Len(t, got, 2, "expected created_label for global + team")
+
+	byName := map[string]fleet.ActivityTypeCreatedLabel{}
+	for _, a := range got {
+		c, ok := a.(fleet.ActivityTypeCreatedLabel)
+		require.True(t, ok, "expected created_label, got %T", a)
+		byName[c.Name] = c
+	}
+	require.Contains(t, byName, "lbl-global")
+	require.Contains(t, byName, "lbl-team")
+	require.Nil(t, byName["lbl-global"].FleetID, "global label should have nil fleet_id")
+	require.NotNil(t, byName["lbl-team"].FleetID, "team label should have a fleet_id")
+	require.NotNil(t, byName["lbl-team"].FleetName)
+	require.Equal(t, teamName, *byName["lbl-team"].FleetName)
+
+	// Phase 2: re-apply identical specs — no activity should fire.
+	apply()
+	require.Empty(t, flush(), "no-op apply should produce no activity")
+
+	// Phase 3: edit the global label's description and the team label's query.
+	writeGlobal(`  - name: lbl-global
+    description: edited-global
+    label_membership_type: dynamic
+    query: SELECT 1
+`)
+	writeTeam(`  - name: lbl-team
+    description: original-team
+    label_membership_type: dynamic
+    query: SELECT 99
+`)
+	apply()
+	got = flush()
+	require.Len(t, got, 2, "expected edited_label for both edits")
+	editedNames := map[string]bool{}
+	for _, a := range got {
+		e, ok := a.(fleet.ActivityTypeEditedLabel)
+		require.True(t, ok, "expected edited_label, got %T", a)
+		editedNames[e.Name] = true
+	}
+	require.True(t, editedNames["lbl-global"])
+	require.True(t, editedNames["lbl-team"])
+
+	// Phase 4: change lbl-global from dynamic to manual (membership_type swap)
+	// and assign one host. Should emit a single edited_label for lbl-global.
+	writeGlobal(`  - name: lbl-global
+    description: edited-global
+    label_membership_type: manual
+    hosts:
+      - label-act-host-1
+`)
+	writeTeam(`  - name: lbl-team
+    description: original-team
+    label_membership_type: dynamic
+    query: SELECT 99
+`)
+	apply()
+	got = flush()
+	require.Len(t, got, 1, "expected edited_label for membership_type change")
+	e, ok := got[0].(fleet.ActivityTypeEditedLabel)
+	require.True(t, ok, "expected edited_label, got %T", got[0])
+	require.Equal(t, "lbl-global", e.Name)
+
+	// Phase 5: extend the manual label's host list. Should emit a single
+	// edited_label even though all other fields stayed the same.
+	writeGlobal(`  - name: lbl-global
+    description: edited-global
+    label_membership_type: manual
+    hosts:
+      - label-act-host-1
+      - label-act-host-2
+`)
+	apply()
+	got = flush()
+	require.Len(t, got, 1, "expected edited_label for host list change")
+	e, ok = got[0].(fleet.ActivityTypeEditedLabel)
+	require.True(t, ok, "expected edited_label, got %T", got[0])
+	require.Equal(t, "lbl-global", e.Name)
+
+	// Phase 5b: re-apply same host list — must be a no-op.
+	apply()
+	require.Empty(t, flush(), "no-op host list should produce no activity")
+
+	// Phase 6: add a host_vitals label alongside the existing labels.
+	writeGlobal(`  - name: lbl-global
+    description: edited-global
+    label_membership_type: manual
+    hosts:
+      - label-act-host-1
+      - label-act-host-2
+  - name: lbl-host-vitals
+    description: vitals-label
+    label_membership_type: host_vitals
+    criteria:
+      vital: end_user_idp_group
+      value: original-group
+`)
+	apply()
+	got = flush()
+	require.Len(t, got, 1, "expected created_label for host_vitals label")
+	c, ok := got[0].(fleet.ActivityTypeCreatedLabel)
+	require.True(t, ok, "expected created_label, got %T", got[0])
+	require.Equal(t, "lbl-host-vitals", c.Name)
+
+	// Phase 7: update the host_vitals criteria — should emit edited_label.
+	writeGlobal(`  - name: lbl-global
+    description: edited-global
+    label_membership_type: manual
+    hosts:
+      - label-act-host-1
+      - label-act-host-2
+  - name: lbl-host-vitals
+    description: vitals-label
+    label_membership_type: host_vitals
+    criteria:
+      vital: end_user_idp_group
+      value: updated-group
+`)
+	apply()
+	got = flush()
+	require.Len(t, got, 1, "expected edited_label for criteria change")
+	e, ok = got[0].(fleet.ActivityTypeEditedLabel)
+	require.True(t, ok, "expected edited_label, got %T", got[0])
+	require.Equal(t, "lbl-host-vitals", e.Name)
+
+	// Phase 7b: re-apply the same criteria — must be a no-op.
+	apply()
+	require.Empty(t, flush(), "no-op criteria re-apply should produce no activity")
+
+	// Phase 8: remove all labels from the spec — gitops issues delete calls
+	// per name, which should each emit a deleted_label activity.
+	writeGlobal("")
+	writeTeam("")
+	apply()
+	got = flush()
+	require.Len(t, got, 3, "expected deleted_label for all three labels")
+	deletedNames := map[string]bool{}
+	for _, a := range got {
+		d, ok := a.(fleet.ActivityTypeDeletedLabel)
+		require.True(t, ok, "expected deleted_label, got %T", a)
+		deletedNames[d.Name] = true
+	}
+	require.True(t, deletedNames["lbl-global"])
+	require.True(t, deletedNames["lbl-team"])
+	require.True(t, deletedNames["lbl-host-vitals"])
 }
 
 // TestGitOpsVPPAppAutoUpdate tests that auto-update settings for VPP apps (iOS/iPadOS)

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	appleMdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
-	mock_pkg "github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/tokenpki"
+	mock_pkg "github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service"
@@ -3425,14 +3425,14 @@ labels:
 	apply()
 	got = flush()
 	require.Len(t, got, 2, "expected edited_label for both edits")
-	editedNames := map[string]bool{}
+	editedNames := map[string]struct{}{}
 	for _, a := range got {
 		e, ok := a.(fleet.ActivityTypeEditedLabel)
 		require.True(t, ok, "expected edited_label, got %T", a)
-		editedNames[e.Name] = true
+		editedNames[e.Name] = struct{}{}
 	}
-	require.True(t, editedNames["lbl-global"])
-	require.True(t, editedNames["lbl-team"])
+	require.Contains(t, editedNames, "lbl-global")
+	require.Contains(t, editedNames, "lbl-team")
 
 	// Phase 4: change lbl-global from dynamic to manual (membership_type swap)
 	// and assign one host. Should emit a single edited_label for lbl-global.

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3527,15 +3527,15 @@ labels:
 	apply()
 	got = flush()
 	require.Len(t, got, 3, "expected deleted_label for all three labels")
-	deletedNames := map[string]bool{}
+	deletedNames := map[string]struct{}{}
 	for _, a := range got {
 		d, ok := a.(fleet.ActivityTypeDeletedLabel)
 		require.True(t, ok, "expected deleted_label, got %T", a)
-		deletedNames[d.Name] = true
+		deletedNames[d.Name] = struct{}{}
 	}
-	require.True(t, deletedNames["lbl-global"])
-	require.True(t, deletedNames["lbl-team"])
-	require.True(t, deletedNames["lbl-host-vitals"])
+	require.Contains(t, deletedNames, "lbl-global")
+	require.Contains(t, deletedNames, "lbl-team")
+	require.Contains(t, deletedNames, "lbl-host-vitals")
 }
 
 // TestGitOpsVPPAppAutoUpdate tests that auto-update settings for VPP apps (iOS/iPadOS)

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -169,6 +169,9 @@ export enum ActivityType {
   DisabledManagedLocalAccount = "disabled_managed_local_account",
   ViewedManagedLocalAccount = "read_managed_local_account",
   CreatedManagedLocalAccount = "created_managed_local_account",
+  CreatedLabel = "created_label",
+  EditedLabel = "edited_label",
+  DeletedLabel = "deleted_label",
 }
 
 /** This is a subset of ActivityType that are shown only for the host past activities */
@@ -305,6 +308,10 @@ export interface IActivityDetails {
   certificate_template_id?: number;
   detail?: string;
   exception?: string;
+  label_id?: number;
+  label_name?: string;
+  fleet_id?: number | null;
+  fleet_name?: string | null;
 }
 
 // maps activity types to their corresponding label to use when filtering activites via the dropdown
@@ -485,4 +492,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
     "Turned off managed local account",
   [ActivityType.ViewedManagedLocalAccount]: "Viewed managed account",
   [ActivityType.CreatedManagedLocalAccount]: "Created managed account",
+  [ActivityType.CreatedLabel]: "Created label",
+  [ActivityType.EditedLabel]: "Edited label",
+  [ActivityType.DeletedLabel]: "Deleted label",
 };

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1839,4 +1839,42 @@ describe("Activity Feed", () => {
       screen.getByText("disabled the software exception for GitOps.")
     ).toBeInTheDocument();
   });
+
+  it("renders a created_label activity for a global label", () => {
+    const activity = createMockActivity({
+      type: ActivityType.CreatedLabel,
+      details: { label_id: 1, label_name: "Workstations" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+    expect(screen.getByText("created a label .")).toBeInTheDocument();
+    expect(screen.getByText("Workstations")).toBeInTheDocument();
+  });
+
+  it("renders an edited_label activity scoped to a fleet", () => {
+    const activity = createMockActivity({
+      type: ActivityType.EditedLabel,
+      details: {
+        label_id: 1,
+        label_name: "Workstations",
+        fleet_id: 5,
+        fleet_name: "Engineering",
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+    expect(
+      screen.getByText("edited the label on the fleet.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Workstations")).toBeInTheDocument();
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+  });
+
+  it("renders a deleted_label activity for a global label", () => {
+    const activity = createMockActivity({
+      type: ActivityType.DeletedLabel,
+      details: { label_id: 1, label_name: "Workstations" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+    expect(screen.getByText("deleted the label .")).toBeInTheDocument();
+    expect(screen.getByText("Workstations")).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1762,6 +1762,57 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  createdLabel: (activity: IActivity) => {
+    const fleetText = activity.details?.fleet_name ? (
+      <>
+        {" "}
+        on the <b>{activity.details.fleet_name}</b> fleet
+      </>
+    ) : (
+      ""
+    );
+    return (
+      <>
+        {" "}
+        created a label <b>{activity.details?.label_name}</b>
+        {fleetText}.
+      </>
+    );
+  },
+  editedLabel: (activity: IActivity) => {
+    const fleetText = activity.details?.fleet_name ? (
+      <>
+        {" "}
+        on the <b>{activity.details.fleet_name}</b> fleet
+      </>
+    ) : (
+      ""
+    );
+    return (
+      <>
+        {" "}
+        edited the label <b>{activity.details?.label_name}</b>
+        {fleetText}.
+      </>
+    );
+  },
+  deletedLabel: (activity: IActivity) => {
+    const fleetText = activity.details?.fleet_name ? (
+      <>
+        {" "}
+        on the <b>{activity.details.fleet_name}</b> fleet
+      </>
+    ) : (
+      ""
+    );
+    return (
+      <>
+        {" "}
+        deleted the label <b>{activity.details?.label_name}</b>
+        {fleetText}.
+      </>
+    );
+  },
 
   createdCustomVariable: (activity: IActivity) => {
     const { custom_variable_name } = activity.details || {};
@@ -2282,6 +2333,15 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     }
     case ActivityType.DeletedPolicy: {
       return TAGGED_TEMPLATES.deletedPolicy(activity);
+    }
+    case ActivityType.CreatedLabel: {
+      return TAGGED_TEMPLATES.createdLabel(activity);
+    }
+    case ActivityType.EditedLabel: {
+      return TAGGED_TEMPLATES.editedLabel(activity);
+    }
+    case ActivityType.DeletedLabel: {
+      return TAGGED_TEMPLATES.deletedLabel(activity);
     }
     case ActivityType.EscrowedDiskEncryptionKey: {
       return TAGGED_TEMPLATES.escrowedDiskEncryptionKey(activity);

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -741,6 +741,18 @@ func (ds *Datastore) Label(ctx context.Context, lid uint, teamFilter fleet.TeamF
 	return ds.labelDB(ctx, lid, teamFilter, ds.reader(ctx))
 }
 
+// LabelMembershipHostIDs returns every host_id row in label_membership for the
+// given label ID. Unlike Label, it applies no team filter on the host side, so
+// it returns the true membership including hosts on teams the caller can't see.
+func (ds *Datastore) LabelMembershipHostIDs(ctx context.Context, labelID uint) ([]uint, error) {
+	var hostIDs []uint
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostIDs,
+		`SELECT host_id FROM label_membership WHERE label_id = ?`, labelID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "selecting label membership host IDs")
+	}
+	return hostIDs, nil
+}
+
 func (ds *Datastore) labelDB(ctx context.Context, lid uint, teamFilter fleet.TeamFilter, q sqlx.QueryerContext) (*fleet.LabelWithTeamName, []uint, error) {
 	stmt := fmt.Sprintf(`
 		SELECT

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -107,6 +107,7 @@ func TestLabels(t *testing.T) {
 		{"ApplyLabelSpecsWithManualTeamLabels", testApplyLabelSpecsWithManualTeamLabels},
 		{"ApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam", testApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam},
 		{"ApplyLabelSpecsManualNilHosts", testApplyLabelSpecsManualNilHosts},
+		{"LabelMembershipHostIDs", testLabelMembershipHostIDs},
 	}
 	// call TruncateTables first to remove migration-created labels
 	TruncateTables(t, ds)
@@ -3605,4 +3606,60 @@ func testApplyLabelSpecsManualNilHosts(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, hosts, 1)
 	require.Equal(t, h1.ID, hosts[0].ID)
+}
+
+func testLabelMembershipHostIDs(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Make a team and a global label, then place a host on the team into the
+	// global label's membership. A team-scoped reader of the label may not
+	// "see" the host via team-filtered counts, but LabelMembershipHostIDs must
+	// always return the unfiltered membership for activity tracking.
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "membership-team"})
+	require.NoError(t, err)
+	teamHost, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:  ptr.String("memb-team-host"), //nolint:modernize
+		NodeKey:        ptr.String("memb-team-host"), //nolint:modernize
+		UUID:           "memb-team-host",
+		Hostname:       "memb-team-host.local",
+		HardwareSerial: "memb-serial-team",
+		Platform:       "darwin",
+		TeamID:         &team.ID,
+	})
+	require.NoError(t, err)
+	globalHost, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:  ptr.String("memb-global-host"), //nolint:modernize
+		NodeKey:        ptr.String("memb-global-host"), //nolint:modernize
+		UUID:           "memb-global-host",
+		Hostname:       "memb-global-host.local",
+		HardwareSerial: "memb-serial-global",
+		Platform:       "darwin",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+		{
+			Name:                "memb-label",
+			LabelMembershipType: fleet.LabelMembershipTypeManual,
+			Hosts:               []string{"memb-team-host.local", "memb-global-host.local"},
+		},
+	}))
+
+	lbl, err := ds.LabelByName(ctx, "memb-label", fleet.TeamFilter{User: test.UserAdmin})
+	require.NoError(t, err)
+
+	// LabelMembershipHostIDs must return both hosts, regardless of team.
+	gotIDs, err := ds.LabelMembershipHostIDs(ctx, lbl.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint{teamHost.ID, globalHost.ID}, gotIDs)
+
+	// Empty membership returns no IDs and no error.
+	emptyLbl, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "memb-label-empty",
+		LabelMembershipType: fleet.LabelMembershipTypeManual,
+	})
+	require.NoError(t, err)
+	gotIDs, err = ds.LabelMembershipHostIDs(ctx, emptyLbl.ID)
+	require.NoError(t, err)
+	require.Empty(t, gotIDs)
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -243,6 +243,10 @@ var ActivityDetailsList = []ActivityDetails{
 	ActivityTypeDisabledManagedLocalAccount{},
 
 	ActivityTypeCanceledSetupExperience{},
+
+	ActivityTypeCreatedLabel{},
+	ActivityTypeEditedLabel{},
+	ActivityTypeDeletedLabel{},
 }
 
 // ActivityDetails is an alias for the canonical ActivityDetails interface defined in server/activity/api.
@@ -1983,4 +1987,37 @@ func (a ActivityTypeCanceledSetupExperience) HostIDs() []uint {
 
 func (a ActivityTypeCanceledSetupExperience) WasFromAutomation() bool {
 	return true
+}
+
+type ActivityTypeCreatedLabel struct {
+	ID        uint    `json:"label_id"`
+	Name      string  `json:"label_name"`
+	FleetID   *uint   `json:"fleet_id,omitempty"`
+	FleetName *string `json:"fleet_name,omitempty"`
+}
+
+func (a ActivityTypeCreatedLabel) ActivityName() string {
+	return "created_label"
+}
+
+type ActivityTypeEditedLabel struct {
+	ID        uint    `json:"label_id"`
+	Name      string  `json:"label_name"`
+	FleetID   *uint   `json:"fleet_id,omitempty"`
+	FleetName *string `json:"fleet_name,omitempty"`
+}
+
+func (a ActivityTypeEditedLabel) ActivityName() string {
+	return "edited_label"
+}
+
+type ActivityTypeDeletedLabel struct {
+	ID        uint    `json:"label_id"`
+	Name      string  `json:"label_name"`
+	FleetID   *uint   `json:"fleet_id,omitempty"`
+	FleetName *string `json:"fleet_name,omitempty"`
+}
+
+func (a ActivityTypeDeletedLabel) ActivityName() string {
+	return "deleted_label"
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -246,6 +246,10 @@ type Datastore interface {
 	LabelByName(ctx context.Context, name string, filter TeamFilter) (*Label, error)
 	// Label returns the label and an array of host IDs members of this label, or an error.
 	Label(ctx context.Context, lid uint, teamFilter TeamFilter) (*LabelWithTeamName, []uint, error)
+	// LabelMembershipHostIDs returns every host_id row in label_membership for
+	// the given label ID, with no team-based filtering. Intended for internal
+	// activity tracking where the unfiltered membership is needed.
+	LabelMembershipHostIDs(ctx context.Context, labelID uint) ([]uint, error)
 	ListLabels(ctx context.Context, filter TeamFilter, opt ListOptions, includeHostCounts bool) ([]*Label, error)
 	LabelsSummary(ctx context.Context, filter TeamFilter) ([]*LabelSummary, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -189,6 +189,8 @@ type LabelByNameFunc func(ctx context.Context, name string, filter fleet.TeamFil
 
 type LabelFunc func(ctx context.Context, lid uint, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error)
 
+type LabelMembershipHostIDsFunc func(ctx context.Context, labelID uint) ([]uint, error)
+
 type ListLabelsFunc func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions, includeHostCounts bool) ([]*fleet.Label, error)
 
 type LabelsSummaryFunc func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSummary, error)
@@ -2148,6 +2150,9 @@ type DataStore struct {
 
 	LabelFunc        LabelFunc
 	LabelFuncInvoked bool
+
+	LabelMembershipHostIDsFunc        LabelMembershipHostIDsFunc
+	LabelMembershipHostIDsFuncInvoked bool
 
 	ListLabelsFunc        ListLabelsFunc
 	ListLabelsFuncInvoked bool
@@ -5296,6 +5301,13 @@ func (s *DataStore) Label(ctx context.Context, lid uint, teamFilter fleet.TeamFi
 	s.LabelFuncInvoked = true
 	s.mu.Unlock()
 	return s.LabelFunc(ctx, lid, teamFilter)
+}
+
+func (s *DataStore) LabelMembershipHostIDs(ctx context.Context, labelID uint) ([]uint, error) {
+	s.mu.Lock()
+	s.LabelMembershipHostIDsFuncInvoked = true
+	s.mu.Unlock()
+	return s.LabelMembershipHostIDsFunc(ctx, labelID)
 }
 
 func (s *DataStore) ListLabels(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions, includeHostCounts bool) ([]*fleet.Label, error) {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -3581,7 +3581,7 @@ func (svc *Service) AddLabelsToHost(ctx context.Context, id uint, labelNames []s
 		return ctxerr.Wrap(ctx, err, "add labels to host")
 	}
 
-	return nil
+	return svc.emitEditedLabelActivities(ctx, labelNames, tmID)
 }
 
 func removeLabelsFromHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
@@ -3620,6 +3620,57 @@ func (svc *Service) RemoveLabelsFromHost(ctx context.Context, id uint, labelName
 		return ctxerr.Wrap(ctx, err, "remove labels from host")
 	}
 
+	return svc.emitEditedLabelActivities(ctx, labelNames, tmID)
+}
+
+// emitEditedLabelActivities emits an edited_label activity per label affected
+// by an add/remove-labels-on-host call. labelNames are assumed already
+// validated against the host's team scope.
+func (svc *Service) emitEditedLabelActivities(ctx context.Context, labelNames []string, hostTeamID uint) error {
+	if len(labelNames) == 0 {
+		return nil
+	}
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return fleet.ErrNoContext
+	}
+	labels, err := svc.ds.LabelsByName(ctx, labelNames, fleet.TeamFilter{
+		User:   authz.UserFromContext(ctx),
+		TeamID: &hostTeamID,
+	})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "look up labels for edited_label activity")
+	}
+	// Validated labels are either global or on hostTeamID, so at most one
+	// distinct non-nil team_id is involved — resolve its name once.
+	var teamName *string
+	for _, l := range labels {
+		if l.TeamID != nil {
+			teamName, err = svc.lookupTeamNameForLabel(ctx, l.TeamID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "lookup team name for label activity")
+			}
+			break
+		}
+	}
+	for _, name := range labelNames {
+		l, ok := labels[name]
+		if !ok {
+			continue
+		}
+		fleetName := teamName
+		if l.TeamID == nil {
+			fleetName = nil
+		}
+		if err := svc.NewActivity(ctx, vc.User, fleet.ActivityTypeEditedLabel{
+			ID:        l.ID,
+			Name:      l.Name,
+			FleetID:   l.TeamID,
+			FleetName: fleetName,
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for edited label")
+		}
+	}
 	return nil
 }
 

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -3648,7 +3648,7 @@ func (svc *Service) emitEditedLabelActivities(ctx context.Context, labelNames []
 	var teamName *string
 	for _, l := range labels {
 		if l.TeamID != nil {
-			teamName, err = svc.lookupTeamNameForLabel(ctx, l.TeamID)
+			teamName, err = svc.lookupTeamName(ctx, l.TeamID)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "lookup team name for label activity")
 			}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -3569,6 +3569,7 @@ func (svc *Service) AddLabelsToHost(ctx context.Context, id uint, labelNames []s
 		tmID = *host.TeamID
 	}
 
+	labelNames = server.RemoveDuplicatesFromSlice(labelNames)
 	labelIDs, err := svc.validateLabelNames(ctx, "add", labelNames, tmID)
 	if err != nil {
 		return err
@@ -3608,6 +3609,7 @@ func (svc *Service) RemoveLabelsFromHost(ctx context.Context, id uint, labelName
 		tmID = *host.TeamID
 	}
 
+	labelNames = server.RemoveDuplicatesFromSlice(labelNames)
 	labelIDs, err := svc.validateLabelNames(ctx, "remove", labelNames, tmID)
 	if err != nil {
 		return err
@@ -3678,8 +3680,6 @@ func (svc *Service) validateLabelNames(ctx context.Context, action string, label
 	if len(labelNames) == 0 {
 		return nil, nil
 	}
-
-	labelNames = server.RemoveDuplicatesFromSlice(labelNames)
 
 	// Filter out empty label string.
 	for i, labelName := range labelNames {

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -503,14 +503,15 @@ func (svc *Service) DeleteLabel(ctx context.Context, name string) error {
 		return err
 	}
 
-	if err := svc.ds.DeleteLabel(ctx, name, filter); err != nil {
-		return err
-	}
-
 	teamName, err := svc.lookupTeamNameForLabel(ctx, label.TeamID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "lookup team name for deleted label")
 	}
+
+	if err := svc.ds.DeleteLabel(ctx, name, filter); err != nil {
+		return err
+	}
+
 	if err := svc.NewActivity(ctx, vc.User, fleet.ActivityTypeDeletedLabel{
 		ID:        label.ID,
 		Name:      label.Name,
@@ -699,9 +700,11 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 	}
 
 	// Look up which regular specs already exist in the target team scope so we
-	// can emit "created" vs "edited" label activities below. The only mutable
-	// label field via spec apply is the description, so we skip the activity
-	// when an existing label's description matches the spec.
+	// can emit "created" vs "edited" label activities below. Spec apply can
+	// update multiple edit-relevant fields for regular labels (for example
+	// description, platform, query, label membership type, host vitals criteria,
+	// and manual-label host membership), so we skip the activity only when an
+	// existing label already matches the spec for those fields.
 	regularSpecNames := make([]string, 0, len(regularSpecs))
 	for _, s := range regularSpecs {
 		regularSpecNames = append(regularSpecNames, s.Name)
@@ -815,6 +818,9 @@ func labelMatchesScope(l *fleet.Label, teamID *uint) bool {
 // IDs around the apply.
 func labelSpecMatchesLabel(spec *fleet.LabelSpec, label *fleet.Label) bool {
 	if spec.Description != label.Description {
+		return false
+	}
+	if spec.Platform != label.Platform {
 		return false
 	}
 	if spec.Query != label.Query {

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -113,6 +113,7 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 	if err := svc.NewActivity(ctx, vc.User, fleet.ActivityTypeCreatedLabel{
 		ID:   label.ID,
 		Name: label.Name,
+		// NOTE: Set FleetID and FleetName as soon as NewLabel supports creating labels on teams.
 	}); err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err, "create activity for label creation")
 	}
@@ -503,7 +504,7 @@ func (svc *Service) DeleteLabel(ctx context.Context, name string) error {
 		return err
 	}
 
-	teamName, err := svc.lookupTeamNameForLabel(ctx, label.TeamID)
+	teamName, err := svc.lookupTeamName(ctx, label.TeamID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "lookup team name for deleted label")
 	}
@@ -721,7 +722,7 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 	}
 	beforeByName := make(map[string]*fleet.Label, len(beforeApply))
 	for name, l := range beforeApply {
-		if labelMatchesScope(l, teamID) {
+		if labelMatchesTeamScope(l, teamID) {
 			beforeByName[name] = l
 		}
 	}
@@ -757,13 +758,13 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "look up labels after apply for activity")
 	}
-	teamName, err := svc.lookupTeamNameForLabel(ctx, teamID)
+	teamName, err := svc.lookupTeamName(ctx, teamID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "lookup team name for label spec activity")
 	}
 	for _, spec := range regularSpecs {
 		label, ok := afterApply[spec.Name]
-		if !ok || !labelMatchesScope(label, teamID) {
+		if !ok || !labelMatchesTeamScope(label, teamID) {
 			continue
 		}
 		existing, existed := beforeByName[spec.Name]
@@ -802,9 +803,7 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 	return nil
 }
 
-// labelMatchesScope reports whether the given label belongs to the team scope
-// identified by teamID (nil means global scope).
-func labelMatchesScope(l *fleet.Label, teamID *uint) bool {
+func labelMatchesTeamScope(l *fleet.Label, teamID *uint) bool {
 	if teamID == nil {
 		return l.TeamID == nil
 	}
@@ -971,9 +970,7 @@ func (svc *Service) BatchValidateLabels(ctx context.Context, teamID *uint, label
 	return byName, nil
 }
 
-// lookupTeamNameForLabel returns the team name for the given team ID, or nil
-// if the team ID is nil (global label).
-func (svc *Service) lookupTeamNameForLabel(ctx context.Context, teamID *uint) (*string, error) {
+func (svc *Service) lookupTeamName(ctx context.Context, teamID *uint) (*string, error) {
 	if teamID == nil {
 		return nil, nil
 	}

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"slices"
 	"strconv"
 
@@ -109,6 +110,13 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 		return nil, nil, err
 	}
 
+	if err := svc.NewActivity(ctx, vc.User, fleet.ActivityTypeCreatedLabel{
+		ID:   label.ID,
+		Name: label.Name,
+	}); err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "create activity for label creation")
+	}
+
 	if label.LabelMembershipType == fleet.LabelMembershipTypeManual {
 		hostIDs := p.HostIDs
 		if len(p.Hosts) > 0 {
@@ -207,7 +215,21 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		}
 	}
 
-	return svc.ds.SaveLabel(ctx, &label.Label, filter)
+	saved, savedHostIDs, err := svc.ds.SaveLabel(ctx, &label.Label, filter)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := svc.NewActivity(ctx, vc.User, fleet.ActivityTypeEditedLabel{
+		ID:        saved.ID,
+		Name:      saved.Name,
+		FleetID:   saved.TeamID,
+		FleetName: saved.TeamName,
+	}); err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "create activity for label edit")
+	}
+
+	return saved, savedHostIDs, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -481,7 +503,23 @@ func (svc *Service) DeleteLabel(ctx context.Context, name string) error {
 		return err
 	}
 
-	return svc.ds.DeleteLabel(ctx, name, filter)
+	if err := svc.ds.DeleteLabel(ctx, name, filter); err != nil {
+		return err
+	}
+
+	teamName, err := svc.lookupTeamNameForLabel(ctx, label.TeamID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "lookup team name for deleted label")
+	}
+	if err := svc.NewActivity(ctx, vc.User, fleet.ActivityTypeDeletedLabel{
+		ID:        label.ID,
+		Name:      label.Name,
+		FleetID:   label.TeamID,
+		FleetName: teamName,
+	}); err != nil {
+		return ctxerr.Wrap(ctx, err, "create activity for label deletion")
+	}
+	return nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -528,7 +566,19 @@ func (svc *Service) DeleteLabelByID(ctx context.Context, id uint) error {
 		}
 	}
 
-	return svc.ds.DeleteLabel(ctx, label.Name, filter)
+	if err := svc.ds.DeleteLabel(ctx, label.Name, filter); err != nil {
+		return err
+	}
+
+	if err := svc.NewActivity(ctx, vc.User, fleet.ActivityTypeDeletedLabel{
+		ID:        label.ID,
+		Name:      label.Name,
+		FleetID:   label.TeamID,
+		FleetName: label.TeamName,
+	}); err != nil {
+		return ctxerr.Wrap(ctx, err, "create activity for label deletion")
+	}
+	return nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -648,11 +698,179 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 		return nil
 	}
 
+	// Look up which regular specs already exist in the target team scope so we
+	// can emit "created" vs "edited" label activities below. The only mutable
+	// label field via spec apply is the description, so we skip the activity
+	// when an existing label's description matches the spec.
+	regularSpecNames := make([]string, 0, len(regularSpecs))
+	for _, s := range regularSpecs {
+		regularSpecNames = append(regularSpecNames, s.Name)
+	}
+	scopeFilter := fleet.TeamFilter{User: user.User, IncludeObserver: true}
+	if teamID != nil {
+		scopeFilter.TeamID = teamID // filter to fetch team labels only
+	} else {
+		scopeFilter.TeamID = new(uint(0)) // filter to fetch global labels only
+	}
+	beforeApply, err := svc.ds.LabelsByName(ctx, regularSpecNames, scopeFilter)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "look up labels before apply")
+	}
+	beforeByName := make(map[string]*fleet.Label, len(beforeApply))
+	for name, l := range beforeApply {
+		if labelMatchesScope(l, teamID) {
+			beforeByName[name] = l
+		}
+	}
+
+	// For manual labels whose spec.Hosts is non-nil, snapshot current host IDs
+	// so we can detect host-membership changes after apply (the apply path
+	// always rewrites membership in this case). We bypass team-filtered Label
+	// reads here so the comparison sees the true membership including hosts on
+	// teams the caller can't see.
+	beforeHostIDs := make(map[string][]uint)
+	for _, spec := range regularSpecs {
+		existing, ok := beforeByName[spec.Name]
+		if !ok || existing.LabelMembershipType != fleet.LabelMembershipTypeManual || spec.Hosts == nil {
+			continue
+		}
+		ids, err := svc.ds.LabelMembershipHostIDs(ctx, existing.ID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "get pre-apply label host IDs")
+		}
+		beforeHostIDs[spec.Name] = ids
+	}
+
 	if err := svc.ds.SetAsideLabels(ctx, teamID, namesToMove, *user.User); err != nil {
 		return ctxerr.Wrap(ctx, err, "cleaning up conflicting other team labels")
 	}
 
-	return svc.ds.ApplyLabelSpecsWithAuthor(ctx, regularSpecs, ptr.Uint(user.UserID()))
+	if err := svc.ds.ApplyLabelSpecsWithAuthor(ctx, regularSpecs, ptr.Uint(user.UserID())); err != nil {
+		return err
+	}
+
+	// Emit created/edited activities for regular specs that were applied.
+	afterApply, err := svc.ds.LabelsByName(ctx, regularSpecNames, scopeFilter)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "look up labels after apply for activity")
+	}
+	teamName, err := svc.lookupTeamNameForLabel(ctx, teamID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "lookup team name for label spec activity")
+	}
+	for _, spec := range regularSpecs {
+		label, ok := afterApply[spec.Name]
+		if !ok || !labelMatchesScope(label, teamID) {
+			continue
+		}
+		existing, existed := beforeByName[spec.Name]
+		if existed {
+			fieldsMatch := labelSpecMatchesLabel(spec, existing)
+			hostsMatch := true
+			if before, tracked := beforeHostIDs[spec.Name]; tracked {
+				after, err := svc.ds.LabelMembershipHostIDs(ctx, label.ID)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "get post-apply label host IDs")
+				}
+				hostsMatch = uintSetsEqual(before, after)
+			}
+			if fieldsMatch && hostsMatch {
+				continue
+			}
+			if err := svc.NewActivity(ctx, user.User, fleet.ActivityTypeEditedLabel{
+				ID:        label.ID,
+				Name:      label.Name,
+				FleetID:   label.TeamID,
+				FleetName: teamName,
+			}); err != nil {
+				return ctxerr.Wrap(ctx, err, "create activity for edited label via spec")
+			}
+		} else {
+			if err := svc.NewActivity(ctx, user.User, fleet.ActivityTypeCreatedLabel{
+				ID:        label.ID,
+				Name:      label.Name,
+				FleetID:   label.TeamID,
+				FleetName: teamName,
+			}); err != nil {
+				return ctxerr.Wrap(ctx, err, "create activity for created label via spec")
+			}
+		}
+	}
+	return nil
+}
+
+// labelMatchesScope reports whether the given label belongs to the team scope
+// identified by teamID (nil means global scope).
+func labelMatchesScope(l *fleet.Label, teamID *uint) bool {
+	if teamID == nil {
+		return l.TeamID == nil
+	}
+	return l.TeamID != nil && *l.TeamID == *teamID
+}
+
+// labelSpecMatchesLabel reports whether the spec's editable top-level fields
+// match the existing label. Fields compared are the ones GitOps can change:
+// description, query, label_membership_type, and host vitals criteria. Host
+// membership for manual labels is compared separately by snapshotting host
+// IDs around the apply.
+func labelSpecMatchesLabel(spec *fleet.LabelSpec, label *fleet.Label) bool {
+	if spec.Description != label.Description {
+		return false
+	}
+	if spec.Query != label.Query {
+		return false
+	}
+	if spec.LabelMembershipType != label.LabelMembershipType {
+		return false
+	}
+	return jsonRawMessageEqual(spec.HostVitalsCriteria, label.HostVitalsCriteria)
+}
+
+// jsonRawMessageEqual compares two json.RawMessage values for semantic
+// equality. The label.criteria column is MySQL json type, which normalizes
+// whitespace and may reorder keys, so a byte comparison would report false
+// negatives across a round-trip.
+func jsonRawMessageEqual(a, b *json.RawMessage) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return len(rawJSONBytes(a)) == 0 && len(rawJSONBytes(b)) == 0
+	}
+	var av, bv any
+	if err := json.Unmarshal(*a, &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(*b, &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+func rawJSONBytes(m *json.RawMessage) []byte {
+	if m == nil {
+		return nil
+	}
+	return *m
+}
+
+func uintSetsEqual(a, b []uint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	set := make(map[uint]struct{}, len(a))
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	for _, x := range b {
+		if _, ok := set[x]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -745,4 +963,17 @@ func (svc *Service) BatchValidateLabels(ctx context.Context, teamID *uint, label
 		}
 	}
 	return byName, nil
+}
+
+// lookupTeamNameForLabel returns the team name for the given team ID, or nil
+// if the team ID is nil (global label).
+func (svc *Service) lookupTeamNameForLabel(ctx context.Context, teamID *uint) (*string, error) {
+	if teamID == nil {
+		return nil, nil
+	}
+	team, err := svc.ds.TeamLite(ctx, *teamID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get team for label activity")
+	}
+	return &team.Name, nil
 }

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -745,7 +745,7 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 		return ctxerr.Wrap(ctx, err, "cleaning up conflicting other team labels")
 	}
 
-	if err := svc.ds.ApplyLabelSpecsWithAuthor(ctx, regularSpecs, ptr.Uint(user.UserID())); err != nil {
+	if err := svc.ds.ApplyLabelSpecsWithAuthor(ctx, regularSpecs, new(user.UserID())); err != nil {
 		return err
 	}
 

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -995,6 +995,29 @@ func TestLabelActivities(t *testing.T) {
 		require.Equal(t, teamName, *got.FleetName)
 	})
 
+	t.Run("delete team label aborts before delete when team lookup fails", func(t *testing.T) {
+		activities = activities[:0]
+		ds.LabelByNameFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) (*fleet.Label, error) {
+			return &fleet.Label{ID: 250, Name: name, TeamID: ptr.Uint(teamID)}, nil
+		}
+		var deleteCalled bool
+		ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+			deleteCalled = true
+			return nil
+		}
+		// Override TeamLite for this subtest only.
+		prevTeamLite := ds.TeamLiteFunc
+		ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+			return nil, assert.AnError
+		}
+		t.Cleanup(func() { ds.TeamLiteFunc = prevTeamLite })
+
+		err := svc.DeleteLabel(ctx, "team-label-fail")
+		require.Error(t, err)
+		require.False(t, deleteCalled, "label must not be deleted when team lookup fails")
+		require.Empty(t, activities, "no activity should be emitted when delete is skipped")
+	})
+
 	t.Run("delete label by ID via UI emits deleted_label", func(t *testing.T) {
 		activities = activities[:0]
 		ds.LabelFunc = func(ctx context.Context, lid uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
@@ -1070,6 +1093,35 @@ func TestLabelActivities(t *testing.T) {
 		}
 		require.True(t, sawCreate, "expected created_label for new-spec")
 		require.True(t, sawEdit, "expected edited_label for edited-spec")
+	})
+
+	t.Run("apply specs detects platform-only change", func(t *testing.T) {
+		activities = activities[:0]
+
+		// Existing label "platform-spec" has Platform="darwin"; spec sets it to
+		// "linux" with all other fields unchanged.
+		var lookupCalls int
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			lookupCalls++
+			return map[string]*fleet.Label{
+				"platform-spec": {ID: 410, Name: "platform-spec", Platform: "darwin", LabelMembershipType: fleet.LabelMembershipTypeDynamic, Query: "SELECT 1"},
+			}, nil
+		}
+		ds.SetAsideLabelsFunc = func(ctx context.Context, notOnTeamID *uint, names []string, user fleet.User) error {
+			return nil
+		}
+		ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+			return nil
+		}
+
+		err := svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+			{Name: "platform-spec", Platform: "windows", LabelMembershipType: fleet.LabelMembershipTypeDynamic, Query: "SELECT 1"},
+		}, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, activities, 1, "platform change should emit edited_label")
+		got, ok := activities[0].(fleet.ActivityTypeEditedLabel)
+		require.True(t, ok, "expected edited_label, got %T", activities[0])
+		require.Equal(t, "platform-spec", got.Name)
 	})
 
 	t.Run("apply specs detects manual-label host membership change", func(t *testing.T) {
@@ -1179,6 +1231,37 @@ func TestLabelActivities(t *testing.T) {
 		require.Equal(t, targetTeamID, *byName["team-manual"].FleetID)
 		require.NotNil(t, byName["team-manual"].FleetName)
 		require.Equal(t, teamName, *byName["team-manual"].FleetName)
+	})
+
+	t.Run("AddLabelsToHost dedupes label names in activities", func(t *testing.T) {
+		activities = activities[:0]
+		const hostID = uint(7100)
+		host := &fleet.Host{ID: hostID, Platform: "darwin"}
+		ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+			return host, nil
+		}
+		ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+			require.Len(t, names, 1, "duplicates should be removed before validation")
+			require.Equal(t, "dup-label", names[0])
+			return map[string]uint{"dup-label": 800}, nil
+		}
+		ds.LabelFunc = func(ctx context.Context, lid uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			return &fleet.LabelWithTeamName{Label: fleet.Label{ID: lid, LabelMembershipType: fleet.LabelMembershipTypeManual}}, nil, nil
+		}
+		ds.AddLabelsToHostFunc = func(ctx context.Context, h uint, ids []uint) error {
+			require.Equal(t, []uint{800}, ids)
+			return nil
+		}
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			require.Equal(t, []string{"dup-label"}, names, "duplicates should be removed before activity emission")
+			return map[string]*fleet.Label{"dup-label": {ID: 800, Name: "dup-label"}}, nil
+		}
+
+		require.NoError(t, svc.AddLabelsToHost(ctx, hostID, []string{"dup-label", "dup-label", "dup-label"}))
+		require.Len(t, activities, 1, "duplicate label names must produce a single activity")
+		got, ok := activities[0].(fleet.ActivityTypeEditedLabel)
+		require.True(t, ok)
+		require.Equal(t, "dup-label", got.Name)
 	})
 
 	t.Run("RemoveLabelsFromHost emits edited_label", func(t *testing.T) {

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
@@ -186,6 +187,9 @@ func TestLabelsAuth(t *testing.T) {
 	}
 	ds.GetLabelSpecFunc = func(ctx context.Context, filter fleet.TeamFilter, name string) (*fleet.LabelSpec, error) {
 		return &fleet.LabelSpec{}, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{ID: tid, Name: fmt.Sprintf("team-%d", tid)}, nil
 	}
 
 	testCases := []struct {
@@ -827,7 +831,7 @@ func TestModifyManualLabel(t *testing.T) {
 		return []uint{99, 100}, nil
 	}
 	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
-		return nil, nil, nil
+		return &fleet.LabelWithTeamName{Label: *lbl}, nil, nil
 	}
 
 	t.Run("using hostnames", func(t *testing.T) {
@@ -883,5 +887,329 @@ func TestNewHostVitalsLabel(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "SELECT %s FROM %s RIGHT JOIN host_scim_user ON (hosts.id = host_scim_user.host_id) JOIN scim_users ON (host_scim_user.scim_user_id = scim_users.id) LEFT JOIN scim_user_group ON (host_scim_user.scim_user_id = scim_user_group.scim_user_id) LEFT JOIN scim_groups ON (scim_user_group.group_id = scim_groups.id) WHERE scim_groups.display_name = ? GROUP BY hosts.id", query)
 		assert.Equal(t, `["admin"]`, string(queryValuesJson))
+	})
+}
+
+func TestLabelActivities(t *testing.T) {
+	ds := new(mock.Store)
+	opts := &TestServerOpts{}
+	svc, ctx := newTestService(t, ds, nil, nil, opts)
+	user := &fleet.User{ID: 7, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
+
+	var activities []activity_api.ActivityDetails
+	opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, a activity_api.ActivityDetails) error {
+		activities = append(activities, a)
+		return nil
+	}
+
+	const teamID = uint(42)
+	teamName := "Workstations"
+	ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+		require.Equal(t, teamID, tid)
+		return &fleet.TeamLite{ID: tid, Name: teamName}, nil
+	}
+
+	t.Run("create global label via UI emits created_label", func(t *testing.T) {
+		activities = activities[:0]
+		ds.NewLabelFunc = func(ctx context.Context, lbl *fleet.Label, opts ...fleet.OptionalArg) (*fleet.Label, error) {
+			lbl.ID = 100
+			return lbl, nil
+		}
+		_, _, err := svc.NewLabel(ctx, fleet.LabelPayload{Name: "global1", Query: "SELECT 1"})
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+		got, ok := activities[0].(fleet.ActivityTypeCreatedLabel)
+		require.True(t, ok, "expected ActivityTypeCreatedLabel, got %T", activities[0])
+		require.Equal(t, uint(100), got.ID)
+		require.Equal(t, "global1", got.Name)
+		require.Nil(t, got.FleetID)
+		require.Nil(t, got.FleetName)
+	})
+
+	t.Run("modify label via UI emits edited_label with team info", func(t *testing.T) {
+		activities = activities[:0]
+		labelID := uint(101)
+		ds.LabelFunc = func(ctx context.Context, lid uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			return &fleet.LabelWithTeamName{
+				Label: fleet.Label{
+					ID:                  lid,
+					Name:                "edited",
+					LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+				},
+			}, nil, nil
+		}
+		ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			return &fleet.LabelWithTeamName{
+				Label:    fleet.Label{ID: lbl.ID, Name: lbl.Name, TeamID: ptr.Uint(teamID)},
+				TeamName: &teamName,
+			}, nil, nil
+		}
+		_, _, err := svc.ModifyLabel(ctx, labelID, fleet.ModifyLabelPayload{Description: ptr.String("new")})
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+		got, ok := activities[0].(fleet.ActivityTypeEditedLabel)
+		require.True(t, ok, "expected ActivityTypeEditedLabel, got %T", activities[0])
+		require.Equal(t, labelID, got.ID)
+		require.Equal(t, "edited", got.Name)
+		require.NotNil(t, got.FleetID)
+		require.Equal(t, teamID, *got.FleetID)
+		require.NotNil(t, got.FleetName)
+		require.Equal(t, teamName, *got.FleetName)
+	})
+
+	t.Run("delete label by name via UI emits deleted_label", func(t *testing.T) {
+		activities = activities[:0]
+		ds.LabelByNameFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) (*fleet.Label, error) {
+			return &fleet.Label{ID: 200, Name: name}, nil
+		}
+		ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+			return nil
+		}
+		err := svc.DeleteLabel(ctx, "to-remove")
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+		got, ok := activities[0].(fleet.ActivityTypeDeletedLabel)
+		require.True(t, ok, "expected ActivityTypeDeletedLabel, got %T", activities[0])
+		require.Equal(t, uint(200), got.ID)
+		require.Equal(t, "to-remove", got.Name)
+		require.Nil(t, got.FleetID)
+	})
+
+	t.Run("delete team label by name resolves team name", func(t *testing.T) {
+		activities = activities[:0]
+		ds.LabelByNameFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) (*fleet.Label, error) {
+			return &fleet.Label{ID: 201, Name: name, TeamID: ptr.Uint(teamID)}, nil
+		}
+		ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+			return nil
+		}
+		err := svc.DeleteLabel(ctx, "team-label")
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+		got, ok := activities[0].(fleet.ActivityTypeDeletedLabel)
+		require.True(t, ok)
+		require.NotNil(t, got.FleetID)
+		require.Equal(t, teamID, *got.FleetID)
+		require.NotNil(t, got.FleetName)
+		require.Equal(t, teamName, *got.FleetName)
+	})
+
+	t.Run("delete label by ID via UI emits deleted_label", func(t *testing.T) {
+		activities = activities[:0]
+		ds.LabelFunc = func(ctx context.Context, lid uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			return &fleet.LabelWithTeamName{
+				Label:    fleet.Label{ID: lid, Name: "delete-by-id", TeamID: ptr.Uint(teamID)},
+				TeamName: &teamName,
+			}, nil, nil
+		}
+		ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+			return nil
+		}
+		err := svc.DeleteLabelByID(ctx, 300)
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+		got, ok := activities[0].(fleet.ActivityTypeDeletedLabel)
+		require.True(t, ok)
+		require.Equal(t, uint(300), got.ID)
+		require.Equal(t, "delete-by-id", got.Name)
+		require.NotNil(t, got.FleetID)
+		require.Equal(t, teamID, *got.FleetID)
+		require.NotNil(t, got.FleetName)
+		require.Equal(t, teamName, *got.FleetName)
+	})
+
+	t.Run("apply specs emits per-label created/edited/no-op", func(t *testing.T) {
+		activities = activities[:0]
+
+		// Pre-existing label "edited-spec" has the OLD description; "noop-spec"
+		// matches the spec exactly so it should produce no activity. After
+		// apply, "new-spec" exists with its newly assigned ID.
+		var lookupCalls int
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			lookupCalls++
+			result := map[string]*fleet.Label{
+				"edited-spec": {ID: 401, Name: "edited-spec", Description: "old", Query: "SELECT 1", LabelMembershipType: fleet.LabelMembershipTypeDynamic},
+				"noop-spec":   {ID: 402, Name: "noop-spec", Description: "same", Query: "SELECT 2", LabelMembershipType: fleet.LabelMembershipTypeDynamic},
+			}
+			if lookupCalls > 1 { // post-apply: new-spec now exists; edited-spec has new desc
+				result["new-spec"] = &fleet.Label{ID: 403, Name: "new-spec", Description: "fresh", Query: "SELECT 3", LabelMembershipType: fleet.LabelMembershipTypeDynamic}
+				result["edited-spec"] = &fleet.Label{ID: 401, Name: "edited-spec", Description: "new", Query: "SELECT 1", LabelMembershipType: fleet.LabelMembershipTypeDynamic}
+			}
+			return result, nil
+		}
+		ds.SetAsideLabelsFunc = func(ctx context.Context, notOnTeamID *uint, names []string, user fleet.User) error {
+			return nil
+		}
+		ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+			return nil
+		}
+
+		err := svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+			{Name: "new-spec", Description: "fresh", Query: "SELECT 3", LabelMembershipType: fleet.LabelMembershipTypeDynamic},
+			{Name: "edited-spec", Description: "new", Query: "SELECT 1", LabelMembershipType: fleet.LabelMembershipTypeDynamic},
+			{Name: "noop-spec", Description: "same", Query: "SELECT 2", LabelMembershipType: fleet.LabelMembershipTypeDynamic},
+		}, nil, nil)
+		require.NoError(t, err)
+
+		// Two activities: one created, one edited; the no-op spec emits nothing.
+		require.Len(t, activities, 2)
+		var sawCreate, sawEdit bool
+		for _, a := range activities {
+			switch v := a.(type) {
+			case fleet.ActivityTypeCreatedLabel:
+				require.Equal(t, "new-spec", v.Name)
+				sawCreate = true
+			case fleet.ActivityTypeEditedLabel:
+				require.Equal(t, "edited-spec", v.Name)
+				require.Equal(t, uint(401), v.ID)
+				sawEdit = true
+			default:
+				t.Fatalf("unexpected activity type %T", a)
+			}
+		}
+		require.True(t, sawCreate, "expected created_label for new-spec")
+		require.True(t, sawEdit, "expected edited_label for edited-spec")
+	})
+
+	t.Run("apply specs detects manual-label host membership change", func(t *testing.T) {
+		activities = activities[:0]
+
+		// Existing manual label "manual-spec" has identical fields to the spec
+		// (so field comparison says no-op), but its host membership will change
+		// from {1,2} to {1,3} after apply.
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			return map[string]*fleet.Label{
+				"manual-spec": {ID: 501, Name: "manual-spec", LabelMembershipType: fleet.LabelMembershipTypeManual},
+			}, nil
+		}
+		var membershipCalls int
+		ds.LabelMembershipHostIDsFunc = func(ctx context.Context, labelID uint) ([]uint, error) {
+			membershipCalls++
+			if membershipCalls == 1 { // before apply
+				return []uint{1, 2}, nil
+			}
+			return []uint{1, 3}, nil // after apply
+		}
+		ds.SetAsideLabelsFunc = func(ctx context.Context, notOnTeamID *uint, names []string, user fleet.User) error {
+			return nil
+		}
+		ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+			return nil
+		}
+
+		err := svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+			{Name: "manual-spec", LabelMembershipType: fleet.LabelMembershipTypeManual, Hosts: []string{"host1", "host3"}},
+		}, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+		got, ok := activities[0].(fleet.ActivityTypeEditedLabel)
+		require.True(t, ok, "expected ActivityTypeEditedLabel for host membership change, got %T", activities[0])
+		require.Equal(t, "manual-spec", got.Name)
+	})
+
+	t.Run("apply specs treats manual-label host no-op as no-op", func(t *testing.T) {
+		activities = activities[:0]
+
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			return map[string]*fleet.Label{
+				"manual-spec": {ID: 502, Name: "manual-spec", LabelMembershipType: fleet.LabelMembershipTypeManual},
+			}, nil
+		}
+		ds.LabelMembershipHostIDsFunc = func(ctx context.Context, labelID uint) ([]uint, error) {
+			return []uint{1, 2}, nil
+		}
+		ds.SetAsideLabelsFunc = func(ctx context.Context, notOnTeamID *uint, names []string, user fleet.User) error {
+			return nil
+		}
+		ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+			return nil
+		}
+
+		err := svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+			{Name: "manual-spec", LabelMembershipType: fleet.LabelMembershipTypeManual, Hosts: []string{"host1", "host2"}},
+		}, nil, nil)
+		require.NoError(t, err)
+		require.Empty(t, activities, "expected no activity for manual-label no-op")
+	})
+
+	t.Run("AddLabelsToHost emits edited_label per requested label", func(t *testing.T) {
+		activities = activities[:0]
+		const hostID = uint(7000)
+		const targetTeamID = uint(42)
+		host := &fleet.Host{ID: hostID, TeamID: ptr.Uint(targetTeamID), Platform: "darwin"}
+		ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+			require.Equal(t, hostID, id)
+			return host, nil
+		}
+		ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+			return map[string]uint{"global-manual": 600, "team-manual": 601}, nil
+		}
+		ds.LabelFunc = func(ctx context.Context, lid uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			lbl := fleet.Label{ID: lid, LabelMembershipType: fleet.LabelMembershipTypeManual}
+			if lid == 601 {
+				lbl.TeamID = ptr.Uint(targetTeamID)
+			}
+			return &fleet.LabelWithTeamName{Label: lbl}, nil, nil
+		}
+		ds.AddLabelsToHostFunc = func(ctx context.Context, h uint, ids []uint) error {
+			require.Equal(t, hostID, h)
+			require.ElementsMatch(t, []uint{600, 601}, ids)
+			return nil
+		}
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			require.NotNil(t, filter.TeamID)
+			require.Equal(t, targetTeamID, *filter.TeamID)
+			return map[string]*fleet.Label{
+				"global-manual": {ID: 600, Name: "global-manual"},
+				"team-manual":   {ID: 601, Name: "team-manual", TeamID: ptr.Uint(targetTeamID)},
+			}, nil
+		}
+
+		require.NoError(t, svc.AddLabelsToHost(ctx, hostID, []string{"global-manual", "team-manual"}))
+		require.Len(t, activities, 2)
+		byName := map[string]fleet.ActivityTypeEditedLabel{}
+		for _, a := range activities {
+			e, ok := a.(fleet.ActivityTypeEditedLabel)
+			require.True(t, ok, "expected edited_label, got %T", a)
+			byName[e.Name] = e
+		}
+		require.Nil(t, byName["global-manual"].FleetID)
+		require.NotNil(t, byName["team-manual"].FleetID)
+		require.Equal(t, targetTeamID, *byName["team-manual"].FleetID)
+		require.NotNil(t, byName["team-manual"].FleetName)
+		require.Equal(t, teamName, *byName["team-manual"].FleetName)
+	})
+
+	t.Run("RemoveLabelsFromHost emits edited_label", func(t *testing.T) {
+		activities = activities[:0]
+		const hostID = uint(7001)
+		host := &fleet.Host{ID: hostID, Platform: "darwin"} // no team
+		ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+			return host, nil
+		}
+		ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+			return map[string]uint{"global-manual": 700}, nil
+		}
+		ds.LabelFunc = func(ctx context.Context, lid uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			return &fleet.LabelWithTeamName{Label: fleet.Label{ID: lid, LabelMembershipType: fleet.LabelMembershipTypeManual}}, nil, nil
+		}
+		ds.RemoveLabelsFromHostFunc = func(ctx context.Context, h uint, ids []uint) error {
+			require.Equal(t, hostID, h)
+			require.Equal(t, []uint{700}, ids)
+			return nil
+		}
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			return map[string]*fleet.Label{
+				"global-manual": {ID: 700, Name: "global-manual"},
+			}, nil
+		}
+
+		require.NoError(t, svc.RemoveLabelsFromHost(ctx, hostID, []string{"global-manual"}))
+		require.Len(t, activities, 1)
+		got, ok := activities[0].(fleet.ActivityTypeEditedLabel)
+		require.True(t, ok)
+		require.Equal(t, "global-manual", got.Name)
+		require.Nil(t, got.FleetID)
 	})
 }


### PR DESCRIPTION
Resolves #36976

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Label operations (create, edit, delete) now generate activities shown in the activity feed with label and optional fleet context.
  * Host label add/remove operations emit corresponding label edited activities; duplicate label names are deduplicated.
  * Label activity types are selectable/filterable in the activity dashboard.

* **Tests**
  * Added unit, integration, and UI tests covering label activity emission, rendering, filtering, and GitOps label lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->