### PR TITLE
Adding changes for Fleet v4.84.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 - Fixed issue where the `include_available_for_install` query param wasn't being applied correctly to the `GET /api/latest/fleet/hosts/{id}/software` endpoint.
 - Fixed disk encryption key modal to not show stale key when switching between hosts.
 - Fixed SCIM user not associating with host when IdP username was set before the SCIM user was created.
-- Fixed  Google Drive version not matching upstream.
+- Fixed Google Drive version not matching upstream.
 - Fixed bug that cleared the MDM lock state if an "idle" message was received right after the lock ACK.
 - Fixed team maintainers, admins, and GitOps users being unable to add certificate templates due to missing read access to certificate authorities.
 - Fixed fleetd installation failure on macOS when installing it through Host details page > Software > Library as a Custom package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Fleet 4.84.1 (Apr 30, 2026)
+
+### Bug fixes
+
+- Fixed Fleet's Docker image failing to start in Kubernetes with an `unknown userid` error, triggered by a fleetctl dependency side effect.
+- Use Docker as the default WiX runtime on macOS (including Apple Silicon) when generating `.msi` packages via `fleetctl package`. Wine is no longer required on macOS for the default path.
+
 ## Fleet 4.84.0 (Apr 24, 2026)
 
 ### IT Admins
@@ -82,7 +89,7 @@
 - Fixed issue where the `include_available_for_install` query param wasn't being applied correctly to the `GET /api/latest/fleet/hosts/{id}/software` endpoint.
 - Fixed disk encryption key modal to not show stale key when switching between hosts.
 - Fixed SCIM user not associating with host when IdP username was set before the SCIM user was created.
-- Fixed Google Drive version not matching upstream.
+- Fixed  Google Drive version not matching upstream.
 - Fixed bug that cleared the MDM lock state if an "idle" message was received right after the lock ACK.
 - Fixed team maintainers, admins, and GitOps users being unable to add certificate templates due to missing read access to certificate authorities.
 - Fixed fleetd installation failure on macOS when installing it through Host details page > Software > Library as a Custom package.

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.9.1
+version: v6.9.2
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.84.0
+appVersion: v4.84.1
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.84.0 # Version of Fleet to deploy
+imageTag: v4.84.1 # Version of Fleet to deploy
 # imagePullSecrets is optional.
 # imagePullSecrets:
 #   - name: docker

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.84.0"
+  default     = "fleetdm/fleet:v4.84.1"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.84.0"
+  default = "fleetdm/fleet:v4.84.1"
 }
 
 variable "software_installers_bucket_name" {

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.84.0",
+  "version": "v4.84.1",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/github-manage/cmd/gm/releases.go
+++ b/tools/github-manage/cmd/gm/releases.go
@@ -207,7 +207,7 @@ Size mapping (low-high):
   XL:  75-100
 
 Usage:
-  gm releases forecast --milestone "Fleet 4.84.0"`,
+  gm releases forecast --milestone "Fleet 4.84.1"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		releasesProjectID := 87 // fleet Releases project
 		milestoneTitle, _ := cmd.Flags().GetString("milestone")
@@ -319,5 +319,5 @@ func init() {
 	releasesSyncEstimatesCmd.Flags().BoolP("overwrite", "o", false, "Overwrite existing Releases estimates (by default, issues with estimates are skipped)")
 	releasesSyncEstimatesCmd.Flags().StringP("milestone", "m", "", "Only process issues in this milestone, e.g., Fleet 4.77.0")
 
-	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.84.0 (required)")
+	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.84.1 (required)")
 }

--- a/tools/github-manage/cmd/gm/releases.go
+++ b/tools/github-manage/cmd/gm/releases.go
@@ -207,7 +207,7 @@ Size mapping (low-high):
   XL:  75-100
 
 Usage:
-  gm releases forecast --milestone "Fleet 4.84.1"`,
+  gm releases forecast --milestone "Fleet 4.84.0"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		releasesProjectID := 87 // fleet Releases project
 		milestoneTitle, _ := cmd.Flags().GetString("milestone")
@@ -319,5 +319,5 @@ func init() {
 	releasesSyncEstimatesCmd.Flags().BoolP("overwrite", "o", false, "Overwrite existing Releases estimates (by default, issues with estimates are skipped)")
 	releasesSyncEstimatesCmd.Flags().StringP("milestone", "m", "", "Only process issues in this milestone, e.g., Fleet 4.77.0")
 
-	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.84.1 (required)")
+	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.84.0 (required)")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Fleet version from v4.84.0 to v4.84.1 across deployment configurations (Helm values, container images, Terraform for AWS/GCP, and npm package) and bumped Helm chart package version v6.9.1 → v6.9.2.
* **Documentation**
  * Updated CLI help/example text to reference the v4.84.1 milestone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->