### PR TITLE
Add include_all label scope to GitOps and fleetctl (#41566)

### DIFF
--- a/changes/41566-policy-report-labels-gitops
+++ b/changes/41566-policy-report-labels-gitops
@@ -1,0 +1,1 @@
+- Wires labels_include_all to GitOps/fleetctl for policies and reports.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1650,18 +1650,13 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 		}
 		// Parse any labels.
 		if policy.LabelsIncludeAny != nil {
-			labels := make([]string, len(policy.LabelsIncludeAny))
-			for i, label := range policy.LabelsIncludeAny {
-				labels[i] = label.LabelName
-			}
-			policySpec["labels_include_any"] = labels
+			policySpec["labels_include_any"] = fleet.LabelIdentsToNames(policy.LabelsIncludeAny)
+		}
+		if policy.LabelsIncludeAll != nil && cmd.AppConfig.License.IsPremium() {
+			policySpec["labels_include_all"] = fleet.LabelIdentsToNames(policy.LabelsIncludeAll)
 		}
 		if policy.LabelsExcludeAny != nil {
-			labels := make([]string, len(policy.LabelsExcludeAny))
-			for i, label := range policy.LabelsExcludeAny {
-				labels[i] = label.LabelName
-			}
-			policySpec["labels_exclude_any"] = labels
+			policySpec["labels_exclude_any"] = fleet.LabelIdentsToNames(policy.LabelsExcludeAny)
 		}
 		result[i] = policySpec
 	}
@@ -1723,11 +1718,10 @@ func (cmd *GenerateGitopsCommand) generateQueries(teamId *uint) ([]map[string]in
 
 		// Parse any labels.
 		if query.LabelsIncludeAny != nil {
-			labels := make([]string, len(query.LabelsIncludeAny))
-			for i, label := range query.LabelsIncludeAny {
-				labels[i] = label.LabelName
-			}
-			querySpec["labels_include_any"] = labels
+			querySpec["labels_include_any"] = fleet.LabelIdentsToNames(query.LabelsIncludeAny)
+		}
+		if query.LabelsIncludeAll != nil && cmd.AppConfig.License.IsPremium() {
+			querySpec["labels_include_all"] = fleet.LabelIdentsToNames(query.LabelsIncludeAll)
 		}
 
 		result[i] = querySpec

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -368,6 +368,22 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 					SoftwareTitleID: 1,
 				},
 			},
+			{
+				PolicyData: fleet.PolicyData{
+					ID:          2,
+					Name:        "Global Policy Include All",
+					Query:       "SELECT * FROM global_policy WHERE id = 2",
+					Resolution:  ptr.String("Do another global thing"),
+					Description: "This is a global policy with include_all scope",
+					Platform:    "darwin",
+					LabelsIncludeAll: []fleet.LabelIdent{{
+						LabelName: "Label C",
+					}, {
+						LabelName: "Label D",
+					}},
+					Type: fleet.PolicyTypeDynamic,
+				},
+			},
 		}, nil
 	}
 	policies := []*fleet.Policy{
@@ -472,6 +488,23 @@ func (MockClient) GetQueries(teamID *uint, name *string) ([]fleet.Query, error) 
 				}},
 				MinOsqueryVersion: "1.2.3",
 				Logging:           "stdout",
+			},
+			{
+				ID:                 2,
+				Name:               "Global Query Include All",
+				Query:              "SELECT * FROM users;",
+				Description:        "This is a global query with include_all scope",
+				Platform:           "darwin",
+				Interval:           7200,
+				ObserverCanRun:     false,
+				AutomationsEnabled: false,
+				LabelsIncludeAll: []fleet.LabelIdent{{
+					LabelName: "Label C",
+				}, {
+					LabelName: "Label D",
+				}},
+				MinOsqueryVersion: "1.2.3",
+				Logging:           "snapshot",
 			},
 		}, nil
 	}

--- a/cmd/fleetctl/fleetctl/get.go
+++ b/cmd/fleetctl/fleetctl/get.go
@@ -345,8 +345,13 @@ func queryToTableRow(query fleet.Query, teamName string) []string {
 
 	if len(query.LabelsIncludeAny) > 0 {
 		scheduleInfo += "\nlabels_include_any:"
-
 		for _, label := range query.LabelsIncludeAny {
+			scheduleInfo += fmt.Sprintf("\n  - %s", label.LabelName)
+		}
+	}
+	if len(query.LabelsIncludeAll) > 0 {
+		scheduleInfo += "\nlabels_include_all:"
+		for _, label := range query.LabelsIncludeAll {
 			scheduleInfo += fmt.Sprintf("\n  - %s", label.LabelName)
 		}
 	}
@@ -479,10 +484,6 @@ func getReportsCommand() *cli.Command {
 
 				if c.Bool(yamlFlagName) || c.Bool(jsonFlagName) {
 					for _, query := range queries {
-						labelsAny := []string{}
-						for _, label := range query.LabelsIncludeAny {
-							labelsAny = append(labelsAny, label.LabelName)
-						}
 						if err := printQuerySpec(c, &fleet.QuerySpec{
 							Name:        query.Name,
 							Description: query.Description,
@@ -496,7 +497,8 @@ func getReportsCommand() *cli.Command {
 							AutomationsEnabled: query.AutomationsEnabled,
 							Logging:            query.Logging,
 							DiscardData:        query.DiscardData,
-							LabelsIncludeAny:   labelsAny,
+							LabelsIncludeAny:   fleet.LabelIdentsToNames(query.LabelsIncludeAny),
+							LabelsIncludeAll:   fleet.LabelIdentsToNames(query.LabelsIncludeAll),
 						}); err != nil {
 							return fmt.Errorf("unable to print query: %w", err)
 						}

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -1850,6 +1850,116 @@ spec:
 	assert.Equal(t, expectedJson, RunAppForTest(t, []string{"get", "report", "--json", "--fleet", "1", "teamQuery1"}))
 }
 
+func TestGetQueryLabelsIncludeAll(t *testing.T) {
+	_, ds := testing_utils.RunServerWithMockedDS(t, &service.TestServerOpts{
+		License: &fleet.LicenseInfo{
+			Tier:       fleet.TierPremium,
+			Expiration: time.Now().Add(24 * time.Hour),
+		},
+	})
+
+	ds.QueryByNameFunc = func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error) {
+		if teamID != nil || name != "qall" {
+			return nil, &notFoundError{}
+		}
+		return &fleet.Query{
+			ID:             77,
+			Name:           "qall",
+			Description:    "include_all roundtrip",
+			Query:          "select 1;",
+			Saved:          true,
+			ObserverCanRun: false,
+			LabelsIncludeAll: []fleet.LabelIdent{
+				{LabelName: "labelA", LabelID: 1},
+				{LabelName: "labelB", LabelID: 2},
+			},
+		}, nil
+	}
+
+	expectedYaml := `---
+apiVersion: v1
+kind: report
+spec:
+  automations_enabled: false
+  description: include_all roundtrip
+  discard_data: false
+  fleet: ""
+  interval: 0
+  labels_include_all:
+  - labelA
+  - labelB
+  logging: ""
+  min_osquery_version: ""
+  name: qall
+  observer_can_run: false
+  platform: ""
+  query: select 1;
+  team: ""
+`
+	expectedJson := `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"include_all roundtrip","discard_data":false,"fleet":"","interval":0,"labels_include_all":["labelA","labelB"],"logging":"","min_osquery_version":"","name":"qall","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
+`
+
+	assert.YAMLEq(t, expectedYaml, RunAppForTest(t, []string{"get", "query", "qall"}))
+	assert.YAMLEq(t, expectedYaml, RunAppForTest(t, []string{"get", "query", "--yaml", "qall"}))
+	assert.JSONEq(t, expectedJson, RunAppForTest(t, []string{"get", "query", "--json", "qall"}))
+}
+
+func TestGetReportsLabelsIncludeAll(t *testing.T) {
+	_, ds := testing_utils.RunServerWithMockedDS(t, &service.TestServerOpts{
+		License: &fleet.LicenseInfo{
+			Tier:       fleet.TierPremium,
+			Expiration: time.Now().Add(24 * time.Hour),
+		},
+	})
+
+	ds.TeamsSummaryFunc = func(ctx context.Context) ([]*fleet.TeamSummary, error) {
+		return []*fleet.TeamSummary{}, nil
+	}
+	ds.ListQueriesFunc = func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, int, int, *fleet.PaginationMetadata, error) {
+		if opt.TeamID != nil {
+			return nil, 0, 0, nil, errors.New("unexpected team scope")
+		}
+		return []*fleet.Query{
+			{
+				ID:    78,
+				Name:  "qall-bulk",
+				Query: "select 1;",
+				Saved: true,
+				LabelsIncludeAll: []fleet.LabelIdent{
+					{LabelName: "labelA", LabelID: 1},
+					{LabelName: "labelB", LabelID: 2},
+				},
+			},
+		}, 1, 0, nil, nil
+	}
+
+	expectedYaml := `---
+apiVersion: v1
+kind: report
+spec:
+  automations_enabled: false
+  description: ""
+  discard_data: false
+  fleet: ""
+  interval: 0
+  labels_include_all:
+  - labelA
+  - labelB
+  logging: ""
+  min_osquery_version: ""
+  name: qall-bulk
+  observer_can_run: false
+  platform: ""
+  query: select 1;
+  team: ""
+`
+	expectedJson := `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"","discard_data":false,"fleet":"","interval":0,"labels_include_all":["labelA","labelB"],"logging":"","min_osquery_version":"","name":"qall-bulk","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
+`
+
+	assert.YAMLEq(t, expectedYaml, RunAppForTest(t, []string{"get", "reports", "--yaml"}))
+	assert.JSONEq(t, expectedJson, RunAppForTest(t, []string{"get", "reports", "--json"}))
+}
+
 // TestGetQueriesAsObservers tests that when observers run `fleectl get queries` they
 // only get queries that they can execute.
 func TestGetQueriesAsObserver(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -398,6 +398,9 @@ func gitopsCommand() *cli.Command {
 						if len(query.LabelsIncludeAny) > 0 {
 							return fmt.Errorf("report %q uses 'labels_include_any', which is only available in Fleet Premium", query.Name)
 						}
+						if len(query.LabelsIncludeAll) > 0 {
+							return fmt.Errorf("report %q uses 'labels_include_all', which is only available in Fleet Premium", query.Name)
+						}
 					}
 				}
 
@@ -933,23 +936,31 @@ func getLabelUsage(config *spec.GitOps) (map[string][]LabelUsage, error) {
 		updateLabelUsage(labels, maintainedApp.Slug, "Fleet Maintained App", result)
 	}
 
-	// Get query label usage
+	// Get query label usage.
 	for _, query := range config.Queries {
-		updateLabelUsage(query.LabelsIncludeAny, query.Name, "Query", result)
+		if len(query.LabelsIncludeAny) > 0 && len(query.LabelsIncludeAll) > 0 {
+			return nil, fmt.Errorf("Query '%s' has multiple label keys; please choose one of `labels_include_any` or `labels_include_all`.", query.Name)
+		}
+		labels := slices.Concat(query.LabelsIncludeAny, query.LabelsIncludeAll)
+		updateLabelUsage(labels, query.Name, "Query", result)
 	}
 
-	// Get policy label usage
+	// Get policy label usage.
 	for _, policy := range config.Policies {
-		var labels []string
+		nonEmptyScopes := 0
 		if len(policy.LabelsIncludeAny) > 0 {
-			labels = policy.LabelsIncludeAny
+			nonEmptyScopes++
+		}
+		if len(policy.LabelsIncludeAll) > 0 {
+			nonEmptyScopes++
 		}
 		if len(policy.LabelsExcludeAny) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("Policy '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", policy.Name)
-			}
-			labels = policy.LabelsExcludeAny
+			nonEmptyScopes++
 		}
+		if nonEmptyScopes > 1 {
+			return nil, fmt.Errorf("Policy '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_include_all`, or `labels_exclude_any`.", policy.Name)
+		}
+		labels := slices.Concat(policy.LabelsIncludeAny, policy.LabelsIncludeAll, policy.LabelsExcludeAny)
 		updateLabelUsage(labels, policy.Name, "Policy", result)
 	}
 

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -6799,3 +6799,144 @@ software:
 		assert.Contains(t, err.Error(), "macos_manual_agent_install")
 	})
 }
+
+func TestGitOpsQueryLabelsMutexRejection(t *testing.T) {
+	// Cannot run t.Parallel() because it sets environment variables
+
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	_, ds := testing_utils.RunServerWithMockedDS(t, &service.TestServerOpts{License: license})
+	setupEmptyGitOpsMocks(ds)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(`
+controls:
+policies:
+agent_options:
+labels:
+  - name: lbl-a
+    description: A
+    label_membership_type: dynamic
+    query: SELECT 1
+  - name: lbl-b
+    description: B
+    label_membership_type: dynamic
+    query: SELECT 2
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: GitOps Test
+  secrets:
+queries:
+  - name: bad-query
+    description: invalid mutex
+    query: SELECT 1
+    labels_include_any:
+      - lbl-a
+    labels_include_all:
+      - lbl-b
+`)
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "bad-query")
+	require.ErrorContains(t, err, "labels_include_any")
+	require.ErrorContains(t, err, "labels_include_all")
+}
+
+func TestGitOpsQueryLabelsIncludeAllUnknownLabel(t *testing.T) {
+	// Cannot run t.Parallel() because it sets environment variables
+
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	_, ds := testing_utils.RunServerWithMockedDS(t, &service.TestServerOpts{License: license})
+	setupEmptyGitOpsMocks(ds)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(`
+controls:
+policies:
+agent_options:
+labels:
+  - name: known-label
+    description: known
+    label_membership_type: dynamic
+    query: SELECT 1
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: GitOps Test
+  secrets:
+queries:
+  - name: refs-missing
+    description: references undefined label
+    query: SELECT 1
+    labels_include_all:
+      - does-not-exist
+`)
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing labels")
+}
+
+func TestGitOpsPolicyLabelsIncludeAllMutexRejection(t *testing.T) {
+	// Cannot run t.Parallel() because it sets environment variables
+
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	_, ds := testing_utils.RunServerWithMockedDS(t, &service.TestServerOpts{License: license})
+	setupEmptyGitOpsMocks(ds)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(`
+controls:
+queries:
+agent_options:
+labels:
+  - name: lbl-a
+    description: A
+    label_membership_type: dynamic
+    query: SELECT 1
+  - name: lbl-b
+    description: B
+    label_membership_type: dynamic
+    query: SELECT 2
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: GitOps Test
+  secrets:
+policies:
+  - name: bad-policy
+    description: invalid mutex
+    query: SELECT 1
+    resolution: ""
+    platform: linux
+    labels_include_all:
+      - lbl-a
+    labels_exclude_any:
+      - lbl-b
+`)
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "bad-policy")
+	require.ErrorContains(t, err, "labels_include_all")
+	require.ErrorContains(t, err, "labels_exclude_any")
+}

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalPolicies.yaml
@@ -13,3 +13,16 @@
   resolution: Do a global thing
   type: dynamic
   webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  critical: false
+  description: This is a global policy with include_all scope
+  labels_include_all:
+  - Label C
+  - Label D
+  name: Global Policy Include All
+  platform: darwin
+  query: SELECT * FROM global_policy WHERE id = 2
+  resolution: Do another global thing
+  type: dynamic
+  webhooks_and_tickets_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalReports.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalReports.yaml
@@ -11,3 +11,16 @@
   platform: darwin
   query: SELECT * FROM os_version;
   discard_data: false
+- automations_enabled: false
+  logging: snapshot
+  min_osquery_version: 1.2.3
+  description: This is a global query with include_all scope
+  interval: 7200
+  labels_include_all:
+  - Label C
+  - Label D
+  name: Global Query Include All
+  observer_can_run: false
+  platform: darwin
+  query: SELECT * FROM users;
+  discard_data: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -198,6 +198,16 @@ policies:
   resolution: Do a global thing
   type: dynamic
   webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  critical: false
+  description: This is a global policy with include_all scope
+  name: Global Policy Include All
+  platform: darwin
+  query: SELECT * FROM global_policy WHERE id = 2
+  resolution: Do another global thing
+  type: dynamic
+  webhooks_and_tickets_enabled: false
 reports:
 - automations_enabled: true
   description: This is a global query
@@ -212,3 +222,13 @@ reports:
   observer_can_run: true
   platform: darwin
   query: SELECT * FROM os_version;
+- automations_enabled: false
+  description: This is a global query with include_all scope
+  discard_data: false
+  interval: 7200
+  logging: snapshot
+  min_osquery_version: 1.2.3
+  name: Global Query Include All
+  observer_can_run: false
+  platform: darwin
+  query: SELECT * FROM users;

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -194,6 +194,19 @@ policies:
   resolution: Do a global thing
   type: dynamic
   webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  critical: false
+  description: This is a global policy with include_all scope
+  labels_include_all:
+  - Label C
+  - Label D
+  name: Global Policy Include All
+  platform: darwin
+  query: SELECT * FROM global_policy WHERE id = 2
+  resolution: Do another global thing
+  type: dynamic
+  webhooks_and_tickets_enabled: false
 reports:
 - automations_enabled: true
   description: This is a global query
@@ -208,3 +221,16 @@ reports:
   observer_can_run: true
   platform: darwin
   query: SELECT * FROM os_version;
+- automations_enabled: false
+  description: This is a global query with include_all scope
+  discard_data: false
+  interval: 7200
+  labels_include_all:
+  - Label C
+  - Label D
+  logging: snapshot
+  min_osquery_version: 1.2.3
+  name: Global Query Include All
+  observer_can_run: false
+  platform: darwin
+  query: SELECT * FROM users;

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1619,6 +1619,7 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					PolicyData: fleet.PolicyData{
 						ID:               policyID,
 						LabelsIncludeAny: fleet.LabelNamesToIdents(spec.LabelsIncludeAny),
+						LabelsIncludeAll: fleet.LabelNamesToIdents(spec.LabelsIncludeAll),
 						LabelsExcludeAny: fleet.LabelNamesToIdents(spec.LabelsExcludeAny),
 					},
 				})

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -6598,6 +6598,52 @@ func testPolicyLabelMembershipCleanup(t *testing.T, ds *Datastore) {
 	// Only the host with BOTH labels should retain membership.
 	wantHostsByPol[policy3.Name] = []uint{hostLabelBoth.ID}
 	assertPolicyMembership(t, ds, polsByName, wantHostsByPol)
+
+	// include_all cleanup via ApplyPolicySpecs (GitOps path).
+	// Re-record membership for all hosts so cleanup has something to remove.
+	for _, h := range []*fleet.Host{hostNoLabels, hostLabel1, hostLabel2, hostLabelBoth} {
+		err = ds.RecordPolicyQueryExecutions(ctx, h, map[uint]*bool{policy3.ID: new(true)}, time.Now(), false, nil)
+		require.NoError(t, err)
+	}
+	wantHostsByPol[policy3.Name] = []uint{hostNoLabels.ID, hostLabel1.ID, hostLabel2.ID, hostLabelBoth.ID}
+	assertPolicyMembership(t, ds, polsByName, wantHostsByPol)
+
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, []*fleet.PolicySpec{
+		{
+			Name:             policy3.Name,
+			Query:            policy3.Query,
+			LabelsIncludeAll: []string{label1.Name, label2.Name},
+			Type:             fleet.PolicyTypeDynamic,
+		},
+	})
+	require.NoError(t, err)
+	// Spec apply should trigger the same membership cleanup — only hostLabelBoth remains.
+	wantHostsByPol[policy3.Name] = []uint{hostLabelBoth.ID}
+	assertPolicyMembership(t, ds, polsByName, wantHostsByPol)
+
+	freshName := "cleanup test policy 4 include_all create"
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, []*fleet.PolicySpec{
+		{
+			Name:             freshName,
+			Query:            "SELECT 1",
+			LabelsIncludeAll: []string{label1.Name, label2.Name},
+			Type:             fleet.PolicyTypeDynamic,
+		},
+	})
+	require.NoError(t, err)
+	allPolicies, err := ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
+	require.NoError(t, err)
+	var freshPolicy *fleet.Policy
+	for _, p := range allPolicies {
+		if p.Name == freshName {
+			freshPolicy = p
+			break
+		}
+	}
+	require.NotNil(t, freshPolicy, "fresh policy created via spec should exist")
+	require.Len(t, freshPolicy.LabelsIncludeAll, 2)
+	require.Empty(t, freshPolicy.LabelsIncludeAny)
+	require.Empty(t, freshPolicy.LabelsExcludeAny)
 }
 
 func testDeletePolicyWithSoftwareActivatesNextActivity(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/query_results.go
+++ b/server/datastore/mysql/query_results.go
@@ -324,11 +324,6 @@ func (ds *Datastore) ListHostReports(
 		whereClause += " AND q.discard_data = 0 AND q.logging_type = 'snapshot'"
 	}
 
-	// labels_include_all is a premium-only feature. On free tier, hide any
-	// query that has include_all labels (require_all=1) from the reports
-	// list, even if such rows pre-exist (e.g. after a tier downgrade).
-	// Mirrors the server-side write gate so include_all data never surfaces
-	// via the reports API on free tier.
 	if !license.IsPremium(ctx) {
 		whereClause += `
 		AND NOT EXISTS (

--- a/server/datastore/mysql/query_results.go
+++ b/server/datastore/mysql/query_results.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
@@ -324,7 +323,7 @@ func (ds *Datastore) ListHostReports(
 		whereClause += " AND q.discard_data = 0 AND q.logging_type = 'snapshot'"
 	}
 
-	if !license.IsPremium(ctx) {
+	if opts.ExcludeIncludeAllQueries {
 		whereClause += `
 		AND NOT EXISTS (
 			SELECT 1 FROM query_labels ql

--- a/server/datastore/mysql/query_results.go
+++ b/server/datastore/mysql/query_results.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
@@ -323,18 +324,50 @@ func (ds *Datastore) ListHostReports(
 		whereClause += " AND q.discard_data = 0 AND q.logging_type = 'snapshot'"
 	}
 
-	// Filter by label membership: include queries that have no labels, or whose
-	// labels overlap with the labels the host belongs to.
+	// labels_include_all is a premium-only feature. On free tier, hide any
+	// query that has include_all labels (require_all=1) from the reports
+	// list, even if such rows pre-exist (e.g. after a tier downgrade).
+	// Mirrors the server-side write gate so include_all data never surfaces
+	// via the reports API on free tier.
+	if !license.IsPremium(ctx) {
+		whereClause += `
+		AND NOT EXISTS (
+			SELECT 1 FROM query_labels ql
+			WHERE ql.query_id = q.id AND ql.require_all = 1
+		)`
+	}
+
+	// Filter by label membership. Two scopes coexist on query_labels via
+	// require_all:
+	//   include_any (require_all=0): host must be in at least ONE of the labels
+	//   include_all (require_all=1): host must be in EVERY one of the labels
 	whereClause += `
-		AND (NOT EXISTS (
-			SELECT 1 FROM query_labels ql WHERE ql.query_id = q.id
-		) OR EXISTS (
-			SELECT 1
-			FROM query_labels ql
-			JOIN label_membership lm ON lm.label_id = ql.label_id AND lm.host_id = ?
-			WHERE ql.query_id = q.id
-		))`
-	whereArgs = append(whereArgs, hostID)
+		AND (
+			NOT EXISTS (
+				SELECT 1 FROM query_labels ql
+				WHERE ql.query_id = q.id AND ql.require_all = 0
+			)
+			OR EXISTS (
+				SELECT 1 FROM query_labels ql
+				JOIN label_membership lm ON lm.label_id = ql.label_id AND lm.host_id = ?
+				WHERE ql.query_id = q.id AND ql.require_all = 0
+			)
+		)
+		AND (
+			NOT EXISTS (
+				SELECT 1 FROM query_labels ql
+				WHERE ql.query_id = q.id AND ql.require_all = 1
+			)
+			OR (
+				SELECT COUNT(*) FROM query_labels ql
+				WHERE ql.query_id = q.id AND ql.require_all = 1
+			) = (
+				SELECT COUNT(*) FROM query_labels ql
+				JOIN label_membership lm ON lm.label_id = ql.label_id AND lm.host_id = ?
+				WHERE ql.query_id = q.id AND ql.require_all = 1
+			)
+		)`
+	whereArgs = append(whereArgs, hostID, hostID)
 
 	// Filter by platform: include queries with no platform restriction, or
 	// whose platform list contains the host's normalized platform.

--- a/server/datastore/mysql/query_results_test.go
+++ b/server/datastore/mysql/query_results_test.go
@@ -1238,6 +1238,57 @@ func testListHostReports(t *testing.T, ds *Datastore) {
 		assert.Contains(t, names, qSave1.Name, "unlabeled query must always be visible")
 	})
 
+	t.Run("label_filtering_include_all", func(t *testing.T) {
+		labelA, err := ds.NewLabel(ctx, &fleet.Label{Name: "include-all-A", Query: "SELECT 1"})
+		require.NoError(t, err)
+		labelB, err := ds.NewLabel(ctx, &fleet.Label{Name: "include-all-B", Query: "SELECT 1"})
+		require.NoError(t, err)
+
+		qIncludeAll, err := ds.NewQuery(ctx, &fleet.Query{
+			Name:     "Include All Query",
+			Query:    "SELECT 1",
+			AuthorID: &user.ID,
+			Saved:    true,
+			Logging:  fleet.LoggingSnapshot,
+			LabelsIncludeAll: []fleet.LabelIdent{
+				{LabelName: labelA.Name},
+				{LabelName: labelB.Name},
+			},
+		})
+		require.NoError(t, err)
+
+		newHost := func(name string) *fleet.Host {
+			return test.NewHost(t, ds, name, "10.0.0.1", "k-"+name, "u-"+name, time.Now())
+		}
+		hostNone := newHost("include-all-host-none")
+		hostOnlyA := newHost("include-all-host-onlyA")
+		hostBoth := newHost("include-all-host-both")
+
+		require.NoError(t, ds.RecordLabelQueryExecutions(ctx, hostOnlyA, map[uint]*bool{labelA.ID: new(true)}, time.Now(), false))
+		require.NoError(t, ds.RecordLabelQueryExecutions(ctx, hostBoth, map[uint]*bool{labelA.ID: new(true), labelB.ID: new(true)}, time.Now(), false))
+
+		opts := fleet.ListHostReportsOptions{
+			IncludeReportsDontStoreResults: true,
+			ListOptions:                    fleet.ListOptions{OrderKey: "name"},
+		}
+
+		hasReport := func(hostID uint) bool {
+			t.Helper()
+			reports, _, _, err := ds.ListHostReports(ctx, hostID, nil, "", opts, fleet.DefaultMaxQueryReportRows)
+			require.NoError(t, err)
+			for _, r := range reports {
+				if r.Name == qIncludeAll.Name {
+					return true
+				}
+			}
+			return false
+		}
+
+		assert.False(t, hasReport(hostNone.ID), "host with NO required labels must not see include_all query")
+		assert.False(t, hasReport(hostOnlyA.ID), "host with SUBSET of required labels must not see include_all query")
+		assert.True(t, hasReport(hostBoth.ID), "host with ALL required labels must see include_all query")
+	})
+
 	t.Run("combined_platform_label_team_filters", func(t *testing.T) {
 		// This test verifies that all three filters (platform, label, team) are
 		// applied simultaneously and are each independently capable of excluding

--- a/server/datastore/mysql/query_results_test.go
+++ b/server/datastore/mysql/query_results_test.go
@@ -1287,6 +1287,25 @@ func testListHostReports(t *testing.T, ds *Datastore) {
 		assert.False(t, hasReport(hostNone.ID), "host with NO required labels must not see include_all query")
 		assert.False(t, hasReport(hostOnlyA.ID), "host with SUBSET of required labels must not see include_all query")
 		assert.True(t, hasReport(hostBoth.ID), "host with ALL required labels must see include_all query")
+
+		// ExcludeIncludeAllQueries hides include_all queries entirely from
+		// the result set, regardless of host membership.
+		excludeOpts := opts
+		excludeOpts.ExcludeIncludeAllQueries = true
+		hasReportExcluded := func(hostID uint) bool {
+			t.Helper()
+			reports, _, _, err := ds.ListHostReports(ctx, hostID, nil, "", excludeOpts, fleet.DefaultMaxQueryReportRows)
+			require.NoError(t, err)
+			for _, r := range reports {
+				if r.Name == qIncludeAll.Name {
+					return true
+				}
+			}
+			return false
+		}
+		assert.False(t, hasReportExcluded(hostNone.ID), "ExcludeIncludeAllQueries must hide include_all from host with no labels")
+		assert.False(t, hasReportExcluded(hostOnlyA.ID), "ExcludeIncludeAllQueries must hide include_all from host with subset of labels")
+		assert.False(t, hasReportExcluded(hostBoth.ID), "ExcludeIncludeAllQueries must hide include_all from host with all labels")
 	})
 
 	t.Run("combined_platform_label_team_filters", func(t *testing.T) {

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1544,6 +1544,9 @@ type ListHostReportsOptions struct {
 	// false (default): only queries with discard_data=0 AND logging_type='snapshot' are returned.
 	// true: all queries are returned, including ones that don't store results.
 	IncludeReportsDontStoreResults bool
+	// ExcludeIncludeAllQueries hides queries that have any include_all
+	// (require_all=1) labels.
+	ExcludeIncludeAllQueries bool
 }
 
 // ApplySpecOptions are the options available when applying a YAML or JSON spec.

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -298,7 +298,7 @@ type LabelIdent struct {
 }
 
 // LabelNamesToIdents wraps each label name in a bare LabelIdent (with LabelID
-// left zero). Returns nil for empty input.
+// left zero).
 func LabelNamesToIdents(names []string) []LabelIdent {
 	if len(names) == 0 {
 		return nil
@@ -306,6 +306,18 @@ func LabelNamesToIdents(names []string) []LabelIdent {
 	out := make([]LabelIdent, len(names))
 	for i, name := range names {
 		out[i] = LabelIdent{LabelName: name}
+	}
+	return out
+}
+
+// LabelIdentsToNames extracts the label names from a slice of LabelIdent.
+func LabelIdentsToNames(idents []LabelIdent) []string {
+	if len(idents) == 0 {
+		return nil
+	}
+	out := make([]string, len(idents))
+	for i, ident := range idents {
+		out[i] = ident.LabelName
 	}
 	return out
 }

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -498,6 +498,7 @@ type PolicySpec struct {
 	// When editing a policy, if this is nil or 0 then the script ID is unset from the policy.
 	ScriptID         *uint    `json:"script_id"`
 	LabelsIncludeAny []string `json:"labels_include_any,omitempty"`
+	LabelsIncludeAll []string `json:"labels_include_all,omitempty"`
 	LabelsExcludeAny []string `json:"labels_exclude_any,omitempty"`
 	// ConditionalAccessEnabled indicates whether this is a policy used for Microsoft conditional access.
 	//
@@ -544,7 +545,7 @@ func (p PolicySpec) Verify() error {
 	if err := verifyPatchPolicy(p.Team, p.Type); err != nil {
 		return err
 	}
-	return verifyLabelScopeMutualExclusion(p.LabelsIncludeAny, nil, p.LabelsExcludeAny)
+	return verifyLabelScopeMutualExclusion(p.LabelsIncludeAny, p.LabelsIncludeAll, p.LabelsExcludeAny)
 }
 
 // FirstDuplicatePolicySpecName returns first duplicate name of policies (in a team) or empty string if no duplicates found

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -398,6 +398,11 @@ type QuerySpec struct {
 	// If not set, then the default value is false.
 	DiscardData      bool     `json:"discard_data"`
 	LabelsIncludeAny []string `json:"labels_include_any,omitempty"`
+	LabelsIncludeAll []string `json:"labels_include_all,omitempty"`
+}
+
+func (q *QuerySpec) Verify() error {
+	return verifyQueryLabelScopeMutualExclusion(q.LabelsIncludeAny, q.LabelsIncludeAll)
 }
 
 func LoadQueriesFromYaml(yml string) ([]*Query, error) {

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -494,8 +494,13 @@ func (svc *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.Poli
 			})
 		}
 
+		// LabelsIncludeAll is premium-only.
+		if len(policy.LabelsIncludeAll) > 0 && !license.IsPremium(ctx) {
+			return fleet.ErrMissingLicense
+		}
+
 		// Make sure any applied labels exist.
-		labels := slices.Concat(policy.LabelsIncludeAny, policy.LabelsExcludeAny)
+		labels := slices.Concat(policy.LabelsIncludeAny, policy.LabelsIncludeAll, policy.LabelsExcludeAny)
 		if len(labels) > 0 {
 			var teamID *uint       // ensure labels specified exist and are global or on the same team as the policy
 			if policy.Team != "" { // if we get 0 as team ID, we'll pull only global labels, which is fine

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2084,6 +2084,9 @@ func (svc *Service) ListHostReports(
 		opts.ListOptions.OrderDirection = fleet.OrderDescending
 	}
 
+	// labels_include_all is a premium-only feature only
+	opts.ExcludeIncludeAllQueries = !license.IsPremium(ctx)
+
 	reports, total, meta, err := svc.ds.ListHostReports(ctx, hostID, host.TeamID, fleet.PlatformFromHost(host.Platform), opts, maxQueryReportRows)
 	if err != nil {
 		return nil, 0, nil, ctxerr.Wrap(ctx, err, "list host reports from datastore")

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -17175,6 +17175,26 @@ func (s *integrationTestSuite) TestLabelScopePremiumGate() {
 	} {
 		s.DoJSON("POST", "/api/latest/fleet/queries", payload, http.StatusPaymentRequired, &fleet.CreateQueryResponse{})
 	}
+
+	// PolicySpec label fields don't carry the `premium:"true"` middleware tag,
+	// so the gate fires at the service layer and returns 402 (PaymentRequired).
+	s.DoJSON("POST", "/api/latest/fleet/spec/policies", fleet.ApplyPolicySpecsRequest{
+		Specs: []*fleet.PolicySpec{{
+			Name:             "spec-premium-gate-" + t.Name(),
+			Query:            "SELECT 1",
+			LabelsIncludeAll: []string{lbl.Name},
+		}},
+	}, http.StatusPaymentRequired, &fleet.ApplyPolicySpecsResponse{})
+
+	// Same for QuerySpec.
+	s.DoJSON("POST", "/api/latest/fleet/spec/queries", fleet.ApplyQuerySpecsRequest{
+		Specs: []*fleet.QuerySpec{{
+			Name:             "qspec-premium-gate-" + t.Name(),
+			Query:            "SELECT 1",
+			Logging:          fleet.LoggingSnapshot,
+			LabelsIncludeAll: []string{lbl.Name},
+		}},
+	}, http.StatusPaymentRequired, &fleet.ApplyQuerySpecsResponse{})
 }
 
 func (s *integrationTestSuite) TestOrgLogoUpload() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -17128,6 +17128,70 @@ func (s *integrationTestSuite) TestListHostReports() {
 		_, hasReportID := firstReport["report_id"]
 		assert.True(t, hasReportID, "expected key 'report_id' in response")
 	})
+
+	t.Run("free_tier_hides_include_all_reports", func(t *testing.T) {
+		labelA, err := s.ds.NewLabel(ctx, &fleet.Label{Name: t.Name() + "-A", Query: "SELECT 1"})
+		require.NoError(t, err)
+		labelB, err := s.ds.NewLabel(ctx, &fleet.Label{Name: t.Name() + "-B", Query: "SELECT 1"})
+		require.NoError(t, err)
+
+		qIncludeAll, err := s.ds.NewQuery(ctx, &fleet.Query{
+			Name:        t.Name() + "_include_all",
+			Query:       "SELECT 1",
+			AuthorID:    &admin.ID,
+			Saved:       true,
+			DiscardData: false,
+			Logging:     fleet.LoggingSnapshot,
+			LabelsIncludeAll: []fleet.LabelIdent{
+				{LabelName: labelA.Name},
+				{LabelName: labelB.Name},
+			},
+		})
+		require.NoError(t, err)
+
+		mkHost := func(suffix string) *fleet.Host {
+			h, err := s.ds.NewHost(ctx, &fleet.Host{
+				DetailUpdatedAt: time.Now(),
+				LabelUpdatedAt:  time.Now(),
+				PolicyUpdatedAt: time.Now(),
+				SeenTime:        time.Now(),
+				OsqueryHostID:   ptr.String(t.Name() + suffix),
+				NodeKey:         ptr.String(t.Name() + suffix),
+				UUID:            uuid.New().String(),
+				Hostname:        t.Name() + "-" + suffix + ".local",
+				Platform:        "linux",
+			})
+			require.NoError(t, err)
+			return h
+		}
+		hostNone := mkHost("none")
+		hostOnlyA := mkHost("onlyA")
+		hostBoth := mkHost("both")
+
+		require.NoError(t, s.ds.RecordLabelQueryExecutions(ctx, hostOnlyA, map[uint]*bool{labelA.ID: new(true)}, time.Now(), false))
+		require.NoError(t, s.ds.RecordLabelQueryExecutions(ctx, hostBoth, map[uint]*bool{labelA.ID: new(true), labelB.ID: new(true)}, time.Now(), false))
+
+		hasIncludeAllReport := func(hostID uint) bool {
+			t.Helper()
+			var resp listHostReportsResponse
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/reports", hostID), nil, http.StatusOK, &resp, "include_reports_dont_store_results", "true")
+			for _, r := range resp.Reports {
+				if r.ReportID == qIncludeAll.ID {
+					return true
+				}
+			}
+			return false
+		}
+
+		// Free tier must hide include_all queries entirely from /hosts/:id/reports —
+		// labels_include_all is premium-only and pre-existing rows (e.g., from a
+		// tier downgrade) must not surface in the reports list, regardless of
+		// label membership. Premium-tier behavior is exercised in the
+		// enterprise integration test.
+		assert.False(t, hasIncludeAllReport(hostNone.ID), "free tier must not surface include_all queries (no labels)")
+		assert.False(t, hasIncludeAllReport(hostOnlyA.ID), "free tier must not surface include_all queries (subset of labels)")
+		assert.False(t, hasIncludeAllReport(hostBoth.ID), "free tier must not surface include_all queries (all labels)")
+	})
 }
 
 // TestLabelScopePremiumGate verifies that the include_all scope fields is

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29749,11 +29749,6 @@ func (s *integrationEnterpriseTestSuite) TestOrgLogoUploadGitOpsAuth() {
 	s.Do("DELETE", "/api/v1/fleet/logo", nil, http.StatusOK, "mode", "dark")
 }
 
-// TestListHostReportsIncludeAllPremium verifies that on premium tier the
-// /hosts/:id/reports endpoint surfaces include_all queries only to hosts that
-// are members of every required label. The free-tier counterpart
-// (TestListHostReports/free_tier_hides_include_all_reports) asserts that the
-// same data is hidden entirely on free tier.
 func (s *integrationEnterpriseTestSuite) TestListHostReportsIncludeAllPremium() {
 	t := s.T()
 	ctx := t.Context()

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29884,4 +29884,3 @@ func (s *integrationEnterpriseTestSuite) TestApplyPolicySpecsBatchMixedScopes() 
 	require.Len(t, byName[validAllName].LabelsIncludeAll, 2)
 	require.Len(t, byName[validExclName].LabelsExcludeAny, 1)
 }
-

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29749,6 +29749,74 @@ func (s *integrationEnterpriseTestSuite) TestOrgLogoUploadGitOpsAuth() {
 	s.Do("DELETE", "/api/v1/fleet/logo", nil, http.StatusOK, "mode", "dark")
 }
 
+// TestListHostReportsIncludeAllPremium verifies that on premium tier the
+// /hosts/:id/reports endpoint surfaces include_all queries only to hosts that
+// are members of every required label. The free-tier counterpart
+// (TestListHostReports/free_tier_hides_include_all_reports) asserts that the
+// same data is hidden entirely on free tier.
+func (s *integrationEnterpriseTestSuite) TestListHostReportsIncludeAllPremium() {
+	t := s.T()
+	ctx := t.Context()
+
+	labelA, err := s.ds.NewLabel(ctx, &fleet.Label{Name: t.Name() + "-A", Query: "SELECT 1"})
+	require.NoError(t, err)
+	labelB, err := s.ds.NewLabel(ctx, &fleet.Label{Name: t.Name() + "-B", Query: "SELECT 1"})
+	require.NoError(t, err)
+
+	admin := s.users[TestAdminUserEmail]
+	qIncludeAll, err := s.ds.NewQuery(ctx, &fleet.Query{
+		Name:        t.Name() + "_include_all",
+		Query:       "SELECT 1",
+		AuthorID:    &admin.ID,
+		Saved:       true,
+		DiscardData: false,
+		Logging:     fleet.LoggingSnapshot,
+		LabelsIncludeAll: []fleet.LabelIdent{
+			{LabelName: labelA.Name},
+			{LabelName: labelB.Name},
+		},
+	})
+	require.NoError(t, err)
+
+	mkHost := func(suffix string) *fleet.Host {
+		h, err := s.ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			OsqueryHostID:   ptr.String(t.Name() + suffix),
+			NodeKey:         ptr.String(t.Name() + suffix),
+			UUID:            uuid.New().String(),
+			Hostname:        t.Name() + "-" + suffix + ".local",
+			Platform:        "linux",
+		})
+		require.NoError(t, err)
+		return h
+	}
+	hostNone := mkHost("none")
+	hostOnlyA := mkHost("onlyA")
+	hostBoth := mkHost("both")
+
+	require.NoError(t, s.ds.RecordLabelQueryExecutions(ctx, hostOnlyA, map[uint]*bool{labelA.ID: new(true)}, time.Now(), false))
+	require.NoError(t, s.ds.RecordLabelQueryExecutions(ctx, hostBoth, map[uint]*bool{labelA.ID: new(true), labelB.ID: new(true)}, time.Now(), false))
+
+	hasIncludeAllReport := func(hostID uint) bool {
+		t.Helper()
+		var resp listHostReportsResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/reports", hostID), nil, http.StatusOK, &resp, "include_reports_dont_store_results", "true")
+		for _, r := range resp.Reports {
+			if r.ReportID == qIncludeAll.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	require.False(t, hasIncludeAllReport(hostNone.ID), "host with no labels must not see include_all query")
+	require.False(t, hasIncludeAllReport(hostOnlyA.ID), "host with subset of labels must not see include_all query")
+	require.True(t, hasIncludeAllReport(hostBoth.ID), "host with all labels must see include_all query on premium")
+}
+
 func (s *integrationEnterpriseTestSuite) TestApplyPolicySpecsBatchMixedScopes() {
 	t := s.T()
 	ctx := context.Background()

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29748,3 +29748,77 @@ func (s *integrationEnterpriseTestSuite) TestOrgLogoUploadGitOpsAuth() {
 	s.token = s.getTestAdminToken()
 	s.Do("DELETE", "/api/v1/fleet/logo", nil, http.StatusOK, "mode", "dark")
 }
+
+func (s *integrationEnterpriseTestSuite) TestApplyPolicySpecsBatchMixedScopes() {
+	t := s.T()
+	ctx := context.Background()
+
+	var lblResp fleet.CreateLabelResponse
+	s.DoJSON("POST", "/api/latest/fleet/labels", fleet.LabelPayload{Name: uuid.NewString(), Query: "SELECT 1"}, http.StatusOK, &lblResp)
+	lblA := lblResp.Label
+	lblResp = fleet.CreateLabelResponse{}
+	s.DoJSON("POST", "/api/latest/fleet/labels", fleet.LabelPayload{Name: uuid.NewString(), Query: "SELECT 2"}, http.StatusOK, &lblResp)
+	lblB := lblResp.Label
+
+	validAnyName := "batch-any-" + t.Name()
+	validAllName := "batch-all-" + t.Name()
+	invalidName := "batch-invalid-" + t.Name()
+
+	assertNonePersisted := func(label string) {
+		policies, err := s.ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
+		require.NoError(t, err)
+		for _, p := range policies {
+			require.NotEqual(t, validAnyName, p.Name, "%s: no spec from rejected batch should persist", label)
+			require.NotEqual(t, validAllName, p.Name, "%s: no spec from rejected batch should persist", label)
+			require.NotEqual(t, invalidName, p.Name, "%s: no spec from rejected batch should persist", label)
+		}
+	}
+
+	// Batch with the mutex-violating spec at the END — proves we don't persist
+	// preceding valid specs once a later one fails validation.
+	rejResp := s.Do("POST", "/api/latest/fleet/spec/policies", fleet.ApplyPolicySpecsRequest{
+		Specs: []*fleet.PolicySpec{
+			{Name: validAnyName, Query: "SELECT 1", LabelsIncludeAny: []string{lblA.Name}},
+			{Name: validAllName, Query: "SELECT 1", LabelsIncludeAll: []string{lblA.Name, lblB.Name}},
+			{Name: invalidName, Query: "SELECT 1", LabelsIncludeAll: []string{lblA.Name}, LabelsExcludeAny: []string{lblB.Name}},
+		},
+	}, http.StatusBadRequest)
+	require.Contains(t, extractServerErrorText(rejResp.Body), fleet.ErrPolicyConflictingLabels.Error())
+	assertNonePersisted("violator-last")
+
+	// Batch with the mutex-violating spec at the FRONT — proves we don't persist
+	// trailing valid specs after a per-spec validation pass that the loop never reaches.
+	rejResp = s.Do("POST", "/api/latest/fleet/spec/policies", fleet.ApplyPolicySpecsRequest{
+		Specs: []*fleet.PolicySpec{
+			{Name: invalidName, Query: "SELECT 1", LabelsIncludeAll: []string{lblA.Name}, LabelsExcludeAny: []string{lblB.Name}},
+			{Name: validAnyName, Query: "SELECT 1", LabelsIncludeAny: []string{lblA.Name}},
+			{Name: validAllName, Query: "SELECT 1", LabelsIncludeAll: []string{lblA.Name, lblB.Name}},
+		},
+	}, http.StatusBadRequest)
+	require.Contains(t, extractServerErrorText(rejResp.Body), fleet.ErrPolicyConflictingLabels.Error())
+	assertNonePersisted("violator-first")
+
+	// Fully-valid 3-spec batch (one per scope) succeeds.
+	validExclName := "batch-excl-" + t.Name()
+	s.Do("POST", "/api/latest/fleet/spec/policies", fleet.ApplyPolicySpecsRequest{
+		Specs: []*fleet.PolicySpec{
+			{Name: validAnyName, Query: "SELECT 1", LabelsIncludeAny: []string{lblA.Name}},
+			{Name: validAllName, Query: "SELECT 1", LabelsIncludeAll: []string{lblA.Name, lblB.Name}},
+			{Name: validExclName, Query: "SELECT 1", LabelsExcludeAny: []string{lblB.Name}},
+		},
+	}, http.StatusOK)
+
+	policies, err := s.ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
+	require.NoError(t, err)
+	byName := make(map[string]*fleet.Policy, len(policies))
+	for _, p := range policies {
+		byName[p.Name] = p
+	}
+	require.Contains(t, byName, validAnyName)
+	require.Contains(t, byName, validAllName)
+	require.Contains(t, byName, validExclName)
+	require.Len(t, byName[validAnyName].LabelsIncludeAny, 1)
+	require.Len(t, byName[validAllName].LabelsIncludeAll, 2)
+	require.Len(t, byName[validExclName].LabelsExcludeAny, 1)
+}
+

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -708,12 +708,26 @@ func applyQuerySpecsEndpoint(ctx context.Context, request interface{}, svc fleet
 }
 
 func (svc *Service) ApplyQuerySpecs(ctx context.Context, specs []*fleet.QuerySpec) error {
-	// 1. Turn specs into queries.
-	queries := []*fleet.Query{}
+	// 1. Validate each spec (nil, premium label scoping, payload verification)
+	// and turn it into a query. Fail-fast on the first invalid spec.
+	isPremium := license.IsPremium(ctx)
+	queries := make([]*fleet.Query, 0, len(specs))
 	for _, spec := range specs {
-		if len(spec.LabelsIncludeAny) > 0 && !license.IsPremium(ctx) {
+		if spec == nil {
+			setAuthCheckedOnPreAuthErr(ctx)
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: "invalid query spec: nil",
+			})
+		}
+		if !isPremium && (len(spec.LabelsIncludeAny) > 0 || len(spec.LabelsIncludeAll) > 0) {
 			setAuthCheckedOnPreAuthErr(ctx)
 			return fleet.ErrMissingLicense
+		}
+		if err := spec.Verify(); err != nil {
+			setAuthCheckedOnPreAuthErr(ctx)
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: fmt.Sprintf("invalid query spec: %s", err),
+			})
 		}
 		query, err := svc.queryFromSpec(ctx, spec)
 		if err != nil {
@@ -802,28 +816,27 @@ func (svc *Service) queryFromSpec(ctx context.Context, spec *fleet.QuerySpec) (*
 	if logging == "" {
 		logging = fleet.LoggingSnapshot
 	}
-	// Find labels by name.
-	var queryLabels []fleet.LabelIdent
-	if len(spec.LabelsIncludeAny) > 0 {
+	// Resolve labels for both supported scopes (mutual exclusion enforced
+	// upstream by spec.Verify, so at most one slice is non-empty in practice).
+	allLabelNames := slices.Concat(spec.LabelsIncludeAny, spec.LabelsIncludeAll)
+	if len(allLabelNames) > 0 {
 		vc, ok := viewer.FromContext(ctx)
 		if !ok {
 			return nil, fleet.ErrNoContext
 		}
-
-		labelsMap, err := svc.ds.LabelsByName(ctx, spec.LabelsIncludeAny, fleet.TeamFilter{User: vc.User, TeamID: teamID})
+		labelsMap, err := svc.ds.LabelsByName(ctx, allLabelNames, fleet.TeamFilter{User: vc.User, TeamID: teamID})
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "get labels by name")
 		}
-		for labelName := range labelsMap {
-			queryLabels = append(queryLabels, fleet.LabelIdent{LabelName: labelName, LabelID: labelsMap[labelName].ID})
-		}
-		// Make sure that all labels were found.
-		for _, label := range spec.LabelsIncludeAny {
-			if _, ok := labelsMap[label]; !ok {
+		for _, name := range allLabelNames {
+			if _, ok := labelsMap[name]; !ok {
 				return nil, ctxerr.New(ctx, "label not found")
 			}
 		}
 	}
+	// LabelID is left zero — updateQueryLabelsInTx resolves names to IDs.
+	includeAny := fleet.LabelNamesToIdents(spec.LabelsIncludeAny)
+	includeAll := fleet.LabelNamesToIdents(spec.LabelsIncludeAll)
 	return &fleet.Query{
 		Name:        spec.Name,
 		Description: spec.Description,
@@ -837,7 +850,8 @@ func (svc *Service) queryFromSpec(ctx context.Context, spec *fleet.QuerySpec) (*
 		AutomationsEnabled: spec.AutomationsEnabled,
 		Logging:            logging,
 		DiscardData:        spec.DiscardData,
-		LabelsIncludeAny:   queryLabels,
+		LabelsIncludeAny:   includeAny,
+		LabelsIncludeAll:   includeAll,
 	}, nil
 }
 
@@ -885,10 +899,6 @@ func (svc *Service) specFromQuery(ctx context.Context, query *fleet.Query) (*fle
 		}
 		teamName = team.Name
 	}
-	labelsAny := []string{}
-	for _, label := range query.LabelsIncludeAny {
-		labelsAny = append(labelsAny, label.LabelName)
-	}
 	return &fleet.QuerySpec{
 		Name:        query.Name,
 		Description: query.Description,
@@ -902,7 +912,8 @@ func (svc *Service) specFromQuery(ctx context.Context, query *fleet.Query) (*fle
 		AutomationsEnabled: query.AutomationsEnabled,
 		Logging:            query.Logging,
 		DiscardData:        query.DiscardData,
-		LabelsIncludeAny:   labelsAny,
+		LabelsIncludeAny:   fleet.LabelIdentsToNames(query.LabelsIncludeAny),
+		LabelsIncludeAll:   fleet.LabelIdentsToNames(query.LabelsIncludeAll),
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41566 

Wires labels_include_all to GitOps and fleetctl for policies and reports.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "include all labels" (labels_include_all) support for queries and policies; CLI, GitOps exports, and API specs now serialize both include-any and include-all.

* **Bug Fixes / Behavior**
  * Policy application and membership cleanup now respect include-all criteria.
  * Host report listing now correctly filters queries by include-all vs include-any and enforces premium gating for include-all.

* **Tests**
  * Added unit and integration tests covering serialization, GitOps validation, premium gating, repo/generate GitOps exports, and batch/spec rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->