### PR TITLE
Allow returning x509 PEM cert instead of PEM-encoded PKCS7 envelope from request_certificate endpoint

### DIFF
--- a/changes/44533-request-pem-certificate
+++ b/changes/44533-request-pem-certificate
@@ -1,1 +1,1 @@
-* Added an option to convert and return a PEM x509 certificate instead of a PEM-encoded PKCS7 envelope from the Request a Certificate endpoint
+* Added an option to convert and return a PEM-encoded X.509 certificate instead of a PEM-encoded PKCS7 envelope from the Request a Certificate endpoint.

--- a/changes/44533-request-pem-certificate
+++ b/changes/44533-request-pem-certificate
@@ -1,0 +1,1 @@
+* Added an option to convert and return a PEM x509 certificate instead of a PEM-encoded PKCS7 envelope from the Request a Certificate endpoint

--- a/ee/server/service/request_certificate.go
+++ b/ee/server/service/request_certificate.go
@@ -154,7 +154,8 @@ func (svc *Service) RequestCertificate(ctx context.Context, p fleet.RequestCerti
 }
 
 // pkcs7EnvelopeToPEM converts a base64-encoded PKCS7 envelope (as returned by an EST
-// /simpleenroll response, per RFC 7030) into one or more PEM-encoded CERTIFICATE blocks.
+// /simpleenroll response, per RFC 7030) into a single PEM-encoded CERTIFICATE block.
+// It returns an error unless the envelope contains exactly one certificate.
 func pkcs7EnvelopeToPEM(envelope []byte) (string, error) {
 	// EST returns base64-encoded PKCS7 with potential whitespace; strip it before decoding.
 	stripped := strings.Map(func(r rune) rune {

--- a/ee/server/service/request_certificate.go
+++ b/ee/server/service/request_certificate.go
@@ -173,17 +173,18 @@ func pkcs7EnvelopeToPEM(envelope []byte) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parsing PKCS7 envelope: %w", err)
 	}
-	if len(p7.Certificates) == 0 {
-		return "", errors.New("PKCS7 envelope contained no certificates")
+	// Per RFC 7030 §4.2.3, the EST /simpleenroll SimplePKIResponse carries the single
+	// issued certificate. Reject anything else so callers don't have to guess which cert
+	// is the leaf.
+	if len(p7.Certificates) != 1 {
+		return "", fmt.Errorf("expected exactly 1 certificate in EST PKCS7 envelope, got %d", len(p7.Certificates))
 	}
 
-	var buf strings.Builder
-	for _, cert := range p7.Certificates {
-		if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
-			return "", fmt.Errorf("encoding certificate to PEM: %w", err)
-		}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: p7.Certificates[0].Raw})
+	if pemBytes == nil {
+		return "", errors.New("encoding certificate to PEM")
 	}
-	return buf.String(), nil
+	return string(pemBytes), nil
 }
 
 func (svc *Service) introspectIDPToken(ctx context.Context, idpClientID, idpToken, idpOauthURL string) (*oauthIntrospectionResponse, error) {

--- a/ee/server/service/request_certificate.go
+++ b/ee/server/service/request_certificate.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/smallstep/pkcs7"
 )
 
 // This code largely adapted from fleet/website/api/controllers/get-est-device-certificate.js
@@ -134,10 +137,53 @@ func (svc *Service) RequestCertificate(ctx context.Context, p fleet.RequestCerti
 		return nil, &fleet.BadRequestError{Message: fmt.Sprintf("EST certificate request failed: %s", err.Error())}
 	}
 	svc.logger.InfoContext(ctx, "Successfully retrieved a certificate from EST", "ca_id", ca.ID, "idp_username", idpUsername)
+
+	if p.ReturnPEMCertificate {
+		pemCert, err := pkcs7EnvelopeToPEM(certificate.Certificate)
+		if err != nil {
+			svc.logger.ErrorContext(ctx, "Failed to convert PKCS7 envelope to PEM certificate", "ca_id", ca.ID, "err", err)
+			return nil, ctxerr.Wrap(ctx, err, "converting PKCS7 envelope to PEM certificate")
+		}
+		return new(pemCert), nil
+	}
+
 	// Wrap the certificate in a PEM block for easier consumption by the client. TODO: If we ever
 	// support CAs other than Hydrant/EST in this API, this may need to be modified to be aware of
 	// their formats.
 	return new("-----BEGIN PKCS7-----\n" + string(certificate.Certificate) + "\n-----END PKCS7-----\n"), nil
+}
+
+// pkcs7EnvelopeToPEM converts a base64-encoded PKCS7 envelope (as returned by an EST
+// /simpleenroll response, per RFC 7030) into one or more PEM-encoded CERTIFICATE blocks.
+func pkcs7EnvelopeToPEM(envelope []byte) (string, error) {
+	// EST returns base64-encoded PKCS7 with potential whitespace; strip it before decoding.
+	stripped := strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == ' ' || r == '\t' {
+			return -1
+		}
+		return r
+	}, string(envelope))
+
+	derBytes, err := base64.StdEncoding.DecodeString(stripped)
+	if err != nil {
+		return "", fmt.Errorf("decoding base64 PKCS7 envelope: %w", err)
+	}
+
+	p7, err := pkcs7.Parse(derBytes)
+	if err != nil {
+		return "", fmt.Errorf("parsing PKCS7 envelope: %w", err)
+	}
+	if len(p7.Certificates) == 0 {
+		return "", errors.New("PKCS7 envelope contained no certificates")
+	}
+
+	var buf strings.Builder
+	for _, cert := range p7.Certificates {
+		if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return "", fmt.Errorf("encoding certificate to PEM: %w", err)
+		}
+	}
+	return buf.String(), nil
 }
 
 func (svc *Service) introspectIDPToken(ctx context.Context, idpClientID, idpToken, idpOauthURL string) (*oauthIntrospectionResponse, error) {

--- a/ee/server/service/request_certificate_test.go
+++ b/ee/server/service/request_certificate_test.go
@@ -437,6 +437,10 @@ func TestRequestCertificate(t *testing.T) {
 		require.Equal(t, "CERTIFICATE", block.Type)
 		require.Equal(t, issuedDER, block.Bytes)
 		require.Empty(t, rest)
+
+		parsed, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		require.Equal(t, "fleetie@example.com", parsed.Subject.CommonName)
 	})
 
 	t.Run("Request a certificate - return_pem_certificate true with whitespace in EST response", func(t *testing.T) {
@@ -467,6 +471,10 @@ func TestRequestCertificate(t *testing.T) {
 		require.NotNil(t, block)
 		require.Equal(t, "CERTIFICATE", block.Type)
 		require.Equal(t, issuedDER, block.Bytes)
+
+		parsed, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		require.Equal(t, "fleetie@example.com", parsed.Subject.CommonName)
 	})
 
 	t.Run("Request a certificate - return_pem_certificate true, malformed PKCS7 returns error", func(t *testing.T) {

--- a/ee/server/service/request_certificate_test.go
+++ b/ee/server/service/request_certificate_test.go
@@ -482,6 +482,28 @@ func TestRequestCertificate(t *testing.T) {
 		require.Nil(t, cert)
 	})
 
+	t.Run("Request a certificate - return_pem_certificate true rejects envelope with multiple certs", func(t *testing.T) {
+		svc, ctx := baseSetupForTests()
+
+		// Build a PKCS7 SignedData containing two certificates to verify we reject anything
+		// that doesn't match RFC 7030's single-issued-certificate response shape.
+		signed, err := pkcs7.NewSignedData(nil)
+		require.NoError(t, err)
+		signed.AddCertificate(parseDERCert(t, generateTestCertDER(t)))
+		signed.AddCertificate(parseDERCert(t, generateTestCertDER(t)))
+		envelope, err := signed.Finish()
+		require.NoError(t, err)
+		hydrantSimpleEnrollResponse = base64.StdEncoding.EncodeToString(envelope)
+
+		cert, err := svc.RequestCertificate(ctx, fleet.RequestCertificatePayload{
+			ID:                   hydrantCA.ID,
+			CSR:                  goodCSR,
+			ReturnPEMCertificate: true,
+		})
+		require.ErrorContains(t, err, "expected exactly 1 certificate")
+		require.Nil(t, cert)
+	})
+
 	t.Run("Request a certificate - return_pem_certificate false preserves PKCS7 wrapping", func(t *testing.T) {
 		svc, ctx := baseSetupForTests()
 
@@ -494,6 +516,14 @@ func TestRequestCertificate(t *testing.T) {
 		require.NotNil(t, cert)
 		require.Equal(t, "-----BEGIN PKCS7-----\n"+hydrantSimpleEnrollResponse+"\n-----END PKCS7-----\n", *cert)
 	})
+}
+
+// parseDERCert parses DER-encoded certificate bytes for use as input to PKCS7 SignedData.
+func parseDERCert(t *testing.T, der []byte) *x509.Certificate {
+	t.Helper()
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
 }
 
 // generateTestCertDER returns DER-encoded bytes of a freshly generated self-signed certificate

--- a/ee/server/service/request_certificate_test.go
+++ b/ee/server/service/request_certificate_test.go
@@ -2,11 +2,19 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +28,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/smallstep/pkcs7"
 	"github.com/stretchr/testify/require"
 )
 
@@ -406,4 +415,100 @@ func TestRequestCertificate(t *testing.T) {
 		})
 		require.ErrorAs(t, err, &invalidCSR)
 	})
+
+	t.Run("Request a certificate - return_pem_certificate true", func(t *testing.T) {
+		svc, ctx := baseSetupForTests()
+
+		issuedDER := generateTestCertDER(t)
+		envelope, err := pkcs7.DegenerateCertificate(issuedDER)
+		require.NoError(t, err)
+		hydrantSimpleEnrollResponse = base64.StdEncoding.EncodeToString(envelope)
+
+		cert, err := svc.RequestCertificate(ctx, fleet.RequestCertificatePayload{
+			ID:                   hydrantCA.ID,
+			CSR:                  goodCSR,
+			ReturnPEMCertificate: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+
+		block, rest := pem.Decode([]byte(*cert))
+		require.NotNil(t, block)
+		require.Equal(t, "CERTIFICATE", block.Type)
+		require.Equal(t, issuedDER, block.Bytes)
+		require.Empty(t, rest)
+	})
+
+	t.Run("Request a certificate - return_pem_certificate true with whitespace in EST response", func(t *testing.T) {
+		svc, ctx := baseSetupForTests()
+
+		issuedDER := generateTestCertDER(t)
+		envelope, err := pkcs7.DegenerateCertificate(issuedDER)
+		require.NoError(t, err)
+		// EST servers may insert line breaks in the base64 body; ensure we tolerate them.
+		b64 := base64.StdEncoding.EncodeToString(envelope)
+		var withNewlines strings.Builder
+		for i := 0; i < len(b64); i += 64 {
+			end := min(i+64, len(b64))
+			withNewlines.WriteString(b64[i:end])
+			withNewlines.WriteByte('\n')
+		}
+		hydrantSimpleEnrollResponse = withNewlines.String()
+
+		cert, err := svc.RequestCertificate(ctx, fleet.RequestCertificatePayload{
+			ID:                   hydrantCA.ID,
+			CSR:                  goodCSR,
+			ReturnPEMCertificate: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+
+		block, _ := pem.Decode([]byte(*cert))
+		require.NotNil(t, block)
+		require.Equal(t, "CERTIFICATE", block.Type)
+		require.Equal(t, issuedDER, block.Bytes)
+	})
+
+	t.Run("Request a certificate - return_pem_certificate true, malformed PKCS7 returns error", func(t *testing.T) {
+		svc, ctx := baseSetupForTests()
+		// hydrantSimpleEnrollResponse defaults to "abc123" which is not a valid PKCS7 envelope.
+
+		cert, err := svc.RequestCertificate(ctx, fleet.RequestCertificatePayload{
+			ID:                   hydrantCA.ID,
+			CSR:                  goodCSR,
+			ReturnPEMCertificate: true,
+		})
+		require.Error(t, err)
+		require.Nil(t, cert)
+	})
+
+	t.Run("Request a certificate - return_pem_certificate false preserves PKCS7 wrapping", func(t *testing.T) {
+		svc, ctx := baseSetupForTests()
+
+		cert, err := svc.RequestCertificate(ctx, fleet.RequestCertificatePayload{
+			ID:                   hydrantCA.ID,
+			CSR:                  goodCSR,
+			ReturnPEMCertificate: false,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.Equal(t, "-----BEGIN PKCS7-----\n"+hydrantSimpleEnrollResponse+"\n-----END PKCS7-----\n", *cert)
+	})
+}
+
+// generateTestCertDER returns DER-encoded bytes of a freshly generated self-signed certificate
+// for use in tests that need a realistic PKCS7 envelope payload.
+func generateTestCertDER(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "fleetie@example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der
 }

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -478,11 +478,12 @@ func (sscepp *SmallstepSCEPProxyCAUpdatePayload) Preprocess() {
 }
 
 type RequestCertificatePayload struct {
-	ID          uint    `url:"id"`             // ID Of the CA the cert is to be requested from.
-	CSR         string  `json:"csr"`           // PEM-encoded CSR
-	IDPOauthURL *string `json:"idp_oauth_url"` // OAuth introspection URL for validating IDP Authentication
-	IDPToken    *string `json:"idp_token"`     // Token for IDP Authentication
-	IDPClientID *string `json:"idp_client_id"` // Client ID for IDP Authentication
+	ID                   uint    `url:"id"`                     // ID Of the CA the cert is to be requested from.
+	CSR                  string  `json:"csr"`                   // PEM-encoded CSR
+	IDPOauthURL          *string `json:"idp_oauth_url"`         // OAuth introspection URL for validating IDP Authentication
+	IDPToken             *string `json:"idp_token"`             // Token for IDP Authentication
+	IDPClientID          *string `json:"idp_client_id"`         // Client ID for IDP Authentication
+	ReturnPEMCertificate bool    `json:"return_pem_certificate"` // If true, the issued certificate is returned as a PEM-encoded CERTIFICATE block instead of the raw PKCS7 envelope.
 }
 
 func (c *RequestCertificatePayload) AuthzType() string {

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -478,11 +478,11 @@ func (sscepp *SmallstepSCEPProxyCAUpdatePayload) Preprocess() {
 }
 
 type RequestCertificatePayload struct {
-	ID                   uint    `url:"id"`                     // ID Of the CA the cert is to be requested from.
-	CSR                  string  `json:"csr"`                   // PEM-encoded CSR
-	IDPOauthURL          *string `json:"idp_oauth_url"`         // OAuth introspection URL for validating IDP Authentication
-	IDPToken             *string `json:"idp_token"`             // Token for IDP Authentication
-	IDPClientID          *string `json:"idp_client_id"`         // Client ID for IDP Authentication
+	ID                   uint    `url:"id"`                      // ID Of the CA the cert is to be requested from.
+	CSR                  string  `json:"csr"`                    // PEM-encoded CSR
+	IDPOauthURL          *string `json:"idp_oauth_url"`          // OAuth introspection URL for validating IDP Authentication
+	IDPToken             *string `json:"idp_token"`              // Token for IDP Authentication
+	IDPClientID          *string `json:"idp_client_id"`          // Client ID for IDP Authentication
 	ReturnPEMCertificate bool    `json:"return_pem_certificate"` // If true, the issued certificate is returned as a PEM-encoded CERTIFICATE block instead of the raw PKCS7 envelope.
 }
 

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -483,7 +483,7 @@ type RequestCertificatePayload struct {
 	IDPOauthURL          *string `json:"idp_oauth_url"`          // OAuth introspection URL for validating IDP Authentication
 	IDPToken             *string `json:"idp_token"`              // Token for IDP Authentication
 	IDPClientID          *string `json:"idp_client_id"`          // Client ID for IDP Authentication
-	ReturnPEMCertificate bool    `json:"return_pem_certificate"` // If true, the issued certificate is returned as a PEM-encoded CERTIFICATE block instead of the raw PKCS7 envelope.
+	ReturnPEMCertificate bool    `json:"return_pem_certificate"` // If true, the issued certificate is returned as a PEM-encoded CERTIFICATE block; if false or omitted, a PEM-encoded PKCS7 block is returned.
 }
 
 func (c *RequestCertificatePayload) AuthzType() string {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44533 

Adds an option to return a PEM certificate from the request_certificate endpoint, rather than the PKCS7 envelope an EST server returns. This allows it to be more easily used in scripts without conversions, at the (small) cost of among other things dropping the PKCS7 envelope which could be signed by the server, etc(though the PEM cert itself should also be)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.


## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Request a Certificate" endpoint can optionally return the issued certificate as a PEM-encoded X.509 CERTIFICATE block instead of a PEM-encoded PKCS#7 envelope.

* **Tests**
  * Added comprehensive tests covering PEM conversion, tolerance for base64 whitespace/newlines, error handling for malformed PKCS#7, and multi-certificate envelope cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->