### PR TITLE
Docs: add `keywordsForDocsearch` meta tags

### DIFF
--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -308,3 +308,4 @@ agent_options:
 
 <meta name="pageOrderInSection" value="300">
 <meta name="description" value="Learn how to use configuration files and the fleetctl command line tool to configure agent options.">
+<meta name="keywordsForDocsearch" value="command line flags, agent config file">

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3497,3 +3497,4 @@ This content was moved to [Public IPs](http://fleetdm.com/docs/deploy/public-ip)
 
 <meta name="pageOrderInSection" value="100">
 <meta name="description" value="This page includes resources for configuring the Fleet binary, managing osquery configurations, and running with systemd.">
+<meta name="keywordsForDocsearch" value="server config, env vars, yaml config, log routing, log streaming, log shipping, server flags, cli flags, session expiry, secrets management, high availability">

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -1317,3 +1317,4 @@ Unlike other options, omitting `smtp_settings` or leaving it blank won't reset t
 <meta name="title" value="GitOps">
 <meta name="description" value="Reference documentation for Fleet's GitOps workflow. See examples and configuration options.">
 <meta name="pageOrderInSection" value="1500">
+<meta name="keywordsForDocsearch" value="configuration as code, org settings, ci/cd, version control, declarative configuration">

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -648,3 +648,4 @@ Below are some projects created by Fleet community members. These projects provi
 
 <meta name="pageOrderInSection" value="400">
 <meta name="description" value="An opinionated view of running Fleet in a production environment, and configuration strategies to enable high availability.">
+<meta name="keywordsForDocsearch" value="production deployment, reverse proxy">

--- a/docs/Deploy/Upgrading-Fleet.md
+++ b/docs/Deploy/Upgrading-Fleet.md
@@ -89,3 +89,4 @@ In each of these cases, breaking changes are clearly communicated in the version
 
 <meta name="pageOrderInSection" value="300">
 <meta name="description" value="Learn how to upgrade your Fleet instance to the latest version.">
+<meta name="keywordsForDocsearch" value="upgrade fleet, database migration, version upgrade, terraform upgrade, aws upgrade, prepare database">

--- a/docs/Deploy/deploy-fleet.md
+++ b/docs/Deploy/deploy-fleet.md
@@ -59,3 +59,4 @@ Looking for other deployment options? Check out the [guides](https://fleetdm.com
 <meta name="pageOrderInSection" value="100">
 <meta name="description" value="Learn how to easily deploy Fleet on Render or AWS with Terraform.">
 <meta name="title" value="Hosting Fleet">
+<meta name="keywordsForDocsearch" value="self-hosted, install fleet, fleet deployment, on-premise, cloud deployment">

--- a/docs/Deploy/deploy-fleet.md
+++ b/docs/Deploy/deploy-fleet.md
@@ -59,4 +59,3 @@ Looking for other deployment options? Check out the [guides](https://fleetdm.com
 <meta name="pageOrderInSection" value="100">
 <meta name="description" value="Learn how to easily deploy Fleet on Render or AWS with Terraform.">
 <meta name="title" value="Hosting Fleet">
-<meta name="keywordsForDocsearch" value="self-hosted, install fleet, fleet deployment, on-premise, cloud deployment">

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -294,3 +294,4 @@ You can't edit the authentication method for your currently logged-in user. To e
 <meta name="title" value="Single sign-on (SSO)">
 <meta name="pageOrderInSection" value="200">
 <meta name="description" value="Learn how to configure single sign-on (SSO)">
+<meta name="keywordsForDocsearch" value="azure ad, just-in-time provisioning, deprovision users">

--- a/docs/Get started/anatomy.md
+++ b/docs/Get started/anatomy.md
@@ -40,3 +40,4 @@ Software in Fleet refers to the following:
 - **Software inventory** an inventory of each host’s installed software, including information about detected vulnerabilities (CVEs). 
 
 <meta name="pageOrderInSection" value="200">
+<meta name="keywordsForDocsearch" value="fleet anatomy, teams, fleet concepts, terminology, glossary">

--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -55,3 +55,4 @@ A collection of guides to help you with Fleet.
 
 <meta name="description" value="Links to deployment tutorials and guides for using Fleet.">
 <meta name="pageOrderInSection" value="300">
+<meta name="keywordsForDocsearch" value="fleet tutorials, getting started, learning resources, fleet guides, walkthroughs">

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -14331,3 +14331,4 @@ Response:
 
 <meta name="description" value="Documentation for Fleet's REST API. See example requests and responses for each API endpoint.">
 <meta name="pageOrderInSection" value="30">
+<meta name="keywordsForDocsearch" value="api reference, api authentication, hosts api, policies api, reports api, scripts api, software api, vulnerabilities api, sessions api, users api, teams api, fleets api, mdm commands api, certificates api, labels api, activities api">


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/12704

Changes:
- Added `keywordsForDocsearch` meta tags to documentation pages.