### PR TITLE
Website: update search filter on controls documentation pages

### DIFF
--- a/website/assets/js/components/docs-nav-and-search.component.js
+++ b/website/assets/js/components/docs-nav-and-search.component.js
@@ -75,7 +75,7 @@ parasails.registerComponent('docsNavAndSearch', {
   mounted: async function() {
     let filterForSearch = {};
     if(this.searchFilter){
-      let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'handbook', 'software'];
+      let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'handbook', 'software', 'controls'];
       if(!searchIndexesThatExist.includes(this.searchFilter)){
         throw new Error(`Invalid 'searchFilter' value provided to <docs-nav-and-search> component. Please change the searchFilter value to one of: ${searchIndexesThatExist.join(', ')}`);
       }

--- a/website/assets/js/components/docs-nav-and-search.component.js
+++ b/website/assets/js/components/docs-nav-and-search.component.js
@@ -75,7 +75,7 @@ parasails.registerComponent('docsNavAndSearch', {
   mounted: async function() {
     let filterForSearch = {};
     if(this.searchFilter){
-      let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'handbook', 'software', 'controls'];
+      let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'handbook', 'controls'];
       if(!searchIndexesThatExist.includes(this.searchFilter)){
         throw new Error(`Invalid 'searchFilter' value provided to <docs-nav-and-search> component. Please change the searchFilter value to one of: ${searchIndexesThatExist.join(', ')}`);
       }

--- a/website/views/pages/docs/command-details.ejs
+++ b/website/views/pages/docs/command-details.ejs
@@ -1,7 +1,7 @@
 <div id="command-details" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
-      <docs-nav-and-search search-filter="queries" current-section="controls" :algolia-public-key="algoliaPublicKey"></docs-nav-and-search>
+      <docs-nav-and-search search-filter="controls" current-section="controls" :algolia-public-key="algoliaPublicKey"></docs-nav-and-search>
       <div purpose="breadcrumbs" class="d-flex flex-row align-items-start">
         <div>
           <a purpose="breadcrumbs-category" class="text-nowrap" :href="'/mdm-commands#'+thisCommand.platform">MDM commands</a>/

--- a/website/views/pages/docs/mdm-commands.ejs
+++ b/website/views/pages/docs/mdm-commands.ejs
@@ -1,7 +1,7 @@
 <div id="mdm-commands-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
-      <docs-nav-and-search  current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>
+      <docs-nav-and-search search-filter="controls" current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>
       <div purpose="platform-filters" class="d-flex justify-content-center"  >
         <div purpose="platform-filter" :class="[selectedPlatform === 'apple' ? 'selected' : '']+' '+[bowser.windows ? 'order-2' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('apple')">
           <h1 class="d-flex align-items-center">

--- a/website/views/pages/docs/os-settings.ejs
+++ b/website/views/pages/docs/os-settings.ejs
@@ -1,7 +1,7 @@
 <div id="os-settings-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
-      <docs-nav-and-search  current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>
+      <docs-nav-and-search search-filter="controls" current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>
       <div purpose="platform-filters" class="d-flex justify-content-center"  >
         <div purpose="platform-filter" :class="[selectedPlatform === 'apple' ? 'selected' : '']+' '+[bowser.windows ? 'order-2' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('apple')">
           <h1 class="d-flex align-items-center">

--- a/website/views/pages/docs/script-details.ejs
+++ b/website/views/pages/docs/script-details.ejs
@@ -1,7 +1,7 @@
 <div id="script-details" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
-      <docs-nav-and-search search-filter="queries" current-section="controls" :algolia-public-key="algoliaPublicKey"></docs-nav-and-search>
+      <docs-nav-and-search search-filter="controls" current-section="controls" :algolia-public-key="algoliaPublicKey"></docs-nav-and-search>
       <div purpose="breadcrumbs" class="d-flex flex-row align-items-start">
         <div>
           <a purpose="breadcrumbs-category" class="text-nowrap" :href="'/scripts#'+thisScript.platform">Scripts</a>/

--- a/website/views/pages/docs/script-library.ejs
+++ b/website/views/pages/docs/script-library.ejs
@@ -1,7 +1,7 @@
 <div id="script-library-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
-      <docs-nav-and-search  current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>
+      <docs-nav-and-search search-filter="controls" current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>
       <div purpose="platform-filters" class="d-flex justify-content-center"  >
         <div purpose="platform-filter" :class="[selectedPlatform === 'apple' ? 'selected' : '']+' '+[bowser.windows ? 'order-2' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('apple')">
           <h1 class="d-flex align-items-center">


### PR DESCRIPTION
Changes:
- Updated the docs-nav-and-search component to support a new `searchFilter` value
- Updated the search filter on pages in the "Controls" section of the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation search now supports filtering by "controls" across command details, MDM commands, OS settings, script details, and script library pages, and the on-page validation and user-facing message for allowed search filters were updated to include "controls".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->