### PR TITLE
Officially deprecated setup_experience.software

### DIFF
--- a/changes/42503-deprecate-software-under-setup-experience
+++ b/changes/42503-deprecate-software-under-setup-experience
@@ -1,0 +1,1 @@
+- Added deprecation warning when using `setup_experience.software` or `macos_setup.software` keys in config

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -937,6 +937,9 @@ func parseControls(top map[string]json.RawMessage, result *GitOps, logFn Logf, y
 
 	// Find the Fleet Secrets in the macos setup script file
 	if result.Controls.MacOSSetup != nil {
+		if result.Controls.MacOSSetup.Software.Set && len(result.Controls.MacOSSetup.Software.Value) > 0 {
+			logFn("[!] 'controls.setup_experience.software / controls.macos_setup.software' is deprecated; set 'setup_experience: true' on individual items under 'software.packages', 'software.app_store_apps', or 'software.fleet_maintained_apps' instead.\n")
+		}
 		if result.Controls.MacOSSetup.Script.Set {
 			startupScriptPath := resolveApplyRelativePath(controlsDir, result.Controls.MacOSSetup.Script.Value)
 			fileBytes, err := os.ReadFile(startupScriptPath)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -3338,7 +3338,7 @@ controls:
 
 		_, err := GitOpsFromFile(yamlPath, dir, nil, logFn)
 		require.NoError(t, err)
-		assert.NotContains(t, logs.String(), "'controls.setup_experience.software / controls.macos_setup.software'  is deprecated")
+		assert.NotContains(t, logs.String(), "'controls.setup_experience.software / controls.macos_setup.software' is deprecated")
 	})
 
 	t.Run("no_warning_when_setup_experience_software_empty", func(t *testing.T) {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -3261,6 +3261,122 @@ org_settings:
 	})
 }
 
+// TestSetupExperienceSoftwareDeprecation verifies that supplying a list of
+// software under `controls.setup_experience.software` emits a deprecation
+// warning steering users toward the per-item `setup_experience: true` form.
+func TestSetupExperienceSoftwareDeprecation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("warning_emitted_when_setup_experience_software_set", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "installer.pkg"), []byte("test"), 0o644))
+
+		config := `
+reports:
+policies:
+agent_options:
+software:
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: Test Org
+  secrets:
+controls:
+  setup_experience:
+    software:
+      - package_path: ./installer.pkg
+      - app_store_id: "1091189122"
+`
+		yamlPath := filepath.Join(dir, "gitops.yml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(config), 0o644))
+
+		var logs strings.Builder
+		logFn := func(format string, a ...any) {
+			logs.WriteString(fmt.Sprintf(format, a...))
+		}
+
+		_, err := GitOpsFromFile(yamlPath, dir, nil, logFn)
+		require.NoError(t, err)
+		assert.Contains(t, logs.String(), "'controls.setup_experience.software' is deprecated")
+		assert.Contains(t, logs.String(), "setup_experience: true")
+	})
+
+	t.Run("no_warning_when_setup_experience_software_unset", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		config := `
+reports:
+policies:
+agent_options:
+software:
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: Test Org
+  secrets:
+controls:
+  setup_experience:
+    enable_end_user_authentication: false
+`
+		yamlPath := filepath.Join(dir, "gitops.yml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(config), 0o644))
+
+		var logs strings.Builder
+		logFn := func(format string, a ...any) {
+			logs.WriteString(fmt.Sprintf(format, a...))
+		}
+
+		_, err := GitOpsFromFile(yamlPath, dir, nil, logFn)
+		require.NoError(t, err)
+		assert.NotContains(t, logs.String(), "'controls.setup_experience.software' is deprecated")
+	})
+
+	t.Run("no_warning_when_setup_experience_software_empty", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		config := `
+reports:
+policies:
+agent_options:
+software:
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: Test Org
+  secrets:
+controls:
+  setup_experience:
+    software: []
+`
+		yamlPath := filepath.Join(dir, "gitops.yml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(config), 0o644))
+
+		var logs strings.Builder
+		logFn := func(format string, a ...any) {
+			logs.WriteString(fmt.Sprintf(format, a...))
+		}
+
+		_, err := GitOpsFromFile(yamlPath, dir, nil, logFn)
+		require.NoError(t, err)
+		assert.NotContains(t, logs.String(), "'controls.setup_experience.software' is deprecated")
+	})
+}
+
 func TestSoftwarePackagesScriptPath(t *testing.T) {
 	t.Parallel()
 	appConfig := &fleet.EnrichedAppConfig{}

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -3302,7 +3302,7 @@ controls:
 
 		_, err := GitOpsFromFile(yamlPath, dir, nil, logFn)
 		require.NoError(t, err)
-		assert.Contains(t, logs.String(), "'controls.setup_experience.software' is deprecated")
+		assert.Contains(t, logs.String(), "'controls.setup_experience.software / controls.macos_setup.software' is deprecated")
 		assert.Contains(t, logs.String(), "setup_experience: true")
 	})
 
@@ -3338,7 +3338,7 @@ controls:
 
 		_, err := GitOpsFromFile(yamlPath, dir, nil, logFn)
 		require.NoError(t, err)
-		assert.NotContains(t, logs.String(), "'controls.setup_experience.software' is deprecated")
+		assert.NotContains(t, logs.String(), "'controls.setup_experience.software / controls.macos_setup.software'  is deprecated")
 	})
 
 	t.Run("no_warning_when_setup_experience_software_empty", func(t *testing.T) {
@@ -3373,7 +3373,7 @@ controls:
 
 		_, err := GitOpsFromFile(yamlPath, dir, nil, logFn)
 		require.NoError(t, err)
-		assert.NotContains(t, logs.String(), "'controls.setup_experience.software' is deprecated")
+		assert.NotContains(t, logs.String(), "'controls.setup_experience.software / controls.macos_setup.software' is deprecated")
 	})
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42503

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  - [X] setting `software:` under `macos_setup` or `setup_experience` triggers the expected warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Using setup_experience.software or macos_setup.software now emits a deprecation warning. Migrate by setting setup_experience: true on individual software items (packages, App Store apps, or fleet-maintained apps).

* **Tests**
  * Added test coverage to verify the deprecation warning is emitted when applicable and absent otherwise.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/44549)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->