### PR TITLE
Add screen-lock MDM profiles and exclusion labels

### DIFF
--- a/handbook/it/README.md
+++ b/handbook/it/README.md
@@ -87,6 +87,27 @@ Once the department approves inventory to be shipped from Fleet IT, follow these
 6. Follow up with the DRI of each issue daily until it's resolved. As needed, loop in their manager, the [Head of People](https://fleetdm.com/handbook/people#team), Fleet's CTO, or the Head of IT. If the test is within 3 days of being overdue, DM the fleetie and their manager, asking to have the issue prioritized and completed before the due date.
 
 
+### Exclude a host from a screen lock policy
+
+The `macOS - Screen lock after inactivity (15 minutes or less)` and `Windows - Interactive logon screen lock timeout configured` policies, plus their associated configuration profiles (`screen-lock-inactivity.mobileconfig`, `Screen lock timeout.xml`), are deployed to every host on the [💻 Workstations](https://github.com/fleetdm/fleet/blob/main/it-and-security/fleets/workstations.yml) fleet. To exclude a host (e.g., a kiosk, a conference-room display driver, or a host under approved temporary investigation), add its Fleet host ID to the matching exclusion label.
+
+1. Confirm the request has security approval per the [policy exception process](https://fleetdm.com/handbook/it/security#security-policy-management-policy). Exceptions must include a business justification and an expiration date no longer than one year.
+2. Look up the host's Fleet ID in [dogfood](https://dogfood.fleetdm.com/dashboard) (visible in the host's URL).
+3. Open a **Draft** pull request against the `fleet` repo editing the appropriate label file:
+   * macOS: [`it-and-security/lib/all/labels/macos-screen-lock-exclusions.yml`](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/all/labels/macos-screen-lock-exclusions.yml)
+   * Windows: [`it-and-security/lib/all/labels/windows-screen-lock-exclusions.yml`](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/all/labels/windows-screen-lock-exclusions.yml)
+4. Add the host ID to the `hosts:` list with a comment identifying the host and the expiration date of the exception. Example:
+   ```
+   hosts:
+     - "1234"  # PR #1234 - exception expires 2026-12-01
+   ```
+5. Wait until all automated checks on the pull request have passed. On the exception or tracking issue (for example the confidential `:help-it` request), add a comment that **links to the pull request**, then convert the draft to **Ready for review**.
+6. Get the PR reviewed and merged. The next `fleetctl gitops` run (on merge to `main`) will:
+   * Add the host to the exclusion label
+   * Remove the configuration profile from that host
+   * Stop counting the host against the screen lock policy
+7. To revoke the exception, remove the host ID line from the label file and merge a follow-up PR. Do not leave `hosts: []` behind on a label that has live exclusions on it — an empty list will wipe **all** members.
+
 
 ## Rituals
 

--- a/handbook/it/README.md
+++ b/handbook/it/README.md
@@ -91,6 +91,8 @@ Once the department approves inventory to be shipped from Fleet IT, follow these
 
 The `macOS - Screen lock after inactivity (15 minutes or less)` and `Windows - Interactive logon screen lock timeout configured` policies, plus their associated configuration profiles (`screen-lock-inactivity.mobileconfig`, `Screen lock timeout.xml`), are deployed to every host on the [💻 Workstations](https://github.com/fleetdm/fleet/blob/main/it-and-security/fleets/workstations.yml) fleet. To exclude a host (e.g., a kiosk, a conference-room display driver, or a host under approved temporary investigation), add its Fleet host ID to the matching exclusion label.
 
+On macOS, contributors who only need a **temporary** break from the screen saver (without changing MDM) should set a [hot corner](https://support.apple.com/guide/mac-help/mchlp3000/mac) to **Disable Screen Saver** in **System Settings → Desktop & Dock → Hot Corners** first. Use the steps below when a **full host exemption** from the profile and policy is required — not for ordinary short-term personal use.
+
 1. Confirm the request has security approval per the [policy exception process](https://fleetdm.com/handbook/it/security#security-policy-management-policy). Exceptions must include a business justification and an expiration date no longer than one year.
 2. Look up the host's Fleet ID in [dogfood](https://dogfood.fleetdm.com/dashboard) (visible in the host's URL).
 3. Open a **Draft** pull request against the `fleet` repo editing the appropriate label file:

--- a/handbook/it/security.md
+++ b/handbook/it/security.md
@@ -235,6 +235,7 @@ Since we can't eliminate the risk of passwords being cracked remotely, we requir
 **User experience impacts**
 
 * Laptops lock after 15 minutes of inactivity. On macOS, once the screen saver has started or the display has slept, there is a one-minute grace period before a password is required to unlock; after that minute, a password is required.
+* On macOS, for a **temporary** stretch when you need the display to stay awake (for example watching a meeting without moving the mouse), you can set a [hot corner](https://support.apple.com/guide/mac-help/mchlp3000/mac) to **Disable Screen Saver** in **System Settings → Desktop & Dock → Hot Corners**. While the pointer rests in that corner, the screen saver will not start; normal timeout applies again when you move the pointer away. This is a self-service workaround for short-term needs only — always lock the machine when you step away.
 * Forgotten passwords can be fixed via MDM instead of relying on potentially dangerous hints.
 * Guest accounts are not available.
 
@@ -243,6 +244,8 @@ Since we can't eliminate the risk of passwords being cracked remotely, we requir
 The same 15-minute inactivity lock is enforced on Fleet-managed Windows hosts via the `LocalPoliciesSecurityOptions/InteractiveLogon_MachineInactivityLimit` CSP (the MDM equivalent of the GPO "Interactive logon: Machine inactivity limit"). Compliance is verified by the `Windows - Interactive logon screen lock timeout configured` Fleet policy, which requires the timeout to be 15 minutes or less.
 
 **Requesting an exception**
+
+Before requesting a host-wide screen lock **exception** on macOS, use a hot corner set to **Disable Screen Saver** (see above) when you only need a brief break from automatic lock. Label exceptions remove MDM enforcement from the device and require security approval with a business justification and expiration date; prefer hot corners for ordinary short-term situations (presentations, demos, long-running local jobs).
 
 In rare cases (e.g., a kiosk, a host driving a conference room display, or temporary troubleshooting) a host may need to be excluded from the screen lock profile and policy. We use static manual labels for this:
 

--- a/handbook/it/security.md
+++ b/handbook/it/security.md
@@ -234,9 +234,22 @@ Since we can't eliminate the risk of passwords being cracked remotely, we requir
 
 **User experience impacts**
 
-* Laptops lock after 20 minutes of inactivity. To voluntarily pause this, a [hot corner](https://support.apple.com/en-mo/guide/mac-help/mchlp3000/mac) can be configured to disable the screen saver. This is useful if you are, for example, watching an online meeting without moving the mouse and want to be sure the laptop will not lock.
+* Laptops lock after 15 minutes of inactivity. On macOS, once the screen saver has started or the display has slept, there is a one-minute grace period before a password is required to unlock; after that minute, a password is required.
 * Forgotten passwords can be fixed via MDM instead of relying on potentially dangerous hints.
 * Guest accounts are not available.
+
+**Windows hosts**
+
+The same 15-minute inactivity lock is enforced on Fleet-managed Windows hosts via the `LocalPoliciesSecurityOptions/InteractiveLogon_MachineInactivityLimit` CSP (the MDM equivalent of the GPO "Interactive logon: Machine inactivity limit"). Compliance is verified by the `Windows - Interactive logon screen lock timeout configured` Fleet policy, which requires the timeout to be 15 minutes or less.
+
+**Requesting an exception**
+
+In rare cases (e.g., a kiosk, a host driving a conference room display, or temporary troubleshooting) a host may need to be excluded from the screen lock profile and policy. We use static manual labels for this:
+
+* macOS hosts: [`macOS screen lock exclusions`](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/all/labels/macos-screen-lock-exclusions.yml)
+* Windows hosts: [`Windows screen lock exclusions`](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/all/labels/windows-screen-lock-exclusions.yml)
+
+Each label is referenced by `labels_exclude_any` on both the policy and the configuration profile, so adding a host's Fleet ID to the label removes the profile and excuses the host from the policy in a single change. See the [Exclude a host from a screen lock policy](https://fleetdm.com/handbook/it#exclude-a-host-from-a-screen-lock-policy) procedure in the IT handbook for the approval and rollout steps.
 
 
 #### iCloud

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -106,6 +106,8 @@ labels:
   - path: ./lib/all/labels/apple-silicon-macos-hosts.yml
   - path: ./lib/all/labels/keynote-14-installed.yml
   - path: ./lib/all/labels/macos-compatibility-extension-installed.yml
+  - path: ./lib/all/labels/macos-screen-lock-exclusions.yml
+  - path: ./lib/all/labels/windows-screen-lock-exclusions.yml
   - path: ./lib/all/labels/team-g-mdm.yml
   - path: ./lib/all/labels/team-g-software.yml
   - path: ./lib/all/labels/nudge-test-devices.yml

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -100,6 +100,9 @@ controls:
       - path: ../lib/macos/configuration-profiles/limit-ad-tracking.mobileconfig
       - path: ../lib/macos/configuration-profiles/misc.mobileconfig
       - path: ../lib/macos/configuration-profiles/prevent-autologon.mobileconfig
+      - path: ../lib/macos/configuration-profiles/screen-lock-inactivity.mobileconfig
+        labels_exclude_any:
+          - macOS screen lock exclusions
       - path: ../lib/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
       - path: ../lib/macos/configuration-profiles/ensure-show-status-bar-is-enabled.mobileconfig
       - path: ../lib/macos/declaration-profiles/Passcode settings.json
@@ -133,6 +136,9 @@ controls:
       - path: ../lib/windows/configuration-profiles/Advanced PowerShell logging.xml
       - path: ../lib/windows/configuration-profiles/Disable OneDrive.xml
       - path: ../lib/windows/configuration-profiles/Disable Guest account.xml
+      - path: ../lib/windows/configuration-profiles/Screen lock timeout.xml
+        labels_exclude_any:
+          - Windows screen lock exclusions
       - path: ../lib/windows/configuration-profiles/Windows Defender compliance settings.xml
   windows_updates:
     deadline_days: 7

--- a/it-and-security/lib/all/labels/macos-screen-lock-exclusions.yml
+++ b/it-and-security/lib/all/labels/macos-screen-lock-exclusions.yml
@@ -1,0 +1,7 @@
+- name: macOS screen lock exclusions
+  description: |
+    Hosts in this label are excluded from the "macOS - Screen lock after inactivity (15 minutes or less)"
+    policy and the corresponding screen-lock-inactivity.mobileconfig configuration profile.
+    Add Fleet host IDs below to exclude a host (hardware_serial or uuid also work).
+  label_membership_type: manual
+  hosts: []

--- a/it-and-security/lib/all/labels/windows-screen-lock-exclusions.yml
+++ b/it-and-security/lib/all/labels/windows-screen-lock-exclusions.yml
@@ -1,0 +1,7 @@
+- name: Windows screen lock exclusions
+  description: |
+    Hosts in this label are excluded from the "Windows - Interactive logon screen lock timeout configured"
+    policy and the corresponding "Screen lock timeout.xml" configuration profile.
+    Add Fleet host IDs below to exclude a host (hardware_serial or uuid also work).
+  label_membership_type: manual
+  hosts: []

--- a/it-and-security/lib/macos/configuration-profiles/screen-lock-inactivity.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/screen-lock-inactivity.mobileconfig
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDescription</key>
+	<string>Starts the screen saver after 15 minutes of inactivity. A password is required to unlock after a one-minute grace period once the screen saver has started or the display has slept.</string>
+	<key>PayloadDisplayName</key>
+	<string>Screen lock after inactivity</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.screen-lock-inactivity</string>
+	<key>PayloadOrganization</key>
+	<string>Fleet Device Management</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>AB1372A9-6297-4108-85C7-0CE557A507AE</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Screen lock after inactivity</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.screen-lock-inactivity.screensaver</string>
+			<key>PayloadType</key>
+			<string>com.apple.screensaver</string>
+			<key>PayloadUUID</key>
+			<string>0D9BCBE2-DA7A-40CD-9FCD-743F322677C2</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<!-- Start the screen saver after 15 minutes of inactivity (must be <= 900 to satisfy the policy). -->
+			<key>idleTime</key>
+			<integer>900</integer>
+			<!-- Require a password to wake from the screen saver or sleep. -->
+			<key>askForPassword</key>
+			<true/>
+			<!-- Seconds after screen saver or display sleep before a password is required (60 = 1 minute; must be <= 60 to satisfy the policy). -->
+			<key>askForPasswordDelay</key>
+			<integer>60</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
+++ b/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
@@ -31,6 +31,8 @@
   resolution: |-
     Screen lock should be automatically enforced by MDM. If this fails, restart the Mac and refetch in Fleet Desktop.
     If it still fails, drop a note in #help-it.
+    If the Mac is enrolled and you only need the display to stay awake briefly (for example a presentation), use System Settings → Desktop & Dock → Hot Corners and set a corner to Disable Screen Saver: https://support.apple.com/guide/mac-help/mchlp3000/mac (that is a temporary user workaround and does not change MDM compliance for this policy).
+    For a host-wide exemption from screen lock, follow the IT handbook after security approval.
   platform: darwin
   labels_exclude_any:
     - macOS screen lock exclusions

--- a/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
+++ b/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
@@ -31,8 +31,6 @@
   resolution: |-
     Screen lock should be automatically enforced by MDM. If this fails, restart the Mac and refetch in Fleet Desktop.
     If it still fails, drop a note in #help-it.
-    If the Mac is enrolled and you only need the display to stay awake briefly (for example a presentation), use System Settings → Desktop & Dock → Hot Corners and set a corner to Disable Screen Saver: https://support.apple.com/guide/mac-help/mchlp3000/mac (that is a temporary user workaround and does not change MDM compliance for this policy).
-    For a host-wide exemption from screen lock, follow the IT handbook after security approval.
   platform: darwin
   labels_exclude_any:
     - macOS screen lock exclusions

--- a/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
+++ b/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
@@ -32,3 +32,5 @@
     Screen lock should be automatically enforced by MDM. If this fails, restart the Mac and refetch in Fleet Desktop.
     If it still fails, drop a note in #help-it.
   platform: darwin
+  labels_exclude_any:
+    - macOS screen lock exclusions

--- a/it-and-security/lib/windows/configuration-profiles/Screen lock timeout.xml
+++ b/it-and-security/lib/windows/configuration-profiles/Screen lock timeout.xml
@@ -1,0 +1,17 @@
+<Replace>
+  <!--
+    Maps to "Interactive logon: Machine inactivity limit" (GPO).
+    Writes HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\InactivityTimeoutSecs.
+    Satisfies the "Windows - Interactive logon screen lock timeout configured" Fleet policy
+    (requires 1-900 seconds). 900 = 15 minutes.
+  -->
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/LocalPoliciesSecurityOptions/InteractiveLogon_MachineInactivityLimit</LocURI>
+    </Target>
+    <Data>900</Data>
+  </Item>
+</Replace>

--- a/it-and-security/lib/windows/configuration-profiles/Screen lock timeout.xml
+++ b/it-and-security/lib/windows/configuration-profiles/Screen lock timeout.xml
@@ -1,10 +1,4 @@
 <Replace>
-  <!--
-    Maps to "Interactive logon: Machine inactivity limit" (GPO).
-    Writes HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\InactivityTimeoutSecs.
-    Satisfies the "Windows - Interactive logon screen lock timeout configured" Fleet policy
-    (requires 1-900 seconds). 900 = 15 minutes.
-  -->
   <Item>
     <Meta>
       <Format xmlns="syncml:metinf">int</Format>

--- a/it-and-security/lib/windows/policies/screen-lock-timeout-configured.yml
+++ b/it-and-security/lib/windows/policies/screen-lock-timeout-configured.yml
@@ -12,3 +12,5 @@
     Screen lock timeout should be automatically enforced by MDM. If this fails, restart your device and refetch in Fleet Desktop.
     If it still fails, drop a note in #help-it.
   platform: windows
+  labels_exclude_any:
+    - Windows screen lock exclusions


### PR DESCRIPTION
Add macOS and Windows screen-lock configuration profiles and manual exclusion labels, and wire them into fleet manifests and policies.

- Add macOS mobileconfig (screen-lock-inactivity) to start screensaver after 900s and require a password with a 60s delay.
- Add Windows configuration (Screen lock timeout.xml) to set InteractiveLogon_MachineInactivityLimit to 900s (15 minutes).
- Create manual labels: "macOS screen lock exclusions" and "Windows screen lock exclusions" (empty host lists).
- Register the new labels in it-and-security/default.yml and include the new profiles in workstations.yml with labels_exclude_any pointing to the appropriate exclusion label.
- Update macOS and Windows policy YAMLs to exclude hosts in the corresponding exclusion labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS and Windows "screen lock exclusions" labels to allow manual exemption of devices.
  * Introduced a macOS configuration profile that enforces a 15-minute inactivity screen lock and requires a password on resume.
  * Introduced a Windows configuration profile setting an equivalent 15-minute inactivity timeout.
  * Screen-lock policies now support label-based exclusions so exempted devices are not affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->