### PR TITLE
API reference typo and missing parameter

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -327,7 +327,7 @@ Retrieves the user data for the authenticated user.
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
-    "fleets": [],
+    "teams": [],
     "fleets": []
   },
   "available_teams" : [

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -306,6 +306,12 @@ Retrieves the user data for the authenticated user.
 
 `GET /api/v1/fleet/me`
 
+#### Parameters
+
+| Name                      | Type   | In   | Description                                                               |
+| ------------------------- | ------ | ---- | ------------------------------------------------------------------------- |
+| include_ui_settings       | boolean| query| If set to true, includes the columns the user hides on the **Hosts** page (default: `false`). |
+
 #### Example
 
 `GET /api/v1/fleet/me`

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -310,7 +310,7 @@ Retrieves the user data for the authenticated user.
 
 | Name                      | Type   | In   | Description                                                               |
 | ------------------------- | ------ | ---- | ------------------------------------------------------------------------- |
-| include_ui_settings       | boolean| query| If set to true, includes the columns the user hides on the **Hosts** page (default: `false`). |
+| include_ui_settings       | boolean | query | If set to true, includes the columns the user hides on the **Hosts** page (default: `false`). |
 
 #### Example
 


### PR DESCRIPTION
- Typo: Double "fleets"
