### PR TITLE
Fixed bug with about to expire CLI banner (#34924)

### DIFF
--- a/changes/34924-expired-license-cli-banner
+++ b/changes/34924-expired-license-cli-banner
@@ -1,0 +1,1 @@
+* Updated the expired Fleet Premium license CLI banner to link to https://fleetdm.com/learn-more-about/downgrading instead of a stale FAQ anchor.

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -157,7 +157,9 @@ spec:
 func TestGetTeams(t *testing.T) {
 	var expiredBanner strings.Builder
 	fleet.WriteExpiredLicenseBanner(&expiredBanner)
-	require.Contains(t, expiredBanner.String(), "Your license for Fleet Premium is about to expire")
+	bannerStr := expiredBanner.String()
+	require.Contains(t, bannerStr, "Your license for Fleet Premium is about to expire")
+	require.Contains(t, bannerStr, "https://fleetdm.com/learn-more-about/downgrading")
 
 	testCases := []struct {
 		name                    string

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -18,7 +18,7 @@ func WriteExpiredLicenseBanner(w io.Writer) {
 		w,
 		"Your license for Fleet Premium is about to expire. If you’d like to renew or have questions about "+
 			"downgrading, please navigate to "+
-			"https://fleetdm.com/docs/using-fleet/faq#how-do-i-downgrade-from-fleet-premium-to-fleet-free and "+
+			"https://fleetdm.com/learn-more-about/downgrading and "+
 			"contact us for help.",
 	)
 	// We need to disable color and print a new line to make it look somewhat neat, otherwise colors continue to the

--- a/server/fleet/utils_test.go
+++ b/server/fleet/utils_test.go
@@ -1,10 +1,20 @@
 package fleet
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestWriteExpiredLicenseBanner(t *testing.T) {
+	var buf strings.Builder
+	WriteExpiredLicenseBanner(&buf)
+	out := buf.String()
+
+	require.Contains(t, out, "Your license for Fleet Premium is about to expire")
+	require.Contains(t, out, "https://fleetdm.com/learn-more-about/downgrading")
+}
 
 func TestVersionToSemvarVersion(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34924

Updated the message shown on about to expire license to point to https://fleetdm.com/learn-more-about/downgrading.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated the help link in the expired Fleet Premium license notification to direct users to current downgrade documentation instead of a stale reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->