### PR TITLE
Validate label platform during gitops --dry-run (#42477)

### DIFF
--- a/changes/42477-gitops-dry-run-label-platform
+++ b/changes/42477-gitops-dry-run-label-platform
@@ -1,0 +1,1 @@
+- Fixed gitops `--dry-run` so it now rejects label specs with invalid `platform` values.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -243,6 +243,36 @@ queries:
 	assert.ErrorContains(t, err, "Fleet Premium")
 }
 
+func TestGitOpsDryRunRejectsInvalidLabelPlatform(t *testing.T) {
+	_, ds := testing_utils.RunServerWithMockedDS(t)
+	setupEmptyGitOpsMocks(ds)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(`
+controls:
+policies:
+agent_options:
+queries:
+labels:
+  - name: Test - Linux invalid platform
+    query: SELECT 1;
+    platform: linux
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: GitOps Test
+  secrets:
+`)
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name(), "--dry-run"})
+	require.ErrorContains(t, err, "invalid platform")
+	require.ErrorContains(t, err, "linux")
+}
+
 func TestGitOpsBasicGlobalPremium(t *testing.T) {
 	// Cannot run t.Parallel() because it sets environment variables
 

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1377,6 +1377,10 @@ func parseLabels(top map[string]json.RawMessage, result *GitOps, baseDir string,
 		if !isASCII(l.Name) {
 			multiError = multierror.Append(multiError, fmt.Errorf("label name must be in ASCII: %s", l.Name))
 		}
+
+		if _, ok := fleet.ValidLabelPlatformVariants[l.Platform]; !ok {
+			multiError = multierror.Append(multiError, fmt.Errorf("invalid platform for label %q: %s", l.Name, l.Platform))
+		}
 		// Check that host vitals criteria is valid
 		if l.HostVitalsCriteria != nil {
 			criteriaJson, err := json.Marshal(l.HostVitalsCriteria)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42477 

Move the platform check into pkg/spec parseLabels so both --dry-run and apply hit the same validation and surface the same error.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitOps `--dry-run` now properly validates platform values specified in label definitions and rejects configurations containing invalid platform entries.

* **Tests**
  * Added validation test to ensure GitOps dry-run appropriately rejects label specifications with unsupported platform values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->