### PR TITLE
Remove duplicate MDM setup instructions for Fleet

### DIFF
--- a/articles/apple-mdm-setup.md
+++ b/articles/apple-mdm-setup.md
@@ -17,25 +17,6 @@ Apple uses Apple Push Notification service (APNs) APNs to authenticate and manag
 
 How to connect Fleet to APNs:
 
-1. In Fleet, navigate to the **Settings > Integrations > Mobile device management (MDM)** page.
-2. Select **Turn on** under the Apple (macOS, iOS, iPadOS) MDM section.
-3. Select **Download CSR** to download a certificate signing request (CSR) for Apple Push Notification service (APNs).
-4. Sign in to [Apple Push Certificates Portal](https://identity.apple.com/pushcert/). If you don't have an Apple ID, select **Create yours now**.
-5. In Apple Push Certificates Portal, select **Create a Certificate**, upload your CSR, and download your APNs certificate.
-6. Upload APNs certificate (.pem file) in Fleet.
-
-### Renew APNs
-
-1. In Fleet, navigate to the **Settings > Integrations > Mobile device management (MDM)** page.
-2. Under **Apple Business Manager** select **Edit** next to **Company-owned (ADE) and personal (BYOD) enrollment...**
-3. Select **Renew certificate** and then select **Download CSR** to download a certificate signing request (CSR) for Apple Push Notification service (APNs).
-4. Sign in to [Apple Push Certificates Portal](https://identity.apple.com/pushcert/).
-5. In Apple Push Certificates Portal, select **Renew** next to your certificate. Make sure that the certificate's **Common Name (CN)** matches the one presented in Fleet. If you choose a different certificate, you must turn MDM off and back on for all Apple hosts.
-6. Upload your CSR and download new APNs certificate.
-7. Upload APNs certificate (.pem file) in Fleet.
-
-How to connect Fleet to APNs:
-
 1. In Fleet, navigate to the **Settings > Integrations > MDM** page.
 2. Select **Turn on** for Apple (macOS, iOS, iPadOS) MDM.
 3. Select **Download CSR** to download a certificate signing request (CSR) for Apple Push Notification service (APNs).


### PR DESCRIPTION
Removed redundant steps for connecting Fleet to APNs and renewing APNs certificate.