### PR TITLE
Fix code default profile

### DIFF
--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -103,38 +103,10 @@ type DEPService struct {
 // GetDefaultProfile returns a godep.Profile with default values set.
 func (d *DEPService) GetDefaultProfile() *godep.Profile {
 	return &godep.Profile{
-		ProfileName:      "Fleet default enrollment profile",
-		AllowPairing:     true,
-		AutoAdvanceSetup: false,
-		IsMultiUser:      false,
-		IsMandatory:      false,
-		IsMDMRemovable:   true,
-		Language:         "en",
-		OrgMagic:         "1",
-		SkipSetupItems: []string{
-			"Appearance",
-			"AppleID",
-			"AppStore",
-			"Biometric",
-			"Diagnostics",
-			"FileVault",
-			"iCloudDiagnostics",
-			"iCloudStorage",
-			"Intelligence",
-			"Location",
-			"OSShowcase",
-			"Payment",
-			"Privacy",
-			"Restore",
-			"ScreenTime",
-			"Siri",
-			"SoftwareUpdate",
-			"TermsOfAddress",
-			"TOS",
-			"UnlockWithWatch",
-			"UpdateCompleted",
-			"Welcome",
-		},
+		ProfileName:    "Fleet default enrollment profile",
+		IsSupervised:   true,
+		IsMDMRemovable: false,
+		SkipSetupItems: []string{},
 	}
 }
 

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -107,7 +107,6 @@ func (d *DEPService) GetDefaultProfile() *godep.Profile {
 		ProfileName:    "Fleet default enrollment profile",
 		IsSupervised:   true,
 		IsMDMRemovable: false,
-		SkipSetupItems: []string{},
 	}
 }
 

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -102,6 +102,7 @@ type DEPService struct {
 
 // GetDefaultProfile returns a godep.Profile with default values set.
 func (d *DEPService) GetDefaultProfile() *godep.Profile {
+	// If this definition change, make sure to update the fleetctl new template file
 	return &godep.Profile{
 		ProfileName:    "Fleet default enrollment profile",
 		IsSupervised:   true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated the default Apple DEP enrollment profile: devices are now marked as supervised and the MDM profile is non-removable.
  * Simplified the returned default profile by removing several previously hard-coded enrollment defaults, reducing complexity and aligning behavior with external templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->