### PR TITLE
fleet-slackbot: make MAX_TOOL_CALLS configurable, default to 100

### DIFF
--- a/tools/fleet-slackbot/README.md
+++ b/tools/fleet-slackbot/README.md
@@ -82,6 +82,7 @@ GITOPS_BASE_PATH=it-and-security                # path within the repo to the Gi
 
 ANTHROPIC_API_KEY=sk-ant-...
 ANTHROPIC_MODEL=claude-opus-4-6                  # optional, this is the default
+MAX_TOOL_CALLS=100                               # safety cap on tool calls per response (default: 100)
 
 FLEET_MCP_URL=http://localhost:8181/sse
 PORT=3000                                        # port for the GitHub webhook listener

--- a/tools/fleet-slackbot/app.js
+++ b/tools/fleet-slackbot/app.js
@@ -57,6 +57,7 @@ mcpClient.addLocalTool(
 const claude = new ClaudeClient({
   apiKey: config.anthropic.apiKey,
   model: config.anthropic.model,
+  maxToolCalls: config.anthropic.maxToolCalls,
   mcpClient,
 });
 

--- a/tools/fleet-slackbot/claude-client.js
+++ b/tools/fleet-slackbot/claude-client.js
@@ -1,17 +1,23 @@
 const Anthropic = require("@anthropic-ai/sdk");
 const SYSTEM_PROMPT = require("./system-prompt");
 
-// Per-response cap on client-side tool invocations. Each call to
-// runAgentLoop (i.e. each user message) starts with a fresh budget; this
-// only stops Claude from looping in tool calls inside a single response,
-// it does not bound how many messages a user can send.
-const MAX_TOOL_CALLS = 12;
+// Default per-response cap on client-side tool invocations. Each call to
+// runAgentLoop (i.e. each user message) starts with a fresh budget. This
+// is a safety net against pathological tool loops, not a normal-path
+// limit — set high enough that legitimate multi-step investigations
+// don't routinely hit it. Override at runtime via the MAX_TOOL_CALLS env
+// var or the `maxToolCalls` constructor option.
+const DEFAULT_MAX_TOOL_CALLS = 100;
 
 class ClaudeClient {
-  constructor({ apiKey, model, mcpClient }) {
+  constructor({ apiKey, model, mcpClient, maxToolCalls }) {
     this.client = new Anthropic({ apiKey, timeout: 10 * 60 * 1000 });
     this.model = model;
     this.mcpClient = mcpClient;
+    this.maxToolCalls =
+      Number.isFinite(maxToolCalls) && maxToolCalls > 0
+        ? maxToolCalls
+        : DEFAULT_MAX_TOOL_CALLS;
   }
 
   /**
@@ -67,11 +73,11 @@ class ClaudeClient {
         return text;
       }
 
-      // Cap the number of tool calls in this turn so a single fan-out
-      // can't push us past the budget. Anything beyond the cap is dropped
-      // with a synthetic "budget exhausted" tool_result so Claude gets a
-      // valid response for every tool_use block it emitted.
-      const remaining = Math.max(0, MAX_TOOL_CALLS - toolCallsExecuted);
+      // Cap the number of tool calls in this turn so a runaway loop
+      // can't push us past the budget. Anything beyond the cap is
+      // dropped with a synthetic "budget exhausted" tool_result so
+      // Claude gets a valid response for every tool_use block it emitted.
+      const remaining = Math.max(0, this.maxToolCalls - toolCallsExecuted);
       const toExecute = toolUseBlocks.slice(0, remaining);
       const toSkip = toolUseBlocks.slice(remaining);
 
@@ -108,9 +114,9 @@ class ClaudeClient {
 
       toolCallsExecuted += toExecute.length;
       messages.push({ role: "user", content: toolResults });
-      console.log(`[claude] Agent loop: ${toExecute.length} tool call(s) executed (${toolCallsExecuted}/${MAX_TOOL_CALLS}), ${toSkip.length} skipped`);
+      console.log(`[claude] Agent loop: ${toExecute.length} tool call(s) executed (${toolCallsExecuted}/${this.maxToolCalls}), ${toSkip.length} skipped`);
 
-      if (toolCallsExecuted >= MAX_TOOL_CALLS) {
+      if (toolCallsExecuted >= this.maxToolCalls) {
         break;
       }
     }
@@ -122,7 +128,7 @@ class ClaudeClient {
     // implementation details. It's asked instead to flag any incomplete or
     // unverified parts of the answer.
     console.log(
-      `[claude] Agent loop hit ${MAX_TOOL_CALLS} tool calls — forcing final response without tools.`
+      `[claude] Agent loop hit ${this.maxToolCalls} tool calls — forcing final response without tools.`
     );
     messages.push({
       role: "user",
@@ -317,5 +323,5 @@ class ClaudeClient {
   }
 }
 
-ClaudeClient.MAX_TOOL_CALLS = MAX_TOOL_CALLS;
+ClaudeClient.DEFAULT_MAX_TOOL_CALLS = DEFAULT_MAX_TOOL_CALLS;
 module.exports = ClaudeClient;

--- a/tools/fleet-slackbot/claude-client.test.js
+++ b/tools/fleet-slackbot/claude-client.test.js
@@ -2,7 +2,8 @@ const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const ClaudeClient = require("./claude-client");
 
-const { MAX_TOOL_CALLS } = ClaudeClient;
+// Use a small cap so the budget-exhaustion test runs fast.
+const TEST_MAX_TOOL_CALLS = 5;
 
 // makeStreamingResponse builds a fake of the object returned by
 // `client.messages.stream(...)` — a thenable-ish thing with `.on(...)` for
@@ -26,9 +27,9 @@ test("runAgentLoop forces a final no-tools response when the budget is exhausted
     messages: {
       stream(params) {
         calls.push(params);
-        // First MAX_TOOL_CALLS turns each emit a single tool_use, so the
+        // First TEST_MAX_TOOL_CALLS turns each emit a single tool_use, so the
         // tool-call counter increments by 1 per turn and trips the cap.
-        if (calls.length <= MAX_TOOL_CALLS) {
+        if (calls.length <= TEST_MAX_TOOL_CALLS) {
           return makeStreamingResponse("tool_use", [
             {
               type: "tool_use",
@@ -65,6 +66,7 @@ test("runAgentLoop forces a final no-tools response when the budget is exhausted
     apiKey: "test",
     model: "claude-test",
     mcpClient: fakeMcpClient,
+    maxToolCalls: TEST_MAX_TOOL_CALLS,
   });
   client.client = fakeClient;
 
@@ -73,12 +75,12 @@ test("runAgentLoop forces a final no-tools response when the budget is exhausted
   assert.equal(result, "Best-effort answer with partial data.");
   assert.equal(
     calls.length,
-    MAX_TOOL_CALLS + 1,
-    `expected ${MAX_TOOL_CALLS} tool-call turns plus one forced no-tools call`
+    TEST_MAX_TOOL_CALLS + 1,
+    `expected ${TEST_MAX_TOOL_CALLS} tool-call turns plus one forced no-tools call`
   );
 
   // All in-budget calls must NOT disable tool use.
-  for (let i = 0; i < MAX_TOOL_CALLS; i++) {
+  for (let i = 0; i < TEST_MAX_TOOL_CALLS; i++) {
     assert.equal(
       calls[i].tool_choice,
       undefined,
@@ -87,11 +89,11 @@ test("runAgentLoop forces a final no-tools response when the budget is exhausted
   }
 
   // The fallback call must disable tool use so Claude is forced to produce text.
-  assert.deepEqual(calls[MAX_TOOL_CALLS].tool_choice, { type: "none" });
+  assert.deepEqual(calls[TEST_MAX_TOOL_CALLS].tool_choice, { type: "none" });
 
   // The fallback call's last user message asks for a best-effort answer
   // with a non-leaky caveat — it must not mention tools, rounds, or limits.
-  const finalMessages = calls[MAX_TOOL_CALLS].messages;
+  const finalMessages = calls[TEST_MAX_TOOL_CALLS].messages;
   const lastUser = finalMessages[finalMessages.length - 1];
   assert.equal(lastUser.role, "user");
   const lastUserText =
@@ -103,13 +105,13 @@ test("runAgentLoop forces a final no-tools response when the budget is exhausted
 });
 
 test("runAgentLoop caps tool calls within a single fanned-out turn", async () => {
-  // One turn emits MAX_TOOL_CALLS + 5 parallel tool_use blocks. Only the
-  // first MAX_TOOL_CALLS may execute; the rest must be answered with a
+  // One turn emits TEST_MAX_TOOL_CALLS + 5 parallel tool_use blocks. Only the
+  // first TEST_MAX_TOOL_CALLS may execute; the rest must be answered with a
   // synthetic "skipped" tool_result so the message history stays valid,
   // and the loop must immediately move to the no-tools fallback.
   const calls = [];
   const executedToolIds = [];
-  const fanOutCount = MAX_TOOL_CALLS + 5;
+  const fanOutCount = TEST_MAX_TOOL_CALLS + 5;
   const fakeClient = {
     messages: {
       stream(params) {
@@ -146,6 +148,7 @@ test("runAgentLoop caps tool calls within a single fanned-out turn", async () =>
     apiKey: "test",
     model: "claude-test",
     mcpClient: fakeMcpClient,
+    maxToolCalls: TEST_MAX_TOOL_CALLS,
   });
   client.client = fakeClient;
   // Wrap callTool to record executions.
@@ -158,7 +161,7 @@ test("runAgentLoop caps tool calls within a single fanned-out turn", async () =>
   const result = await client.runAgentLoop("Fan out.");
 
   assert.equal(result, "Capped fan-out answer.");
-  assert.equal(executedToolIds.length, MAX_TOOL_CALLS);
+  assert.equal(executedToolIds.length, TEST_MAX_TOOL_CALLS);
   // Two stream calls total: the fan-out turn, then the no-tools fallback.
   assert.equal(calls.length, 2);
   assert.deepEqual(calls[1].tool_choice, { type: "none" });
@@ -176,7 +179,7 @@ test("runAgentLoop caps tool calls within a single fanned-out turn", async () =>
   const results = toolResultMessage.content.filter((b) => b.type === "tool_result");
   assert.equal(results.length, fanOutCount);
   const skippedResults = results.filter((r) => r.is_error === true);
-  assert.equal(skippedResults.length, fanOutCount - MAX_TOOL_CALLS);
+  assert.equal(skippedResults.length, fanOutCount - TEST_MAX_TOOL_CALLS);
 });
 
 test("runAgentLoop returns end_turn text without forcing the fallback when Claude finishes early", async () => {
@@ -202,4 +205,32 @@ test("runAgentLoop returns end_turn text without forcing the fallback when Claud
   const result = await client.runAgentLoop("Hello");
   assert.equal(result, "Done.");
   assert.equal(callCount, 1);
+});
+
+test("ClaudeClient maxToolCalls defaults to DEFAULT_MAX_TOOL_CALLS and accepts override", () => {
+  const def = new ClaudeClient({
+    apiKey: "test",
+    model: "claude-test",
+    mcpClient: { getAnthropicTools: () => [] },
+  });
+  assert.equal(def.maxToolCalls, ClaudeClient.DEFAULT_MAX_TOOL_CALLS);
+
+  const overridden = new ClaudeClient({
+    apiKey: "test",
+    model: "claude-test",
+    mcpClient: { getAnthropicTools: () => [] },
+    maxToolCalls: 7,
+  });
+  assert.equal(overridden.maxToolCalls, 7);
+
+  // Invalid values fall back to the default rather than disabling the cap.
+  for (const bad of [0, -1, NaN, undefined, null, "lots", Infinity]) {
+    const c = new ClaudeClient({
+      apiKey: "test",
+      model: "claude-test",
+      mcpClient: { getAnthropicTools: () => [] },
+      maxToolCalls: bad,
+    });
+    assert.equal(c.maxToolCalls, ClaudeClient.DEFAULT_MAX_TOOL_CALLS);
+  }
 });

--- a/tools/fleet-slackbot/config.js
+++ b/tools/fleet-slackbot/config.js
@@ -15,6 +15,7 @@ const config = {
   anthropic: {
     apiKey: process.env.ANTHROPIC_API_KEY,
     model: process.env.ANTHROPIC_MODEL || "claude-opus-4-6",
+    maxToolCalls: parseInt(process.env.MAX_TOOL_CALLS || "100", 10),
   },
   webhook: {
     secret: process.env.GITHUB_WEBHOOK_SECRET,


### PR DESCRIPTION
## Summary

The 12-call cap was tripping routinely on legitimate multi-step investigations. Bump the default to 100 and let it be overridden via the `MAX_TOOL_CALLS` env var so it can be tuned on Render without code changes.

- `config.js`: parse `MAX_TOOL_CALLS` env var (default 100)
- `claude-client.js`: accept `maxToolCalls` in the constructor; fall back to `DEFAULT_MAX_TOOL_CALLS` for missing or invalid values (0, negative, NaN, Infinity, non-numeric strings)
- `app.js`: thread `config.anthropic.maxToolCalls` through
- `README`: document the env var
- tests: inject a small `TEST_MAX_TOOL_CALLS` so the budget-exhaustion paths run fast; add a test covering default + override + invalid-value validation

## Test plan

- [x] `yarn test` passes (4/4 tests)
- [ ] Set `MAX_TOOL_CALLS=200` in Render, deploy, and confirm logs show \`Agent loop hit 200 tool calls\` (or no longer trip the cap on previously-failing queries)
- [ ] Unset `MAX_TOOL_CALLS` and confirm the default of 100 applies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- The maximum number of tool calls allowed during interactions is now configurable through an environment variable, with a default limit of 100 calls instead of being hardcoded.

**Tests**
- Enhanced test coverage for the configurable tool call limit feature, including validation of defaults and handling of invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->