### PR TITLE
Lower CVE-2025-0938 spot-check threshold to absorb VulnCheck drift

### DIFF
--- a/cmd/cve/validate/main.go
+++ b/cmd/cve/validate/main.go
@@ -50,9 +50,9 @@ func checkNVDVulnerabilities(vulnPath string, logger *slog.Logger) {
 	if !ok {
 		panic("failed to cast CVE-2025-0938 to a Vuln")
 	}
-	// NVD lists CVE-2025-0938 as Deferred with zero configurations, so any CPE match here
-	// proves VulnCheck enrichment ran. Threshold trails the historical count to tolerate
-	// VulnCheck dropping a row.
+	// NVD lists CVE-2025-0938 as Deferred with zero configurations, so a multi-row CPE
+	// match list here is the sanity check that VulnCheck enrichment ran. Threshold trails
+	// the historical count of 6 to tolerate VulnCheck dropping a row.
 	if len(vulnEntry.Schema().Configurations.Nodes) < 1 || len(vulnEntry.Schema().Configurations.Nodes[0].CPEMatch) < 3 {
 		panic(errors.New("enriched vulnerability spot-check failed for Python on CVE-2025-0938"))
 	}

--- a/cmd/cve/validate/main.go
+++ b/cmd/cve/validate/main.go
@@ -50,7 +50,10 @@ func checkNVDVulnerabilities(vulnPath string, logger *slog.Logger) {
 	if !ok {
 		panic("failed to cast CVE-2025-0938 to a Vuln")
 	}
-	if len(vulnEntry.Schema().Configurations.Nodes) < 1 || len(vulnEntry.Schema().Configurations.Nodes[0].CPEMatch) < 6 {
+	// NVD lists CVE-2025-0938 as Deferred with zero configurations, so any CPE match here
+	// proves VulnCheck enrichment ran. Threshold trails the historical count to tolerate
+	// VulnCheck dropping a row.
+	if len(vulnEntry.Schema().Configurations.Nodes) < 1 || len(vulnEntry.Schema().Configurations.Nodes[0].CPEMatch) < 3 {
 		panic(errors.New("enriched vulnerability spot-check failed for Python on CVE-2025-0938"))
 	}
 


### PR DESCRIPTION
## Summary

`cmd/cve/validate/main.go` requires `>= 6` CPE matches in the first configurations node of `CVE-2025-0938`, which exactly matched the historical VulnCheck enrichment count. With zero margin, a single dropped row in VulnCheck data panics the daily `Generate CVE` workflow in `fleetdm/vulnerabilities`.

NVD lists this CVE as `Deferred` with no `configurations` block, so any CPE match in the output proves enrichment ran. The seed-based incremental sync path masks data drift (it preserves the previously-stored configurations and skips re-enrichment), so the regression only surfaces when the workflow falls back to a full sync — at which point the validate spot-check fails the entire run.

This drops the floor to 3 so VulnCheck losing a row does not break the build, while still catching a complete enrichment failure.

Companion fix in `fleetdm/vulnerabilities`: https://github.com/fleetdm/vulnerabilities/pull/34 (authenticate the seed-fetch GitHub call so it stops falling back to full sync on rate-limit 403s).

Failing run that motivated this: https://github.com/fleetdm/vulnerabilities/actions/runs/25226854671/job/73972413678

## Test plan

- [ ] Run `go run cmd/cve/validate/main.go --db_dir <feed dir>` against the latest healthy NVD feed bundle from `fleetdm/vulnerabilities` releases — exits clean
- [ ] Next scheduled `Generate CVE` run that hits the full-sync path validates successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made CVE-2025-0938 validation more tolerant of data variations in vulnerability configuration reporting, reducing false failures from expected data drift.
  * Maintained existing strict failure handling behavior when validation ultimately detects a critical mismatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->