### PR TITLE
Fleet UI: Add missing enable android mdm state

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tests.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+
+import SoftwareAppStoreAndroid from "./SoftwareAppStoreAndroid";
+
+const router = createMockRouter();
+
+describe("SoftwareAppStoreAndroid", () => {
+  it("shows enable Android MDM message when Android MDM is not configured", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isAndroidMdmEnabledAndConfigured: false,
+        },
+      },
+    });
+
+    render(<SoftwareAppStoreAndroid currentTeamId={1} router={router} />);
+
+    expect(screen.getByText("Android MDM isn't enabled")).toBeInTheDocument();
+    expect(
+      screen.getByText("To add Android apps, first enable Android MDM.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Enable Android MDM" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Android form when Android MDM is enabled", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isAndroidMdmEnabledAndConfigured: true,
+        },
+      },
+    });
+
+    render(<SoftwareAppStoreAndroid currentTeamId={1} router={router} />);
+
+    expect(
+      screen.queryByText("Android MDM isn't enabled")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tests.tsx
@@ -7,11 +7,12 @@ import SoftwareAppStoreAndroid from "./SoftwareAppStoreAndroid";
 const router = createMockRouter();
 
 describe("SoftwareAppStoreAndroid", () => {
-  it("shows enable Android MDM message when Android MDM is not configured", () => {
+  it("shows enable button for admins when Android MDM is not configured", () => {
     const render = createCustomRenderer({
       context: {
         app: {
           isPremiumTier: true,
+          isGlobalAdmin: true,
           isAndroidMdmEnabledAndConfigured: false,
         },
       },
@@ -28,11 +29,37 @@ describe("SoftwareAppStoreAndroid", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows ask your admin copy for non-admins when Android MDM is not configured", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: false,
+          isAnyTeamAdmin: false,
+          isAndroidMdmEnabledAndConfigured: false,
+        },
+      },
+    });
+
+    render(<SoftwareAppStoreAndroid currentTeamId={1} router={router} />);
+
+    expect(screen.getByText("Android MDM isn't enabled")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "To add Android apps, ask your admin to enable Android MDM."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Enable Android MDM" })
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the Android form when Android MDM is enabled", () => {
     const render = createCustomRenderer({
       context: {
         app: {
           isPremiumTier: true,
+          isGlobalAdmin: true,
           isAndroidMdmEnabledAndConfigured: true,
         },
       },

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tests.tsx
@@ -35,7 +35,6 @@ describe("SoftwareAppStoreAndroid", () => {
         app: {
           isPremiumTier: true,
           isGlobalAdmin: false,
-          isAnyTeamAdmin: false,
           isAndroidMdmEnabledAndConfigured: false,
         },
       },

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
@@ -19,16 +19,26 @@ const baseClass = "software-app-store-android";
 
 interface IEnableAndroidMdmMessageProps {
   onEnableMdm: () => void;
+  isAdmin: boolean;
 }
 
 const EnableAndroidMdmMessage = ({
   onEnableMdm,
+  isAdmin,
 }: IEnableAndroidMdmMessageProps) => (
   <EmptyState
     variant="form"
     header="Android MDM isn't enabled"
-    info="To add Android apps, first enable Android MDM."
-    primaryButton={<Button onClick={onEnableMdm}>Enable Android MDM</Button>}
+    info={
+      isAdmin
+        ? "To add Android apps, first enable Android MDM."
+        : "To add Android apps, ask your admin to enable Android MDM."
+    }
+    primaryButton={
+      isAdmin ? (
+        <Button onClick={onEnableMdm}>Enable Android MDM</Button>
+      ) : undefined
+    }
   />
 );
 
@@ -42,9 +52,13 @@ const SoftwareAppStoreAndroid = ({
   router,
 }: ISoftwareAppStoreProps) => {
   const { renderFlash } = useContext(NotificationContext);
-  const { isPremiumTier, isAndroidMdmEnabledAndConfigured } = useContext(
-    AppContext
-  );
+  const {
+    isPremiumTier,
+    isAndroidMdmEnabledAndConfigured,
+    isGlobalAdmin,
+    isAnyTeamAdmin,
+  } = useContext(AppContext);
+  const isAdmin = !!(isGlobalAdmin || isAnyTeamAdmin);
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -103,7 +117,12 @@ const SoftwareAppStoreAndroid = ({
     }
 
     if (!isAndroidMdmEnabledAndConfigured) {
-      return <EnableAndroidMdmMessage onEnableMdm={onEnableAndroidMdm} />;
+      return (
+        <EnableAndroidMdmMessage
+          onEnableMdm={onEnableAndroidMdm}
+          isAdmin={isAdmin}
+        />
+      );
     }
 
     return (

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
@@ -56,9 +56,7 @@ const SoftwareAppStoreAndroid = ({
     isPremiumTier,
     isAndroidMdmEnabledAndConfigured,
     isGlobalAdmin,
-    isAnyTeamAdmin,
   } = useContext(AppContext);
-  const isAdmin = !!(isGlobalAdmin || isAnyTeamAdmin);
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -120,7 +118,7 @@ const SoftwareAppStoreAndroid = ({
       return (
         <EnableAndroidMdmMessage
           onEnableMdm={onEnableAndroidMdm}
-          isAdmin={isAdmin}
+          isAdmin={!!isGlobalAdmin}
         />
       );
     }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
@@ -7,6 +7,8 @@ import { AppContext } from "context/app";
 import softwareAPI from "services/entities/software";
 
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
+import EmptyState from "components/EmptyState";
+import Button from "components/buttons/Button";
 import { ISoftwareAndroidFormData } from "pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm";
 
 import { getPathWithQueryParams } from "utilities/url";
@@ -14,6 +16,21 @@ import SoftwareAndroidForm from "pages/SoftwarePage/components/forms/SoftwareAnd
 import { getErrorMessage } from "./helpers";
 
 const baseClass = "software-app-store-android";
+
+interface IEnableAndroidMdmMessageProps {
+  onEnableMdm: () => void;
+}
+
+const EnableAndroidMdmMessage = ({
+  onEnableMdm,
+}: IEnableAndroidMdmMessageProps) => (
+  <EmptyState
+    variant="form"
+    header="Android MDM isn't enabled"
+    info="To add Android apps, first enable Android MDM."
+    primaryButton={<Button onClick={onEnableMdm}>Enable Android MDM</Button>}
+  />
+);
 
 interface ISoftwareAppStoreProps {
   currentTeamId: number;
@@ -25,7 +42,9 @@ const SoftwareAppStoreAndroid = ({
   router,
 }: ISoftwareAppStoreProps) => {
   const { renderFlash } = useContext(NotificationContext);
-  const { isPremiumTier } = useContext(AppContext);
+  const { isPremiumTier, isAndroidMdmEnabledAndConfigured } = useContext(
+    AppContext
+  );
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -35,6 +54,10 @@ const SoftwareAppStoreAndroid = ({
         fleet_id: currentTeamId,
       })
     );
+  };
+
+  const onEnableAndroidMdm = () => {
+    router.push(PATHS.ADMIN_INTEGRATIONS_MDM_ANDROID);
   };
 
   const onAddSoftware = async (formData: ISoftwareAndroidFormData) => {
@@ -77,6 +100,10 @@ const SoftwareAppStoreAndroid = ({
       return (
         <PremiumFeatureMessage className={`${baseClass}__premium-message`} />
       );
+    }
+
+    if (!isAndroidMdmEnabledAndConfigured) {
+      return <EnableAndroidMdmMessage onEnableMdm={onEnableAndroidMdm} />;
     }
 
     return (

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tests.tsx
@@ -76,7 +76,6 @@ describe("SoftwareAppStoreVpp", () => {
         app: {
           isPremiumTier: true,
           isGlobalAdmin: false,
-          isAnyTeamAdmin: false,
         },
       },
     });
@@ -134,7 +133,6 @@ describe("SoftwareAppStoreVpp", () => {
         app: {
           isPremiumTier: true,
           isGlobalAdmin: false,
-          isAnyTeamAdmin: false,
         },
       },
     });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tests.tsx
@@ -11,14 +11,26 @@ const baseUrl = (path: string) => `/api/latest/fleet${path}`;
 
 const router = createMockRouter();
 
-const renderWithContext = createCustomRenderer({
-  withBackendMock: true,
-  context: {
-    app: {
-      isPremiumTier: true,
-      isGlobalAdmin: true,
-    },
-  },
+const emptyVppHandler = http.get(baseUrl("/vpp_tokens"), () => {
+  return HttpResponse.json({ vpp_tokens: [] });
+});
+
+const labelsHandler = http.get(baseUrl("/labels/summary"), () => {
+  return HttpResponse.json({ labels: [] });
+});
+
+const teamMismatchVppHandler = http.get(baseUrl("/vpp_tokens"), () => {
+  return HttpResponse.json({
+    vpp_tokens: [
+      {
+        id: 1,
+        org_name: "Test Org",
+        location: "US",
+        renew_date: "2027-01-01",
+        teams: [{ team_id: 999, name: "Other fleet" }],
+      },
+    ],
+  });
 });
 
 describe("SoftwareAppStoreVpp", () => {
@@ -26,19 +38,20 @@ describe("SoftwareAppStoreVpp", () => {
     mockServer.resetHandlers();
   });
 
-  it("shows enable VPP message when no VPP tokens exist", async () => {
-    mockServer.use(
-      http.get(baseUrl("/vpp_tokens"), () => {
-        return HttpResponse.json({ vpp_tokens: [] });
-      }),
-      http.get(baseUrl("/labels/summary"), () => {
-        return HttpResponse.json({ labels: [] });
-      })
-    );
+  it("shows enable VPP button for admins when no VPP tokens exist", async () => {
+    mockServer.use(emptyVppHandler, labelsHandler);
 
-    renderWithContext(
-      <SoftwareAppStoreVpp currentTeamId={1} router={router} />
-    );
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: true,
+        },
+      },
+    });
+
+    render(<SoftwareAppStoreVpp currentTeamId={1} router={router} />);
 
     await waitFor(() => {
       expect(
@@ -54,29 +67,50 @@ describe("SoftwareAppStoreVpp", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows add fleet to VPP message when team has no VPP token", async () => {
-    mockServer.use(
-      http.get(baseUrl("/vpp_tokens"), () => {
-        return HttpResponse.json({
-          vpp_tokens: [
-            {
-              id: 1,
-              org_name: "Test Org",
-              location: "US",
-              renew_date: "2027-01-01",
-              teams: [{ team_id: 999, name: "Other fleet" }],
-            },
-          ],
-        });
-      }),
-      http.get(baseUrl("/labels/summary"), () => {
-        return HttpResponse.json({ labels: [] });
-      })
-    );
+  it("shows ask your admin copy for non-admins when no VPP tokens exist", async () => {
+    mockServer.use(emptyVppHandler, labelsHandler);
 
-    renderWithContext(
-      <SoftwareAppStoreVpp currentTeamId={1} router={router} />
-    );
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: false,
+          isAnyTeamAdmin: false,
+        },
+      },
+    });
+
+    render(<SoftwareAppStoreVpp currentTeamId={1} router={router} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Volume Purchasing Program \(VPP\) isn't enabled/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("To add App Store apps, ask your admin to enable VPP.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Enable VPP" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows add fleet to VPP button for admins when team has no VPP token", async () => {
+    mockServer.use(teamMismatchVppHandler, labelsHandler);
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: true,
+        },
+      },
+    });
+
+    render(<SoftwareAppStoreVpp currentTeamId={1} router={router} />);
 
     await waitFor(() => {
       expect(
@@ -89,5 +123,39 @@ describe("SoftwareAppStoreVpp", () => {
     expect(
       screen.getByRole("button", { name: "Edit VPP" })
     ).toBeInTheDocument();
+  });
+
+  it("shows ask your admin copy for non-admins when team has no VPP token", async () => {
+    mockServer.use(teamMismatchVppHandler, labelsHandler);
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: false,
+          isAnyTeamAdmin: false,
+        },
+      },
+    });
+
+    render(<SoftwareAppStoreVpp currentTeamId={1} router={router} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /This fleet isn't added to Volume Purchasing Program \(VPP\)/i
+        )
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        "To add App Store apps, ask your admin to add this fleet to VPP."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit VPP" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tests.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import mockServer from "test/mock-server";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+
+import SoftwareAppStoreVpp from "./SoftwareAppStoreVpp";
+
+const baseUrl = (path: string) => `/api/latest/fleet${path}`;
+
+const router = createMockRouter();
+
+const renderWithContext = createCustomRenderer({
+  withBackendMock: true,
+  context: {
+    app: {
+      isPremiumTier: true,
+      isGlobalAdmin: true,
+    },
+  },
+});
+
+describe("SoftwareAppStoreVpp", () => {
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  it("shows enable VPP message when no VPP tokens exist", async () => {
+    mockServer.use(
+      http.get(baseUrl("/vpp_tokens"), () => {
+        return HttpResponse.json({ vpp_tokens: [] });
+      }),
+      http.get(baseUrl("/labels/summary"), () => {
+        return HttpResponse.json({ labels: [] });
+      })
+    );
+
+    renderWithContext(
+      <SoftwareAppStoreVpp currentTeamId={1} router={router} />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Volume Purchasing Program \(VPP\) isn't enabled/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("To add App Store apps, first enable VPP.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Enable VPP" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows add fleet to VPP message when team has no VPP token", async () => {
+    mockServer.use(
+      http.get(baseUrl("/vpp_tokens"), () => {
+        return HttpResponse.json({
+          vpp_tokens: [
+            {
+              id: 1,
+              org_name: "Test Org",
+              location: "US",
+              renew_date: "2027-01-01",
+              teams: [{ team_id: 999, name: "Other fleet" }],
+            },
+          ],
+        });
+      }),
+      http.get(baseUrl("/labels/summary"), () => {
+        return HttpResponse.json({ labels: [] });
+      })
+    );
+
+    renderWithContext(
+      <SoftwareAppStoreVpp currentTeamId={1} router={router} />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /This fleet isn't added to Volume Purchasing Program \(VPP\)/i
+        )
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Edit VPP" })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -102,10 +102,7 @@ const SoftwareAppStoreVpp = ({
   router,
 }: ISoftwareAppStoreProps) => {
   const { renderFlash } = useContext(NotificationContext);
-  const { isPremiumTier, isGlobalAdmin, isAnyTeamAdmin } = useContext(
-    AppContext
-  );
-  const isAdmin = !!(isGlobalAdmin || isAnyTeamAdmin);
+  const { isPremiumTier, isGlobalAdmin } = useContext(AppContext);
   const queryClient = useQueryClient();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -240,7 +237,7 @@ const SoftwareAppStoreVpp = ({
       return (
         <EnableVppMessage
           onEnableVpp={() => router.push(PATHS.ADMIN_INTEGRATIONS_VPP)}
-          isAdmin={isAdmin}
+          isAdmin={!!isGlobalAdmin}
         />
       );
     }
@@ -249,7 +246,7 @@ const SoftwareAppStoreVpp = ({
       return (
         <AddTeamToVppMessage
           onEditVpp={() => router.push(PATHS.ADMIN_INTEGRATIONS_VPP)}
-          isAdmin={isAdmin}
+          isAdmin={!!isGlobalAdmin}
         />
       );
     }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -35,27 +35,41 @@ const baseClass = "software-app-store-vpp";
 
 interface IEnableVppMessage {
   onEnableVpp: () => void;
+  isAdmin: boolean;
 }
 
-const EnableVppMessage = ({ onEnableVpp }: IEnableVppMessage) => (
+const EnableVppMessage = ({ onEnableVpp, isAdmin }: IEnableVppMessage) => (
   <EmptyState
     variant="list"
     header="Volume Purchasing Program (VPP) isn't enabled"
-    info="To add App Store apps, first enable VPP."
-    primaryButton={<Button onClick={onEnableVpp}>Enable VPP</Button>}
+    info={
+      isAdmin
+        ? "To add App Store apps, first enable VPP."
+        : "To add App Store apps, ask your admin to enable VPP."
+    }
+    primaryButton={
+      isAdmin ? <Button onClick={onEnableVpp}>Enable VPP</Button> : undefined
+    }
   />
 );
 
 interface IAddTeamToVppMessage {
   onEditVpp: () => void;
+  isAdmin: boolean;
 }
 
-const AddTeamToVppMessage = ({ onEditVpp }: IAddTeamToVppMessage) => (
+const AddTeamToVppMessage = ({ onEditVpp, isAdmin }: IAddTeamToVppMessage) => (
   <EmptyState
     variant="list"
     header="This fleet isn't added to Volume Purchasing Program (VPP)"
-    info="To add App Store apps, first add this fleet to VPP."
-    primaryButton={<Button onClick={onEditVpp}>Edit VPP</Button>}
+    info={
+      isAdmin
+        ? "To add App Store apps, first add this fleet to VPP."
+        : "To add App Store apps, ask your admin to add this fleet to VPP."
+    }
+    primaryButton={
+      isAdmin ? <Button onClick={onEditVpp}>Edit VPP</Button> : undefined
+    }
   />
 );
 
@@ -88,7 +102,10 @@ const SoftwareAppStoreVpp = ({
   router,
 }: ISoftwareAppStoreProps) => {
   const { renderFlash } = useContext(NotificationContext);
-  const { isPremiumTier } = useContext(AppContext);
+  const { isPremiumTier, isGlobalAdmin, isAnyTeamAdmin } = useContext(
+    AppContext
+  );
+  const isAdmin = !!(isGlobalAdmin || isAnyTeamAdmin);
   const queryClient = useQueryClient();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -223,6 +240,7 @@ const SoftwareAppStoreVpp = ({
       return (
         <EnableVppMessage
           onEnableVpp={() => router.push(PATHS.ADMIN_INTEGRATIONS_VPP)}
+          isAdmin={isAdmin}
         />
       );
     }
@@ -231,6 +249,7 @@ const SoftwareAppStoreVpp = ({
       return (
         <AddTeamToVppMessage
           onEditVpp={() => router.push(PATHS.ADMIN_INTEGRATIONS_VPP)}
+          isAdmin={isAdmin}
         />
       );
     }


### PR DESCRIPTION
## Issue
Closes #44616 

## Description 
- Match Android MDM enable state to VPP enable state
- Conditional enable state for non-global admins that they need to ask their admin to enable (removes dead link to enable for those users)

## Screenshot

<img width="1438" height="675" alt="Screenshot 2026-05-01 at 4 32 42 PM" src="https://github.com/user-attachments/assets/a0d45a84-3f8f-4a20-8c1a-c9fb945554fa" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Android MDM setup now displays configuration-aware messaging with role-based action buttons.
  * VPP setup messaging is now role-based, with setup actions shown only to administrators.

* **Tests**
  * Added test coverage for Android MDM configuration and admin role scenarios.
  * Added test coverage for VPP token and team configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->