### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/dialpad/darwin.json
+++ b/ee/maintained-apps/outputs/dialpad/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2603.3.5",
+      "version": "2604.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2603.3.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2604.0.0') < 0);"
       },
       "installer_url": "https://download.dialpad.com/osx/arm64/dialpad.pkg",
       "install_script_ref": "d3e137fc",

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.162.2",
+      "version": "7.162.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.162.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.162.5') < 0);"
       },
-      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.162.2-win-x64.exe",
+      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.162.5-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "ac6f4aee85316193a5802c0a7ee159ed4cdf2ec5353a2150a4de71a45373489a",
+      "sha256": "a47361db025ac3c4c6eeb33c360adec84da7420c2949cae0ab5a2ae84ca1fd3c",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated supported Dialpad version to 2604.0.0 for macOS with corresponding patch detection updates
- Updated supported Granola version to 7.162.5 for Windows, including new installer package and updated verification checksums

<!-- end of auto-generated comment: release notes by coderabbit.ai -->