### PR TITLE
Website: update homepage hero mobile styles

### DIFF
--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -1249,6 +1249,7 @@
     }
     [purpose='homepage-hero'] {
       padding-top: 32px;
+      height: 770px;
 
     }
     [purpose='homepage-content'] {

--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -1249,7 +1249,7 @@
     }
     [purpose='homepage-hero'] {
       padding-top: 32px;
-      height: 770px;
+      height: 790px;
 
     }
     [purpose='homepage-content'] {


### PR DESCRIPTION
Changes:
- Updated the height of the homepage hero at <575px screen widths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the homepage hero layout on small screens to use a fixed height at the mobile breakpoint, ensuring more predictable spacing and visual balance.
  * This change improves consistency of the hero section across narrow viewports and reduces layout shifts when viewing the site on phones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->