### PR TITLE
osquery: stop conditional access ticker after wait

### DIFF
--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2587,7 +2587,9 @@ func (svc *Service) setHostConditionalAccess(
 		)
 		logger.DebugContext(ctx, "set compliance status message sent")
 		startTime := time.Now()
-		for range time.Tick(conditionalAccessSetWaitTime) {
+		ticker := time.NewTicker(conditionalAccessSetWaitTime)
+		defer ticker.Stop()
+		for range ticker.C {
 			if time.Since(startTime) > timeout {
 				return ctxerr.Errorf(ctx, "timeout waiting for message after %s", time.Since(startTime))
 			}


### PR DESCRIPTION
Closes #42901. `time.Tick` leaks the ticker on every macOS host checkin with Microsoft Conditional Access enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved resource management in the macOS conditional access polling process to prevent potential resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->