### PR TITLE
service: nil-check empty FMA versions before indexing

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2241,6 +2241,9 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 			if err != nil {
 				return fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
 			}
+			if len(versions) == 0 {
+				return fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
+			}
 
 			// This is a bit inefficient as we are duplicating strings for categories and install/uninstall scripts,
 			// but it can be optimized in softwareBatchUpload if it accepted only passing category and script content IDs.


### PR DESCRIPTION
Closes #44542. `software.fleet_maintained_apps[].version: "^99"` returned an empty FMA versions slice; the bare `versions[0]` panicked the server with `index out of range [0] with length 0`. Return the documented `errMajorVersionNotFound` error instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling for software installer version requests to properly return a "not found" error when requested major versions are unavailable, preventing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->