### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/dbeaver-community/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-community/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.0.3",
+      "version": "26.0.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.0.4') < 0);"
       },
-      "installer_url": "https://dbeaver.io/files/26.0.3/dbeaver-ce-26.0.3-macos-aarch64.dmg",
+      "installer_url": "https://dbeaver.io/files/26.0.4/dbeaver-ce-26.0.4-macos-aarch64.dmg",
       "install_script_ref": "15b32d4c",
       "uninstall_script_ref": "d5f7201c",
-      "sha256": "bfc0902d04403b32d8d4fab120417368aa374622dbfe2f508713d06474ae82e2",
+      "sha256": "46434f6293ca270da728e9d1f3ad19198678e7f1b5e32d39d9779258a116be04",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/lulu/darwin.json
+++ b/ee/maintained-apps/outputs/lulu/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.1",
+      "version": "4.3.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app' AND version_compare(bundle_short_version, '4.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app' AND version_compare(bundle_short_version, '4.3.2') < 0);"
       },
-      "installer_url": "https://github.com/objective-see/LuLu/releases/download/v4.3.1/LuLu_4.3.1.dmg",
+      "installer_url": "https://github.com/objective-see/LuLu/releases/download/v4.3.2/LuLu_4.3.2.dmg",
       "install_script_ref": "ce9e2a3c",
       "uninstall_script_ref": "94fe3378",
-      "sha256": "cc0366527f1f4123295fd13329a08031a660afd256076ddab03e6074365cef93",
+      "sha256": "651d85539cb7008b33b8571215a8b8040f4f26d77306675e9c8972294a80f541",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.12.12",
+      "version": "2.12.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.13') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.12/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.13/Stats.dmg",
       "install_script_ref": "4e50c2e6",
       "uninstall_script_ref": "9c854aeb",
-      "sha256": "4acaf32dde402016fa390cfcfd7afd162c309cd46480528d28915041b4451ffd",
+      "sha256": "4f64594886a09647caf1750978f6b90fac84787b7f2d2c764ccc5cb0e775e088",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.04.27.15.32.03",
+      "version": "0.2026.04.29.08.57.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.04.27.15.32.03') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.04.29.08.57.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.04.27.15.32.stable_03/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.04.29.08.57.stable_01/Warp.dmg",
       "install_script_ref": "ec5da61d",
       "uninstall_script_ref": "54d05203",
       "sha256": "no_check",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS application configurations to support new versions:
    * DBeaver Community 26.0.4
    * Lulu 4.3.2
    * Stats 2.12.13
    * Warp 0.2026.04.29.08.57.01

<!-- end of auto-generated comment: release notes by coderabbit.ai -->