### PR TITLE
Fleet UI: Fix dataset text alignment

### DIFF
--- a/changes/43688-fix-text-alignment-issues
+++ b/changes/43688-fix-text-alignment-issues
@@ -1,0 +1,1 @@
+* Fleet UI: Fix subtle text alignment issues

--- a/frontend/components/DataSet/DataSet.tsx
+++ b/frontend/components/DataSet/DataSet.tsx
@@ -7,6 +7,12 @@ interface IDataSetProps {
   title: React.ReactNode;
   value: React.ReactNode;
   orientation?: "horizontal" | "vertical";
+  /** When true, aligns the value row by text baseline instead of vertical
+   * center. Use this when the value contains only text (with or without
+   * tooltips) so neighboring DataSets in a horizontal row share the same
+   * baseline. Do NOT use when the value contains icons, buttons, or status
+   * indicators that need vertical centering. */
+  textOnly?: boolean;
   className?: string;
 }
 
@@ -14,10 +20,12 @@ const DataSet = ({
   title,
   value,
   orientation = "vertical",
+  textOnly = false,
   className,
 }: IDataSetProps) => {
   const classNames = classnames(baseClass, className, {
     [`${baseClass}__horizontal`]: orientation === "horizontal",
+    [`${baseClass}--text-only`]: textOnly,
   });
 
   return (

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -7,7 +7,7 @@
   dt {
     font-weight: $bold;
     display: flex;
-    align-items: baseline;
+    align-items: baseline; // Aligns titles with and without tooltips
     color: $core-fleet-black;
     line-height: $line-height;
   }

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -7,6 +7,7 @@
   dt {
     font-weight: $bold;
     display: flex;
+    align-items: baseline;
     color: $core-fleet-black;
     line-height: $line-height;
   }
@@ -16,6 +17,10 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  &--text-only dd {
+    align-items: baseline;
   }
 
   &__horizontal {

--- a/frontend/components/DeviceUserError/_styles.scss
+++ b/frontend/components/DeviceUserError/_styles.scss
@@ -44,6 +44,6 @@
     font-weight: normal;
     font-size: $x-small;
     text-align: center;
-    line-height: 21px; // Matches design
+    line-height: $line-height;
   }
 }

--- a/frontend/components/EmptyState/_styles.scss
+++ b/frontend/components/EmptyState/_styles.scss
@@ -111,7 +111,7 @@ $ghost-cell-padding-x: $pad-large; // 24px, matches Figma
     h3 {
       font-size: $small; // 16px per Figma
       font-weight: $bold;
-      line-height: 1.5;
+      line-height: $line-height;
       color: $core-fleet-black;
       margin: 0;
     }
@@ -121,7 +121,7 @@ $ghost-cell-padding-x: $pad-large; // 24px, matches Figma
   &__additional-info {
     @include help-text;
 
-    line-height: 1.5;
+    line-height: $line-height;
     text-align: center;
     margin: 0;
   }

--- a/frontend/components/IconStatusMessage/_styles.scss
+++ b/frontend/components/IconStatusMessage/_styles.scss
@@ -15,5 +15,5 @@
 
 .icon-status-message__content {
   flex: 1;
-  line-height: 1.5;
+  line-height: $line-height;
 }

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -25,7 +25,7 @@
   &__content-wrapper {
     margin-top: $pad-large;
     font-size: $x-small;
-    line-height: 1.5;
+    line-height: $line-height;
 
     .input-field {
       width: 100%;

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -10,11 +10,12 @@
     line-height: inherit; // Same line height as parent
   }
 
+  // text-decoration dashed cannot be used as it's not firefox compatible so must use border-bottom
+  // margin-bottom -1px is to compensate for the 1px height of the underline using border-bottom
   &__underline {
     width: fit-content;
-    text-decoration: underline dashed $ui-fleet-black-50;
-    text-decoration-thickness: 0.9px;
-    text-underline-offset: 3px;
+    border-bottom: 1px dashed $ui-fleet-black-50;
+    margin-bottom: -1px;
   }
 
   &__tip-text {

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -13,6 +13,7 @@
   &__underline {
     width: fit-content;
     text-decoration: underline dashed $ui-fleet-black-50;
+    text-decoration-thickness: 0.9px;
     text-underline-offset: 3px;
   }
 

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -7,31 +7,16 @@
 
   &__element {
     white-space: nowrap;
-    line-height: initial;
+    line-height: inherit; // Same line height as parent
   }
 
   &__underline {
     width: fit-content;
-    border-bottom: 1px dashed $ui-fleet-black-50;
+    text-decoration: underline dashed $ui-fleet-black-50;
+    text-underline-offset: 3px;
   }
 
   &__tip-text {
     @include tooltip-text;
-  }
-}
-
-// for firefox we need to slightly shift the tooltip text to fit in line with the
-// other text next to the tooltip. This is because firefox renders the layout
-// slightly differently than webkit and edge, which makes it appear higher
-// than text next to it.
-// TODO: investigate more to see if there is a solution that will work
-// cross browser.
-@-moz-document url-prefix() {
-  .component__tooltip-wrapper {
-    &__underline {
-      position: relative;
-      top: 2px;
-      padding-bottom: 1px;
-    }
   }
 }

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -228,7 +228,7 @@ $base-class: "button";
     margin: 0;
     padding: 0;
     height: auto;
-    line-height: normal;
+    line-height: $line-height;
     display: inline-flex;
     align-items: center;
     gap: $pad-xsmall;
@@ -246,8 +246,6 @@ $base-class: "button";
       top: 0;
     }
   }
-
-
 
   // &--icon is used for svg icon buttons without text
   &--text-icon,

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -79,7 +79,7 @@
   &__help-text {
     font-size: $x-small;
     font-weight: $regular;
-    line-height: $line-height7;
+    line-height: $line-height;
     letter-spacing: 1px;
     color: $core-fleet-blue;
 

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -1,5 +1,5 @@
 .input-field {
-  line-height: 1.5;
+  line-height: $line-height;
   background-color: $core-fleet-white;
   border: solid 1px $ui-fleet-black-10;
   border-radius: $border-radius;
@@ -79,7 +79,7 @@
   &__help-text {
     font-size: $x-small;
     font-weight: $regular;
-    line-height: 1.57;
+    line-height: $line-height7;
     letter-spacing: 1px;
     color: $core-fleet-blue;
 

--- a/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/_styles.scss
@@ -25,8 +25,6 @@
     }
 
     .component__tooltip-wrapper__underline {
-      border-bottom: none;
-      text-decoration: underline dashed $ui-fleet-black-50;
       text-underline-offset: 5px;
     }
   }

--- a/frontend/components/side_panels/QuerySidePanel/QueryTableNotes/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTableNotes/_styles.scss
@@ -6,10 +6,9 @@
 
   // overriding default FleetMarkdown styles here
   &__notes-markdown {
-
     li {
       margin-bottom: $pad-medium;
-      line-height: 1.5;
+      line-height: $line-height;
 
       &:last-child {
         margin-bottom: 0;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityTypeDropdown/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityTypeDropdown/_styles.scss
@@ -4,7 +4,7 @@
     top: 0;
     padding-top: $pad-small;
     background-color: $core-fleet-white;
-   
+
     .icon {
       position: absolute;
       left: 12px;
@@ -14,7 +14,7 @@
 
   &__search-input {
     width: 100%;
-    line-height: 1.5;
+    line-height: $line-height;
     background-color: $core-fleet-white;
     border: solid 1px $ui-fleet-black-10;
     border-radius: $border-radius;

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
@@ -62,14 +62,12 @@ const SoftwareVulnSummary = ({
             {cvss_score && (
               <DataSet
                 title={
-                  <TooltipWrapper
-                    tipContent="The worst case impact across different environments (CVSS version 3.x base score). This data is reported by the National Vulnerability Database (NVD)."
-                    // to match neighboring tooltip wrapper
-                  >
+                  <TooltipWrapper tipContent="The worst case impact across different environments (CVSS version 3.x base score). This data is reported by the National Vulnerability Database (NVD).">
                     Severity
                   </TooltipWrapper>
                 }
                 value={cvss_score}
+                textOnly
               />
             )}
             {epss_probability && (
@@ -83,7 +81,6 @@ const SoftwareVulnSummary = ({
                   <ProbabilityOfExploit
                     probabilityOfExploit={epss_probability}
                     cisaKnownExploit={cisa_known_exploit}
-                    // to avoid tooltip wrapper above
                     tooltipPosition="bottom"
                   />
                 }
@@ -109,6 +106,7 @@ const SoftwareVulnSummary = ({
                     tooltipPosition="bottom"
                   />
                 }
+                textOnly
               />
             )}
           </>
@@ -129,6 +127,7 @@ const SoftwareVulnSummary = ({
               tooltipPosition="bottom"
             />
           }
+          textOnly
         />
         <DataSet
           title="Affected hosts"
@@ -145,6 +144,7 @@ const SoftwareVulnSummary = ({
               lastUpdatedAt={hosts_count_updated_at}
             />
           }
+          textOnly
         />
       </dl>
     </Card>

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
@@ -25,16 +25,10 @@
     flex-direction: row;
     gap: 24px 40px;
     flex-wrap: wrap;
+    align-items: baseline;
 
-    .data-set {
-      height: 40px;
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-
-      .component__tooltip-wrapper__underline {
-        top: 0;
-      }
+    .data-set .component__tooltip-wrapper__underline {
+      top: 0;
     }
 
     .tooltip__tooltip-text {

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
@@ -9,10 +9,6 @@
     &__links {
       display: flex;
       gap: 1.2rem;
-
-      .component__tooltip-wrapper__underline {
-        top: 0;
-      }
     }
   }
 
@@ -26,10 +22,6 @@
     gap: 24px 40px;
     flex-wrap: wrap;
     align-items: baseline;
-
-    .data-set .component__tooltip-wrapper__underline {
-      top: 0;
-    }
 
     .tooltip__tooltip-text {
       white-space: pre-wrap;

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
@@ -14,7 +14,7 @@
 
   &__description {
     font-size: $x-small;
-    line-height: 21px;
+    line-height: $line-height;
   }
 
   &__description-list {

--- a/frontend/pages/SoftwarePage/components/cards/DetailsNoHosts/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/cards/DetailsNoHosts/_styles.scss
@@ -4,7 +4,7 @@
   text-align: center;
   * {
     font-size: $x-small;
-    line-height: 21px;
+    line-height: $line-height;
     margin: 0;
   }
 }

--- a/frontend/pages/admin/OrgSettingsPage/_styles.scss
+++ b/frontend/pages/admin/OrgSettingsPage/_styles.scss
@@ -13,7 +13,7 @@
     }
 
     .info-banner {
-      line-height: 1.5;
+      line-height: $line-height;
     }
 
     .app-config-form {

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/_styles.scss
@@ -25,7 +25,7 @@
 
   &__input {
     width: 100%;
-    line-height: 1.5;
+    line-height: $line-height;
     background-color: $core-fleet-white;
     border: solid 1px $ui-fleet-black-10;
     border-radius: $border-radius;

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/_styles.scss
@@ -25,7 +25,7 @@
 
   .textarea-wrapper {
     font-size: $x-small;
-    line-height: 1.5;
+    line-height: $line-height;
     width: 100%;
   }
   &__failure-state {

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportCard.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportCard.tsx
@@ -105,6 +105,7 @@ const HostReportCard = ({
             key={key}
             title={key}
             value={<TooltipTruncatedText value={value} />}
+            textOnly
           />
         ))}
       </div>

--- a/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
+++ b/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
@@ -73,13 +73,18 @@ const InventoryVersion = ({
       borderRadiusSize="medium"
     >
       <div className={`${baseClass}__row`}>
-        <DataSet title="Version" value={version.version} />
+        <DataSet title="Version" value={version.version} textOnly />
         <DataSet
           title="Type"
           value={formatSoftwareType({ source, extension_for })}
+          textOnly
         />
         {bundleIdentifier && (
-          <DataSet title="Bundle identifier" value={bundleIdentifier} />
+          <DataSet
+            title="Bundle identifier"
+            value={bundleIdentifier}
+            textOnly
+          />
         )}
         {version.last_opened_at !== undefined && (
           <DataSet
@@ -89,6 +94,7 @@ const InventoryVersion = ({
                 ? dateAgo(version.last_opened_at)
                 : "Never"
             }
+            textOnly
           />
         )}
       </div>

--- a/frontend/pages/labels/components/LabelForm/_styles.scss
+++ b/frontend/pages/labels/components/LabelForm/_styles.scss
@@ -9,7 +9,7 @@
     font-size: $x-small;
     font-weight: $regular;
     color: $ui-fleet-black-75;
-    line-height: 1.5;
+    line-height: $line-height;
   }
 
   &__label-platform {

--- a/frontend/pages/policies/live/LivePolicyPage/_styles.scss
+++ b/frontend/pages/policies/live/LivePolicyPage/_styles.scss
@@ -44,7 +44,7 @@
   &__empty-entity-search {
     margin-top: $pad-small;
     font-size: $x-small;
-    line-height: 21px; /* 150% */
+    line-height: $line-height;
   }
 
   &__targets-button-wrap {

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -149,9 +149,4 @@
       }
     }
   }
-  .reveal-button {
-    .component__tooltip-wrapper__underline {
-      position: initial;
-    }
-  }
 }

--- a/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
+++ b/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
@@ -27,9 +27,6 @@
     display: flex;
     gap: $pad-large;
     font-size: $x-small;
-    .component__tooltip-wrapper__underline {
-      top: 0px;
-    }
   }
 
   &__automations,

--- a/frontend/pages/queries/live/LiveQueryPage/_styles.scss
+++ b/frontend/pages/queries/live/LiveQueryPage/_styles.scss
@@ -45,7 +45,7 @@
   &__empty-entity-search {
     margin-top: $pad-small;
     font-size: $x-small;
-    line-height: 21px; /* 150% */
+    line-height: $line-height;
   }
 
   &__targets-button-wrap {

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -14,7 +14,7 @@ body {
   font-family: "Inter", sans-serif;
   font-size: $medium;
   height: 100%;
-  line-height: 1.5;
+  line-height: $line-height;
 }
 
 // Applied briefly by theme.ts during toggle to fade all colors smoothly.
@@ -76,7 +76,7 @@ p {
   // Desired default line-height for text is 1.5x the font size for paragrah text.
   // This allows for a comfortable reading experience by adding space between
   // multiline paragraphs.
-  line-height: 1.5;
+  line-height: $line-height;
   font-size: $x-small;
 }
 

--- a/frontend/styles/var/fonts.scss
+++ b/frontend/styles/var/fonts.scss
@@ -10,5 +10,5 @@ $large: px-to-rem(24);
 $regular: 400;
 $bold: 600;
 
-$line-height: $line-height;
+$line-height: 1.5;
 $line-height-large: 1.75;

--- a/frontend/styles/var/fonts.scss
+++ b/frontend/styles/var/fonts.scss
@@ -10,5 +10,5 @@ $large: px-to-rem(24);
 $regular: 400;
 $bold: 600;
 
-$line-height: 1.5;
+$line-height: $line-height;
 $line-height-large: 1.75;


### PR DESCRIPTION
## Issue
Closes #43688 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subtle text alignment inconsistencies across data displays and tooltip-bearing elements for more consistent baseline alignment.

* **Style**
  * Standardized line-height across components using a shared design token for improved typographic consistency.
  * Refined tooltip underline spacing and related text rendering for more accurate visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenrecording and screenshots

### Chrome screen recording

https://fleetdm.zoom.us/clips/share/qr3cY0NHTGuYqCX-vHWY3w

### Safari screenshots

<img width="1521" height="753" alt="Screenshot 2026-05-04 at 12 08 41 PM" src="https://github.com/user-attachments/assets/2e6ebb53-973f-4709-85f7-12ebdc392bcf" />
<img width="1459" height="650" alt="Screenshot 2026-05-04 at 12 08 23 PM" src="https://github.com/user-attachments/assets/017d1f6f-f956-4b64-8be1-92713393e8b9" />


### Firefox screenshots

<img width="1280" height="796" alt="Screenshot 2026-05-04 at 12 03 38 PM" src="https://github.com/user-attachments/assets/47bc6ff5-8737-4e95-808b-5bc85060fe80" />
<img width="1279" height="840" alt="Screenshot 2026-05-04 at 12 03 26 PM" src="https://github.com/user-attachments/assets/7cec219b-e5f9-41c6-a2af-b12b0fc93e99" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually
