### PR TITLE
Load test terraform fixes

### DIFF
--- a/.github/workflows/loadtest-infra.yml
+++ b/.github/workflows/loadtest-infra.yml
@@ -171,6 +171,7 @@ jobs:
           if [[ `terraform workspace show` = "${{ inputs.terraform_workspace }}" ]];
           then
             echo "TERRAFORM WORKSPACE: MATCHES - ${{ inputs.terraform_workspace }}"
+            terraform apply -target='module.loadtest.module.byo-db.module.ecs.aws_iam_role.execution' -target='module.loadtest.module.byo-db.module.ecs.aws_iam_role.main[0]'
             terraform apply -auto-approve
           else
             echo "TERRAFORM WORKSPACE: DOES NOT MATCH INPUT - ${{ inputs.terraform_workspace }}"

--- a/.github/workflows/loadtest-infra.yml
+++ b/.github/workflows/loadtest-infra.yml
@@ -171,7 +171,7 @@ jobs:
           if [[ `terraform workspace show` = "${{ inputs.terraform_workspace }}" ]];
           then
             echo "TERRAFORM WORKSPACE: MATCHES - ${{ inputs.terraform_workspace }}"
-            terraform apply -target='module.loadtest.module.byo-db.module.ecs.aws_iam_role.execution' -target='module.loadtest.module.byo-db.module.ecs.aws_iam_role.main[0]'
+            terraform apply -target='module.loadtest.module.byo-db.module.ecs.aws_iam_role.execution' -target='module.loadtest.module.byo-db.module.ecs.aws_iam_role.main[0]' -auto-approve
             terraform apply -auto-approve
           else
             echo "TERRAFORM WORKSPACE: DOES NOT MATCH INPUT - ${{ inputs.terraform_workspace }}"

--- a/infrastructure/loadtesting/terraform/infra/docker.tf
+++ b/infrastructure/loadtesting/terraform/infra/docker.tf
@@ -27,7 +27,7 @@ resource "aws_ecr_repository" "fleet" {
 }
 
 resource "docker_image" "dockerhub" {
-  name = "fleetdm/fleet:${var.tag}"
+  name          = "fleetdm/fleet:${var.tag}"
   pull_triggers = [data.docker_registry_image.dockerhub.sha256_digest]
 }
 

--- a/infrastructure/loadtesting/terraform/infra/internal_alb.tf
+++ b/infrastructure/loadtesting/terraform/infra/internal_alb.tf
@@ -27,9 +27,9 @@ resource "aws_lb" "internal" {
   idle_timeout               = 905
   drop_invalid_header_fields = true
   access_logs {
-      bucket  = module.logging_alb.log_s3_bucket_id
-      prefix  = local.customer
-      enabled = true
+    bucket  = module.logging_alb.log_s3_bucket_id
+    prefix  = local.customer
+    enabled = true
   }
 }
 

--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -47,11 +47,11 @@ locals {
       FLEET_AUTH_SSO_SESSION_VALIDITY_PERIOD         = "15m"
       FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE            = "500"
       FLEET_SERVER_GZIP_RESPONSES                    = "true"
-      
+
 
       # Load TLS Certificate for RDS Authentication
-      FLEET_MYSQL_TLS_CA              = local.cert_path
-      FLEET_MYSQL_READ_REPLICA_TLS_CA = local.cert_path
+      FLEET_MYSQL_TLS_CA                  = local.cert_path
+      FLEET_MYSQL_READ_REPLICA_TLS_CA     = local.cert_path
       FLEET_MYSQL_READ_REPLICA_TLS_CONFIG = "custom"
     },
     local.otel_environment_variables,

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -48,6 +48,7 @@ module "loadtest" {
     # VPN
     subnets             = data.terraform_remote_state.shared.outputs.vpc.database_subnets
     allowed_cidr_blocks = concat(data.terraform_remote_state.shared.outputs.vpc.private_subnets_cidr_blocks, local.vpn_cidr_blocks)
+    monitoring_interval = 0
     db_parameters = {
       # 8mb up from 262144 (256k) default
       sort_buffer_size = 8388608
@@ -79,6 +80,17 @@ module "loadtest" {
   }
   ecs_cluster = {
     cluster_name = local.customer
+    cluster_configuration = {
+      execute_command_configuration = {
+        logging = "OVERRIDE"
+        log_configuration = {
+          cloud_watch_log_group_name = "/aws/ecs/${local.customer}"
+        }
+      }
+    }
+    cloudwatch_log_group = {
+      retention_in_days = 365
+    }
   }
   fleet_config = {
     image               = local.fleet_image

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -55,6 +55,9 @@ module "loadtest" {
     db_cluster_parameters = {
       require_secure_transport = "ON"
     }
+    observability = {
+      performance_insights_enabled = false
+    }
   }
   redis_config = {
     name                          = local.customer

--- a/infrastructure/loadtesting/terraform/infra/variables.tf
+++ b/infrastructure/loadtesting/terraform/infra/variables.tf
@@ -55,8 +55,8 @@ variable "redis_instance_count" {
   default     = 3
 
   validation {
-    condition     = var.redis_instance_count >= 3
-    error_message = "var.redis_instance_count must be greater than or equal to 3."
+    condition     = var.redis_instance_count >= 1
+    error_message = "var.redis_instance_count must be greater than or equal to 1."
   }
 }
 


### PR DESCRIPTION
- Disable performance insights
- Allow redis instance count >=1
- Properly set ecs_cluster logging config path
- Targeted apply with auto approve for pre-creating fleet and execution roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced ECS cluster logging with CloudWatch integration and extended log retention to 365 days.
  * Adjusted RDS monitoring configuration and disabled performance insights for operational optimization.
  * Reduced minimum Redis instance requirement from 3 to 1 for greater deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->