### PR TITLE
Add Fleet Desktop launch agent configuration profile

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -114,6 +114,7 @@ labels:
   - path: ./lib/all/labels/macs-with-microsoft-autoupdate-installed.yml
   - path: ./lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
   - path: ./lib/all/labels/macs-with-fleet-desktop-installed.yml
+  - path: ./lib/all/labels/macs-with-fleet-desktop-launch-agent-profile.yml
   - path: ./lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
   - path: ./lib/all/labels/departments.yml
   - path: ./lib/all/labels/idp-group-saml-aws-vpn.yml

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -117,6 +117,9 @@ controls:
       - path: ../lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
         labels_include_any:
           - "Microsoft AutoUpdate installed"
+      - path: ../lib/macos/configuration-profiles/fleet-desktop-launchagent.mobileconfig
+        labels_include_any:
+          - "Macs with Fleet Desktop.app installed"
   setup_experience:
     macos_bootstrap_package: ""
     enable_end_user_authentication: true

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -117,7 +117,7 @@ controls:
       - path: ../lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
         labels_include_any:
           - "Microsoft AutoUpdate installed"
-      - path: ../lib/macos/configuration-profiles/fleet-desktop-launchagent.mobileconfig
+      - path: ../lib/macos/configuration-profiles/fleet-desktop-launch-agent.mobileconfig
         labels_include_any:
           - "Macs with Fleet Desktop.app installed"
   setup_experience:
@@ -164,6 +164,7 @@ policies:
   # - path: ../lib/macos/policies/1password-installed.yml https://github.com/fleetdm/fleet/pull/44179
   # - path: ../lib/macos/policies/nudge-installed.yml
   - path: ../lib/macos/policies/install-nudge-assets.yml
+  - path: ../lib/macos/policies/install-fleet-desktop-launch-agent.yml
   - path: ../lib/macos/policies/santa-endpoint-security-extension-active.yml
   - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/macos/policies/battery-health-check.yml
@@ -218,6 +219,12 @@ software:
         - Productivity
     - path: ../lib/macos/software/nudge-assets.yml # Nudge assets for macOS
       self_service: false
+      categories:
+        - Utilities
+    - path: ../lib/macos/software/fleet-desktop-launch-agent.yml
+      self_service: false
+      labels_include_any:
+        - "Macs with Fleet Desktop.app launch agent MDM profile"
       categories:
         - Utilities
     - path: ../lib/macos/scripts/enable-touch-id-sudo.sh # Enable Touch ID for sudo

--- a/it-and-security/lib/all/labels/macs-with-fleet-desktop-launch-agent-profile.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-desktop-launch-agent-profile.yml
@@ -1,0 +1,5 @@
+- name: Macs with Fleet Desktop.app launch agent MDM profile
+  description: macOS hosts that have the Fleet Desktop.app launch agent configuration profile installed
+  query: SELECT 1 FROM macos_profiles WHERE identifier = 'com.fleetdm.profile.fleet-desktop-launchagent' LIMIT 1;
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launch-agent.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launch-agent.mobileconfig
@@ -33,9 +33,9 @@
         </dict>
     </array>
     <key>PayloadDescription</key>
-    <string>Configures managed Login and Background items for Fleet Desktop.</string>
+    <string>Configures managed Login and Background items for Fleet Desktop.app.</string>
     <key>PayloadDisplayName</key>
-    <string>Fleet Desktop login item management</string>
+    <string>Fleet Desktop.app login item management</string>
     <key>PayloadIdentifier</key>
     <string>com.fleetdm.profile.fleet-desktop-launchagent</string>
     <key>PayloadOrganization</key>

--- a/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launchagent.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launchagent.mobileconfig
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadDescription</key>
+            <string>Manages the Fleet Desktop.app launch agent so it can run at login without prompting the user.</string>
+            <key>PayloadDisplayName</key>
+            <string>Fleet Desktop.app launch agent</string>
+            <key>PayloadIdentifier</key>
+            <string>com.fleetdm.servicemanagement.fleet-desktop-launchagent</string>
+            <key>PayloadType</key>
+            <string>com.apple.servicemanagement</string>
+            <key>PayloadUUID</key>
+            <string>A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>Rules</key>
+            <array>
+                <dict>
+                    <key>RuleType</key>
+                    <string>Label</string>
+                    <key>RuleValue</key>
+                    <string>com.fleetdm.fleet-desktop-hidden</string>
+                    <key>TeamIdentifier</key>
+                    <string>8VBZ3948LU</string>
+                    <key>Comment</key>
+                    <string>Allow Fleet Desktop.app launch agent to run at login without user prompt.</string>
+                </dict>
+            </array>
+        </dict>
+    </array>
+    <key>PayloadDescription</key>
+    <string>Configures managed Login and Background items for Fleet Desktop.</string>
+    <key>PayloadDisplayName</key>
+    <string>Fleet Desktop login item management</string>
+    <key>PayloadIdentifier</key>
+    <string>com.fleetdm.profile.fleet-desktop-launchagent</string>
+    <key>PayloadOrganization</key>
+    <string>Fleet</string>
+    <key>PayloadRemovalDisallowed</key>
+    <true/>
+    <key>PayloadScope</key>
+    <string>System</string>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadUUID</key>
+    <string>F9E8D7C6-B5A4-4938-8271-605F4E3D2C1B</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+</dict>
+</plist>

--- a/it-and-security/lib/macos/policies/install-fleet-desktop-launch-agent.yml
+++ b/it-and-security/lib/macos/policies/install-fleet-desktop-launch-agent.yml
@@ -2,7 +2,7 @@
   query: SELECT 1 FROM package_receipts WHERE package_id = 'com.fleetdm.fleet-desktop-launchagent' LIMIT 1;
   critical: false
   description: Ensures the Fleet Desktop.app launch agent helper package is installed after the MDM profile is present.
-  resolution: Fleet installs this package when the policy fails. If it still fails after a refetch, contact #help-it. If the receipt never appears, confirm the installer package_id matches this policy query.
+  resolution: "Fleet installs the launch agent package after it verifies the MDM profile is present. If it still fails after a refetch, contact #help-it."
   install_software:
     package_path: ../software/fleet-desktop-launch-agent.yml
   labels_include_any:

--- a/it-and-security/lib/macos/policies/install-fleet-desktop-launch-agent.yml
+++ b/it-and-security/lib/macos/policies/install-fleet-desktop-launch-agent.yml
@@ -1,0 +1,10 @@
+- name: macOS - Fleet Desktop.app launch agent installed
+  query: SELECT 1 FROM package_receipts WHERE package_id = 'com.fleetdm.fleet-desktop-launchagent' LIMIT 1;
+  critical: false
+  description: Ensures the Fleet Desktop.app launch agent helper package is installed after the MDM profile is present.
+  resolution: Fleet installs this package when the policy fails. If it still fails after a refetch, contact #help-it. If the receipt never appears, confirm the installer package_id matches this policy query.
+  install_software:
+    package_path: ../software/fleet-desktop-launch-agent.yml
+  labels_include_any:
+    - "Macs with Fleet Desktop.app launch agent MDM profile"
+  platform: darwin

--- a/it-and-security/lib/macos/software/fleet-desktop-launch-agent.yml
+++ b/it-and-security/lib/macos/software/fleet-desktop-launch-agent.yml
@@ -1,0 +1,4 @@
+hash_sha256: 709ef77fc7b590a61d7d9da6754095d3e0749d42bf3b1607cf34fb3cd53c708d
+display_name: Fleet Desktop.app launch agent
+icon:
+  path: ../../all/icons/fleet-desktop-icon.png


### PR DESCRIPTION
Add a new macOS configuration profile (fleet-desktop-launchagent.mobileconfig) that configures managed login/background items to allow Fleet Desktop.app's launch agent to run at login without prompting the user. Also reference the profile in it-and-security/fleets/workstations.yml so hosts labeled as having Fleet Desktop.app installed will match the control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS configuration profile and software package to deploy Fleet Desktop.app launch agent via MDM, enabling the app to run at system login without user interaction on managed macOS devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->