### PR TITLE
docs: enumerate supported SAN keys for Android certificates (#41472)

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -854,7 +854,7 @@ How to deploy SCEP certificates to Android hosts:
 6. In **SubjSubject alternative name (SAN)**, enter the certificate's SAN. Separate SAN fields with a comma (`,`). Each field is a key-value pair. See [supported keys](https://fleetdm.com/docs/configuration/yaml-files#android-settings-certificates).
 7. Select **Save**. Fleet will deploy the certificate to your Android hosts.
 
-You can use [Fleet's host variables](https://fleetdm.com/docs/configuration/yaml-files#variables) in **Subject name** and **Subject alternative name** to make the certificate unique to each host.
+You can use [Fleet's host variables](https://fleetdm.com/guides/fleet-variables) in **Subject name** and **Subject alternative name** to make the certificate unique to each host.
 
 If something goes wrong, errors will appear on each host's **Host details > OS settings**.
 

--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -850,8 +850,11 @@ How to deploy SCEP certificates to Android hosts:
 2. In Fleet, head to **Controls > OS settings > Certificates** and select **Add certificate**.
 3. In **Name**, enter a name for the certificate (e.g., "wifi-certificate"). This name is used as the certificate alias to reference in configuration profiles (e.g. [WiFi configuration](https://developers.google.com/android/management/configure-networks#eap_authentication)).
 4. In **Certificate authority**, select the custom SCEP CA you created in step 1.
-5. In **Subject name**, enter the certificate's subject name (SN). Separate subject fields by a ",". You can use [Fleet's host variables](https://fleetdm.com/docs/configuration/yaml-files#variables) to make the certificate unique to each host. For example: `CN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME, OU=$FLEET_VAR_HOST_UUID, ST=$FLEET_VAR_HOST_HARDWARE_SERIAL`.
-6. Select **Save**. Fleet will deploy the certificate to your Android hosts.
+5. In **Subject name (SN)**, enter the certificate's subject name (SN). Separate subject fields with a comma (`,`). 
+6. In **SubjSubject alternative name (SAN)**, enter the certificate's SAN. Separate SAN fields with a comma (`,`). Each field is a key-value pair. See [supported keys](https://fleetdm.com/docs/configuration/yaml-files#android-settings-certificates).
+7. Select **Save**. Fleet will deploy the certificate to your Android hosts.
+
+You can use [Fleet's host variables](https://fleetdm.com/docs/configuration/yaml-files#variables) in **Subject name** and **Subject alternative name** to make the certificate unique to each host.
 
 If something goes wrong, errors will appear on each host's **Host details > OS settings**.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -503,7 +503,7 @@ Use `labels_include_all` to target hosts that have all labels, `labels_include_a
 
   Example: `"DNS=wifi.example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"`.
 
-You can use [Fleet's host variables](https://fleetdm.com/docs/configuration/yaml-files#variables) in `subject_name` and `subject_alternative_name` to make the certificate unique to each host.
+You can use [Fleet's host variables](https://fleetdm.com/guides/fleet-variables) in `subject_name` and `subject_alternative_name` to make the certificate unique to each host.
 
 #### Variables
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -493,15 +493,17 @@ Use `labels_include_all` to target hosts that have all labels, `labels_include_a
 
 - `name` is the name of the certificate. Name can be used as a certificate alias to reference in configuration profiles (custom settings).
 - `certificate_authority_name` is the name of the [certificate authority (CA)](#certificate-authorities) to issue the certificate from. Currently, only a custom SCEP CA is supported.
-- `subject_name` is the certificate's subject name (SN). Separate subject fields by a ",". For example: "/CN=john@example.com/O=Acme Inc.".
-- `subject_alternative_name` is the certificate's subject alternative name (SAN). Separate SAN fields by a ",". Each field is a `KEY=value` pair. Supported keys (case-insensitive) are:
+- `subject_name` is the certificate's subject name (SN). Separate subject fields with a comma (`,`). For example: "/CN=john@example.com/O=Acme Inc.".
+- `subject_alternative_name` is the certificate's subject alternative name (SAN). Separate SAN fields with a comma (`,`). Each field is a key-value pair. Supported keys (case-insensitive) are:
   - `DNS` for a DNS hostname (e.g. `DNS=wifi.example.com`).
   - `EMAIL` for an email address / RFC 822 name (e.g. `EMAIL=john@example.com`).
   - `UPN` for a Microsoft User Principal Name (e.g. `UPN=john@corp.example.com`), commonly used for Active Directory / Intune Wi-Fi authentication.
   - `IP` for an IPv4 or IPv6 address (e.g. `IP=10.0.0.1` or `IP=2001:db8::1`).
   - `URI` for a URI (e.g. `URI=spiffe://example.com/workload/wifi`).
 
-  Example: `"DNS=wifi.example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"`. Variables are supported in SAN values, with the same allow-list as `subject_name`.
+  Example: `"DNS=wifi.example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"`.
+
+You can use [Fleet's host variables](https://fleetdm.com/docs/configuration/yaml-files#variables) in `subject_name` and `subject_alternative_name` to make the certificate unique to each host.
 
 #### Variables
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -435,7 +435,7 @@ controls:
       - name: wifi-certificate
         certificate_authority_name: EST_WIFI
         subject_name: CN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME, OU=$FLEET_VAR_HOST_UUID, ST=$FLEET_VAR_HOST_HARDWARE_SERIAL
-        subject_alternative_name: "DNS=example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME
+        subject_alternative_name: "DNS=example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"
   setup_experience: # Available in Fleet Premium
     bootstrap_package: https://example.org/bootstrap_package.pkg
     enable_end_user_authentication: true
@@ -494,7 +494,14 @@ Use `labels_include_all` to target hosts that have all labels, `labels_include_a
 - `name` is the name of the certificate. Name can be used as a certificate alias to reference in configuration profiles (custom settings).
 - `certificate_authority_name` is the name of the [certificate authority (CA)](#certificate-authorities) to issue the certificate from. Currently, only a custom SCEP CA is supported.
 - `subject_name` is the certificate's subject name (SN). Separate subject fields by a ",". For example: "/CN=john@example.com/O=Acme Inc.".
-- `subject_alternative_name` is the certificate's subject alternative name (SAN). Separate fields by a ",". For example: "UPN=john@example".
+- `subject_alternative_name` is the certificate's subject alternative name (SAN). Separate SAN fields by a ",". Each field is a `KEY=value` pair. Supported keys (case-insensitive) are:
+  - `DNS` for a DNS hostname (e.g. `DNS=wifi.example.com`).
+  - `EMAIL` for an email address / RFC 822 name (e.g. `EMAIL=john@example.com`).
+  - `UPN` for a Microsoft User Principal Name (e.g. `UPN=john@corp.example.com`), commonly used for Active Directory / Intune Wi-Fi authentication.
+  - `IP` for an IPv4 or IPv6 address (e.g. `IP=10.0.0.1` or `IP=2001:db8::1`).
+  - `URI` for a URI (e.g. `URI=spiffe://example.com/workload/wifi`).
+
+  Example: `"DNS=wifi.example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"`. Variables are supported in SAN values, with the same allow-list as `subject_name`.
 
 #### Variables
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -754,8 +754,8 @@ Add a certificate template to deploy a certificate to all hosts on the fleet. Fl
 | name   | string | body | **Required.** The name of the certificate. Name can be used as certificate alias to reference in configuration profiles. |
 | fleet_id      | string  | body | _Available in Fleet Premium_. The ID of the fleet to add profiles to. |
 | certificate_authority_id   | integer | body | **Required.** The certificate authority (CA) ID to issue certificate from. Currently, only custom SCEP CA is supported. To get ID use [List certificate authorities](#list-certificate-authorities-cas). |
-| subject_name       | string | body |**Required** The certificate's subject name (SN). Separate subject fields by a ",". For example: "CN=john@example.com,O=Acme Inc.".    |
-| subject_alternative_name       | string | body | The certificate's subject alternative name (SAN). Separate SAN fields by a ",". Each field is a `KEY=value` pair. Supported keys (case-insensitive): `DNS` (DNS hostname), `EMAIL` (RFC 822 name / email), `UPN` (Microsoft User Principal Name, commonly used for Active Directory / Intune Wi-Fi auth), `IP` (IPv4 or IPv6 address), `URI`. Variables are supported with the same allow-list as `subject_name`. For example: `"DNS=wifi.example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"`.    |
+| subject_name       | string | body |**Required** The certificate's subject name (SN). Separate subject fields with a comma (`,`). For example: "CN=john@example.com,O=Acme Inc.".    |
+| subject_alternative_name       | string | body | The certificate's subject alternative name (SAN). Separate SAN fields with a comma (`,`). Each field is a key-value pair. See [supported keys](https://fleetdm.com/docs/configuration/yaml-files#android-settings-certificates). Example: `DNS=wifi.example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME`.    |
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -755,7 +755,7 @@ Add a certificate template to deploy a certificate to all hosts on the fleet. Fl
 | fleet_id      | string  | body | _Available in Fleet Premium_. The ID of the fleet to add profiles to. |
 | certificate_authority_id   | integer | body | **Required.** The certificate authority (CA) ID to issue certificate from. Currently, only custom SCEP CA is supported. To get ID use [List certificate authorities](#list-certificate-authorities-cas). |
 | subject_name       | string | body |**Required** The certificate's subject name (SN). Separate subject fields by a ",". For example: "CN=john@example.com,O=Acme Inc.".    |
-| subject_alternative_name       | string | body | The certificate's subject alternative name (SAN). Separate SAN fields by a ",". For example: "DNS=example.com,UPN=marko@example.com".    |
+| subject_alternative_name       | string | body | The certificate's subject alternative name (SAN). Separate SAN fields by a ",". Each field is a `KEY=value` pair. Supported keys (case-insensitive): `DNS` (DNS hostname), `EMAIL` (RFC 822 name / email), `UPN` (Microsoft User Principal Name, commonly used for Active Directory / Intune Wi-Fi auth), `IP` (IPv4 or IPv6 address), `URI`. Variables are supported with the same allow-list as `subject_name`. For example: `"DNS=wifi.example.com, UPN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"`.    |
 
 #### Example
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41472
