### PR TITLE
Remove TODO in story template comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -68,7 +68,7 @@ It is [planned and ready](https://fleetdm.com/handbook/company/development-group
 <!-- The following sections can be removed if they are inapplicable for this User Story -->
 
 #### Core flow
-<!-- Product TODO -->
+<!-- Product TO DO -->
 - TODO
 - TODO
 - TODO
@@ -97,7 +97,7 @@ It is [planned and ready](https://fleetdm.com/handbook/company/development-group
 
 #### Edge cases
 
-<!-- QA TODO: Replace the TODO below with relevant edge cases or remove this section if not applicable -->
+<!-- QA TO DO: Replace the TO DO below with relevant edge cases or remove this section if not applicable -->
 
 <!-- Edge case examples:
 1. Invalid or unexpected input values


### PR DESCRIPTION
Small QoL improvement. During standup, speccing, etc we check the board for stories with open TODOs. There have recently been some TODOs added in comments so while you can't find a TODO with ctrl+f if you edit the markdown you'll find one. This just makes them "TO DOs" in the comments so they don't get flagged by filtering for TODO if not removed. Actual visual content of template left alone