### PR TITLE
Require bug fixes to be manually validated in community PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -25,6 +25,7 @@ TODO
 
 ### 🧑‍💻  Steps to reproduce
 <!-- Provide step-by-step actions of how to recreate this bug in a clean install of Fleet. (This helps others understand and fix it more quickly.) -->
+<!-- PRs that fix this bug must include reproduction and manual verification. -->
 
 These steps:
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -96,6 +96,8 @@ If you're assigned a community pull request (PR) for review, it is important to 
 
 If the PR is a quick fix (i.e. typo) or obvious technical improvement that doesn't change the product, it can be merged.
 
+If the PR is a bug fix that the author has not validated manually, close the PR. Notify the author that the PR will be re-opened and reviewed after they validate the fix.
+
 Make sure to create a Github issue and link it to the PR so that we can track the changes in our release process. Make sure to assign the correct milestone to the issue (by having an issue, QA will make sure the fix is not causing regressions).
 
 **For PRs that change the product:**


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #
Changes to the handbook and bug issue template to address automated AI workflows that attempt to fix bugs, but don't include any manual verification.
