### PR TITLE
(WIP) Handbook: pause First Impressions, create BYOD working group, reshuffle Power to the PC

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -53,7 +53,7 @@ The goal of the MDM group is to increase and exceed [Fleet's product maturity go
 | Engineering Manager               | [George Karr](https://www.linkedin.com/in/george-karr-4977b441/) _([@georgekarrv](https://github.com/georgekarrv))_
 | Tech Lead                         | [Jordan Montgomery](https://www.linkedin.com/in/jordan-montgomery-54553651/) _([@JordanMontgomery](https://github.com/JordanMontgomery))_
 | Quality Assurance                 | [Christopher Noel](https://www.linkedin.com/in/chrstphr/) _([@chrstphr84](https://github.com/chrstphr84))_
-| Software Engineer                 | [Magnus Jensen](https://linkedin.com/in/magnus-holm-jensen) ([@MagnusHJensen](https://github.com/magnushjensen)), [Martin Angers](https://www.linkedin.com/in/martin-angers-3210305/) _([@mna](https://github.com/mna))_, Andrew Mellor _([@andymFleet](https://github.com/andymFleet))_
+| Software Engineer                 | [Magnus Jensen](https://linkedin.com/in/magnus-holm-jensen) ([@MagnusHJensen](https://github.com/magnushjensen)), [Martin Angers](https://www.linkedin.com/in/martin-angers-3210305/) _([@mna](https://github.com/mna))_
 
 **Areas of expertise**:
 - MDM protocol & configuration
@@ -202,6 +202,8 @@ The goal of the website group is to increase and exceed Fleet's product maturity
 
 ### First Impressions group
 
+> **Paused** as of 2026-05-04. Engineering capacity is being redirected to Power to the PC and the new BYOD working group. We expect to resume First Impressions after backfilling the open MDM SWE role.
+
 The goal of the First Impressions working group is to make changes to the core Fleet product that improve first impressions of Fleet at workshops, conferences, and demos.
 
 | Responsibility                    | Human(s)                  |
@@ -209,7 +211,7 @@ The goal of the First Impressions working group is to make changes to the core F
 | Product Designer                  | [Noah Talerman](https://www.linkedin.com/in/noah-talerman/) _([@noahtalerman](https://github.com/noahtalerman))_, [Mike McNeil](https://www.linkedin.com/in/mikermcneil/) _([@mikermcneil](https://github.com/mikermcneil))_
 | Engineering Manager               | [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
 | Quality Assurance                 | [Andrey Kizimenko](https://www.linkedin.com/in/andrey-kizimenko-988900214/) _([@AndreyKizimenko](https://github.com/AndreyKizimenko))_
-| Software Engineer                 | [Scott Gress](https://www.linkedin.com/in/scottgress/) _([@sgress454](https://github.com/sgress454))_, [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
+| Software Engineer                 | [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
 
 > The [Slack channel](https://fleetdm.slack.com/archives/C0ACJ8L1FD0), [kanban board](https://github.com/orgs/fleetdm/projects/105/), and [GitHub label](https://github.com/fleetdm/fleet/labels?q=%23g-first-impressions) for this working group is `#g-first-impressions`.
 
@@ -224,9 +226,26 @@ The goal of the Power to the PC working group is to empower Windows users to ful
 | Engineering Manager               | [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
 | Tech Lead                         | [Victor Lyuboslavsky](https://www.linkedin.com/in/lyuboslavsky/) _([@getvictor](https://github.com/getvictor))_
 | Quality Assurance                 | [Andrey Kizimenko](https://www.linkedin.com/in/andrey-kizimenko-988900214/) _([@AndreyKizimenko](https://github.com/AndreyKizimenko))_
-| Software Engineer                 | [Konstantin Sykulev](https://www.linkedin.com/in/konstantins/) _([@ksykulev](https://github.com/ksykulev))_
+| Software Engineer                 | [Scott Gress](https://www.linkedin.com/in/scottgress/) _([@sgress454](https://github.com/sgress454))_
 
 > The [Slack channel](https://fleetdm.slack.com/archives/C0AQY8D7FM4), [kanban board](https://github.com/orgs/fleetdm/projects/106/), and [GitHub label](https://github.com/fleetdm/fleet/labels?q=%23g-power-to-pc) for this working group is `#g-power-to-pc`.
+
+
+### BYOD group
+
+> _Goal TBD. Starting point: enable Fleet customers to manage employee-owned (BYOD) devices, with initial focus on Android (Cisco onboarding)._
+
+The BYOD working group is the new home for cross-platform BYOD device management. Konstantin moves over from Power to the PC to take ownership of the deliverable, joined by Andrew Mellor (formerly MDM).
+
+| Responsibility                    | Human(s)                  |
+|:----------------------------------|:--------------------------|
+| Product Designer                  | _TBD_
+| Engineering Manager               | [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
+| Tech Lead                         | [Konstantin Sykulev](https://www.linkedin.com/in/konstantins/) _([@ksykulev](https://github.com/ksykulev))_
+| Quality Assurance                 | _TBD_
+| Software Engineer                 | Andrew Mellor _([@andymFleet](https://github.com/andymFleet))_
+
+> Slack channel, kanban board, and GitHub label (`#g-byod`) to be created.
 
 <!--
 Example working group section

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -235,7 +235,7 @@ The goal of the Power to the PC working group is to empower Windows users to ful
 
 > _Goal TBD. Starting point: enable Fleet customers to manage employee-owned (BYOD) devices_
 
-The BYOD working group is the new home for cross-platform BYOD device management. Konstantin moves over from Power to the PC to take ownership of the deliverable, joined by Andrew Mellor (formerly MDM).
+The BYOD working group is the new home for cross-platform BYOD device management. 
 
 | Responsibility                    | Human(s)                  |
 |:----------------------------------|:--------------------------|

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -202,7 +202,7 @@ The goal of the website group is to increase and exceed Fleet's product maturity
 
 ### First Impressions group
 
-> **Paused** as of 2026-05-04. Engineering capacity is being redirected to Power to the PC and the new BYOD working group. We expect to resume First Impressions after backfilling the open MDM SWE role.
+> **Paused** as of 2026-05-19. Engineering capacity is being redirected to Power to the PC and the new BYOD working group. We expect to resume First Impressions after backfilling the open MDM SWE role.
 
 The goal of the First Impressions working group is to make changes to the core Fleet product that improve first impressions of Fleet at workshops, conferences, and demos.
 
@@ -233,7 +233,7 @@ The goal of the Power to the PC working group is to empower Windows users to ful
 
 ### BYOD group
 
-> _Goal TBD. Starting point: enable Fleet customers to manage employee-owned (BYOD) devices, with initial focus on Android (Cisco onboarding)._
+> _Goal TBD. Starting point: enable Fleet customers to manage employee-owned (BYOD) devices_
 
 The BYOD working group is the new home for cross-platform BYOD device management. Konstantin moves over from Power to the PC to take ownership of the deliverable, joined by Andrew Mellor (formerly MDM).
 


### PR DESCRIPTION
**IMPORTANT NOTE:** This is a scratch PR we're using to transparently discuss working group composition. We're still working on it, so there will be revisions, and we'll be seeking feedback from anyone affected. No decisions are made until the PR is merged. 

> Draft PR. Starting point for the working-group restructure conversation. Not ready to merge until we align on the questions below.

## Proposed changes next release cycle (in this PR)

- **First Impressions:** paused. Engineering capacity redirects to Power to the PC.
- **Power to the PC:** Scott Gress joins as SWE (Konstantin moves out).
- **BYOD (new working group):** Konstantin Sykulev (Tech Lead), Andrew Mellor (SWE). Andrew moves over from MDM. Goal, PD, and QA TBD.
- **MDM:** Andrew Mellor removed. Backfill via open MDM SWE req.

## End-state we're working toward

After we backfill and onboard the open SWE roles, each product group transitions to a working group. Eight working groups total.

| # | Working group              | Goal                                                                 | Notes                                                                                                                                                                                              |
|---|----------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 1 | First Impressions          | Improve first impressions at workshops, conferences, demos.          |  Temporary pause                                                                                                                                                            |
| 2 | Power to the PC            | Empower Windows users to fully leverage Fleet as an MDM.             |                                                                                                                                                                                                    |
| 3 | BYOD                       | Enroll all your BYOD devices. |  @noahtalerman pointed out that a lot of the Android work in front of us is company-owned. Is there a reason for focusing exclusively on BYOD? From an efficiency perspective, it would be better for one group to own both.                                                                                                                                                                                                   |
| 4 | Apple @ Work _(was MDM)_   | Increase and exceed maturity in Apple device management.             |                                                                                                                                                        |
| 5 | Auto Patching  _(was Software)_     | Patch in hours, not weeks.                                           |   |
| 6 | Supply Chain  _(was Security & Compliance)_ | Detect in minutes, not in hours.                                                       |      |
| 7 | _TBD_ _(was Orchestration)_| _TBD._ "Identity"?                                                   | What's the goal? Should drive a business outcome we'd put on an ROI slide at QBR.                                                                                                                  |
| 8 | DEX                      |  Improve Digital Employee Experience using Fleet.                     | 