### PR TITLE
Remove comments from Agent options in the UI

### DIFF
--- a/frontend/utilities/yaml/index.ts
+++ b/frontend/utilities/yaml/index.ts
@@ -18,23 +18,7 @@ export const agentOptionsToYaml = (agentOpts: any) => {
     delete agentOpts.overrides;
   }
 
-  const flagsComment = "# Requires fleetd agent\n";
-
-  // always show the informational comment above "command_line_flags". When
-  // the key is present — even set to {} or null — render it as-is, since
-  // those empty values have special semantics; when absent, suggest it with
-  // a commented-out placeholder.
-  let yamlString = yaml.dump(agentOpts);
-  if ("command_line_flags" in agentOpts) {
-    yamlString = yamlString.replace(
-      /^command_line_flags:/m,
-      `${flagsComment}command_line_flags:`
-    );
-  } else {
-    yamlString += `${flagsComment}# command_line_flags: {}\n`;
-  }
-
-  return yamlString;
+  return yaml.dump(agentOpts);
 };
 
 export default constructErrorString;

--- a/frontend/utilities/yaml/yaml.tests.ts
+++ b/frontend/utilities/yaml/yaml.tests.ts
@@ -1,47 +1,38 @@
 import { agentOptionsToYaml } from "utilities/yaml";
 
-const FLAGS_COMMENT = "# Requires fleetd agent\n";
-
 describe("agentOptionsToYaml", () => {
-  it("adds a commented-out placeholder when the command_line_flags key is absent", () => {
-    expect(agentOptionsToYaml({ config: {} })).toContain(
-      `${FLAGS_COMMENT}# command_line_flags: {}\n`
+  it("omits command_line_flags when absent", () => {
+    expect(agentOptionsToYaml({ config: {} })).not.toContain(
+      "command_line_flags"
     );
   });
 
-  it("adds a commented-out placeholder when agent options are unset", () => {
-    expect(agentOptionsToYaml(null)).toContain(
-      `${FLAGS_COMMENT}# command_line_flags: {}\n`
-    );
+  it("omits command_line_flags when agent options are unset", () => {
+    expect(agentOptionsToYaml(null)).not.toContain("command_line_flags");
   });
 
-  it("renders command_line_flags set to an empty object as-is, with the comment above it", () => {
+  it("renders command_line_flags when set to an empty object", () => {
     const result = agentOptionsToYaml({
       config: {},
       command_line_flags: {},
     });
-    expect(result).toContain(`${FLAGS_COMMENT}command_line_flags: {}`);
-    expect(result).not.toContain("# command_line_flags: {}");
+    expect(result).toContain("command_line_flags: {}");
   });
 
-  it("renders command_line_flags set to null as-is, with the comment above it", () => {
+  it("renders command_line_flags when set to null", () => {
     const result = agentOptionsToYaml({
       config: {},
       command_line_flags: null,
     });
-    expect(result).toContain(`${FLAGS_COMMENT}command_line_flags: null`);
-    expect(result).not.toContain("# command_line_flags: {}");
+    expect(result).toContain("command_line_flags: null");
   });
 
-  it("renders non-empty command_line_flags with the comment above it", () => {
+  it("renders non-empty command_line_flags", () => {
     const result = agentOptionsToYaml({
       config: {},
       command_line_flags: { verbose: true },
     });
-    expect(result).toContain(
-      `${FLAGS_COMMENT}command_line_flags:\n  verbose: true`
-    );
-    expect(result).not.toContain("# command_line_flags: {}");
+    expect(result).toContain("command_line_flags:\n  verbose: true");
   });
 
   it("omits an empty overrides key", () => {


### PR DESCRIPTION
**Related issue:** Resolves #35615

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved YAML output generation for agent options. Empty command line flags are now cleanly omitted, and unnecessary comment blocks are removed for a more concise output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->