### PR TITLE
Handbook: Add ritual and handbook section about responding to website code scanning alerts

### DIFF
--- a/handbook/engineering/engineering.rituals.yml
+++ b/handbook/engineering/engineering.rituals.yml
@@ -186,5 +186,12 @@
   description: "Review the release planning project board to ensure issues are progressing appropriately towards the next release." 
   moreInfoUrl: "https://github.com/orgs/fleetdm/projects/87"
   dri: "lukeheath"
+-
+  task: "Respond to website code scanning alerts"
+  startedOn: "2024-05-04" 
+  frequency: "Weekly" 
+  description: "Respond to code scanning alerts for the website/ folder in the \"Security and quality\" tab of the Fleet repo" 
+  moreInfoUrl: "https://fleetdm.com/handbook/engineering/website#respond-to-website-code-scanning-alerts"
+  dri: "eashaw"
 
 

--- a/handbook/engineering/engineering.rituals.yml
+++ b/handbook/engineering/engineering.rituals.yml
@@ -193,5 +193,8 @@
   description: "Respond to code scanning alerts for the website/ folder in the \"Security and quality\" tab of the Fleet repo" 
   moreInfoUrl: "https://fleetdm.com/handbook/engineering/website#respond-to-website-code-scanning-alerts"
   dri: "eashaw"
+  autoIssue:  
+    labels: [ "#g-website" ] 
+    repo: "fleet"
 
 

--- a/handbook/engineering/website.md
+++ b/handbook/engineering/website.md
@@ -130,7 +130,7 @@ If the action fails, please complete the following steps:
 Every week, the website maintainer looks for any new [code scanning alerts](https://github.com/fleetdm/fleet/security/code-scanning) that have been created for the `website/` folder. If any are found they:
 1. Determine if the alert is affecting the production evironment. If this is an alert for a vulnerability in a depedency, then the maintainer will look at what brings the depedency into the codebase.
 2. Respond to the alert. 
-   - If the alert is for code that has been merged into the repo, the maintiner will create a patch to fix it. 
+   - If the alert is for code that has been merged into the repo, the maintiner will create a pull request to fix it. 
    - If the alert is for a dependency that runs in production, the maintainer will upgrade it to a version that is not affected by the vulnerability. 
    - If the alert is for a devDependency or a dependency of a devDependency, the maintainer will dismiss the alert as a false-positive, because it does not affect the production environment.
 

--- a/handbook/engineering/website.md
+++ b/handbook/engineering/website.md
@@ -125,5 +125,16 @@ If the action fails, please complete the following steps:
 3. Head to the fleetdm/fleet GitHub repository and re-run the Deploy Fleet Website action.
 
 
+## Respond to website code scanning alerts
+
+Every week, the website maintainer looks for any new [code scanning alerts](https://github.com/fleetdm/fleet/security/code-scanning) that have been created for the `website/` folder. If any are found they:
+1. Determine if the alert is affecting the production evironment. If this is an alert for a vulnerability in a depedency, then the maintainer will look at what brings the depedency into the codebase.
+2. Respond to the alert. 
+   - If the alert is for code that has been merged into the repo, the maintiner will create a patch to fix it. 
+   - If the alert is for a dependency that runs in production, the maintainer will upgrade it to a version that is not affected by the vulnerability. 
+   - If the alert is for a devDependency or a dependency of a devDependency, the maintainer will dismiss the alert as a false-positive, because it does not affect the production environment.
+
+
+
 <meta name="maintainedBy" value="lukeheath">
 <meta name="description" value="Processes for maintaining and releasing changes to fleetdm.com.">


### PR DESCRIPTION
Changes:
- Added a new section to the website handbook page about responding to website code scanning alerts.
- Added a "Respond to website code scanning alerts" ritual to the engineering rituals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established a weekly process for responding to website code scanning alerts to enhance code quality and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->