### PR TITLE
Add Cloud Run service log destination

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -553,6 +553,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			StsAssumeRoleArn: config.Lambda.StsAssumeRoleArn,
 			StsExternalID:    config.Lambda.StsExternalID,
 		},
+		CloudRunService: logging.CloudRunServiceConfig{},
 		PubSub: logging.PubSubConfig{
 			Project: config.PubSub.Project,
 		},
@@ -581,6 +582,8 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	loggingConfig.Firehose.StreamName = config.Firehose.StatusStream
 	loggingConfig.Kinesis.StreamName = config.Kinesis.StatusStream
 	loggingConfig.Lambda.Function = config.Lambda.StatusFunction
+	loggingConfig.CloudRunService.URL = config.CloudRunService.StatusURL
+	loggingConfig.CloudRunService.Audience = config.CloudRunService.StatusAudience
 	loggingConfig.PubSub.Topic = config.PubSub.StatusTopic
 	loggingConfig.PubSub.AddAttributes = false // only used by result logs
 	loggingConfig.KafkaREST.Topic = config.KafkaREST.StatusTopic
@@ -598,6 +601,8 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	loggingConfig.Firehose.StreamName = config.Firehose.ResultStream
 	loggingConfig.Kinesis.StreamName = config.Kinesis.ResultStream
 	loggingConfig.Lambda.Function = config.Lambda.ResultFunction
+	loggingConfig.CloudRunService.URL = config.CloudRunService.ResultURL
+	loggingConfig.CloudRunService.Audience = config.CloudRunService.ResultAudience
 	loggingConfig.PubSub.Topic = config.PubSub.ResultTopic
 	loggingConfig.PubSub.AddAttributes = config.PubSub.AddAttributes
 	loggingConfig.KafkaREST.Topic = config.KafkaREST.ResultTopic
@@ -616,6 +621,8 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		loggingConfig.Firehose.StreamName = config.Firehose.AuditStream
 		loggingConfig.Kinesis.StreamName = config.Kinesis.AuditStream
 		loggingConfig.Lambda.Function = config.Lambda.AuditFunction
+		loggingConfig.CloudRunService.URL = config.CloudRunService.AuditURL
+		loggingConfig.CloudRunService.Audience = config.CloudRunService.AuditAudience
 		loggingConfig.PubSub.Topic = config.PubSub.AuditTopic
 		loggingConfig.PubSub.AddAttributes = false // only used by result logs
 		loggingConfig.KafkaREST.Topic = config.KafkaREST.AuditTopic

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -1126,7 +1126,7 @@ Valid time units are `s`, `m`, `h`.
 This is the log output plugin that should be used for osquery status logs received from clients. Check out the [reference documentation for log destinations](https://fleetdm.com/docs/using-fleet/log-destinations).
 
 
-Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`, `nats`, and `stdout`.
+Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `cloudrun_service`, `pubsub`, `kafkarest`, `nats`, and `stdout`.
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_OSQUERY_STATUS_LOG_PLUGIN`
@@ -1140,7 +1140,7 @@ Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`
 
 This is the log output plugin that should be used for osquery result logs received from clients. Check out the [reference documentation for log destinations](https://fleetdm.com/docs/using-fleet/log-destinations).
 
-Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`, `nats`, and `stdout`.
+Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `cloudrun_service`, `pubsub`, `kafkarest`, `nats`, and `stdout`.
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_OSQUERY_RESULT_LOG_PLUGIN`
@@ -1368,7 +1368,7 @@ This flag only has effect if `activity_enable_audit_log` is set to `true`.
 
 Each plugin has additional configuration options. Please see the configuration section linked below for your logging plugin.
 
-Options are [`filesystem`](#filesystem), [`firehose`](#firehose), [`kinesis`](#kinesis), [`lambda`](#lambda), [`pubsub`](#pubsub), [`kafkarest`](#kafka-rest-proxy-logging), [`nats`](#nats), and `stdout` (no additional configuration needed).
+Options are [`filesystem`](#filesystem), [`firehose`](#firehose), [`kinesis`](#kinesis), [`lambda`](#lambda), [`cloudrun_service`](#cloud-run-service), [`pubsub`](#pubsub), [`kafkarest`](#kafka-rest-proxy-logging), [`nats`](#nats), and `stdout` (no additional configuration needed).
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_ACTIVITY_AUDIT_LOG_PLUGIN`
@@ -2040,6 +2040,100 @@ The IAM role used to send to Lambda must allow the following permissions on
 the function listed:
 
 - `lambda:InvokeFunction`
+
+## Cloud Run service
+
+### cloudrun_service_status_url
+
+This flag only has effect if `osquery_status_log_plugin` is set to `cloudrun_service`.
+
+Cloud Run service URL to write osquery status logs received from clients. Fleet sends each log as a raw JSON request body.
+
+- Default value: none
+- Environment variable: `FLEET_CLOUDRUN_SERVICE_STATUS_URL`
+- Config file format:
+  ```yaml
+  cloudrun_service:
+    status_url: https://status-service-abc-uc.a.run.app/logs/status
+  ```
+
+### cloudrun_service_status_audience
+
+This flag only has effect if `osquery_status_log_plugin` is set to `cloudrun_service`.
+
+Audience to use when Fleet authenticates to the Cloud Run service for status logs with a Google-signed ID token from Application Default Credentials. For Cloud Run, this is usually the service root URL, for example `https://status-service-abc-uc.a.run.app/`.
+
+If this value is omitted, Fleet sends unauthenticated HTTP requests.
+
+- Default value: none
+- Environment variable: `FLEET_CLOUDRUN_SERVICE_STATUS_AUDIENCE`
+- Config file format:
+  ```yaml
+  cloudrun_service:
+    status_audience: https://status-service-abc-uc.a.run.app/
+  ```
+
+### cloudrun_service_result_url
+
+This flag only has effect if `osquery_result_log_plugin` is set to `cloudrun_service`.
+
+Cloud Run service URL to write osquery result logs received from clients. Fleet sends each log as a raw JSON request body.
+
+- Default value: none
+- Environment variable: `FLEET_CLOUDRUN_SERVICE_RESULT_URL`
+- Config file format:
+  ```yaml
+  cloudrun_service:
+    result_url: https://result-service-abc-uc.a.run.app/logs/result
+  ```
+
+### cloudrun_service_result_audience
+
+This flag only has effect if `osquery_result_log_plugin` is set to `cloudrun_service`.
+
+Audience to use when Fleet authenticates to the Cloud Run service for result logs with a Google-signed ID token from Application Default Credentials. For Cloud Run, this is usually the service root URL, for example `https://result-service-abc-uc.a.run.app/`.
+
+If this value is omitted, Fleet sends unauthenticated HTTP requests.
+
+- Default value: none
+- Environment variable: `FLEET_CLOUDRUN_SERVICE_RESULT_AUDIENCE`
+- Config file format:
+  ```yaml
+  cloudrun_service:
+    result_audience: https://result-service-abc-uc.a.run.app/
+  ```
+
+### cloudrun_service_audit_url
+
+This flag only has effect if `activity_audit_log_plugin` is set to `cloudrun_service`.
+
+Cloud Run service URL to write audit logs. Fleet sends each log as a raw JSON request body.
+
+- Default value: none
+- Environment variable: `FLEET_CLOUDRUN_SERVICE_AUDIT_URL`
+- Config file format:
+  ```yaml
+  cloudrun_service:
+    audit_url: https://audit-service-abc-uc.a.run.app/logs/audit
+  ```
+
+### cloudrun_service_audit_audience
+
+This flag only has effect if `activity_audit_log_plugin` is set to `cloudrun_service`.
+
+Audience to use when Fleet authenticates to the Cloud Run service for audit logs with a Google-signed ID token from Application Default Credentials. For Cloud Run, this is usually the service root URL, for example `https://audit-service-abc-uc.a.run.app/`.
+
+If this value is omitted, Fleet sends unauthenticated HTTP requests.
+
+- Default value: none
+- Environment variable: `FLEET_CLOUDRUN_SERVICE_AUDIT_AUDIENCE`
+- Config file format:
+  ```yaml
+  cloudrun_service:
+    audit_audience: https://audit-service-abc-uc.a.run.app/
+  ```
+
+The service account used by Fleet must be allowed to invoke the target Cloud Run service.
 
 ## PubSub
 

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -233,7 +233,7 @@ For results to go to Fleet, the osquery `--logger_plugin` flag must be set to `t
 Folks typically use Fleet to ship logs to data lakes and SIEMs like Splunk, the ELK stack, and Graylog.
 
 Fleet supports multiple logging destinations for scheduled query results and status logs. The `--osquery_result_log_plugin` and `--osquery_status_log_plugin` can be set to:
-`filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`, `nats`, and `stdout`.
+`filesystem`, `firehose`, `kinesis`, `lambda`, `cloudrun_service`, `pubsub`, `kafkarest`, `nats`, and `stdout`.
 See:
   - https://fleetdm.com/docs/deploying/configuration#osquery-result-log-plugin.
   - https://fleetdm.com/docs/deploying/configuration#osquery-status-log-plugin.

--- a/frontend/components/LogDestinationIndicator/LogDestinationIndicator.tsx
+++ b/frontend/components/LogDestinationIndicator/LogDestinationIndicator.tsx
@@ -40,6 +40,8 @@ const LogDestinationIndicator = ({
         return "Amazon Kinesis Data Streams";
       case "lambda":
         return "AWS Lambda";
+      case "cloudrun_service":
+        return "Google Cloud Run";
       case "pubsub":
         return "Google Cloud Pub/Sub";
       case "kafka":
@@ -86,6 +88,13 @@ const LogDestinationIndicator = ({
           <>
             Each time a report runs, the data <br />
             is sent to AWS Lambda.
+          </>
+        );
+      case "cloudrun_service":
+        return (
+          <>
+            Each time a report runs, the data <br />
+            is sent to Google Cloud Run.
           </>
         );
       case "pubsub":

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -247,6 +247,7 @@ export type LogDestination =
   | "firehose"
   | "kinesis"
   | "lambda"
+  | "cloudrun_service"
   | "pubsub"
   | "kafka"
   | "nats"

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -361,6 +361,16 @@ type LambdaConfig struct {
 	AuditFunction    string `yaml:"audit_function"`
 }
 
+// CloudRunServiceConfig defines configs for the Cloud Run service logging plugin
+type CloudRunServiceConfig struct {
+	StatusURL      string `yaml:"status_url"`
+	StatusAudience string `yaml:"status_audience"`
+	ResultURL      string `yaml:"result_url"`
+	ResultAudience string `yaml:"result_audience"`
+	AuditURL       string `yaml:"audit_url"`
+	AuditAudience  string `yaml:"audit_audience"`
+}
+
 // S3Config defines config to enable file carving storage to an S3 bucket
 type S3Config struct {
 	Bucket           string `yaml:"bucket"`
@@ -670,6 +680,7 @@ type FleetConfig struct {
 	Firehose                   FirehoseConfig
 	Kinesis                    KinesisConfig
 	Lambda                     LambdaConfig
+	CloudRunService            CloudRunServiceConfig `yaml:"cloudrun_service"`
 	S3                         S3Config
 	Email                      EmailConfig
 	SES                        SESConfig
@@ -1420,6 +1431,20 @@ func (man Manager) addConfigs() {
 	man.addConfigString("lambda.audit_function", "",
 		"Lambda function name for audit logs")
 
+	// Cloud Run service
+	man.addConfigString("cloudrun_service.status_url", "",
+		"Cloud Run service URL for status logs")
+	man.addConfigString("cloudrun_service.status_audience", "",
+		"Audience to use when authenticating to the Cloud Run service for status logs with a Google-signed ID token")
+	man.addConfigString("cloudrun_service.result_url", "",
+		"Cloud Run service URL for result logs")
+	man.addConfigString("cloudrun_service.result_audience", "",
+		"Audience to use when authenticating to the Cloud Run service for result logs with a Google-signed ID token")
+	man.addConfigString("cloudrun_service.audit_url", "",
+		"Cloud Run service URL for audit logs")
+	man.addConfigString("cloudrun_service.audit_audience", "",
+		"Audience to use when authenticating to the Cloud Run service for audit logs with a Google-signed ID token")
+
 	// S3 for file carving: Deprecated
 	man.addConfigString("s3.bucket", "", "Deprecated: Bucket where to store file carves")
 	man.addConfigString("s3.prefix", "", "Deprecated: Prefix under which carves are stored")
@@ -1832,6 +1857,14 @@ func (man Manager) LoadConfig() FleetConfig {
 			AuditFunction:    man.getConfigString("lambda.audit_function"),
 			StsAssumeRoleArn: man.getConfigString("lambda.sts_assume_role_arn"),
 			StsExternalID:    man.getConfigString("lambda.sts_external_id"),
+		},
+		CloudRunService: CloudRunServiceConfig{
+			StatusURL:      man.getConfigString("cloudrun_service.status_url"),
+			StatusAudience: man.getConfigString("cloudrun_service.status_audience"),
+			ResultURL:      man.getConfigString("cloudrun_service.result_url"),
+			ResultAudience: man.getConfigString("cloudrun_service.result_audience"),
+			AuditURL:       man.getConfigString("cloudrun_service.audit_url"),
+			AuditAudience:  man.getConfigString("cloudrun_service.audit_audience"),
 		},
 		S3: man.loadS3Config(),
 		Email: EmailConfig{

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1704,6 +1704,16 @@ type LambdaConfig struct {
 	AuditFunction  string `json:"audit_function"`
 }
 
+// CloudRunServiceConfig shadows config.CloudRunServiceConfig.
+type CloudRunServiceConfig struct {
+	StatusURL      string `json:"status_url"`
+	StatusAudience string `json:"status_audience"`
+	ResultURL      string `json:"result_url"`
+	ResultAudience string `json:"result_audience"`
+	AuditURL       string `json:"audit_url"`
+	AuditAudience  string `json:"audit_audience"`
+}
+
 // KafkaRESTConfig shadows config.KafkaRESTConfig
 type KafkaRESTConfig struct {
 	StatusTopic string `json:"status_topic"`

--- a/server/logging/cloudrun_service.go
+++ b/server/logging/cloudrun_service.go
@@ -1,0 +1,96 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	platformhttp "github.com/fleetdm/fleet/v4/server/platform/http"
+	"google.golang.org/api/idtoken"
+)
+
+const (
+	// Cloud Run HTTP/1 requests are limited to 32 MiB. HTTP/2 can support
+	// larger requests, but keeping this limit makes oversized log behavior
+	// predictable for default Cloud Run services.
+	cloudRunServiceMaxSizeOfPayload = 32 * 1024 * 1024
+	cloudRunServiceTimeout          = 30 * time.Second
+)
+
+type cloudRunServiceLogWriter struct {
+	client *http.Client
+	url    string
+	logger *slog.Logger
+}
+
+func NewCloudRunServiceLogWriter(ctx context.Context, serviceURL, audience string, logger *slog.Logger) (*cloudRunServiceLogWriter, error) {
+	if serviceURL == "" {
+		return nil, errors.New("Cloud Run service URL missing")
+	}
+
+	var client *http.Client
+	if audience != "" {
+		idTokenClient, err := idtoken.NewClient(ctx, audience)
+		if err != nil {
+			return nil, fmt.Errorf("create Cloud Run service ID token client: %w", err)
+		}
+		idTokenClient.Timeout = cloudRunServiceTimeout
+		client = idTokenClient
+	} else {
+		client = fleethttp.NewClient(fleethttp.WithTimeout(cloudRunServiceTimeout))
+	}
+
+	return &cloudRunServiceLogWriter{
+		client: client,
+		url:    serviceURL,
+		logger: logger,
+	}, nil
+}
+
+func (w *cloudRunServiceLogWriter) Write(ctx context.Context, logs []json.RawMessage) error {
+	for _, log := range logs {
+		if len(log) > cloudRunServiceMaxSizeOfPayload {
+			return fmt.Errorf("cloudrun_service POST to %s: log size %d exceeds 32 MiB request limit", platformhttp.MaskSecretURLParams(w.url), len(log))
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewReader(log))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		w.logger.DebugContext(ctx, "sending Cloud Run service request",
+			"url", platformhttp.MaskSecretURLParams(w.url),
+		)
+
+		resp, err := w.client.Do(req)
+		if err != nil {
+			return fmt.Errorf("cloudrun_service POST to %s failed: %w", platformhttp.MaskSecretURLParams(w.url), platformhttp.MaskURLError(err))
+		}
+
+		if resp.StatusCode < http.StatusOK || resp.StatusCode > 299 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 513))
+			resp.Body.Close()
+			bodyStr := string(body)
+			if len(bodyStr) > 512 {
+				bodyStr = bodyStr[:512]
+			}
+			w.logger.DebugContext(ctx, "non-success response from Cloud Run service",
+				"url", platformhttp.MaskSecretURLParams(w.url),
+				"status_code", resp.StatusCode,
+				"body", bodyStr,
+			)
+			return fmt.Errorf("cloudrun_service POST to %s returned status %d", platformhttp.MaskSecretURLParams(w.url), resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+
+	return nil
+}

--- a/server/logging/cloudrun_service.go
+++ b/server/logging/cloudrun_service.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
@@ -33,6 +34,10 @@ type cloudRunServiceLogWriter struct {
 func NewCloudRunServiceLogWriter(ctx context.Context, serviceURL, audience string, logger *slog.Logger) (*cloudRunServiceLogWriter, error) {
 	if serviceURL == "" {
 		return nil, errors.New("Cloud Run service URL missing")
+	}
+	parsedServiceURL, err := url.Parse(serviceURL)
+	if err != nil || parsedServiceURL.Scheme == "" || parsedServiceURL.Host == "" {
+		return nil, fmt.Errorf("invalid Cloud Run service URL: %q", serviceURL)
 	}
 
 	var client *http.Client

--- a/server/logging/cloudrun_service.go
+++ b/server/logging/cloudrun_service.go
@@ -89,6 +89,7 @@ func (w *cloudRunServiceLogWriter) Write(ctx context.Context, logs []json.RawMes
 			)
 			return fmt.Errorf("cloudrun_service POST to %s returned status %d", platformhttp.MaskSecretURLParams(w.url), resp.StatusCode)
 		}
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}
 

--- a/server/logging/cloudrun_service_test.go
+++ b/server/logging/cloudrun_service_test.go
@@ -1,0 +1,73 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeCloudRunServiceWriterWithClient(client *http.Client, serviceURL string) *cloudRunServiceLogWriter {
+	return &cloudRunServiceLogWriter{
+		client: client,
+		url:    serviceURL,
+		logger: slog.New(slog.DiscardHandler),
+	}
+}
+
+func TestCloudRunServiceSendsEachRawLog(t *testing.T) {
+	ctx := context.Background()
+	var bodies []json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		bodies = append(bodies, json.RawMessage(body))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	writer := makeCloudRunServiceWriterWithClient(server.Client(), server.URL)
+
+	err := writer.Write(ctx, logs)
+	require.NoError(t, err)
+	require.Equal(t, logs, bodies)
+}
+
+func TestCloudRunServiceReturnsErrorOnHTTPError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	writer := makeCloudRunServiceWriterWithClient(server.Client(), server.URL)
+
+	err := writer.Write(ctx, []json.RawMessage{json.RawMessage(`{"foo":"bar"}`)})
+	require.ErrorContains(t, err, "status 400")
+}
+
+func TestCloudRunServiceReturnsErrorOnRequestFailure(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	serviceURL := server.URL
+	server.Close()
+
+	writer := makeCloudRunServiceWriterWithClient(server.Client(), serviceURL)
+
+	err := writer.Write(ctx, []json.RawMessage{json.RawMessage(`{"foo":"bar"}`)})
+	require.Error(t, err)
+}
+
+func TestNewCloudRunServiceLogWriterRequiresURL(t *testing.T) {
+	_, err := NewCloudRunServiceLogWriter(context.Background(), "", "", slog.New(slog.DiscardHandler))
+	require.ErrorContains(t, err, "Cloud Run service URL missing")
+}

--- a/server/logging/cloudrun_service_test.go
+++ b/server/logging/cloudrun_service_test.go
@@ -71,3 +71,8 @@ func TestNewCloudRunServiceLogWriterRequiresURL(t *testing.T) {
 	_, err := NewCloudRunServiceLogWriter(context.Background(), "", "", slog.New(slog.DiscardHandler))
 	require.ErrorContains(t, err, "Cloud Run service URL missing")
 }
+
+func TestNewCloudRunServiceLogWriterRequiresValidURL(t *testing.T) {
+	_, err := NewCloudRunServiceLogWriter(context.Background(), "not-a-url", "", slog.New(slog.DiscardHandler))
+	require.ErrorContains(t, err, "invalid Cloud Run service URL")
+}

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -56,6 +56,11 @@ type LambdaConfig struct {
 	StsExternalID    string
 }
 
+type CloudRunServiceConfig struct {
+	URL      string
+	Audience string
+}
+
 type PubSubConfig struct {
 	Topic string
 
@@ -91,14 +96,15 @@ type NatsConfig struct {
 type Config struct {
 	Plugin string
 
-	Filesystem FilesystemConfig
-	Webhook    WebhookConfig
-	Firehose   FirehoseConfig
-	Kinesis    KinesisConfig
-	Lambda     LambdaConfig
-	PubSub     PubSubConfig
-	KafkaREST  KafkaRESTConfig
-	Nats       NatsConfig
+	Filesystem      FilesystemConfig
+	Webhook         WebhookConfig
+	Firehose        FirehoseConfig
+	Kinesis         KinesisConfig
+	Lambda          LambdaConfig
+	CloudRunService CloudRunServiceConfig
+	PubSub          PubSubConfig
+	KafkaREST       KafkaRESTConfig
+	Nats            NatsConfig
 }
 
 func NewJSONLogger(ctx context.Context, name string, config Config, logger *slog.Logger) (fleet.JSONLogger, error) {
@@ -170,6 +176,17 @@ func NewJSONLogger(ctx context.Context, name string, config Config, logger *slog
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create lambda %s logger: %w", name, err)
+		}
+		return fleet.JSONLogger(writer), nil
+	case "cloudrun_service":
+		writer, err := NewCloudRunServiceLogWriter(
+			ctx,
+			config.CloudRunService.URL,
+			config.CloudRunService.Audience,
+			logger,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create cloudrun_service %s logger: %w", name, err)
 		}
 		return fleet.JSONLogger(writer), nil
 	case "pubsub":

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -203,6 +203,18 @@ func (svc *Service) LoggingConfig(ctx context.Context) (*fleet.Logging, error) {
 					AuditFunction:  conf.Lambda.AuditFunction,
 				},
 			}
+		case "cloudrun_service":
+			*lp.target = fleet.LoggingPlugin{
+				Plugin: "cloudrun_service",
+				Config: fleet.CloudRunServiceConfig{
+					StatusURL:      conf.CloudRunService.StatusURL,
+					StatusAudience: conf.CloudRunService.StatusAudience,
+					ResultURL:      conf.CloudRunService.ResultURL,
+					ResultAudience: conf.CloudRunService.ResultAudience,
+					AuditURL:       conf.CloudRunService.AuditURL,
+					AuditAudience:  conf.CloudRunService.AuditAudience,
+				},
+			}
 		case "pubsub":
 			*lp.target = fleet.LoggingPlugin{
 				Plugin: "pubsub",

--- a/server/service/service_appconfig_test.go
+++ b/server/service/service_appconfig_test.go
@@ -164,6 +164,15 @@ func TestService_LoggingConfig(t *testing.T) {
 		AuditFunction:  testLambdaPluginConfig().Lambda.AuditFunction,
 	}
 
+	cloudRunServiceConfig := fleet.CloudRunServiceConfig{
+		StatusURL:      testCloudRunServicePluginConfig().CloudRunService.StatusURL,
+		StatusAudience: testCloudRunServicePluginConfig().CloudRunService.StatusAudience,
+		ResultURL:      testCloudRunServicePluginConfig().CloudRunService.ResultURL,
+		ResultAudience: testCloudRunServicePluginConfig().CloudRunService.ResultAudience,
+		AuditURL:       testCloudRunServicePluginConfig().CloudRunService.AuditURL,
+		AuditAudience:  testCloudRunServicePluginConfig().CloudRunService.AuditAudience,
+	}
+
 	pubsubConfig := fleet.PubSubConfig{
 		PubSubConfig: config.PubSubConfig{
 			Project:       testPubSubPluginConfig().PubSub.Project,
@@ -268,6 +277,27 @@ func TestService_LoggingConfig(t *testing.T) {
 				Audit: fleet.LoggingPlugin{
 					Plugin: "lambda",
 					Config: lambdaConfig,
+				},
+			},
+		},
+		{
+			name:   "test cloudrun_service config",
+			fields: fields{config: testCloudRunServicePluginConfig()},
+			args:   args{ctx: test.UserContext(context.Background(), test.UserAdmin)},
+			want: &fleet.Logging{
+				Debug: true,
+				Json:  false,
+				Result: fleet.LoggingPlugin{
+					Plugin: "cloudrun_service",
+					Config: cloudRunServiceConfig,
+				},
+				Status: fleet.LoggingPlugin{
+					Plugin: "cloudrun_service",
+					Config: cloudRunServiceConfig,
+				},
+				Audit: fleet.LoggingPlugin{
+					Plugin: "cloudrun_service",
+					Config: cloudRunServiceConfig,
 				},
 			},
 		},

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -757,6 +757,22 @@ func testLambdaPluginConfig() config.FleetConfig {
 	return c
 }
 
+func testCloudRunServicePluginConfig() config.FleetConfig {
+	c := config.TestConfig()
+	c.Osquery.ResultLogPlugin = "cloudrun_service"
+	c.Osquery.StatusLogPlugin = "cloudrun_service"
+	c.Activity.AuditLogPlugin = "cloudrun_service"
+	c.CloudRunService = config.CloudRunServiceConfig{
+		StatusURL:      "https://example.run.app/status",
+		StatusAudience: "https://example.run.app/",
+		ResultURL:      "https://example.run.app/result",
+		ResultAudience: "https://example.run.app/",
+		AuditURL:       "https://example.run.app/audit",
+		AuditAudience:  "https://example.run.app/",
+	}
+	return c
+}
+
 func testPubSubPluginConfig() config.FleetConfig {
 	c := config.TestConfig()
 	c.Osquery.ResultLogPlugin = "pubsub"


### PR DESCRIPTION
## Summary

- Add a `cloudrun_service` log destination for osquery status logs, osquery result logs, and audit logs.
- Send each log as a raw JSON request body with strict error handling on request failures and non-2xx responses.
- Support authenticated Cloud Run service calls with per-destination Google ID token audiences.
- Document the new server configuration and expose the plugin in app config/frontend logging types.

## Why

Fleet already supports AWS Lambda as a direct serverless log destination. This adds the analogous Cloud Run service path without changing the existing webhook behavior, which uses an envelope payload and best-effort delivery.

## AI usage

This PR was implemented with AI assistance and human reviewed by Robbie Trencheny.

## Testing

- `go test ./server/logging`
- `go test ./server/service -run TestService_LoggingConfig`
- `go test ./server/config`
- `go test ./cmd/fleet -run '^$'`
- `make lint-go-incremental`

Note: full `go test ./cmd/fleet` was not runnable locally because tests require the `mysql_test` service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud Run as a logging destination for osquery status, result, and audit logs, with configurable endpoints and authentication audiences.
  * UI now shows "Google Cloud Run" as a log destination and includes a matching tooltip.

* **Tests**
  * Added unit tests and test helpers covering Cloud Run logging behavior and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->