### PR TITLE
Allow concurrent `make lint-go` executions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ lint-js:
 .help-short--lint-go:
 	@echo "Run the Go linters"
 lint-go:
-	golangci-lint run --timeout 15m
+	golangci-lint run --allow-serial-runners --timeout 15m
 ifndef SKIP_INCREMENTAL
 	$(MAKE) lint-go-incremental
 endif
@@ -231,7 +231,7 @@ endif
 .help-short--lint-go-incremental:
 	@echo "Run the incremental Go linters"
 lint-go-incremental: custom-gcl
-	./custom-gcl run -c .golangci-incremental.yml --new-from-merge-base=origin/main --timeout 15m ./...
+	./custom-gcl run --allow-serial-runners -c .golangci-incremental.yml --new-from-merge-base=origin/main --timeout 15m ./...
 
 custom-gcl:
 	golangci-lint custom


### PR DESCRIPTION
Usually I type `make lint-go` > enter, and then I go to do other stuff and when I come back to the terminal I see this error (possibly because VS Code is also running it?):
```
$ make lint-go
golangci-lint run --timeout 15m
Error: parallel golangci-lint is running
The command is terminated due to an error: parallel golangci-lint is running
```

Flag `--allow-serial-runners` is useful for this scenario:
```
--allow-serial-runners  Allow multiple golangci-lint instances running, but serialize them around a lock.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for linting tools to enhance performance during development and testing cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->