### PR TITLE
add script output to GitOps

### DIFF
--- a/changes/44082-add-script-output-to-gitops
+++ b/changes/44082-add-script-output-to-gitops
@@ -1,0 +1,1 @@
+- Added output to GitOps for scripts, indicating how many would or be applied when running.

--- a/changes/44082-add-script-output-to-gitops
+++ b/changes/44082-add-script-output-to-gitops
@@ -1,1 +1,1 @@
-- Added output to GitOps for scripts, indicating how many would or be applied when running.
+- Added output to GitOps for scripts, indicating how many scripts would be applied (dry run) or were applied.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7010,5 +7010,5 @@ software:
 	// Real run.
 	logs = RunAppForTest(t, []string{"gitops", "-f", globalPath, "-f", teamPath})
 	assert.Contains(t, logs, "[+] applied 1 script\n")
-	assert.Contains(t, logs, fmt.Sprintf("[+] applying 1 script for fleet %s\n", teamName))
+	assert.Contains(t, logs, fmt.Sprintf("[+] applied 1 script for fleet %s\n", teamName))
 }

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -6943,3 +6943,72 @@ policies:
 	require.ErrorContains(t, err, "labels_include_all")
 	require.ErrorContains(t, err, "labels_exclude_any")
 }
+
+func TestGitOpsScriptsLogging(t *testing.T) {
+	// Cannot run t.Parallel() because SetupFullGitOpsPremiumServer sets env vars.
+	ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
+
+	// Echo back a ScriptResponse for each input script so the real-run no-team
+	// log line reflects the count of scripts sent to the server. (In dry-run,
+	// the service short-circuits before reaching this mock.)
+	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) ([]fleet.ScriptResponse, error) {
+		responses := make([]fleet.ScriptResponse, len(scripts))
+		for i, s := range scripts {
+			responses[i] = fleet.ScriptResponse{ID: uint(i + 1), Name: s.Name, TeamID: s.TeamID} //nolint:gosec // dismiss G115
+		}
+		return responses, nil
+	}
+
+	// No labels — keep the test focused on scripts.
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return nil, nil
+	}
+
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "script.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(`echo "hello"`), 0o644))
+
+	globalPath := filepath.Join(tmpDir, "global.yml")
+	require.NoError(t, os.WriteFile(globalPath, []byte(`
+controls:
+  scripts:
+    - path: ./script.sh
+queries:
+policies:
+agent_options:
+org_settings:
+  server_settings:
+    server_url: $FLEET_SERVER_URL
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: $ORG_NAME
+  secrets:
+    - secret: globalSecret
+software:
+`), 0o644))
+
+	teamPath := filepath.Join(tmpDir, "team.yml")
+	require.NoError(t, os.WriteFile(teamPath, []byte(`
+name: $TEST_TEAM_NAME
+team_settings:
+  secrets:
+    - secret: team-secret
+agent_options:
+controls:
+  scripts:
+    - path: ./script.sh
+policies:
+queries:
+software:
+`), 0o644))
+
+	// Dry run.
+	logs := RunAppForTest(t, []string{"gitops", "-f", globalPath, "-f", teamPath, "--dry-run"})
+	assert.Contains(t, logs, "[+] would've applied 1 script\n")
+	assert.Contains(t, logs, fmt.Sprintf("[+] would've applied 1 script for fleet %s\n", teamName))
+
+	// Real run.
+	logs = RunAppForTest(t, []string{"gitops", "-f", globalPath, "-f", teamPath})
+	assert.Contains(t, logs, "[+] applied 1 script\n")
+	assert.Contains(t, logs, fmt.Sprintf("[+] applying 1 script for fleet %s\n", teamName))
+}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -527,6 +527,7 @@ const (
 	dryRunAppliedFormat     = "[+] would've applied %s\n"
 	appliedFormat           = "[+] applied %s\n"
 	applyingTeamFormat      = "[+] applying %s for fleet %s\n"
+	appliedTeamFormat       = "[+] applied %s for fleet %s\n"
 	dryRunAppliedTeamFormat = "[+] would've applied %s for fleet %s\n"
 )
 
@@ -1074,10 +1075,10 @@ func (c *Client) ApplyGroup(
 				teamsScripts[tmName] = scriptResponses
 				if opts.DryRun {
 					// We split here on dry-run to capture the number we want to apply
-					logfn(format, numberWithPluralization(len(scripts), "script", "scripts"), tmName)
+					logfn(dryRunAppliedTeamFormat, numberWithPluralization(len(scripts), "script", "scripts"), tmName)
 				} else {
 					// vs. the number that actually got applied and returned by the server
-					logfn(format, numberWithPluralization(len(scriptResponses), "script", "scripts"), tmName)
+					logfn(appliedTeamFormat, numberWithPluralization(len(scriptResponses), "script", "scripts"), tmName)
 				}
 			}
 		}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -664,6 +664,12 @@ func (c *Client) ApplyGroup(
 				return nil, nil, nil, nil, fmt.Errorf("applying scripts for unassigned hosts: %w", err)
 			}
 			teamsScripts["No team"] = noTeamScripts
+
+			if opts.DryRun {
+				logfn(dryRunAppliedFormat, numberWithPluralization(len(scriptPayloads), "script", "scripts"))
+			} else {
+				logfn(appliedFormat, numberWithPluralization(len(noTeamScripts), "script", "scripts"))
+			}
 		}
 
 		rules, err := extractAppCfgYaraRules(specs.AppConfig)
@@ -1066,6 +1072,13 @@ func (c *Client) ApplyGroup(
 					return nil, nil, nil, nil, fmt.Errorf("applying scripts for fleet %q: %w", tmName, err)
 				}
 				teamsScripts[tmName] = scriptResponses
+				if opts.DryRun {
+					// We split here on dry-run to capture the number we want to apply
+					logfn(format, numberWithPluralization(len(scripts), "script", "scripts"), tmName)
+				} else {
+					// vs. the number that actually got applied and returned by the server
+					logfn(format, numberWithPluralization(len(scriptResponses), "script", "scripts"), tmName)
+				}
 			}
 		}
 		if len(tmSoftwarePackagesPayloads) > 0 {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44082

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced GitOps script logging: reports how many scripts would be applied in dry‑run mode or were actually applied, with per-team and per-fleet breakdowns.

* **Tests**
  * Added test coverage validating logging output for both dry‑run and real execution, ensuring reported script counts and per-team/fleet messages are accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->