### PR TITLE
Add Primo link to their logo

### DIFF
--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -29,7 +29,7 @@
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
               <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <a href="https://www.getprimo.com/" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
+              <a href="https://eu1.hubs.ly/H0v39T-0" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
@@ -43,7 +43,7 @@
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
               <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <a href="https://www.getprimo.com/" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
+              <a href="https://eu1.hubs.ly/H0v39T-0" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -29,7 +29,7 @@
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
               <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
+              <a href="https://www.getprimo.com/" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
@@ -43,7 +43,7 @@
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
               <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
+              <a href="https://www.getprimo.com/" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -29,7 +29,7 @@
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
               <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <a href="https://eu1.hubs.ly/H0v39T-0" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
+              <a href="https://eu1.hubs.ly/H0v39T-0" target="_blank" rel="noopener noreferrer" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -43,7 +43,7 @@
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
               <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <a href="https://eu1.hubs.ly/H0v39T-0" target="_blank" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
+              <a href="https://eu1.hubs.ly/H0v39T-0" target="_blank" rel="noopener noreferrer" no-icon><img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png"></a>
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">


### PR DESCRIPTION
Adds a link to the partner logo scrollbar for Primo's logo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Primo partner logo in both carousel rows is now clickable and opens the Primo site in a new tab.
  * Both carousel links use a no-icon presentation for a cleaner, consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->