### PR TITLE
Update changelog for fleetd 1.25.0 release

### DIFF
--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Orbit 1.25.0 (May 05, 2026)
+
+* Updated go to 1.26.2
+
+* When a Windows disk is already encrypted and Fleet needs the recovery key, orbit now rotates the recovery key (adds a new Fleet-managed protector and removes old ones) instead of decrypting and re-encrypting the entire disk. This avoids the FVE_E_AUTOUNLOCK_ENABLED error loop on machines with secondary drives using auto-unlock.
+
+* Added `network_quality` table from https://github.com/macadmins/osquery-extension to macOS.
+* Bumped https://github.com/macadmins/osquery-extension to v1.4.1.
+
+* Removed debugging symbols from orbit and Fleet Desktop executables.
+
+* Orbit passes EUA token during enrollment request
+
+* Fixed Windows Autopilot SSO prompt not recoverable if closed by periodically re-opening the SSO browser window every 5 minutes until authentication is completed.
+
+* Wrapped Get-ItemProperty calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. System.InvalidCastException) from malformed registry entries, logging the offending path instead of aborting.
+
 ## Orbit 1.54.0 (Apr 07, 2026)
 
 * Fixed orbit crash loop when `updates-metadata.json` has incorrect file permissions by self-healing via `chmod` instead of fatally erroring.

--- a/orbit/changes/33555-better-error-handling-of-win-pre-install-setup
+++ b/orbit/changes/33555-better-error-handling-of-win-pre-install-setup
@@ -1,1 +1,0 @@
-* Wrapped Get-ItemProperty calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. System.InvalidCastException) from malformed registry entries, logging the offending path instead of aborting.

--- a/orbit/changes/38230-sso-window-reopen
+++ b/orbit/changes/38230-sso-window-reopen
@@ -1,1 +1,0 @@
-* Fixed Windows Autopilot SSO prompt not recoverable if closed by periodically re-opening the SSO browser window every 5 minutes until authentication is completed.

--- a/orbit/changes/41379-orbit-eua
+++ b/orbit/changes/41379-orbit-eua
@@ -1,1 +1,0 @@
-* Orbit passes EUA token during enrollment request

--- a/orbit/changes/43259-fleetd-remove-debugging-symbols
+++ b/orbit/changes/43259-fleetd-remove-debugging-symbols
@@ -1,1 +1,0 @@
-* Removed debugging symbols from orbit and Fleet Desktop executables.

--- a/orbit/changes/44202-update-macadmins-osquery-extension
+++ b/orbit/changes/44202-update-macadmins-osquery-extension
@@ -1,2 +1,0 @@
-* Added `network_quality` table from https://github.com/macadmins/osquery-extension to macOS.
-* Bumped https://github.com/macadmins/osquery-extension to v1.4.1.

--- a/orbit/changes/issue-40809-bitlocker-key-rotation
+++ b/orbit/changes/issue-40809-bitlocker-key-rotation
@@ -1,1 +1,0 @@
-- When a Windows disk is already encrypted and Fleet needs the recovery key, orbit now rotates the recovery key (adds a new Fleet-managed protector and removes old ones) instead of decrypting and re-encrypting the entire disk. This avoids the FVE_E_AUTOUNLOCK_ENABLED error loop on machines with secondary drives using auto-unlock.

--- a/orbit/changes/update-go-1.26.2
+++ b/orbit/changes/update-go-1.26.2
@@ -1,1 +1,0 @@
-* Updated go to 1.26.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Artifacts**
  * Removed debugging symbols from Fleet Desktop and Orbit executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->