### PR TITLE
Fix gitops 500 when software title icon bytes are missing

### DIFF
--- a/changes/43511-gitops-icon-update-recovers
+++ b/changes/43511-gitops-icon-update-recovers
@@ -1,0 +1,1 @@
+- Fixed `fleetctl gitops` failing with HTTP 500 on subsequent runs when a custom software icon's bytes were missing or had failed integrity in the icon store. The server now returns a 409 Conflict from the metadata-only icon update path, and the gitops client falls back to a full upload to recover the bytes automatically.

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3060,9 +3060,11 @@ settings:
 // TestGitOpsIconUpdateRecoversWhenBytesAreMissing exercises the gitops
 // client's fallback from a metadata-only icon update to a full upload
 // when the server reports the bytes for a known hash are missing. Two
-// titles in the same team share an icon; truncating the shared bytes
-// after the first run forces one title through the update path on the
-// next run, which must recover by re-uploading.
+// titles in the same team share an icon. After the first run we mutate
+// one title's icon row to point at a hash with no bytes and truncate
+// the real bytes; the next gitops run forces that title through the
+// update path with a hash whose bytes are missing, and the client must
+// recover by re-uploading.
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsIconUpdateRecoversWhenBytesAreMissing() {
 	t := s.T()
 	ctx := context.Background()
@@ -3142,7 +3144,6 @@ settings:
 	require.NoError(t, err)
 	require.Len(t, titles, 2)
 
-	// Both titles should share the same storage_id.
 	var storageIDs []string
 	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
 		return sqlx.SelectContext(ctx, q, &storageIDs,
@@ -3157,6 +3158,21 @@ settings:
 	originalSize := info.Size()
 	require.Positive(t, originalSize)
 
+	// Force divergence: redirect one title's icon row to a fake hash
+	// (no bytes will exist at that storage id) and truncate the real
+	// bytes so the integrity check on the genuine hash also fails. On
+	// the next gitops run, the title with the fake storage_id will be
+	// routed through IconsToUpdate (its server hash differs from the
+	// local hash, but the local hash is in UploadedHashes from the
+	// other title's row), and the server will refuse the metadata-only
+	// update because the bytes for the local hash are gone.
+	const fakeHash = "deadbeef0000000000000000000000000000000000000000000000000000beef"
+	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			"UPDATE software_title_icons SET storage_id = ? WHERE team_id = ? AND software_title_id = ?",
+			fakeHash, team.ID, titles[0].ID)
+		return err
+	})
 	require.NoError(t, os.Truncate(iconPath, 0))
 
 	secondRunOut := fleetctl.RunAppForTest(t, []string{
@@ -3168,6 +3184,14 @@ settings:
 	info, err = os.Stat(iconPath)
 	require.NoError(t, err)
 	require.Equal(t, originalSize, info.Size())
+
+	var afterStorageIDs []string
+	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &afterStorageIDs,
+			"SELECT DISTINCT storage_id FROM software_title_icons WHERE team_id = ?", team.ID)
+	})
+	require.Len(t, afterStorageIDs, 1)
+	require.Equal(t, storageID, afterStorageIDs[0])
 }
 
 // TestGitOpsTeamLabels tests operations around team labels

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3057,6 +3057,119 @@ settings:
 	require.Equal(t, originalSize, info.Size())
 }
 
+// TestGitOpsIconUpdateRecoversWhenBytesAreMissing exercises the gitops
+// client's fallback from a metadata-only icon update to a full upload
+// when the server reports the bytes for a known hash are missing. Two
+// titles in the same team share an icon; truncating the shared bytes
+// after the first run forces one title through the update path on the
+// next run, which must recover by re-uploading.
+func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsIconUpdateRecoversWhenBytesAreMissing() {
+	t := s.T()
+	ctx := context.Background()
+
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+
+	const (
+		globalTemplate = `
+agent_options:
+controls:
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+policies:
+reports:
+`
+
+		teamTemplate = `
+controls:
+software:
+  packages:
+    - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+      icon:
+        path: %s/testdata/gitops/lib/icon.png
+    - url: ${SOFTWARE_INSTALLER_URL}/vim.deb
+      icon:
+        path: %s/testdata/gitops/lib/icon.png
+reports:
+policies:
+agent_options:
+name: %s
+settings:
+  secrets: [{"secret":"enroll_secret"}]
+`
+	)
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to get runtime caller info")
+	dirPath := filepath.Dir(currentFile)
+	dirPath = filepath.Join(dirPath, "../../fleetctl")
+	dirPath, err := filepath.Abs(filepath.Clean(dirPath))
+	require.NoError(t, err)
+
+	globalFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = globalFile.WriteString(globalTemplate)
+	require.NoError(t, err)
+	require.NoError(t, globalFile.Close())
+
+	teamName := uuid.NewString()
+	teamFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = fmt.Fprintf(teamFile, teamTemplate, dirPath, dirPath, teamName)
+	require.NoError(t, err)
+	require.NoError(t, teamFile.Close())
+
+	t.Setenv("FLEET_URL", s.Server.URL)
+	testing_utils.StartSoftwareInstallerServer(t)
+
+	firstRunOut := fleetctl.RunAppForTest(t, []string{
+		"gitops", "--config", fleetctlConfig.Name(),
+		"-f", globalFile.Name(), "-f", teamFile.Name(),
+	})
+	s.assertRealRunOutput(t, firstRunOut)
+	require.Contains(t, firstRunOut, "set icons on 2 software titles")
+
+	team, err := s.DS.TeamByName(ctx, teamName)
+	require.NoError(t, err)
+
+	titles, _, _, err := s.DS.ListSoftwareTitles(ctx,
+		fleet.SoftwareTitleListOptions{TeamID: &team.ID},
+		fleet.TeamFilter{User: test.UserAdmin})
+	require.NoError(t, err)
+	require.Len(t, titles, 2)
+
+	// Both titles should share the same storage_id.
+	var storageIDs []string
+	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &storageIDs,
+			"SELECT DISTINCT storage_id FROM software_title_icons WHERE team_id = ?", team.ID)
+	})
+	require.Len(t, storageIDs, 1)
+	storageID := storageIDs[0]
+
+	iconPath := filepath.Join(s.iconDir, "software-title-icons", storageID)
+	info, err := os.Stat(iconPath)
+	require.NoError(t, err)
+	originalSize := info.Size()
+	require.Positive(t, originalSize)
+
+	require.NoError(t, os.Truncate(iconPath, 0))
+
+	secondRunOut := fleetctl.RunAppForTest(t, []string{
+		"gitops", "--config", fleetctlConfig.Name(),
+		"-f", globalFile.Name(), "-f", teamFile.Name(),
+	})
+	s.assertRealRunOutput(t, secondRunOut)
+
+	info, err = os.Stat(iconPath)
+	require.NoError(t, err)
+	require.Equal(t, originalSize, info.Size())
+}
+
 // TestGitOpsTeamLabels tests operations around team labels
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsTeamLabels() {
 	t := s.T()

--- a/ee/server/service/software_title_icons.go
+++ b/ee/server/service/software_title_icons.go
@@ -114,7 +114,9 @@ func (svc *Service) UploadSoftwareTitleIcon(ctx context.Context, payload *fleet.
 					return fleet.SoftwareTitleIcon{}, ctxerr.Wrap(ctx, err, "storing icon")
 				}
 			} else {
-				return fleet.SoftwareTitleIcon{}, ctxerr.New(ctx, fmt.Sprintf("software title icon with hash '%s' does not exist", payload.StorageID))
+				return fleet.SoftwareTitleIcon{}, ctxerr.Wrap(ctx, &fleet.ConflictError{
+					Message: fmt.Sprintf("software title icon with hash '%s' does not exist in the icon store", payload.StorageID),
+				}, "icon bytes missing for metadata-only update")
 			}
 		}
 	}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3294,7 +3294,7 @@ FROM
 	LEFT JOIN fleet_maintained_apps fma ON
 		si.fleet_maintained_app_id = fma.id
 WHERE
-	global_or_team_id = ?
+	si.global_or_team_id = ? AND si.is_active = 1
 
 UNION ALL
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3294,7 +3294,7 @@ FROM
 	LEFT JOIN fleet_maintained_apps fma ON
 		si.fleet_maintained_app_id = fma.id
 WHERE
-	si.global_or_team_id = ? AND si.is_active = 1
+	global_or_team_id = ?
 
 UNION ALL
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -267,6 +267,27 @@ func (c IconChanges) WithSoftware(packages []SoftwarePackageResponse, vppApps []
 		software = append(software, vppApps[i])
 	}
 
+	// Dedup by title ID, preferring the row with a populated LocalIconHash.
+	// Otherwise an unmatched duplicate response row would append the title
+	// to TitleIDsToRemoveIconsFrom and race with the active row's planning.
+	seen := make(map[uint]int, len(software))
+	deduped := make([]CanHaveSoftwareIcon, 0, len(software))
+	for _, sw := range software {
+		titleID := sw.GetTitleID()
+		if titleID == nil {
+			continue
+		}
+		if idx, found := seen[*titleID]; found {
+			if deduped[idx].GetLocalIconHash() == "" && sw.GetLocalIconHash() != "" {
+				deduped[idx] = sw
+			}
+			continue
+		}
+		seen[*titleID] = len(deduped)
+		deduped = append(deduped, sw)
+	}
+	software = deduped
+
 	// don't (duplicate) upload (of) icons that we don't need to
 	for _, sw := range software {
 		teamID := sw.GetTeamID()

--- a/server/fleet/software_installer_test.go
+++ b/server/fleet/software_installer_test.go
@@ -273,3 +273,64 @@ func TestIsScriptPackage(t *testing.T) {
 		})
 	}
 }
+
+func TestIconChangesDedupesDuplicateTitleRows(t *testing.T) {
+	titleID := uint(100)
+	hash := "abc123"
+	localPath := "/tmp/icon.png"
+
+	packages := []SoftwarePackageResponse{
+		{
+			TeamID:        ptr.Uint(1),
+			TitleID:       &titleID,
+			HashSHA256:    "active-pkg-sha",
+			IconHash:      hash,
+			IconFilename:  "icon.png",
+			LocalIconHash: hash,
+			LocalIconPath: localPath,
+		},
+		{
+			TeamID:       ptr.Uint(1),
+			TitleID:      &titleID,
+			HashSHA256:   "inactive-pkg-sha",
+			IconHash:     hash,
+			IconFilename: "icon.png",
+		},
+	}
+
+	changes := IconChanges{}.WithSoftware(packages, nil)
+
+	require.Empty(t, changes.TitleIDsToRemoveIconsFrom)
+	require.Empty(t, changes.IconsToUpload)
+	require.Empty(t, changes.IconsToUpdate)
+}
+
+func TestIconChangesDedupPrefersPopulatedRow(t *testing.T) {
+	titleID := uint(100)
+	hash := "abc123"
+	localPath := "/tmp/icon.png"
+
+	packages := []SoftwarePackageResponse{
+		{
+			TeamID:       ptr.Uint(1),
+			TitleID:      &titleID,
+			HashSHA256:   "inactive-pkg-sha",
+			IconHash:     hash,
+			IconFilename: "icon.png",
+		},
+		{
+			TeamID:        ptr.Uint(1),
+			TitleID:       &titleID,
+			HashSHA256:    "active-pkg-sha",
+			IconHash:      hash,
+			IconFilename:  "icon.png",
+			LocalIconHash: hash,
+			LocalIconPath: localPath,
+		},
+	}
+
+	changes := IconChanges{}.WithSoftware(packages, nil)
+	require.Empty(t, changes.TitleIDsToRemoveIconsFrom)
+	require.Empty(t, changes.IconsToUpload)
+	require.Empty(t, changes.IconsToUpdate)
+}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2562,10 +2562,22 @@ func (c *Client) doGitOpsIcons(iconUpdates fleet.IconChanges, concurrentUploads 
 	updates.SetLimit(concurrentUpdates)
 	for _, toUpdate := range iconUpdates.IconsToUpdate {
 		updates.Go(func() error {
-			if err := c.UpdateIcon(iconUpdates.TeamID, toUpdate.TitleID, filepath.Base(toUpdate.Path), toUpdate.Hash); err != nil {
+			err := c.UpdateIcon(iconUpdates.TeamID, toUpdate.TitleID, filepath.Base(toUpdate.Path), toUpdate.Hash)
+			if err == nil {
+				return nil
+			}
+			if !errors.Is(err, ErrIconBytesMissing) {
 				return fmt.Errorf("failed to update software icon %s: %w", toUpdate.Path, err)
 			}
 
+			iconReader, openErr := os.OpenFile(toUpdate.Path, os.O_RDONLY, 0o0755)
+			if openErr != nil {
+				return fmt.Errorf("failed to read software icon for fallback upload %s: %w", toUpdate.Path, openErr)
+			}
+			defer iconReader.Close()
+			if uploadErr := c.UploadIcon(iconUpdates.TeamID, toUpdate.TitleID, filepath.Base(toUpdate.Path), iconReader); uploadErr != nil {
+				return fmt.Errorf("failed to recover software icon via upload %s: %w", toUpdate.Path, uploadErr)
+			}
 			return nil
 		})
 	}

--- a/server/service/client_software.go
+++ b/server/service/client_software.go
@@ -206,6 +206,12 @@ func (c *Client) UpdateIcon(teamID uint, titleID uint, filename string, hash str
 	return c.putIcon(teamID, titleID, writer, buf)
 }
 
+// ErrIconBytesMissing is returned by UpdateIcon when the server has the
+// software_title_icons row but the underlying bytes for the requested storage
+// hash are missing or fail integrity. Callers can fall back to a full upload
+// to recover.
+var ErrIconBytesMissing = errors.New("icon bytes missing on server")
+
 func (c *Client) putIcon(teamID uint, titleID uint, writer *multipart.Writer, buf bytes.Buffer) error {
 	response, err := c.doContextWithBodyAndHeaders(
 		context.Background(),
@@ -224,11 +230,14 @@ func (c *Client) putIcon(teamID uint, titleID uint, writer *multipart.Writer, bu
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
+	switch response.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusConflict:
+		return ErrIconBytesMissing
+	default:
 		return fmt.Errorf("update icon: unexpected status code: %d", response.StatusCode)
 	}
-
-	return nil
 }
 
 func (c *Client) DeleteIcon(teamID uint, titleID uint) error {


### PR DESCRIPTION
Fixes #43511

## Summary

Builds on #44540 (which prevents new drift between `software_title_icons` rows and bytes in the icon store) by detecting and recovering from drift that already exists.

  - The metadata-only icon update path now returns `409 Conflict` instead of a generic `500` when the requested storage hash has no bytes in the store.
  - `fleetctl gitops` recognizes the `409` and falls back to a full upload for that title, restoring the bytes.
  - The icon planner deduplicates batch-set response rows by title ID, preferring the row with a populated local hash, so legacy inactive installer rows can no longer schedule a spurious icon delete.

  ## Testing

  - Unit tests cover the planner dedup (both orderings of duplicate rows).
  - New integration test exercises upload > truncate bytes > recover via the client-side fallback, verifying the icon is restored to its original size.
  - Existing `TestGitOpsIconRecoversAfterClearingStaleHash` and `TestGitOpsSoftwareIcons` still pass; no behavior change for the no-op or clean-state paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitOps now automatically recovers when software icon bytes are missing or corrupted on the server by falling back to a full upload to restore the bytes.
  * Added deduplication of duplicate software title entries to prevent redundant icon update operations.

* **Tests**
  * Added integration test to validate automatic recovery behavior when icon bytes are missing after hash mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->