### PR TITLE
Changes to ease testing while releasing fleetd to TUF

### DIFF
--- a/tools/fleetd-linux/README.md
+++ b/tools/fleetd-linux/README.md
@@ -10,6 +10,10 @@ To build all docker images run:
 ```sh
 ./tools/fleetd-linux/build-all.sh
 ```
+To build all docker images using `edge` channels from our staging TUF:
+```sh
+UPDATE_URL=https://updates-staging.fleetdm.com ORBIT_CHANNEL=edge DESKTOP_CHANNEL=edge OSQUERYD_CHANNEL=edge ./tools/fleetd-linux/build-all.sh
+```
 
 ## Run fleetd containers
 

--- a/tools/fleetd-linux/build-all.sh
+++ b/tools/fleetd-linux/build-all.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 script_dir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 cd "$script_dir"
 
-echo "Building fleetd deb package..."
+echo "Building fleetd deb (amd64) package..."
 fleetctl package --type=deb \
 	--enable-scripts \
 	--fleet-url=https://host.docker.internal:8080 \
@@ -13,9 +13,13 @@ fleetctl package --type=deb \
 	--fleet-certificate=../osquery/fleet.crt \
 	--disable-open-folder \
 	--outfile=fleet-osquery_amd64.deb \
+    ${UPDATE_URL:+--update-url=$UPDATE_URL} \
+    ${ORBIT_CHANNEL:+--orbit-channel=$ORBIT_CHANNEL} \
+    ${DESKTOP_CHANNEL:+--desktop-channel=$DESKTOP_CHANNEL} \
+    ${OSQUERYD_CHANNEL:+--osqueryd-channel=$OSQUERYD_CHANNEL} \
 	--debug
 
-echo "Building fleetd rpm package..."
+echo "Building fleetd rpm (amd64) package..."
 fleetctl package --type=rpm \
 	--enable-scripts \
 	--fleet-url=https://host.docker.internal:8080 \
@@ -23,6 +27,10 @@ fleetctl package --type=rpm \
 	--fleet-certificate=../osquery/fleet.crt \
 	--disable-open-folder \
 	--outfile=fleet-osquery_amd64.rpm \
+    ${UPDATE_URL:+--update-url=$UPDATE_URL} \
+    ${ORBIT_CHANNEL:+--orbit-channel=$ORBIT_CHANNEL} \
+    ${DESKTOP_CHANNEL:+--desktop-channel=$DESKTOP_CHANNEL} \
+    ${OSQUERYD_CHANNEL:+--osqueryd-channel=$OSQUERYD_CHANNEL} \
 	--debug
 
 echo "Building docker images..."

--- a/tools/fleetd-linux/docker-compose.yml
+++ b/tools/fleetd-linux/docker-compose.yml
@@ -19,16 +19,16 @@ services:
     platform: *default-platform
     environment: *default-environment
     cap_add: *default-caps
-    restart: on-failure
+    restart: always
   fedora43-fleetd:
     image: "fleetd-fedora-43"
     platform: *default-platform
     environment: *default-environment
     cap_add: *default-caps
-    restart: on-failure
+    restart: always
   debian13.4-fleetd:
     image: "fleetd-debian-13.4"
     platform: *default-platform
     environment: *default-environment
     cap_add: *default-caps
-    restart: on-failure
+    restart: always

--- a/tools/fleetd-linux/docker-compose.yml
+++ b/tools/fleetd-linux/docker-compose.yml
@@ -19,16 +19,16 @@ services:
     platform: *default-platform
     environment: *default-environment
     cap_add: *default-caps
-    restart: always
+    restart: unless-stopped
   fedora43-fleetd:
     image: "fleetd-fedora-43"
     platform: *default-platform
     environment: *default-environment
     cap_add: *default-caps
-    restart: always
+    restart: unless-stopped
   debian13.4-fleetd:
     image: "fleetd-debian-13.4"
     platform: *default-platform
     environment: *default-environment
     cap_add: *default-caps
-    restart: always
+    restart: unless-stopped


### PR DESCRIPTION
This eases the testing of fleetd updates (to `edge`) on Linux amd64 (from macOS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now accepts optional CLI configuration parameters (--update-url, --orbit-channel, --desktop-channel, --osqueryd-channel) to customize package generation during builds.
  * Containerized fleetd services now use a restart policy that keeps services running unless explicitly stopped, improving reliability and reducing downtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->