### PR TITLE
fix UI elements in script library not respecting GitOps mode

### DIFF
--- a/changes/44196-script-library-gitops-fixes
+++ b/changes/44196-script-library-gitops-fixes
@@ -1,0 +1,1 @@
+- Fixed UI elements in script library not respecting GitOps mode when enabled. 

--- a/frontend/pages/ManageControlsPage/Scripts/components/EditScriptModal/EditScriptModal.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/EditScriptModal/EditScriptModal.tsx
@@ -7,6 +7,7 @@ import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
 import RunScriptHelpText from "pages/hosts/components/ScriptDetailsModal/RunScriptHelpText";
 import scriptAPI from "services/entities/scripts";
+import useGitOpsMode from "hooks/useGitOpsMode";
 
 import Button from "components/buttons/Button";
 import DataError from "components/DataError";
@@ -14,6 +15,7 @@ import Editor from "components/Editor";
 import Modal from "components/Modal";
 import ModalFooter from "components/ModalFooter";
 import Spinner from "components/Spinner";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 import { ScriptContent } from "interfaces/script";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -93,6 +95,7 @@ const EditScriptModal = ({
     isTeamTechnician,
     isGlobalTechnician,
   } = useContext(AppContext);
+  const { gitOpsModeEnabled } = useGitOpsMode();
 
   const isTechnician = !!isTeamTechnician || !!isGlobalTechnician;
 
@@ -194,6 +197,7 @@ const EditScriptModal = ({
             onBlur={onBlur}
             onChange={onChange}
             value={scriptFormData}
+            readOnly={gitOpsModeEnabled}
           />
           <RunScriptHelpText
             className="form-field__help-text"
@@ -209,13 +213,19 @@ const EditScriptModal = ({
                 <Button onClick={onExit} variant="inverse">
                   Cancel
                 </Button>
-                <Button
-                  onClick={onSave}
-                  isLoading={isSubmitting}
-                  disabled={!!formError}
-                >
-                  Save
-                </Button>
+                <GitOpsModeTooltipWrapper
+                  renderChildren={(gitopsEnabled) => {
+                    return (
+                      <Button
+                        onClick={onSave}
+                        isLoading={isSubmitting}
+                        disabled={!!formError || gitopsEnabled}
+                      >
+                        Save
+                      </Button>
+                    );
+                  }}
+                />
               </>
             }
           />

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from "@testing-library/react";
-import { renderWithSetup } from "test/test-utils";
+import { createCustomRenderer, renderWithSetup } from "test/test-utils";
 import { IScript } from "interfaces/script";
 import React from "react";
+import scriptAPI from "services/entities/scripts";
 import ScriptListItem from "./ScriptListItem";
+
+jest.mock("services/entities/scripts", () => ({
+  __esModule: true,
+  default: { downloadScript: jest.fn() },
+}));
 
 const MAC_SCRIPT: IScript = {
   id: 1,
@@ -115,5 +121,53 @@ describe("ScriptListItem", () => {
     expect(onEdit).toHaveBeenCalledWith(MAC_SCRIPT);
     expect(onClickScript).not.toHaveBeenCalled();
     expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  describe("with GitOps mode enabled", () => {
+    const renderWithGitOps = () => {
+      const customRender = createCustomRenderer({
+        context: {
+          app: {
+            config: {
+              gitops: {
+                gitops_mode_enabled: true,
+                repository_url: "https://github.com/fleetdm/fleet",
+              },
+            },
+          },
+        },
+      });
+
+      return customRender(
+        <ScriptListItem
+          script={MAC_SCRIPT}
+          onDelete={onDelete}
+          onEdit={onEdit}
+          onClickScript={onClickScript}
+        />
+      );
+    };
+
+    it("does not call onEdit, onDelete, or onClickScript when clicking the disabled pencil/trash", async () => {
+      const { user } = renderWithGitOps();
+
+      await user.click(screen.getByTestId("pencil-icon"));
+      await user.click(screen.getByTestId("trash-icon"));
+
+      expect(onEdit).not.toHaveBeenCalled();
+      expect(onDelete).not.toHaveBeenCalled();
+      expect(onClickScript).not.toHaveBeenCalled();
+    });
+
+    it("still calls download when the download button is clicked", async () => {
+      (scriptAPI.downloadScript as jest.Mock).mockResolvedValue("script body");
+
+      const { user } = renderWithGitOps();
+
+      await user.click(screen.getByTestId("download-icon"));
+
+      expect(scriptAPI.downloadScript).toHaveBeenCalledWith(MAC_SCRIPT.id);
+      expect(onClickScript).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
@@ -86,23 +86,20 @@ const ScriptListItem = ({
 
   const { graphicName, platform } = getFileRenderDetails(script.name);
 
-  const onClickEdit = (evt: React.MouseEvent | React.KeyboardEvent) => {
-    evt.stopPropagation();
+  const onClickEdit = () => {
     onEdit(script);
   };
 
-  const onClickDownload = (evt: React.MouseEvent | React.KeyboardEvent) => {
-    evt.stopPropagation();
+  const onClickDownload = () => {
     onDownload(script, renderFlash);
   };
 
-  const onClickDelete = (evt: React.MouseEvent | React.KeyboardEvent) => {
-    evt.stopPropagation();
+  const onClickDelete = () => {
     onDelete(script);
   };
 
   const actions = (
-    <>
+    <div onClick={(evt) => evt.stopPropagation()}>
       <GitOpsModeTooltipWrapper
         renderChildren={(disableChildren) => (
           <Button
@@ -134,7 +131,7 @@ const ScriptListItem = ({
           </Button>
         )}
       />
-    </>
+    </div>
   );
 
   return (


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44196 


https://github.com/user-attachments/assets/4a013290-0089-4b98-86a6-544ca26d1896


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Script library UI now respects GitOps mode: editor is read-only and save actions are disabled when enabled.
  * Action buttons no longer inadvertently propagate clicks, preventing unintended interactions in the script list.

* **Tests**
  * Added tests verifying GitOps-mode behavior for edit/delete/download actions and download handling without external calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->