### PR TITLE
Remove 1Password custom package

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -205,11 +205,6 @@ reports:
 software:
   packages:
     # macOS apps
-    - path: ../lib/macos/software/1password.yml # 1Password for macOS
-      self_service: true
-      setup_experience: true
-      categories:
-        - Security
     - path: ../lib/macos/software/fleet-keynote-theme.yml # Fleet Keynote theme for macOS
       self_service: true
       labels_include_any:

--- a/it-and-security/lib/macos/software/1password.yml
+++ b/it-and-security/lib/macos/software/1password.yml
@@ -1,1 +1,0 @@
-url: https://downloads.1password.com/mac/1Password.pkg


### PR DESCRIPTION
Remove the 1Password package entry from it-and-security/fleets/workstations.yml (including its self_service, setup_experience and categories fields) and delete the corresponding descriptor file it-and-security/lib/macos/software/1password.yml which contained the download URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed 1Password from macOS self-service software packages. The application remains available through fleet-maintained apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->