### PR TITLE
Re-add install policies for 1Password and Nudge

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -160,8 +160,8 @@ policies:
   - path: ../lib/macos/policies/all-software-updates-installed.yml
   - path: ../lib/macos/policies/disk-encryption-check.yml
   - path: ../lib/macos/policies/disk-space-check.yml
-  # - path: ../lib/macos/policies/1password-installed.yml https://github.com/fleetdm/fleet/pull/44179
-  # - path: ../lib/macos/policies/nudge-installed.yml
+  - path: ../lib/macos/policies/1password-installed.yml
+  - path: ../lib/macos/policies/nudge-installed.yml
   - path: ../lib/macos/policies/install-nudge-assets.yml
   - path: ../lib/macos/policies/install-fleet-desktop-launch-agent.yml
   - path: ../lib/macos/policies/santa-endpoint-security-extension-active.yml
@@ -178,7 +178,7 @@ policies:
   - path: ../lib/windows/policies/all-windows-updates-installed.yml
   - path: ../lib/windows/policies/disk-encryption-check.yml
   - path: ../lib/windows/policies/disk-space-check.yml
-  # - path: ../lib/windows/policies/1password-installed.yml
+  - path: ../lib/windows/policies/1password-installed.yml
   - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/windows/policies/battery-health-check.yml
   - path: ../lib/windows/policies/windows-defender-compliance-check.yml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Enabled additional security and software installation policies for macOS workstations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->