### PR TITLE
Add regression test for renaming a patch policy via GitOps (#43687)

### DIFF
--- a/changes/43687-rename-patch-policy-regression-test
+++ b/changes/43687-rename-patch-policy-regression-test
@@ -1,0 +1,1 @@
+* Added a regression test that covers renaming a patch policy referencing a Fleet-maintained app via GitOps.

--- a/changes/43687-rename-patch-policy-regression-test
+++ b/changes/43687-rename-patch-policy-regression-test
@@ -1,1 +1,0 @@
-* Added a regression test that covers renaming a patch policy referencing a Fleet-maintained app via GitOps.

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -89,6 +89,7 @@ func TestPolicies(t *testing.T) {
 		{"PolicyModificationResetsAttemptNumber", testPolicyModificationResetsAttemptNumber},
 		{"TeamPatchPolicy", testTeamPatchPolicy},
 		{"ApplyPolicySpecsDynamicAndPatchSameFMA", testApplyPolicySpecsDynamicAndPatchSameFMA},
+		{"ApplyPolicySpecsRenamePatchPolicyRegression43687", testApplyPolicySpecsRenamePatchPolicyRegression43687},
 		{"TeamPolicyAutomationFilter", testTeamPolicyAutomationFilter},
 		{"BatchedPolicyMembershipCleanup", testBatchedPolicyMembershipCleanup},
 		{"BatchedPolicyMembershipCleanupOnPolicyUpdate", testBatchedPolicyMembershipCleanupOnPolicyUpdate},
@@ -7993,6 +7994,86 @@ func testApplyPolicySpecsDynamicAndPatchSameFMA(t *testing.T, ds *Datastore) {
 	require.Equal(t, "patch-fma", patch.Name)
 	require.NotNil(t, patch.PatchSoftwareTitleID, "patch policy must set patch_software_title_id")
 	require.Equal(t, fmaTitleID, *patch.PatchSoftwareTitleID)
+}
+
+// testApplyPolicySpecsRenamePatchPolicyRegression43687 reproduces the customer
+// scenario from issue #43687: GitOps renaming a patch policy that references
+// an FMA (e.g. "Adobe Reader up to date" -> "Adobe Reader") used to 5xx with
+// "applying policy specs: select policies id: sql: no rows in result set"
+// because the upsert UPDATE matched by (team_id, patch_software_title_id) but
+// did not update the name, and the post-upsert SELECT then looked up the row
+// by the new name and found nothing.
+func testApplyPolicySpecsRenamePatchPolicyRegression43687(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-43687"})
+	require.NoError(t, err)
+
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Adobe Reader",
+		Slug:             "adobe-reader/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "com.adobe.Reader",
+	})
+	require.NoError(t, err)
+
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:        "hello",
+		PreInstallQuery:      "SELECT 1",
+		PostInstallScript:    "world",
+		StorageID:            "storage-43687",
+		Filename:             "adobe-reader",
+		Title:                "Adobe Reader",
+		Version:              "1.0",
+		Source:               "apps",
+		Platform:             "darwin",
+		BundleIdentifier:     "com.adobe.Reader",
+		UserID:               user1.ID,
+		TeamID:               &team.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: &maintainedApp.ID,
+	})
+	require.NoError(t, err)
+
+	// Apply the original patch policy with the auto-generated-style name.
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, []*fleet.PolicySpec{
+		{
+			Name:                   "Adobe Reader up to date",
+			Team:                   team.Name,
+			Type:                   fleet.PolicyTypePatch,
+			FleetMaintainedAppSlug: "adobe-reader/darwin",
+		},
+	})
+	require.NoError(t, err)
+
+	policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "")
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	require.Equal(t, "Adobe Reader up to date", policies[0].Name)
+	originalID := policies[0].ID
+
+	// Rename the policy via GitOps. Same FMA slug, only the name changes. The
+	// pre-fix code path failed here with "select policies id: sql: no rows in
+	// result set" because the ON DUPLICATE KEY UPDATE matched by
+	// (team_id, patch_software_title_id) but did not update name, and the
+	// follow-up SELECT WHERE name = "Adobe Reader" returned no rows.
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, []*fleet.PolicySpec{
+		{
+			Name:                   "Adobe Reader",
+			Team:                   team.Name,
+			Type:                   fleet.PolicyTypePatch,
+			FleetMaintainedAppSlug: "adobe-reader/darwin",
+		},
+	})
+	require.NoError(t, err)
+
+	// The same row must now carry the new name (update, not delete + recreate).
+	policies, _, err = ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "")
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	require.Equal(t, originalID, policies[0].ID)
+	require.Equal(t, "Adobe Reader", policies[0].Name)
+	require.Equal(t, fleet.PolicyTypePatch, policies[0].Type)
 }
 
 func testTeamPolicyAutomationFilter(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
**Related issue:** Resolves #43687

## Summary
Added a regression test for the issue above. Seems to have been fixed in #43420 as part of 4.83.1.

# Checklist for submitter

- [x] Changes file added
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Testing

- Created a patch policy for Adobe Acrobat Reader for the Workstations fleet.
- Ran generate-gitops.
- Renamed the entry for this patch policy to have the "EDITED -" prefix.
- Ran gitops.
- Ran succeeded and I see the policy's name was updated on the UI.

<img width="761" height="411" alt="Screenshot 2026-05-05 at 8 14 45 PM" src="https://github.com/user-attachments/assets/4091e4db-d935-40ef-8d85-4ae9094af24e" />

<img width="1242" height="357" alt="Screenshot 2026-05-05 at 8 21 05 PM" src="https://github.com/user-attachments/assets/1f13d5bc-3293-403f-9353-fa8f9a93d39d" />
