### PR TITLE
Missing docs for "List host's reports" endpoint

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8849,6 +8849,7 @@ Resets [webhook and ticket policy automations](https://fleetdm.com/docs/using-fl
 ## Reports
 
 - [List reports](#list-reports)
+- [List host's reports](#list-hosts-reports)
 - [Get report](#get-report)
 - [Get report data](#get-report-data)
 - [Get host's report data](#get-hosts-report-data)
@@ -9017,6 +9018,89 @@ Returns a list of reports. To see each report's data, use the [get report data](
   "count": 200
 }
 ```
+
+### List host's reports
+
+Lists the saved reports that run on a host, along with the first result for each report that saves results.
+
+`GET /api/v1/fleet/hosts/:id/reports`
+
+#### Parameters
+
+| Name               | Type    | In    | Description                                                                                                   |
+| ------------------ | ------- | ----- | ------------------------------------------------------------------------------------------------------------- |
+| id                 | integer | path  | **Required**. The host's ID.                                                                                  |
+| query              | string  | query | Search query keywords. Searchable fields include `name`.                                                      |
+| exclude_no_results | boolean | query | If `true`, exclude reports that don't save results. Default is `false`.                                       |
+| page               | integer | query | Page number of the results to fetch.                                                                          |
+| per_page           | integer | query | Results per page.                                                                                             |
+| order_key          | string  | query | What to order results by. Valid options are `"name"` and `"last_fetched"`. Default is `"name"`.               |
+| order_direction    | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
+
+#### Example
+
+`GET /api/v1/fleet/hosts/123/reports`
+
+##### Default response
+
+`Status: 200`
+
+```json
+{
+  "reports": [
+    {
+      "id": 31,
+      "name": "List USB devices",
+      "description": "Retrieves USB devices and their details.",
+      "query": "SELECT model, vendor FROM usb_devices;",
+      "logging": "snapshot",
+      "discard_data": false,
+      "total_results_count": 4,
+      "last_fetched": "2021-01-19T17:08:31Z",
+      "first_result_columns": {
+        "model": "USB 2.0 Hub",
+        "vendor": "VIA Labs, Inc."
+      }
+    },
+    {
+      "id": 44,
+      "name": "Get operating system version",
+      "description": "Retrieves the host's operating system version.",
+      "query": "SELECT name, version, major, minor, patch FROM os_version;",
+      "logging": "differential",
+      "discard_data": false,
+      "total_results_count": 1,
+      "last_fetched": "2021-01-20T14:52:09Z",
+      "first_result_columns": {
+        "name": "macOS",
+        "version": "14.2.1",
+        "major": "14",
+        "minor": "2",
+        "patch": "1"
+      }
+    },
+    {
+      "id": 52,
+      "name": "Check disk encryption status",
+      "description": "Checks disk encryption status.",
+      "query": "SELECT 1 FROM disk_encryption WHERE encrypted = 1;",
+      "logging": "snapshot",
+      "discard_data": true,
+      "total_results_count": 0,
+      "last_fetched": "2021-01-21T09:30:00Z",
+      "first_result_columns": null
+    }
+  ],
+  "meta": {
+    "has_next_results": false,
+    "has_previous_results": false
+  },
+  "count": 3
+}
+```
+
+> The report's first row reflects the order returned by the underlying [table](https://fleetdm.com/tables) implementation. Without an `ORDER BY` clause in the query, this order is not guaranteed to be consistent across runs — particularly for tables backed by live OS state (e.g. processes, network connections). To ensure a predictable first result, add `ORDER BY <column>` to your query.
+  
 
 ### Get report
 


### PR DESCRIPTION
Add missing docs for https://github.com/fleetdm/fleet/issues/40187

(The [original PR](https://github.com/fleetdm/fleet/pull/41569) was accidentally closed instead of merged, and since I used Kilo for the initial draft, I don't have permission to re-open it.)