### PR TITLE
Limit expired host cleanup per run

### DIFF
--- a/changes/limit-expired-host-cleanup-batch
+++ b/changes/limit-expired-host-cleanup-batch
@@ -1,0 +1,1 @@
+* Limited automatic host expiry cleanup to a bounded number of expired hosts per cron run.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -34,6 +34,9 @@ var (
 	hostIssuesInsertBatchSize                = 10000
 	hostIssuesUpdateFailingPoliciesBatchSize = 10000
 	hostsDeleteBatchSize                     = 5000
+	// Cap automatic host expiry cleanup per cron run so large churn/backlog events
+	// are drained across runs instead of all at once.
+	expiredHostsCleanupBatchSize = 5000
 )
 
 var (
@@ -3679,14 +3682,24 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]fleet.DeletedHo
 	}
 
 	var teamsUsingGlobalExpiry []uint
-	teamsUsingCustomExpiry := map[uint]int{}
+	type teamExpiry struct {
+		id     uint
+		window int
+	}
+	var teamsUsingCustomExpiry []teamExpiry
 	for _, team := range teams {
 		if !team.Config.HostExpirySettings.HostExpiryEnabled {
 			teamsUsingGlobalExpiry = append(teamsUsingGlobalExpiry, team.ID)
 		} else {
-			teamsUsingCustomExpiry[team.ID] = team.Config.HostExpirySettings.HostExpiryWindow
+			teamsUsingCustomExpiry = append(teamsUsingCustomExpiry, teamExpiry{
+				id:     team.ID,
+				window: team.Config.HostExpirySettings.HostExpiryWindow,
+			})
 		}
 	}
+	sort.Slice(teamsUsingCustomExpiry, func(i, j int) bool {
+		return teamsUsingCustomExpiry[i].id < teamsUsingCustomExpiry[j].id
+	})
 
 	// Usual clean up queries used to be like this:
 	// DELETE FROM hosts WHERE id in (SELECT host_id FROM host_seen_times WHERE seen_time < DATE_SUB(NOW(), INTERVAL ? DAY))
@@ -3706,61 +3719,64 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]fleet.DeletedHo
 	//
 	// To avoid prematurely deleting hosts that are ingested from Apple DEP, we cross-reference the
 	// host_dep_assignments table.
-	findHostsSql := `SELECT h.id FROM hosts h
+	hostLastSeenSQL := `COALESCE(GREATEST(COALESCE(hst.seen_time, ne.last_seen_at), COALESCE(ne.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'), h.created_at)`
+	findHostsSql := `SELECT h.id, ? AS expiry_window, ` + hostLastSeenSQL + ` AS last_seen_at FROM hosts h
 		LEFT JOIN host_seen_times hst ON h.id = hst.host_id
 		LEFT JOIN host_dep_assignments hda ON h.id = hda.host_id
 		LEFT JOIN nano_enrollments ne ON ne.id=h.uuid AND ne.type IN ('Device', 'User Enrollment (Device)')
-		WHERE COALESCE(GREATEST(COALESCE(hst.seen_time, ne.last_seen_at), COALESCE(ne.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'), h.created_at) < DATE_SUB(NOW(), INTERVAL ? DAY)
+		WHERE ` + hostLastSeenSQL + ` < DATE_SUB(NOW(), INTERVAL ? DAY)
 			AND (hda.host_id IS NULL OR hda.deleted_at IS NOT NULL)`
 
-	var allIdsToDelete []uint
-	hostIDToExpiryWindow := make(map[uint]int)
+	if expiredHostsCleanupBatchSize <= 0 {
+		return nil, nil
+	}
+
+	var candidateQueries []string
+	var candidateArgs []interface{}
 	// Process hosts using global expiry
 	if ac.HostExpirySettings.HostExpiryEnabled {
-		sqlQuery := findHostsSql + " AND (team_id IS NULL"
-		args := []interface{}{ac.HostExpirySettings.HostExpiryWindow}
+		sqlQuery := findHostsSql + " AND (h.team_id IS NULL"
+		args := []interface{}{ac.HostExpirySettings.HostExpiryWindow, ac.HostExpirySettings.HostExpiryWindow}
 		if len(teamsUsingGlobalExpiry) > 0 {
-			sqlQuery += " OR team_id IN (?)"
-			sqlQuery, args, err = sqlx.In(sqlQuery, args[0], teamsUsingGlobalExpiry)
+			sqlQuery += " OR h.team_id IN (?)"
+			args = append(args, teamsUsingGlobalExpiry)
+			sqlQuery, args, err = sqlx.In(sqlQuery, args...)
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "building query to get expired host ids")
 			}
 		}
 		sqlQuery += ")"
-		var globalIDs []uint
-		err = ds.writer(ctx).SelectContext(
-			ctx,
-			&globalIDs,
-			sqlQuery,
-			args...,
-		)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting global expired hosts")
-		}
-		for _, id := range globalIDs {
-			hostIDToExpiryWindow[id] = ac.HostExpirySettings.HostExpiryWindow
-		}
-		allIdsToDelete = append(allIdsToDelete, globalIDs...)
+		candidateQueries = append(candidateQueries, sqlQuery)
+		candidateArgs = append(candidateArgs, args...)
 	}
 
 	// Process hosts using team expiry
-	for teamId, expiry := range teamsUsingCustomExpiry {
-		var ids []uint
-		sqlQuery := findHostsSql + " AND team_id = ?"
-		args := []interface{}{expiry, teamId}
-		err = ds.writer(ctx).SelectContext(
-			ctx,
-			&ids,
-			sqlQuery,
-			args...,
-		)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting team expired hosts")
-		}
-		for _, id := range ids {
-			hostIDToExpiryWindow[id] = expiry
-		}
-		allIdsToDelete = append(allIdsToDelete, ids...)
+	for _, team := range teamsUsingCustomExpiry {
+		sqlQuery := findHostsSql + " AND h.team_id = ?"
+		candidateQueries = append(candidateQueries, sqlQuery)
+		candidateArgs = append(candidateArgs, team.window, team.window, team.id)
+	}
+
+	if len(candidateQueries) == 0 {
+		return nil, nil
+	}
+
+	type expiredHostCandidate struct {
+		ID           uint `db:"id"`
+		ExpiryWindow int  `db:"expiry_window"`
+	}
+	var expiredHosts []expiredHostCandidate
+	expiredHostsQuery := `SELECT id, expiry_window FROM (` + strings.Join(candidateQueries, " UNION ALL ") + `) expired_hosts ORDER BY last_seen_at ASC, id ASC LIMIT ?`
+	candidateArgs = append(candidateArgs, expiredHostsCleanupBatchSize)
+	if err := ds.writer(ctx).SelectContext(ctx, &expiredHosts, expiredHostsQuery, candidateArgs...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting expired hosts")
+	}
+
+	allIdsToDelete := make([]uint, 0, len(expiredHosts))
+	hostIDToExpiryWindow := make(map[uint]int, len(expiredHosts))
+	for _, host := range expiredHosts {
+		allIdsToDelete = append(allIdsToDelete, host.ID)
+		hostIDToExpiryWindow[host.ID] = host.ExpiryWindow
 	}
 
 	// Get host details before deletion for activity creation

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -129,6 +129,7 @@ func TestHosts(t *testing.T) {
 		{"HostsListFailingPolicies", printReadsInTest(testHostsListFailingPolicies)},
 		{"HostsListBatchScriptExecution", testHostsListByBatchScriptExecutionStatus},
 		{"HostsExpiration", testHostsExpiration},
+		{"HostsExpirationBatchSize", testHostsExpirationBatchSize},
 		{"IOSHostExpiration", testIOSHostsExpiration},
 		{"DEPHostExpiration", testDEPHostsExpiration},
 		{"AppleMDMHostWithoutOrbitExpiration", testAppleMDMHostsWithoutOrbitExpiration},
@@ -5697,6 +5698,88 @@ func testHostsExpiration(t *testing.T, ds *Datastore) {
 
 	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 5)
 	require.Len(t, hosts, 5)
+}
+
+func testHostsExpirationBatchSize(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	originalExpiredHostsCleanupBatchSize := expiredHostsCleanupBatchSize
+	expiredHostsCleanupBatchSize = 2
+	t.Cleanup(func() {
+		expiredHostsCleanupBatchSize = originalExpiredHostsCleanupBatchSize
+	})
+
+	const globalHostExpiryWindow = 10
+	const teamHostExpiryWindow = 5
+
+	ac, err := ds.AppConfig(ctx)
+	require.NoError(t, err)
+	ac.HostExpirySettings.HostExpiryEnabled = true
+	ac.HostExpirySettings.HostExpiryWindow = globalHostExpiryWindow
+	require.NoError(t, ds.SaveAppConfig(ctx, ac))
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "batch-expiry-team"})
+	require.NoError(t, err)
+	team.Config.HostExpirySettings.HostExpiryEnabled = true
+	team.Config.HostExpirySettings.HostExpiryWindow = teamHostExpiryWindow
+	team, err = ds.SaveTeam(ctx, team)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	createHost := func(id int, seenTime time.Time, teamID *uint) uint {
+		host, err := ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        seenTime,
+			OsqueryHostID:   ptr.String(strconv.Itoa(id)),
+			NodeKey:         ptr.String(fmt.Sprintf("%d", id)),
+			UUID:            fmt.Sprintf("%d", id),
+			Hostname:        fmt.Sprintf("batch-expiry-%d.local", id),
+		})
+		require.NoError(t, err)
+		if teamID != nil {
+			require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(teamID, []uint{host.ID})))
+		}
+		return host.ID
+	}
+
+	oldestGlobalID := createHost(1, now.Add(-20*24*time.Hour), nil)
+	oldestTeamID := createHost(2, now.Add(-19*24*time.Hour), &team.ID)
+	newerGlobalID := createHost(3, now.Add(-18*24*time.Hour), nil)
+	newerTeamID := createHost(4, now.Add(-17*24*time.Hour), &team.ID)
+	createHost(5, now, nil)
+
+	filter := fleet.TeamFilter{User: test.UserAdmin}
+	hosts := listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 5)
+	require.Len(t, hosts, 5)
+
+	hostDetails, err := ds.CleanupExpiredHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hostDetails, 2)
+	deleted := make([]uint, len(hostDetails))
+	for i, detail := range hostDetails {
+		deleted[i] = detail.ID
+	}
+	require.ElementsMatch(t, []uint{oldestGlobalID, oldestTeamID}, deleted)
+
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 3)
+	require.Len(t, hosts, 3)
+
+	hostDetails, err = ds.CleanupExpiredHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hostDetails, 2)
+	deleted = make([]uint, len(hostDetails))
+	for i, detail := range hostDetails {
+		deleted[i] = detail.ID
+	}
+	require.ElementsMatch(t, []uint{newerGlobalID, newerTeamID}, deleted)
+
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 1)
+	require.Len(t, hosts, 1)
+
+	hostDetails, err = ds.CleanupExpiredHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hostDetails, 0)
 }
 
 func testIOSHostsExpiration(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
## Summary
- Cap automatic expired host cleanup to 5,000 hosts per cron run.
- Apply the cap directly in the expired-host candidate query so large backlogs are drained across runs instead of selected/deleted all at once.
- Avoid a full candidate-set UNION sort/materialization step; the query now returns up to the cap without ordering the full expired-host backlog.
- Add datastore coverage that verifies an expired-host backlog drains across multiple cleanup runs.

## Testing
- go test ./server/datastore/mysql -run 'TestHosts/HostsExpiration|TestHosts/HostsExpirationBatchSize|TestHosts/TeamHostsExpiration|TestHosts/IOSHostExpiration|TestHosts/DEPHostExpiration|TestHosts/AppleMDMHostWithoutOrbitExpiration' -count=1
- go test ./server/service -run TestCleanupExpiredHostsActivities -count=1
- git diff --check