### PR TITLE
Update chart styles / fix bugs

### DIFF
--- a/frontend/interfaces/charts.ts
+++ b/frontend/interfaces/charts.ts
@@ -11,6 +11,7 @@ export interface IDataSet {
   description?: ReactNode;
   tooltipFormatter?: TooltipFormatter;
   theme?: ChartTheme;
+  relativeScale?: boolean;
 }
 
 export interface IFormattedDataPoint {

--- a/frontend/pages/DashboardPage/_styles.scss
+++ b/frontend/pages/DashboardPage/_styles.scss
@@ -33,6 +33,11 @@
     }
   }
 
+  .card {
+    box-sizing: border-box;
+    overflow-x: hidden;
+  }
+
   &__platforms {
     display: flex;
     align-items: center;
@@ -75,11 +80,6 @@
   &__charts-row {
     display: grid;
     row-gap: $gap-page-component;
-
-    .card {
-      box-sizing: border-box;
-      overflow-x: hidden;
-    }
 
     @media screen and (min-width: $break-md) {
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/frontend/pages/DashboardPage/_styles.scss
+++ b/frontend/pages/DashboardPage/_styles.scss
@@ -76,6 +76,11 @@
     display: grid;
     row-gap: $gap-page-component;
 
+    .card {
+      box-sizing: border-box;
+      overflow-x: hidden;
+    }
+
     @media screen and (min-width: $break-md) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
       column-gap: $gap-page-component;

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -49,21 +49,9 @@ const DATASETS: IDataSet[] = [
         during a given hour.
       </>
     ),
-    tooltipFormatter: ({
-      value,
-      total,
-      percentage,
-    }: {
-      value: number;
-      total?: number;
-      percentage?: number;
-    }) => (
-      <>
-        {percentage}% active
-        <br />({total ? `${value} / ${total}` : 0} hosts)
-      </>
-    ),
-    relativeScale: false,
+    tooltipFormatter: ({ value }: { value: number }) =>
+      `${value.toLocaleString()} hosts`,
+    relativeScale: true,
   },
   {
     name: "cve",
@@ -82,23 +70,24 @@ const DATASETS: IDataSet[] = [
           vulnerabilities
         </a>{" "}
         during a given hour.
+        <br />
+        <br />
+        Want more control over this chart? Comprehensive vulnerability filtering
+        is{" "}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://github.com/fleetdm/fleet/issues/44746"
+        >
+          coming soon
+        </a>
+        .
       </>
     ),
-    tooltipFormatter: ({
-      value,
-      total,
-      percentage,
-    }: {
-      value: number;
-      total?: number;
-      percentage?: number;
-    }) => (
-      <>
-        {percentage}% exposed
-        <br />({total ? `${value} / ${total}` : 0} hosts)
-      </>
-    ),
+    tooltipFormatter: ({ value }: { value: number }) =>
+      `${value.toLocaleString()} hosts`,
     theme: "red",
+    relativeScale: true,
   },
 ];
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -257,6 +257,7 @@ const ChartCard = ({
                 }
               }}
               className={`${baseClass}__dataset-dropdown`}
+              nowrapMenu
             />
           ) : (
             <h2 className={`${baseClass}__title`}>{currentDataset.label}</h2>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -44,9 +44,11 @@ const DATASETS: IDataSet[] = [
     defaultChartType: "checkerboard",
     description: (
       <>
-        Shows the number of hosts detected online
+        The number of hosts detected online during a given hour.
         <br />
-        during a given hour.
+        A host is considered online if it&rsquo;s actively checking in to Fleet.
+        <br />
+        This includes sleeping hosts (e.g. lid closed).{" "}
       </>
     ),
     tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -50,7 +50,7 @@ const DATASETS: IDataSet[] = [
       </>
     ),
     tooltipFormatter: ({ value }: { value: number }) =>
-      `${value.toLocaleString()} hosts`,
+      `${value.toLocaleString()} host${value === 1 ? "" : "s"} online`,
     relativeScale: true,
   },
   {
@@ -85,7 +85,7 @@ const DATASETS: IDataSet[] = [
       </>
     ),
     tooltipFormatter: ({ value }: { value: number }) =>
-      `${value.toLocaleString()} hosts`,
+      `${value.toLocaleString()} host${value === 1 ? "" : "s"}`,
     theme: "red",
     relativeScale: true,
   },

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -63,7 +63,7 @@ const DATASETS: IDataSet[] = [
         <br />({total ? `${value} / ${total}` : 0} hosts)
       </>
     ),
-    relativeScale: true,
+    relativeScale: false,
   },
   {
     name: "cve",

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -63,6 +63,7 @@ const DATASETS: IDataSet[] = [
         <br />({total ? `${value} / ${total}` : 0} hosts)
       </>
     ),
+    relativeScale: true,
   },
   {
     name: "cve",
@@ -240,6 +241,7 @@ const ChartCard = ({
       selectedDays: CHART_DAYS,
       theme: currentDataset.theme,
       tooltipFormatter: currentDataset.tooltipFormatter,
+      relativeScale: currentDataset.relativeScale,
     };
 
     switch (currentDataset.defaultChartType) {

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
@@ -170,6 +170,87 @@ describe("CheckerboardViz", () => {
     }
   });
 
+  it("stretches the color ramp across the dataset's min/max when relativeScale is true", async () => {
+    // All values fall in the 0–20% range, which the default fixed-threshold
+    // ramp would collapse entirely into level-1 (with 0% pinned to level-0).
+    // Relative scaling should rescale the non-zero values across levels 1–5.
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 0,
+        percentage: 0,
+      },
+      {
+        timestamp: "2026-03-01T02:00:00",
+        label: "Mar 1, 2am",
+        value: 4,
+        percentage: 4,
+      },
+      {
+        timestamp: "2026-03-01T04:00:00",
+        label: "Mar 1, 4am",
+        value: 8,
+        percentage: 8,
+      },
+      {
+        timestamp: "2026-03-01T06:00:00",
+        label: "Mar 1, 6am",
+        value: 12,
+        percentage: 12,
+      },
+      {
+        timestamp: "2026-03-01T08:00:00",
+        label: "Mar 1, 8am",
+        value: 16,
+        percentage: 16,
+      },
+      {
+        timestamp: "2026-03-01T10:00:00",
+        label: "Mar 1, 10am",
+        value: 20,
+        percentage: 20,
+      },
+    ];
+
+    // Sanity check: with the default fixed ramp, every non-zero point lands
+    // in level-1.
+    const { container: defaultContainer } = renderWithSetup(
+      <CheckerboardViz data={points} selectedDays={1} />
+    );
+    await waitFor(() => {
+      expect(defaultContainer.querySelectorAll("rect").length).toBeGreaterThan(
+        0
+      );
+    });
+    const defaultClasses = Array.from(
+      defaultContainer.querySelectorAll("rect")
+    ).map((r) => r.getAttribute("class") || "");
+    for (let level = 2; level <= 5; level += 1) {
+      expect(defaultClasses.some((c) => c.includes(`--level-${level}`))).toBe(
+        false
+      );
+    }
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={points} selectedDays={1} relativeScale />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    const classNames = Array.from(container.querySelectorAll("rect")).map(
+      (r) => r.getAttribute("class") || ""
+    );
+    // 0% stays reserved for level-0 even when the ramp is stretched.
+    expect(classNames.some((c) => c.includes("--level-0"))).toBe(true);
+    // The remaining values should span all five non-zero levels.
+    for (let level = 1; level <= 5; level += 1) {
+      expect(classNames.some((c) => c.includes(`--level-${level}`))).toBe(true);
+    }
+  });
+
   it("renders the legend with all color levels", () => {
     const data = generateData(1);
     renderWithSetup(<CheckerboardViz data={data} selectedDays={30} />);

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -215,6 +215,20 @@ const CheckerboardViz = ({
     }
   }, [gridWidth]);
 
+  // Also snap to the right edge whenever the wrapper resizes while the
+  // grid is clipped, so a window resize keeps the most recent data in view.
+  useEffect(() => {
+    const el = scrollWrapperRef.current;
+    if (!el) return undefined;
+    const observer = new ResizeObserver(() => {
+      if (el.scrollWidth > el.clientWidth) {
+        el.scrollLeft = el.scrollWidth;
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   // Compute x-axis date labels: start, middle, end
   const xAxisDates = useMemo(() => {
     if (dayLabels.length < 2) return { start: "", middle: "", end: "" };

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -81,7 +81,9 @@ const CheckerboardViz = ({
     getColorLevel = (percentage: number): number => {
       if (percentage === 0) return 0;
       const scaled = ((percentage - minPerc) / range) * 5;
-      return Math.min(5, Math.ceil(scaled));
+      // Level zero is reserved for real 0, so ensure we return
+      // something between 1 and 5.
+      return Math.min(5, Math.ceil(scaled)) || 1;
     };
   }
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -58,7 +58,7 @@ const CheckerboardViz = ({
   const [hoveredCell, setHoveredCell] = useState<ICellData | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const [tooltipAlign, setTooltipAlign] = useState<"left" | "center" | "right">(
-    "center",
+    "center"
   );
 
   let getColorLevel;

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -102,15 +102,6 @@ const CheckerboardViz = ({
     return () => observer.disconnect();
   }, []);
 
-  // Scroll the grid to the far right on mount so the most recent data is
-  // visible by default.
-  useEffect(() => {
-    const el = scrollWrapperRef.current;
-    if (el) {
-      el.scrollLeft = el.scrollWidth;
-    }
-  }, []);
-
   // Hours per slot: 3 for 30-day, 2 for 7/14-day, 1 for 24-hour
   const is24h = selectedDays === 1;
   let hoursPerSlot = 1;
@@ -213,6 +204,16 @@ const CheckerboardViz = ({
   const cellH = CELL_H * scale;
   const gridWidth = cellW * numCols + CELL_GAP * (numCols - 1);
   const gridHeight = cellH * numRows + CELL_GAP * (numRows - 1);
+
+  // Scroll the grid to the far right so the most recent data is visible by
+  // default. Re-runs when the grid resizes (e.g. when the card crosses the
+  // wide breakpoint and cells scale up, growing scrollWidth).
+  useEffect(() => {
+    const el = scrollWrapperRef.current;
+    if (el) {
+      el.scrollLeft = el.scrollWidth;
+    }
+  }, [gridWidth]);
 
   // Compute x-axis date labels: start, middle, end
   const xAxisDates = useMemo(() => {

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -302,7 +302,9 @@ const CheckerboardViz = ({
                   ry={3}
                   className={`${baseClass}__cell ${baseClass}__cell--level-${level}`}
                   role="img"
-                  aria-label={`${cell.dayLabel}, ${cell.hourLabel}: ${cell.percentage}% of hosts online`}
+                  aria-label={`${cell.dayLabel}, ${cell.hourLabel}: ${
+                    cell.value
+                  } host${cell.value === 1 ? "" : "s"}`}
                   onMouseEnter={(e) => handleMouseEnter(cell, e)}
                   onMouseLeave={handleMouseLeave}
                 />

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -10,17 +10,6 @@ import {
 
 const baseClass = "checkerboard-viz";
 
-// Returns a CSS class suffix for the color level (0-5). Buckets match the
-// six legend swatches declared in _styles.scss (level-0 is the no-data swatch).
-const getColorLevel = (percentage: number): number => {
-  if (percentage === 0) return 0;
-  if (percentage <= 20) return 1;
-  if (percentage <= 40) return 2;
-  if (percentage <= 60) return 3;
-  if (percentage <= 80) return 4;
-  return 5;
-};
-
 const formatHourLabel = (hourVal: number): string => {
   if (hourVal === 0) return "12am";
   if (hourVal < 12) return `${hourVal}am`;
@@ -43,6 +32,7 @@ interface ICheckerboardVizProps {
   selectedDays: number;
   theme?: ChartTheme;
   tooltipFormatter?: TooltipFormatter;
+  relativeScale?: boolean;
 }
 
 // These are calculated at a chart width of 580px and columns.
@@ -60,6 +50,7 @@ const CheckerboardViz = ({
   selectedDays,
   theme = "green",
   tooltipFormatter,
+  relativeScale = false,
 }: ICheckerboardVizProps): JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isWide, setIsWide] = useState(false);
@@ -68,6 +59,31 @@ const CheckerboardViz = ({
   const [tooltipAlign, setTooltipAlign] = useState<"left" | "center" | "right">(
     "center"
   );
+
+  let getColorLevel;
+  if (!relativeScale) {
+    getColorLevel = (percentage: number): number => {
+      if (percentage === 0) return 0;
+      if (percentage <= 20) return 1;
+      if (percentage <= 40) return 2;
+      if (percentage <= 60) return 3;
+      if (percentage <= 80) return 4;
+      return 5;
+    };
+  } else {
+    // When relativeScale is true, the color ramp is based on the min/max in
+    // this dataset, not fixed percentage thresholds. This surfaces more
+    // variation when values are generally low or generally high.
+    const minPerc = Math.min(...data.map((d) => d.percentage));
+    const maxPerc = Math.max(...data.map((d) => d.percentage));
+    const range = maxPerc - minPerc || 1; // avoid divide-by-zero
+
+    getColorLevel = (percentage: number): number => {
+      if (percentage === 0) return 0;
+      const scaled = ((percentage - minPerc) / range) * 5;
+      return Math.min(5, Math.ceil(scaled));
+    };
+  }
 
   useEffect(() => {
     const node = containerRef.current;

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -53,11 +53,12 @@ const CheckerboardViz = ({
   relativeScale = false,
 }: ICheckerboardVizProps): JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollWrapperRef = useRef<HTMLDivElement>(null);
   const [isWide, setIsWide] = useState(false);
   const [hoveredCell, setHoveredCell] = useState<ICellData | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const [tooltipAlign, setTooltipAlign] = useState<"left" | "center" | "right">(
-    "center"
+    "center",
   );
 
   let getColorLevel;
@@ -99,6 +100,15 @@ const CheckerboardViz = ({
     });
     observer.observe(node);
     return () => observer.disconnect();
+  }, []);
+
+  // Scroll the grid to the far right on mount so the most recent data is
+  // visible by default.
+  useEffect(() => {
+    const el = scrollWrapperRef.current;
+    if (el) {
+      el.scrollLeft = el.scrollWidth;
+    }
   }, []);
 
   // Hours per slot: 3 for 30-day, 2 for 7/14-day, 1 for 24-hour
@@ -280,7 +290,7 @@ const CheckerboardViz = ({
           </div>
         )}
 
-        <div className={`${baseClass}__scroll-wrapper`}>
+        <div ref={scrollWrapperRef} className={`${baseClass}__scroll-wrapper`}>
           {/* Grid cells */}
           <svg width={gridWidth} height={gridHeight}>
             {grid.map((cell) => {

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -284,18 +284,23 @@ const CheckerboardViz = ({
             {grid.map((cell) => {
               const col = is24h ? cell.hourRow : cell.dayIndex;
               const row = is24h ? 0 : cell.hourRow;
+              const level = getColorLevel(cell.percentage);
+              // Filled cells have a bg-colored 1px stroke that visually blends
+              // away. The level-0 (empty) cell uses a colored stroke instead,
+              // so without insetting it would look 1px larger than filled
+              // cells. Inset by half the stroke so the outline's outer edge
+              // sits where the filled cell's invisible stroke does.
+              const inset = level === 0 ? 0.5 : 0;
               return (
                 <rect
                   key={`${cell.dayIndex}-${cell.hourRow}`}
-                  x={col * (cellW + CELL_GAP)}
-                  y={row * (cellH + CELL_GAP)}
-                  width={cellW}
-                  height={cellH}
+                  x={col * (cellW + CELL_GAP) + inset}
+                  y={row * (cellH + CELL_GAP) + inset}
+                  width={cellW - inset * 2}
+                  height={cellH - inset * 2}
                   rx={3}
                   ry={3}
-                  className={`${baseClass}__cell ${baseClass}__cell--level-${getColorLevel(
-                    cell.percentage
-                  )}`}
+                  className={`${baseClass}__cell ${baseClass}__cell--level-${level}`}
                   role="img"
                   aria-label={`${cell.dayLabel}, ${cell.hourLabel}: ${cell.percentage}% of hosts online`}
                   onMouseEnter={(e) => handleMouseEnter(cell, e)}

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -122,7 +122,7 @@ const CheckerboardViz = ({
           value: point.value,
           total: point.total,
           percentage: point.percentage,
-          dayLabel: format(date, "MMM d"),
+          dayLabel: format(date, "EEEE, MMM d"),
           hourLabel: formatHourLabel(date.getHours()),
         };
       });
@@ -181,7 +181,7 @@ const CheckerboardViz = ({
           percentage: point?.percentage ?? 0,
           value: point?.value ?? 0,
           total: point?.total,
-          dayLabel: format(date, "MMM d"),
+          dayLabel: format(date, "EEEE, MMM d"),
           hourLabel: formatHourLabel(hourVal),
         });
       }

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -24,7 +24,7 @@
   }
 
   &__title {
-    font-size: $small;
+    font-size: $medium !important;
     font-weight: $bold;
     margin: 0 !important;
     line-height: 1;
@@ -38,7 +38,9 @@
 
     // Override inline styles from DropdownWrapper to make it look like a heading.
     // !important is needed because react-select applies inline styles via the
-    // styles prop which always beat class-based selectors.
+    // styles prop which always beat class-based selectors. Padding is zeroed
+    // so the dropdown's text baseline aligns horizontally with the
+    // HostsEnrolledCard heading rendered alongside it.
     .react-select__control {
       background-color: transparent !important;
       border-color: transparent !important;
@@ -54,9 +56,10 @@
     }
 
     .react-select__single-value {
-      font-size: $small;
+      font-size: $medium;
       font-weight: $bold;
       color: $core-fleet-black;
+      line-height: 1;
     }
 
     .react-select__indicator-separator {
@@ -64,7 +67,11 @@
     }
 
     .react-select__value-container {
-      padding: 4px 0 4px 8px;
+      padding: 0;
+    }
+
+    .react-select__indicators {
+      padding: 0;
     }
   }
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -15,6 +15,7 @@
   &__description-tooltip {
     display: inline-flex;
     align-items: center;
+    line-height: 1;
   }
 
   &__header-right {
@@ -36,17 +37,27 @@
       display: none;
     }
 
-    // Override inline styles from DropdownWrapper to make it look like a heading.
-    // !important is needed because react-select applies inline styles via the
-    // styles prop which always beat class-based selectors. Padding is zeroed
-    // so the dropdown's text baseline aligns horizontally with the
-    // HostsEnrolledCard heading rendered alongside it.
+    // DropdownWrapper sets the react-select container to a fixed 36px height
+    // via inline styles, which makes the chart-card header taller than the
+    // HostsEnrolledCard heading next to it. Collapse the SelectContainer to
+    // its natural content height so both card headings line up.
+    > div {
+      height: auto !important;
+    }
+
     .react-select__control {
       background-color: transparent !important;
       border-color: transparent !important;
+      border-width: 0 !important;
       box-shadow: none !important;
-      padding: 0;
-      min-height: auto;
+      // !important overrides DropdownWrapper's inline 8px left/right padding
+      // so the dropdown text starts at the card's left edge, matching the
+      // HostsEnrolledCard heading.
+      padding: 0 !important;
+      // !important defeats react-select's default 38px min-height on the
+      // control so the chart-card header collapses to its content height
+      // and lines up with the HostsEnrolledCard h2 next door.
+      min-height: 0 !important;
     }
 
     // When menu is open, show the border
@@ -89,6 +100,9 @@
   }
 
   &__settings-btn {
+    // Button variant="inverse" applies a 36px height that would make the
+    // chart-card header taller than HostsEnrolledCard's bare h2 next door.
+    // Shrink to content height so headers match.
     display: flex;
     align-items: center;
     justify-content: center;
@@ -96,6 +110,8 @@
     background: transparent;
     cursor: pointer;
     color: $ui-fleet-black-75;
+    height: auto !important;
+    padding: 0 !important;
   }
 
   &__chart-container {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -4,8 +4,7 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: $pad-medium;
-    position: relative;
-    top: -2.5px;
+    min-height: 28px;
   }
 
   &__header-left {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -4,6 +4,8 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: $pad-medium;
+    position: relative;
+    top: -2.5px;
   }
 
   &__header-left {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -146,8 +146,33 @@
     min-width: 0;
     overflow-x: auto;
 
+    // Mac users with "Show scroll bars: Always" set in System Settings see a
+    // permanent scrollbar gutter that overlaps the cells. Force overlay-style
+    // behaviour: the track stays transparent and the thumb only appears when
+    // the user hovers the chart.
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+
+    &::-webkit-scrollbar {
+      height: 6px;
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: transparent;
+      border-radius: 3px;
+    }
+
     svg {
       display: block;
+    }
+  }
+
+  &:hover &__scroll-wrapper {
+    scrollbar-color: $ui-fleet-black-25 transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: $ui-fleet-black-25;
     }
   }
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -27,7 +27,7 @@
   }
 
   &__title {
-    font-size: $medium !important;
+    font-size: $medium;
     font-weight: $bold;
     margin: 0 !important;
     line-height: 1;

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -333,6 +333,10 @@
     &--level-0 {
       fill: none;
       stroke: var(--level-0);
+      // SVG only fires hover on filled regions or stroked lines; without
+      // pointer-events: all, hovering inside an outlined-only cell does
+      // nothing because the interior has no fill.
+      pointer-events: all;
       // HTML legend swatch can't use SVG stroke; inset shadow gives the same
       // outlined-only look without changing the swatch's outer dimensions.
       background-color: transparent;

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -54,7 +54,7 @@
     }
 
     .react-select__single-value {
-      font-size: 18px;
+      font-size: $small;
       font-weight: $bold;
       color: $core-fleet-black;
     }
@@ -111,7 +111,6 @@
     border-radius: $border-radius;
     font-size: $xx-small;
     box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.1);
-
   }
 
   &__tooltip-label {
@@ -125,7 +124,7 @@
 
   .react-tooltip {
     a {
-      color: $core-fleet-white;
+      color: $static-white;
       display: inline;
       font-size: $xx-small;
     }
@@ -268,11 +267,11 @@
 
     body.dark-mode & {
       --level-0: #515256;
-      --level-1: #2E363D;
-      --level-2: #2B4747;
+      --level-1: #2e363d;
+      --level-2: #2b4747;
       --level-3: #006246;
-      --level-4: #008B64;
-      --level-5: #00C28B;
+      --level-4: #008b64;
+      --level-5: #00c28b;
     }
   }
 
@@ -283,6 +282,15 @@
     --level-3: #d28282;
     --level-4: #9a0000;
     --level-5: #5b0000;
+
+    body.dark-mode & {
+      --level-0: #515256;
+      --level-1: #3d2e2e;
+      --level-2: #472b2b;
+      --level-3: #640000;
+      --level-4: #8b0000;
+      --level-5: #c20000;
+    }
   }
 
   &__cell {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -290,8 +290,12 @@
     stroke-width: 1px;
 
     &--level-0 {
-      fill: var(--level-0);
-      background-color: var(--level-0);
+      fill: none;
+      stroke: var(--level-0);
+      // HTML legend swatch can't use SVG stroke; inset shadow gives the same
+      // outlined-only look without changing the swatch's outer dimensions.
+      background-color: transparent;
+      box-shadow: inset 0 0 0 1px var(--level-0);
     }
 
     &--level-1 {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -86,6 +86,14 @@
     .react-select__indicators {
       padding: 0;
     }
+
+    // nowrapMenu anchors the menu to the right edge of the control, which is
+    // designed for table-filter dropdowns. Re-anchor to the left so the menu
+    // drops down under the title text rather than under the chevron.
+    .react-select__menu {
+      left: 0 !important;
+      right: auto !important;
+    }
   }
 
   &__filtered-badge {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -27,7 +27,7 @@
   }
 
   &__title {
-    font-size: $medium;
+    font-size: $small;
     font-weight: $bold;
     margin: 0 !important;
     line-height: 1;
@@ -69,7 +69,7 @@
     }
 
     .react-select__single-value {
-      font-size: $medium;
+      font-size: $small;
       font-weight: $bold;
       color: $core-fleet-black;
       line-height: 1;

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -292,11 +292,11 @@
 
     body.dark-mode & {
       --level-0: #515256;
-      --level-1: #3d2e2e;
-      --level-2: #472b2b;
-      --level-3: #640000;
-      --level-4: #8b0000;
-      --level-5: #c20000;
+      --level-1: #5a2727;
+      --level-2: #7d2c2c;
+      --level-3: #a83232;
+      --level-4: #d04040;
+      --level-5: #ff5c5c;
     }
   }
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -265,6 +265,15 @@
     --level-3: #82d2b9;
     --level-4: #009a7d;
     --level-5: #005b4a;
+
+    body.dark-mode & {
+      --level-0: #515256;
+      --level-1: #2E363D;
+      --level-2: #2B4747;
+      --level-3: #006246;
+      --level-4: #008B64;
+      --level-5: #00C28B;
+    }
   }
 
   &--theme-red {

--- a/frontend/pages/DashboardPage/cards/HostCountCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostCountCard/_styles.scss
@@ -72,11 +72,7 @@
   }
 }
 
-// Aligns with $break-md (990px) used by the dashboard grid layouts so the
-// card's internal layout switches at the same width its containing grid
-// switches between single-column and multi-column. A mismatch here caused a
-// few-pixel-wide window of overflow at viewport widths just below 990px.
-@media (max-width: ($break-md - 1)) {
+@media (max-width: 980px) {
   .host-count-card {
     &__card {
       text-align: center;

--- a/frontend/pages/DashboardPage/cards/HostCountCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostCountCard/_styles.scss
@@ -72,7 +72,11 @@
   }
 }
 
-@media (max-width: 980px) {
+// Aligns with $break-md (990px) used by the dashboard grid layouts so the
+// card's internal layout switches at the same width its containing grid
+// switches between single-column and multi-column. A mismatch here caused a
+// few-pixel-wide window of overflow at viewport widths just below 990px.
+@media (max-width: ($break-md - 1)) {
   .host-count-card {
     &__card {
       text-align: center;

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -232,6 +232,7 @@ const HostsEnrolledCard = ({
               tickFormatter={formatTick}
               axisLine={false}
               tickLine={false}
+              tickMargin={6}
               tick={{ fontSize: tickFontSize }}
             />
             <YAxis

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -217,7 +217,16 @@ const HostsEnrolledCard = ({
             barCategoryGap="25%"
           >
             <CartesianGrid horizontal={false} strokeDasharray="3 3" />
-            <CartesianGrid vertical={false} />
+            <CartesianGrid
+              vertical={false}
+              horizontalCoordinatesGenerator={({ offset }) => {
+                const { top, height } = offset;
+                const bandHeight = height / data.length;
+                return data
+                  .map((_, i) => top + i * bandHeight)
+                  .concat(top + height);
+              }}
+            />
             <XAxis
               type="number"
               tickFormatter={formatTick}

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { InjectedRouter } from "react-router";
 import {
   BarChart,
@@ -22,6 +22,14 @@ const baseClass = "hosts-enrolled-card";
 // up the themed values for the SVG fills.
 const BAR_COLOR = "var(--core-fleet-green)";
 const BAR_HOVER_COLOR = "var(--core-fleet-green-over)";
+
+// Match the checkerboard's cell-grid height so the bar plot lines up with the
+// cells next to it (excluding the checkerboard's x-axis labels and legend).
+// Values come from CheckerboardViz: cellH * numRows + CELL_GAP * (numRows - 1)
+// for the 30-day view (numRows = 8).
+const CHART_HEIGHT_NARROW = 190; // 19 * 8 + 2 * 7
+const CHART_HEIGHT_WIDE = 242; // 28.5 * 8 + 2 * 7
+const WIDE_THRESHOLD = 700; // mirror CheckerboardViz
 
 export interface IHostPlatformCounts {
   darwin: number;
@@ -93,6 +101,7 @@ interface IYAxisTickProps {
   x?: number;
   y?: number;
   payload?: { value: string; index: number };
+  fontSize: number;
   isClickable: (index: number) => boolean;
   onLabelClick: (index: number) => void;
 }
@@ -101,6 +110,7 @@ const ClickableYAxisTick = ({
   x = 0,
   y = 0,
   payload,
+  fontSize,
   isClickable,
   onLabelClick,
 }: IYAxisTickProps): JSX.Element => {
@@ -116,7 +126,7 @@ const ClickableYAxisTick = ({
         y={0}
         dy={4}
         textAnchor="end"
-        fontSize={14}
+        fontSize={fontSize}
         className={clickable ? `${baseClass}__tick--clickable` : undefined}
       >
         {payload.value}
@@ -170,63 +180,92 @@ const HostsEnrolledCard = ({
     return getLabelId(datum.platform) !== undefined;
   };
 
+  // Mirror CheckerboardViz's wide-mode detection so the bar chart's plot area
+  // matches the cell grid height in both layouts.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isWide, setIsWide] = useState(false);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return undefined;
+    setIsWide(node.getBoundingClientRect().width >= WIDE_THRESHOLD);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setIsWide(entry.contentRect.width >= WIDE_THRESHOLD);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const chartHeight = isWide ? CHART_HEIGHT_WIDE : CHART_HEIGHT_NARROW;
+  // 7 platforms in ~166px (narrow) leaves ~23px per row, so the default 14px
+  // ticks crowd. Step down a couple sizes when narrow.
+  const tickFontSize = isWide ? 14 : 11;
+  // ChromeOS is the widest label and just barely doesn't fit at 80/60, so add
+  // a bit of breathing room.
+  const yAxisWidth = isWide ? 90 : 68;
+
   return (
-    <div className={baseClass}>
+    <div className={baseClass} ref={containerRef}>
       <h2 className={`${baseClass}__title`}>Hosts enrolled</h2>
-      <ResponsiveContainer width="100%" height={280}>
-        <BarChart
-          data={data}
-          layout="vertical"
-          margin={{ top: 0, right: 20, bottom: 0, left: 0 }}
-          barCategoryGap="25%"
-        >
-          <CartesianGrid horizontal={false} strokeDasharray="3 3" />
-          <CartesianGrid vertical={false} />
-          <XAxis
-            type="number"
-            tickFormatter={formatTick}
-            axisLine={false}
-            tickLine={false}
-            tick={{ fontSize: 14 }}
-          />
-          <YAxis
-            type="category"
-            dataKey="label"
-            axisLine={false}
-            tickLine={false}
-            width={80}
-            tick={
-              <ClickableYAxisTick
-                isClickable={isTickClickable}
-                onLabelClick={handleTickClick}
-              />
-            }
-          />
-          <Tooltip
-            content={<HostsEnrolledTooltip />}
-            cursor={false}
-            isAnimationActive={false}
-          />
-          <Bar
-            dataKey="count"
-            radius={[0, 4, 4, 0]}
-            barSize={16}
-            isAnimationActive={false}
-            activeBar={{ fill: BAR_HOVER_COLOR }}
-            onClick={(d) => handleBarClick(d.payload as IPlatformDatum)}
+      <div className={`${baseClass}__chart-container`}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <BarChart
+            data={data}
+            layout="vertical"
+            margin={{ top: 0, right: 20, bottom: 0, left: 0 }}
+            barCategoryGap="25%"
           >
-            {data.map((entry) => (
-              <Cell
-                key={entry.label}
-                fill={BAR_COLOR}
-                className={
-                  entry.count > 0 ? `${baseClass}__bar--clickable` : undefined
-                }
-              />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+            <CartesianGrid horizontal={false} strokeDasharray="3 3" />
+            <CartesianGrid vertical={false} />
+            <XAxis
+              type="number"
+              tickFormatter={formatTick}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: tickFontSize }}
+            />
+            <YAxis
+              type="category"
+              dataKey="label"
+              axisLine={false}
+              tickLine={false}
+              width={yAxisWidth}
+              interval={0}
+              tick={
+                <ClickableYAxisTick
+                  fontSize={tickFontSize}
+                  isClickable={isTickClickable}
+                  onLabelClick={handleTickClick}
+                />
+              }
+            />
+            <Tooltip
+              content={<HostsEnrolledTooltip />}
+              cursor={false}
+              isAnimationActive={false}
+            />
+            <Bar
+              dataKey="count"
+              radius={[0, 4, 4, 0]}
+              barSize={16}
+              isAnimationActive={false}
+              activeBar={{ fill: BAR_HOVER_COLOR }}
+              onClick={(d) => handleBarClick(d.payload as IPlatformDatum)}
+            >
+              {data.map((entry) => (
+                <Cell
+                  key={entry.label}
+                  fill={BAR_COLOR}
+                  className={
+                    entry.count > 0 ? `${baseClass}__bar--clickable` : undefined
+                  }
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -7,11 +7,9 @@
   }
 
   // The bar chart's plot height is set inline to match the checkerboard's
-  // cell-grid height (see CHART_HEIGHT_* in HostsEnrolledCard.tsx). The
-  // min-height + centering mirrors .chart-card__chart-container so the bar
-  // chart sits in the same vertical band as the checkerboard cells.
+  // cell-grid height (see CHART_HEIGHT_* in HostsEnrolledCard.tsx).
   &__chart-container {
-    min-height: 280px;
+    min-height: 250px;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -3,6 +3,9 @@
     font-weight: $bold;
     margin: 0 0 $pad-medium !important;
     line-height: 1;
+    min-height: 28px;
+    display: flex;
+    align-items: center;
   }
 
   // The bar chart's plot height is set inline to match the checkerboard's

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -5,6 +5,17 @@
     margin: 0 0 $pad-medium !important;
   }
 
+  // The bar chart's plot height is set inline to match the checkerboard's
+  // cell-grid height (see CHART_HEIGHT_* in HostsEnrolledCard.tsx). The
+  // min-height + centering mirrors .chart-card__chart-container so the bar
+  // chart sits in the same vertical band as the checkerboard cells.
+  &__chart-container {
+    min-height: 280px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   // Theme-aware axis tick text. CSS fill overrides the inline fill attribute
   // recharts adds to its default <text> elements. Font size stays inline
   // (recharts measures it via getComputedStyle to lay out the axis).

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -1,6 +1,5 @@
 .hosts-enrolled-card {
   &__title {
-    font-size: $medium !important;
     font-weight: $bold;
     margin: 0 0 $pad-medium !important;
     line-height: 1;

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -1,8 +1,9 @@
 .hosts-enrolled-card {
   &__title {
-    font-size: $small;
+    font-size: $medium !important;
     font-weight: $bold;
     margin: 0 0 $pad-medium !important;
+    line-height: 1;
   }
 
   // The bar chart's plot height is set inline to match the checkerboard's


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44676 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased

## Testing

- [ ] Added/updated automated tests
just style fixes, but the ["disable features: frontend" PR](https://github.com/fleetdm/fleet/pull/44797) has some tests
  - [X] QA'd all new/changed functionality manually
  - [x] make hosts enrolled chart match height w/ checkerboard
  - [x] use empty boxes with outline instead of filled boxes for 0 value
  - [x] use dark-mode colors for green theme
  - [x] put host enrolled chart bars between horizontal rules instead of on top of them
  - [x] only show date and # of hosts in tooltip, no percentage or denominator
  - [X] add day of week to checkerboard tooltip
  - [x] use comma in tooltip numbers
  - [x] use relative shading in both datasets
  - [x] make text size match between hosts enrolled and checkerboard titles
  - [x] on vuln chart tooltip, add "Want more control over this chart?  Comprehensive vulnerability filtering is [coming soon](link to this issue: https://github.com/fleetdm/fleet/issues/44746)."
  - [x] on vuln chart tooltip, fix link styling in dark mode
  - [x] change "Hosts active" => "Hosts online" 
  - [x] Update tooltip copy to "The number of hosts detected online during a given hour. A host is considered online if it's actively checking in to Fleet. This includes sleeping hosts (e.g. lid closed)."
  - [X] Fix issue where at smaller widths, the entire page has a horizontal scrollbar
  - [X] Make charts stay pegged to the right side when first loaded and when resizing window 

Charts align:
<img width="1223" height="479" alt="image" src="https://github.com/user-attachments/assets/4a7ba859-a0aa-43c6-a06b-4ef8361e2418" />

Data tooltip:
<img width="162" height="77" alt="image" src="https://github.com/user-attachments/assets/5b1768e4-0736-4e45-ad49-6faf31958352" />

Vuln tooltip:
<img width="387" height="123" alt="image" src="https://github.com/user-attachments/assets/98c2096f-fa4e-4b06-917e-ec6eed844b05" />

Hosts online tooltip:
<img width="360" height="113" alt="image" src="https://github.com/user-attachments/assets/bd65cd1d-0f0c-4c72-a31d-ffe602cacd9c" />

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional relative scaling for chart visualizations
  * Responsive chart sizing in the Hosts Enrolled card

* **Improvements**
  * Dataset label updated to "Hosts online"
  * Tooltips and labels show formatted host counts with proper pluralization
  * Day labels now include weekday for clearer dates
  * Chart descriptions mention upcoming vulnerability filtering
  * Tighter header, dropdown, scrollbar, and dark‑mode styling

* **Tests**
  * Updated dataset heading test and added a relative‑scale color ramp test
<!-- end of auto-generated comment: release notes by coderabbit.ai -->