### PR TITLE
Fix IdP department host vital missing when SCIM PATCH carries extra attrs (#41996)

### DIFF
--- a/changes/41996-department-idp-host-vital-not-populating-for-some-users
+++ b/changes/41996-department-idp-host-vital-not-populating-for-some-users
@@ -1,0 +1,1 @@
+- Fixed an issue where the IdP "Department" host vital would not populate for users whose IdP-to-SCIM mapping included enterprise extension attributes that Fleet does not store.

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -3184,6 +3184,68 @@ func testPatchUserAttributes(t *testing.T, s *Suite) {
 		assert.Equal(t, "Engineering", m["department"])
 	})
 
+	t.Run("Patch department alongside extra enterprise attributes (no-path, flat keys)", func(t *testing.T) {
+		const enterpriseURN = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+		patchPayload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op": "replace",
+					"value": map[string]any{
+						enterpriseURN + ":department":     "Internal Tools",
+						enterpriseURN + ":employeeNumber": "EMP-12345",
+						enterpriseURN + ":costCenter":     "CC-90",
+					},
+				},
+			},
+		}
+
+		var resp map[string]any
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPayload, http.StatusOK, &resp)
+		ext, ok := resp[enterpriseURN].(map[string]any)
+		require.True(t, ok, "enterprise extension should be present in response")
+		assert.Equal(t, "Internal Tools", ext["department"])
+		// Fleet does not store employeeNumber/costCenter — they must not appear in the response.
+		_, hasEmp := ext["employeeNumber"]
+		assert.False(t, hasEmp, "employeeNumber should not be stored")
+		_, hasCC := ext["costCenter"]
+		assert.False(t, hasCC, "costCenter should not be stored")
+	})
+
+	t.Run("Patch with explicit path on extra enterprise attribute is silently skipped", func(t *testing.T) {
+		const enterpriseURN = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+		// Set a known department first so this.
+		const knownDept = "BeforeNoOp"
+		setDeptPayload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{"op": "replace", "path": enterpriseURN + ":department", "value": knownDept},
+			},
+		}
+		var setResp map[string]any
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), setDeptPayload, http.StatusOK, &setResp)
+
+		// Now PATCH only an unrecognized enterprise attribute.
+		patchPayload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":    "replace",
+					"path":  enterpriseURN + ":employeeNumber",
+					"value": "EMP-OTHER",
+				},
+			},
+		}
+
+		var resp map[string]any
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPayload, http.StatusOK, &resp)
+		ext, ok := resp[enterpriseURN].(map[string]any)
+		require.True(t, ok, "enterprise extension should still be present after the no-op PATCH")
+		assert.Equal(t, knownDept, ext["department"], "department must be unchanged by a no-op PATCH on an extra attribute")
+		_, hasEmp := ext["employeeNumber"]
+		assert.False(t, hasEmp, "employeeNumber must not be stored")
+	})
+
 	// ///////////////////////////////////////////////
 	// Tests for patching with explicit operation path
 

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -3214,7 +3214,9 @@ func testPatchUserAttributes(t *testing.T, s *Suite) {
 
 	t.Run("Patch with explicit path on extra enterprise attribute is silently skipped", func(t *testing.T) {
 		const enterpriseURN = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
-		// Set a known department first so this.
+		// Set a known department first so we can prove the no-op PATCH below leaves
+		// it untouched (this subtest is therefore self-contained — it does not rely
+		// on state established by an earlier subtest).
 		const knownDept = "BeforeNoOp"
 		setDeptPayload := map[string]any{
 			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
@@ -3244,6 +3246,35 @@ func testPatchUserAttributes(t *testing.T, s *Suite) {
 		assert.Equal(t, knownDept, ext["department"], "department must be unchanged by a no-op PATCH on an extra attribute")
 		_, hasEmp := ext["employeeNumber"]
 		assert.False(t, hasEmp, "employeeNumber must not be stored")
+	})
+
+	t.Run("Patch with nested enterprise extension map is rejected by SCIM library", func(t *testing.T) {
+		// The nested form below — where the enterprise URN is the top-level key and the
+		// value is a sub-object — is not accepted by the elimity SCIM library because
+		// validateEmptyPath parses each top-level key as a SCIM path, and a URI alone
+		// (no attribute name after it) fails to parse. This test pins down that
+		// behavior so a future library bump that quietly starts to accept the nested
+		// form will be caught: Fleet only handles the flat
+		// form (urn:...:User:department), and that assumption is load-bearing here.
+		const enterpriseURN = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+		patchPayload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op": "replace",
+					"value": map[string]any{
+						enterpriseURN: map[string]any{
+							"department":     "Sales",
+							"employeeNumber": "EMP-99",
+						},
+					},
+				},
+			},
+		}
+
+		var errResp map[string]any
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPayload, http.StatusBadRequest, &errResp)
+		assert.EqualValues(t, []any{"urn:ietf:params:scim:api:messages:2.0:Error"}, errResp["schemas"])
 	})
 
 	// ///////////////////////////////////////////////

--- a/ee/server/scim/scim.go
+++ b/ee/server/scim/scim.go
@@ -170,6 +170,12 @@ func RegisterSCIM(
 			SchemaExtensions: []scim.SchemaExtension{
 				{
 					Schema: schema.Schema{
+						// Fleet stores only `department`, but we declare the full RFC 7643
+						// §4.3 enterprise attribute set so the elimity SCIM library accepts
+						// (rather than 400s) PATCH payloads from IdPs that bundle these
+						// alongside `department`. The handler reads only what it needs and
+						// silently drops the rest — see the `default` branches in
+						// UserHandler.Patch.
 						Attributes: []schema.CoreAttribute{
 							schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
 								Name:     "department",
@@ -202,6 +208,9 @@ func RegisterSCIM(
 										Name:           "$ref",
 										ReferenceTypes: []schema.AttributeReferenceType{"User"},
 									}),
+									// `displayName` is ReadOnly per RFC 7643 §4.3. The elimity
+									// library silently strips ReadOnly sub-attrs from client
+									// input, so we don't need to tolerate it in the handler.
 									schema.SimpleStringParams(schema.StringParams{
 										Name:       "displayName",
 										Mutability: schema.AttributeMutabilityReadOnly(),
@@ -356,16 +365,11 @@ func debugSCIMPayloadsEnabled() bool {
 	return false
 }
 
-// maxDumpedSCIMBodyBytes caps how much of a SCIM request body the debug payload dump
-// middleware writes to the log. Larger bodies are still passed through to the handler
-// unchanged, but only this many bytes are emitted to the log to keep entries bounded.
-const maxDumpedSCIMBodyBytes = 64 * 1024
-
 // debugPayloadDumpMiddleware logs the raw SCIM request body to scimLogger when enabled
-// is true. The middleware buffers at most maxDumpedSCIMBodyBytes from the body for the log entry
-// and stitches the buffered head back in front of the unread remainder via io.MultiReader
-// so the downstream handler still sees the complete body. This caps memory use on the
-// dump path even for large payloads while preserving SCIM correctness.
+// is true. The full body is read into memory, written to the log, and then restored
+// for the downstream handler via a fresh io.ReadCloser. This is intentionally simple
+// at the cost of memory: SCIM payloads are small in practice, and the flag is intended
+// only for ad-hoc IdP debugging on a non-production cluster (see debugSCIMPayloadsEnabled).
 func debugPayloadDumpMiddleware(logger *slog.Logger, enabled bool, next http.Handler) http.Handler {
 	if !enabled {
 		return next
@@ -374,72 +378,29 @@ func debugPayloadDumpMiddleware(logger *slog.Logger, enabled bool, next http.Han
 		ctx := r.Context()
 		if r.Body == nil || r.Body == http.NoBody {
 			logger.WarnContext(ctx, "scim payload dump",
-				"method", r.Method, "path", r.URL.Path, "size", 0, "truncated", false, "body", "")
+				"method", r.Method, "path", r.URL.Path, "size", 0, "body", "")
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		head := make([]byte, maxDumpedSCIMBodyBytes)
-		n, err := io.ReadFull(r.Body, head)
-		// fullyRead is true when the body is exhausted by ReadFull (shorter than the
-		// head buffer). Used below to skip the truncation probe, which would otherwise
-		// invoke Read on an already-exhausted body and may surface spurious errors on
-		// some http.Body implementations.
-		fullyRead := errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
-		switch {
-		case err == nil, fullyRead:
-			// Either the buffer is full or the body fits entirely on the buffer.
-		default:
-			logger.ErrorContext(ctx, "scim payload dump: failed to read body",
+		body, err := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		if err != nil {
+			// Fail the request explicitly rather than passing an empty body to the
+			// downstream handler — that would surface as a confusing JSON parse
+			// error and mask the real read failure.
+			logger.ErrorContext(ctx, "scim payload dump: failed to read body — failing request to surface error",
 				"method", r.Method, "path", r.URL.Path, "err", err)
-			// Body is partially consumed and unreadable; reset to empty so the downstream
-			// handler fails cleanly rather than hanging waiting for bytes.
-			_ = r.Body.Close()
-			r.Body = io.NopCloser(bytes.NewReader(nil))
-			next.ServeHTTP(w, r)
+			http.Error(w, "internal error reading request body", http.StatusInternalServerError)
 			return
 		}
-		head = head[:n]
 
-		// Probe one byte beyond the cap to detect whether the body was truncated for
-		// logging purposes. Skip the probe when ReadFull already exhausted the body —
-		// a probe Read on an exhausted body adds no information and can spuriously log.
-		var probe [1]byte
-		var truncated bool
-		if !fullyRead {
-			probeN, probeErr := r.Body.Read(probe[:])
-			truncated = probeN > 0
-			if probeErr != nil && !errors.Is(probeErr, io.EOF) {
-				logger.WarnContext(ctx, "scim payload dump: probe read error",
-					"method", r.Method, "path", r.URL.Path, "err", probeErr)
-			}
-		}
-
-		// Build the restored body. Always include head; include the probe byte and
-		// remaining body only if we managed to read past the cap.
 		logger.WarnContext(ctx, "scim payload dump",
 			"method", r.Method, "path", r.URL.Path,
-			"size", len(head), "truncated", truncated, "body", string(head))
-		if truncated {
-			origBody := r.Body
-			r.Body = readCloser{
-				Reader: io.MultiReader(bytes.NewReader(head), bytes.NewReader(probe[:1]), origBody),
-				Closer: origBody,
-			}
-		} else {
-			_ = r.Body.Close()
-			r.Body = io.NopCloser(bytes.NewReader(head))
-		}
+			"size", len(body), "body", string(body))
+		r.Body = io.NopCloser(bytes.NewReader(body))
 		next.ServeHTTP(w, r)
 	})
-}
-
-// readCloser pairs an io.Reader with an independent io.Closer. It is used by
-// debugPayloadDumpMiddleware to expose a stitched body (head + probe + remaining
-// original body) while still propagating Close() to the underlying http.Request.Body.
-type readCloser struct {
-	io.Reader
-	io.Closer
 }
 
 // LastRequestMiddleware saves the details of the last request to SCIM endpoints in the datastore.

--- a/ee/server/scim/scim.go
+++ b/ee/server/scim/scim.go
@@ -367,9 +367,7 @@ func debugSCIMPayloadsEnabled() bool {
 
 // debugPayloadDumpMiddleware logs the raw SCIM request body to scimLogger when enabled
 // is true. The full body is read into memory, written to the log, and then restored
-// for the downstream handler via a fresh io.ReadCloser. This is intentionally simple
-// at the cost of memory: SCIM payloads are small in practice, and the flag is intended
-// only for ad-hoc IdP debugging on a non-production cluster (see debugSCIMPayloadsEnabled).
+// for the downstream handler via a fresh io.ReadCloser.
 func debugPayloadDumpMiddleware(logger *slog.Logger, enabled bool, next http.Handler) http.Handler {
 	if !enabled {
 		return next

--- a/ee/server/scim/scim.go
+++ b/ee/server/scim/scim.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/elimity-com/scim"
@@ -174,6 +175,39 @@ func RegisterSCIM(
 								Name:     "department",
 								Required: false,
 							})),
+							schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+								Name:     "employeeNumber",
+								Required: false,
+							})),
+							schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+								Name:     "costCenter",
+								Required: false,
+							})),
+							schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+								Name:     "organization",
+								Required: false,
+							})),
+							schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+								Name:     "division",
+								Required: false,
+							})),
+							schema.ComplexCoreAttribute(schema.ComplexParams{
+								Name:        "manager",
+								Description: optional.NewString("The User's manager. A complex type that optionally allows service providers to represent organizational hierarchy by referencing the 'id' attribute of another User."),
+								SubAttributes: []schema.SimpleParams{
+									schema.SimpleStringParams(schema.StringParams{
+										Name: "value",
+									}),
+									schema.SimpleReferenceParams(schema.ReferenceParams{
+										Name:           "$ref",
+										ReferenceTypes: []schema.AttributeReferenceType{"User"},
+									}),
+									schema.SimpleStringParams(schema.StringParams{
+										Name:       "displayName",
+										Mutability: schema.AttributeMutabilityReadOnly(),
+									}),
+								},
+							}),
 						},
 						Description: optional.NewString("Enterprise User"),
 						ID:          "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
@@ -216,10 +250,13 @@ func RegisterSCIM(
 		return err
 	}
 
+	dumpPayloadsEnabled := debugSCIMPayloadsEnabled()
+
 	// Apply middleware including OTEL instrumentation
 	applyMiddleware := func(prefix string, server http.Handler) http.Handler {
 		handler := http.StripPrefix(prefix, server)
 		handler = AuthorizationMiddleware(authorizer, scimLogger, handler)
+		handler = debugPayloadDumpMiddleware(scimLogger, dumpPayloadsEnabled, handler)
 		handler = auth.AuthenticatedUserMiddleware(svc, scimErrorHandler, handler)
 		handler = LastRequestMiddleware(ds, scimLogger, handler)
 		handler = log.LogResponseEndMiddleware(scimLogger, handler)
@@ -306,6 +343,92 @@ func scimOTELMiddleware(next http.Handler, prefix string, cfg config.FleetConfig
 			}),
 		)
 		instrumentedHandler.ServeHTTP(w, r)
+	})
+}
+
+// debugSCIMPayloadsEnabled reports whether the FLEET_DEBUG_SCIM_PAYLOADS environment
+// variable is set to a truthy value.
+func debugSCIMPayloadsEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("FLEET_DEBUG_SCIM_PAYLOADS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// maxDumpedSCIMBodyBytes caps how much of a SCIM request body the debug payload dump
+// middleware writes to the log. Larger bodies are still passed through to the handler
+// unchanged, but only this many bytes are emitted to the log to keep entries bounded.
+const maxDumpedSCIMBodyBytes = 64 * 1024
+
+// debugPayloadDumpMiddleware logs the raw SCIM request body to scimLogger when enabled
+// is true. The middleware buffers at most maxDumpedSCIMBodyBytes from the body for the log entry
+// and stitches the buffered head back in front of the unread remainder via io.MultiReader
+// so the downstream handler still sees the complete body. This caps memory use on the
+// dump path even for large payloads while preserving SCIM correctness.
+func debugPayloadDumpMiddleware(logger *slog.Logger, enabled bool, next http.Handler) http.Handler {
+	if !enabled {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		if r.Body == nil || r.Body == http.NoBody {
+			logger.WarnContext(ctx, "scim payload dump",
+				"method", r.Method, "path", r.URL.Path, "size", 0, "truncated", false, "body", "")
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		head := make([]byte, maxDumpedSCIMBodyBytes)
+		n, err := io.ReadFull(r.Body, head)
+		// fullyRead is true when the body is exhausted by ReadFull (shorter than the
+		// head buffer). Used below to skip the truncation probe, which would otherwise
+		// invoke Read on an already-exhausted body and may surface spurious errors on
+		// some http.Body implementations.
+		fullyRead := errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+		switch {
+		case err == nil, fullyRead:
+			// Either the buffer is full or the body fits entirely on the buffer.
+		default:
+			logger.ErrorContext(ctx, "scim payload dump: failed to read body",
+				"method", r.Method, "path", r.URL.Path, "err", err)
+			// Body is partially consumed and unreadable; reset to empty so the downstream
+			// handler fails cleanly rather than hanging waiting for bytes.
+			_ = r.Body.Close()
+			r.Body = io.NopCloser(bytes.NewReader(nil))
+			next.ServeHTTP(w, r)
+			return
+		}
+		head = head[:n]
+
+		// Probe one byte beyond the cap to detect whether the body was truncated for
+		// logging purposes. Skip the probe when ReadFull already exhausted the body —
+		// a probe Read on an exhausted body adds no information and can spuriously log.
+		var probe [1]byte
+		var truncated bool
+		if !fullyRead {
+			probeN, probeErr := r.Body.Read(probe[:])
+			truncated = probeN > 0
+			if probeErr != nil && !errors.Is(probeErr, io.EOF) {
+				logger.WarnContext(ctx, "scim payload dump: probe read error",
+					"method", r.Method, "path", r.URL.Path, "err", probeErr)
+			}
+		}
+
+		// Build the restored body. Always include head; include the probe byte and
+		// remaining body only if we managed to read past the cap.
+		var restored io.Reader = bytes.NewReader(head)
+		if truncated {
+			restored = io.MultiReader(restored, bytes.NewReader(probe[:1]), r.Body)
+		} else {
+			_ = r.Body.Close()
+		}
+
+		logger.WarnContext(ctx, "scim payload dump",
+			"method", r.Method, "path", r.URL.Path,
+			"size", len(head), "truncated", truncated, "body", string(head))
+		r.Body = io.NopCloser(restored)
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/ee/server/scim/scim.go
+++ b/ee/server/scim/scim.go
@@ -417,19 +417,29 @@ func debugPayloadDumpMiddleware(logger *slog.Logger, enabled bool, next http.Han
 
 		// Build the restored body. Always include head; include the probe byte and
 		// remaining body only if we managed to read past the cap.
-		var restored io.Reader = bytes.NewReader(head)
-		if truncated {
-			restored = io.MultiReader(restored, bytes.NewReader(probe[:1]), r.Body)
-		} else {
-			_ = r.Body.Close()
-		}
-
 		logger.WarnContext(ctx, "scim payload dump",
 			"method", r.Method, "path", r.URL.Path,
 			"size", len(head), "truncated", truncated, "body", string(head))
-		r.Body = io.NopCloser(restored)
+		if truncated {
+			origBody := r.Body
+			r.Body = readCloser{
+				Reader: io.MultiReader(bytes.NewReader(head), bytes.NewReader(probe[:1]), origBody),
+				Closer: origBody,
+			}
+		} else {
+			_ = r.Body.Close()
+			r.Body = io.NopCloser(bytes.NewReader(head))
+		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// readCloser pairs an io.Reader with an independent io.Closer. It is used by
+// debugPayloadDumpMiddleware to expose a stitched body (head + probe + remaining
+// original body) while still propagating Close() to the underlying http.Request.Body.
+type readCloser struct {
+	io.Reader
+	io.Closer
 }
 
 // LastRequestMiddleware saves the details of the last request to SCIM endpoints in the datastore.

--- a/ee/server/scim/scim_test.go
+++ b/ee/server/scim/scim_test.go
@@ -1,0 +1,152 @@
+package scim
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugPayloadDumpMiddleware(t *testing.T) {
+	const samplePayload = `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[]}`
+
+	t.Run("disabled returns next handler unchanged", func(t *testing.T) {
+		var downstreamBody []byte
+		var downstreamReadErr error
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamBody, downstreamReadErr = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		handler := debugPayloadDumpMiddleware(logger, false, next)
+
+		req := httptest.NewRequest(http.MethodPatch, "/api/v1/fleet/scim/Users/1", strings.NewReader(samplePayload))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.NoError(t, downstreamReadErr)
+		assert.True(t, bytes.Equal([]byte(samplePayload), downstreamBody),
+			"downstream handler must see the original body byte-for-byte")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Empty(t, buf.String(), "no logs should be emitted when middleware is disabled")
+	})
+
+	t.Run("enabled logs body and downstream still receives it", func(t *testing.T) {
+		var downstreamBody []byte
+		var downstreamReadErr error
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamBody, downstreamReadErr = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		handler := debugPayloadDumpMiddleware(logger, true, next)
+
+		req := httptest.NewRequest(http.MethodPatch, "/api/v1/fleet/scim/Users/1", strings.NewReader(samplePayload))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.NoError(t, downstreamReadErr)
+		assert.True(t, bytes.Equal([]byte(samplePayload), downstreamBody),
+			"downstream handler must see the original body byte-for-byte after dump")
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		out := buf.String()
+		assert.Contains(t, out, `msg="scim payload dump"`)
+		assert.Contains(t, out, "method=PATCH")
+		assert.Contains(t, out, "/api/v1/fleet/scim/Users/1")
+		// slog's text handler wraps the body in quotes and backslash-escapes inner quotes,
+		// so look for distinctive unquoted tokens instead of the raw payload string.
+		assert.Contains(t, out, "PatchOp")
+		assert.Contains(t, out, "Operations")
+	})
+
+	t.Run("enabled with empty body logs without erroring", func(t *testing.T) {
+		var downstreamCalled bool
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamCalled = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		handler := debugPayloadDumpMiddleware(logger, true, next)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet/scim/Users", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.True(t, downstreamCalled)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		out := buf.String()
+		assert.Contains(t, out, `msg="scim payload dump"`)
+		assert.Contains(t, out, "method=GET")
+	})
+
+	t.Run("enabled truncates large body in log but passes full body downstream", func(t *testing.T) {
+		// Append a recognizable tail marker after the truncation cap so we can prove the
+		// log doesn't include it (truncation actually happened) while the downstream
+		// handler still sees the full body including the marker (passthrough preserved).
+		const tailMarker = "TAIL_MARKER_NOT_IN_LOG_XYZ"
+		large := strings.Repeat("A", maxDumpedSCIMBodyBytes+1024) + tailMarker
+
+		var downstreamBody []byte
+		var downstreamReadErr error
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamBody, downstreamReadErr = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		handler := debugPayloadDumpMiddleware(logger, true, next)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/scim/Users", strings.NewReader(large))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.NoError(t, downstreamReadErr)
+		assert.Len(t, downstreamBody, len(large), "downstream must still see the full body length")
+		assert.Contains(t, string(downstreamBody), tailMarker, "downstream must receive bytes beyond the log cap")
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		out := buf.String()
+		assert.Contains(t, out, "size="+strconv.Itoa(maxDumpedSCIMBodyBytes), "log should report the capped size")
+		assert.Contains(t, out, "truncated=true", "log should mark the entry as truncated")
+		assert.NotContains(t, out, tailMarker, "log must not contain bytes past the cap")
+	})
+
+	t.Run("enabled body equal to cap is not marked truncated", func(t *testing.T) {
+		body := strings.Repeat("A", maxDumpedSCIMBodyBytes)
+
+		var downstreamBody []byte
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		handler := debugPayloadDumpMiddleware(logger, true, next)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/scim/Users", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Len(t, downstreamBody, len(body))
+		out := buf.String()
+		assert.Contains(t, out, "size="+strconv.Itoa(maxDumpedSCIMBodyBytes))
+		assert.Contains(t, out, "truncated=false")
+	})
+}

--- a/ee/server/scim/scim_test.go
+++ b/ee/server/scim/scim_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,8 +15,8 @@ import (
 )
 
 // closeTrackingBody wraps an io.Reader and records whether Close has been called.
-// It is used to verify that debugPayloadDumpMiddleware propagates Close() to the
-// original request body even when it stitches the body via io.MultiReader.
+// It is used to verify that debugPayloadDumpMiddleware closes the original request
+// body after consuming it for logging.
 type closeTrackingBody struct {
 	io.Reader
 	closed bool
@@ -41,6 +41,13 @@ func TestDebugPayloadDumpMiddleware(t *testing.T) {
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
 		handler := debugPayloadDumpMiddleware(logger, false, next)
+
+		// Lock in the zero-overhead promise: when disabled the middleware must return
+		// the next handler unchanged, not a wrapped one.
+		assert.Equal(t,
+			reflect.ValueOf(next).Pointer(),
+			reflect.ValueOf(handler).Pointer(),
+			"disabled middleware must return next handler unchanged")
 
 		req := httptest.NewRequest(http.MethodPatch, "/api/v1/fleet/scim/Users/1", strings.NewReader(samplePayload))
 		rec := httptest.NewRecorder()
@@ -106,51 +113,13 @@ func TestDebugPayloadDumpMiddleware(t *testing.T) {
 		assert.Contains(t, out, "method=GET")
 	})
 
-	t.Run("enabled truncates large body in log but passes full body downstream", func(t *testing.T) {
-		// Append a recognizable tail marker after the truncation cap so we can prove the
-		// log doesn't include it (truncation actually happened) while the downstream
-		// handler still sees the full body including the marker (passthrough preserved).
-		const tailMarker = "TAIL_MARKER_NOT_IN_LOG_XYZ"
-		large := strings.Repeat("A", maxDumpedSCIMBodyBytes+1024) + tailMarker
-
-		var downstreamBody []byte
-		var downstreamReadErr error
-		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			downstreamBody, downstreamReadErr = io.ReadAll(r.Body)
-			w.WriteHeader(http.StatusOK)
-		})
-
-		var buf bytes.Buffer
-		logger := slog.New(slog.NewTextHandler(&buf, nil))
-		handler := debugPayloadDumpMiddleware(logger, true, next)
-
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/scim/Users", strings.NewReader(large))
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-
-		require.NoError(t, downstreamReadErr)
-		assert.Len(t, downstreamBody, len(large), "downstream must still see the full body length")
-		assert.Contains(t, string(downstreamBody), tailMarker, "downstream must receive bytes beyond the log cap")
-		assert.Equal(t, http.StatusOK, rec.Code)
-
-		out := buf.String()
-		assert.Contains(t, out, "size="+strconv.Itoa(maxDumpedSCIMBodyBytes), "log should report the capped size")
-		assert.Contains(t, out, "truncated=true", "log should mark the entry as truncated")
-		assert.NotContains(t, out, tailMarker, "log must not contain bytes past the cap")
-	})
-
-	t.Run("enabled truncated path closes the original body", func(t *testing.T) {
-		// Regression: the truncated branch wraps the stitched body via a struct that must
-		// propagate Close() to the original http.Request.Body. Previously it used
-		// io.NopCloser, which leaked the underlying body/connection.
-		body := strings.Repeat("A", maxDumpedSCIMBodyBytes+10)
-		tracker := &closeTrackingBody{Reader: strings.NewReader(body)}
+	t.Run("enabled closes the original request body", func(t *testing.T) {
+		// The middleware must close the original body after reading it for the log,
+		// otherwise the underlying connection / body resource leaks.
+		tracker := &closeTrackingBody{Reader: strings.NewReader(samplePayload)}
 
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = io.ReadAll(r.Body)
-			// The http.Server normally calls Close after the handler returns; emulate that here
-			// so we can assert close propagation works end-to-end through our wrapper.
-			_ = r.Body.Close()
 			w.WriteHeader(http.StatusOK)
 		})
 
@@ -164,11 +133,14 @@ func TestDebugPayloadDumpMiddleware(t *testing.T) {
 		handler.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.True(t, tracker.closed, "original body Close must be called when path is truncated")
+		assert.True(t, tracker.closed, "original body Close must be called after the middleware reads it")
 	})
 
-	t.Run("enabled body equal to cap is not marked truncated", func(t *testing.T) {
-		body := strings.Repeat("A", maxDumpedSCIMBodyBytes)
+	t.Run("enabled logs full body even for large payloads", func(t *testing.T) {
+		// The middleware reads the entire body and writes it to the log unchanged.
+		// Use a marker at the tail to prove we logged past any small head buffer.
+		const tailMarker = "TAIL_MARKER_PRESENT_IN_LOG"
+		large := strings.Repeat("A", 100*1024) + tailMarker
 
 		var downstreamBody []byte
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -180,14 +152,14 @@ func TestDebugPayloadDumpMiddleware(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
 		handler := debugPayloadDumpMiddleware(logger, true, next)
 
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/scim/Users", strings.NewReader(body))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/scim/Users", strings.NewReader(large))
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Len(t, downstreamBody, len(body))
+		assert.Len(t, downstreamBody, len(large), "downstream must see the full body")
+
 		out := buf.String()
-		assert.Contains(t, out, "size="+strconv.Itoa(maxDumpedSCIMBodyBytes))
-		assert.Contains(t, out, "truncated=false")
+		assert.Contains(t, out, tailMarker, "log must include the full body, including bytes past any head buffer")
 	})
 }

--- a/ee/server/scim/scim_test.go
+++ b/ee/server/scim/scim_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// closeTrackingBody wraps an io.Reader and records whether Close has been called.
+// It is used to verify that debugPayloadDumpMiddleware propagates Close() to the
+// original request body even when it stitches the body via io.MultiReader.
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closeTrackingBody) Close() error {
+	c.closed = true
+	return nil
+}
+
 func TestDebugPayloadDumpMiddleware(t *testing.T) {
 	const samplePayload = `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[]}`
 
@@ -124,6 +137,34 @@ func TestDebugPayloadDumpMiddleware(t *testing.T) {
 		assert.Contains(t, out, "size="+strconv.Itoa(maxDumpedSCIMBodyBytes), "log should report the capped size")
 		assert.Contains(t, out, "truncated=true", "log should mark the entry as truncated")
 		assert.NotContains(t, out, tailMarker, "log must not contain bytes past the cap")
+	})
+
+	t.Run("enabled truncated path closes the original body", func(t *testing.T) {
+		// Regression: the truncated branch wraps the stitched body via a struct that must
+		// propagate Close() to the original http.Request.Body. Previously it used
+		// io.NopCloser, which leaked the underlying body/connection.
+		body := strings.Repeat("A", maxDumpedSCIMBodyBytes+10)
+		tracker := &closeTrackingBody{Reader: strings.NewReader(body)}
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.ReadAll(r.Body)
+			// The http.Server normally calls Close after the handler returns; emulate that here
+			// so we can assert close propagation works end-to-end through our wrapper.
+			_ = r.Body.Close()
+			w.WriteHeader(http.StatusOK)
+		})
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		handler := debugPayloadDumpMiddleware(logger, true, next)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/scim/Users", nil)
+		req.Body = tracker
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.True(t, tracker.closed, "original body Close must be called when path is truncated")
 	})
 
 	t.Run("enabled body equal to cap is not marked truncated", func(t *testing.T) {

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -664,6 +664,8 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 	// Store previous active state before applying patches
 	previousActive := user.Active
 
+	// modified is set when at least one recognized op was processed.
+	modified := false
 	for _, op := range operations {
 		if op.Op != scim.PatchOperationAdd && op.Op != scim.PatchOperationReplace && op.Op != scim.PatchOperationRemove {
 			u.logger.InfoContext(ctx, "unsupported patch operation", "op", op.Op)
@@ -688,44 +690,51 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case userNameAttr:
 					err = u.patchUserName(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case activeAttr:
 					err = u.patchActive(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case nameAttr + "." + givenNameAttr:
 					err = u.patchGivenName(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case nameAttr + "." + familyNameAttr:
 					err = u.patchFamilyName(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case nameAttr:
 					err = u.patchName(ctx, v, op, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case emailsAttr:
 					err = u.patchEmails(ctx, v, op, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case extensionEnterpriseUserAttributes + ":" + departmentAttr:
 					err = u.patchDepartment(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				default:
-					u.logger.InfoContext(ctx, "unsupported patch value field", "field", k)
-					return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+					u.logger.WarnContext(ctx, "unsupported patch value field", "field", k)
 				}
 			}
 		case op.Path.String() == externalIdAttr:
@@ -733,53 +742,61 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == userNameAttr:
 			err = u.patchUserName(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == activeAttr:
 			err = u.patchActive(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == nameAttr+"."+givenNameAttr:
 			err = u.patchGivenName(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == nameAttr+"."+familyNameAttr:
 			err = u.patchFamilyName(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == nameAttr:
 			err = u.patchName(ctx, op.Value, op, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == emailsAttr:
 			err = u.patchEmails(ctx, op.Value, op, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.AttributePath.String() == emailsAttr:
 			err = u.patchEmailsWithPathFiltering(ctx, op, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.AttributePath.String() == extensionEnterpriseUserAttributes+":"+departmentAttr:
 			err = u.patchDepartment(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		default:
-			u.logger.InfoContext(ctx, "unsupported patch path", "path", op.Path)
-			return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			u.logger.WarnContext(ctx, "unsupported patch path", "path", op.Path)
 		}
 	}
 
-	if len(operations) != 0 {
+	if modified {
 		err = u.ds.ReplaceScimUser(ctx, user)
 		switch {
 		case fleet.IsNotFound(err):
@@ -794,7 +811,10 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 			return scim.Resource{}, err
 		}
 
-		// Check if user was deactivated and delete matching Fleet user if so
+		// Check if user was deactivated and delete matching Fleet user if so.
+		// This sits inside `if modified` because patchActive only runs when at least
+		// one recognized op was applied; if modified is false, user.Active equals
+		// previousActive and no deactivation can have occurred.
 		if wasDeactivated(previousActive, user.Active) {
 			if err := u.deleteMatchingFleetUser(ctx, user); err != nil {
 				u.logger.ErrorContext(ctx, "failed to delete fleet user on deactivation", "err", err)
@@ -1207,8 +1227,7 @@ func (u *UserHandler) patchName(ctx context.Context, v any, op scim.PatchOperati
 			}
 			user.FamilyName = &familyName
 		default:
-			u.logger.InfoContext(ctx, "unsupported patch value field", "field", nameAttr+"."+nameKey)
-			return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			u.logger.WarnContext(ctx, "unsupported name subattribute", "field", nameAttr+"."+nameKey)
 		}
 	}
 	return nil

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -664,13 +664,17 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 	// Store previous active state before applying patches
 	previousActive := user.Active
 
-	// modified is set when at least one recognized op was processed.
-	modified := false
+	allUnknown := true
 	for _, op := range operations {
 		if op.Op != scim.PatchOperationAdd && op.Op != scim.PatchOperationReplace && op.Op != scim.PatchOperationRemove {
 			u.logger.InfoContext(ctx, "unsupported patch operation", "op", op.Op)
 			return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 		}
+
+		// pathRecognized starts true for explicit-path operations (the default branch
+		// flips it to false for unknown paths) and false for op.Path == nil ops, where
+		// recognition is delegated to the inner-loop's keyRecognized flag instead.
+		pathRecognized := op.Path != nil
 		switch {
 		// If path is not specified, we look for the path in the value attribute.
 		case op.Path == nil:
@@ -684,119 +688,69 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 				return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
 			for k, v := range newValues {
+				keyRecognized := true
 				switch k {
 				case externalIdAttr:
 					err = u.patchExternalId(ctx, op.Op, v, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				case userNameAttr:
 					err = u.patchUserName(ctx, op.Op, v, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				case activeAttr:
 					err = u.patchActive(ctx, op.Op, v, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				case nameAttr + "." + givenNameAttr:
 					err = u.patchGivenName(ctx, op.Op, v, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				case nameAttr + "." + familyNameAttr:
 					err = u.patchFamilyName(ctx, op.Op, v, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				case nameAttr:
 					err = u.patchName(ctx, v, op, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				case emailsAttr:
 					err = u.patchEmails(ctx, v, op, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				case extensionEnterpriseUserAttributes + ":" + departmentAttr:
 					err = u.patchDepartment(ctx, op.Op, v, user)
-					if err != nil {
-						return scim.Resource{}, err
-					}
-					modified = true
 				default:
-					u.logger.WarnContext(ctx, "unsupported patch value field", "field", k)
+					keyRecognized = false
+					u.logger.InfoContext(ctx, "unsupported patch value field", "field", k)
+				}
+				if err != nil {
+					return scim.Resource{}, err
+				}
+				if keyRecognized {
+					allUnknown = false
 				}
 			}
 		case op.Path.String() == externalIdAttr:
 			err = u.patchExternalId(ctx, op.Op, op.Value, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.String() == userNameAttr:
 			err = u.patchUserName(ctx, op.Op, op.Value, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.String() == activeAttr:
 			err = u.patchActive(ctx, op.Op, op.Value, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.String() == nameAttr+"."+givenNameAttr:
 			err = u.patchGivenName(ctx, op.Op, op.Value, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.String() == nameAttr+"."+familyNameAttr:
 			err = u.patchFamilyName(ctx, op.Op, op.Value, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.String() == nameAttr:
 			err = u.patchName(ctx, op.Value, op, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.String() == emailsAttr:
 			err = u.patchEmails(ctx, op.Value, op, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.AttributePath.String() == emailsAttr:
 			err = u.patchEmailsWithPathFiltering(ctx, op, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		case op.Path.AttributePath.String() == extensionEnterpriseUserAttributes+":"+departmentAttr:
 			err = u.patchDepartment(ctx, op.Op, op.Value, user)
-			if err != nil {
-				return scim.Resource{}, err
-			}
-			modified = true
 		default:
-			u.logger.WarnContext(ctx, "unsupported patch path", "path", op.Path)
+			pathRecognized = false
+			u.logger.InfoContext(ctx, "unsupported patch path", "path", op.Path)
+		}
+		if err != nil {
+			return scim.Resource{}, err
+		}
+		// For op.Path == nil, the inner loop already updated allUnknown via
+		// keyRecognized, and pathRecognized stays false by design here — do NOT
+		// also flip allUnknown based on pathRecognized for the no-path branch.
+		if pathRecognized {
+			allUnknown = false
 		}
 	}
 
-	if modified {
+	if !allUnknown {
 		err = u.ds.ReplaceScimUser(ctx, user)
 		switch {
 		case fleet.IsNotFound(err):
@@ -812,9 +766,9 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 		}
 
 		// Check if user was deactivated and delete matching Fleet user if so.
-		// This sits inside `if modified` because patchActive only runs when at least
-		// one recognized op was applied; if modified is false, user.Active equals
-		// previousActive and no deactivation can have occurred.
+		// This sits inside `if !allUnknown` because patchActive only runs when at
+		// least one recognized op was applied; if every op was unrecognized,
+		// user.Active equals previousActive and no deactivation can have occurred.
 		if wasDeactivated(previousActive, user.Active) {
 			if err := u.deleteMatchingFleetUser(ctx, user); err != nil {
 				u.logger.ErrorContext(ctx, "failed to delete fleet user on deactivation", "err", err)
@@ -1227,7 +1181,7 @@ func (u *UserHandler) patchName(ctx context.Context, v any, op scim.PatchOperati
 			}
 			user.FamilyName = &familyName
 		default:
-			u.logger.WarnContext(ctx, "unsupported name subattribute", "field", nameAttr+"."+nameKey)
+			u.logger.InfoContext(ctx, "unsupported name subattribute", "field", nameAttr+"."+nameKey)
 		}
 	}
 	return nil

--- a/ee/server/scim/users_test.go
+++ b/ee/server/scim/users_test.go
@@ -1029,3 +1029,130 @@ func TestUserHandlerCreateReactivation(t *testing.T) {
 		assert.False(t, mocks.ds.CreateScimUserFuncInvoked)
 	})
 }
+
+func TestUserHandlerPatchUnknownAttributes(t *testing.T) {
+	const enterpriseExtURN = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+
+	setupMocks := func(t *testing.T) (*testMocks, *fleet.ScimUser, **fleet.ScimUser) {
+		t.Helper()
+		mocks := newTestMocks()
+		existingUser := newTestScimUser(&scimUserOpts{active: new(true), givenName: "John", familyName: "Doe"})
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingUser, nil
+		}
+		var saved *fleet.ScimUser
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) error {
+			saved = user
+			return nil
+		}
+		return mocks, existingUser, &saved
+	}
+
+	t.Run("explicit-path with unrecognized path is ignored, department in same batch is applied", func(t *testing.T) {
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		deptPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":department"))
+		require.NoError(t, err)
+		unknownPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":employeeNumber"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "EMP-1"},
+			{Op: scim.PatchOperationReplace, Path: &deptPath, Value: "Engineering"},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Engineering", *(*saved).Department)
+	})
+
+	t.Run("no-path value with unrecognized field is ignored, department in same value is applied", func(t *testing.T) {
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					enterpriseExtURN + ":department":     "Sales",
+					enterpriseExtURN + ":employeeNumber": "EMP-2",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Sales", *(*saved).Department)
+	})
+
+	t.Run("patchName ignores unrecognized name subattributes", func(t *testing.T) {
+		// givenName/familyName get applied; honorificPrefix and middleName are silently
+		// dropped instead of aborting the PATCH.
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					"name": map[string]any{
+						"givenName":       "WithPrefix",
+						"familyName":      "User",
+						"honorificPrefix": "Mr",
+						"middleName":      "Q",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).GivenName)
+		require.NotNil(t, (*saved).FamilyName)
+		assert.Equal(t, "WithPrefix", *(*saved).GivenName)
+		assert.Equal(t, "User", *(*saved).FamilyName)
+	})
+
+	t.Run("PATCH with only unrecognized explicit-path operations skips database write", func(t *testing.T) {
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		unknownPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":employeeNumber"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "EMP-1"},
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "EMP-2"},
+		})
+		require.NoError(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+
+	t.Run("PATCH with only unrecognized no-path fields skips database write", func(t *testing.T) {
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					enterpriseExtURN + ":employeeNumber": "EMP-1",
+					enterpriseExtURN + ":costCenter":     "CC-1",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+}

--- a/ee/server/scim/users_test.go
+++ b/ee/server/scim/users_test.go
@@ -1155,4 +1155,59 @@ func TestUserHandlerPatchUnknownAttributes(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
 	})
+
+	t.Run("add op with unrecognized explicit path is silently skipped", func(t *testing.T) {
+		// The recognition refactor applies equally to add ops; verify a no-op add on
+		// an unrecognized path doesn't 400 and doesn't trigger a DB write.
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		unknownPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":employeeNumber"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationAdd, Path: &unknownPath, Value: "EMP-1"},
+		})
+		require.NoError(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+
+	t.Run("remove op with unrecognized explicit path is silently skipped", func(t *testing.T) {
+		// Removing an attribute Fleet doesn't store is a no-op by definition; verify
+		// it doesn't 400 and doesn't trigger a DB write.
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		unknownPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":costCenter"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationRemove, Path: &unknownPath, Value: nil},
+		})
+		require.NoError(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+
+	t.Run("add op with unrecognized path mixed with recognized op applies the recognized one", func(t *testing.T) {
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		unknownPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":employeeNumber"))
+		require.NoError(t, err)
+		deptPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":department"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationAdd, Path: &unknownPath, Value: "EMP-2"},
+			{Op: scim.PatchOperationAdd, Path: &deptPath, Value: "Sales"},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Sales", *(*saved).Department)
+	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41996 

Some IdPs push SCIM PATCH operations that bundle `department` with other RFC 7643 §4.3 enterprise attributes that Fleet does not store. Before this change the SCIM library rejected those payloads with a 400 because the schema only declared 'department'.

An environment variable was added (FLEET_DEBUG_SCIM_PAYLOADS) for aiding in further debugging this if the issue persist.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IdP "Department" host vital now populates correctly for users when SCIM mappings include enterprise extension attributes.

* **New Features**
  * Optional SCIM request payload dumping for debugging, toggleable via environment.
  * Expanded SCIM Enterprise User schema with employee number, cost center, organization, division, and manager fields.

* **Improvements**
  * PATCH handling skips unknown enterprise attributes without failing and avoids unnecessary datastore writes.

* **Tests**
  * Added coverage for department patching, unknown-attribute PATCH behavior, and payload-dump logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->