### PR TITLE
Fleet UI: Controls > Setup experience descriptions cleanup

### DIFF
--- a/frontend/components/SectionHeader/_styles.scss
+++ b/frontend/components/SectionHeader/_styles.scss
@@ -1,6 +1,7 @@
 .section-header {
   display: flex;
   justify-content: space-between;
+  align-items: baseline;
 
   &__left-header {
     display: flex;

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -1,9 +1,14 @@
 // Matches the fade-in on `.react-tabs__tab-panel--selected` for TabNav pages
-// that render content via React Router children instead of <TabPanel>. Consumers
-// should wrap their routed content in this class with `key={location.pathname}`
-// so the element remounts on tab change and re-triggers the animation.
+// that render content via React Router children instead of <TabPanel>.
+// Pages that key this element by pathname get the fade on every route change.
+// ManageControlsPage omits the key here and uses __fade (keyed by tab index)
+// so only top-level tab switches animate, not sub-route navigation.
 .tab-nav-routed-content {
   animation: fade-in 250ms ease-out;
+
+  &__fade {
+    animation: fade-in 250ms ease-out;
+  }
 }
 
 .tab-nav {

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -186,14 +186,16 @@ const ManageControlsPage = ({
             </TabList>
           </Tabs>
         </TabNav>
-        <div key={location?.pathname} className="tab-nav-routed-content">
-          {React.cloneElement(children, {
-            teamIdForApi,
-            currentPage: page,
-            queryParams: parseOSUpdatesCurrentVersionsQueryParams(
-              location.query
-            ),
-          })}
+        <div className="tab-nav-routed-content">
+          <div key={currentTabIndex} className="tab-nav-routed-content__fade">
+            {React.cloneElement(children, {
+              teamIdForApi,
+              currentPage: page,
+              queryParams: parseOSUpdatesCurrentVersionsQueryParams(
+                location.query
+              ),
+            })}
+          </div>
         </div>
       </div>
     );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tests.tsx
@@ -45,6 +45,29 @@ const setupDefaultBackendMocks = () => {
 };
 
 describe("BootstrapPackage", () => {
+  it("renders the page description on the empty state when MDM isn't configured", async () => {
+    setupDefaultBackendMocks();
+    mockServer.use(
+      createGetConfigHandler({
+        mdm: createMockMdmConfig({ enabled_and_configured: false }),
+      })
+    );
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<BootstrapPackage router={createMockRouter()} currentTeamId={0} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/turn on automatic enrollment/)
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Upload a bootstrap package to install a configuration/)
+    ).toBeVisible();
+  });
+
   it("renders the 'turn on automatic enrollment' message when MDM isn't configured", async () => {
     setupDefaultBackendMocks();
     mockServer.use(

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
@@ -180,23 +180,21 @@ const BootstrapPackage = ({
     );
 
     return (
-      <SetupExperienceContentContainer className={`${baseClass}__content`}>
-        <div className={`${baseClass}__uploader-container`}>
-          {bootstrapPackageView}
-          <BootstrapAdvancedOptions
-            currentTeamId={currentTeamId}
-            disableInstallManually={
-              noPackageUploaded ||
-              hasSetupExperienceInstallSoftware ||
-              hasSetupExperienceScript
-            }
-            selectManualAgentInstall={selectedManualAgentInstall}
-            onChange={(manualAgentInstall) => {
-              setSelectedManualAgentInstall(manualAgentInstall);
-            }}
-          />
-        </div>
-      </SetupExperienceContentContainer>
+      <>
+        {bootstrapPackageView}
+        <BootstrapAdvancedOptions
+          currentTeamId={currentTeamId}
+          disableInstallManually={
+            noPackageUploaded ||
+            hasSetupExperienceInstallSoftware ||
+            hasSetupExperienceScript
+          }
+          selectManualAgentInstall={selectedManualAgentInstall}
+          onChange={(manualAgentInstall) => {
+            setSelectedManualAgentInstall(manualAgentInstall);
+          }}
+        />
+      </>
     );
   };
 
@@ -250,7 +248,9 @@ const BootstrapPackage = ({
         variant="right-panel"
         content="Upload a bootstrap package to install a configuration management tool (e.g. Munki, Chef, or Puppet) on macOS hosts that automatically enroll to Fleet."
       />
-      {renderContent()}
+      <SetupExperienceContentContainer>
+        {renderContent()}
+      </SetupExperienceContentContainer>
       {showDeleteBootstrapPackageModal && (
         <DeleteBootstrapPackageModal
           onDelete={onDelete}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
@@ -24,6 +24,7 @@ import Spinner from "components/Spinner";
 import EmptyState from "components/EmptyState";
 import Button from "components/buttons/Button";
 import SectionHeader from "components/SectionHeader";
+import PageDescription from "components/PageDescription";
 import CustomLink from "components/CustomLink";
 
 import PackageUploader from "./components/BootstrapPackageUploader";
@@ -210,12 +211,13 @@ const BootstrapPackage = ({
     if (isLoading) {
       return <Spinner />;
     }
-    if (
-      !(
-        globalConfig?.mdm.enabled_and_configured &&
-        globalConfig?.mdm.apple_bm_enabled_and_configured
-      )
-    ) {
+
+    const mdmNotConfigured = !(
+      globalConfig?.mdm.enabled_and_configured &&
+      globalConfig?.mdm.apple_bm_enabled_and_configured
+    );
+
+    if (mdmNotConfigured) {
       return (
         <EmptyState
           variant="form"
@@ -243,6 +245,10 @@ const BootstrapPackage = ({
             text="Preview end user experience"
           />
         }
+      />
+      <PageDescription
+        variant="right-panel"
+        content="Upload a bootstrap package to install a configuration management tool (e.g. Munki, Chef, or Puppet) on macOS hosts that automatically enroll to Fleet."
       />
       {renderContent()}
       {showDeleteBootstrapPackageModal && (

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/_styles.scss
@@ -1,9 +1,3 @@
 .bootstrap-package {
   @include vertical-card-layout;
-
-  &__uploader-container {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-large;
-  }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/BootstrapPackageUploader.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/BootstrapPackageUploader.tsx
@@ -9,8 +9,6 @@ import FileUploader from "components/FileUploader";
 
 import { UPLOAD_ERROR_MESSAGES, getErrorMessage } from "./helpers";
 
-const baseClass = "bootstrap-package-uploader";
-
 interface IBootstrapPackageUploaderProps {
   currentTeamId: number;
   onUpload: () => void;
@@ -54,15 +52,13 @@ const BootstrapPackageUploader = ({
   };
 
   return (
-    <div className={baseClass}>
-      <FileUploader
-        message="Package (.pkg)"
-        graphicName="file-pkg"
-        accept=".pkg"
-        onFileUpload={onUploadFile}
-        isLoading={showLoading}
-      />
-    </div>
+    <FileUploader
+      message="Package (.pkg)"
+      graphicName="file-pkg"
+      accept=".pkg"
+      onFileUpload={onUploadFile}
+      isLoading={showLoading}
+    />
   );
 };
 

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/BootstrapPackageUploader.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/BootstrapPackageUploader.tsx
@@ -55,11 +55,6 @@ const BootstrapPackageUploader = ({
 
   return (
     <div className={baseClass}>
-      <p>
-        Upload a bootstrap package to install a configuration management tool
-        (e.g. Munki, Chef, or Puppet) on macOS hosts that automatically enroll
-        to Fleet.
-      </p>
       <FileUploader
         message="Package (.pkg)"
         graphicName="file-pkg"

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/_styles.scss
@@ -1,6 +1,2 @@
 .bootstrap-package-uploader {
-  > p {
-    font-size: $x-small;
-    margin: 0 0 $pad-large;
-  }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageUploader/_styles.scss
@@ -1,2 +1,0 @@
-.bootstrap-package-uploader {
-}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tests.tsx
@@ -10,15 +10,25 @@ import { createMockMdmConfig } from "__mocks__/configMock";
 
 import InstallSoftware from "./InstallSoftware";
 
+const setupMdmNotConfigured = () => {
+  mockServer.use(createSetupExperienceSoftwareHandler());
+  mockServer.use(
+    createGetConfigHandler({
+      mdm: createMockMdmConfig({ enabled_and_configured: false }),
+    })
+  );
+  mockServer.use(createGetTeamHandler({}));
+};
+
+const setupMdmConfigured = () => {
+  mockServer.use(createSetupExperienceSoftwareHandler());
+  mockServer.use(createGetConfigHandler());
+  mockServer.use(createGetTeamHandler({}));
+};
+
 describe("InstallSoftware", () => {
   it("renders the page description on the empty state when MDM isn't configured", async () => {
-    mockServer.use(createSetupExperienceSoftwareHandler());
-    mockServer.use(
-      createGetConfigHandler({
-        mdm: createMockMdmConfig({ enabled_and_configured: false }),
-      })
-    );
-    mockServer.use(createGetTeamHandler({}));
+    setupMdmNotConfigured();
     const render = createCustomRenderer({
       withBackendMock: true,
     });
@@ -35,6 +45,59 @@ describe("InstallSoftware", () => {
       expect(
         screen.getByText(/Turn on MDM and automatic enrollment/)
       ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Install software on hosts that automatically enroll/)
+    ).toBeVisible();
+  });
+
+  it("renders the software form when MDM is configured", async () => {
+    setupMdmConfigured();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(
+      <InstallSoftware
+        router={createMockRouter()}
+        currentTeamId={1}
+        urlPlatformParam="macos"
+      />
+    );
+
+    // Page description is always visible
+    expect(
+      screen.getByText(/Install software on hosts that automatically enroll/)
+    ).toBeVisible();
+
+    // The form renders (Save button appears)
+    expect(
+      await screen.findByRole("button", { name: "Save" })
+    ).toBeVisible();
+  });
+
+  it("renders the Android empty state with correct messaging", async () => {
+    mockServer.use(createSetupExperienceSoftwareHandler());
+    mockServer.use(
+      createGetConfigHandler({
+        mdm: createMockMdmConfig({ android_enabled_and_configured: false }),
+      })
+    );
+    mockServer.use(createGetTeamHandler({}));
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(
+      <InstallSoftware
+        router={createMockRouter()}
+        currentTeamId={1}
+        urlPlatformParam="android"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Turn on Android MDM/)).toBeInTheDocument();
     });
     expect(
       screen.getByText(/Install software on hosts that automatically enroll/)

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tests.tsx
@@ -71,9 +71,7 @@ describe("InstallSoftware", () => {
     ).toBeVisible();
 
     // The form renders (Save button appears)
-    expect(
-      await screen.findByRole("button", { name: "Save" })
-    ).toBeVisible();
+    expect(await screen.findByRole("button", { name: "Save" })).toBeVisible();
   });
 
   it("renders the Android empty state with correct messaging", async () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tests.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+
+import mockServer from "test/mock-server";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import { createSetupExperienceSoftwareHandler } from "test/handlers/setup-experience-handlers";
+import { createGetConfigHandler } from "test/handlers/config-handlers";
+import { createGetTeamHandler } from "test/handlers/team-handlers";
+import { createMockMdmConfig } from "__mocks__/configMock";
+
+import InstallSoftware from "./InstallSoftware";
+
+describe("InstallSoftware", () => {
+  it("renders the page description on the empty state when MDM isn't configured", async () => {
+    mockServer.use(createSetupExperienceSoftwareHandler());
+    mockServer.use(
+      createGetConfigHandler({
+        mdm: createMockMdmConfig({ enabled_and_configured: false }),
+      })
+    );
+    mockServer.use(createGetTeamHandler({}));
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(
+      <InstallSoftware
+        router={createMockRouter()}
+        currentTeamId={1}
+        urlPlatformParam="macos"
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Turn on MDM and automatic enrollment/)
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Install software on hosts that automatically enroll/)
+    ).toBeVisible();
+  });
+});

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -90,7 +90,6 @@ const InstallSoftware = ({
       ...DEFAULT_USE_QUERY_OPTIONS,
       select: (res) => res.software_titles,
       enabled: isValidPlatform,
-      keepPreviousData: true,
     }
   );
 
@@ -168,54 +167,45 @@ const InstallSoftware = ({
       // (gated at the checkbox level inside InstallSoftwareForm).
       const turnOnMdm = turnOnAppleMdm || turnOnAndroidMdm;
 
-      return (
-        <SetupExperienceContentContainer>
-          {turnOnMdm ? (
-            <EmptyState
-              header={
-                platform === "android"
-                  ? "Turn on Android MDM"
-                  : "Additional configuration required"
-              }
-              info={
-                platform === "android"
-                  ? "Turn on MDM to install software during setup experience."
-                  : "Turn on MDM and automatic enrollment to install software during setup experience."
-              }
-              primaryButton={
-                <Button
-                  onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}
-                >
-                  Turn on
-                </Button>
-              }
-            />
-          ) : (
-            <InstallSoftwareForm
-              currentTeamId={currentTeamId}
-              hasManualAgentInstall={hasManualAgentInstall}
-              softwareTitles={softwareTitles}
-              platform={platform}
-              savedRequireAllSoftwareMacOS={
-                currentTeamId
-                  ? teamConfig?.mdm?.setup_experience
-                      ?.require_all_software_macos
-                  : globalConfig?.mdm?.setup_experience
-                      ?.require_all_software_macos
-              }
-              savedRequireAllSoftwareWindows={
-                currentTeamId
-                  ? teamConfig?.mdm?.setup_experience
-                      ?.require_all_software_windows
-                  : globalConfig?.mdm?.setup_experience
-                      ?.require_all_software_windows
-              }
-              isWindowsMdmEnabled={!!isWindowsMdmEnabled}
-              router={router}
-              refetchSoftwareTitles={refetchSoftwareTitles}
-            />
-          )}
-        </SetupExperienceContentContainer>
+      return turnOnMdm ? (
+        <EmptyState
+          header={
+            platform === "android"
+              ? "Turn on Android MDM"
+              : "Additional configuration required"
+          }
+          info={
+            platform === "android"
+              ? "Turn on MDM to install software during setup experience."
+              : "Turn on MDM and automatic enrollment to install software during setup experience."
+          }
+          primaryButton={
+            <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
+              Turn on
+            </Button>
+          }
+        />
+      ) : (
+        <InstallSoftwareForm
+          currentTeamId={currentTeamId}
+          hasManualAgentInstall={hasManualAgentInstall}
+          softwareTitles={softwareTitles}
+          platform={platform}
+          savedRequireAllSoftwareMacOS={
+            currentTeamId
+              ? teamConfig?.mdm?.setup_experience?.require_all_software_macos
+              : globalConfig?.mdm?.setup_experience?.require_all_software_macos
+          }
+          savedRequireAllSoftwareWindows={
+            currentTeamId
+              ? teamConfig?.mdm?.setup_experience?.require_all_software_windows
+              : globalConfig?.mdm?.setup_experience
+                  ?.require_all_software_windows
+          }
+          isWindowsMdmEnabled={!!isWindowsMdmEnabled}
+          router={router}
+          refetchSoftwareTitles={refetchSoftwareTitles}
+        />
       );
     }
 
@@ -238,42 +228,46 @@ const InstallSoftware = ({
         variant="right-panel"
         content="Install software on hosts that automatically enroll to Fleet."
       />
-      {isLoadingConfig ? (
-        <Spinner />
-      ) : (
-        <TabNav secondary>
-          <Tabs
-            selectedIndex={PLATFORM_BY_INDEX.indexOf(selectedPlatform)}
-            onSelect={handleTabChange}
-          >
-            <TabList>
-              <Tab>
-                <TabText>macOS</TabText>
-              </Tab>
-              <Tab>
-                <TabText>Windows</TabText>
-              </Tab>
-              <Tab>
-                <TabText>Linux</TabText>
-              </Tab>
-              <Tab>
-                <TabText>iOS</TabText>
-              </Tab>
-              <Tab>
-                <TabText>iPadOS</TabText>
-              </Tab>
-              <Tab>
-                <TabText>Android</TabText>
-              </Tab>
-            </TabList>
-            {PLATFORM_BY_INDEX.map((platform) => {
-              return (
-                <TabPanel key={platform}>{renderTabContent(platform)}</TabPanel>
-              );
-            })}
-          </Tabs>
-        </TabNav>
-      )}
+      <SetupExperienceContentContainer>
+        {isLoadingConfig ? (
+          <Spinner />
+        ) : (
+          <TabNav secondary>
+            <Tabs
+              selectedIndex={PLATFORM_BY_INDEX.indexOf(selectedPlatform)}
+              onSelect={handleTabChange}
+            >
+              <TabList>
+                <Tab>
+                  <TabText>macOS</TabText>
+                </Tab>
+                <Tab>
+                  <TabText>Windows</TabText>
+                </Tab>
+                <Tab>
+                  <TabText>Linux</TabText>
+                </Tab>
+                <Tab>
+                  <TabText>iOS</TabText>
+                </Tab>
+                <Tab>
+                  <TabText>iPadOS</TabText>
+                </Tab>
+                <Tab>
+                  <TabText>Android</TabText>
+                </Tab>
+              </TabList>
+              {PLATFORM_BY_INDEX.map((platform) => {
+                return (
+                  <TabPanel key={platform}>
+                    {renderTabContent(platform)}
+                  </TabPanel>
+                );
+              })}
+            </Tabs>
+          </TabNav>
+        )}
+      </SetupExperienceContentContainer>
     </section>
   );
 };

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -90,6 +90,7 @@ const InstallSoftware = ({
       ...DEFAULT_USE_QUERY_OPTIONS,
       select: (res) => res.software_titles,
       enabled: isValidPlatform,
+      keepPreviousData: true,
     }
   );
 
@@ -169,7 +170,6 @@ const InstallSoftware = ({
 
       return (
         <SetupExperienceContentContainer>
-          <PageDescription content="Install software on hosts that automatically enroll to Fleet." />
           {turnOnMdm ? (
             <EmptyState
               header={
@@ -233,6 +233,10 @@ const InstallSoftware = ({
             text="Preview end user experience"
           />
         }
+      />
+      <PageDescription
+        variant="right-panel"
+        content="Install software on hosts that automatically enroll to Fleet."
       />
       {isLoadingConfig ? (
         <Spinner />

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
@@ -15,6 +15,28 @@ import { createMockMdmConfig } from "__mocks__/configMock";
 import RunScript from "./RunScript";
 
 describe("RunScript", () => {
+  it("should render the page description on the empty state when MDM isn't configured", async () => {
+    mockServer.use(errorNoSetupExperienceScriptHandler);
+    mockServer.use(
+      createGetConfigHandler({
+        mdm: createMockMdmConfig({ enabled_and_configured: false }),
+      })
+    );
+    mockServer.use(createGetTeamHandler({}));
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<RunScript router={createMockRouter()} currentTeamId={1} />);
+
+    expect(
+      await screen.findByText(/turn on automatic enrollment/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Upload a script to run on macOS hosts/)
+    ).toBeVisible();
+  });
+
   it("should render the 'turn on automatic enrollment' message when MDM isn't configured", async () => {
     mockServer.use(errorNoSetupExperienceScriptHandler);
     mockServer.use(

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
@@ -17,6 +17,7 @@ import { IConfig } from "interfaces/config";
 import { API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
 
 import SectionHeader from "components/SectionHeader";
+import PageDescription from "components/PageDescription";
 import DataError from "components/DataError";
 import Spinner from "components/Spinner";
 import CustomLink from "components/CustomLink";
@@ -86,64 +87,60 @@ const RunScript = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
       return <Spinner />;
     }
 
-    if (
-      !(
-        globalConfig?.mdm.enabled_and_configured &&
-        globalConfig?.mdm.apple_bm_enabled_and_configured
-      )
-    ) {
-      return (
-        <EmptyState
-          variant="list"
-          header="Additional configuration required"
-          info="Supported on macOS. To customize, first turn on automatic enrollment."
-          primaryButton={
-            <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
-              Turn on
-            </Button>
-          }
-        />
-      );
-    }
-
     if (isScriptError && scriptError.status !== 404) {
       return <DataError />;
     }
 
+    const mdmNotConfigured = !(
+      globalConfig?.mdm.enabled_and_configured &&
+      globalConfig?.mdm.apple_bm_enabled_and_configured
+    );
+
     return (
-      <SetupExperienceContentContainer>
-        <div className={`${baseClass}__description-container`}>
-          <p className={`${baseClass}__description`}>
-            Upload a script to run on macOS hosts that automatically enroll to
-            Fleet.
-          </p>
-          {!script ? (
-            <SetupExperienceScriptUploader
-              currentTeamId={currentTeamId}
-              hasManualAgentInstall={hasManualAgentInstall}
-              onUpload={onUpload}
-            />
-          ) : (
-            <>
-              <p className={`${baseClass}__run-message`}>
-                Script will run during setup:
-              </p>
-              <SetupExperienceScriptCard
-                script={script}
-                onDelete={() => setShowDeleteScriptModal(true)}
-              />
-            </>
-          )}
-        </div>
-        {showDeleteScriptModal && script && (
-          <DeleteSetupExperienceScriptModal
-            currentTeamId={currentTeamId}
-            scriptName={script.name}
-            onDeleted={onDelete}
-            onExit={() => setShowDeleteScriptModal(false)}
+      <>
+        {mdmNotConfigured ? (
+          <EmptyState
+            variant="list"
+            header="Additional configuration required"
+            info="Supported on macOS. To customize, first turn on automatic enrollment."
+            primaryButton={
+              <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
+                Turn on
+              </Button>
+            }
           />
+        ) : (
+          <SetupExperienceContentContainer>
+            <div className={`${baseClass}__description-container`}>
+              {!script ? (
+                <SetupExperienceScriptUploader
+                  currentTeamId={currentTeamId}
+                  hasManualAgentInstall={hasManualAgentInstall}
+                  onUpload={onUpload}
+                />
+              ) : (
+                <>
+                  <p className={`${baseClass}__run-message`}>
+                    Script will run during setup:
+                  </p>
+                  <SetupExperienceScriptCard
+                    script={script}
+                    onDelete={() => setShowDeleteScriptModal(true)}
+                  />
+                </>
+              )}
+            </div>
+            {showDeleteScriptModal && script && (
+              <DeleteSetupExperienceScriptModal
+                currentTeamId={currentTeamId}
+                scriptName={script.name}
+                onDeleted={onDelete}
+                onExit={() => setShowDeleteScriptModal(false)}
+              />
+            )}
+          </SetupExperienceContentContainer>
         )}
-      </SetupExperienceContentContainer>
+      </>
     );
   };
 
@@ -158,6 +155,10 @@ const RunScript = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
             text="Preview end user experience"
           />
         }
+      />
+      <PageDescription
+        variant="right-panel"
+        content="Upload a script to run on macOS hosts that automatically enroll to Fleet."
       />
       {renderContent()}
     </section>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
@@ -96,50 +96,36 @@ const RunScript = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
       globalConfig?.mdm.apple_bm_enabled_and_configured
     );
 
-    return (
+    if (mdmNotConfigured) {
+      return (
+        <EmptyState
+          variant="list"
+          header="Additional configuration required"
+          info="Supported on macOS. To customize, first turn on automatic enrollment."
+          primaryButton={
+            <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
+              Turn on
+            </Button>
+          }
+        />
+      );
+    }
+
+    return !script ? (
+      <SetupExperienceScriptUploader
+        currentTeamId={currentTeamId}
+        hasManualAgentInstall={hasManualAgentInstall}
+        onUpload={onUpload}
+      />
+    ) : (
       <>
-        {mdmNotConfigured ? (
-          <EmptyState
-            variant="list"
-            header="Additional configuration required"
-            info="Supported on macOS. To customize, first turn on automatic enrollment."
-            primaryButton={
-              <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
-                Turn on
-              </Button>
-            }
-          />
-        ) : (
-          <SetupExperienceContentContainer>
-            <div className={`${baseClass}__description-container`}>
-              {!script ? (
-                <SetupExperienceScriptUploader
-                  currentTeamId={currentTeamId}
-                  hasManualAgentInstall={hasManualAgentInstall}
-                  onUpload={onUpload}
-                />
-              ) : (
-                <>
-                  <p className={`${baseClass}__run-message`}>
-                    Script will run during setup:
-                  </p>
-                  <SetupExperienceScriptCard
-                    script={script}
-                    onDelete={() => setShowDeleteScriptModal(true)}
-                  />
-                </>
-              )}
-            </div>
-            {showDeleteScriptModal && script && (
-              <DeleteSetupExperienceScriptModal
-                currentTeamId={currentTeamId}
-                scriptName={script.name}
-                onDeleted={onDelete}
-                onExit={() => setShowDeleteScriptModal(false)}
-              />
-            )}
-          </SetupExperienceContentContainer>
-        )}
+        <p className={`${baseClass}__run-message`}>
+          Script will run during setup:
+        </p>
+        <SetupExperienceScriptCard
+          script={script}
+          onDelete={() => setShowDeleteScriptModal(true)}
+        />
       </>
     );
   };
@@ -160,7 +146,17 @@ const RunScript = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
         variant="right-panel"
         content="Upload a script to run on macOS hosts that automatically enroll to Fleet."
       />
-      {renderContent()}
+      <SetupExperienceContentContainer>
+        {renderContent()}
+      </SetupExperienceContentContainer>
+      {showDeleteScriptModal && script && (
+        <DeleteSetupExperienceScriptModal
+          currentTeamId={currentTeamId}
+          scriptName={script.name}
+          onDeleted={onDelete}
+          onExit={() => setShowDeleteScriptModal(false)}
+        />
+      )}
     </section>
   );
 };

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/_styles.scss
@@ -1,11 +1,6 @@
 .run-script {
   @include vertical-card-layout;
 
-  &__description {
-    margin-top: 0;
-    margin-bottom: $pad-large;
-  }
-
   &__run-message {
     margin: 0 0 $pad-small;
     font-weight: $bold;

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+
+import mockServer from "test/mock-server";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import { createGetConfigHandler } from "test/handlers/config-handlers";
+import { createGetTeamHandler } from "test/handlers/team-handlers";
+import { createMockMdmConfig } from "__mocks__/configMock";
+
+import SetupAssistant from "./SetupAssistant";
+
+describe("SetupAssistant", () => {
+  it("renders the page description on the empty state when MDM isn't configured", async () => {
+    mockServer.use(
+      createGetConfigHandler({
+        mdm: createMockMdmConfig({ enabled_and_configured: false }),
+      })
+    );
+    mockServer.use(createGetTeamHandler({}));
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<SetupAssistant router={createMockRouter()} currentTeamId={1} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/first turn on automatic enrollment/)
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Add an automatic enrollment profile/)
+    ).toBeVisible();
+  });
+});

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
@@ -1,22 +1,46 @@
 import React from "react";
+import { http, HttpResponse } from "msw";
 import { screen, waitFor } from "@testing-library/react";
 
 import mockServer from "test/mock-server";
-import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import {
+  baseUrl,
+  createCustomRenderer,
+  createMockRouter,
+} from "test/test-utils";
 import { createGetConfigHandler } from "test/handlers/config-handlers";
 import { createGetTeamHandler } from "test/handlers/team-handlers";
 import { createMockMdmConfig } from "__mocks__/configMock";
 
 import SetupAssistant from "./SetupAssistant";
 
+const enrollmentProfileUrl = baseUrl("/enrollment_profiles/automatic");
+const defaultEnrollmentProfileUrl = baseUrl(
+  "/enrollment_profiles/automatic/default"
+);
+
+const setupMdmConfigured = () => {
+  mockServer.use(createGetConfigHandler());
+  mockServer.use(createGetTeamHandler({}));
+};
+
+const setupMdmNotConfigured = () => {
+  mockServer.use(
+    createGetConfigHandler({
+      mdm: createMockMdmConfig({ enabled_and_configured: false }),
+    })
+  );
+  mockServer.use(createGetTeamHandler({}));
+};
+
 describe("SetupAssistant", () => {
   it("renders the page description on the empty state when MDM isn't configured", async () => {
+    setupMdmNotConfigured();
     mockServer.use(
-      createGetConfigHandler({
-        mdm: createMockMdmConfig({ enabled_and_configured: false }),
+      http.get(enrollmentProfileUrl, () => {
+        return new HttpResponse("Not found", { status: 404 });
       })
     );
-    mockServer.use(createGetTeamHandler({}));
     const render = createCustomRenderer({
       withBackendMock: true,
     });
@@ -28,6 +52,58 @@ describe("SetupAssistant", () => {
         screen.getByText(/first turn on automatic enrollment/)
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(/Add an automatic enrollment profile/)
+    ).toBeVisible();
+  });
+
+  it("renders the profile uploader when MDM is configured and no profile is uploaded", async () => {
+    setupMdmConfigured();
+    mockServer.use(
+      http.get(enrollmentProfileUrl, () => {
+        return new HttpResponse("Not found", { status: 404 });
+      })
+    );
+    mockServer.use(
+      http.get(defaultEnrollmentProfileUrl, () => {
+        return HttpResponse.json({
+          enrollment_profile: { is_mandatory: true },
+        });
+      })
+    );
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<SetupAssistant router={createMockRouter()} currentTeamId={1} />);
+
+    expect(
+      await screen.findByRole("button", { name: "Add profile" })
+    ).toBeVisible();
+    expect(
+      screen.getByText(/Add an automatic enrollment profile/)
+    ).toBeVisible();
+  });
+
+  it("renders the profile card when a profile has been uploaded", async () => {
+    setupMdmConfigured();
+    mockServer.use(
+      http.get(enrollmentProfileUrl, () => {
+        return HttpResponse.json({
+          team_id: 1,
+          name: "test-profile.json",
+          uploaded_at: "2024-01-01T00:00:00Z",
+          enrollment_profile: {},
+        });
+      })
+    );
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<SetupAssistant router={createMockRouter()} currentTeamId={1} />);
+
+    expect(await screen.findByText("test-profile.json")).toBeVisible();
     expect(
       screen.getByText(/Add an automatic enrollment profile/)
     ).toBeVisible();

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import PATHS from "router/paths";
 
 import SectionHeader from "components/SectionHeader";
+import PageDescription from "components/PageDescription";
 import Spinner from "components/Spinner";
 import CustomLink from "components/CustomLink";
 import EmptyState from "components/EmptyState";
@@ -112,59 +113,17 @@ const SetupAssistant = ({
     isLoadingEnrollmentProfile ||
     isLoadingDefaultEnrollmentProfile;
 
-  const renderSetupAssistantView = () => {
-    return (
-      <SetupExperienceContentContainer>
-        <div className={`${baseClass}__upload-container`}>
-          <p className={`${baseClass}__section-description`}>
-            Add an automatic enrollment profile to customize Setup Assistant.{" "}
-            <CustomLink
-              url="https://fleetdm.com/learn-more-about/enrollment-profiles"
-              text="Learn more"
-              newTab
-            />
-          </p>
-          {enrollmentProfileNotFound || !enrollmentProfileData ? (
-            <>
-              {defaultEnrollmentProfileData && (
-                <SetupAssistantProfileCard
-                  profile={
-                    defaultEnrollmentProfileData as IAppleSetupEnrollmentProfileResponse
-                  }
-                  defaultProfile
-                />
-              )}
-              <SetupAssistantProfileUploader
-                currentTeamId={currentTeamId}
-                onUpload={onUpload}
-              />
-            </>
-          ) : (
-            <SetupAssistantProfileCard
-              profile={enrollmentProfileData}
-              onDelete={() => setShowDeleteProfileModal(true)}
-            />
-          )}
-          <AdvancedOptionsForm
-            key={String(defaultReleaseDeviceSetting)}
-            currentTeamId={currentTeamId}
-            defaultReleaseDevice={defaultReleaseDeviceSetting}
-          />
-        </div>
-      </SetupExperienceContentContainer>
-    );
-  };
-
   const renderContent = () => {
     if (isLoading) {
       return <Spinner />;
     }
-    if (
-      !(
-        globalConfig?.mdm.enabled_and_configured &&
-        globalConfig?.mdm.apple_bm_enabled_and_configured
-      )
-    ) {
+
+    const mdmNotConfigured = !(
+      globalConfig?.mdm.enabled_and_configured &&
+      globalConfig?.mdm.apple_bm_enabled_and_configured
+    );
+
+    if (mdmNotConfigured) {
       return (
         <EmptyState
           variant="form"
@@ -178,7 +137,37 @@ const SetupAssistant = ({
         />
       );
     }
-    return renderSetupAssistantView();
+
+    return (
+      <>
+        {enrollmentProfileNotFound || !enrollmentProfileData ? (
+          <>
+            {defaultEnrollmentProfileData && (
+              <SetupAssistantProfileCard
+                profile={
+                  defaultEnrollmentProfileData as IAppleSetupEnrollmentProfileResponse
+                }
+                defaultProfile
+              />
+            )}
+            <SetupAssistantProfileUploader
+              currentTeamId={currentTeamId}
+              onUpload={onUpload}
+            />
+          </>
+        ) : (
+          <SetupAssistantProfileCard
+            profile={enrollmentProfileData}
+            onDelete={() => setShowDeleteProfileModal(true)}
+          />
+        )}
+        <AdvancedOptionsForm
+          key={String(defaultReleaseDeviceSetting)}
+          currentTeamId={currentTeamId}
+          defaultReleaseDevice={defaultReleaseDeviceSetting}
+        />
+      </>
+    );
   };
 
   return (
@@ -193,7 +182,24 @@ const SetupAssistant = ({
           />
         }
       />
-      {renderContent()}
+      <PageDescription
+        variant="right-panel"
+        content={
+          <>
+            Add an automatic enrollment profile to customize Setup Assistant.{" "}
+            <CustomLink
+              url="https://fleetdm.com/learn-more-about/enrollment-profiles"
+              text="Learn more"
+              newTab
+            />
+          </>
+        }
+      />
+      <SetupExperienceContentContainer>
+        <div className={`${baseClass}__upload-container`}>
+          {renderContent()}
+        </div>
+      </SetupExperienceContentContainer>
       {showDeleteProfileModal && (
         <DeleteAutoEnrollmentProfile
           currentTeamId={currentTeamId}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
@@ -196,9 +196,7 @@ const SetupAssistant = ({
         }
       />
       <SetupExperienceContentContainer>
-        <div className={`${baseClass}__upload-container`}>
-          {renderContent()}
-        </div>
+        {renderContent()}
       </SetupExperienceContentContainer>
       {showDeleteProfileModal && (
         <DeleteAutoEnrollmentProfile

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/_styles.scss
@@ -1,10 +1,3 @@
 .setup-assistant {
   @include vertical-card-layout;
-
-  &__upload-container {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-large;
-  }
-
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/_styles.scss
@@ -7,7 +7,4 @@
     gap: $pad-large;
   }
 
-  &__section-description {
-    margin: 0;
-  }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
@@ -7,6 +7,7 @@ import { IConfig, IMdmConfig } from "interfaces/config";
 import { ITeamConfig } from "interfaces/team";
 
 import SectionHeader from "components/SectionHeader/SectionHeader";
+import PageDescription from "components/PageDescription";
 import Spinner from "components/Spinner";
 import CustomLink from "components/CustomLink";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
@@ -153,6 +154,10 @@ const Users = ({ currentTeamId }: ISetupExperienceCardProps) => {
             text="Preview end user experience"
           />
         }
+      />
+      <PageDescription
+        variant="right-panel"
+        content="Configure end user authentication and local account settings for hosts that automatically enroll to Fleet."
       />
       {renderContent()}
     </section>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
@@ -131,15 +131,13 @@ const Users = ({ currentTeamId }: ISetupExperienceCardProps) => {
     }
     const mdmConfig = globalConfig.mdm;
     return (
-      <SetupExperienceContentContainer>
-        <UsersForm
-          currentTeamId={currentTeamId}
-          defaultIsEndUserAuthEnabled={defaultIsEndUserAuthEnabled}
-          defaultLockEndUserInfo={defaultLockEndUserInfo}
-          defaultEnableManagedLocalAccount={defaultEnableManagedLocalAccount}
-          isIdPConfigured={isIdPConfigured(mdmConfig)}
-        />
-      </SetupExperienceContentContainer>
+      <UsersForm
+        currentTeamId={currentTeamId}
+        defaultIsEndUserAuthEnabled={defaultIsEndUserAuthEnabled}
+        defaultLockEndUserInfo={defaultLockEndUserInfo}
+        defaultEnableManagedLocalAccount={defaultEnableManagedLocalAccount}
+        isIdPConfigured={isIdPConfigured(mdmConfig)}
+      />
     );
   };
 
@@ -159,7 +157,9 @@ const Users = ({ currentTeamId }: ISetupExperienceCardProps) => {
         variant="right-panel"
         content="Configure end user authentication and local account settings for hosts that automatically enroll to Fleet."
       />
-      {renderContent()}
+      <SetupExperienceContentContainer>
+        {renderContent()}
+      </SetupExperienceContentContainer>
     </section>
   );
 };

--- a/frontend/pages/admin/AdminWrapper.tsx
+++ b/frontend/pages/admin/AdminWrapper.tsx
@@ -98,8 +98,13 @@ const AdminWrapper = ({
             </TabList>
           </Tabs>
         </TabNav>
-        <div key={pathname} className="tab-nav-routed-content">
-          {children}
+        <div className="tab-nav-routed-content">
+          <div
+            key={getTabIndex(pathname)}
+            className="tab-nav-routed-content__fade"
+          >
+            {children}
+          </div>
         </div>
       </>
     </MainContent>


### PR DESCRIPTION
## Issue
Closes #37827

## Description
- This PR refactors the "Setup experience" pages to surface section descriptions on empty states.
- It adds PageDescription components to multiple setup cards (BootstrapPackage, InstallSoftware, RunScript, SetupAssistant, Users), restructures their layouts to wrap content in SetupExperienceContentContainer, and introduces fade transitions for tab navigation.
- Supporting CSS changes include baseline alignment in SectionHeader and a new fade animation structure in TabNav.
- Tests are added to verify description visibility in empty states.
- Unnecessary wrapper divs and inline styles are removed from component renderers.

## Screen recording 

<img width="924" height="673" alt="Screenshot 2026-05-06 at 10 11 58 AM" src="https://github.com/user-attachments/assets/432d6495-c646-4fe0-b3ff-877da48bb1e3" />

Watch recording 2x
https://fleetdm.zoom.us/clips/share/Vvv0mCm5TkKsEKzUR3YizQ

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added descriptive panels to setup experience pages for improved guidance.
  * Introduced fade animations for smoother transitions when switching between tabs.

* **Style**
  * Refined layouts and spacing across setup cards for better visual organization.

* **Tests**
  * Expanded test coverage for setup experience pages with additional scenarios for MDM configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->