### PR TITLE
[API] Fix endpoint naming for rotating managed account password

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5700,7 +5700,7 @@ _Available in Fleet Premium_
 
 Rotates the managed local account password for a host.
 
-`POST /api/v1/fleet/hosts/:id/managed_local_account/rotate`
+`POST /api/v1/fleet/hosts/:id/managed_account_password/rotate`
 
 #### Parameters
 
@@ -5710,7 +5710,7 @@ Rotates the managed local account password for a host.
 
 #### Example
 
-`POST /api/v1/fleet/hosts/123/managed_local_account/rotate`
+`POST /api/v1/fleet/hosts/123/managed_account_password/rotate`
 
 ##### Default response
 


### PR DESCRIPTION
Updated API endpoint documentation for rotating managed local account passwords.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37142 