### PR TITLE
Use bash shebang in generated scripts

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/scripts.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts.go
@@ -437,7 +437,7 @@ func (s *scriptBuilder) Symlink(source, target string) {
 // correct order.
 func (s *scriptBuilder) String() string {
 	var script strings.Builder
-	script.WriteString("#!/bin/sh\n\n")
+	script.WriteString("#!/bin/bash\n\n")
 
 	if len(s.variables) > 0 {
 		// write variables, order them alphabetically to produce deterministic


### PR DESCRIPTION
Summary
Switches the maintained-apps homebrew script generator from #!/bin/sh to #!/bin/bash so the declared interpreter matches what the scripts actually use.

Why
The generated install/uninstall scripts use bash-only constructs throughout — [[ ... ]], (( ... )), local, eval, indexed/associative arrays, ${var:1} substring expansion, $EUID, SECONDS — but declared #!/bin/sh. They've worked in production because macOS's /bin/sh is bash in POSIX mode, but the shebang was technically inaccurate.

These functions are direct ports of Homebrew's own implementation (referenced in scripts.go), and Homebrew itself uses bash. Declaring #!/bin/bash makes the generated scripts match the source they were ported from and removes a portability lie.

This change is safe because:

- Fleet's shebang validator already accepts /bin/bash (server/fleet/scripts.go:488)
- Orbit direct-executes scripts with recognized shebangs (orbit/pkg/scripts/exec_nonwindows.go:31), so the kernel honors #!/bin/bash
- These scripts only run on macOS, which always ships /bin/bash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installer script shell configuration to improve compatibility and reliability across different system environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->