### PR TITLE
Feat/host expiry cleanup batching

### DIFF
--- a/changes/limit-expired-host-cleanup-batch
+++ b/changes/limit-expired-host-cleanup-batch
@@ -1,0 +1,1 @@
+* Limited automatic host expiry cleanup to a bounded number of expired hosts per cron run.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3725,17 +3725,22 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]fleet.DeletedHo
 		return nil, nil
 	}
 
-	var expiryWindowCases []string
-	var expiryWindowArgs []interface{}
-	for _, team := range teamsUsingCustomExpiry {
-		expiryWindowCases = append(expiryWindowCases, "WHEN h.team_id = ? THEN ?")
-		expiryWindowArgs = append(expiryWindowArgs, team.id, team.window)
-	}
-	expiryWindowCases = append(expiryWindowCases, "ELSE ?")
+	defaultExpiryWindow := 0
 	if ac.HostExpirySettings.HostExpiryEnabled {
-		expiryWindowArgs = append(expiryWindowArgs, ac.HostExpirySettings.HostExpiryWindow)
-	} else {
-		expiryWindowArgs = append(expiryWindowArgs, 0)
+		defaultExpiryWindow = ac.HostExpirySettings.HostExpiryWindow
+	}
+	expiryWindowArgs := []interface{}{defaultExpiryWindow}
+	expiryWindowSQL := "? AS expiry_window"
+	if len(teamsUsingCustomExpiry) > 0 {
+		var expiryWindowCases []string
+		expiryWindowArgs = []interface{}{}
+		for _, team := range teamsUsingCustomExpiry {
+			expiryWindowCases = append(expiryWindowCases, "WHEN h.team_id = ? THEN ?")
+			expiryWindowArgs = append(expiryWindowArgs, team.id, team.window)
+		}
+		expiryWindowCases = append(expiryWindowCases, "ELSE ?")
+		expiryWindowArgs = append(expiryWindowArgs, defaultExpiryWindow)
+		expiryWindowSQL = "CASE " + strings.Join(expiryWindowCases, " ") + " END AS expiry_window"
 	}
 
 	var expirationConditions []string
@@ -3764,7 +3769,7 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]fleet.DeletedHo
 		ExpiryWindow int  `db:"expiry_window"`
 	}
 	var expiredHosts []expiredHostCandidate
-	expiredHostsQuery := `SELECT h.id, CASE ` + strings.Join(expiryWindowCases, " ") + ` END AS expiry_window FROM hosts h
+	expiredHostsQuery := `SELECT h.id, ` + expiryWindowSQL + ` FROM hosts h
 		LEFT JOIN host_seen_times hst ON h.id = hst.host_id
 		LEFT JOIN host_dep_assignments hda ON h.id = hda.host_id
 		LEFT JOIN nano_enrollments ne ON ne.id=h.uuid AND ne.type IN ('Device', 'User Enrollment (Device)')

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -34,6 +34,9 @@ var (
 	hostIssuesInsertBatchSize                = 10000
 	hostIssuesUpdateFailingPoliciesBatchSize = 10000
 	hostsDeleteBatchSize                     = 5000
+	// Cap automatic host expiry cleanup per cron run so large churn/backlog events
+	// are drained across runs instead of all at once.
+	expiredHostsCleanupBatchSize = 5000
 )
 
 var (
@@ -3679,14 +3682,24 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]fleet.DeletedHo
 	}
 
 	var teamsUsingGlobalExpiry []uint
-	teamsUsingCustomExpiry := map[uint]int{}
+	type teamExpiry struct {
+		id     uint
+		window int
+	}
+	var teamsUsingCustomExpiry []teamExpiry
 	for _, team := range teams {
 		if !team.Config.HostExpirySettings.HostExpiryEnabled {
 			teamsUsingGlobalExpiry = append(teamsUsingGlobalExpiry, team.ID)
 		} else {
-			teamsUsingCustomExpiry[team.ID] = team.Config.HostExpirySettings.HostExpiryWindow
+			teamsUsingCustomExpiry = append(teamsUsingCustomExpiry, teamExpiry{
+				id:     team.ID,
+				window: team.Config.HostExpirySettings.HostExpiryWindow,
+			})
 		}
 	}
+	sort.Slice(teamsUsingCustomExpiry, func(i, j int) bool {
+		return teamsUsingCustomExpiry[i].id < teamsUsingCustomExpiry[j].id
+	})
 
 	// Usual clean up queries used to be like this:
 	// DELETE FROM hosts WHERE id in (SELECT host_id FROM host_seen_times WHERE seen_time < DATE_SUB(NOW(), INTERVAL ? DAY))
@@ -3706,61 +3719,73 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]fleet.DeletedHo
 	//
 	// To avoid prematurely deleting hosts that are ingested from Apple DEP, we cross-reference the
 	// host_dep_assignments table.
-	findHostsSql := `SELECT h.id FROM hosts h
+	hostLastSeenSQL := `COALESCE(GREATEST(COALESCE(hst.seen_time, ne.last_seen_at), COALESCE(ne.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'), h.created_at)`
+
+	if expiredHostsCleanupBatchSize <= 0 {
+		return nil, nil
+	}
+
+	var expiryWindowCases []string
+	var expiryWindowArgs []interface{}
+	for _, team := range teamsUsingCustomExpiry {
+		expiryWindowCases = append(expiryWindowCases, "WHEN h.team_id = ? THEN ?")
+		expiryWindowArgs = append(expiryWindowArgs, team.id, team.window)
+	}
+	expiryWindowCases = append(expiryWindowCases, "ELSE ?")
+	if ac.HostExpirySettings.HostExpiryEnabled {
+		expiryWindowArgs = append(expiryWindowArgs, ac.HostExpirySettings.HostExpiryWindow)
+	} else {
+		expiryWindowArgs = append(expiryWindowArgs, 0)
+	}
+
+	var expirationConditions []string
+	var expirationArgs []interface{}
+	if ac.HostExpirySettings.HostExpiryEnabled {
+		condition := "(h.team_id IS NULL"
+		if len(teamsUsingGlobalExpiry) > 0 {
+			condition += " OR h.team_id IN (?)"
+			expirationArgs = append(expirationArgs, teamsUsingGlobalExpiry)
+		}
+		condition += ") AND " + hostLastSeenSQL + " < DATE_SUB(NOW(), INTERVAL ? DAY)"
+		expirationConditions = append(expirationConditions, condition)
+		expirationArgs = append(expirationArgs, ac.HostExpirySettings.HostExpiryWindow)
+	}
+	for _, team := range teamsUsingCustomExpiry {
+		expirationConditions = append(expirationConditions, "(h.team_id = ? AND "+hostLastSeenSQL+" < DATE_SUB(NOW(), INTERVAL ? DAY))")
+		expirationArgs = append(expirationArgs, team.id, team.window)
+	}
+
+	if len(expirationConditions) == 0 {
+		return nil, nil
+	}
+
+	type expiredHostCandidate struct {
+		ID           uint `db:"id"`
+		ExpiryWindow int  `db:"expiry_window"`
+	}
+	var expiredHosts []expiredHostCandidate
+	expiredHostsQuery := `SELECT h.id, CASE ` + strings.Join(expiryWindowCases, " ") + ` END AS expiry_window FROM hosts h
 		LEFT JOIN host_seen_times hst ON h.id = hst.host_id
 		LEFT JOIN host_dep_assignments hda ON h.id = hda.host_id
 		LEFT JOIN nano_enrollments ne ON ne.id=h.uuid AND ne.type IN ('Device', 'User Enrollment (Device)')
-		WHERE COALESCE(GREATEST(COALESCE(hst.seen_time, ne.last_seen_at), COALESCE(ne.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'), h.created_at) < DATE_SUB(NOW(), INTERVAL ? DAY)
-			AND (hda.host_id IS NULL OR hda.deleted_at IS NOT NULL)`
-
-	var allIdsToDelete []uint
-	hostIDToExpiryWindow := make(map[uint]int)
-	// Process hosts using global expiry
-	if ac.HostExpirySettings.HostExpiryEnabled {
-		sqlQuery := findHostsSql + " AND (team_id IS NULL"
-		args := []interface{}{ac.HostExpirySettings.HostExpiryWindow}
-		if len(teamsUsingGlobalExpiry) > 0 {
-			sqlQuery += " OR team_id IN (?)"
-			sqlQuery, args, err = sqlx.In(sqlQuery, args[0], teamsUsingGlobalExpiry)
-			if err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "building query to get expired host ids")
-			}
-		}
-		sqlQuery += ")"
-		var globalIDs []uint
-		err = ds.writer(ctx).SelectContext(
-			ctx,
-			&globalIDs,
-			sqlQuery,
-			args...,
-		)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting global expired hosts")
-		}
-		for _, id := range globalIDs {
-			hostIDToExpiryWindow[id] = ac.HostExpirySettings.HostExpiryWindow
-		}
-		allIdsToDelete = append(allIdsToDelete, globalIDs...)
+		WHERE (hda.host_id IS NULL OR hda.deleted_at IS NOT NULL)
+			AND (` + strings.Join(expirationConditions, " OR ") + `)
+		LIMIT ?`
+	expiredHostsArgs := append(expiryWindowArgs, expirationArgs...)
+	expiredHostsArgs = append(expiredHostsArgs, expiredHostsCleanupBatchSize)
+	expiredHostsQuery, expiredHostsArgs, err = sqlx.In(expiredHostsQuery, expiredHostsArgs...)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "building query to get expired hosts")
+	}
+	if err := ds.writer(ctx).SelectContext(ctx, &expiredHosts, expiredHostsQuery, expiredHostsArgs...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting expired hosts")
 	}
 
-	// Process hosts using team expiry
-	for teamId, expiry := range teamsUsingCustomExpiry {
-		var ids []uint
-		sqlQuery := findHostsSql + " AND team_id = ?"
-		args := []interface{}{expiry, teamId}
-		err = ds.writer(ctx).SelectContext(
-			ctx,
-			&ids,
-			sqlQuery,
-			args...,
-		)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting team expired hosts")
-		}
-		for _, id := range ids {
-			hostIDToExpiryWindow[id] = expiry
-		}
-		allIdsToDelete = append(allIdsToDelete, ids...)
+	allIdsToDelete := make([]uint, 0, len(expiredHosts))
+	hostIDToExpiryWindow := make(map[uint]int, len(expiredHosts))
+	for _, host := range expiredHosts {
+		allIdsToDelete = append(allIdsToDelete, host.ID)
+		hostIDToExpiryWindow[host.ID] = host.ExpiryWindow
 	}
 
 	// Get host details before deletion for activity creation

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -129,6 +129,7 @@ func TestHosts(t *testing.T) {
 		{"HostsListFailingPolicies", printReadsInTest(testHostsListFailingPolicies)},
 		{"HostsListBatchScriptExecution", testHostsListByBatchScriptExecutionStatus},
 		{"HostsExpiration", testHostsExpiration},
+		{"HostsExpirationBatchSize", testHostsExpirationBatchSize},
 		{"IOSHostExpiration", testIOSHostsExpiration},
 		{"DEPHostExpiration", testDEPHostsExpiration},
 		{"AppleMDMHostWithoutOrbitExpiration", testAppleMDMHostsWithoutOrbitExpiration},
@@ -5697,6 +5698,86 @@ func testHostsExpiration(t *testing.T, ds *Datastore) {
 
 	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 5)
 	require.Len(t, hosts, 5)
+}
+
+func testHostsExpirationBatchSize(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	originalExpiredHostsCleanupBatchSize := expiredHostsCleanupBatchSize
+	expiredHostsCleanupBatchSize = 2
+	t.Cleanup(func() {
+		expiredHostsCleanupBatchSize = originalExpiredHostsCleanupBatchSize
+	})
+
+	const globalHostExpiryWindow = 10
+	const teamHostExpiryWindow = 5
+
+	ac, err := ds.AppConfig(ctx)
+	require.NoError(t, err)
+	ac.HostExpirySettings.HostExpiryEnabled = true
+	ac.HostExpirySettings.HostExpiryWindow = globalHostExpiryWindow
+	require.NoError(t, ds.SaveAppConfig(ctx, ac))
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "batch-expiry-team"})
+	require.NoError(t, err)
+	team.Config.HostExpirySettings.HostExpiryEnabled = true
+	team.Config.HostExpirySettings.HostExpiryWindow = teamHostExpiryWindow
+	team, err = ds.SaveTeam(ctx, team)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	createHost := func(id int, seenTime time.Time, teamID *uint) uint {
+		host, err := ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        seenTime,
+			OsqueryHostID:   ptr.String(strconv.Itoa(id)),
+			NodeKey:         ptr.String(fmt.Sprintf("%d", id)),
+			UUID:            fmt.Sprintf("%d", id),
+			Hostname:        fmt.Sprintf("batch-expiry-%d.local", id),
+		})
+		require.NoError(t, err)
+		if teamID != nil {
+			require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(teamID, []uint{host.ID})))
+		}
+		return host.ID
+	}
+
+	oldestGlobalID := createHost(1, now.Add(-20*24*time.Hour), nil)
+	oldestTeamID := createHost(2, now.Add(-19*24*time.Hour), &team.ID)
+	newerGlobalID := createHost(3, now.Add(-18*24*time.Hour), nil)
+	newerTeamID := createHost(4, now.Add(-17*24*time.Hour), &team.ID)
+	createHost(5, now, nil)
+
+	filter := fleet.TeamFilter{User: test.UserAdmin}
+	hosts := listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 5)
+	require.Len(t, hosts, 5)
+
+	hostDetails, err := ds.CleanupExpiredHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hostDetails, 2)
+	deleted := make([]uint, 0, 4)
+	for _, detail := range hostDetails {
+		deleted = append(deleted, detail.ID)
+	}
+
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 3)
+	require.Len(t, hosts, 3)
+
+	hostDetails, err = ds.CleanupExpiredHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hostDetails, 2)
+	for _, detail := range hostDetails {
+		deleted = append(deleted, detail.ID)
+	}
+	require.ElementsMatch(t, []uint{oldestGlobalID, oldestTeamID, newerGlobalID, newerTeamID}, deleted)
+
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{}, 1)
+	require.Len(t, hosts, 1)
+
+	hostDetails, err = ds.CleanupExpiredHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hostDetails, 0)
 }
 
 func testIOSHostsExpiration(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited automatic expired host cleanup to a bounded batch size per cron run for safer, more efficient operations.

* **New Features**
  * Added support for per-team custom expiry windows in host cleanup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->