### PR TITLE
Run ingest workflow every 4 hours

### DIFF
--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -8,8 +8,7 @@ on:
       - 'ee/maintained-apps/**'
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * *'
-    - cron: '0 21 * * *'
+    - cron: '0 */4 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Replace the two fixed daily cron entries (0 14 * * * and 0 21 * * *) with a single every-4-hours schedule (0 */4 * * *) for .github/workflows/ingest-maintained-apps.yml. This consolidates and increases the ingest job frequency to run hourly at 4-hour intervals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the schedule for the maintained apps ingestion workflow to run more frequently (every 4 hours instead of at fixed times).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->