### PR TITLE
Clarify SMTP TLS error and surface STARTTLS toggle (#34104)

### DIFF
--- a/changes/34104-smtp-starttls-error-message
+++ b/changes/34104-smtp-starttls-error-message
@@ -1,0 +1,1 @@
+- Replaced the cryptic "startTLS error: ..." flash with a prescriptive message when saving SMTP settings fails because SSL/TLS is disabled but STARTTLS is still enabled, and added a tooltip on the SSL/TLS checkbox pointing to the STARTTLS toggle in Advanced options.

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tests.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tests.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithSetup, createMockRouter } from "test/test-utils";
+
+import createMockConfig from "__mocks__/configMock";
+
+import Smtp from "./Smtp";
+
+describe("Smtp", () => {
+  const mockHandleSubmit = jest.fn().mockResolvedValue(true);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders an always-visible STARTTLS hint under the SSL/TLS checkbox", () => {
+    const mockConfig = createMockConfig();
+
+    renderWithSetup(
+      <Smtp
+        appConfig={mockConfig}
+        handleSubmit={mockHandleSubmit}
+        isUpdatingSettings={false}
+        router={createMockRouter()}
+      />
+    );
+
+    expect(screen.getByText(/first turn off STARTTLS in/i)).toBeInTheDocument();
+  });
+
+  it("renders the longer STARTTLS guidance on hover of the SSL/TLS checkbox label", async () => {
+    const mockConfig = createMockConfig();
+
+    const { user } = renderWithSetup(
+      <Smtp
+        appConfig={mockConfig}
+        handleSubmit={mockHandleSubmit}
+        isUpdatingSettings={false}
+        router={createMockRouter()}
+      />
+    );
+
+    const label = screen.getByText("Use SSL/TLS to connect (recommended)");
+    await user.hover(label);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/STARTTLS must first be disabled in/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tests.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tests.tsx
@@ -13,22 +13,7 @@ describe("Smtp", () => {
     jest.clearAllMocks();
   });
 
-  it("renders an always-visible STARTTLS hint under the SSL/TLS checkbox", () => {
-    const mockConfig = createMockConfig();
-
-    renderWithSetup(
-      <Smtp
-        appConfig={mockConfig}
-        handleSubmit={mockHandleSubmit}
-        isUpdatingSettings={false}
-        router={createMockRouter()}
-      />
-    );
-
-    expect(screen.getByText(/first turn off STARTTLS in/i)).toBeInTheDocument();
-  });
-
-  it("renders the longer STARTTLS guidance on hover of the SSL/TLS checkbox label", async () => {
+  it("renders the STARTTLS guidance on hover of the SSL/TLS checkbox label", async () => {
     const mockConfig = createMockConfig();
 
     const { user } = renderWithSetup(

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
@@ -297,6 +297,13 @@ const Smtp = ({
             name="smtpEnableSSLTLS"
             value={smtpEnableSSLTLS}
             parseTarget
+            labelTooltipContent={
+              <>
+                To disable this setting, STARTTLS must first be disabled in{" "}
+                <strong>Organization settings</strong> &gt;{" "}
+                <strong>Advanced options</strong>.
+              </>
+            }
           >
             Use SSL/TLS to connect (recommended)
           </Checkbox>

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -19,6 +19,10 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
+// ErrSTARTTLSWithoutSSLTLS is returned when a STARTTLS handshake fails while
+// the user has SSL/TLS disabled and SSL cert verification enabled.
+var ErrSTARTTLSWithoutSSLTLS = errors.New("STARTTLS must be disabled if not using SSL/TLS to connect.")
+
 func NewService(config config.FleetConfig) (fleet.MailService, error) {
 	switch strings.ToLower(config.Email.EmailBackend) {
 	case "ses":
@@ -214,6 +218,11 @@ func (m mailService) sendMail(ctx context.Context, e fleet.Email, msg []byte) er
 	if e.SMTPSettings.SMTPEnableStartTLS {
 		if ok, _ := client.Extension("STARTTLS"); ok {
 			if err = client.StartTLS(tlsConfig); err != nil {
+				// Surface a prescriptive error only when the user has SSL/TLS
+				// off and SSL cert verification on.
+				if !e.SMTPSettings.SMTPEnableTLS && e.SMTPSettings.SMTPVerifySSLCerts {
+					return ErrSTARTTLSWithoutSSLTLS
+				}
 				return fmt.Errorf("startTLS error: %w", err)
 			}
 		}

--- a/server/mail/mail_test.go
+++ b/server/mail/mail_test.go
@@ -1,13 +1,16 @@
 package mail
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,9 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testMailpitSMTPPort = getTestMailpitSMTPPort()
-var testMailpitWebURL = getTestMailpitWebURL()
-var testSMTP4DevSMTPPort = getTestSMTP4DevSMTPPort()
+var (
+	testMailpitSMTPPort  = getTestMailpitSMTPPort()
+	testMailpitWebURL    = getTestMailpitWebURL()
+	testSMTP4DevSMTPPort = getTestSMTP4DevSMTPPort()
+)
 
 func getTestMailpitSMTPPort() uint {
 	if port := os.Getenv("FLEET_MAILPIT_SMTP_PORT"); port != "" {
@@ -309,6 +314,109 @@ func TestTemplateProcessor(t *testing.T) {
 	out, err := mailer.Message()
 	require.Nil(t, err)
 	assert.NotNil(t, out)
+}
+
+func startFakeSMTPServerFailingSTARTTLS(t *testing.T) (host string, port uint) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+				r := bufio.NewReader(c)
+				_, _ = io.WriteString(c, "220 fake.smtp.test ESMTP\r\n")
+				for {
+					line, err := r.ReadString('\n')
+					if err != nil {
+						return
+					}
+					cmd := strings.ToUpper(strings.TrimSpace(line))
+					switch {
+					case strings.HasPrefix(cmd, "EHLO"), strings.HasPrefix(cmd, "HELO"):
+						_, _ = io.WriteString(c, "250-fake.smtp.test\r\n250 STARTTLS\r\n")
+					case cmd == "STARTTLS":
+						_, _ = io.WriteString(c, "220 Ready to start TLS\r\n")
+						// Close immediately so the client's TLS handshake fails.
+						return
+					case cmd == "QUIT":
+						_, _ = io.WriteString(c, "221 Bye\r\n")
+						return
+					default:
+						_, _ = io.WriteString(c, "500 unrecognized\r\n")
+					}
+				}
+			}(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		<-done
+	})
+
+	addr := ln.Addr().(*net.TCPAddr)
+	return "127.0.0.1", uint(addr.Port) //nolint:gosec // dismiss G115 — TCPAddr.Port is in [0, 65535]
+}
+
+// fakeMailer satisfies fleet.Mailer without depending on bindata templates.
+type fakeMailer struct{}
+
+func (fakeMailer) Message() ([]byte, error) { return []byte("Subject: test\r\n\r\nbody\r\n"), nil }
+
+func TestSendMailSTARTTLSFailureWithoutSSLTLS(t *testing.T) {
+	host, port := startFakeSMTPServerFailingSTARTTLS(t)
+
+	err := Test(mailService{}, fleet.Email{
+		Subject: "test",
+		To:      []string{"to@example.com"},
+		SMTPSettings: fleet.SMTPSettings{
+			SMTPConfigured:           true,
+			SMTPAuthenticationType:   fleet.AuthTypeNameNone,
+			SMTPAuthenticationMethod: fleet.AuthMethodNamePlain,
+			SMTPVerifySSLCerts:       true,
+			SMTPEnableTLS:            false,
+			SMTPEnableStartTLS:       true,
+			SMTPPort:                 port,
+			SMTPServer:               host,
+			SMTPSenderAddress:        "test@example.com",
+		},
+		Mailer: fakeMailer{},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSTARTTLSWithoutSSLTLS)
+}
+
+func TestSendMailSTARTTLSFailureWithVerifyOff(t *testing.T) {
+	host, port := startFakeSMTPServerFailingSTARTTLS(t)
+
+	err := Test(mailService{}, fleet.Email{
+		Subject: "test",
+		To:      []string{"to@example.com"},
+		SMTPSettings: fleet.SMTPSettings{
+			SMTPConfigured:           true,
+			SMTPAuthenticationType:   fleet.AuthTypeNameNone,
+			SMTPAuthenticationMethod: fleet.AuthMethodNamePlain,
+			SMTPVerifySSLCerts:       false, // user opted into skip-verify
+			SMTPEnableTLS:            false,
+			SMTPEnableStartTLS:       true,
+			SMTPPort:                 port,
+			SMTPServer:               host,
+			SMTPSenderAddress:        "test@example.com",
+		},
+		Mailer: fakeMailer{},
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrSTARTTLSWithoutSSLTLS)
+	require.Contains(t, err.Error(), "startTLS error")
 }
 
 func Test_getFrom(t *testing.T) {

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"html/template"
 	"strings"
 
@@ -64,6 +65,9 @@ func (svc *Service) sendTestEmail(ctx context.Context, config *fleet.AppConfig) 
 	}
 
 	if err := mail.Test(svc.mailService, testMail); err != nil {
+		if errors.Is(err, mail.ErrSTARTTLSWithoutSSLTLS) {
+			return mail.ErrSTARTTLSWithoutSSLTLS
+		}
 		return MailError{Message: err.Error()}
 	}
 	return nil


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34104 

When saving SMTP settings with SSL/TLS off, STARTTLS on, and SSL cert verification on, the test-email send produced an opaque Go cert error that gave users no actionable hint. The two TLS-related toggles also live on different settings cards with no cross-reference, which made the conflict hard to spot before hitting Save.

<img width="1284" height="779" alt="Screenshot 2026-05-06 at 1 40 59 PM" src="https://github.com/user-attachments/assets/0e596854-179c-4c51-89d2-57202e4fe834" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced a cryptic SMTP error with a clear, prescriptive message when SSL/TLS is disabled but STARTTLS is enabled.
  * Added a tooltip to the SSL/TLS checkbox explaining the relationship with STARTTLS and where to change Advanced options.
* **Tests**
  * Added tests covering the STARTTLS failure scenario and the new tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->