### PR TITLE
Enable Apple hardware attestation for workstations

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -87,6 +87,7 @@ reports:
   - path: ./lib/macos/reports/detect-apns-certificate.yml
   - path: ./lib/macos/reports/collect-xprotect-reports.yml
 controls:
+  apple_require_hardware_attestation: true
   enable_disk_encryption: true
   macos_migration:
     enable: true

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -75,7 +75,6 @@ agent_options:
     desktop: stable
 controls:
   enable_disk_encryption: true
-  apple_require_hardware_attestation: true
   apple_settings:
     configuration_profiles:
       - path: ../lib/macos/configuration-profiles/date-time.mobileconfig

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -75,6 +75,7 @@ agent_options:
     desktop: stable
 controls:
   enable_disk_encryption: true
+  apple_require_hardware_attestation: true
   apple_settings:
     configuration_profiles:
       - path: ../lib/macos/configuration-profiles/date-time.mobileconfig


### PR DESCRIPTION
Set apple_require_hardware_attestation: true in it-and-security/fleets/workstations.yml under controls to require hardware-backed attestation for Apple devices. This strengthens security for managed macOS workstations by enforcing hardware attestation checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Apple hardware attestation requirement to security controls configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->