### PR TITLE
Changing default setting in active campaign

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -1112,7 +1112,7 @@
     <script>
       (function(e,t,o,n,p,r,i){e.visitorGlobalObjectAlias=n;e[e.visitorGlobalObjectAlias]=e[e.visitorGlobalObjectAlias]||function(){(e[e.visitorGlobalObjectAlias].q=e[e.visitorGlobalObjectAlias].q||[]).push(arguments)};e[e.visitorGlobalObjectAlias].l=(new Date).getTime();r=t.createElement("script");r.src=o;r.async=true;i=t.getElementsByTagName("script")[0];i.parentNode.insertBefore(r,i)})(window,document,"https://diffuser-cdn.app-us1.com/diffuser/diffuser.js","vgo");
       vgo('setAccount', '652899825');
-      vgo('setTrackByDefault', false);
+      vgo('setTrackByDefault', true);
       vgo('process');
     </script>      
    <% } %>


### PR DESCRIPTION
Troubleshooting why ActiveCampaign does not see visits from emails.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Default tracking in the ActiveCampaign integration is now enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->