### PR TITLE
Warn when labels key appears in no-team/unassigned GitOps files

### DIFF
--- a/changes/42522-labels-not-supported-in-no-team
+++ b/changes/42522-labels-not-supported-in-no-team
@@ -1,0 +1,1 @@
+- Improved `fleetctl gitops` to warn when `labels:` is specified in no-team/unassigned files, where it is not supported.

--- a/changes/42522-reject-labels-in-no-team
+++ b/changes/42522-reject-labels-in-no-team
@@ -1,0 +1,1 @@
+* Fixed `fleetctl gitops` silently accepting a `labels:` key in `no-team.yml` / `unassigned.yml`. A warning is now logged and the key is ignored.

--- a/changes/42522-reject-labels-in-no-team
+++ b/changes/42522-reject-labels-in-no-team
@@ -1,1 +1,0 @@
-* Fixed `fleetctl gitops` silently accepting a `labels:` key in `no-team.yml` / `unassigned.yml`. A warning is now logged and the key is ignored.

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -523,7 +523,7 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	if _, ok := top["labels"]; ok {
 		result.LabelsPresent = true
 		if result.IsNoTeam() {
-			multiError = multierror.Append(multiError, fmt.Errorf("'labels' is not supported in %s", filepath.Base(filePath)))
+			logFn("[!] 'labels' is not supported in %s. This key will be ignored.\n", filepath.Base(filePath))
 		} else {
 			multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
 		}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -521,10 +521,10 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 
 	// Get the labels. LabelsPresent tracks whether the key was in the YAML.
 	if _, ok := top["labels"]; ok {
+		result.LabelsPresent = true
 		if result.IsNoTeam() {
-			logFn("[!] 'labels' is not supported in %s. This key will be ignored.\n", filepath.Base(filePath))
+			multiError = multierror.Append(multiError, fmt.Errorf("'labels' is not supported in %s", filepath.Base(filePath)))
 		} else {
-			result.LabelsPresent = true
 			multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
 		}
 	}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -521,8 +521,12 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 
 	// Get the labels. LabelsPresent tracks whether the key was in the YAML.
 	if _, ok := top["labels"]; ok {
-		result.LabelsPresent = true
-		multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
+		if result.IsNoTeam() {
+			logFn("[!] 'labels' is not supported in %s. This key will be ignored.\n", filepath.Base(filePath))
+		} else {
+			result.LabelsPresent = true
+			multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
+		}
 	}
 	// Get other top-level entities.
 	multiError = parseControls(top, result, logFn, filePath, multiError)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2414,26 +2414,37 @@ labels:
 	})
 }
 
-func TestLabelsIgnoredInNoTeamFile(t *testing.T) {
+func TestLabelsRejectedInNoTeamFile(t *testing.T) {
 	t.Parallel()
 
-	config := "name: No team\nlabels:\n  - name: test-label\n    query: \"SELECT 1;\"\n    description: test\nsoftware:\npolicies:\n"
-	noTeamPath, noTeamBasePath := createNamedFileOnTempDir(t, "no-team.yml", config)
+	t.Run("no-team.yml", func(t *testing.T) {
+		t.Parallel()
 
-	var logMessages []string
-	captureLogf := func(format string, a ...any) {
-		logMessages = append(logMessages, fmt.Sprintf(format, a...))
-	}
+		config := "name: No team\nlabels:\n  - name: test-label\n    query: \"SELECT 1;\"\n    description: test\nsoftware:\npolicies:\n"
+		noTeamPath, noTeamBasePath := createNamedFileOnTempDir(t, "no-team.yml", config)
 
-	gitops, err := GitOpsFromFile(noTeamPath, noTeamBasePath, nil, captureLogf)
-	require.NoError(t, err)
+		gitops, err := GitOpsFromFile(noTeamPath, noTeamBasePath, nil, nopLogf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'labels' is not supported in no-team.yml")
 
-	// Labels should be marked as present when the key exists, but they should NOT be parsed for no-team files.
-	assert.True(t, gitops.LabelsPresent, "labels should be marked as present when explicitly set in no-team file")
-	assert.Empty(t, gitops.Labels, "labels should not be parsed in no-team file")
+		// LabelsPresent should be true (the key was in the YAML), but labels should not be parsed.
+		assert.True(t, gitops.LabelsPresent, "labels should be marked as present when explicitly set in no-team file")
+		assert.Empty(t, gitops.Labels, "labels should not be parsed in no-team file")
+	})
 
-	// A warning should have been logged.
-	assert.Contains(t, strings.Join(logMessages, "\n"), "'labels' is not supported in no-team.yml")
+	t.Run("unassigned.yml", func(t *testing.T) {
+		t.Parallel()
+
+		config := "name: Unassigned\nlabels:\n  - name: test-label\n    query: \"SELECT 1;\"\n    description: test\nsoftware:\npolicies:\n"
+		unassignedPath, unassignedBasePath := createNamedFileOnTempDir(t, "unassigned.yml", config)
+
+		gitops, err := GitOpsFromFile(unassignedPath, unassignedBasePath, nil, nopLogf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'labels' is not supported in unassigned.yml")
+
+		assert.True(t, gitops.LabelsPresent, "labels should be marked as present when explicitly set in unassigned file")
+		assert.Empty(t, gitops.Labels, "labels should not be parsed in unassigned file")
+	})
 }
 
 func TestParsePoliciesGlob(t *testing.T) {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2414,6 +2414,28 @@ labels:
 	})
 }
 
+func TestLabelsIgnoredInNoTeamFile(t *testing.T) {
+	t.Parallel()
+
+	config := "name: No team\nlabels:\n  - name: test-label\n    query: \"SELECT 1;\"\n    description: test\nsoftware:\npolicies:\n"
+	noTeamPath, noTeamBasePath := createNamedFileOnTempDir(t, "no-team.yml", config)
+
+	var logMessages []string
+	captureLogf := func(format string, a ...interface{}) {
+		logMessages = append(logMessages, fmt.Sprintf(format, a...))
+	}
+
+	gitops, err := GitOpsFromFile(noTeamPath, noTeamBasePath, nil, captureLogf)
+	require.NoError(t, err)
+
+	// Labels should NOT be parsed for no-team files.
+	assert.False(t, gitops.LabelsPresent, "labels should not be marked as present in no-team file")
+	assert.Empty(t, gitops.Labels, "labels should not be parsed in no-team file")
+
+	// A warning should have been logged.
+	assert.Contains(t, strings.Join(logMessages, "\n"), "'labels' is not supported in no-team.yml")
+}
+
 func TestParsePoliciesGlob(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2414,7 +2414,7 @@ labels:
 	})
 }
 
-func TestLabelsRejectedInNoTeamFile(t *testing.T) {
+func TestLabelsIgnoredInNoTeamFile(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no-team.yml", func(t *testing.T) {
@@ -2423,13 +2423,20 @@ func TestLabelsRejectedInNoTeamFile(t *testing.T) {
 		config := "name: No team\nlabels:\n  - name: test-label\n    query: \"SELECT 1;\"\n    description: test\nsoftware:\npolicies:\n"
 		noTeamPath, noTeamBasePath := createNamedFileOnTempDir(t, "no-team.yml", config)
 
-		gitops, err := GitOpsFromFile(noTeamPath, noTeamBasePath, nil, nopLogf)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "'labels' is not supported in no-team.yml")
+		var logMessages []string
+		captureLogf := func(format string, a ...any) {
+			logMessages = append(logMessages, fmt.Sprintf(format, a...))
+		}
+
+		gitops, err := GitOpsFromFile(noTeamPath, noTeamBasePath, nil, captureLogf)
+		require.NoError(t, err)
 
 		// LabelsPresent should be true (the key was in the YAML), but labels should not be parsed.
 		assert.True(t, gitops.LabelsPresent, "labels should be marked as present when explicitly set in no-team file")
 		assert.Empty(t, gitops.Labels, "labels should not be parsed in no-team file")
+
+		// A warning should have been logged.
+		assert.Contains(t, strings.Join(logMessages, "\n"), "'labels' is not supported in no-team.yml")
 	})
 
 	t.Run("unassigned.yml", func(t *testing.T) {
@@ -2438,12 +2445,18 @@ func TestLabelsRejectedInNoTeamFile(t *testing.T) {
 		config := "name: Unassigned\nlabels:\n  - name: test-label\n    query: \"SELECT 1;\"\n    description: test\nsoftware:\npolicies:\n"
 		unassignedPath, unassignedBasePath := createNamedFileOnTempDir(t, "unassigned.yml", config)
 
-		gitops, err := GitOpsFromFile(unassignedPath, unassignedBasePath, nil, nopLogf)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "'labels' is not supported in unassigned.yml")
+		var logMessages []string
+		captureLogf := func(format string, a ...any) {
+			logMessages = append(logMessages, fmt.Sprintf(format, a...))
+		}
+
+		gitops, err := GitOpsFromFile(unassignedPath, unassignedBasePath, nil, captureLogf)
+		require.NoError(t, err)
 
 		assert.True(t, gitops.LabelsPresent, "labels should be marked as present when explicitly set in unassigned file")
 		assert.Empty(t, gitops.Labels, "labels should not be parsed in unassigned file")
+
+		assert.Contains(t, strings.Join(logMessages, "\n"), "'labels' is not supported in unassigned.yml")
 	})
 }
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2428,8 +2428,8 @@ func TestLabelsIgnoredInNoTeamFile(t *testing.T) {
 	gitops, err := GitOpsFromFile(noTeamPath, noTeamBasePath, nil, captureLogf)
 	require.NoError(t, err)
 
-	// Labels should NOT be parsed for no-team files.
-	assert.False(t, gitops.LabelsPresent, "labels should not be marked as present in no-team file")
+	// Labels should be marked as present when the key exists, but they should NOT be parsed for no-team files.
+	assert.True(t, gitops.LabelsPresent, "labels should be marked as present when explicitly set in no-team file")
 	assert.Empty(t, gitops.Labels, "labels should not be parsed in no-team file")
 
 	// A warning should have been logged.

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2421,7 +2421,7 @@ func TestLabelsIgnoredInNoTeamFile(t *testing.T) {
 	noTeamPath, noTeamBasePath := createNamedFileOnTempDir(t, "no-team.yml", config)
 
 	var logMessages []string
-	captureLogf := func(format string, a ...interface{}) {
+	captureLogf := func(format string, a ...any) {
 		logMessages = append(logMessages, fmt.Sprintf(format, a...))
 	}
 


### PR DESCRIPTION
Closes #42522

## Changes

When `labels:` appears in a no-team/unassigned GitOps file, log a warning and skip label parsing. This matches the existing pattern used by `agent_options` and `reports` in no-team files.

A warning (not an error) is used intentionally to avoid breaking existing customer GitOps pipelines that may already have `labels:` in their no-team file.

**After fix:**
```
[!] 'labels' is not supported in unassigned.yml. This key will be ignored.
```

## Testing

### Manual testing

Built `fleetctl` from the fixed branch against a local Fleet server (premium license).

| Scenario | Result |
|---|---|
| `unassigned.yml` dry-run | Warning printed, succeeds |
| `unassigned.yml` real run | Warning printed, succeeds |
| `no-team.yml` dry-run | Warning printed, succeeds |
| `no-team.yml` real run | Warning printed, succeeds |
| `unassigned.yml` without labels | No warning, succeeds (no regression) |

### Unit tests

- **`TestLabelsIgnoredInNoTeamFile`**: Sub-tests for both `no-team.yml` and `unassigned.yml` assert: (1) no error, (2) `LabelsPresent` is true, (3) no labels parsed, (4) warning logged.