### PR TITLE
Enable JIT provisioning by default for new deployments

### DIFF
--- a/changes/38438-jit-provisioning-default
+++ b/changes/38438-jit-provisioning-default
@@ -1,0 +1,2 @@
+- Enabled JIT (just-in-time) SSO user provisioning by default for new Fleet
+installations.

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -858,7 +858,7 @@ The `sso_settings` section lets you define [single sign-on (SSO)](https://fleetd
 - `entity_id` is the entity ID: a Uniform Resource Identifier (URI) that you use to identify Fleet when configuring the identity provider. It must exactly match the Entity ID field used in identity provider configuration (default: `""`).
 - `metadata` is the metadata (in XML format) provided by the identity provider. (default: `""`)
 - `metadata_url` is the URL that references the identity provider metadata. Only one of  `metadata` or `metadata_url` is required (default: `""`).
-- `enable_jit_provisioning` specifies whether or not to enable [just-in-time user provisioning](https://fleetdm.com/docs/deploy/single-sign-on-sso#just-in-time-jit-user-provisioning) (default: `false`).
+- `enable_jit_provisioning` specifies whether or not to enable [just-in-time user provisioning](https://fleetdm.com/docs/deploy/single-sign-on-sso#just-in-time-jit-user-provisioning) (default: `true`).
 - `enable_sso_idp_login` specifies whether or not to allow single sign-on login initiated by identity provider (default: `false`).
 - `sso_server_url` is used if the URL your Fleet users (admins, maintainers, observers) use to login to Fleet via SSO is different than the base URL of your Fleet instance. If not configured, login via SSO will use the base URL of the Fleet instance.
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -175,7 +175,9 @@ If you're configuring end user authentication head to **Settings > Integrations 
 
 `Applies only to Fleet Premium`
 
-Fleet can automatically create users using just-in-time (JIT) provisioning. To enable this, go to **Settings > Integrations > Single sign-on (SSO) > Fleet users** and check **Create user and sync permissions on login**.
+Fleet can automatically create users using just-in-time (JIT) provisioning. This is enabled by default on new installations.
+
+If you're using a version where this wasn't on by default, or you'd like to change the setting, go to **Settings > Integrations > Single sign-on (SSO) > Fleet users** and check **Create user and sync permissions on login**.
 
 When enabled, Fleet will automatically create an account when a user logs in for the first time with the configured SSO. The new account's email and full name are copied from the user data in the SSO response.
 
@@ -193,7 +195,7 @@ For this to work correctly make sure that:
 
 ### Customization of user roles
 
-> **Note:** This feature requires setting `sso_settings.enable_jit_provisioning` to `true`.
+> **Note:** This feature requires `sso_settings.enable_jit_provisioning` to be set to `true` (which it is by default).
 
 Users created via JIT provisioning can be assigned Fleet roles using SAML custom attributes that are sent by the IdP in `SAMLResponse`s during login.
 Fleet will attempt to parse SAML custom attributes with the following format:

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1100,8 +1100,9 @@ func (c *AppConfig) ApplyDefaultsForNewInstalls() {
 	agentOptions := json.RawMessage(`{"config": {"options": {"pack_delimiter": "/", "logger_tls_period": 10, "distributed_plugin": "tls", "disable_distributed": false, "logger_tls_endpoint": "/api/osquery/log", "distributed_interval": 10, "distributed_tls_max_attempts": 3}, "decorators": {"load": ["SELECT uuid AS host_uuid FROM system_info;", "SELECT hostname AS hostname FROM system_info;"]}}, "overrides": {}}`)
 	c.AgentOptions = &agentOptions
 
-	// Make sure an empty SSOSettings is set.
+	// Add default values for SSOSettings.
 	var ssoSettings SSOSettings
+	ssoSettings.EnableJITProvisioning = true
 	c.SSOSettings = &ssoSettings
 
 	c.Features.ApplyDefaultsForNewInstalls()

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -356,6 +356,13 @@ func TestFeaturesApplyDefaults(t *testing.T) {
 	})
 }
 
+func TestAppConfigApplyDefaultsForNewInstalls(t *testing.T) {
+	var c AppConfig
+	c.ApplyDefaultsForNewInstalls()
+	require.NotNil(t, c.SSOSettings)
+	require.True(t, c.SSOSettings.EnableJITProvisioning)
+}
+
 func TestHistoricalDataSettingsEnabled(t *testing.T) {
 	t.Run("uptime dataset returns Uptime field", func(t *testing.T) {
 		h := HistoricalDataSettings{Uptime: true, Vulnerabilities: false}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -2004,12 +2004,6 @@ func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *
 			existingSSOProviderSettings = existing.SSOSettings.SSOProviderSettings
 		}
 		validateSSOProviderSettings(p.SSOSettings.SSOProviderSettings, existingSSOProviderSettings, invalid)
-
-		if !lic.IsPremium() {
-			if p.SSOSettings.EnableJITProvisioning {
-				invalid.Append("enable_jit_provisioning", ErrMissingLicense.Error())
-			}
-		}
 	}
 }
 

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -477,46 +477,6 @@ func TestSSOValidationValidatesSchemaInMetadataURL(t *testing.T) {
 	}
 }
 
-func TestJITProvisioning(t *testing.T) {
-	config := fleet.AppConfig{
-		SSOSettings: &fleet.SSOSettings{
-			EnableSSO:             true,
-			EnableJITProvisioning: true,
-			SSOProviderSettings: fleet.SSOProviderSettings{
-				EntityID:    "fleet",
-				IDPName:     "onelogin",
-				MetadataURL: "http://isser.metadata.com",
-			},
-		},
-	}
-
-	t.Run("doesn't allow to enable JIT provisioning without a premium license", func(t *testing.T) {
-		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{})
-		require.True(t, invalid.HasErrors())
-		assert.Contains(t, invalid.Error(), "enable_jit_provisioning")
-		assert.Contains(t, invalid.Error(), "missing or invalid license")
-	})
-
-	t.Run("allows JIT provisioning to be enabled with a premium license", func(t *testing.T) {
-		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{Tier: fleet.TierPremium})
-		require.False(t, invalid.HasErrors())
-	})
-
-	t.Run("doesn't care if JIT provisioning is set to false on free licenses", func(t *testing.T) {
-		invalid := &fleet.InvalidArgumentError{}
-		oldConfig := &fleet.AppConfig{
-			SSOSettings: &fleet.SSOSettings{
-				EnableJITProvisioning: false,
-			},
-		}
-		config.SSOSettings.EnableJITProvisioning = false
-		validateSSOSettings(config, oldConfig, invalid, &fleet.LicenseInfo{})
-		require.False(t, invalid.HasErrors())
-	})
-}
-
 func TestAppConfigSecretsObfuscated(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -438,8 +438,8 @@ func (s *integrationSSOTestSuite) TestSSOLoginWithMetadata() {
 	}`, metadata)), http.StatusOK, &acResp)
 	require.NotNil(t, acResp)
 
-	// Create sso_user2@example.com if it doesn't exist (because this is
-	// a free instance and doesn't support enable_jit_provisioning).
+	// Create sso_user2@example.com if it doesn't exist. Free instances won't
+	// run JIT provisioning even though enable_jit_provisioning defaults to true.
 	u := &fleet.User{
 		Name:       "SSO User 2",
 		Email:      "sso_user2@example.com",
@@ -478,8 +478,8 @@ func (s *integrationSSOTestSuite) TestSSOLoginNoEntityID() {
 	err = s.ds.SaveAppConfig(context.Background(), ac)
 	require.NoError(t, err)
 
-	// Create sso_user2@example.com if it doesn't exist (because this is
-	// a free instance and doesn't support enable_jit_provisioning).
+	// Create sso_user2@example.com if it doesn't exist. Free instances won't
+	// run JIT provisioning even though enable_jit_provisioning defaults to true.
 	u := &fleet.User{
 		Name:       "SSO User 2",
 		Email:      "sso_user2@example.com",
@@ -516,8 +516,8 @@ func (s *integrationSSOTestSuite) TestSSOLoginSAMLResponseTampered() {
 	}`, testSAMLIDPMetadataURL)), http.StatusOK, &acResp)
 	require.NotNil(t, acResp)
 
-	// Create sso_user2@example.com if it doesn't exist (because this is
-	// a free instance and doesn't support enable_jit_provisioning).
+	// Create sso_user2@example.com if it doesn't exist. Free instances won't
+	// run JIT provisioning even though enable_jit_provisioning defaults to true.
 	u := &fleet.User{
 		Name:       "SSO User 2",
 		Email:      "sso_user2@example.com",


### PR DESCRIPTION
**Related issue:** Resolves #38438

Removed checking for non-premium users around this setting as well, since it's already disabled in the UI [(`frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx#L296-L316`)](https://github.com/fleetdm/fleet/blob/main/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx#L296-L316) for them, and it seems that JIT provisioning won't run for non-premium users even if set to `true` [(`ee/server/service/users.go#L12-L14`)](https://github.com/fleetdm/fleet/blob/main/ee/server/service/users.go#L12-L14).

I used Claude to help with this, but read every line. I understand what was changed, but would appreciate some extra scrutiny around what it recommended for the changes to tests.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


## New Fleet configuration settings

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
  - @spalmesano0: this part I'm not sure about. https://fleetdm.com/docs/configuration/yaml-files#sso-settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JIT (just-in-time) SSO user provisioning is now enabled by default for new Fleet installations, streamlining single sign-on setup.

* **Tests**
  * Enhanced SSO configuration tests to validate JIT provisioning defaults and improve validation accuracy for existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->