### PR TITLE
Fleet UI: Host details page empty states

### DIFF
--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -60,6 +60,7 @@ interface ITableContainerProps<T = any> {
   isAllPagesSelected: boolean; // TODO: make dependent on showMarkAllPages
   toggleAllPagesSelected?: any; // TODO: an event type and make it dependent on showMarkAllPages
   searchable?: boolean;
+  disableSearch?: boolean;
   wideSearch?: boolean;
   disablePagination?: boolean;
   /**
@@ -152,6 +153,7 @@ const TableContainer = <T,>({
   isAllPagesSelected,
   toggleAllPagesSelected,
   searchable,
+  disableSearch,
   wideSearch,
   disablePagination,
   disableNextPage,
@@ -401,6 +403,7 @@ const TableContainer = <T,>({
                       placeholder={inputPlaceHolder}
                       defaultValue={searchQuery}
                       onChange={onSearchQueryChange}
+                      disabled={disableSearch}
                     />
                   </div>
                 </TooltipWrapper>
@@ -419,6 +422,7 @@ const TableContainer = <T,>({
               placeholder={inputPlaceHolder}
               defaultValue={searchQuery}
               onChange={onSearchQueryChange}
+              disabled={disableSearch}
             />
           </div>
         )}
@@ -475,6 +479,7 @@ const TableContainer = <T,>({
                       placeholder={inputPlaceHolder}
                       defaultValue={searchQuery}
                       onChange={onSearchQueryChange}
+                      disabled={disableSearch}
                     />
                   </div>
                 </TooltipWrapper>
@@ -489,6 +494,7 @@ const TableContainer = <T,>({
     customControl,
     disableActionButton,
     disableCount,
+    disableSearch,
     disableTableHeader,
     inputPlaceHolder,
     isLoading,

--- a/frontend/components/TableContainer/TableCount/TableCount.tsx
+++ b/frontend/components/TableContainer/TableCount/TableCount.tsx
@@ -2,13 +2,17 @@ import React from "react";
 
 import { generateResultsCountText } from "../utilities/TableContainerUtils";
 
+const baseClass = "table-count";
+
 interface ITableCountProps {
   name: string;
   count?: number;
 }
 
 const TableCount = ({ name, count }: ITableCountProps): JSX.Element => {
-  return <span>{generateResultsCountText(name, count)}</span>;
+  return (
+    <span className={baseClass}>{generateResultsCountText(name, count)}</span>
+  );
 };
 
 export default TableCount;

--- a/frontend/components/TableContainer/TableCount/_styles.scss
+++ b/frontend/components/TableContainer/TableCount/_styles.scss
@@ -1,0 +1,5 @@
+.table-count {
+  font-size: $x-small;
+  font-weight: $bold;
+  color: $core-fleet-black;
+}

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -70,6 +70,16 @@
     }
   }
 
+  &__input-wrapper--disabled {
+    .input-icon-field__icon {
+      color: $ui-fleet-black-50;
+
+      svg path {
+        fill: $ui-fleet-black-50;
+      }
+    }
+  }
+
   &__input-wrapper:not(&__input-wrapper--disabled) {
     .input-icon-field__input:hover {
       border: 1px solid $ui-fleet-black-50;

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -31,6 +31,11 @@
       border: 1px solid $ui-fleet-black-50;
     }
 
+    &--is-disabled {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
     &--is-focused,
     &--menu-is-open {
       box-shadow: none;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1111,6 +1111,7 @@ const HostDetailsPage = ({
 
   const showReportsTab =
     !isIosOrIpadosHost && !isAndroidHost && !isChromeOsHost;
+  const showPoliciesTab = !isIosOrIpadosHost && !isAndroidHost;
 
   const hostDetailsSubNav: IHostDetailsSubNavItem[] = [
     {
@@ -1133,12 +1134,16 @@ const HostDetailsPage = ({
           },
         ]
       : []),
-    {
-      name: "Policies",
-      title: "policies",
-      pathname: PATHS.HOST_POLICIES(hostIdFromURL),
-      count: failingPoliciesCount,
-    },
+    ...(showPoliciesTab
+      ? [
+          {
+            name: "Policies",
+            title: "policies",
+            pathname: PATHS.HOST_POLICIES(hostIdFromURL),
+            count: failingPoliciesCount,
+          },
+        ]
+      : []),
   ];
 
   const hostSoftwareSubNav: IHostDetailsSubNavItem[] = [
@@ -1552,18 +1557,41 @@ const HostDetailsPage = ({
                       config?.server_settings?.query_reports_disabled
                     }
                     showReportsEmptyState={showReportsEmptyState}
+                    canScheduleReport={!isOnlyObserver}
+                    onScheduleReport={() =>
+                      router.push(
+                        getPathWithQueryParams(PATHS.NEW_REPORT, {
+                          host_id: host.id,
+                          fleet_id: host.team_id,
+                        })
+                      )
+                    }
                   />
                 </TabPanel>
               )}
-              <TabPanel>
-                <PoliciesCard
-                  policies={host?.policies || []}
-                  isLoading={isLoadingHost}
-                  togglePolicyDetailsModal={togglePolicyDetailsModal}
-                  hostPlatform={host.platform}
-                  currentTeamId={currentTeam?.id}
-                />
-              </TabPanel>
+              {showPoliciesTab && (
+                <TabPanel>
+                  <PoliciesCard
+                    policies={host?.policies || []}
+                    isLoading={isLoadingHost}
+                    togglePolicyDetailsModal={togglePolicyDetailsModal}
+                    hostPlatform={host.platform}
+                    currentTeamId={currentTeam?.id}
+                    canManagePolicies={
+                      isGlobalAdmin ||
+                      isGlobalMaintainer ||
+                      isTeamMaintainerOrTeamAdmin
+                    }
+                    onManagePolicies={() =>
+                      router.push(
+                        getPathWithQueryParams(PATHS.MANAGE_POLICIES, {
+                          fleet_id: host.team_id,
+                        })
+                      )
+                    }
+                  />
+                </TabPanel>
+              )}
             </Tabs>
           </TabNav>
           {showDeleteHostModal && (

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1202,10 +1202,9 @@ const HostDetailsPage = ({
     host?.team_id
   );
 
-  const isHostTeamObserverPlus = permissions.isObserverPlus(
-    currentUser,
-    host?.team_id ?? null
-  );
+  const isHostTeamObserverPlus =
+    !!currentUser &&
+    permissions.isObserverPlus(currentUser, host?.team_id ?? null);
 
   // CTA permissions are checked against the host's specific team, not the
   // currently selected team in the nav. Must align with the /reports/new

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1202,17 +1202,20 @@ const HostDetailsPage = ({
     host?.team_id
   );
 
+  const isHostTeamObserverPlus = permissions.isObserverPlus(
+    currentUser,
+    host?.team_id ?? null
+  );
+
   // CTA permissions are checked against the host's specific team, not the
-  // currently selected team in the nav. A user may be an admin on one team
-  // but only an observer on the host's team, so we must verify their role
-  // on the team this host actually belongs to.
+  // currently selected team in the nav. Must align with the /reports/new
+  // route guard (AuthAnyMaintainerAdminObserverPlusRoutes).
   const canScheduleReport =
     isGlobalAdmin ||
     isGlobalMaintainer ||
-    isGlobalTechnician ||
     isHostTeamAdmin ||
     isHostTeamMaintainer ||
-    isHostTeamTechnician;
+    isHostTeamObserverPlus;
 
   const canManagePolicies =
     isGlobalAdmin ||

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1202,6 +1202,24 @@ const HostDetailsPage = ({
     host?.team_id
   );
 
+  // CTA permissions are checked against the host's specific team, not the
+  // currently selected team in the nav. A user may be an admin on one team
+  // but only an observer on the host's team, so we must verify their role
+  // on the team this host actually belongs to.
+  const canScheduleReport =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isGlobalTechnician ||
+    isHostTeamAdmin ||
+    isHostTeamMaintainer ||
+    isHostTeamTechnician;
+
+  const canManagePolicies =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isHostTeamAdmin ||
+    isHostTeamMaintainer;
+
   const bootstrapPackageData = {
     status: host?.mdm.setup_experience?.bootstrap_package_status,
     details: host?.mdm.setup_experience?.details,
@@ -1557,7 +1575,7 @@ const HostDetailsPage = ({
                       config?.server_settings?.query_reports_disabled
                     }
                     showReportsEmptyState={showReportsEmptyState}
-                    canScheduleReport={!isOnlyObserver}
+                    canScheduleReport={canScheduleReport}
                     onScheduleReport={() =>
                       router.push(
                         getPathWithQueryParams(PATHS.NEW_REPORT, {
@@ -1577,11 +1595,7 @@ const HostDetailsPage = ({
                     togglePolicyDetailsModal={togglePolicyDetailsModal}
                     hostPlatform={host.platform}
                     currentTeamId={currentTeam?.id}
-                    canManagePolicies={
-                      isGlobalAdmin ||
-                      isGlobalMaintainer ||
-                      isTeamMaintainerOrTeamAdmin
-                    }
+                    canManagePolicies={canManagePolicies}
                     onManagePolicies={() =>
                       router.push(
                         getPathWithQueryParams(PATHS.MANAGE_POLICIES, {

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tests.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tests.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 
-import { createCustomRenderer, createMockRouter, baseUrl } from "test/test-utils";
+import {
+  createCustomRenderer,
+  createMockRouter,
+  baseUrl,
+} from "test/test-utils";
 import mockServer from "test/mock-server";
 import createMockUser from "__mocks__/userMock";
 
@@ -71,9 +75,7 @@ describe("HostReportsTab", () => {
     );
 
     // Empty state copy
-    expect(
-      await screen.findByText("No reports scheduled")
-    ).toBeInTheDocument();
+    expect(await screen.findByText("No reports scheduled")).toBeInTheDocument();
     expect(
       screen.getByText(
         /Select Refetch to load the latest data from this host, or schedule a report/
@@ -105,13 +107,13 @@ describe("HostReportsTab", () => {
       },
     });
 
-    render(
-      <HostReportsTab {...baseProps} canScheduleReport={false} />
-    );
+    render(<HostReportsTab {...baseProps} canScheduleReport={false} />);
 
+    expect(await screen.findByText("No reports scheduled")).toBeInTheDocument();
     expect(
-      await screen.findByText("No reports scheduled")
+      screen.getByText("Select Refetch to load the latest data from this host.")
     ).toBeInTheDocument();
+    expect(screen.queryByText(/schedule a report/)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /schedule a report/i })
     ).not.toBeInTheDocument();

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tests.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tests.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import { createCustomRenderer, createMockRouter, baseUrl } from "test/test-utils";
+import mockServer from "test/mock-server";
+import createMockUser from "__mocks__/userMock";
+
+import HostReportsTab from "./HostReportsTab";
+
+const mockRouter = createMockRouter();
+
+const emptyReportsResponse = {
+  reports: [],
+  count: 0,
+  meta: { has_previous_results: false, has_next_results: false },
+};
+
+const populatedReportsResponse = {
+  reports: [
+    {
+      report_id: 1,
+      name: "Test Report",
+      description: "A test report",
+      last_fetched: "2024-01-01T00:00:00Z",
+      first_result: { col1: "val1" },
+      n_host_results: 5,
+      report_clipped: false,
+      store_results: true,
+    },
+  ],
+  count: 1,
+  meta: { has_previous_results: false, has_next_results: false },
+};
+
+const createHostReportsHandler = (response: Record<string, unknown>) =>
+  http.get(baseUrl("/hosts/:id/reports"), () => {
+    return HttpResponse.json(response);
+  });
+
+const baseProps = {
+  hostId: 1,
+  hostName: "test-host",
+  router: mockRouter,
+  location: {
+    pathname: "/hosts/1",
+    query: {},
+  },
+};
+
+describe("HostReportsTab", () => {
+  it("renders truly empty state with disabled controls and Schedule a report CTA", async () => {
+    mockServer.use(createHostReportsHandler(emptyReportsResponse));
+    const onScheduleReport = jest.fn();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <HostReportsTab
+        {...baseProps}
+        canScheduleReport
+        onScheduleReport={onScheduleReport}
+      />
+    );
+
+    // Empty state copy
+    expect(
+      await screen.findByText("No reports scheduled")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Select Refetch to load the latest data from this host, or schedule a report/
+      )
+    ).toBeInTheDocument();
+
+    // Schedule a report CTA
+    expect(
+      screen.getByRole("button", { name: /schedule a report/i })
+    ).toBeInTheDocument();
+
+    // Shows 0 reports count
+    expect(screen.getByText("0 reports")).toBeInTheDocument();
+
+    // Search is disabled
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    expect(searchInput).toBeDisabled();
+  });
+
+  it("renders truly empty state without Schedule CTA when user lacks permission", async () => {
+    mockServer.use(createHostReportsHandler(emptyReportsResponse));
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isOnlyObserver: true,
+          currentUser: createMockUser({ global_role: "observer" }),
+        },
+      },
+    });
+
+    render(
+      <HostReportsTab {...baseProps} canScheduleReport={false} />
+    );
+
+    expect(
+      await screen.findByText("No reports scheduled")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /schedule a report/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders populated state with enabled controls", async () => {
+    mockServer.use(createHostReportsHandler(populatedReportsResponse));
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(<HostReportsTab {...baseProps} />);
+
+    expect(await screen.findByText("1 report")).toBeInTheDocument();
+
+    // Search is NOT disabled
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    expect(searchInput).not.toBeDisabled();
+  });
+});

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
@@ -19,6 +19,8 @@ import Slider from "components/forms/fields/Slider";
 import DropdownWrapper from "components/forms/fields/DropdownWrapper";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Pagination from "components/Pagination";
+import EmptyState from "components/EmptyState";
+import Button from "components/buttons/Button";
 
 import HostReportCard from "./HostReportCard";
 import EmptyReports from "./EmptyReports";
@@ -71,6 +73,8 @@ interface IHostReportsTabProps {
   };
   saveReportsDisabledInConfig?: boolean;
   showReportsEmptyState?: boolean;
+  canScheduleReport?: boolean;
+  onScheduleReport?: () => void;
 }
 
 const HostReportsTab = ({
@@ -80,6 +84,8 @@ const HostReportsTab = ({
   location,
   saveReportsDisabledInConfig,
   showReportsEmptyState = false,
+  canScheduleReport,
+  onScheduleReport,
 }: IHostReportsTabProps): JSX.Element => {
   const searchQuery = location.query.query ?? "";
   const sortOption: SortOption =
@@ -199,9 +205,11 @@ const HostReportsTab = ({
 
   // No reports should be available if MDM enrollment is pending so hide any previous reports
   // that may be associated with the host to prevent confusion while pending
-  if ((totalCount === 0 && !searchQuery) || showReportsEmptyState) {
+  if (showReportsEmptyState) {
     return <EmptyReports isSearching={false} />;
   }
+
+  const isTrulyEmpty = totalCount === 0 && !searchQuery;
 
   return (
     <div className={baseClass}>
@@ -217,6 +225,7 @@ const HostReportsTab = ({
               activeText="Show reports that don't store results"
               inactiveText="Show reports that don't store results"
               className={`${baseClass}__toggle`}
+              disabled={isTrulyEmpty}
             />
           )}
         </div>
@@ -228,16 +237,30 @@ const HostReportsTab = ({
             onChange={onSortChange}
             className={`${baseClass}__sort-dropdown`}
             variant="table-filter"
+            isDisabled={isTrulyEmpty}
           />
           <SearchField
             placeholder="Search by name"
             defaultValue={searchQuery}
             onChange={onSearchChange}
+            disabled={isTrulyEmpty}
           />
         </div>
       </div>
 
-      {reports.length === 0 && searchQuery ? (
+      {isTrulyEmpty ? (
+        <EmptyState
+          header="No reports scheduled"
+          info="Select Refetch to load the latest data from this host, or schedule a report."
+          primaryButton={
+            canScheduleReport ? (
+              <Button onClick={onScheduleReport} type="button">
+                Schedule a report
+              </Button>
+            ) : undefined
+          }
+        />
+      ) : reports.length === 0 && searchQuery ? (
         <EmptyReports isSearching />
       ) : (
         <>

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
@@ -250,7 +250,7 @@ const HostReportsTab = ({
         </div>
       </div>
 
-      {isTrulyEmpty ? (
+      {isTrulyEmpty && (
         <EmptyState
           header="No reports scheduled"
           info={
@@ -266,9 +266,11 @@ const HostReportsTab = ({
             ) : undefined
           }
         />
-      ) : reports.length === 0 && searchQuery ? (
+      )}
+      {!isTrulyEmpty && reports.length === 0 && searchQuery && (
         <EmptyReports isSearching />
-      ) : (
+      )}
+      {!isTrulyEmpty && reports.length > 0 && (
         <>
           <div className={`${baseClass}__reports-list`}>
             {reports.map((report) => (

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
@@ -225,7 +225,6 @@ const HostReportsTab = ({
               activeText="Show reports that don't store results"
               inactiveText="Show reports that don't store results"
               className={`${baseClass}__toggle`}
-              disabled={isTrulyEmpty}
             />
           )}
         </div>
@@ -251,7 +250,11 @@ const HostReportsTab = ({
       {isTrulyEmpty ? (
         <EmptyState
           header="No reports scheduled"
-          info="Select Refetch to load the latest data from this host, or schedule a report."
+          info={
+            canScheduleReport
+              ? "Select Refetch to load the latest data from this host, or schedule a report."
+              : "Select Refetch to load the latest data from this host."
+          }
           primaryButton={
             canScheduleReport ? (
               <Button onClick={onScheduleReport} type="button">

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
@@ -218,6 +218,9 @@ const HostReportsTab = ({
           <span className={`${baseClass}__count`}>
             {totalCount} {pluralize(totalCount, "report")}
           </span>
+          {/* Slider stays enabled even when empty — the "truly empty" state
+              may be caused by don't-store-results reports being filtered out,
+              and the user needs the toggle to reveal them. */}
           {!saveReportsDisabledInConfig && (
             <Slider
               value={showDontStoreResults}

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -612,6 +612,8 @@ const HostSoftwareLibrary = ({
         pagePath={pathname}
         selfService={queryParams.self_service}
         teamId={queryParams.fleet_id}
+        canAddSoftware={canAddSoftware}
+        onAddSoftware={onAddSoftware}
       />
     );
   };

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -135,8 +135,6 @@ const HostSoftwareLibrary = ({
   const {
     isGlobalAdmin,
     isGlobalMaintainer,
-    isTeamAdmin,
-    isTeamMaintainer,
     isGlobalTechnician,
     currentUser,
   } = useContext(AppContext);
@@ -462,17 +460,26 @@ const HostSoftwareLibrary = ({
     isHostOnline,
   ]);
 
+  const isHostTeamAdmin = permissions.isTeamAdmin(currentUser, hostTeamId);
+  const isHostTeamMaintainer = permissions.isTeamMaintainer(
+    currentUser,
+    hostTeamId
+  );
+
   const hasSWWriteRole = Boolean(
     isGlobalAdmin ||
       isGlobalMaintainer ||
-      isTeamAdmin ||
-      isTeamMaintainer ||
+      isHostTeamAdmin ||
+      isHostTeamMaintainer ||
       isGlobalTechnician ||
       permissions.isTeamTechnician(currentUser, hostTeamId)
   );
 
   const canAddSoftware =
-    (isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer) &&
+    (isGlobalAdmin ||
+      isGlobalMaintainer ||
+      isHostTeamAdmin ||
+      isHostTeamMaintainer) &&
     !isAndroidHost;
 
   // 4.77 Currently Android apps can only be installed via self-service by end user

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tests.tsx
@@ -46,7 +46,9 @@ describe("HostSoftwareLibraryTable", () => {
 
     // Empty state copy
     expect(screen.getByText("No software found")).toBeInTheDocument();
-    expect(screen.getByText("Add software to install.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add software to install on this host.")
+    ).toBeInTheDocument();
 
     // Add software CTA button in empty state
     expect(
@@ -69,6 +71,9 @@ describe("HostSoftwareLibraryTable", () => {
     });
 
     expect(screen.getByText("No software found")).toBeInTheDocument();
+    expect(
+      screen.getByText("No software has been added for this host.")
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /add software/i })
     ).not.toBeInTheDocument();

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tests.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import { HostPlatform } from "interfaces/platform";
+
+import createMockUser from "__mocks__/userMock";
+import { createMockGetHostSoftwareResponse } from "__mocks__/hostMock";
+import HostSoftwareLibraryTable from "./HostSoftwareLibraryTable";
+
+const mockRouter = createMockRouter();
+
+describe("HostSoftwareLibraryTable", () => {
+  const baseProps = {
+    tableConfig: [],
+    data: createMockGetHostSoftwareResponse(),
+    enhancedData: [],
+    platform: "darwin" as HostPlatform,
+    isLoading: false,
+    router: mockRouter,
+    sortHeader: "name",
+    sortDirection: "asc" as "asc" | "desc",
+    searchQuery: "",
+    page: 0,
+    pagePath: "/hosts/1/software",
+    selfService: false,
+  };
+
+  const renderWithContext = (props = {}) =>
+    createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    })(<HostSoftwareLibraryTable {...baseProps} {...props} />);
+
+  it("renders truly empty state with disabled controls and Add software CTA", () => {
+    const onAddSoftware = jest.fn();
+    renderWithContext({
+      data: createMockGetHostSoftwareResponse({ count: 0, software: [] }),
+      enhancedData: [],
+      canAddSoftware: true,
+      onAddSoftware,
+    });
+
+    // Empty state copy
+    expect(screen.getByText("No software found")).toBeInTheDocument();
+    expect(screen.getByText("Add software to install.")).toBeInTheDocument();
+
+    // Add software CTA button in empty state
+    expect(
+      screen.getByRole("button", { name: /add software/i })
+    ).toBeInTheDocument();
+
+    // Shows 0 items count
+    expect(screen.getByText("0 items")).toBeInTheDocument();
+
+    // Search is disabled
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    expect(searchInput).toBeDisabled();
+  });
+
+  it("renders truly empty state without Add software CTA when user lacks permission", () => {
+    renderWithContext({
+      data: createMockGetHostSoftwareResponse({ count: 0, software: [] }),
+      enhancedData: [],
+      canAddSoftware: false,
+    });
+
+    expect(screen.getByText("No software found")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add software/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders filtered empty state with enabled controls", () => {
+    renderWithContext({
+      data: createMockGetHostSoftwareResponse({ count: 0, software: [] }),
+      enhancedData: [],
+      searchQuery: "nonexistent",
+    });
+
+    // Search is NOT disabled
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    expect(searchInput).not.toBeDisabled();
+  });
+
+  // Android software installs are not currently supported from the library table.
+  // The parent (HostDetailsPage) also guards this, but the table has a defensive fallback.
+  it("renders Android unsupported state", () => {
+    renderWithContext({
+      platform: "android",
+    });
+
+    expect(
+      screen.getByText(/installers are not supported for this host/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
@@ -159,7 +159,11 @@ const HostSoftwareLibraryTable = ({
       return (
         <EmptyState
           header="No software found"
-          info="Add software to install."
+          info={
+            canAddSoftware
+              ? "Add software to install on this host."
+              : "No software has been added for this host."
+          }
           primaryButton={
             canAddSoftware ? (
               <Button onClick={onAddSoftware} type="button">

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
@@ -17,6 +17,7 @@ import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
+import Button from "components/buttons/Button";
 import EmptySoftwareTable from "pages/SoftwarePage/components/tables/EmptySoftwareTable";
 import TableCount from "components/TableContainer/TableCount";
 import EmptyState from "components/EmptyState";
@@ -42,6 +43,8 @@ interface IHostSoftwareLibraryTableProps {
   pagePath: string;
   selfService: boolean;
   teamId?: number;
+  canAddSoftware?: boolean;
+  onAddSoftware?: () => void;
 }
 
 const HostSoftwareLibraryTable = ({
@@ -58,6 +61,8 @@ const HostSoftwareLibraryTable = ({
   page,
   pagePath,
   teamId,
+  canAddSoftware,
+  onAddSoftware,
 }: IHostSoftwareLibraryTableProps) => {
   const determineQueryParamChange = useCallback(
     (newTableQuery: ITableQueryData) => {
@@ -143,18 +148,30 @@ const HostSoftwareLibraryTable = ({
 
   const count = data?.count || data?.software?.length || 0;
   const isSoftwareNotDetected = count === 0 && searchQuery === "";
+  const isTrulyEmpty = isSoftwareNotDetected && !selfService;
 
   const memoizedSoftwareCount = useCallback(() => {
-    if (isSoftwareNotDetected) {
-      return null;
-    }
-
     return <TableCount name="items" count={count} />;
-  }, [count, isSoftwareNotDetected]);
+  }, [count]);
 
   const memoizedEmptyComponent = useCallback(() => {
+    if (isTrulyEmpty) {
+      return (
+        <EmptyState
+          header="No software found"
+          info="Add software to install."
+          primaryButton={
+            canAddSoftware ? (
+              <Button onClick={onAddSoftware} type="button">
+                Add software
+              </Button>
+            ) : undefined
+          }
+        />
+      );
+    }
     return <EmptySoftwareTable noSearchQuery={searchQuery === ""} />;
-  }, [searchQuery]);
+  }, [searchQuery, isTrulyEmpty, canAddSoftware, onAddSoftware]);
 
   if (isAndroid(platform)) {
     return (
@@ -185,6 +202,7 @@ const HostSoftwareLibraryTable = ({
             )
           }
           variant="table-filter"
+          isDisabled={isTrulyEmpty}
         />
       </div>
     );
@@ -211,6 +229,7 @@ const HostSoftwareLibraryTable = ({
         showMarkAllPages={false}
         isAllPagesSelected={false}
         searchable
+        disableSearch={isTrulyEmpty}
         manualSortBy
       />
     </div>

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -57,15 +57,30 @@ describe("HostPolicies", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders empty state without Manage policies CTA when user lacks permission", () => {
+  it("renders empty state without Manage policies CTA or manage clause when user lacks permission", () => {
     renderWithContext({
       canManagePolicies: false,
     });
 
     expect(screen.getByText("No policies checked")).toBeInTheDocument();
     expect(
+      screen.getByText(/Select Refetch to load the latest data from this host\./)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/manage its policies/)).not.toBeInTheDocument();
+    expect(
       screen.queryByRole("button", { name: /manage policies/i })
     ).not.toBeInTheDocument();
+  });
+
+  it("renders device user copy when deviceUser is true", () => {
+    renderWithContext({
+      deviceUser: true,
+      canManagePolicies: false,
+    });
+
+    expect(
+      screen.getByText(/Select Refetch to load the latest data from your device\./)
+    ).toBeInTheDocument();
   });
 
   it("renders policy count when policies exist", () => {

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -64,7 +64,9 @@ describe("HostPolicies", () => {
 
     expect(screen.getByText("No policies checked")).toBeInTheDocument();
     expect(
-      screen.getByText(/Select Refetch to load the latest data from this host\./)
+      screen.getByText(
+        /Select Refetch to load the latest data from this host\./
+      )
     ).toBeInTheDocument();
     expect(screen.queryByText(/manage its policies/)).not.toBeInTheDocument();
     expect(
@@ -79,7 +81,9 @@ describe("HostPolicies", () => {
     });
 
     expect(
-      screen.getByText(/Select Refetch to load the latest data from your device\./)
+      screen.getByText(
+        /Select Refetch to load the latest data from your device\./
+      )
     ).toBeInTheDocument();
   });
 

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+import { noop } from "lodash";
+import { IHostPolicy } from "interfaces/policy";
+
+import HostPolicies from "./HostPolicies";
+
+const createMockHostPolicy = (
+  overrides?: Partial<IHostPolicy>
+): IHostPolicy => ({
+  id: 1,
+  name: "Test Policy",
+  query: "SELECT 1;",
+  description: "A test policy",
+  author_id: 1,
+  author_name: "Test User",
+  author_email: "test@test.com",
+  resolution: "Fix it",
+  platform: "darwin",
+  team_id: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  critical: false,
+  calendar_events_enabled: false,
+  conditional_access_enabled: false,
+  type: "dynamic",
+  response: "pass",
+  ...overrides,
+});
+
+const baseProps = {
+  policies: [] as IHostPolicy[],
+  isLoading: false,
+  togglePolicyDetailsModal: noop,
+  hostPlatform: "darwin",
+};
+
+const renderWithContext = (props = {}) =>
+  createCustomRenderer()(<HostPolicies {...baseProps} {...props} />);
+
+describe("HostPolicies", () => {
+  it("renders empty state with Manage policies CTA when user has permission", () => {
+    renderWithContext({
+      canManagePolicies: true,
+      onManagePolicies: jest.fn(),
+    });
+
+    expect(screen.getByText("No policies checked")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Select Refetch to load the latest data from this host, or manage its policies/
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /manage policies/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty state without Manage policies CTA when user lacks permission", () => {
+    renderWithContext({
+      canManagePolicies: false,
+    });
+
+    expect(screen.getByText("No policies checked")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /manage policies/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders policy count when policies exist", () => {
+    const policies = [
+      createMockHostPolicy({ id: 1, name: "Policy A", response: "pass" }),
+      createMockHostPolicy({ id: 2, name: "Policy B", response: "fail" }),
+      createMockHostPolicy({ id: 3, name: "Policy C", response: "pass" }),
+    ];
+
+    renderWithContext({ policies });
+
+    expect(screen.getByText("3 policies")).toBeInTheDocument();
+  });
+
+  it("does not render for iOS hosts", () => {
+    renderWithContext({ hostPlatform: "ios" });
+
+    expect(
+      screen.getByText(/policies are not supported for this host/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No policies checked")).not.toBeInTheDocument();
+  });
+
+  it("does not render for Android hosts", () => {
+    renderWithContext({ hostPlatform: "android" });
+
+    expect(
+      screen.getByText(/policies are not supported for this host/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No policies checked")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -40,12 +40,13 @@ const renderWithContext = (props = {}) =>
   createCustomRenderer()(<HostPolicies {...baseProps} {...props} />);
 
 describe("HostPolicies", () => {
-  it("renders empty state with Manage policies CTA when user has permission", () => {
+  it("renders empty state with 0 count and Manage policies CTA when user has permission", () => {
     renderWithContext({
       canManagePolicies: true,
       onManagePolicies: jest.fn(),
     });
 
+    expect(screen.getByText("0 policies")).toBeInTheDocument();
     expect(screen.getByText("No policies checked")).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -6,7 +6,9 @@ import { isAndroid } from "interfaces/platform";
 import { IHostPolicy } from "interfaces/policy";
 import { SUPPORT_LINK } from "utilities/constants";
 import TableContainer from "components/TableContainer";
+import TableCount from "components/TableContainer/TableCount";
 import EmptyState from "components/EmptyState";
+import Button from "components/buttons/Button";
 import CardHeader from "components/CardHeader";
 import CustomLink from "components/CustomLink";
 import InfoBanner from "components/InfoBanner";
@@ -30,6 +32,8 @@ interface IPoliciesProps {
   currentTeamId?: number;
   conditionalAccessEnabled?: boolean;
   conditionalAccessBypassed?: boolean;
+  canManagePolicies?: boolean;
+  onManagePolicies?: () => void;
 }
 
 interface IHostPoliciesRowProps extends Row {
@@ -46,6 +50,8 @@ const Policies = ({
   currentTeamId,
   conditionalAccessEnabled,
   conditionalAccessBypassed,
+  canManagePolicies,
+  onManagePolicies,
 }: IPoliciesProps): JSX.Element => {
   const tableHeaders = generatePolicyTableHeaders(currentTeamId);
   if (deviceUser) {
@@ -127,18 +133,14 @@ const Policies = ({
     if (policies.length === 0) {
       return (
         <EmptyState
-          header={
-            <>
-              No policies are checked{" "}
-              {deviceUser ? `on your device` : `for this host`}
-            </>
-          }
-          info={
-            <>
-              Expecting to see policies? Try selecting “Refetch” to ask{" "}
-              {deviceUser ? `your device ` : `this host `}
-              to report new vitals.
-            </>
+          header="No policies checked"
+          info="Select Refetch to load the latest data from this host, or manage its policies."
+          primaryButton={
+            canManagePolicies ? (
+              <Button onClick={onManagePolicies} type="button">
+                Manage policies
+              </Button>
+            ) : undefined
           }
         />
       );
@@ -156,7 +158,9 @@ const Policies = ({
           emptyComponent={() => <></>}
           showMarkAllPages={false}
           isAllPagesSelected={false}
-          disableCount
+          renderCount={() => (
+            <TableCount name="policies" count={policies.length} />
+          )}
           disableMultiRowSelect // Removes hover/click state
           isClientSidePagination
           onClickRow={onClickRow}

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -131,10 +131,14 @@ const Policies = ({
     }
 
     if (policies.length === 0) {
+      const target = deviceUser ? "your device" : "this host";
+      const manageClause = canManagePolicies
+        ? ", or manage its policies."
+        : ".";
       return (
         <EmptyState
           header="No policies checked"
-          info="Select Refetch to load the latest data from this host, or manage its policies."
+          info={`Select Refetch to load the latest data from ${target}${manageClause}`}
           primaryButton={
             canManagePolicies ? (
               <Button onClick={onManagePolicies} type="button">

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -136,17 +136,20 @@ const Policies = ({
         ? ", or manage its policies."
         : ".";
       return (
-        <EmptyState
-          header="No policies checked"
-          info={`Select Refetch to load the latest data from ${target}${manageClause}`}
-          primaryButton={
-            canManagePolicies ? (
-              <Button onClick={onManagePolicies} type="button">
-                Manage policies
-              </Button>
-            ) : undefined
-          }
-        />
+        <>
+          <TableCount name="policies" count={0} />
+          <EmptyState
+            header="No policies checked"
+            info={`Select Refetch to load the latest data from ${target}${manageClause}`}
+            primaryButton={
+              canManagePolicies ? (
+                <Button onClick={onManagePolicies} type="button">
+                  Manage policies
+                </Button>
+              ) : undefined
+            }
+          />
+        </>
       );
     }
 

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -9,7 +9,6 @@ import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import EmptyState from "components/EmptyState";
 import Button from "components/buttons/Button";
-import CardHeader from "components/CardHeader";
 import CustomLink from "components/CustomLink";
 import InfoBanner from "components/InfoBanner";
 import IconStatusMessage from "components/IconStatusMessage";

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -135,6 +135,7 @@ const Policies = ({
       const manageClause = canManagePolicies
         ? ", or manage its policies."
         : ".";
+
       return (
         <>
           <TableCount name="policies" count={0} />
@@ -177,12 +178,7 @@ const Policies = ({
     );
   };
 
-  return (
-    <div className={baseClass}>
-      <CardHeader header="Policies" />
-      {renderHostPolicies()}
-    </div>
-  );
+  return <div className={baseClass}>{renderHostPolicies()}</div>;
 };
 
 export default Policies;

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
@@ -37,14 +37,49 @@ describe("HostSoftwareTable", () => {
       },
     })(<HostSoftwareTable {...baseProps} {...props} />);
 
-  it("renders the empty state when no software is detected", () => {
+  it("renders truly empty state with disabled controls", () => {
     renderWithContext({
       data: createMockGetHostSoftwareResponse({
         count: 0,
         software: [],
       }),
     });
-    expect(screen.getByText(/no software detected/i)).toBeInTheDocument();
+
+    // Empty state copy
+    expect(screen.getByText("No software found")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Expecting to see software\? Check back later/i)
+    ).toBeInTheDocument();
+
+    // Shows 0 items count
+    expect(screen.getByText("0 items")).toBeInTheDocument();
+
+    // Search is disabled
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    expect(searchInput).toBeDisabled();
+
+    // Filter button is disabled
+    const filterBtn = screen.getByRole("button", { name: /filter/i });
+    expect(filterBtn).toBeDisabled();
+  });
+
+  it("renders filtered empty state with enabled controls", () => {
+    renderWithContext({
+      data: createMockGetHostSoftwareResponse({
+        count: 0,
+        software: [],
+      }),
+      searchQuery: "nonexistent",
+    });
+
+    // Falls through to the standard empty software table
+    expect(
+      screen.getByText(/no items match the current search criteria/i)
+    ).toBeInTheDocument();
+
+    // Search is NOT disabled
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    expect(searchInput).not.toBeDisabled();
   });
 
   it("renders custom filter button when filters are applied", () => {
@@ -68,8 +103,7 @@ describe("HostSoftwareTable", () => {
     ).toBeInTheDocument();
   });
 
-  // This includes empty state for BYOD iphone/ipads
-  it("renders generic empty state when no filters are applied and platform is iPad/iPhone", () => {
+  it("renders truly empty state for iPad/iPhone", () => {
     renderWithContext({
       platform: "ipados",
       data: createMockGetHostSoftwareResponse({
@@ -78,6 +112,6 @@ describe("HostSoftwareTable", () => {
       }),
     });
 
-    expect(screen.getByText(/no software detected/i)).toBeInTheDocument();
+    expect(screen.getByText("No software found")).toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -167,7 +167,8 @@ const HostSoftwareTable = ({
   // Truly empty: no software at all, no active search/filters
   const isTrulyEmpty = isSoftwareNotDetected && !hasVulnFilters;
 
-  const showFilterHeaders = isTrulyEmpty || hasData || hasQuery || hasVulnFilters;
+  const showFilterHeaders =
+    isTrulyEmpty || hasData || hasQuery || hasVulnFilters;
 
   const memoizedSoftwareCount = useCallback(() => {
     return <TableCount name="items" count={count} />;

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -24,6 +24,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 
+import EmptyState from "components/EmptyState";
 import EmptySoftwareTable from "pages/SoftwarePage/components/tables/EmptySoftwareTable";
 import TableCount from "components/TableContainer/TableCount";
 import { VulnsNotSupported } from "pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable";
@@ -157,21 +158,20 @@ const HostSoftwareTable = ({
   const count = data?.count || data?.software?.length || 0;
   const isSoftwareNotDetected = count === 0 && searchQuery === "";
 
-  const memoizedSoftwareCount = useCallback(() => {
-    if (isSoftwareNotDetected) {
-      return null;
-    }
-
-    return <TableCount name="items" count={count} />;
-  }, [count, isSoftwareNotDetected]);
-
   // Determines if a user should be able to filter or search in the table
   const hasData = data && data.software.length > 0;
   const hasQuery = searchQuery !== "";
   const vulnFilterDetails = getVulnFilterRenderDetails(vulnFilters);
   const hasVulnFilters = vulnFilterDetails.filterCount > 0;
 
-  const showFilterHeaders = hasData || hasQuery || hasVulnFilters;
+  // Truly empty: no software at all, no active search/filters
+  const isTrulyEmpty = isSoftwareNotDetected && !hasVulnFilters;
+
+  const showFilterHeaders = isTrulyEmpty || hasData || hasQuery || hasVulnFilters;
+
+  const memoizedSoftwareCount = useCallback(() => {
+    return <TableCount name="items" count={count} />;
+  }, [count]);
 
   const onClickMyDeviceRow = useCallback(
     (row: IHostSoftwareRowProps) => {
@@ -191,7 +191,11 @@ const HostSoftwareTable = ({
         tipContent={vulnFilterDetails.tooltipText}
         disableTooltip={!hasVulnFilters}
       >
-        <Button variant="inverse" onClick={onAddFiltersClick}>
+        <Button
+          variant="inverse"
+          onClick={onAddFiltersClick}
+          disabled={isTrulyEmpty}
+        >
           <Icon name="filter" />
           <span>{vulnFilterDetails.buttonText}</span>
         </Button>
@@ -214,13 +218,20 @@ const HostSoftwareTable = ({
         pageSize={DEFAULT_PAGE_SIZE}
         inputPlaceHolder="Search by name or vulnerability (CVE)"
         onQueryChange={onQueryChange}
-        emptyComponent={() => (
-          <EmptyComponent
-            hasVulnFilters={hasVulnFilters}
-            platform={platform}
-            searchQuery={searchQuery}
-          />
-        )}
+        emptyComponent={() =>
+          isTrulyEmpty ? (
+            <EmptyState
+              header="No software found"
+              info="Expecting to see software? Check back later."
+            />
+          ) : (
+            <EmptyComponent
+              hasVulnFilters={hasVulnFilters}
+              platform={platform}
+              searchQuery={searchQuery}
+            />
+          )
+        }
         customControl={
           showFilterHeaders ? renderCustomFiltersButton : undefined
         }
@@ -228,6 +239,7 @@ const HostSoftwareTable = ({
         showMarkAllPages={false}
         isAllPagesSelected={false}
         searchable={showFilterHeaders}
+        disableSearch={isTrulyEmpty}
         manualSortBy
         keyboardSelectableRows={isMyDevicePage}
         // my device page row clickability


### PR DESCRIPTION
## Issue
Closes #44326 4.86.0
Second half of #35483 from 4.85.0

## Description
- Part 3 of many of #35483 
- This is just updating the host details page empty states

## Screenrecording

Shows host details page > software library, reports, and policies empty states

https://github.com/user-attachments/assets/f70cfe5b-131c-43f5-96bc-04eb49da582c



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added schedule report functionality with permission-based controls
  * Added manage policies CTA with conditional button visibility
  * Added software installation capability with role-based permissions
  * Policies tab now conditionally displays based on device type

* **Improvements**
  * Enhanced empty states with contextual action buttons
  * Improved search and filter control behavior in tables
  * Better permission-derived feature visibility across host details pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->