### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2026.104",
+      "version": "1.2026.118",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '1.2026.104') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '1.2026.118') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2026.104_1776709323.dmg",
+      "installer_url": "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2026.118_1777682760.dmg",
       "install_script_ref": "c2132138",
       "uninstall_script_ref": "8e1e14dd",
-      "sha256": "aec119a7a536caa3c35757e27ff9ba4628726ac140a207c85bf025b292173285",
+      "sha256": "8b6f103e2b3dd58e0a685f0f2dfedfa2cf51f37b9b2bf56979489859060d4f83",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/docker-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/docker-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.71.0",
+      "version": "4.72.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND version_compare(bundle_short_version, '4.71.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND version_compare(bundle_short_version, '4.72.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/mac/main/arm64/225177/Docker.dmg",
+      "installer_url": "https://desktop.docker.com/mac/main/arm64/225998/Docker.dmg",
       "install_script_ref": "fe655671",
       "uninstall_script_ref": "f8ed2624",
-      "sha256": "56a78b132696b747c40b151af57ecdbd8529b5f4dac4d436cd0d767721a957b4",
+      "sha256": "306e83f80748f41d36123544c2a0268b42167874ac75c52a46b86155e7093b8e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/inkscape/darwin.json
+++ b/ee/maintained-apps/outputs/inkscape/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.3",
+      "version": "1.4.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.inkscape.Inkscape';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.inkscape.Inkscape' AND version_compare(bundle_short_version, '1.4.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.inkscape.Inkscape' AND version_compare(bundle_short_version, '1.4.4') < 0);"
       },
-      "installer_url": "https://media.inkscape.org/dl/resources/file/Inkscape-1.4.3_arm64.dmg",
+      "installer_url": "https://media.inkscape.org/dl/resources/file/Inkscape-1.4.4_arm64.dmg",
       "install_script_ref": "ab3c3b86",
       "uninstall_script_ref": "86844299",
-      "sha256": "f4aa9c9b2e06db432c6f81a494ad9aa59b87cb7d9539cd7e6f6000002cb9edff",
+      "sha256": "eacca94ab01e59467cdd5452a2867c3734450f9a4cfb3346956cc9b07f34f3f1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/mongodb-compass/darwin.json
+++ b/ee/maintained-apps/outputs/mongodb-compass/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.49.5",
+      "version": "1.49.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mongodb.compass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mongodb.compass' AND version_compare(bundle_short_version, '1.49.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mongodb.compass' AND version_compare(bundle_short_version, '1.49.6') < 0);"
       },
-      "installer_url": "https://downloads.mongodb.com/compass/mongodb-compass-1.49.5-darwin-arm64.dmg",
+      "installer_url": "https://downloads.mongodb.com/compass/mongodb-compass-1.49.6-darwin-arm64.dmg",
       "install_script_ref": "14733ba0",
       "uninstall_script_ref": "eaad5ef8",
-      "sha256": "37d8081de8778ac08a737c7954fb801022fa4fe7557155e8b4ae1308e5bf7bfa",
+      "sha256": "5b6923487e787b8cd3b6c2004153dee808d13347863facb9e8ede1184a9019ff",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/proxyman/darwin.json
+++ b/ee/maintained-apps/outputs/proxyman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.9.0",
+      "version": "6.10.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.proxyman.NSProxy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.proxyman.NSProxy' AND version_compare(bundle_short_version, '6.9.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.proxyman.NSProxy' AND version_compare(bundle_short_version, '6.10.0') < 0);"
       },
-      "installer_url": "https://download.proxyman.com/60900/Proxyman_6.9.0.dmg",
+      "installer_url": "https://download.proxyman.com/61000/Proxyman_6.10.0.dmg",
       "install_script_ref": "0152bcaa",
       "uninstall_script_ref": "11711ba9",
-      "sha256": "d6150f2f9dfc9cf81f5ea5e94b6871eb355ad28c94c074ad548417e53803e5a8",
+      "sha256": "7175e835eec424daff05a73037f373b54538cb4b1bc79ad46476d2f18d4e30f9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/twingate/windows.json
+++ b/ee/maintained-apps/outputs/twingate/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "20.26.90.8546",
+      "version": "20.26.120.9484",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.90.8546') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.120.9484') < 0);"
       },
-      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.90.8546/TwingateWindowsInstaller.msi",
+      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.120.9484/TwingateWindowsInstaller.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "72d99820",
-      "sha256": "18a24d6915c830a689d0eb6c4459946508b3bd4a74aa298142d78811be2b68b2",
+      "sha256": "910be7968824db00f772a433ec6b4f56d839e840127cbd6a2b191917b3f343e5",
       "default_categories": [
         "Productivity"
       ],


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version information for ChatGPT (1.2026.118), Docker Desktop (4.72.0), Inkscape (1.4.4), MongoDB Compass (1.49.6), Proxyman (6.10.0), and Twingate (20.26.120.9484). Deployment manifests have been refreshed with latest installer URLs and verification checksums, ensuring accurate application tracking and proper installation validation across macOS and Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->