### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/twingate/darwin.json
+++ b/ee/maintained-apps/outputs/twingate/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.85",
+      "version": "2026.120",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.twingate.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.twingate.macos' AND version_compare(bundle_short_version, '2026.85') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.twingate.macos' AND version_compare(bundle_short_version, '2026.120') < 0);"
       },
-      "installer_url": "https://binaries.twingate.com/client/macos/2026.85.23872/Twingate.pkg",
+      "installer_url": "https://binaries.twingate.com/client/macos/2026.120.24748/Twingate.pkg",
       "install_script_ref": "bc774d90",
       "uninstall_script_ref": "7acfe28f",
-      "sha256": "a7e0a6afea03c3d1902b526ccdc403bccd41a9a3565f258c97f972848ba4f28e",
+      "sha256": "586da34201d8dd4afb7e777efb4ce8c93b0a3afa34ab26782b6c608382594ee1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/windsurf/darwin.json
+++ b/ee/maintained-apps/outputs/windsurf/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.1.32",
+      "version": "2.2.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '2.1.32') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '2.2.17') < 0);"
       },
-      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/63e54ba26dd2a1b975c172966dff80bad8ae74c7/Windsurf-darwin-arm64-2.1.32.dmg",
+      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/a65d6c4e1fd335336d7a0b601099811667e184ca/Windsurf-darwin-arm64-2.2.17.dmg",
       "install_script_ref": "c8128892",
       "uninstall_script_ref": "956d8488",
-      "sha256": "898a9ed6797494b666346ab5c327f2c2dd87614be7a3e7e2b17085d052a9089a",
+      "sha256": "d424ea8a7e2bd93daea3811677b2b893f8bc26f0590d7db011a98ee338186691",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.1",
+      "version": "1.1.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.1.6') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.0.1/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.1.6/Zed-aarch64.dmg",
       "install_script_ref": "7a64bca0",
       "uninstall_script_ref": "315158ff",
-      "sha256": "3c16b7d4fe33270186784e0bf1605c18c7c8cd5d2c3ab094abfce910cf33a7f2",
+      "sha256": "fa4bcb1b2ebadb808c9bc33f7d1543f14f611ba1c8dd08b21cd0ac4984cb1c89",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zotero/darwin.json
+++ b/ee/maintained-apps/outputs/zotero/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero' AND version_compare(bundle_short_version, '9.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero' AND version_compare(bundle_short_version, '9.0.3') < 0);"
       },
-      "installer_url": "https://download.zotero.org/client/release/9.0.2/Zotero-9.0.2.dmg",
+      "installer_url": "https://download.zotero.org/client/release/9.0.3/Zotero-9.0.3.dmg",
       "install_script_ref": "c792140b",
       "uninstall_script_ref": "34c55f94",
-      "sha256": "02d03b147677d1ced823d9b196ff7107f5a77c42874ce2e48d3a6ce8dc3ed64a",
+      "sha256": "7aaa8c6c916740ef542bc24e9b7d48cbd9bdc797546271e2c0f0d72be274836b",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS installer versions: Twingate (2026.85 → 2026.120), Windsurf (2.1.32 → 2.2.17), Zed (1.0.1 → 1.1.6), and Zotero (9.0.2 → 9.0.3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->