### PR TITLE
update linux page with whitepaper cta

### DIFF
--- a/website/views/pages/landing-pages/linux-management.ejs
+++ b/website/views/pages/landing-pages/linux-management.ejs
@@ -11,8 +11,8 @@
             <p>Support developers’ choice of Linux without losing visibility or control. <br>Manage Linux, macOS, and Windows in one place.</p>
           </div>
           <div purpose="button-row" class="d-flex justify-content-center align-items-center">
-            <a purpose="cta-button" href="/contact?sendMessage" no-underline>Talk to us</a>
-            <a purpose="video-button"  @click="clickOpenVideoModal('fleet-in-three-minutes')"><img alt="Play" class="d-inline" src="/images/icon-play-video-32x32@2x.png">See Fleet in action <span>3 mins</span></a>
+            <a purpose="cta-button" class="btn btn-primary" href="/whitepapers/it-leaders-guide-to-linux-device-management">Read the whitepaper</a>
+            <a purpose="video-button" @click="clickOpenVideoModal('fleet-in-three-minutes')"><img alt="Play" class="d-inline" src="/images/icon-play-video-32x32@2x.png">See Fleet in action <span>3 mins</span></a>
           </div>
         </div>
       </div><%/* landing-page-hero */%>
@@ -124,7 +124,7 @@
         <h4>Linux Device Management</h4>
         <h1>Support Linux without adding complexity</h1>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="mr-0" href="/contact" no-underline>Get a demo</a>
+          <a purpose="cta-button" class="btn btn-primary" href="/whitepapers/it-leaders-guide-to-linux-device-management">Read the whitepaper</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updated Linux page main cta to download new Linux white paper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced primary demo/contact CTAs with a prominent "Read the whitepaper" CTA on the Linux management landing page (hero and bottom sections).
  * Preserved the "See Fleet in action" video CTA in the hero section; layout updated for consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->