### PR TITLE
Make activity list end-date filter consistent (#38437)

### DIFF
--- a/changes/38437-activity-list-date-filter-consistency
+++ b/changes/38437-activity-list-date-filter-consistency
@@ -1,0 +1,1 @@
+- Made `created_at` upper-bound filtering consistent on the list activities API. The endpoint now caps results at `now` by default whether or not `start_created_at` is provided, matching the documented behavior of `end_created_at`.

--- a/server/activity/internal/mysql/activity.go
+++ b/server/activity/internal/mysql/activity.go
@@ -92,12 +92,13 @@ func (ds *Datastore) ListActivities(ctx context.Context, opt types.ListOptions) 
 		args = append(args, opt.StartCreatedAt)
 	}
 
+	// Always cap the upper bound on created_at so that results are consistent
+	// regardless of whether StartCreatedAt is provided. Defaults to now per the
+	// REST API contract.
+	activitiesQ += " AND a.created_at <= ?"
 	if opt.EndCreatedAt != "" {
-		activitiesQ += " AND a.created_at <= ?"
 		args = append(args, opt.EndCreatedAt)
-	} else if opt.StartCreatedAt != "" {
-		// When filtering by start date, cap at now to ensure consistent results
-		activitiesQ += " AND a.created_at <= ?"
+	} else {
 		args = append(args, time.Now().UTC())
 	}
 

--- a/server/activity/internal/mysql/activity.go
+++ b/server/activity/internal/mysql/activity.go
@@ -93,8 +93,7 @@ func (ds *Datastore) ListActivities(ctx context.Context, opt types.ListOptions) 
 	}
 
 	// Always cap the upper bound on created_at so that results are consistent
-	// regardless of whether StartCreatedAt is provided. Defaults to now per the
-	// REST API contract.
+	// regardless of whether StartCreatedAt is provided. Defaults to now.
 	activitiesQ += " AND a.created_at <= ?"
 	if opt.EndCreatedAt != "" {
 		args = append(args, opt.EndCreatedAt)

--- a/server/activity/internal/mysql/activity_test.go
+++ b/server/activity/internal/mysql/activity_test.go
@@ -182,11 +182,13 @@ func testListActivitiesDateRangeFilter(t *testing.T, env *testEnv) {
 	userID := env.InsertUser(t, "testuser", "test@example.com")
 	now := time.Now().UTC().Truncate(time.Second)
 
-	// Only create activities in the past/present (activities can't have future creation dates)
+	// Includes a future-dated row to verify that the default upper bound caps
+	// at now regardless of whether StartCreatedAt is provided.
 	dates := []time.Time{
 		now.Add(-48 * time.Hour),
 		now.Add(-24 * time.Hour),
 		now,
+		now.Add(24 * time.Hour),
 	}
 	for _, dt := range dates {
 		env.InsertActivityWithTime(t, &userID, "test_activity", map[string]any{}, dt)
@@ -198,10 +200,12 @@ func testListActivitiesDateRangeFilter(t *testing.T, env *testEnv) {
 		end       string
 		wantCount int
 	}{
-		{"no filter", "", "", 3},
-		{"start only", now.Add(-72 * time.Hour).Format(time.RFC3339), "", 3},
+		{"no filter excludes future", "", "", 3},
+		{"start only excludes future", now.Add(-72 * time.Hour).Format(time.RFC3339), "", 3},
 		{"start and end", now.Add(-72 * time.Hour).Format(time.RFC3339), now.Add(-12 * time.Hour).Format(time.RFC3339), 2},
 		{"end only", "", now.Add(-30 * time.Hour).Format(time.RFC3339), 1},
+		{"end inclusive of exact match", "", now.Format(time.RFC3339), 3},
+		{"end in future includes future", "", now.Add(48 * time.Hour).Format(time.RFC3339), 4},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38437 

The list activities endpoint applied an implicit `created_at <= now` cap only when `start_created_at` was set, leaving the upper bound unbounded in every other case, this was changed so that we now apply that cap unconditionally and override only when the caller passes an explicit `end_created_at` (as peer the REST docs).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent date filtering in the activities list API. Results are now consistently capped at the current time by default, even when only a start date is specified, ensuring predictable filtering behavior across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->