### PR TITLE
Add tests for serve.go pure helpers (#33370)

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -434,7 +434,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			os.Exit(1)
 		}
 	case fleet.NeedsFleetv4732Fix:
-		printFleetv4732FixNeededMessage(os.Stdout)
+		printFleetv4732FixNeededMessage()
 		if !config.Upgrades.AllowMissingMigrations {
 			os.Exit(1)
 		}
@@ -450,7 +450,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			os.Exit(1)
 		}
 	case fleet.NoMigrationsCompleted:
-		printDatabaseNotInitializedError(os.Stdout)
+		printDatabaseNotInitializedError()
 		os.Exit(1)
 	}
 
@@ -2031,8 +2031,8 @@ func createActivityBoundedContext(svc fleet.Service, dbConns *common_mysql.DBCon
 	return activitySvc, activityRoutes
 }
 
-func printDatabaseNotInitializedError(w io.Writer) {
-	fmt.Fprintf(w, "################################################################################\n"+
+func printDatabaseNotInitializedError() {
+	fmt.Printf("################################################################################\n"+
 		"# ERROR:\n"+
 		"#   Your Fleet database is not initialized. Fleet cannot start up.\n"+
 		"#\n"+
@@ -2059,8 +2059,8 @@ func printMissingMigrationsWarning(w io.Writer, tables []int64, data []int64) {
 		tablesAndDataToString(tables, data), os.Args[0])
 }
 
-func printFleetv4732FixNeededMessage(w io.Writer) {
-	fmt.Fprintf(w, "################################################################################\n"+
+func printFleetv4732FixNeededMessage() {
+	fmt.Printf("################################################################################\n"+
 		"# WARNING:\n"+
 		"#   Your Fleet database has misnumbered migrations introduced in some released\n"+
 		"#   v4.73.2 artifacts. Fleet will automatically perform this fix prior to database\n"+

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -10,6 +10,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/rand"
 	"net/http"
@@ -433,7 +434,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			os.Exit(1)
 		}
 	case fleet.NeedsFleetv4732Fix:
-		printFleetv4732FixNeededMessage()
+		printFleetv4732FixNeededMessage(os.Stdout)
 		if !config.Upgrades.AllowMissingMigrations {
 			os.Exit(1)
 		}
@@ -444,12 +445,12 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		}
 	case fleet.SomeMigrationsCompleted:
 		tables, data := migrationStatus.MissingTable, migrationStatus.MissingData
-		printMissingMigrationsWarning(tables, data)
+		printMissingMigrationsWarning(os.Stdout, tables, data)
 		if !config.Upgrades.AllowMissingMigrations {
 			os.Exit(1)
 		}
 	case fleet.NoMigrationsCompleted:
-		printDatabaseNotInitializedError()
+		printDatabaseNotInitializedError(os.Stdout)
 		os.Exit(1)
 	}
 
@@ -2030,8 +2031,8 @@ func createActivityBoundedContext(svc fleet.Service, dbConns *common_mysql.DBCon
 	return activitySvc, activityRoutes
 }
 
-func printDatabaseNotInitializedError() {
-	fmt.Printf("################################################################################\n"+
+func printDatabaseNotInitializedError(w io.Writer) {
+	fmt.Fprintf(w, "################################################################################\n"+
 		"# ERROR:\n"+
 		"#   Your Fleet database is not initialized. Fleet cannot start up.\n"+
 		"#\n"+
@@ -2040,8 +2041,8 @@ func printDatabaseNotInitializedError() {
 		os.Args[0])
 }
 
-func printMissingMigrationsWarning(tables []int64, data []int64) {
-	fmt.Printf("################################################################################\n"+
+func printMissingMigrationsWarning(w io.Writer, tables []int64, data []int64) {
+	fmt.Fprintf(w, "################################################################################\n"+
 		"# WARNING:\n"+
 		"#   Your Fleet database is missing required migrations. This is likely to cause\n"+
 		"#   errors in Fleet.\n"+
@@ -2058,8 +2059,8 @@ func printMissingMigrationsWarning(tables []int64, data []int64) {
 		tablesAndDataToString(tables, data), os.Args[0])
 }
 
-func printFleetv4732FixNeededMessage() {
-	fmt.Printf("################################################################################\n"+
+func printFleetv4732FixNeededMessage(w io.Writer) {
+	fmt.Fprintf(w, "################################################################################\n"+
 		"# WARNING:\n"+
 		"#   Your Fleet database has misnumbered migrations introduced in some released\n"+
 		"#   v4.73.2 artifacts. Fleet will automatically perform this fix prior to database\n"+

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -1475,14 +1475,21 @@ func TestInitLicense(t *testing.T) {
 	})
 }
 
+var captureStdoutMu sync.Mutex
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
+	captureStdoutMu.Lock()
+	defer captureStdoutMu.Unlock()
 
 	origStdout := os.Stdout
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	os.Stdout = w
-	defer func() { os.Stdout = origStdout }()
+	defer func() {
+		os.Stdout = origStdout
+		_ = r.Close()
+	}()
 
 	var buf bytes.Buffer
 	done := make(chan struct{})

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -1347,6 +1348,7 @@ func TestOTELResourceCreation(t *testing.T) {
 }
 
 func TestArgsToString(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		args []driver.NamedValue
@@ -1395,15 +1397,18 @@ func TestArgsToString(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tc.want, argsToString(tc.args))
 		})
 	}
 }
 
 func TestGetTLSConfig(t *testing.T) {
+	t.Parallel()
 	expectedCurves := []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384}
 
 	t.Run("modern", func(t *testing.T) {
+		t.Parallel()
 		cfg := getTLSConfig(config.TLSProfileModern)
 		require.NotNil(t, cfg)
 		assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
@@ -1419,6 +1424,7 @@ func TestGetTLSConfig(t *testing.T) {
 	})
 
 	t.Run("intermediate", func(t *testing.T) {
+		t.Parallel()
 		cfg := getTLSConfig(config.TLSProfileIntermediate)
 		require.NotNil(t, cfg)
 		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
@@ -1439,7 +1445,9 @@ func TestGetTLSConfig(t *testing.T) {
 }
 
 func TestInitLicense(t *testing.T) {
+	t.Parallel()
 	t.Run("dev license", func(t *testing.T) {
+		t.Parallel()
 		cfg := &config.FleetConfig{}
 		license, err := initLicense(cfg, true, false)
 		require.NoError(t, err)
@@ -1450,6 +1458,7 @@ func TestInitLicense(t *testing.T) {
 	})
 
 	t.Run("dev expired license", func(t *testing.T) {
+		t.Parallel()
 		cfg := &config.FleetConfig{}
 		license, err := initLicense(cfg, false, true)
 		require.NoError(t, err)
@@ -1459,6 +1468,7 @@ func TestInitLicense(t *testing.T) {
 	})
 
 	t.Run("no license key", func(t *testing.T) {
+		t.Parallel()
 		cfg := &config.FleetConfig{}
 		license, err := initLicense(cfg, false, false)
 		require.NoError(t, err)
@@ -1466,4 +1476,46 @@ func TestInitLicense(t *testing.T) {
 		assert.Equal(t, fleet.TierFree, license.Tier)
 		assert.Empty(t, cfg.License.Key)
 	})
+}
+
+func TestPrintMissingMigrationsWarning(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name           string
+		tables         []int64
+		data           []int64
+		wantSubstrings []string
+	}{
+		{
+			name:           "tables only",
+			tables:         []int64{1, 2, 3},
+			wantSubstrings: []string{"tables=[1 2 3]", "missing required migrations"},
+		},
+		{
+			name:           "data only",
+			data:           []int64{4, 5},
+			wantSubstrings: []string{"data=[4 5]"},
+		},
+		{
+			name:           "tables and data",
+			tables:         []int64{1},
+			data:           []int64{2},
+			wantSubstrings: []string{"tables=[1], data=[2]"},
+		},
+		{
+			name:           "neither",
+			wantSubstrings: []string{"unknown"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			printMissingMigrationsWarning(&buf, tc.tables, tc.data)
+			out := buf.String()
+			for _, sub := range tc.wantSubstrings {
+				assert.Contains(t, out, sub)
+			}
+			assert.Contains(t, out, os.Args[0])
+		})
+	}
 }

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -1401,12 +1400,6 @@ func TestArgsToString(t *testing.T) {
 	}
 }
 
-func TestNopPusher(t *testing.T) {
-	resp, err := nopPusher{}.Push(t.Context(), []string{"a", "b"})
-	require.NoError(t, err)
-	require.Nil(t, resp)
-}
-
 func TestGetTLSConfig(t *testing.T) {
 	expectedCurves := []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384}
 
@@ -1473,88 +1466,4 @@ func TestInitLicense(t *testing.T) {
 		assert.Equal(t, fleet.TierFree, license.Tier)
 		assert.Empty(t, cfg.License.Key)
 	})
-}
-
-var captureStdoutMu sync.Mutex
-
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	captureStdoutMu.Lock()
-	defer captureStdoutMu.Unlock()
-
-	origStdout := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-	defer func() {
-		os.Stdout = origStdout
-		_ = r.Close()
-	}()
-
-	var buf bytes.Buffer
-	done := make(chan struct{})
-	go func() {
-		_, _ = io.Copy(&buf, r)
-		close(done)
-	}()
-
-	fn()
-	require.NoError(t, w.Close())
-	<-done
-	return buf.String()
-}
-
-func TestPrintDatabaseNotInitializedError(t *testing.T) {
-	out := captureStdout(t, printDatabaseNotInitializedError)
-	assert.Contains(t, out, "Your Fleet database is not initialized")
-	assert.Contains(t, out, "prepare db")
-	assert.Contains(t, out, os.Args[0])
-}
-
-func TestPrintMissingMigrationsWarning(t *testing.T) {
-	for _, tc := range []struct {
-		name           string
-		tables         []int64
-		data           []int64
-		wantSubstrings []string
-	}{
-		{
-			name:           "tables only",
-			tables:         []int64{1, 2, 3},
-			wantSubstrings: []string{"tables=[1 2 3]", "missing required migrations"},
-		},
-		{
-			name:           "data only",
-			data:           []int64{4, 5},
-			wantSubstrings: []string{"data=[4 5]"},
-		},
-		{
-			name:           "tables and data",
-			tables:         []int64{1},
-			data:           []int64{2},
-			wantSubstrings: []string{"tables=[1], data=[2]"},
-		},
-		{
-			name:           "neither",
-			wantSubstrings: []string{"unknown"},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			out := captureStdout(t, func() {
-				printMissingMigrationsWarning(tc.tables, tc.data)
-			})
-			for _, sub := range tc.wantSubstrings {
-				assert.Contains(t, out, sub)
-			}
-			assert.Contains(t, out, os.Args[0])
-		})
-	}
-}
-
-func TestPrintFleetv4732FixNeededMessage(t *testing.T) {
-	out := captureStdout(t, printFleetv4732FixNeededMessage)
-	assert.Contains(t, out, "misnumbered migrations")
-	assert.Contains(t, out, "v4.73.2")
-	assert.Contains(t, out, "prepare db")
-	assert.Contains(t, out, os.Args[0])
 }

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -1397,7 +1397,6 @@ func TestArgsToString(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			assert.Equal(t, tc.want, argsToString(tc.args))
 		})
 	}
@@ -1408,7 +1407,6 @@ func TestGetTLSConfig(t *testing.T) {
 	expectedCurves := []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384}
 
 	t.Run("modern", func(t *testing.T) {
-		t.Parallel()
 		cfg := getTLSConfig(config.TLSProfileModern)
 		require.NotNil(t, cfg)
 		assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
@@ -1424,7 +1422,6 @@ func TestGetTLSConfig(t *testing.T) {
 	})
 
 	t.Run("intermediate", func(t *testing.T) {
-		t.Parallel()
 		cfg := getTLSConfig(config.TLSProfileIntermediate)
 		require.NotNil(t, cfg)
 		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
@@ -1447,7 +1444,6 @@ func TestGetTLSConfig(t *testing.T) {
 func TestInitLicense(t *testing.T) {
 	t.Parallel()
 	t.Run("dev license", func(t *testing.T) {
-		t.Parallel()
 		cfg := &config.FleetConfig{}
 		license, err := initLicense(cfg, true, false)
 		require.NoError(t, err)
@@ -1458,7 +1454,6 @@ func TestInitLicense(t *testing.T) {
 	})
 
 	t.Run("dev expired license", func(t *testing.T) {
-		t.Parallel()
 		cfg := &config.FleetConfig{}
 		license, err := initLicense(cfg, false, true)
 		require.NoError(t, err)
@@ -1468,7 +1463,6 @@ func TestInitLicense(t *testing.T) {
 	})
 
 	t.Run("no license key", func(t *testing.T) {
-		t.Parallel()
 		cfg := &config.FleetConfig{}
 		license, err := initLicense(cfg, false, false)
 		require.NoError(t, err)
@@ -1508,7 +1502,6 @@ func TestPrintMissingMigrationsWarning(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			var buf bytes.Buffer
 			printMissingMigrationsWarning(&buf, tc.tables, tc.data)
 			out := buf.String()

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
+	"database/sql/driver"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1342,4 +1345,209 @@ func TestOTELResourceCreation(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, res)
+}
+
+func TestArgsToString(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []driver.NamedValue
+		want string
+	}{
+		{
+			name: "empty",
+			args: nil,
+			want: "{}",
+		},
+		{
+			name: "single positional",
+			args: []driver.NamedValue{{Value: "hello"}},
+			want: "{hello}",
+		},
+		{
+			name: "single named",
+			args: []driver.NamedValue{{Name: "id", Value: 42}},
+			want: "{id=42}",
+		},
+		{
+			name: "multiple named",
+			args: []driver.NamedValue{
+				{Name: "id", Value: 1},
+				{Name: "name", Value: "alice"},
+			},
+			want: "{id=1, name=alice}",
+		},
+		{
+			name: "mixed positional and named",
+			args: []driver.NamedValue{
+				{Name: "id", Value: 1},
+				{Value: "second"},
+			},
+			want: "{id=1, second}",
+		},
+		{
+			name: "mixed value types",
+			args: []driver.NamedValue{
+				{Value: 1},
+				{Value: "two"},
+				{Value: true},
+				{Value: nil},
+			},
+			want: "{1, two, true, <nil>}",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, argsToString(tc.args))
+		})
+	}
+}
+
+func TestNopPusher(t *testing.T) {
+	resp, err := nopPusher{}.Push(t.Context(), []string{"a", "b"})
+	require.NoError(t, err)
+	require.Nil(t, resp)
+}
+
+func TestGetTLSConfig(t *testing.T) {
+	expectedCurves := []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384}
+
+	t.Run("modern", func(t *testing.T) {
+		cfg := getTLSConfig(config.TLSProfileModern)
+		require.NotNil(t, cfg)
+		assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+		assert.True(t, cfg.PreferServerCipherSuites)
+		assert.ElementsMatch(t, expectedCurves, cfg.CurvePreferences)
+		assert.ElementsMatch(t, []uint16{
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		}, cfg.CipherSuites)
+	})
+
+	t.Run("intermediate", func(t *testing.T) {
+		cfg := getTLSConfig(config.TLSProfileIntermediate)
+		require.NotNil(t, cfg)
+		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+		assert.True(t, cfg.PreferServerCipherSuites)
+		assert.ElementsMatch(t, expectedCurves, cfg.CurvePreferences)
+		assert.ElementsMatch(t, []uint16{
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		}, cfg.CipherSuites)
+	})
+}
+
+func TestInitLicense(t *testing.T) {
+	t.Run("dev license", func(t *testing.T) {
+		cfg := &config.FleetConfig{}
+		license, err := initLicense(cfg, true, false)
+		require.NoError(t, err)
+		require.NotNil(t, license)
+		assert.True(t, license.IsPremium())
+		assert.False(t, license.IsExpired())
+		assert.NotEmpty(t, cfg.License.Key, "dev license should populate the config key")
+	})
+
+	t.Run("dev expired license", func(t *testing.T) {
+		cfg := &config.FleetConfig{}
+		license, err := initLicense(cfg, false, true)
+		require.NoError(t, err)
+		require.NotNil(t, license)
+		assert.True(t, license.IsExpired())
+		assert.NotEmpty(t, cfg.License.Key, "dev expired license should populate the config key")
+	})
+
+	t.Run("no license key", func(t *testing.T) {
+		cfg := &config.FleetConfig{}
+		license, err := initLicense(cfg, false, false)
+		require.NoError(t, err)
+		require.NotNil(t, license)
+		assert.Equal(t, fleet.TierFree, license.Tier)
+		assert.Empty(t, cfg.License.Key)
+	})
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+	require.NoError(t, w.Close())
+	<-done
+	return buf.String()
+}
+
+func TestPrintDatabaseNotInitializedError(t *testing.T) {
+	out := captureStdout(t, printDatabaseNotInitializedError)
+	assert.Contains(t, out, "Your Fleet database is not initialized")
+	assert.Contains(t, out, "prepare db")
+	assert.Contains(t, out, os.Args[0])
+}
+
+func TestPrintMissingMigrationsWarning(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		tables         []int64
+		data           []int64
+		wantSubstrings []string
+	}{
+		{
+			name:           "tables only",
+			tables:         []int64{1, 2, 3},
+			wantSubstrings: []string{"tables=[1 2 3]", "missing required migrations"},
+		},
+		{
+			name:           "data only",
+			data:           []int64{4, 5},
+			wantSubstrings: []string{"data=[4 5]"},
+		},
+		{
+			name:           "tables and data",
+			tables:         []int64{1},
+			data:           []int64{2},
+			wantSubstrings: []string{"tables=[1], data=[2]"},
+		},
+		{
+			name:           "neither",
+			wantSubstrings: []string{"unknown"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				printMissingMigrationsWarning(tc.tables, tc.data)
+			})
+			for _, sub := range tc.wantSubstrings {
+				assert.Contains(t, out, sub)
+			}
+			assert.Contains(t, out, os.Args[0])
+		})
+	}
+}
+
+func TestPrintFleetv4732FixNeededMessage(t *testing.T) {
+	out := captureStdout(t, printFleetv4732FixNeededMessage)
+	assert.Contains(t, out, "misnumbered migrations")
+	assert.Contains(t, out, "v4.73.2")
+	assert.Contains(t, out, "prepare db")
+	assert.Contains(t, out, os.Args[0])
 }


### PR DESCRIPTION
First PR in the staged plan from [#33370](https://github.com/fleetdm/fleet/issues/33370#issuecomment-4394807680). Adds unit tests for several testable helpers in `cmd/fleet/serve.go` — argument stringification, TLS profile config, license initialization, and the missing-migrations warning.

The migrations-warning test required threading `io.Writer` through `printMissingMigrationsWarning` so it can pass `*bytes.Buffer` instead of mutating `os.Stdout`. The other two database-state print functions stay as-is since they aren't tested in this PR.

**Related issue:** Part of #33370 (intentionally not using auto-close keywords since this is the first of multiple PRs against this issue).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests

## Database migrations

_N/A — no database migrations in this PR._

## New Fleet configuration settings

_N/A — no new configuration settings._

## fleetd/orbit/Fleet Desktop

_N/A — no agent code changes._
