### PR TITLE
iOS/iPadOS managed config: validator (#43963)

### DIFF
--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -2699,7 +2699,7 @@ func testAddDeleteAndroidAppWithConfiguration(t *testing.T, ds *Datastore) {
 
 	test.CreateInsertGlobalVPPToken(t, ds)
 
-	testConfig := json.RawMessage(`{"ManagedConfiguration": {"DisableShareScreen": true, "DisableComputerAudio": true}}`)
+	testConfig := []byte(`{"ManagedConfiguration": {"DisableShareScreen": true, "DisableComputerAudio": true}}`)
 	// Create android and VPP apps
 	app1, err := ds.InsertVPPAppWithTeam(ctx, &fleet.VPPApp{
 		Name: "android1", BundleIdentifier: "android1",
@@ -2738,7 +2738,7 @@ func testAddDeleteAndroidAppWithConfiguration(t *testing.T, ds *Datastore) {
 	require.NotZero(t, meta2.VPPAppsTeamsID)
 
 	// Edit android app
-	newConfig := json.RawMessage(`{"workProfileWidgets": "WORK_PROFILE_WIDGETS_ALLOWED"}`)
+	newConfig := []byte(`{"workProfileWidgets": "WORK_PROFILE_WIDGETS_ALLOWED"}`)
 	app1.VPPAppTeam.Configuration = newConfig
 	_, err = ds.InsertVPPAppWithTeam(ctx, app1, &team1.ID)
 	require.NoError(t, err)
@@ -2750,7 +2750,7 @@ func testAddDeleteAndroidAppWithConfiguration(t *testing.T, ds *Datastore) {
 	require.Equal(t, newConfig, meta.Configuration)
 
 	// Add invalid configuration
-	badConfig := json.RawMessage(`"-": "-"`)
+	badConfig := []byte(`"-": "-"`)
 	app1.VPPAppTeam.Configuration = badConfig
 	_, err = ds.InsertVPPAppWithTeam(ctx, app1, &team1.ID)
 	require.Error(t, err)

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -2588,7 +2588,7 @@ func testAndroidAppConfigs(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	config1 := json.RawMessage(`{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED", "managedConfiguration": {"1":1}}`)
-	expectedConfig1 := json.RawMessage(`{"workProfileWidgets": "WORK_PROFILE_WIDGETS_ALLOWED", "managedConfiguration": {"1": 1}}`)
+	expectedConfig1 := []byte(`{"workProfileWidgets": "WORK_PROFILE_WIDGETS_ALLOWED", "managedConfiguration": {"1": 1}}`)
 
 	_, err = ds.SetTeamVPPApps(ctx, &team.ID, []fleet.VPPAppTeam{
 		{VPPAppID: app1.VPPAppID, SelfService: true, DisplayName: ptr.String("name 1")},
@@ -2611,9 +2611,9 @@ func testAndroidAppConfigs(t *testing.T, ds *Datastore) {
 		}
 	}
 
-	require.Equal(t, json.RawMessage(nil), assigned[app1.VPPAppID].Configuration)
-	require.Equal(t, json.RawMessage(nil), assigned[app2.VPPAppID].Configuration)
-	require.Equal(t, json.RawMessage(`{}`), assigned[app3.VPPAppID].Configuration)
+	require.Equal(t, []byte(nil), assigned[app1.VPPAppID].Configuration)
+	require.Equal(t, []byte(nil), assigned[app2.VPPAppID].Configuration)
+	require.Equal(t, []byte(`{}`), assigned[app3.VPPAppID].Configuration)
 	require.Equal(t, expectedConfig1, assigned[app4.VPPAppID].Configuration)
 
 	_, err = ds.SetTeamVPPApps(ctx, &team.ID, []fleet.VPPAppTeam{
@@ -2645,9 +2645,9 @@ func testAndroidAppConfigs(t *testing.T, ds *Datastore) {
 		}
 	}
 
-	require.Equal(t, json.RawMessage(nil), assigned[app1.VPPAppID].Configuration)
-	require.Equal(t, json.RawMessage(`{"managedConfiguration": 1}`), assigned[app2.VPPAppID].Configuration)
-	require.Equal(t, json.RawMessage(`{}`), assigned[app3.VPPAppID].Configuration)
+	require.Equal(t, []byte(nil), assigned[app1.VPPAppID].Configuration)
+	require.Equal(t, []byte(`{"managedConfiguration": 1}`), assigned[app2.VPPAppID].Configuration)
+	require.Equal(t, []byte(`{}`), assigned[app3.VPPAppID].Configuration)
 	require.Equal(t, expectedConfig1, assigned[app4.VPPAppID].Configuration)
 
 	// Delete all

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -1,9 +1,11 @@
 package fleet
 
 import (
-	"encoding/json"
 	"fmt"
+	"regexp"
 	"time"
+
+	"howett.net/plist"
 )
 
 type VPPAppID struct {
@@ -56,12 +58,12 @@ type VPPAppTeam struct {
 	// app creation if AddAutoInstallPolicy is true.
 	AddedAutomaticInstallPolicy *Policy `json:"-"`
 	DisplayName                 *string `json:"display_name"`
-	// Configuration is a json file used to customize Android app
-	// behavior/settings. Applicable to Android apps only.
-	Configuration       json.RawMessage `json:"configuration,omitempty"`
-	AutoUpdateEnabled   *bool           `json:"-"`
-	AutoUpdateStartTime *string         `json:"-"`
-	AutoUpdateEndTime   *string         `json:"-"`
+	// Configuration is the managed app configuration payload. JSON for Android,
+	// plist XML for iOS / iPadOS.
+	Configuration       []byte  `json:"configuration,omitempty"`
+	AutoUpdateEnabled   *bool   `json:"-"`
+	AutoUpdateStartTime *string `json:"-"`
+	AutoUpdateEndTime   *string `json:"-"`
 }
 
 func (v VPPAppTeam) GetPlatform() string {
@@ -129,9 +131,9 @@ type VPPAppStoreApp struct {
 	// "Browsers", etc.
 	Categories  []string `json:"categories"`
 	DisplayName string   `json:"display_name"`
-	// Configuration is a json file used to customize Android app
-	// behavior/settings. Applicable to Android apps only.
-	Configuration json.RawMessage `json:"configuration,omitempty"`
+	// Configuration is the managed app configuration payload. JSON for Android,
+	// plist XML for iOS / iPadOS.
+	Configuration []byte `json:"configuration,omitempty"`
 }
 
 // VPPAppStatusSummary represents aggregated status metrics for a VPP app.
@@ -197,6 +199,76 @@ type AppStoreAppUpdatePayload struct {
 	LabelsIncludeAll []string
 	Categories       []string
 	DisplayName      *string
-	Configuration    json.RawMessage
+	Configuration    []byte
 	SoftwareAutoUpdateConfig
 }
+
+// FleetVarsSupportedInAppleAppConfig is the allow-list of Fleet variables that
+// can appear in an iOS / iPadOS managed app configuration plist. Subset of the
+// variables supported in Apple configuration profiles — credential variables
+// (NDES, SCEP, DigiCert) don't fit the InstallApplication command shape.
+var FleetVarsSupportedInAppleAppConfig = []FleetVarName{
+	FleetVarHostUUID,
+	FleetVarHostHardwareSerial,
+	FleetVarHostPlatform,
+	FleetVarHostEndUserEmailIDP,
+	FleetVarHostEndUserIDPUsername,
+	FleetVarHostEndUserIDPUsernameLocalPart,
+	FleetVarHostEndUserIDPGroups,
+	FleetVarHostEndUserIDPDepartment,
+	FleetVarHostEndUserIDPFullname,
+}
+
+var fleetVarTokenRegexp = regexp.MustCompile(`\$(?:\{)?FLEET_VAR_([A-Z0-9_]+)(?:\})?`)
+
+// ValidateAppleAppConfiguration validates a managed app configuration payload
+// for an iOS or iPadOS InstallApplication command. The payload must be a plist
+// whose root element is a <dict>; string values may contain Fleet variable
+// tokens drawn from FleetVarsSupportedInAppleAppConfig. Empty input is allowed
+// — callers decide whether to store or clear.
+func ValidateAppleAppConfiguration(config []byte) error {
+	if len(config) == 0 {
+		return nil
+	}
+
+	var root map[string]any
+	if _, err := plist.Unmarshal(config, &root); err != nil {
+		return NewInvalidArgumentError("configuration", fmt.Sprintf("invalid plist: %s", err))
+	}
+
+	allowed := make(map[FleetVarName]struct{}, len(FleetVarsSupportedInAppleAppConfig))
+	for _, v := range FleetVarsSupportedInAppleAppConfig {
+		allowed[v] = struct{}{}
+	}
+
+	return walkAppleAppConfigStrings(root, func(s string) error {
+		for _, m := range fleetVarTokenRegexp.FindAllStringSubmatch(s, -1) {
+			name := FleetVarName(m[1])
+			if _, ok := allowed[name]; !ok {
+				return NewInvalidArgumentError("configuration", fmt.Sprintf("unsupported variable $FLEET_VAR_%s", name))
+			}
+		}
+		return nil
+	})
+}
+
+func walkAppleAppConfigStrings(v any, fn func(string) error) error {
+	switch val := v.(type) {
+	case string:
+		return fn(val)
+	case map[string]any:
+		for _, child := range val {
+			if err := walkAppleAppConfigStrings(child, fn); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, child := range val {
+			if err := walkAppleAppConfigStrings(child, fn); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -2,9 +2,10 @@ package fleet
 
 import (
 	"fmt"
-	"regexp"
+	"slices"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"howett.net/plist"
 )
 
@@ -219,13 +220,11 @@ var FleetVarsSupportedInAppleAppConfig = []FleetVarName{
 	FleetVarHostEndUserIDPFullname,
 }
 
-var fleetVarTokenRegexp = regexp.MustCompile(`\$(?:\{)?FLEET_VAR_([A-Z0-9_]+)(?:\})?`)
-
 // ValidateAppleAppConfiguration validates a managed app configuration payload
 // for an iOS or iPadOS InstallApplication command. The payload must be a plist
-// whose root element is a <dict>; string values may contain Fleet variable
-// tokens drawn from FleetVarsSupportedInAppleAppConfig. Empty input is allowed
-// — callers decide whether to store or clear.
+// whose root element is a <dict>, and any Fleet variable tokens in the raw
+// content must be drawn from FleetVarsSupportedInAppleAppConfig. Empty input
+// is allowed — callers decide whether to store or clear.
 func ValidateAppleAppConfiguration(config []byte) error {
 	if len(config) == 0 {
 		return nil
@@ -236,37 +235,9 @@ func ValidateAppleAppConfiguration(config []byte) error {
 		return NewInvalidArgumentError("configuration", fmt.Sprintf("invalid plist: %s", err))
 	}
 
-	allowed := make(map[FleetVarName]struct{}, len(FleetVarsSupportedInAppleAppConfig))
-	for _, v := range FleetVarsSupportedInAppleAppConfig {
-		allowed[v] = struct{}{}
-	}
-
-	return walkAppleAppConfigStrings(root, func(s string) error {
-		for _, m := range fleetVarTokenRegexp.FindAllStringSubmatch(s, -1) {
-			name := FleetVarName(m[1])
-			if _, ok := allowed[name]; !ok {
-				return NewInvalidArgumentError("configuration", fmt.Sprintf("unsupported variable $FLEET_VAR_%s", name))
-			}
-		}
-		return nil
-	})
-}
-
-func walkAppleAppConfigStrings(v any, fn func(string) error) error {
-	switch val := v.(type) {
-	case string:
-		return fn(val)
-	case map[string]any:
-		for _, child := range val {
-			if err := walkAppleAppConfigStrings(child, fn); err != nil {
-				return err
-			}
-		}
-	case []any:
-		for _, child := range val {
-			if err := walkAppleAppConfigStrings(child, fn); err != nil {
-				return err
-			}
+	for _, name := range variables.Find(string(config)) {
+		if !slices.Contains(FleetVarsSupportedInAppleAppConfig, FleetVarName(name)) {
+			return NewInvalidArgumentError("configuration", fmt.Sprintf("unsupported variable $FLEET_VAR_%s", name))
 		}
 	}
 	return nil

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -242,10 +242,14 @@ func ValidateAppleAppConfiguration(config []byte) error {
 		return NewInvalidArgumentError("configuration", "configuration must be an XML plist")
 	}
 
-	// Scan the decoded structure (not the raw bytes) so XML-entity-encoded
-	// tokens like &#x24;FLEET_VAR_NDES_SCEP_CHALLENGE — which the parser
-	// resolves back to a literal $-prefixed string — can't slip past the
-	// allow-list check.
+	// Raw-bytes scan catches structural bypasses (duplicate keys, trailing
+	// siblings) invisible to the decoded tree. The decoded-tree walk below
+	// catches XML-entity-encoded tokens the regex won't match.
+	for _, name := range variables.Find(string(config)) {
+		if !slices.Contains(FleetVarsSupportedInAppleAppConfig, FleetVarName(name)) {
+			return NewInvalidArgumentError("configuration", fmt.Sprintf("unsupported variable $FLEET_VAR_%s", name))
+		}
+	}
 	if name, ok := findUnsupportedFleetVar(root); ok {
 		return NewInvalidArgumentError("configuration", fmt.Sprintf("unsupported variable $FLEET_VAR_%s", name))
 	}

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -221,25 +221,63 @@ var FleetVarsSupportedInAppleAppConfig = []FleetVarName{
 }
 
 // ValidateAppleAppConfiguration validates a managed app configuration payload
-// for an iOS or iPadOS InstallApplication command. The payload must be a plist
-// whose root element is a <dict>, and any Fleet variable tokens in the raw
-// content must be drawn from FleetVarsSupportedInAppleAppConfig. Empty input
-// is allowed — callers decide whether to store or clear.
+// for an iOS or iPadOS InstallApplication command. The payload must be an XML
+// plist whose root element is a <dict>, and any Fleet variable tokens used in
+// string values or keys must be drawn from FleetVarsSupportedInAppleAppConfig.
+// Empty input is allowed — callers decide whether to store or clear.
 func ValidateAppleAppConfiguration(config []byte) error {
 	if len(config) == 0 {
 		return nil
 	}
 
 	var root map[string]any
-	if _, err := plist.Unmarshal(config, &root); err != nil {
+	format, err := plist.Unmarshal(config, &root)
+	if err != nil {
 		return NewInvalidArgumentError("configuration", fmt.Sprintf("invalid plist: %s", err))
 	}
+	// Apple's MDM InstallApplication only accepts XML plist for the
+	// Configuration dict; reject binary, OpenStep and GNUStep formats up front
+	// so admins don't get surprised when devices reject the install.
+	if format != plist.XMLFormat {
+		return NewInvalidArgumentError("configuration", "configuration must be an XML plist")
+	}
 
-	for _, name := range variables.Find(string(config)) {
-		if !slices.Contains(FleetVarsSupportedInAppleAppConfig, FleetVarName(name)) {
-			return NewInvalidArgumentError("configuration", fmt.Sprintf("unsupported variable $FLEET_VAR_%s", name))
-		}
+	// Scan the decoded structure (not the raw bytes) so XML-entity-encoded
+	// tokens like &#x24;FLEET_VAR_NDES_SCEP_CHALLENGE — which the parser
+	// resolves back to a literal $-prefixed string — can't slip past the
+	// allow-list check.
+	if name, ok := findUnsupportedFleetVar(root); ok {
+		return NewInvalidArgumentError("configuration", fmt.Sprintf("unsupported variable $FLEET_VAR_%s", name))
 	}
 	return nil
 }
 
+// findUnsupportedFleetVar walks v's keys and string values and returns the
+// first $FLEET_VAR_* token that is not in FleetVarsSupportedInAppleAppConfig.
+// The second return is false when every referenced variable is allowed.
+func findUnsupportedFleetVar(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		for _, name := range variables.Find(t) {
+			if !slices.Contains(FleetVarsSupportedInAppleAppConfig, FleetVarName(name)) {
+				return name, true
+			}
+		}
+	case map[string]any:
+		for k, val := range t {
+			if name, ok := findUnsupportedFleetVar(k); ok {
+				return name, ok
+			}
+			if name, ok := findUnsupportedFleetVar(val); ok {
+				return name, ok
+			}
+		}
+	case []any:
+		for _, val := range t {
+			if name, ok := findUnsupportedFleetVar(val); ok {
+				return name, ok
+			}
+		}
+	}
+	return "", false
+}

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -60,7 +60,7 @@ type VPPAppTeam struct {
 	AddedAutomaticInstallPolicy *Policy `json:"-"`
 	DisplayName                 *string `json:"display_name"`
 	// Configuration is the managed app configuration payload. JSON for Android,
-	// plist XML for iOS / iPadOS.
+	// XML for iOS / iPadOS.
 	Configuration       []byte  `json:"configuration,omitempty"`
 	AutoUpdateEnabled   *bool   `json:"-"`
 	AutoUpdateStartTime *string `json:"-"`
@@ -133,7 +133,7 @@ type VPPAppStoreApp struct {
 	Categories  []string `json:"categories"`
 	DisplayName string   `json:"display_name"`
 	// Configuration is the managed app configuration payload. JSON for Android,
-	// plist XML for iOS / iPadOS.
+	// XML for iOS / iPadOS.
 	Configuration []byte `json:"configuration,omitempty"`
 }
 

--- a/server/fleet/vpp_test.go
+++ b/server/fleet/vpp_test.go
@@ -76,6 +76,24 @@ func TestValidateAppleAppConfiguration(t *testing.T) {
 			wantErr: true,
 			errSub:  "unsupported variable $FLEET_VAR_BOGUS_NAME",
 		},
+		{
+			name: "all standard plist value types accepted",
+			input: `<dict>
+	<key>S</key><string>val</string>
+	<key>I</key><integer>42</integer>
+	<key>R</key><real>3.14</real>
+	<key>T</key><true/>
+	<key>F</key><false/>
+	<key>D</key><data>YWJj</data>
+	<key>A</key><array><string>x</string><integer>1</integer></array>
+</dict>`,
+		},
+		{
+			name:    "ASCII control character in string value",
+			input:   "<dict><key>K</key><string>x\x01y</string></dict>",
+			wantErr: true,
+			errSub:  "invalid plist",
+		},
 	}
 
 	for _, c := range cases {

--- a/server/fleet/vpp_test.go
+++ b/server/fleet/vpp_test.go
@@ -100,6 +100,48 @@ func TestValidateAppleAppConfiguration(t *testing.T) {
 			wantErr: true,
 			errSub:  "invalid plist",
 		},
+		{
+			name:    "hex-entity-encoded $ does not bypass disallow list",
+			input:   `<dict><key>K</key><string>&#x24;FLEET_VAR_NDES_SCEP_CHALLENGE</string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_NDES_SCEP_CHALLENGE",
+		},
+		{
+			name:    "decimal-entity-encoded $ does not bypass disallow list",
+			input:   `<dict><key>K</key><string>&#36;FLEET_VAR_NDES_SCEP_CHALLENGE</string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_NDES_SCEP_CHALLENGE",
+		},
+		{
+			name:    "disallowed variable inside a CDATA section is caught",
+			input:   `<dict><key>K</key><string><![CDATA[$FLEET_VAR_NDES_SCEP_CHALLENGE]]></string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_NDES_SCEP_CHALLENGE",
+		},
+		{
+			name:    "disallowed variable nested inside an array is caught",
+			input:   `<dict><key>K</key><array><dict><key>Inner</key><string>$FLEET_VAR_BOGUS</string></dict></array></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_BOGUS",
+		},
+		{
+			name:    "disallowed variable used as a key is caught",
+			input:   `<dict><key>$FLEET_VAR_BOGUS</key><string>x</string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_BOGUS",
+		},
+		{
+			name:    "openstep dict format rejected",
+			input:   `{ServerURL = "https://x.com";}`,
+			wantErr: true,
+			errSub:  "must be an XML plist",
+		},
+		{
+			name:    "binary plist rejected",
+			input:   "bplist00\xd1\x01\x02Q1Q2\x08\x0b\r\x00\x00\x00\x00\x00\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0f",
+			wantErr: true,
+			errSub:  "must be an XML plist",
+		},
 	}
 
 	for _, c := range cases {

--- a/server/fleet/vpp_test.go
+++ b/server/fleet/vpp_test.go
@@ -1,0 +1,94 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAppleAppConfiguration(t *testing.T) {
+	const fragment = `<dict>
+	<key>ServerURL</key>
+	<string>https://example.com</string>
+	<key>EnableTelemetry</key>
+	<true/>
+</dict>`
+
+	const fullDoc = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ServerURL</key>
+	<string>https://example.com</string>
+</dict>
+</plist>`
+
+	const nested = `<dict>
+	<key>Outer</key>
+	<dict>
+		<key>Inner</key>
+		<string>value</string>
+	</dict>
+	<key>List</key>
+	<array>
+		<dict>
+			<key>K</key>
+			<string>v</string>
+		</dict>
+	</array>
+</dict>`
+
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errSub  string
+	}{
+		{name: "empty", input: ""},
+		{name: "bare dict fragment", input: fragment},
+		{name: "full plist document", input: fullDoc},
+		{name: "nested dict and array of dicts", input: nested},
+		{name: "garbage non-XML", input: "not a plist", wantErr: true, errSub: "invalid plist"},
+		{name: "malformed XML unclosed tag", input: "<dict><key>foo</key><string>bar", wantErr: true, errSub: "invalid plist"},
+		{name: "root is array", input: `<array><string>x</string></array>`, wantErr: true, errSub: "invalid plist"},
+		{name: "root is string", input: `<string>oops</string>`, wantErr: true, errSub: "invalid plist"},
+		{
+			name:  "allowed variable",
+			input: `<dict><key>HostID</key><string>$FLEET_VAR_HOST_UUID</string></dict>`,
+		},
+		{
+			name:  "allowed variable with braces",
+			input: `<dict><key>HostID</key><string>${FLEET_VAR_HOST_UUID}</string></dict>`,
+		},
+		{
+			name:  "multiple allowed variables in one string",
+			input: `<dict><key>K</key><string>https://x/$FLEET_VAR_HOST_UUID/$FLEET_VAR_HOST_HARDWARE_SERIAL</string></dict>`,
+		},
+		{
+			name:    "credential variable not allowed in app config",
+			input:   `<dict><key>K</key><string>$FLEET_VAR_NDES_SCEP_CHALLENGE</string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_NDES_SCEP_CHALLENGE",
+		},
+		{
+			name:    "unknown variable name",
+			input:   `<dict><key>K</key><string>$FLEET_VAR_BOGUS_NAME</string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_BOGUS_NAME",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateAppleAppConfiguration([]byte(c.input))
+			if c.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.errSub)
+				var iae *InvalidArgumentError
+				require.ErrorAs(t, err, &iae)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/server/fleet/vpp_test.go
+++ b/server/fleet/vpp_test.go
@@ -94,6 +94,12 @@ func TestValidateAppleAppConfiguration(t *testing.T) {
 			wantErr: true,
 			errSub:  "invalid plist",
 		},
+		{
+			name:    "json null token",
+			input:   "null",
+			wantErr: true,
+			errSub:  "invalid plist",
+		},
 	}
 
 	for _, c := range cases {

--- a/server/fleet/vpp_test.go
+++ b/server/fleet/vpp_test.go
@@ -131,6 +131,18 @@ func TestValidateAppleAppConfiguration(t *testing.T) {
 			errSub:  "unsupported variable $FLEET_VAR_BOGUS",
 		},
 		{
+			name:    "duplicate key bypass: disallowed var hidden by last-wins map semantics",
+			input:   `<dict><key>K</key><string>$FLEET_VAR_NDES_SCEP_CHALLENGE</string><key>K</key><string>safe_value</string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_NDES_SCEP_CHALLENGE",
+		},
+		{
+			name:    "trailing sibling bypass: disallowed var in element dropped by parser",
+			input:   `<dict><key>K</key><string>safe</string></dict><dict><key>X</key><string>$FLEET_VAR_NDES_SCEP_CHALLENGE</string></dict>`,
+			wantErr: true,
+			errSub:  "unsupported variable $FLEET_VAR_NDES_SCEP_CHALLENGE",
+		},
+		{
 			name:    "openstep dict format rejected",
 			input:   `{ServerURL = "https://x.com";}`,
 			wantErr: true,

--- a/server/service/integration_android_software_test.go
+++ b/server/service/integration_android_software_test.go
@@ -771,7 +771,7 @@ func (s *integrationMDMTestSuite) TestBatchAndroidApps() {
 			TeamID: teamID,
 		}, http.StatusOK, &titleResp)
 		require.Equal(t, "app_1", *titleResp.SoftwareTitle.ApplicationID)
-		require.Equal(t, json.RawMessage(`{}`), titleResp.SoftwareTitle.AppStoreApp.Configuration)
+		require.Equal(t, []byte(`{}`), titleResp.SoftwareTitle.AppStoreApp.Configuration)
 
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleApp2), &getSoftwareTitleRequest{
 			ID:     titleApp2,
@@ -800,7 +800,7 @@ func (s *integrationMDMTestSuite) TestBatchAndroidApps() {
 			TeamID: teamID,
 		}, http.StatusOK, &titleResp)
 		require.Equal(t, "app_1", *titleResp.SoftwareTitle.ApplicationID)
-		require.Equal(t, json.RawMessage(`{}`), titleResp.SoftwareTitle.AppStoreApp.Configuration)
+		require.Equal(t, []byte(`{}`), titleResp.SoftwareTitle.AppStoreApp.Configuration)
 
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleApp2), &getSoftwareTitleRequest{
 			ID:     titleApp2,


### PR DESCRIPTION
Part of #38790 (iOS / iPadOS managed app configuration).

Closes #43963.

Adds `ValidateAppleAppConfiguration` and the `FleetVarsSupportedInAppleAppConfig` allow-list in `server/fleet/vpp.go`. Walks the decoded plist (keys + string values) so XML-entity-encoded `$FLEET_VAR_*` tokens can't slip past the disallow check, and rejects non-XML plist formats (binary, OpenStep, GNUStep) since Apple's `InstallApplication` only accepts XML.

Stacked PRs (review bottom up):
- #43963 validator (this PR)
- 43964 datastore
- 43965 service wiring
- 43969 gitops
- 43966 InstallApplication Configuration dict injection
- 43967 Fleet variable expansion
- 43968 send-paths audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for Apple managed app configurations to allow only supported Fleet variable placeholders, reject malformed plist formats, and accept empty payloads.

* **Bug Fixes**
  * Improved handling of app configuration payloads to ensure consistent validation and error responses across Android and iOS flows.

* **Tests**
  * Added comprehensive tests covering plist validation, allowed/disallowed variables, and edge cases to increase reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/44930)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->