### PR TITLE
Ignore critical CVE in fleetdm/fleetctl docker image

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -292,6 +292,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-08 12:06:46
 
+### [CVE-2026-33845](https://nvd.nist.gov/vuln/detail/CVE-2026-33845)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/fleetctl functionality does not make use of gnutls.
+- **Products:** `fleetctl`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-05-07 12:01:42
+
 ### [CVE-2026-33810](https://nvd.nist.gov/vuln/detail/CVE-2026-33810)
 - **Author:** @lucasmrod
 - **Status:** `affected`

--- a/security/vex/fleetctl/CVE-2026-33845.vex.json
+++ b/security/vex/fleetctl/CVE-2026-33845.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-34c3fbffb8fb4d12ae1572ab80e792852d8cede22032ba9d77a0fa841129683f",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-07T12:01:42.509509-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33845"
+      },
+      "timestamp": "2026-05-07T12:01:42.509509-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/fleetctl functionality does not make use of gnutls.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/25480975109/job/74764798920

New run: https://github.com/fleetdm/fleet/actions/runs/25504007303.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessment documentation confirming fleetctl is not affected by CVE-2026-33845.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->