### PR TITLE
Change runner from ubuntu-latest to ubuntu-16core

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16core
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
We're hitting our max of 60 concurrent GitHub runners on the default size. I'm added a new large runner that is pay-as-you-go. These have their own max concurrent runners, so it's a way for us to increase our overall max as well as speed up runs that take a long time and run frequently. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD analysis infrastructure configuration for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->