### PR TITLE
Website: update default consent mode set in website header

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -50,10 +50,8 @@
           wait_for_update: 2000,
       });
       gtag("set", "ads_data_redaction", true);
-      gtag("set", "url_passthrough", true);
     </script>
 
-    <% /* GTM */ %>
     <% /* Global site tag (gtag.js) - Google Analytics */%>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-JC3DRNY1GV"></script>
     <script>


### PR DESCRIPTION
Changes:
- Disabled url_passthrough in the default consent mode set for GA4, and removed a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google Analytics consent initialization configuration with adjusted timing parameters for consent updates and modified tracking parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->