### PR TITLE
Fix policy detail page for team users

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -111,6 +111,7 @@ const generateTableHeaders = (
       accessor: "name",
       Cell: (cellProps: ICellProps): JSX.Element => {
         const { critical, id, team_id, type } = cellProps.row.original;
+        const isInherited = team_id === null;
         return (
           <LinkCell
             className="w250"
@@ -124,7 +125,7 @@ const generateTableHeaders = (
                     Patch
                   </PillBadge>
                 )}
-                {viewingTeamPolicies && team_id === null && (
+                {viewingTeamPolicies && isInherited && (
                   <PillBadge tipContent="This policy runs on all hosts.">
                     Inherited
                   </PillBadge>
@@ -132,7 +133,10 @@ const generateTableHeaders = (
               </>
             }
             path={getPathWithQueryParams(PATHS.POLICY_DETAILS(id), {
-              fleet_id: team_id,
+              // For inherited policies preserve the current fleet for back-nav,
+              // and flag the link so the details page uses the global endpoint.
+              fleet_id: isInherited ? selectedTeamId : team_id,
+              inherited_policy: isInherited ? "true" : undefined,
             })}
           />
         );

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -118,7 +118,7 @@ const PolicyDetailsPage = ({
   >(
     ["policy", policyId, teamIdForApi, isInheritedPolicyLink],
     () =>
-      !isInheritedPolicyLink && teamIdForApi && teamIdForApi > 0
+      !isInheritedPolicyLink && teamIdForApi !== undefined
         ? teamPoliciesAPI.load(teamIdForApi, policyId as number)
         : globalPoliciesAPI.load(policyId as number),
     {

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -36,7 +36,7 @@ interface IPolicyDetailsPageProps {
   location: {
     pathname: string;
     search: string;
-    query: { fleet_id?: string };
+    query: { fleet_id?: string; inherited_policy?: string };
   };
 }
 
@@ -105,14 +105,20 @@ const PolicyDetailsPage = ({
     router.push(PATHS.MANAGE_POLICIES);
   }
 
+  // Inherited (global) policies clicked from a team's policy list pass this
+  // hint so we fetch from the global endpoint even though the URL carries a
+  // fleet_id (team users can't render a teamless URL — useTeamIdParam
+  // redirects them to their default team).
+  const isInheritedPolicyLink = location.query.inherited_policy === "true";
+
   const { isLoading, data: storedPolicy, error: apiError } = useQuery<
     IStoredPolicyResponse,
     Error,
     IPolicy
   >(
-    ["policy", policyId, teamIdForApi],
+    ["policy", policyId, teamIdForApi, isInheritedPolicyLink],
     () =>
-      teamIdForApi && teamIdForApi > 0
+      !isInheritedPolicyLink && teamIdForApi && teamIdForApi > 0
         ? teamPoliciesAPI.load(teamIdForApi, policyId as number)
         : globalPoliciesAPI.load(policyId as number),
     {

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -391,11 +391,15 @@ const PolicyDetailsPage = ({
               />
             )}
             {renderAuthor()}
-            {currentTeam && (
+            {storedPolicy && (
               <DataSet
                 className={`${baseClass}__fleet`}
                 title="Fleet"
-                value={currentTeam.name}
+                value={
+                  storedPolicy.team_id === null
+                    ? "All fleets"
+                    : currentTeam?.name
+                }
               />
             )}
             {renderPlatforms()}


### PR DESCRIPTION
Resolves #44949.

Unreleased, so no changes file.

## Testing

- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly detect and mark inherited (global) policies in the policies table.
  * Ensure policy detail links for inherited policies load global policy data and include an inherited flag.
  * Display fleet information consistently: inherited/global policies show as "All fleets", while team policies show the team name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->