### PR TITLE
Disable auto-updates for new macOS hosts

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -128,7 +128,7 @@ controls:
   macos_updates:
     deadline:
     minimum_version:
-    update_new_hosts: true
+    update_new_hosts: false
   windows_settings:
     configuration_profiles:
       - path: ../lib/windows/configuration-profiles/Enable firewall.xml


### PR DESCRIPTION
Set macos_updates.update_new_hosts to false in the workstations fleet config to prevent automatic updates from being applied to newly enrolled macOS hosts. This change enables controlled rollout and testing of updates before enabling automatic updates for new machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified macOS workstation update configuration to disable automatic updates for newly provisioned hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->