### PR TITLE
Fix relative spread + calendar dates on checkerboard

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -150,7 +150,9 @@ const ChartCard = ({
 
   const queryParams: IChartRequestParams = useMemo(() => {
     return {
-      days: CHART_DAYS,
+      // Add an extra data to ensure we get the full # of calendar days
+      // represented in the chart, regardless of timezone.
+      days: CHART_DAYS + 1,
       tz_offset: new Date().getTimezoneOffset(),
       fleet_id: currentTeamId,
       label_ids: chartFilters.labelIDs.length

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -150,7 +150,7 @@ const ChartCard = ({
 
   const queryParams: IChartRequestParams = useMemo(() => {
     return {
-      // Add an extra data to ensure we get the full # of calendar days
+      // Add an extra day to ensure we get the full # of calendar days
       // represented in the chart, regardless of timezone.
       days: CHART_DAYS + 1,
       tz_offset: new Date().getTimezoneOffset(),

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
@@ -251,6 +251,96 @@ describe("CheckerboardViz", () => {
     }
   });
 
+  it("ignores 0% data points when computing the relative scale's min", async () => {
+    // 0% represents a "no data" cell that should always render at level-0
+    // and must not pull the ramp's lower bound down. With the non-zero
+    // values clustered at 80–100, including 0 in the min would stretch
+    // the range to [0, 100] and collapse 80–100 into the top two levels.
+    // Excluding 0 narrows the range to [80, 100] so the values span all
+    // five non-zero levels.
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 0,
+        percentage: 0,
+      },
+      {
+        timestamp: "2026-03-01T02:00:00",
+        label: "Mar 1, 2am",
+        value: 80,
+        percentage: 80,
+      },
+      {
+        timestamp: "2026-03-01T04:00:00",
+        label: "Mar 1, 4am",
+        value: 85,
+        percentage: 85,
+      },
+      {
+        timestamp: "2026-03-01T06:00:00",
+        label: "Mar 1, 6am",
+        value: 90,
+        percentage: 90,
+      },
+      {
+        timestamp: "2026-03-01T08:00:00",
+        label: "Mar 1, 8am",
+        value: 95,
+        percentage: 95,
+      },
+      {
+        timestamp: "2026-03-01T10:00:00",
+        label: "Mar 1, 10am",
+        value: 100,
+        percentage: 100,
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={points} selectedDays={1} relativeScale />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    const classNames = Array.from(container.querySelectorAll("rect")).map(
+      (r) => r.getAttribute("class") || ""
+    );
+    // 0% still renders at level-0.
+    expect(classNames.some((c) => c.includes("--level-0"))).toBe(true);
+    // The 80–100 cluster spans all five non-zero levels because 0% is
+    // excluded from the min.
+    for (let level = 1; level <= 5; level += 1) {
+      expect(classNames.some((c) => c.includes(`--level-${level}`))).toBe(true);
+    }
+  });
+
+  it("trims leading days when given more days than selectedDays", async () => {
+    // Caller requests `selectedDays + 1` days of data so the trailing
+    // `selectedDays` calendar days are full even for users west of UTC.
+    // The grid should still render exactly `selectedDays` columns.
+    const data = generateData(31);
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={data} selectedDays={30} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    // 30-day view → hoursPerSlot=3 → 8 hour rows per day.
+    // 30 days × 8 rows = 240 cells (not 31 × 8 = 248).
+    const rects = container.querySelectorAll("rect");
+    expect(rects).toHaveLength(240);
+
+    // The first day in the input (Mar 1) should have been trimmed; the
+    // earliest visible day should be Mar 2.
+    expect(screen.getByText("Mar 2")).toBeInTheDocument();
+    expect(screen.queryByText("Mar 1")).not.toBeInTheDocument();
+  });
+
   it("renders the legend with all color levels", () => {
     const data = generateData(1);
     renderWithSetup(<CheckerboardViz data={data} selectedDays={30} />);

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -75,8 +75,12 @@ const CheckerboardViz = ({
     // When relativeScale is true, the color ramp is based on the min/max in
     // this dataset, not fixed percentage thresholds. This surfaces more
     // variation when values are generally low or generally high.
-    const minPerc = Math.min(...data.map((d) => d.percentage));
-    const maxPerc = Math.max(...data.map((d) => d.percentage));
+    // Exclude 0% points from the min/max calculation — they represent
+    // "no data" cells (level-0) and would otherwise compress the ramp
+    // toward zero whenever the grid contains empty slots.
+    const nonZeroPercs = data.map((d) => d.percentage).filter((p) => p > 0);
+    const minPerc = nonZeroPercs.length ? Math.min(...nonZeroPercs) : 0;
+    const maxPerc = nonZeroPercs.length ? Math.max(...nonZeroPercs) : 0;
     const range = maxPerc - minPerc || 1; // avoid divide-by-zero
 
     getColorLevel = (percentage: number): number => {
@@ -164,13 +168,21 @@ const CheckerboardViz = ({
       }
     });
 
+    // The API window is anchored to "now" in UTC, so for users west of UTC
+    // the earliest local calendar day in the response is partially populated
+    // (the leading hours fall before the window starts). The caller works
+    // around this by requesting `selectedDays + 1` so the trailing
+    // `selectedDays` local days are always full. Trim the leading partial
+    // day(s) here so the grid only renders the requested window.
+    const visibleDays = dayOrder.slice(-selectedDays);
+
     // Emit one cell per (day, slot) pair in a fixed grid. Days with no data
     // for a given slot still get a cell with percentage 0 so the grid stays
     // rectangular and the color ramp renders the "no data" swatch.
     const labels: string[] = [];
     const cells: ICellData[] = [];
 
-    dayOrder.forEach((dayKey, dayIndex) => {
+    visibleDays.forEach((dayKey, dayIndex) => {
       const date = parseISO(dayKey);
       labels.push(format(date, "MMM d"));
       const hourMap = dayMap.get(dayKey);
@@ -191,7 +203,7 @@ const CheckerboardViz = ({
     });
 
     return { grid: cells, dayLabels: labels };
-  }, [data, hoursPerSlot, hourRows, is24h]);
+  }, [data, hoursPerSlot, hourRows, is24h, selectedDays]);
 
   const numDays = dayLabels.length || 1;
 

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -96,6 +96,12 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("unknown chart metric: %s", metric)}
 	}
 
+	// Don't allow requesting more days than the charts are designed to handle.
+	// This mostly prevents expensive queries for large day ranges.
+	if opts.Days < 1 || opts.Days > 31 {
+		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("invalid days value: %d (must be between 1 and 31)", opts.Days)}
+	}
+
 	// Resolution must be 0 or a positive divisor of 24.
 	if opts.Resolution < 0 || (opts.Resolution != 0 && 24%opts.Resolution != 0) {
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("invalid resolution value: %d (must be 0 or a positive divisor of 24)", opts.Resolution)}

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -96,12 +96,6 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("unknown chart metric: %s", metric)}
 	}
 
-	// Validate days preset.
-	validDays := map[int]struct{}{1: {}, 7: {}, 14: {}, 30: {}}
-	if _, ok := validDays[opts.Days]; !ok {
-		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("invalid days value: %d (must be 1, 7, 14, or 30)", opts.Days)}
-	}
-
 	// Resolution must be 0 or a positive divisor of 24.
 	if opts.Resolution < 0 || (opts.Resolution != 0 && 24%opts.Resolution != 0) {
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("invalid resolution value: %d (must be 0 or a positive divisor of 24)", opts.Resolution)}

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -145,16 +145,6 @@ func TestGetChartDataUnknownMetric(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown chart metric")
 }
 
-func TestGetChartDataInvalidDays(t *testing.T) {
-	ds := &mockDatastore{}
-	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
-	svc.RegisterDataset(&chart.UptimeDataset{})
-
-	_, err := svc.GetChartData(t.Context(), "uptime", api.RequestOpts{Days: 5})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid days value")
-}
-
 func TestGetChartDataInvalidResolution(t *testing.T) {
 	ds := &mockDatastore{}
 	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -145,6 +145,24 @@ func TestGetChartDataUnknownMetric(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown chart metric")
 }
 
+func TestGetChartDataInvalidDays(t *testing.T) {
+	ds := &mockDatastore{}
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.UptimeDataset{})
+
+	_, err := svc.GetChartData(t.Context(), "uptime", api.RequestOpts{Days: 32})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid days value")
+
+	_, err = svc.GetChartData(t.Context(), "uptime", api.RequestOpts{Days: 0})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid days value")
+
+	_, err = svc.GetChartData(t.Context(), "uptime", api.RequestOpts{Days: -1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid days value")
+}
+
 func TestGetChartDataInvalidResolution(t *testing.T) {
 	ds := &mockDatastore{}
 	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44958

# Details

Fixes two issues on the checkerboard:

1. Ensures that the chart shows data going back 30 calendar days (not 720 hours) if it has it
2. Leaves `0` values out of the chart color band calculations in "relative" color mode

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

**Before**

Colors clustered in top 3 levels, empty boxes in first column:
<img width="705" height="416" alt="image" src="https://github.com/user-attachments/assets/b867a1a9-4c52-4b96-92fd-04e7848c6295" />

**After**

Colors spread over all levels, no empty boxes in first column:
<img width="707" height="412" alt="image" src="https://github.com/user-attachments/assets/c67e11c5-6dd8-4e66-9c32-9d9213ccb24f" />

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Charts request an extra day to ensure full calendar-day coverage across timezones.
  * Checkerboard visualization excludes empty/no-data slots from relative color scaling so color ramps reflect non-zero data.
  * Calendar view trims leading partial days so the displayed window matches the selected range.

* **New Features**
  * Chart date-range selection expanded to support any value from 1–31 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->