### PR TITLE
Update fleet-desktop checksums

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
@@ -1,6 +1,6 @@
 cask "fleet-desktop" do
   version "1.2.0"
-  sha256 "4e7352b5faac94f8176a8291d170663f220fd4268ee33dd67b2723f7fe721a09"
+  sha256 "d58a07e71d350b6c7fc39319080c28ad56d298f41ef45c67e0114940dce41420"
 
   url "https://github.com/allenhouchins/fleet-desktop/releases/download/v#{version}/fleet_desktop-v#{version}.pkg"
   name "Fleet Desktop"

--- a/ee/maintained-apps/inputs/homebrew/custom-tap/api/fleet-desktop.json
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/api/fleet-desktop.json
@@ -14,7 +14,7 @@
   "skip_livecheck": false,
   "bundle_version": null,
   "bundle_short_version": null,
-  "sha256": "4e7352b5faac94f8176a8291d170663f220fd4268ee33dd67b2723f7fe721a09",
+  "sha256": "d58a07e71d350b6c7fc39319080c28ad56d298f41ef45c67e0114940dce41420",
   "artifacts": [
     {
       "uninstall": [
@@ -72,6 +72,6 @@
   "languages": [],
   "ruby_source_path": "Casks/fleet-desktop.rb",
   "ruby_source_checksum": {
-    "sha256": "54320e7f3daaf9ad437b1abdc8978730453c227b2436b4f961ec011e61b39f16"
+    "sha256": "22014d0a5d40491927793478b16940b9c38306b8a7c44058e0b356bb17a35493"
   }
 }

--- a/ee/maintained-apps/outputs/fleet-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/fleet-desktop/darwin.json
@@ -9,7 +9,7 @@
       "installer_url": "https://github.com/allenhouchins/fleet-desktop/releases/download/v1.2.0/fleet_desktop-v1.2.0.pkg",
       "install_script_ref": "b6404dfa",
       "uninstall_script_ref": "e179ad0c",
-      "sha256": "4e7352b5faac94f8176a8291d170663f220fd4268ee33dd67b2723f7fe721a09",
+      "sha256": "d58a07e71d350b6c7fc39319080c28ad56d298f41ef45c67e0114940dce41420",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Update SHA256 checksums for fleet-desktop (v1.2.0) across Homebrew cask, API metadata, and darwin output. Adjusts the cask sha256, API sha256 and ruby_source_checksum to match the rebuilt package artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package verification checksums for Fleet Desktop v1.2.0 to ensure proper installation integrity and validation across supported distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->