### PR TITLE
fix LP long title and chapter numbering (en and fr versions)

### DIFF
--- a/articles/IT-leaders-guide-to-Linux-device-management-fr.md
+++ b/articles/IT-leaders-guide-to-Linux-device-management-fr.md
@@ -1,4 +1,4 @@
-### L’adoption de Linux progresse. La gestion structurée n’a pas suivi.
+### Linux grandit. La gestion, non.
 
 * macOS et Windows disposent d’écosystèmes MDM matures. Linux n’a pas d’équivalent.
 * La plupart des équipes gèrent leurs postes Linux avec des scripts, Ansible ou Puppet. Cela couvre le déploiement, mais laisse des lacunes en matière de conformité et de visibilité en temps réel.
@@ -15,23 +15,23 @@ Vous découvrirez un modèle de maturité pour planifier votre démarche d’ado
 
 ### Liste des chapitres
 
-- **Pourquoi les appareils Linux sont importants**
+1. **Pourquoi les appareils Linux sont importants**
     * Ce qui stimule l’adoption de Linux en entreprise et pourquoi la gestion n’est plus facultative.
-- **L’analyse de rentabilité de la gestion des appareils Linux**
+2. **L’analyse de rentabilité de la gestion des appareils Linux**
     * Coûts, conformité, rétention des talents et le prix de l’inaction.
-- **Définir vos besoins en gestion des appareils Linux**
+3. **Définir vos besoins en gestion des appareils Linux**
     * Les questions clés à poser et un modèle de maturité pour préparer vos objectifs.
-- **Provisionnement automatisé des postes Linux en entreprise**
+4. **Provisionnement automatisé des postes Linux en entreprise**
     * Le fossé du provisionnement, les approches d’enrôlement et ce à quoi ressemble le zero-touch sous Linux.
-- **Référentiels de sécurité pour Linux**
+5. **Référentiels de sécurité pour Linux**
     * Pourquoi les référentiels sont essentiels, ce qu’il faut appliquer et comment lutter contre la dérive de configuration.
-- **Gestion des applications et des certificats pour Linux**
+6. **Gestion des applications et des certificats pour Linux**
     * Les défis de la distribution logicielle, le fossé de la notarisation, la rapidité des correctifs et la réduction des durées de vie des certificats.
-- **Protéger les appareils Linux**
+7. **Protéger les appareils Linux**
     * Les menaces USB et Bluetooth, le problème du sudo, et le verrouillage et l’effacement à distance.
-- **Garder le contrôle de vos logiciels et de vos données**
+8. **Garder le contrôle de vos logiciels et de vos données**
     * Souveraineté logicielle, souveraineté des données, et pourquoi vos outils de gestion devraient refléter les valeurs qui ont fait le succès de Linux.
-- **Choisir la bonne solution**
+9. **Choisir la bonne solution**
     * Exigences métier et techniques, un tableau de critères d’évaluation et une méthode structurée pour comparer les plateformes.
 
 <meta name="articleTitle" value="Le guide du responsable IT pour la gestion des appareils Linux"> 

--- a/articles/IT-leaders-guide-to-Linux-device-management.md
+++ b/articles/IT-leaders-guide-to-Linux-device-management.md
@@ -1,4 +1,4 @@
-### Linux adoption is growing. Management hasn't kept up.
+### Linux is growing. Management isn't.
 
 * macOS and Windows have mature management ecosystems. Linux does not.
 * Compliance frameworks don't grant exemptions by operating system.
@@ -15,23 +15,23 @@ You'll learn about a maturity model for planning your adoption path, a clear fra
 
 ### Chapter list
 
-- **Why Linux devices are important**
+1. **Why Linux devices are important**
     * What's driving enterprise Linux adoption and why management is no longer optional.
-- **The business case for managing Linux devices**
+2. **The business case for managing Linux devices**
     * Cost, compliance, talent retention, and the price of inaction.
-- **Defining your Linux device management needs**
+3. **Defining your Linux device management needs**
     * Key questions to ask and a maturity model to map your goals.
-- **Automated provisioning for Linux desktop in the enterprise**
+4. **Automated provisioning for Linux desktop in the enterprise**
     * The provisioning gap, enrollment approaches, and what zero-touch looks like on Linux.
-- **Security baselines for Linux**
+5. **Security baselines for Linux**
     * Why baselines matter, what to enforce, and how to fight configuration drift.
-- **App and certificate management for Linux**
+6. **App and certificate management for Linux**
     * Software distribution challenges, the notarization gap, patching speed, and shrinking certificate lifetimes.
-- **Protecting the Linux device**
+7. **Protecting the Linux device**
     * USB and Bluetooth threats, the sudo problem, and remote lock and wipe.
-- **Controlling your software and your data**
+8. **Controlling your software and your data**
     * Software sovereignty, data sovereignty, and why your management tooling should reflect the values that made Linux worth adopting.
-- **Choosing the right solution**
+9. **Choosing the right solution**
     * Business and technical requirements, an evaluation criteria table, and a structured way to compare platforms.
 
 


### PR DESCRIPTION
Fixed an overly long first title on the en and fr version of landing page which made the page look sloppy. Made the language tighter. Also updated the filenames to all lowercase to match the slugs to align with standards, and make it easier to find the files when editing.