### PR TITLE
Remove "VPP" from "Installed App Store app" activity

### DIFF
--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -429,7 +429,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
   enabled_windows_mdm: "Turned on Windows MDM",
   enabled_windows_mdm_migration: "Turned on Windows MDM migration",
   fleet_enrolled: "Host enrolled",
-  installed_app_store_app: "Installed App Store (VPP) app",
+  installed_app_store_app: "Installed App Store app",
   installed_software: "Install software",
   live_query: "Ran live report",
   locked_host: "Locked host",


### PR DESCRIPTION
We now support both iOS and Android for this: [`docs/Contributing/reference/audit-logs.md#L1747`](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/audit-logs.md?plain=1#L1747).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the activity filter label text for installed app store apps by removing unnecessary notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->