### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "147.0.3912.98",
+      "version": "148.0.3967.54",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '147.0.3912.98') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '148.0.3967.54') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/3c7e1edd-f94e-4d94-8a36-e1d06fef510c/MicrosoftEdge-147.0.3912.98.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/cdfa4ae5-32af-4de8-911f-737254ab5e1a/MicrosoftEdge-148.0.3967.54.dmg",
       "install_script_ref": "caf6f785",
       "uninstall_script_ref": "81159c4c",
-      "sha256": "885170fa7a5afb7c966a18be3759455bb5fe745b83d8747b7e80e54e598a461f",
+      "sha256": "4b58dad6f2904d4dcc0a24acafd95d8085378d60f30ed77dcebce19de06f82e8",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Microsoft Edge macOS managed app payload to version 148.0.3967.54 with updated installer and verification checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->