### PR TITLE
Fix batch of unreleased dark-mode and UI bugs

### DIFF
--- a/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tsx
+++ b/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tsx
@@ -44,7 +44,7 @@ export const HumanTimeDiffWithDateTip = ({
           type="dark"
           effect="solid"
           id={`tooltip-${id}`}
-          backgroundColor="#3e4771"
+          backgroundColor="var(--tooltip-bg)"
         >
           {internationalTimeFormat(new Date(timeString))}
         </ReactTooltip>

--- a/frontend/components/SidePanelPage/_styles.scss
+++ b/frontend/components/SidePanelPage/_styles.scss
@@ -17,13 +17,16 @@ $main-max-width-including-padding: 1280px + 32px + 32px; // Cannot use variables
   position: relative;
   width: 100%;
 
-  // Fixed side panel: always flush right, always 340px wide
+  // Fixed side panel: always flush right, always 340px wide. min-height
+  // (not height) so the panel background extends past the parent when the
+  // panel's own content (e.g. schema docs on Report/Label/Policy pages) is
+  // taller than main-content.
   .side-panel-content {
     position: absolute;
     top: 0;
     right: 0;
     width: $side-panel-width;
-    height: 100%;
+    min-height: 100%;
     z-index: 2;
   }
 

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -17,9 +17,11 @@
   // No background color as TabNav is often over a background gradient
 
   // react-tabs ships a default `:focus::after` that paints a 5px #fff bar
-  // below the focused tab; suppress it so we control the focus indicator.
+  // below the focused tab. Hide its visuals (not `content`) so our own
+  // ::after rules for selected/hover/focus-visible still paint.
   .react-tabs__tab:focus::after {
-    content: none;
+    height: 0;
+    background: transparent;
   }
 
   .react-tabs {

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -128,15 +128,6 @@
           }
         }
 
-        &:focus-visible {
-          outline: none; // Undo primary tabbing through app styling as it runs into edges
-
-          .tab-text {
-            outline: 1px solid $core-focused-outline;
-            outline-offset: 1px;
-          }
-        }
-
         &--selected {
           background-color: transparent;
 
@@ -157,6 +148,20 @@
             width: 100%;
             height: 0;
             border-bottom: 2px solid $nav-active-underline;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+          }
+        }
+
+        &:focus-visible {
+          outline: none; // Undo primary tabbing through app styling as it runs into edges
+
+          &::after {
+            content: "";
+            width: 100%;
+            height: 0;
+            border-bottom: 3px solid $core-focused-outline;
             position: absolute;
             bottom: 0;
             left: 0;

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -131,10 +131,13 @@
         &:focus-visible {
           outline: none; // Undo primary tabbing through app styling as it runs into edges
 
+          // Outline drawn snug to the text. A larger offset combined with the
+          // rounded corners produced a visible gap between the indicator and
+          // the active-tab underline that read as a stray light artifact in
+          // dark mode (#44905).
           .tab-text {
             outline: 1px solid $core-focused-outline;
-            outline-offset: 3px;
-            border-radius: $border-radius;
+            outline-offset: 1px;
           }
         }
 

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -4,6 +4,7 @@
 // ManageControlsPage omits the key here and uses __fade (keyed by tab index)
 // so only top-level tab switches animate, not sub-route navigation.
 .tab-nav-routed-content {
+  margin-top: $gap-page-component; // Mirror .react-tabs__tab-panel--selected
   animation: fade-in 250ms ease-out;
 
   &__fade {

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -15,6 +15,12 @@
   top: 0;
   // No background color as TabNav is often over a background gradient
 
+  // react-tabs ships a default `:focus::after` that paints a 5px #fff bar
+  // below the focused tab; suppress it so we control the focus indicator.
+  .react-tabs__tab:focus::after {
+    content: none;
+  }
+
   .react-tabs {
     // Remove 12px top margin react-tab adds causing buggy 12px gap in all uses
     // TODO: Find upstream fix
@@ -118,14 +124,6 @@
 
         &:hover {
           background-color: transparent;
-        }
-
-        // Aligns underline correctly when focused
-        &:focus {
-          &:after {
-            left: 0;
-            bottom: 0;
-          }
         }
 
         &--selected {

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -131,10 +131,6 @@
         &:focus-visible {
           outline: none; // Undo primary tabbing through app styling as it runs into edges
 
-          // Outline drawn snug to the text. A larger offset combined with the
-          // rounded corners produced a visible gap between the indicator and
-          // the active-tab underline that read as a stray light artifact in
-          // dark mode (#44905).
           .tab-text {
             outline: 1px solid $core-focused-outline;
             outline-offset: 1px;

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -17,11 +17,16 @@
   // No background color as TabNav is often over a background gradient
 
   // react-tabs ships a default `:focus::after` that paints a 5px #fff bar
-  // below the focused tab. Hide its visuals (not `content`) so our own
-  // ::after rules for selected/hover/focus-visible still paint.
+  // below the focused tab and is imported twice in our bundle, so its
+  // positioning (left/right/bottom) re-asserts itself after our state rules.
+  // Hide the visuals AND normalize the position so --selected / :hover /
+  // :focus-visible underlines stay where we put them.
   .react-tabs__tab:focus::after {
     height: 0;
     background: transparent;
+    left: 0;
+    right: auto;
+    bottom: 0;
   }
 
   .react-tabs {

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -279,7 +279,7 @@ $shadow-transition-width: 16px;
           cursor: pointer;
         }
         &:active {
-          background-color: $ui-vibrant-blue-10-opaque; // opaque needed for horizontal scroll shadow
+          background-color: $ui-vibrant-blue-10; // opaque needed for horizontal scroll shadow
         }
       }
 

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -279,7 +279,7 @@ $shadow-transition-width: 16px;
           cursor: pointer;
         }
         &:active {
-          background-color: $ui-vibrant-blue-10; // opaque needed for horizontal scroll shadow
+          background-color: $ui-vibrant-blue-10;
         }
       }
 

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -258,6 +258,7 @@ const TeamsDropdown = ({
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
       margin: 0,
+      color: COLORS["core-fleet-black"],
     }),
     option: (baseStyles, state) => ({
       ...baseStyles,

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -91,9 +91,6 @@
     border-radius: $border-radius;
     background-color: $core-fleet-white;
 
-    // The chip's "×" remove icon. Render the default react-select character
-    // in a themed neutral color that respects light/dark mode, instead of
-    // overlaying a fixed-color PNG (which read as blue on the chip background).
     .Select-value-icon {
       border: 0;
       float: right;
@@ -286,8 +283,6 @@
     box-sizing: border-box;
   }
 
-  // Override react-select's hardcoded grey-on-rest / red-on-hover for the
-  // "clear all" X. The red doesn't match Fleet's icon-only button styles.
   .Select-clear-zone {
     color: $ui-fleet-black-50;
     transition: color 150ms ease-in-out;

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -91,34 +91,23 @@
     border-radius: $border-radius;
     background-color: $core-fleet-white;
 
+    // The chip's "×" remove icon. Render the default react-select character
+    // in a themed neutral color that respects light/dark mode, instead of
+    // overlaying a fixed-color PNG (which read as blue on the chip background).
     .Select-value-icon {
       border: 0;
       float: right;
-      position: relative;
       line-height: 28px;
       width: 20px;
       padding: 0;
       margin: 0 5px;
-      text-indent: -999em;
-
-      &::after {
-        transition: color 150ms ease-in-out;
-        content: url(../assets/images/icon-close-fleet-black-16x16@2x.png);
-        transform: scale(0.5);
-        position: absolute;
-        top: -5px;
-        left: -5px;
-        visibility: visible;
-        font-size: $x-small;
-        color: $ui-gray;
-        text-indent: 0;
-      }
+      text-align: center;
+      font-size: $small;
+      color: $ui-fleet-black-50;
+      transition: color 150ms ease-in-out;
 
       &:hover {
-        &::after {
-          content: url("../assets/images/icon-close-fleet-black-16x16@2x.png");
-          transform: scale(0.5);
-        }
+        color: $core-fleet-black;
       }
     }
 
@@ -295,6 +284,17 @@
     font-size: $x-small;
     line-height: 34px;
     box-sizing: border-box;
+  }
+
+  // Override react-select's hardcoded grey-on-rest / red-on-hover for the
+  // "clear all" X. The red doesn't match Fleet's icon-only button styles.
+  .Select-clear-zone {
+    color: $ui-fleet-black-50;
+    transition: color 150ms ease-in-out;
+
+    &:hover {
+      color: $core-fleet-black;
+    }
   }
   .Select-input {
     color: $core-fleet-black;

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -234,6 +234,7 @@ const HostsEnrolledCard = ({
               tickLine={false}
               tickMargin={6}
               tick={{ fontSize: tickFontSize }}
+              allowDecimals={false}
             />
             <YAxis
               type="category"

--- a/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
@@ -12,8 +12,7 @@
     background-color: $ui-warning;
     padding: $pad-xsmall;
     font-size: $xx-small;
-    // Static dark text — the warning surface stays yellow in both themes, so
-    // the foreground must stay dark to keep contrast in dark mode.
+    // Surface stays yellow in both themes; text must stay dark for contrast.
     color: $static-black;
     font-weight: $bold;
     border-radius: $border-radius;

--- a/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
@@ -12,16 +12,19 @@
     background-color: $ui-warning;
     padding: $pad-xsmall;
     font-size: $xx-small;
-    color: $core-fleet-black;
+    // Static dark text — the warning surface stays yellow in both themes, so
+    // the foreground must stay dark to keep contrast in dark mode.
+    color: $static-black;
     font-weight: $bold;
     border-radius: $border-radius;
 
     &.warning {
       background-color: $ui-warning;
+      color: $static-black;
     }
 
     &.error {
-      color: $core-fleet-white;
+      color: $static-white;
       background-color: $core-vibrant-red;
     }
   }

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -45,6 +45,11 @@
   --ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
   --ui-vibrant-blue-25: #d9d9fe;
   --ui-vibrant-blue-10: #f1f0ff;
+  // Opaque equivalent of --ui-vibrant-blue-10 used by table rows that sit
+  // above a horizontal scroll-shadow gradient (must be opaque so the gradient
+  // doesn't show through). Themed separately so dark mode doesn't pick up the
+  // pure-blue cast that an alpha-on-dark composite produces.
+  --ui-vibrant-blue-10-opaque: #f1f0ff;
   --tooltip-bg: #3e4771;
 
   // Notifications & status
@@ -146,7 +151,10 @@ body.dark-mode {
   --ui-shadow: #32363e;
   --ui-vibrant-blue-50: rgba(123, 121, 255, 0.3);
   --ui-vibrant-blue-25: #282736;
-  --ui-vibrant-blue-10: #1e1f2a;
+  // Neutral surface tint for selected/active rows. Pure-blue tints read as
+  // navy against the dark UI; this mirrors the surface hierarchy instead.
+  --ui-vibrant-blue-10: #2c2f37;
+  --ui-vibrant-blue-10-opaque: #2c2f37;
   --tooltip-bg: #353940;
 
   // Notifications & status — slightly brighter
@@ -300,15 +308,12 @@ $dark-mode-table-header: #282c33;
 $dark-mode-table-row: #1f2229;
 $dark-mode-nav-hover: #1f2228;
 
-// Opaque colors for table shadows — compile-time SCSS math, not themed.
-// These are subtle edge effects; dark-mode polish can refine them later.
-$ui-vibrant-blue-10-alpha: (255-240)/255; // rgba(241, 240, 255)
-$ui-vibrant-blue-10-opaque: rgba(
-  (241-240) / $ui-vibrant-blue-10-alpha,
-  (240-240) / $ui-vibrant-blue-10-alpha,
-  (255-240) / $ui-vibrant-blue-10-alpha,
-  $ui-vibrant-blue-10-alpha
-);
+// Opaque colors for table shadows — themed via CSS custom properties so dark
+// mode gets a neutral surface instead of a pure-blue alpha-on-dark composite.
+$ui-vibrant-blue-10-opaque: var(--ui-vibrant-blue-10-opaque);
+
+// Compile-time SCSS math — not themed. These are subtle edge effects;
+// dark-mode polish can refine them later.
 $ui-off-white-alpha: (255-249)/255; // rgba(249, 250, 252)
 $ui-off-white-opaque: rgba(
   (249-249) / $ui-off-white-alpha,

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -45,10 +45,8 @@
   --ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
   --ui-vibrant-blue-25: #d9d9fe;
   --ui-vibrant-blue-10: #f1f0ff;
-  // Opaque equivalent of --ui-vibrant-blue-10 used by table rows that sit
-  // above a horizontal scroll-shadow gradient (must be opaque so the gradient
-  // doesn't show through). Themed separately so dark mode doesn't pick up the
-  // pure-blue cast that an alpha-on-dark composite produces.
+  // Opaque variant for surfaces above a scroll-shadow gradient. Themed
+  // separately so dark mode doesn't composite as a navy tint.
   --ui-vibrant-blue-10-opaque: #f1f0ff;
   --tooltip-bg: #3e4771;
 
@@ -151,8 +149,6 @@ body.dark-mode {
   --ui-shadow: #32363e;
   --ui-vibrant-blue-50: rgba(123, 121, 255, 0.3);
   --ui-vibrant-blue-25: #282736;
-  // Neutral surface tint for selected/active rows. Pure-blue tints read as
-  // navy against the dark UI; this mirrors the surface hierarchy instead.
   --ui-vibrant-blue-10: #2c2f37;
   --ui-vibrant-blue-10-opaque: #2c2f37;
   --tooltip-bg: #353940;
@@ -308,12 +304,10 @@ $dark-mode-table-header: #282c33;
 $dark-mode-table-row: #1f2229;
 $dark-mode-nav-hover: #1f2228;
 
-// Opaque colors for table shadows — themed via CSS custom properties so dark
-// mode gets a neutral surface instead of a pure-blue alpha-on-dark composite.
 $ui-vibrant-blue-10-opaque: var(--ui-vibrant-blue-10-opaque);
 
-// Compile-time SCSS math — not themed. These are subtle edge effects;
-// dark-mode polish can refine them later.
+// Opaque colors for table shadows — compile-time SCSS math, not themed.
+// These are subtle edge effects; dark-mode polish can refine them later.
 $ui-off-white-alpha: (255-249)/255; // rgba(249, 250, 252)
 $ui-off-white-opaque: rgba(
   (249-249) / $ui-off-white-alpha,

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -45,9 +45,6 @@
   --ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
   --ui-vibrant-blue-25: #d9d9fe;
   --ui-vibrant-blue-10: #f1f0ff;
-  // Opaque variant for surfaces above a scroll-shadow gradient. Themed
-  // separately so dark mode doesn't composite as a navy tint.
-  --ui-vibrant-blue-10-opaque: #f1f0ff;
   --tooltip-bg: #3e4771;
 
   // Notifications & status
@@ -150,7 +147,6 @@ body.dark-mode {
   --ui-vibrant-blue-50: rgba(123, 121, 255, 0.3);
   --ui-vibrant-blue-25: #282736;
   --ui-vibrant-blue-10: #2c2f37;
-  --ui-vibrant-blue-10-opaque: #2c2f37;
   --tooltip-bg: #353940;
 
   // Notifications & status — slightly brighter
@@ -303,8 +299,6 @@ $static-black: #192147;
 $dark-mode-table-header: #282c33;
 $dark-mode-table-row: #1f2229;
 $dark-mode-nav-hover: #1f2228;
-
-$ui-vibrant-blue-10-opaque: var(--ui-vibrant-blue-10-opaque);
 
 // Opaque colors for table shadows — compile-time SCSS math, not themed.
 // These are subtle edge effects; dark-mode polish can refine them later.


### PR DESCRIPTION
## Summary

Validated each fix locally. 

Bundle fix for 12 reported unreleased bugs in the `~unreleased bug` + `#g-first-impressions` queue. Three shared root causes account for most of them; the rest are small standalone fixes.

### Shared root-cause fixes
- **`HumanTimeDiffWithDateTip.tsx`** — tooltip `backgroundColor` was hardcoded to `#3e4771`. Switched to `var(--tooltip-bg)` so it themes correctly in dark mode. Resolves #44902 and #44904.
- **`colors.scss`** — dark-mode `--ui-vibrant-blue-10` retoned from `#1e1f2a` (read as navy) to a neutral `#2c2f37`. Resolves #44899 and #44928.
- **`Dropdown/_styles.scss`** — chip `×` is now visible and themed: removed the `text-indent: -999em` that hid react-select's default character and the `::after` PNG overlay (the referenced asset doesn't exist in the repo). `.Select-clear-zone` overrides react-select's default red-on-hover with neutral tokens. Resolves #44661, #44856, #44859.

### Standalone fixes
- **`HostsEnrolledCard.tsx`** — `allowDecimals={false}` on the XAxis so small host counts no longer render half-unit ticks. Resolves #44711.
- **`HostHeader/_styles.scss`** — device-status tag now uses `$static-black` / `$static-white` so foreground text stays legible against the static warning/error surfaces in dark mode. Resolves #44864.
- **`TeamsDropdown.tsx`** — themed `color` added to the `input` slot in `customStyles` so the search-input text isn't dark-on-dark. Resolves #44898.
- **`TabNav/_styles.scss`** — replaced the secondary-tab focus outline with a thicker focused-color underline at the tab bottom; the prior outline rectangle read as a stray light box around the focused tab in dark mode. Resolves #44905.
- **`SidePanelPage/_styles.scss`** — side panel uses `min-height: 100%` instead of `height: 100%` so the background extends with its own content when taller than main-content (schema docs on Report/Label/Policy pages). Resolves #44907.

## Issues closed
- #44661
- #44711
- #44856
- #44859
- #44864
- #44898
- #44899
- #44902
- #44904
- #44905
- #44907
- #44928

## Test plan
- [x] Dashboard → Hosts enrolled card: gear modal → confirm Labels/Platforms chip \`×\` icons render in neutral grey (light + dark), and the clear-all \`×\` hover is neutral, not red.
- [x] Dashboard → Hosts enrolled bar chart: with 1–3 hosts on a platform, confirm X-axis shows whole-number ticks only.
- [x] Dashboard → Hosts active settings modal → TAB through to Exclude hosts / Specific hosts tab: confirm the focus indicator is a thicker underline at the bottom (no white box around the text).
- [x] Host details (dark mode): hover Last seen / Last restarted / Last fetched / Added to Fleet — tooltip background should be themed, not bright blue.
- [ ] Host details with a locked host (dark mode): confirm the \"Locked\" badge text is dark and readable on the yellow surface.
- [x] Top-nav Fleet/team selector → click into search field (dark mode): typed text should be light, not dark-on-dark.
- [ ] Any single-select dropdown (dark mode): selected option highlight should be a neutral surface, not navy.
- [x] Software → Titles: click a row in dark mode — active highlight should be neutral, not navy.
- [x] Reports / Labels / Policies query editor with the schema sidebar open: scroll a long table's columns past the bottom of main-content — the sidebar background should extend with the content, not cut off.
- [x] Visual smoke test in light mode for each of the above to confirm no regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tooltip background unified to use theme variable for consistency.
  * Side panel layout adjusted to allow background to extend with overflowing content.
  * Tab navigation spacing and focus/underline indicators improved.
  * Dropdown input, clear/icon and Teams dropdown text styling clarified for consistent visuals.
  * Table row active state and host status tag colors refined.
  * Color theme values updated for better dark-mode contrast.

* **Bug Fixes**
  * Chart axis labels now display whole numbers only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->