### PR TITLE
Document macOS MDM CertificateList ingestion (PR 4/8)

### DIFF
--- a/articles/view-certificates-in-host-vitals.md
+++ b/articles/view-certificates-in-host-vitals.md
@@ -19,6 +19,8 @@ Fleet API users can access host certificate information via the "Get host's cert
 
 For macOS hosts, Fleet retrieves certificate information using osquery's `certificates` [table](https://fleetdm.com/learn-more-about/certificates-query). For iOS and iPadOS hosts, Fleet retrieves certificates via MDM using the `CertificateList` [command](https://developer.apple.com/documentation/devicemanagement/certificate-list-command).
 
+When a macOS host installs a configuration profile containing an ACME payload, Fleet also retrieves the resulting certificate via the MDM `CertificateList` command. This surfaces hardware-bound ACME certificates that don't appear in osquery's `certificates` table. Ingestion runs per-host on each ACME profile install and re-install — there is no recurring cadence — so certificates from a given profile become visible the first time the profile is installed or re-deployed on a host.
+
 ## Conclusion
 
 The certificates section in host vitals provides you with a quick overview of the certificates installed on your macOS, iOS, and iPadOS devices. This feature helps you identify and troubleshoot certificate-related issues that may prevent your end users from connecting to the corporate network.

--- a/changes/42827-macos-mdm-certificate-ingestion
+++ b/changes/42827-macos-mdm-certificate-ingestion
@@ -1,0 +1,1 @@
+* Surface hardware-bound ACME certificates on macOS host vitals by retrieving them via the MDM `CertificateList` command when an ACME-bearing configuration profile is installed or re-installed.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5195,6 +5195,8 @@ Available for macOS, iOS, iPadOS, and Windows hosts only. Requires Fleet's MDM t
 
 Retrieves the certificates installed on a host.
 
+For macOS hosts, certificates from MDM-delivered profiles containing an ACME payload are retrieved via the MDM `CertificateList` command on each profile install and re-install (not on a recurring cadence). Hardware-bound ACME certificates that aren't visible to osquery first appear in the response after the host installs or re-installs the delivering profile.
+
 `GET /api/v1/fleet/hosts/:id/certificates`
 
 #### Parameters


### PR DESCRIPTION
**Related issue:** Resolves #44343

## What this PR does

- Update the host vitals certificates guide to describe macOS MDM `CertificateList` ingestion for ACME profiles (per-host on profile install/re-install, no recurring cadence).
- Update the REST API "Get host's certificates" endpoint doc with the same ingestion note.
- Add a Phase 1 release-notes entry under `changes/`.

## Why this is needed

Phase 1 (#42827) makes hardware-bound ACME certificates visible on macOS for the first time. The existing docs describe macOS cert ingestion as osquery-only, which is now incomplete. This PR closes that gap so customers know when the new visibility activates and what triggers it.

# Checklist for submitter

Docs-only — runtime/test checklist sections do not apply.