### PR TITLE
Website: Update infrastructure-as-code.ejs

### DIFF
--- a/website/views/pages/infrastructure-as-code.ejs
+++ b/website/views/pages/infrastructure-as-code.ejs
@@ -21,7 +21,7 @@
 
     <div purpose="page-section">
       <div purpose="section-title">
-        <h2>ClickOps does not scale</h2>
+        <h2>There is another way</h2>
         <p>Most device management happens through a GUI: click, configure, repeat. That works at small scale. As your organization grows, manual processes create problems that compound.</p>
       </div>
       <div purpose="features-section">


### PR DESCRIPTION
50% of Fleet customers don't use IaC, and have huge fleets.  It's not that ClickOps doesn't scale-- it's that there's another way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "There is another way" section header on the Infrastructure as Code page with revised wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->