### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.23.1",
+      "version": "0.23.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.23.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.23.2') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.23.1/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.23.2/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "f6ad7a9e",
-      "sha256": "72eaee5b5a58eede327e222b00b08c1b22aeb6dc99d73e093a21533706d26c6f",
+      "sha256": "51478c7392e30bfe266844427eb438ab6b31e99456e9037a0cf9b02f1cb174c7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.9.3",
+      "version": "12.9.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.9.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.9.7') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.9.3/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.9.7/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "5b41187d",
-      "sha256": "afad5aa11c1b0c963ab12a73ea7df88f3bdfdf80a0f59178a102d4d14e2e3061",
+      "sha256": "402a907882c3928c786009cec59295ab16c9c50aac77ce5d9b6bbbc616e49f1b",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated support for Ollama macOS from version 0.23.1 to 0.23.2
  * Updated support for Postman macOS from version 12.9.3 to 12.9.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->