### PR TITLE
always assign profile to missing devices due to replica lag

### DIFF
--- a/changes/44980-always-assign-profile-missing-devices
+++ b/changes/44980-always-assign-profile-missing-devices
@@ -1,0 +1,1 @@
+- Fixed an issue where replica lag could lead to devices not being assigned a setup experience profile, on device sync from DEP.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -4883,7 +4883,7 @@ WHERE
 		totalProcessed += len(serials)
 	}
 	if totalProcessed != len(serials) {
-		ds.logger.ErrorContext(ctx, fmt.Sprintf("screen dep serials: expected to process %d serials but processed %d", len(serials), totalProcessed))
+		ds.logger.WarnContext(ctx, fmt.Sprintf("screen dep serials: expected to process %d serials but processed %d", len(serials), totalProcessed))
 	}
 
 	return skipSerialsByOrgName, serialsByOrgName, nil

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -856,7 +856,7 @@ func (d *DEPService) processDeviceResponse(
 		if len(missing) > 0 {
 			// We did not get all serials passed in, back assigned to a bucket, could be due to potential replica lag.
 			// We force the remaining serials into the assign bucket, to ensure they get processed.
-			d.logger.InfoContext(ctx, "found missing serials after cooldown screening, adding them to assign profile operation", "serials", fmt.Sprintf("%s", missing), "count", len(missing), "org_name", abmOrganizationName)
+			logger.InfoContext(ctx, "found missing serials after cooldown screening, adding them to assign profile operation", "serials", missing, "count", len(missing), "org_name", abmOrganizationName)
 			assignSerials[abmOrganizationName] = append(assignSerials[abmOrganizationName], missing...)
 		}
 

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -834,6 +834,32 @@ func (d *DEPService) processDeviceResponse(
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "process device response")
 		}
+
+		seen := make(map[string]struct{}, len(serials))
+		for _, ss := range skipSerials {
+			for _, s := range ss {
+				seen[s] = struct{}{}
+			}
+		}
+		for _, ss := range assignSerials {
+			for _, s := range ss {
+				seen[s] = struct{}{}
+			}
+		}
+		var missing []string
+		for _, s := range serials {
+			if _, ok := seen[s]; !ok {
+				missing = append(missing, s)
+			}
+		}
+
+		if len(missing) > 0 {
+			// We did not get all serials passed in, back assigned to a bucket, could be due to potential replica lag.
+			// We force the remaining serials into the assign bucket, to ensure they get processed.
+			d.logger.InfoContext(ctx, "found missing serials after cooldown screening, adding them to assign profile operation", "serials", fmt.Sprintf("%s", missing), "count", len(missing), "org_name", abmOrganizationName)
+			assignSerials[abmOrganizationName] = append(assignSerials[abmOrganizationName], missing...)
+		}
+
 		if len(skipSerials) > 0 {
 			// NOTE: the `dep_cooldown` job of the `integrations`` cron picks up the assignments
 			// after the cooldown period is over

--- a/server/mdm/apple/apple_mdm_external_test.go
+++ b/server/mdm/apple/apple_mdm_external_test.go
@@ -17,6 +17,7 @@ import (
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/godep"
+	"github.com/fleetdm/fleet/v4/server/platform/mysql/testing_utils"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
@@ -528,4 +529,100 @@ func TestDEPService_RunAssigner(t *testing.T) {
 			return nil
 		})
 	})
+}
+
+// TestDEPService_RunAssigner_ReplicaLag exercises the bug from #44980:
+// IngestMDMAppleDevicesFromDEPSync writes ghost host rows + host_dep_assignments
+// to the primary, then ScreenDEPAssignProfileSerialsForCooldown reads from the
+// replica. Under replica lag, the cooldown SELECT returns no rows for the new
+// serials and they get silently dropped from both the skip and assign buckets.
+//
+// We use the dummy-replica harness with explicit replication control: any writes
+// that happen between RunReplication() calls remain on the primary only, exactly
+// matching the production lag scenario.
+func TestDEPService_RunAssigner_ReplicaLag(t *testing.T) {
+	ctx := context.Background()
+	opts := &testing_utils.DatastoreTestOptions{
+		DummyReplica:   true,
+		UniqueTestName: "dep_runassigner_replica_lag",
+	}
+	ds := mysql.CreateMySQLDSWithOptions(t, opts)
+	t.Cleanup(func() { ds.Close() })
+
+	const abmTokenOrgName = "test_org"
+	depStorage, err := ds.NewMDMAppleDEPStorage()
+	require.NoError(t, err)
+
+	mysql.SetTestABMAssets(t, ds, abmTokenOrgName)
+	// Replicate ABM-related rows (abm_tokens, certs, app_config) so the JOIN target
+	// for the screen query exists on the replica. The lag we want to simulate is
+	// for the ghost-host rows ingested *during* RunAssigner, not for ABM setup.
+	opts.RunReplication()
+
+	laggedSerial := "LAGGED-001"
+	onTimeSerial := "ONTIME-001"
+	devices := []godep.Device{
+		{SerialNumber: laggedSerial, OpType: "added"},
+		{SerialNumber: onTimeSerial, OpType: "added"},
+	}
+
+	var assignedSerials []string
+	syncCallCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		encoder := json.NewEncoder(w)
+		switch r.URL.Path {
+		case "/session":
+			_, _ = w.Write([]byte(`{"auth_session_token": "session123"}`))
+		case "/account":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"admin_id": "admin123", "org_name": "%s"}`, abmTokenOrgName)))
+		case "/profile":
+			require.NoError(t, encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile123"}))
+		case "/server/devices", "/devices/sync":
+			syncCallCount++
+			// Return our two devices on the very first sync; empty thereafter so the
+			// syncer terminates instead of looping on the same devices.
+			if syncCallCount == 1 {
+				require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: devices}))
+			} else {
+				require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: nil}))
+			}
+		case "/profile/devices":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var assignReq godep.Profile
+			require.NoError(t, json.Unmarshal(body, &assignReq))
+			assignedSerials = append(assignedSerials, assignReq.Devices...)
+			apiResp := godep.ProfileResponse{
+				ProfileUUID: assignReq.ProfileUUID,
+				Devices:     map[string]string{},
+			}
+			for _, s := range assignReq.Devices {
+				apiResp.Devices[s] = string(fleet.DEPAssignProfileResponseSuccess)
+			}
+			require.NoError(t, encoder.Encode(apiResp))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	require.NoError(t, depStorage.StoreConfig(ctx, abmTokenOrgName, &nanodep_client.Config{BaseURL: srv.URL}))
+	logger := slog.New(slog.Default().Handler())
+	svc := apple_mdm.NewDEPService(ds, depStorage, logger)
+
+	// CRITICAL: never call opts.RunReplication() after this point. RunAssigner
+	// internally:
+	//   1. Writes the new hosts + host_dep_assignments to the primary
+	//      (IngestMDMAppleDevicesFromDEPSync).
+	//   2. Immediately calls ScreenDEPAssignProfileSerialsForCooldown, which reads
+	//      from the replica. The replica is stale, so the JOIN finds no rows and
+	//      drops the serials.
+	require.NoError(t, svc.RunAssigner(ctx))
+
+	// Both serials must reach AssignProfile, even though their host /
+	// host_dep_assignments rows were invisible to the cooldown screen on the
+	// lagged replica.
+	require.ElementsMatch(t, []string{laggedSerial, onTimeSerial}, assignedSerials,
+		"serials newly inserted on primary but not yet replicated must still be sent to AssignProfile")
 }

--- a/server/mdm/apple/apple_mdm_external_test.go
+++ b/server/mdm/apple/apple_mdm_external_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/platform/mysql/testing_utils"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -540,7 +541,6 @@ func TestDEPService_RunAssigner_ReplicaLag(t *testing.T) {
 		UniqueTestName: "dep_runassigner_replica_lag",
 	}
 	ds := mysql.CreateMySQLDSWithOptions(t, opts)
-	t.Cleanup(func() { ds.Close() })
 
 	const abmTokenOrgName = "test_org"
 	depStorage, err := ds.NewMDMAppleDEPStorage()
@@ -568,23 +568,23 @@ func TestDEPService_RunAssigner_ReplicaLag(t *testing.T) {
 		case "/session":
 			_, _ = w.Write([]byte(`{"auth_session_token": "session123"}`))
 		case "/account":
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"admin_id": "admin123", "org_name": "%s"}`, abmTokenOrgName)))
+			_, _ = w.Write(fmt.Appendf([]byte{}, `{"admin_id": "admin123", "org_name": "%s"}`, abmTokenOrgName))
 		case "/profile":
-			require.NoError(t, encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile123"}))
+			assert.NoError(t, encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile123"}))
 		case "/server/devices", "/devices/sync":
 			syncCallCount++
 			// Return our two devices on the very first sync; empty thereafter so the
 			// syncer terminates instead of looping on the same devices.
 			if syncCallCount == 1 {
-				require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: devices}))
+				assert.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: devices}))
 			} else {
-				require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: nil}))
+				assert.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: nil}))
 			}
 		case "/profile/devices":
 			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			var assignReq godep.Profile
-			require.NoError(t, json.Unmarshal(body, &assignReq))
+			assert.NoError(t, json.Unmarshal(body, &assignReq))
 			assignedSerials = append(assignedSerials, assignReq.Devices...)
 			apiResp := godep.ProfileResponse{
 				ProfileUUID: assignReq.ProfileUUID,
@@ -593,7 +593,7 @@ func TestDEPService_RunAssigner_ReplicaLag(t *testing.T) {
 			for _, s := range assignReq.Devices {
 				apiResp.Devices[s] = string(fleet.DEPAssignProfileResponseSuccess)
 			}
-			require.NoError(t, encoder.Encode(apiResp))
+			assert.NoError(t, encoder.Encode(apiResp))
 		default:
 			t.Errorf("unexpected request to %s", r.URL.Path)
 		}
@@ -601,7 +601,7 @@ func TestDEPService_RunAssigner_ReplicaLag(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	require.NoError(t, depStorage.StoreConfig(ctx, abmTokenOrgName, &nanodep_client.Config{BaseURL: srv.URL}))
-	logger := slog.New(slog.Default().Handler())
+	logger := slog.New(slog.DiscardHandler)
 	svc := apple_mdm.NewDEPService(ds, depStorage, logger)
 
 	require.NoError(t, svc.RunAssigner(ctx))

--- a/server/mdm/apple/apple_mdm_external_test.go
+++ b/server/mdm/apple/apple_mdm_external_test.go
@@ -531,15 +531,8 @@ func TestDEPService_RunAssigner(t *testing.T) {
 	})
 }
 
-// TestDEPService_RunAssigner_ReplicaLag exercises the bug from #44980:
-// IngestMDMAppleDevicesFromDEPSync writes ghost host rows + host_dep_assignments
-// to the primary, then ScreenDEPAssignProfileSerialsForCooldown reads from the
-// replica. Under replica lag, the cooldown SELECT returns no rows for the new
-// serials and they get silently dropped from both the skip and assign buckets.
-//
 // We use the dummy-replica harness with explicit replication control: any writes
-// that happen between RunReplication() calls remain on the primary only, exactly
-// matching the production lag scenario.
+// that happen between RunReplication() calls remain on the primary node only.
 func TestDEPService_RunAssigner_ReplicaLag(t *testing.T) {
 	ctx := context.Background()
 	opts := &testing_utils.DatastoreTestOptions{
@@ -611,14 +604,8 @@ func TestDEPService_RunAssigner_ReplicaLag(t *testing.T) {
 	logger := slog.New(slog.Default().Handler())
 	svc := apple_mdm.NewDEPService(ds, depStorage, logger)
 
-	// CRITICAL: never call opts.RunReplication() after this point. RunAssigner
-	// internally:
-	//   1. Writes the new hosts + host_dep_assignments to the primary
-	//      (IngestMDMAppleDevicesFromDEPSync).
-	//   2. Immediately calls ScreenDEPAssignProfileSerialsForCooldown, which reads
-	//      from the replica. The replica is stale, so the JOIN finds no rows and
-	//      drops the serials.
 	require.NoError(t, svc.RunAssigner(ctx))
+	// never call opts.RunReplication() after this point, so we exercise the replica lag.
 
 	// Both serials must reach AssignProfile, even though their host /
 	// host_dep_assignments rows were invisible to the cooldown screen on the


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44980

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually (Not, outside of tests due to exercising replica lag is difficult)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of device profile assignment by ensuring all devices receive profiles consistently, even when replica lag affects device synchronization from Device Enrollment Program services.

* **Tests**
  * Added test coverage validating device profile assignment behavior under replica lag scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->