### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.3.22",
+      "version": "3.3.27",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.3.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.3.27') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/38a27120cfc7419a5efa38420665eaeeed1e7b32/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/80b138a7a0a948e1a798e9ed7867d76a1ba9a318/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "a4458d81",
-      "sha256": "09bf7d495b8f40fe0e8704abe57d05739e4c6e54b5c4dd0a63a870357572a487",
+      "sha256": "c4b3f9737d3136e653de2b1fa6f55b9d72ba45b20997d96aa304c3f0151217e8",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox/windows.json
+++ b/ee/maintained-apps/outputs/firefox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.0.1",
+      "version": "150.0.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '150.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '150.0.2') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/150.0.1/win64/en-US/Firefox%20Setup%20150.0.1.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/150.0.2/win64/en-US/Firefox%20Setup%20150.0.2.exe",
       "install_script_ref": "80fb9175",
       "uninstall_script_ref": "8b5e20e4",
-      "sha256": "21936d1c7c9667c85c4637cb832259c0e70942f4b928ed9436699f0ccfad53bd",
+      "sha256": "0458e29f4f4b709b6677d07656937abecde7eff2069db19884d0fa0ddc531e83",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/google-drive/darwin.json
+++ b/ee/maintained-apps/outputs/google-drive/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "124.0",
+      "version": "125.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs' AND version_compare(bundle_short_version, '124.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs' AND version_compare(bundle_short_version, '125.0') < 0);"
       },
       "installer_url": "https://dl.google.com/drive-file-stream/5-percent/GoogleDrive.dmg",
       "install_script_ref": "fe628b65",

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.23.1",
+      "version": "0.23.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.23.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.23.2') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.23.1/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.23.2/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "f6ad7a9e",
-      "sha256": "72eaee5b5a58eede327e222b00b08c1b22aeb6dc99d73e093a21533706d26c6f",
+      "sha256": "51478c7392e30bfe266844427eb438ab6b31e99456e9037a0cf9b02f1cb174c7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.9.3",
+      "version": "12.9.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.9.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.9.7') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.9.3/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.9.7/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "5b41187d",
-      "sha256": "afad5aa11c1b0c963ab12a73ea7df88f3bdfdf80a0f59178a102d4d14e2e3061",
+      "sha256": "402a907882c3928c786009cec59295ab16c9c50aac77ce5d9b6bbbc616e49f1b",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated version records for maintained applications: Cursor macOS (3.3.27), Firefox Windows (150.0.2), Google Drive macOS (125.0), Ollama macOS (0.23.2), and Postman macOS (12.9.7). Version verification metadata and installation parameters have been synchronized to reflect the latest releases, ensuring accurate system monitoring and compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->