### PR TITLE
Standardize macOS configuration profiles

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/1password-managed-settings.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/1password-managed-settings.mobileconfig
@@ -2,40 +2,40 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.4AF68654-3F58-4ACC-8D10-131B472BBD40</string>
+	<key>PayloadUUID</key>
+	<string>8DA31C9C-43AD-44A6-A6BE-2EF4D4536DB3</string>
+	<key>PayloadDisplayName</key>
+	<string>1Password Managed Settings</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>1Password</string>
-			<key>PayloadIdentifier</key>
-			<string>com.1password.1password.470862F2-AD47-45B7-9392-A0FF912FC23C</string>
 			<key>PayloadType</key>
 			<string>com.1password.1password</string>
-			<key>PayloadUUID</key>
-			<string>470862F2-AD47-45B7-9392-A0FF912FC23C</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.1password.1password.470862F2-AD47-45B7-9392-A0FF912FC23C</string>
+			<key>PayloadUUID</key>
+			<string>477048FA-EB38-4966-8A2F-C721706F1A64</string>
+			<key>updates.updateChannel</key>
+			<string>PRODUCTION</string>
 			<key>privacy.checkCompromisedWebsites</key>
 			<true/>
+			<key>updates.autoUpdate</key>
+			<true/>
+			<key>PayloadDisplayName</key>
+			<string>1Password</string>
 			<key>privacy.checkHibp</key>
 			<true/>
 			<key>security.authenticatedUnlock.appleTouchId</key>
 			<true/>
-			<key>updates.autoUpdate</key>
-			<true/>
-			<key>updates.updateChannel</key>
-			<string>PRODUCTION</string>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>1Password Managed Settings</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.4AF68654-3F58-4ACC-8D10-131B472BBD40</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>4AF68654-3F58-4ACC-8D10-131B472BBD40</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/1password-managed-settings.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/1password-managed-settings.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.4AF68654-3F58-4ACC-8D10-131B472BBD40</string>
 	<key>PayloadUUID</key>
-	<string>8DA31C9C-43AD-44A6-A6BE-2EF4D4536DB3</string>
+	<string>4AF68654-3F58-4ACC-8D10-131B472BBD40</string>
 	<key>PayloadDisplayName</key>
 	<string>1Password Managed Settings</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.1password.1password.470862F2-AD47-45B7-9392-A0FF912FC23C</string>
 			<key>PayloadUUID</key>
-			<string>477048FA-EB38-4966-8A2F-C721706F1A64</string>
+			<string>470862F2-AD47-45B7-9392-A0FF912FC23C</string>
 			<key>updates.updateChannel</key>
 			<string>PRODUCTION</string>
 			<key>privacy.checkCompromisedWebsites</key>

--- a/it-and-security/lib/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
@@ -2,44 +2,44 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.appstore.updates.FDCAEEFA-4FFE-4CFD-8C9D-DD718424BCAA</string>
+	<key>PayloadUUID</key>
+	<string>85373119-015A-4683-A506-26933698B537</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on App Store automatic updates</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.appstore.updates.0BCF86EE-7163-4580-9EA8-2F01EA8CA059</string>
+			<key>PayloadUUID</key>
+			<string>DAE5F4B7-E9DA-47AC-B867-3F8C68FD704A</string>
 			<key>AutomaticallyInstallAppUpdates</key>
 			<true/>
 			<key>PayloadDescription</key>
 			<string>Automatically install App Store updates</string>
 			<key>PayloadDisplayName</key>
 			<string>Automatically install App Store updates</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.appstore.updates.0BCF86EE-7163-4580-9EA8-2F01EA8CA059</string>
 			<key>PayloadOrganization</key>
 			<string></string>
-			<key>PayloadType</key>
-			<string>com.apple.SoftwareUpdate</string>
-			<key>PayloadUUID</key>
-			<string>0BCF86EE-7163-4580-9EA8-2F01EA8CA059</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 	</array>
-	<key>PayloadDescription</key>
-	<string>Enables App Store automatic updates</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on App Store automatic updates</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.appstore.updates.FDCAEEFA-4FFE-4CFD-8C9D-DD718424BCAA</string>
 	<key>PayloadOrganization</key>
 	<string>FleetDM</string>
 	<key>PayloadRemovalDisallowed</key>
 	<true/>
+	<key>PayloadDescription</key>
+	<string>Enables App Store automatic updates</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>FDCAEEFA-4FFE-4CFD-8C9D-DD718424BCAA</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.appstore.updates.FDCAEEFA-4FFE-4CFD-8C9D-DD718424BCAA</string>
 	<key>PayloadUUID</key>
-	<string>85373119-015A-4683-A506-26933698B537</string>
+	<string>FDCAEEFA-4FFE-4CFD-8C9D-DD718424BCAA</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on App Store automatic updates</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.appstore.updates.0BCF86EE-7163-4580-9EA8-2F01EA8CA059</string>
 			<key>PayloadUUID</key>
-			<string>DAE5F4B7-E9DA-47AC-B867-3F8C68FD704A</string>
+			<string>0BCF86EE-7163-4580-9EA8-2F01EA8CA059</string>
 			<key>AutomaticallyInstallAppUpdates</key>
 			<true/>
 			<key>PayloadDescription</key>

--- a/it-and-security/lib/macos/configuration-profiles/chrome-enrollment.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/chrome-enrollment.mobileconfig
@@ -2,40 +2,40 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.github.erikberglund.ProfileCreator.B6965621-36DF-46F6-839D-0F6591C9CA57</string>
+	<key>PayloadUUID</key>
+	<string>FCC667C4-3766-4E92-941E-4CA911EA6CCD</string>
+	<key>PayloadDisplayName</key>
+	<string>Enroll in managed Google Chrome</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>CloudManagementEnrollmentToken</key>
-			<string>$FLEET_SECRET_MANAGED_CHROME_ENROLLMENT_TOKEN</string>
-			<key>CloudReportingEnabled</key>
-			<true/>
-			<key>PayloadDisplayName</key>
-			<string>Google Chrome</string>
-			<key>PayloadIdentifier</key>
-			<string>com.github.erikberglund.ProfileCreator.B6965621-36DF-46F6-839D-0F6591C9CA57.com.google.Chrome.3022549B-B3AA-45C2-B980-E63E5CDBBACE</string>
-			<key>PayloadOrganization</key>
-			<string></string>
 			<key>PayloadType</key>
 			<string>com.google.Chrome</string>
-			<key>PayloadUUID</key>
-			<string>3022549B-B3AA-45C2-B980-E63E5CDBBACE</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.github.erikberglund.ProfileCreator.B6965621-36DF-46F6-839D-0F6591C9CA57.com.google.Chrome.3022549B-B3AA-45C2-B980-E63E5CDBBACE</string>
+			<key>PayloadUUID</key>
+			<string>4B6BE5F0-5C5E-4F02-A1AD-677DFEECD751</string>
+			<key>PayloadOrganization</key>
+			<string></string>
+			<key>CloudReportingEnabled</key>
+			<true/>
+			<key>CloudManagementEnrollmentToken</key>
+			<string>$FLEET_SECRET_MANAGED_CHROME_ENROLLMENT_TOKEN</string>
+			<key>PayloadDisplayName</key>
+			<string>Google Chrome</string>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>Enroll in managed Google Chrome</string>
-	<key>PayloadIdentifier</key>
-	<string>com.github.erikberglund.ProfileCreator.B6965621-36DF-46F6-839D-0F6591C9CA57</string>
 	<key>PayloadOrganization</key>
 	<string>com.fleetdm.management</string>
 	<key>PayloadScope</key>
 	<string>User</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>B6965621-36DF-46F6-839D-0F6591C9CA57</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/chrome-enrollment.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/chrome-enrollment.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.B6965621-36DF-46F6-839D-0F6591C9CA57</string>
 	<key>PayloadUUID</key>
-	<string>FCC667C4-3766-4E92-941E-4CA911EA6CCD</string>
+	<string>B6965621-36DF-46F6-839D-0F6591C9CA57</string>
 	<key>PayloadDisplayName</key>
 	<string>Enroll in managed Google Chrome</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.github.erikberglund.ProfileCreator.B6965621-36DF-46F6-839D-0F6591C9CA57.com.google.Chrome.3022549B-B3AA-45C2-B980-E63E5CDBBACE</string>
 			<key>PayloadUUID</key>
-			<string>4B6BE5F0-5C5E-4F02-A1AD-677DFEECD751</string>
+			<string>3022549B-B3AA-45C2-B980-E63E5CDBBACE</string>
 			<key>PayloadOrganization</key>
 			<string></string>
 			<key>CloudReportingEnabled</key>

--- a/it-and-security/lib/macos/configuration-profiles/date-time.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/date-time.mobileconfig
@@ -2,42 +2,42 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on set time and date automatically</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section2.TimeDate</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>C352A927-0C49-4AB2-AC98-27CE9F3391D7</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section2.TimeDate</string>
+	<key>PayloadUUID</key>
+	<string>271B7DA7-0CC9-4928-A9BF-2D1A9BEFD926</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on set time and date automatically</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>2.2.1 - Ensure Set time and date automatically is Enabled</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.applicationaccess</string>
 			<key>PayloadType</key>
 			<string>com.apple.applicationaccess</string>
-			<key>PayloadUUID</key>
-			<string>031F88EC-976F-4599-8532-DDB4809E2573</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadUUID</key>
+			<string>DF97B6F2-044F-41A7-A1B3-6B838A035A68</string>
+			<key>PayloadDisplayName</key>
+			<string>2.2.1 - Ensure Set time and date automatically is Enabled</string>
 			<key>forceAutomaticDateAndTime</key>
 			<true/>
 		</dict>
 	</array>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadOrganization</key>
+	<string>Center for Internet Security</string>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/date-time.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/date-time.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.TimeDate</string>
 	<key>PayloadUUID</key>
-	<string>271B7DA7-0CC9-4928-A9BF-2D1A9BEFD926</string>
+	<string>C352A927-0C49-4AB2-AC98-27CE9F3391D7</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on set time and date automatically</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.applicationaccess</string>
 			<key>PayloadUUID</key>
-			<string>DF97B6F2-044F-41A7-A1B3-6B838A035A68</string>
+			<string>031F88EC-976F-4599-8532-DDB4809E2573</string>
 			<key>PayloadDisplayName</key>
 			<string>2.2.1 - Ensure Set time and date automatically is Enabled</string>
 			<key>forceAutomaticDateAndTime</key>

--- a/it-and-security/lib/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig
@@ -2,28 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Disable Bluetooth sharing</string>
-	<key>PayloadEnabled</key>
-	<true/>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section2.BluetoothSharing</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>5CEBD712-28EB-432B-84C7-AA28A5A383D8</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section2.BluetoothSharing</string>
+	<key>PayloadUUID</key>
+	<string>CC10A605-0639-4DE0-9BF1-E391F6C6DE05</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable Bluetooth sharing</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>0240DD1C-70DC-4766-9018-04322BFEEAD1</string>
+			<key>PayloadUUID</key>
+			<string>F0998078-BC41-4340-9201-E9F987063CFC</string>
+			<key>PayloadEnabled</key>
+			<true/>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.apple.Bluetooth</key>
@@ -44,17 +45,15 @@
 			<string>Disables Bluetooth Sharing</string>
 			<key>PayloadDisplayName</key>
 			<string>Custom</string>
-			<key>PayloadEnabled</key>
-			<true/>
-			<key>PayloadIdentifier</key>
-			<string>0240DD1C-70DC-4766-9018-04322BFEEAD1</string>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadUUID</key>
-			<string>0240DD1C-70DC-4766-9018-04322BFEEAD1</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 	</array>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-bluetooth-file-sharing.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.BluetoothSharing</string>
 	<key>PayloadUUID</key>
-	<string>CC10A605-0639-4DE0-9BF1-E391F6C6DE05</string>
+	<string>5CEBD712-28EB-432B-84C7-AA28A5A383D8</string>
 	<key>PayloadDisplayName</key>
 	<string>Disable Bluetooth sharing</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>0240DD1C-70DC-4766-9018-04322BFEEAD1</string>
 			<key>PayloadUUID</key>
-			<string>F0998078-BC41-4340-9201-E9F987063CFC</string>
+			<string>0240DD1C-70DC-4766-9018-04322BFEEAD1</string>
 			<key>PayloadEnabled</key>
 			<true/>
 			<key>PayloadContent</key>

--- a/it-and-security/lib/macos/configuration-profiles/disable-content-caching.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-content-caching.mobileconfig
@@ -2,40 +2,40 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section2.ContentCaching</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>D1DCE625-F264-4F01-81A0-B091EABC89AF</string>
-	<key>PayloadDisplayName</key>
-	<string>Disable content caching</string>
-	<key>PayloadEnabled</key>
-	<true/>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section2.ContentCaching</string>
+	<key>PayloadUUID</key>
+	<string>E645FBD3-6BED-4DAF-8FB8-63CB5C310223</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable content caching</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Restrictions</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.applicationaccess.8647A91D-E292-4149-B6A3-DD87558C86BF</string>
 			<key>PayloadType</key>
 			<string>com.apple.applicationaccess</string>
-			<key>PayloadUUID</key>
-			<string>4A37CAB3-28C4-41EC-892E-0A5B1721BAD0</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.applicationaccess.8647A91D-E292-4149-B6A3-DD87558C86BF</string>
+			<key>PayloadUUID</key>
+			<string>15236DA8-3DBB-430A-A072-65534483B774</string>
 			<key>allowContentCaching</key>
 			<false/>
+			<key>PayloadDisplayName</key>
+			<string>Restrictions</string>
 		</dict>
 	</array>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/disable-content-caching.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-content-caching.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.ContentCaching</string>
 	<key>PayloadUUID</key>
-	<string>E645FBD3-6BED-4DAF-8FB8-63CB5C310223</string>
+	<string>D1DCE625-F264-4F01-81A0-B091EABC89AF</string>
 	<key>PayloadDisplayName</key>
 	<string>Disable content caching</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.applicationaccess.8647A91D-E292-4149-B6A3-DD87558C86BF</string>
 			<key>PayloadUUID</key>
-			<string>15236DA8-3DBB-430A-A072-65534483B774</string>
+			<string>4A37CAB3-28C4-41EC-892E-0A5B1721BAD0</string>
 			<key>allowContentCaching</key>
 			<false/>
 			<key>PayloadDisplayName</key>

--- a/it-and-security/lib/macos/configuration-profiles/disable-guest-account.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-guest-account.mobileconfig
@@ -2,30 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>PayloadContent</key>
-    <array>
-        <dict>
-            <key>DisableGuestAccount</key>
-            <true/>
-            <key>PayloadIdentifier</key>
-            <string>com.example.myaccountpayload</string>
-            <key>PayloadType</key>
-            <string>com.apple.MCX</string>
-            <key>PayloadUUID</key>
-            <string>5d4e377c-108c-44af-a46e-97a5aac1e270</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-        </dict>
-    </array>
-    <key>PayloadDisplayName</key>
-    <string>Disable guest account</string>
-    <key>PayloadIdentifier</key>
-    <string>com.fleet.disable-guest-account</string>
-    <key>PayloadType</key>
-    <string>Configuration</string>
-    <key>PayloadUUID</key>
-    <string>8cd28a9d-625e-4056-bbd0-43617bb8efb7</string>
-    <key>PayloadVersion</key>
-    <integer>1</integer>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleet.disable-guest-account</string>
+	<key>PayloadUUID</key>
+	<string>D05166FA-3FD4-4EF4-AAFF-CF79FA5E0C0E</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable guest account</string>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.MCX</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.example.myaccountpayload</string>
+			<key>PayloadUUID</key>
+			<string>7D09119D-3019-4A39-A1BC-89B076142B4D</string>
+			<key>DisableGuestAccount</key>
+			<true/>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/disable-guest-account.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-guest-account.mobileconfig
@@ -23,6 +23,8 @@
 			<string>com.example.myaccountpayload</string>
 			<key>PayloadUUID</key>
 			<string>7D09119D-3019-4A39-A1BC-89B076142B4D</string>
+			<key>PayloadDisplayName</key>
+			<string>Disable Guest Account</string>
 			<key>DisableGuestAccount</key>
 			<true/>
 		</dict>

--- a/it-and-security/lib/macos/configuration-profiles/disable-guest-shares.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-guest-shares.mobileconfig
@@ -2,27 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Disable guest access to shared folders</string>
-	<key>PayloadEnabled</key>
-	<true/>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section5.GuestSharing</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>86D6058B-C580-484C-A807-2E5EDA29A6DF</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section5.GuestSharing</string>
+	<key>PayloadUUID</key>
+	<string>12079707-D14E-4B25-B468-81B52458A61B</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable guest access to shared folders</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>A09998F2-A265-453E-9A80-2FED489F085C</string>
+			<key>PayloadUUID</key>
+			<string>A3EEBB71-CBA4-43BC-8A3F-987947F052FB</string>
+			<key>PayloadDisplayName</key>
+			<string>Custom</string>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.apple.AppleFileServer</key>
@@ -40,21 +42,21 @@
 				</dict>
 			</dict>
 			<key>PayloadDescription</key>
-			<string>6.1.4 - Ensure "Allow guest to connect to shared folders" is Disabled</string>
-			<key>PayloadDisplayName</key>
-			<string>Custom</string>
+			<string>6.1.4 - Ensure &quot;Allow guest to connect to shared folders&quot; is Disabled</string>
 			<key>PayloadEnabled</key>
 			<true/>
-			<key>PayloadIdentifier</key>
-			<string>A09998F2-A265-453E-9A80-2FED489F085C</string>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadUUID</key>
-			<string>A09998F2-A265-453E-9A80-2FED489F085C</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>EEB04D28-6A3F-4D30-9A8D-B05E6002B46B</string>
+			<key>PayloadUUID</key>
+			<string>98810DF4-5E04-4471-9A03-2E63E819DCEA</string>
+			<key>PayloadEnabled</key>
+			<true/>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.apple.smb.server</key>
@@ -72,20 +74,18 @@
 				</dict>
 			</dict>
 			<key>PayloadDescription</key>
-			<string>6.1.4 - Ensure "Allow guest to connect to shared folders" is Disabled</string>
+			<string>6.1.4 - Ensure &quot;Allow guest to connect to shared folders&quot; is Disabled</string>
 			<key>PayloadDisplayName</key>
 			<string>Custom</string>
-			<key>PayloadEnabled</key>
-			<true/>
-			<key>PayloadIdentifier</key>
-			<string>EEB04D28-6A3F-4D30-9A8D-B05E6002B46B</string>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadUUID</key>
-			<string>EEB04D28-6A3F-4D30-9A8D-B05E6002B46B</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 	</array>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/disable-guest-shares.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-guest-shares.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section5.GuestSharing</string>
 	<key>PayloadUUID</key>
-	<string>12079707-D14E-4B25-B468-81B52458A61B</string>
+	<string>86D6058B-C580-484C-A807-2E5EDA29A6DF</string>
 	<key>PayloadDisplayName</key>
 	<string>Disable guest access to shared folders</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>A09998F2-A265-453E-9A80-2FED489F085C</string>
 			<key>PayloadUUID</key>
-			<string>A3EEBB71-CBA4-43BC-8A3F-987947F052FB</string>
+			<string>A09998F2-A265-453E-9A80-2FED489F085C</string>
 			<key>PayloadDisplayName</key>
 			<string>Custom</string>
 			<key>PayloadContent</key>
@@ -54,7 +54,7 @@
 			<key>PayloadIdentifier</key>
 			<string>EEB04D28-6A3F-4D30-9A8D-B05E6002B46B</string>
 			<key>PayloadUUID</key>
-			<string>98810DF4-5E04-4471-9A03-2E63E819DCEA</string>
+			<string>EEB04D28-6A3F-4D30-9A8D-B05E6002B46B</string>
 			<key>PayloadEnabled</key>
 			<true/>
 			<key>PayloadContent</key>

--- a/it-and-security/lib/macos/configuration-profiles/disable-internet-sharing.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-internet-sharing.mobileconfig
@@ -2,42 +2,42 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Disable internet sharing</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section2.InternetSharing</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>685F2446-2DDD-4840-A219-46703868B12B</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section2.InternetSharing</string>
+	<key>PayloadUUID</key>
+	<string>61FC4FDA-05D4-41EA-922C-5968C336138F</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable internet sharing</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>6.1.3 - Ensure Guest Account Is Disabled</string>
-			<key>PayloadIdentifier</key>
-			<string>CIS.macOS.internetsharing</string>
 			<key>PayloadType</key>
 			<string>com.apple.MCX</string>
-			<key>PayloadUUID</key>
-			<string>CC8EE9F2-3AC3-45CB-8389-1873C9459A29</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>CIS.macOS.internetsharing</string>
+			<key>PayloadUUID</key>
+			<string>FAD5484A-A9AC-4574-B701-067BA5996923</string>
 			<key>forceInternetSharingOff</key>
 			<true/>
+			<key>PayloadDisplayName</key>
+			<string>6.1.3 - Ensure Guest Account Is Disabled</string>
 		</dict>
 	</array>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadOrganization</key>
+	<string>Center for Internet Security</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/disable-internet-sharing.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-internet-sharing.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.InternetSharing</string>
 	<key>PayloadUUID</key>
-	<string>61FC4FDA-05D4-41EA-922C-5968C336138F</string>
+	<string>685F2446-2DDD-4840-A219-46703868B12B</string>
 	<key>PayloadDisplayName</key>
 	<string>Disable internet sharing</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>CIS.macOS.internetsharing</string>
 			<key>PayloadUUID</key>
-			<string>FAD5484A-A9AC-4574-B701-067BA5996923</string>
+			<string>CC8EE9F2-3AC3-45CB-8389-1873C9459A29</string>
 			<key>forceInternetSharingOff</key>
 			<true/>
 			<key>PayloadDisplayName</key>

--- a/it-and-security/lib/macos/configuration-profiles/disable-media-sharing.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-media-sharing.mobileconfig
@@ -2,46 +2,46 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Disable media sharing</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section2.MediaSharing</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>F8C75AB0-FDE9-46D0-A929-EC109BA61706</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section2.MediaSharing</string>
+	<key>PayloadUUID</key>
+	<string>30AB3B15-AF3C-46F3-9283-29F03BBECC2C</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable media sharing</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>2.4.11 - Ensure Media Sharing Is Disabled</string>
-			<key>PayloadIdentifier</key>
-			<string>CIS.macOS.mediasharingdisabled</string>
 			<key>PayloadType</key>
 			<string>com.apple.preferences.sharing.SharingPrefsExtension</string>
-			<key>PayloadUUID</key>
-			<string>20DD77EF-A359-4D63-87AA-30AFC916B261</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>CIS.macOS.mediasharingdisabled</string>
+			<key>PayloadUUID</key>
+			<string>3C11598F-FACF-4ED7-8477-2163FC0990D4</string>
 			<key>homeSharingUIStatus</key>
-			<integer>0</integer>
-			<key>legacySharingUIStatus</key>
 			<integer>0</integer>
 			<key>mediaSharingUIStatus</key>
 			<integer>0</integer>
+			<key>PayloadDisplayName</key>
+			<string>2.4.11 - Ensure Media Sharing Is Disabled</string>
+			<key>legacySharingUIStatus</key>
+			<integer>0</integer>
 		</dict>
 	</array>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadOrganization</key>
+	<string>Center for Internet Security</string>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/disable-media-sharing.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-media-sharing.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.MediaSharing</string>
 	<key>PayloadUUID</key>
-	<string>30AB3B15-AF3C-46F3-9283-29F03BBECC2C</string>
+	<string>F8C75AB0-FDE9-46D0-A929-EC109BA61706</string>
 	<key>PayloadDisplayName</key>
 	<string>Disable media sharing</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>CIS.macOS.mediasharingdisabled</string>
 			<key>PayloadUUID</key>
-			<string>3C11598F-FACF-4ED7-8477-2163FC0990D4</string>
+			<string>20DD77EF-A359-4D63-87AA-30AFC916B261</string>
 			<key>homeSharingUIStatus</key>
 			<integer>0</integer>
 			<key>mediaSharingUIStatus</key>

--- a/it-and-security/lib/macos/configuration-profiles/disable-safari-safefiles.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-safari-safefiles.mobileconfig
@@ -2,27 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Disable Safari Safe Files</string>
-	<key>PayloadEnabled</key>
-	<true/>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.Section6.SafariSafeFiles</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>EC6020B6-EAF9-4632-BCD4-FE2A289EFF05</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.Section6.SafariSafeFiles</string>
+	<key>PayloadUUID</key>
+	<string>ADCE9EF1-B05D-4D32-9599-8C4B703AAEA8</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable Safari Safe Files</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>3589C72C-145C-43D1-85D9-7EECE1201775</string>
+			<key>PayloadUUID</key>
+			<string>2147345D-4DC3-446C-8F16-960063DA685E</string>
+			<key>PayloadEnabled</key>
+			<true/>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.apple.Safari</key>
@@ -43,17 +45,15 @@
 			<string>6.3 - Ensure Automatic Opening of Safe Files in Safari Is Disabled</string>
 			<key>PayloadDisplayName</key>
 			<string>Custom</string>
-			<key>PayloadEnabled</key>
-			<true/>
-			<key>PayloadIdentifier</key>
-			<string>3589C72C-145C-43D1-85D9-7EECE1201775</string>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadUUID</key>
-			<string>3589C72C-145C-43D1-85D9-7EECE1201775</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 	</array>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadEnabled</key>
+	<true/>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/disable-safari-safefiles.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/disable-safari-safefiles.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.Section6.SafariSafeFiles</string>
 	<key>PayloadUUID</key>
-	<string>ADCE9EF1-B05D-4D32-9599-8C4B703AAEA8</string>
+	<string>EC6020B6-EAF9-4632-BCD4-FE2A289EFF05</string>
 	<key>PayloadDisplayName</key>
 	<string>Disable Safari Safe Files</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>3589C72C-145C-43D1-85D9-7EECE1201775</string>
 			<key>PayloadUUID</key>
-			<string>2147345D-4DC3-446C-8F16-960063DA685E</string>
+			<string>3589C72C-145C-43D1-85D9-7EECE1201775</string>
 			<key>PayloadEnabled</key>
 			<true/>
 			<key>PayloadContent</key>

--- a/it-and-security/lib/macos/configuration-profiles/enable-doh.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/enable-doh.mobileconfig
@@ -2,9 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.paulmillr.apple-dns</string>
+	<key>PayloadUUID</key>
+	<string>62919323-09CB-4F3C-83C7-A43D6C76DCE0</string>
+	<key>PayloadDisplayName</key>
+	<string>Configure Cloudflare encrypted DNS over HTTPS</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
+			<key>PayloadUUID</key>
+			<string>7B73D8B5-314E-474D-8328-8F4721593C45</string>
+			<key>ProhibitDisablement</key>
+			<false/>
 			<key>DNSSettings</key>
 			<dict>
 				<key>DNSProtocol</key>
@@ -23,31 +43,11 @@
 			<string>Configures device to use Cloudflare Encrypted DNS over HTTPS</string>
 			<key>PayloadDisplayName</key>
 			<string>Cloudflare DNS over HTTPS</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
-			<key>PayloadType</key>
-			<string>com.apple.dnsSettings.managed</string>
-			<key>PayloadUUID</key>
-			<string>35d5c8a0-afa6-4b36-a9fe-099a997b44ad</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
-			<key>ProhibitDisablement</key>
-			<false/>
 		</dict>
 	</array>
 	<key>PayloadDescription</key>
 	<string>Adds the Cloudflare DNS to Big Sur and iOS 14 based systems</string>
-	<key>PayloadDisplayName</key>
-	<string>Configure Cloudflare encrypted DNS over HTTPS</string>
-	<key>PayloadIdentifier</key>
-	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>A4475135-633A-4F15-A79B-BE15093DC97A</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/enable-firewall-logging.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/enable-firewall-logging.mobileconfig
@@ -2,46 +2,46 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on Firewall logging</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section3.Logging</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>B106812C-DFDB-441C-9545-11FE40C1C5E9</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section3.Logging</string>
+	<key>PayloadUUID</key>
+	<string>767E4EA8-B387-4D4F-B8F5-5E68518A3FF6</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on Firewall logging</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>3.6 - Ensure Firewall Is Enabled and Configured</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.security.firewall</string>
 			<key>PayloadType</key>
 			<string>com.apple.security.firewall</string>
-			<key>PayloadUUID</key>
-			<string>FDC200F2-7D54-4257-AD45-B653B03C0BF9</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
-			<key>EnableFirewall</key>
-			<true/>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.security.firewall</string>
+			<key>PayloadUUID</key>
+			<string>E1037F74-3254-405B-A944-EF5C82581A23</string>
 			<key>EnableLogging</key>
 			<true/>
-			<key>LoggingOption</key>			
+			<key>LoggingOption</key>
 			<string>detail</string>
+			<key>PayloadDisplayName</key>
+			<string>3.6 - Ensure Firewall Is Enabled and Configured</string>
+			<key>EnableFirewall</key>
+			<true/>
 		</dict>
 	</array>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 12.0 (v1.0.0)</string>
+	<key>PayloadOrganization</key>
+	<string>Center for Internet Security</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadScope</key>
+	<string>System</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/enable-firewall-logging.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/enable-firewall-logging.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section3.Logging</string>
 	<key>PayloadUUID</key>
-	<string>767E4EA8-B387-4D4F-B8F5-5E68518A3FF6</string>
+	<string>B106812C-DFDB-441C-9545-11FE40C1C5E9</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on Firewall logging</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.security.firewall</string>
 			<key>PayloadUUID</key>
-			<string>E1037F74-3254-405B-A944-EF5C82581A23</string>
+			<string>FDC200F2-7D54-4257-AD45-B653B03C0BF9</string>
 			<key>EnableLogging</key>
 			<true/>
 			<key>LoggingOption</key>

--- a/it-and-security/lib/macos/configuration-profiles/enable-gatekeeper.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/enable-gatekeeper.mobileconfig
@@ -2,44 +2,44 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on Gatekeeper</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section2.GateKeeper</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>CA95CACF-8D79-4D6F-B804-653B90D7E437</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section2.GateKeeper</string>
+	<key>PayloadUUID</key>
+	<string>83D5AEBA-A214-4ACF-9DC6-1F59EBEF70F9</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on Gatekeeper</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>2.5.2.1 - Ensure Gatekeeper Is Enabled</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.systempolicy.control</string>
 			<key>PayloadType</key>
 			<string>com.apple.systempolicy.control</string>
-			<key>PayloadUUID</key>
-			<string>38554FF7-80E0-4EF1-BA44-7DE20B407797</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.systempolicy.control</string>
+			<key>PayloadUUID</key>
+			<string>34F3BE3F-894F-4F8C-97F5-C516431B5E74</string>
 			<key>AllowIdentifiedDevelopers</key>
 			<true/>
 			<key>EnableAssessment</key>
 			<true/>
+			<key>PayloadDisplayName</key>
+			<string>2.5.2.1 - Ensure Gatekeeper Is Enabled</string>
 		</dict>
 	</array>
+	<key>PayloadOrganization</key>
+	<string>Center for Internet Security</string>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/enable-gatekeeper.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/enable-gatekeeper.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.GateKeeper</string>
 	<key>PayloadUUID</key>
-	<string>83D5AEBA-A214-4ACF-9DC6-1F59EBEF70F9</string>
+	<string>CA95CACF-8D79-4D6F-B804-653B90D7E437</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on Gatekeeper</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.systempolicy.control</string>
 			<key>PayloadUUID</key>
-			<string>34F3BE3F-894F-4F8C-97F5-C516431B5E74</string>
+			<string>38554FF7-80E0-4EF1-BA44-7DE20B407797</string>
 			<key>AllowIdentifiedDevelopers</key>
 			<true/>
 			<key>EnableAssessment</key>

--- a/it-and-security/lib/macos/configuration-profiles/enforce-library-validation.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/enforce-library-validation.mobileconfig
@@ -2,28 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on Library Validation</string>
-	<key>PayloadEnabled</key>
-	<true/>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section4.LibraryValidation</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>5D7D35E5-541C-4A1A-9CBB-B1336455803B</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section4.LibraryValidation</string>
+	<key>PayloadUUID</key>
+	<string>3BD11D62-C52E-4D16-B198-C8EE448593E4</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on Library Validation</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>065655A2-90A6-4ABB-8179-0E2F3E7ADC4F</string>
+			<key>PayloadUUID</key>
+			<string>2D4AEF9B-18A2-43B7-8FE2-92C0ABF9C2E9</string>
+			<key>PayloadDescription</key>
+			<string>Disables Library Validation</string>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.apple.security.libraryvalidation</key>
@@ -40,21 +41,19 @@
 					</array>
 				</dict>
 			</dict>
-			<key>PayloadDescription</key>
-			<string>Disables Library Validation</string>
-			<key>PayloadDisplayName</key>
-			<string>5.20 - Ensure Library Validation Is Enabled</string>
 			<key>PayloadEnabled</key>
 			<true/>
-			<key>PayloadIdentifier</key>
-			<string>065655A2-90A6-4ABB-8179-0E2F3E7ADC4F</string>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadUUID</key>
-			<string>065655A2-90A6-4ABB-8179-0E2F3E7ADC4F</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
+			<key>PayloadDisplayName</key>
+			<string>5.20 - Ensure Library Validation Is Enabled</string>
 		</dict>
 	</array>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/enforce-library-validation.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/enforce-library-validation.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section4.LibraryValidation</string>
 	<key>PayloadUUID</key>
-	<string>3BD11D62-C52E-4D16-B198-C8EE448593E4</string>
+	<string>5D7D35E5-541C-4A1A-9CBB-B1336455803B</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on Library Validation</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>065655A2-90A6-4ABB-8179-0E2F3E7ADC4F</string>
 			<key>PayloadUUID</key>
-			<string>2D4AEF9B-18A2-43B7-8FE2-92C0ABF9C2E9</string>
+			<string>065655A2-90A6-4ABB-8179-0E2F3E7ADC4F</string>
 			<key>PayloadDescription</key>
 			<string>Disables Library Validation</string>
 			<key>PayloadContent</key>

--- a/it-and-security/lib/macos/configuration-profiles/ensure-show-status-bar-is-enabled.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/ensure-show-status-bar-is-enabled.mobileconfig
@@ -1,37 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-	<dict>
-		<key>PayloadContent</key>
-		<array>
-			<dict>
-				<key>PayloadDisplayName</key>
-				<string>Ensure Show Status Bar Is Enabled</string>
-				<key>PayloadType</key>
-				<string>com.apple.Safari</string>
-				<key>PayloadIdentifier</key>
-				<string>com.fleetdm.cis-ensure-show-status-bar-is-enabled</string>
-				<key>PayloadUUID</key>
-				<string>708B39DB-E2B7-405C-A523-88F3DDC8DFFC</string>
-				<key>ShowOverlayStatusBar</key>
-				<true/>
-			</dict>
-		</array>
-		<key>PayloadDescription</key>
-		<string>Ensure Show Status Bar Is Enabled</string>
-		<key>PayloadDisplayName</key>
-		<string>Ensure Show Status Bar Is Enabled</string>
-		<key>PayloadIdentifier</key>
-		<string>com.fleetdm.cis-ensure-show-status-bar-is-enabled</string>
-		<key>PayloadRemovalDisallowed</key>
-		<false/>
-		<key>PayloadScope</key>
-		<string>System</string>
-		<key>PayloadType</key>
-		<string>Configuration</string>
-		<key>PayloadUUID</key>
-		<string>00FB5D02-8044-4E6F-884C-D73E7A32A2E7</string>
-		<key>PayloadVersion</key>
-		<integer>1</integer>
-	</dict>
+<dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-ensure-show-status-bar-is-enabled</string>
+	<key>PayloadUUID</key>
+	<string>949F0A1F-0486-4B47-A75C-E6D578F74300</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Show Status Bar Is Enabled</string>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.Safari</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-ensure-show-status-bar-is-enabled</string>
+			<key>PayloadUUID</key>
+			<string>75AC3663-83A9-4A94-A423-981F6113A1A7</string>
+			<key>PayloadDisplayName</key>
+			<string>Ensure Show Status Bar Is Enabled</string>
+			<key>ShowOverlayStatusBar</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadDescription</key>
+	<string>Ensure Show Status Bar Is Enabled</string>
+</dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/ensure-show-status-bar-is-enabled.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/ensure-show-status-bar-is-enabled.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.cis-ensure-show-status-bar-is-enabled</string>
 	<key>PayloadUUID</key>
-	<string>949F0A1F-0486-4B47-A75C-E6D578F74300</string>
+	<string>00FB5D02-8044-4E6F-884C-D73E7A32A2E7</string>
 	<key>PayloadDisplayName</key>
 	<string>Ensure Show Status Bar Is Enabled</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.cis-ensure-show-status-bar-is-enabled</string>
 			<key>PayloadUUID</key>
-			<string>75AC3663-83A9-4A94-A423-981F6113A1A7</string>
+			<string>708B39DB-E2B7-405C-A523-88F3DDC8DFFC</string>
 			<key>PayloadDisplayName</key>
 			<string>Ensure Show Status Bar Is Enabled</string>
 			<key>ShowOverlayStatusBar</key>

--- a/it-and-security/lib/macos/configuration-profiles/firewall.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/firewall.mobileconfig
@@ -2,48 +2,48 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.F302AA03-F873-4249-A1C3-7BD94B9B855F</string>
+	<key>PayloadUUID</key>
+	<string>253B89F8-0F0D-423A-8D21-42EFAB2E30F1</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on Firewall stealth mode</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>AllowSigned</key>
-			<true/>
-			<key>BlockAllIncoming</key>
-			<false/>
-			<key>EnableFirewall</key>
-			<true/>
-			<key>EnableStealthMode</key>
-			<false/>
+			<key>PayloadType</key>
+			<string>com.apple.security.firewall</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.0E0E1617-E88D-45C6-9E9B-C56BFD80C730</string>
+			<key>PayloadUUID</key>
+			<string>33E24FC2-014F-43A6-94E1-51ED905BF530</string>
 			<key>PayloadDescription</key>
 			<string>Configures Firewall settings</string>
 			<key>PayloadDisplayName</key>
 			<string>Firewall</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.0E0E1617-E88D-45C6-9E9B-C56BFD80C730</string>
 			<key>PayloadOrganization</key>
 			<string></string>
-			<key>PayloadType</key>
-			<string>com.apple.security.firewall</string>
-			<key>PayloadUUID</key>
-			<string>0E0E1617-E88D-45C6-9E9B-C56BFD80C730</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
+			<key>BlockAllIncoming</key>
+			<false/>
+			<key>AllowSigned</key>
+			<true/>
+			<key>EnableFirewall</key>
+			<true/>
+			<key>EnableStealthMode</key>
+			<false/>
 		</dict>
 	</array>
-	<key>PayloadDescription</key>
-	<string>Configures the firewall to be enabled in stealth mode</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on Firewall stealth mode</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.F302AA03-F873-4249-A1C3-7BD94B9B855F</string>
 	<key>PayloadOrganization</key>
 	<string>Fleet</string>
+	<key>PayloadDescription</key>
+	<string>Configures the firewall to be enabled in stealth mode</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>F302AA03-F873-4249-A1C3-7BD94B9B855F</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/firewall.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/firewall.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.F302AA03-F873-4249-A1C3-7BD94B9B855F</string>
 	<key>PayloadUUID</key>
-	<string>253B89F8-0F0D-423A-8D21-42EFAB2E30F1</string>
+	<string>F302AA03-F873-4249-A1C3-7BD94B9B855F</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on Firewall stealth mode</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.0E0E1617-E88D-45C6-9E9B-C56BFD80C730</string>
 			<key>PayloadUUID</key>
-			<string>33E24FC2-014F-43A6-94E1-51ED905BF530</string>
+			<string>0E0E1617-E88D-45C6-9E9B-C56BFD80C730</string>
 			<key>PayloadDescription</key>
 			<string>Configures Firewall settings</string>
 			<key>PayloadDisplayName</key>

--- a/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launch-agent.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launch-agent.mobileconfig
@@ -2,53 +2,53 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>PayloadContent</key>
-    <array>
-        <dict>
-            <key>PayloadDescription</key>
-            <string>Manages the Fleet Desktop.app launch agent so it can run at login without prompting the user.</string>
-            <key>PayloadDisplayName</key>
-            <string>Fleet Desktop.app launch agent</string>
-            <key>PayloadIdentifier</key>
-            <string>com.fleetdm.servicemanagement.fleet-desktop-launchagent</string>
-            <key>PayloadType</key>
-            <string>com.apple.servicemanagement</string>
-            <key>PayloadUUID</key>
-            <string>A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-            <key>Rules</key>
-            <array>
-                <dict>
-                    <key>RuleType</key>
-                    <string>Label</string>
-                    <key>RuleValue</key>
-                    <string>com.fleetdm.fleet-desktop-hidden</string>
-                    <key>TeamIdentifier</key>
-                    <string>8VBZ3948LU</string>
-                    <key>Comment</key>
-                    <string>Allow Fleet Desktop.app launch agent to run at login without user prompt.</string>
-                </dict>
-            </array>
-        </dict>
-    </array>
-    <key>PayloadDescription</key>
-    <string>Configures managed Login and Background items for Fleet Desktop.app.</string>
-    <key>PayloadDisplayName</key>
-    <string>Fleet Desktop.app login item management</string>
-    <key>PayloadIdentifier</key>
-    <string>com.fleetdm.profile.fleet-desktop-launchagent</string>
-    <key>PayloadOrganization</key>
-    <string>Fleet</string>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
-    <key>PayloadScope</key>
-    <string>System</string>
-    <key>PayloadType</key>
-    <string>Configuration</string>
-    <key>PayloadUUID</key>
-    <string>F9E8D7C6-B5A4-4938-8271-605F4E3D2C1B</string>
-    <key>PayloadVersion</key>
-    <integer>1</integer>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.profile.fleet-desktop-launchagent</string>
+	<key>PayloadUUID</key>
+	<string>56473CDB-534C-4A1F-99FE-A89FEEFF0B45</string>
+	<key>PayloadDisplayName</key>
+	<string>Fleet Desktop.app login item management</string>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.servicemanagement</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.servicemanagement.fleet-desktop-launchagent</string>
+			<key>PayloadUUID</key>
+			<string>5555D26D-A26C-46DD-B834-E0C9989276EE</string>
+			<key>PayloadDescription</key>
+			<string>Manages the Fleet Desktop.app launch agent so it can run at login without prompting the user.</string>
+			<key>Rules</key>
+			<array>
+				<dict>
+					<key>RuleType</key>
+					<string>Label</string>
+					<key>RuleValue</key>
+					<string>com.fleetdm.fleet-desktop-hidden</string>
+					<key>TeamIdentifier</key>
+					<string>8VBZ3948LU</string>
+					<key>Comment</key>
+					<string>Allow Fleet Desktop.app launch agent to run at login without user prompt.</string>
+				</dict>
+			</array>
+			<key>PayloadDisplayName</key>
+			<string>Fleet Desktop.app launch agent</string>
+		</dict>
+	</array>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadDescription</key>
+	<string>Configures managed Login and Background items for Fleet Desktop.app.</string>
+	<key>PayloadOrganization</key>
+	<string>Fleet</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launch-agent.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-desktop-launch-agent.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.profile.fleet-desktop-launchagent</string>
 	<key>PayloadUUID</key>
-	<string>56473CDB-534C-4A1F-99FE-A89FEEFF0B45</string>
+	<string>F9E8D7C6-B5A4-4938-8271-605F4E3D2C1B</string>
 	<key>PayloadDisplayName</key>
 	<string>Fleet Desktop.app login item management</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.servicemanagement.fleet-desktop-launchagent</string>
 			<key>PayloadUUID</key>
-			<string>5555D26D-A26C-46DD-B834-E0C9989276EE</string>
+			<string>A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D</string>
 			<key>PayloadDescription</key>
 			<string>Manages the Fleet Desktop.app launch agent so it can run at login without prompting the user.</string>
 			<key>Rules</key>

--- a/it-and-security/lib/macos/configuration-profiles/fleet-okta-conditional-access.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-okta-conditional-access.mobileconfig
@@ -1,31 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<!-- Trusted CA certificate -->
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.conditional-access-okta</string>
+	<key>PayloadUUID</key>
+	<string>4104C587-3E3D-4CDC-9F24-E55FE63004F2</string>
+	<key>PayloadDisplayName</key>
+	<string>Fleet conditional access for Okta</string>
 	<key>PayloadContent</key>
 	<array>
-        <!-- Trusted CA certificate -->
-        <dict>
-            <key>PayloadCertificateFileName</key>
-            <string>conditional_access_ca.der</string>
-            <key>PayloadContent</key>
-            <data>$DOGFOOD_OKTA_CA_CERTIFICATE</data>
-            <key>PayloadDescription</key>
-            <string>Fleet conditional access CA certificate</string>
-            <key>PayloadDisplayName</key>
-            <string>Fleet conditional access CA</string>
-            <key>PayloadIdentifier</key>
-            <string>com.fleetdm.conditional-access-ca</string>
-            <key>PayloadType</key>
-            <string>com.apple.security.root</string>
-            <key>PayloadUUID</key>
-            <string>c6d7357b-5b6b-5577-bd3f-e6c886bad550</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-        </dict>
 		<!-- SCEP configuration -->
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.security.root</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.conditional-access-ca</string>
+			<key>PayloadUUID</key>
+			<string>FD2893F3-6FD9-4FBC-A26F-D698E4EC47A9</string>
 			<key>PayloadContent</key>
+			<data>
+			$DOGFOOD_OKTA_CA_CERTIFICATE
+			</data>
+			<key>PayloadDescription</key>
+			<string>Fleet conditional access CA certificate</string>
+			<key>PayloadCertificateFileName</key>
+			<string>conditional_access_ca.der</string>
+			<key>PayloadDisplayName</key>
+			<string>Fleet conditional access CA</string>
+		</dict>
+		<!-- Identity preference for mTLS endpoint -->
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.security.scep</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.conditional-access-scep</string>
+			<key>PayloadUUID</key>
+			<string>E42B2DBC-DB2A-4DD8-A413-41E432842F2B</string>
+			<key>PayloadDescription</key>
+			<string>Configures SCEP for Fleet conditional access for Okta certificate</string>
+			<key>PayloadContent</key>
+			<!-- Chrome web browser configuration -->
 			<dict>
 				<key>URL</key>
 				<string>https://dogfood.fleetdm.com/api/fleet/conditional_access/scep</string>
@@ -37,10 +61,10 @@
 				<string>RSA</string>
 				<key>Key Usage</key>
 				<integer>5</integer>
-                <key>ExtendedKeyUsage</key>
-                <array>
-                    <string>1.3.6.1.5.5.7.3.2</string>
-                </array>
+				<key>ExtendedKeyUsage</key>
+				<array>
+					<string>1.3.6.1.5.5.7.3.2</string>
+				</array>
 				<key>Subject</key>
 				<array>
 					<array>
@@ -61,97 +85,73 @@
 				<integer>3</integer>
 				<key>RetryDelay</key>
 				<integer>10</integer>
-                <!-- ACL for browser access -->
-                <key>AllowAllAppsAccess</key>
-                <true/>
-                <key>KeyIsExtractable</key>
-                <false/>
+				<!-- ACL for browser access -->
+				<key>AllowAllAppsAccess</key>
+				<true/>
+				<key>KeyIsExtractable</key>
+				<false/>
 			</dict>
-			<key>PayloadDescription</key>
-			<string>Configures SCEP for Fleet conditional access for Okta certificate</string>
 			<key>PayloadDisplayName</key>
 			<string>Fleet conditional access SCEP</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.conditional-access-scep</string>
+		</dict>
+		<dict>
 			<key>PayloadType</key>
-			<string>com.apple.security.scep</string>
-			<key>PayloadUUID</key>
-			<string>478f8ebd-ded5-5808-962d-36da7aa06afe</string>
+			<string>com.apple.security.identitypreference</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.conditional-access-preference</string>
+			<key>PayloadUUID</key>
+			<string>B8444DA6-9474-460F-BB7D-CF92E9035183</string>
+			<key>PayloadDescription</key>
+			<string>Identity preference for mTLS endpoints</string>
+			<key>PayloadCertificateUUID</key>
+			<string>478f8ebd-ded5-5808-962d-36da7aa06afe</string>
+			<key>PayloadDisplayName</key>
+			<string>Fleet mTLS identity preference</string>
+			<key>Name</key>
+			<string>https://okta.dogfood.fleetdm.com</string>
 		</dict>
-        <!-- Identity preference for mTLS endpoint -->
-        <dict>
-            <key>Name</key>
-            <string>https://okta.dogfood.fleetdm.com</string>
-            <key>PayloadCertificateUUID</key>
-            <string>478f8ebd-ded5-5808-962d-36da7aa06afe</string>
-            <key>PayloadDescription</key>
-            <string>Identity preference for mTLS endpoints</string>
-            <key>PayloadDisplayName</key>
-            <string>Fleet mTLS identity preference</string>
-            <key>PayloadIdentifier</key>
-            <string>com.fleetdm.conditional-access-preference</string>
-            <key>PayloadType</key>
-            <string>com.apple.security.identitypreference</string>
-            <key>PayloadUUID</key>
-            <string>686b683a-9052-5fe5-8dca-31b51b17bb2c</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-        </dict>
-        <!-- Chrome web browser configuration -->
-        <dict>
-            <key>PayloadType</key>
-            <string>com.apple.ManagedClient.preferences</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-            <key>PayloadIdentifier</key>
-            <string>com.fleetdm.chrome.certs</string>
-            <key>PayloadUUID</key>
-            <string>1c1ab10a-e7b5-5c76-937e-03001cc9bffb</string>
-            <key>PayloadDisplayName</key>
-            <string>Chrome mTLS auto-select</string>
-            <key>PayloadContent</key>
-            <dict>
-                <key>com.google.Chrome</key>
-                <dict>
-                    <key>Forced</key>
-                    <array>
-                        <dict>
-                            <key>mcx_preference_settings</key>
-                            <dict>
-                                <key>AllowPolicyInIncognito</key>
-                                <true/>
-                                <key>AutoSelectCertificateForUrls</key>
-                                <array>
-                                    <!-- MUST be stringified JSON -->
-                                    <string>{"pattern":"https://okta.dogfood.fleetdm.com","filter":{"SUBJECT":{"CN":"Fleet conditional access for Okta"}}}</string>
-                                </array>
-                            </dict>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.chrome.certs</string>
+			<key>PayloadUUID</key>
+			<string>89D47D93-B124-451B-9615-D2E2AA75BD7E</string>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.google.Chrome</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>AllowPolicyInIncognito</key>
+								<true/>
+								<key>AutoSelectCertificateForUrls</key>
+								<array>
+									<string>{&quot;pattern&quot;:&quot;https://okta.dogfood.fleetdm.com&quot;,&quot;filter&quot;:{&quot;SUBJECT&quot;:{&quot;CN&quot;:&quot;Fleet conditional access for Okta&quot;}}}</string>
+								</array>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>PayloadDisplayName</key>
+			<string>Chrome mTLS auto-select</string>
+		</dict>
 	</array>
-	<key>PayloadDescription</key>
-	<string>Configures SCEP enrollment for Okta conditional access</string>
-	<key>PayloadDisplayName</key>
-	<string>Fleet conditional access for Okta</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.conditional-access-okta</string>
 	<key>PayloadOrganization</key>
 	<string>Fleet Device Management</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadDescription</key>
+	<string>Configures SCEP enrollment for Okta conditional access</string>
 	<key>PayloadScope</key>
 	<string>User</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>fa49f664-378e-5098-bc32-d8160215f873</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>
-

--- a/it-and-security/lib/macos/configuration-profiles/fleet-okta-conditional-access.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-okta-conditional-access.mobileconfig
@@ -106,7 +106,7 @@
 			<key>PayloadDescription</key>
 			<string>Identity preference for mTLS endpoints</string>
 			<key>PayloadCertificateUUID</key>
-			<string>478f8ebd-ded5-5808-962d-36da7aa06afe</string>
+			<string>E42B2DBC-DB2A-4DD8-A413-41E432842F2B</string>
 			<key>PayloadDisplayName</key>
 			<string>Fleet mTLS identity preference</string>
 			<key>Name</key>

--- a/it-and-security/lib/macos/configuration-profiles/full-disk-access-for-fleetd.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/full-disk-access-for-fleetd.mobileconfig
@@ -2,23 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.github.erikberglund.ProfileCreator.2C1ED825-A0C3-4274-B0AD-40B80FCA4F71</string>
+	<key>PayloadUUID</key>
+	<string>BBAB45FD-0687-4823-95F9-2F0AD66ADA54</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on full disk access for fleetd</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDescription</key>
-			<string>Configures Privacy Preferences Policy Control settings</string>
-			<key>PayloadDisplayName</key>
-			<string>Privacy Preferences Policy Control</string>
-			<key>PayloadIdentifier</key>
-			<string>com.github.erikberglund.ProfileCreator.2C1ED825-A0C3-4274-B0AD-40B80FCA4F71.com.apple.TCC.configuration-profile-policy.10C7E72A-C594-43B0-BB45-154848EBAED8</string>
-			<key>PayloadOrganization</key>
-			<string></string>
 			<key>PayloadType</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
-			<key>PayloadUUID</key>
-			<string>10C7E72A-C594-43B0-BB45-154848EBAED8</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.github.erikberglund.ProfileCreator.2C1ED825-A0C3-4274-B0AD-40B80FCA4F71.com.apple.TCC.configuration-profile-policy.10C7E72A-C594-43B0-BB45-154848EBAED8</string>
+			<key>PayloadUUID</key>
+			<string>FA1E27E2-F7D7-4732-8FB8-17CB829C1523</string>
+			<key>PayloadDisplayName</key>
+			<string>Privacy Preferences Policy Control</string>
+			<key>PayloadDescription</key>
+			<string>Configures Privacy Preferences Policy Control settings</string>
 			<key>Services</key>
 			<dict>
 				<key>SystemPolicyAllFiles</key>
@@ -27,7 +35,7 @@
 						<key>Allowed</key>
 						<true/>
 						<key>CodeRequirement</key>
-						<string>identifier "com.fleetdm.orbit" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8VBZ3948LU"</string>
+						<string>identifier &quot;com.fleetdm.orbit&quot; and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = &quot;8VBZ3948LU&quot;</string>
 						<key>Comment</key>
 						<string></string>
 						<key>Identifier</key>
@@ -41,7 +49,7 @@
 						<key>Allowed</key>
 						<true/>
 						<key>CodeRequirement</key>
-						<string>identifier "com.fleetdm.orbit" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8VBZ3948LU"</string>
+						<string>identifier &quot;com.fleetdm.orbit&quot; and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = &quot;8VBZ3948LU&quot;</string>
 						<key>Comment</key>
 						<string></string>
 						<key>Identifier</key>
@@ -53,23 +61,15 @@
 					</dict>
 				</array>
 			</dict>
+			<key>PayloadOrganization</key>
+			<string></string>
 		</dict>
 	</array>
 	<key>PayloadDescription</key>
 	<string>Grants full disk access to orbit and orbit edge</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on full disk access for fleetd</string>
-	<key>PayloadIdentifier</key>
-	<string>com.github.erikberglund.ProfileCreator.2C1ED825-A0C3-4274-B0AD-40B80FCA4F71</string>
 	<key>PayloadOrganization</key>
 	<string>FleetDM</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>2C1ED825-A0C3-4274-B0AD-40B80FCA4F71</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/full-disk-access-for-fleetd.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/full-disk-access-for-fleetd.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.2C1ED825-A0C3-4274-B0AD-40B80FCA4F71</string>
 	<key>PayloadUUID</key>
-	<string>BBAB45FD-0687-4823-95F9-2F0AD66ADA54</string>
+	<string>2C1ED825-A0C3-4274-B0AD-40B80FCA4F71</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on full disk access for fleetd</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.github.erikberglund.ProfileCreator.2C1ED825-A0C3-4274-B0AD-40B80FCA4F71.com.apple.TCC.configuration-profile-policy.10C7E72A-C594-43B0-BB45-154848EBAED8</string>
 			<key>PayloadUUID</key>
-			<string>FA1E27E2-F7D7-4732-8FB8-17CB829C1523</string>
+			<string>10C7E72A-C594-43B0-BB45-154848EBAED8</string>
 			<key>PayloadDisplayName</key>
 			<string>Privacy Preferences Policy Control</string>
 			<key>PayloadDescription</key>

--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -2,831 +2,831 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>PayloadContent</key>
-    <array>
-        <dict>
-            <key>PayloadDescription</key>
-            <string>Google Chrome managed bookmarks</string>
-            <key>PayloadDisplayName</key>
-            <string>Google Chrome managed bookmarks</string>
-            <key>PayloadIdentifier</key>
-            <string>com.google.Chrome.Fleet.ManagedBookmarks</string>
-            <key>PayloadType</key>
-            <string>com.google.Chrome</string>
-            <key>PayloadUUID</key>
-            <string>BCEC63A3-F17A-4F73-8521-6E54927B3537</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-            <key>ManagedBookmarks</key>
-            <array>
-                <dict>
-                    <key>name</key>
-                    <string>👋 New Fleeties | Fleet handbook</string>
-                    <key>url</key>
-                    <string>https://fleetdm.com/handbook/company/communications#new-fleeties</string>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>📖 The handbook</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>📖 The handbook (fleetdm.com)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🔭 Values 🔴🟠🟢🔵🟣 (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company#values</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🔭 Org chart (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company#org-chart</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🔭 Company (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>💭 Why this way? (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/why-this-way</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🔐 Security (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/it/security#security</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🛰️ Communications (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/communications</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🛰️ Writing (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/communications#writing</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🛰️ Writing in Fleet-flavored markdown (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/communications#writing-in-fleet-flavored-markdown</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🛠️ Leadership (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/leadership</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🚂 Getting a contract reviewed (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/go-to-market-operations#getting-a-contract-reviewed</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🚂 Getting a contract signed (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/go-to-market-operations#getting-a-contract-signed</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>📓 Releases notes (Fleet Docs)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/releases</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>📓 Get started (Fleet Docs)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/docs/get-started/why-fleet</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>📓 Tutorials and guides (Fleet Docs)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/docs/get-started/tutorials-and-guides</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>The Handbook | The GitLab Handbook</string>
-                            <key>url</key>
-                            <string>https://handbook.gitlab.com/handbook/</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Security Tools Terms - Google Sheets</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/spreadsheets/d/1bF7ct4Ibyo-GPaehFRwZrlN2PQqQmyi1D1gx-gqNlpc/edit?gid=0#gid=0</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>fleetdm.com</string>
-                            <key>children</key>
-                            <array>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Query generator</string>
-                                    <key>url</key>
-                                    <string>https://fleetdm.com/query-generator</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>License key tool</string>
-                                    <key>url</key>
-                                    <string>https://fleetdm.com/admin/generate-license#login</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>🏷️ Pricing (fleetdm.com)</string>
-                                    <key>url</key>
-                                    <string>https://fleetdm.com/pricing</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>🎙️ Announcements (fleetdm.com)</string>
-                                    <key>url</key>
-                                    <string>https://fleetdm.com/announcements</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>🧑‍🚀 Open positions (Handbook)</string>
-                                    <key>url</key>
-                                    <string>https://fleetdm.com/handbook/company#open-positions</string>
-                                </dict>
-                            </array>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string> The ABCs</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🗂️</string>
-                            <key>children</key>
-                            <array>
-                                <dict>
-                                    <key>name</key>
-                                    <string>All hands - ask me anything (AMA) - Google Docs</string>
-                                    <key>url</key>
-                                    <string>https://docs.google.com/document/d/1tKsaZmJ7BP8arWia_CUerbQY4p20O-oBABjG2aDmC0w/edit?tab=t.0</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>+new whiteboard</string>
-                                    <key>url</key>
-                                    <string>https://docs.google.com/document/create?usp=drive_web&amp;ouid=110737225569469728451&amp;folder=1prO98fmB2WKzpubZ2-z0sju9dQ4ijpNE</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>TEMPLATE - Meeting doc - Google Docs</string>
-                                    <key>url</key>
-                                    <string>https://docs.google.com/document/d/1TaZ654gTwadWGDYhP3zuAzWe0eiY0s9NhaU9KLCokgw/copy</string>
-                                </dict>
-                            </array>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>⛵️ Cheat sheets and useful links</string>
-                            <key>children</key>
-                            <array>
-                                <dict>
-                                    <key>name</key>
-                                    <string>git-cheat-sheet-education</string>
-                                    <key>url</key>
-                                    <string>https://education.github.com/git-cheat-sheet-education.pdf</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>GitHub Desktop keyboard shortcuts - GitHub Docs</string>
-                                    <key>url</key>
-                                    <string>https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/overview/github-desktop-keyboard-shortcuts</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Basic writing and formatting syntax - GitHub Docs</string>
-                                    <key>url</key>
-                                    <string>https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Keyboard shortcuts - GitHub Docs</string>
-                                    <key>url</key>
-                                    <string>https://docs.github.com/en/get-started/accessibility/keyboard-shortcuts#navigating-within-code-files</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>About code owners - GitHub Docs</string>
-                                    <key>url</key>
-                                    <string>https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string># Move this file into your user directory and rename this file to ".zshrc".txt - Google Drive</string>
-                                    <key>url</key>
-                                    <string>https://drive.google.com/file/d/10MrYfln6srMhj09HE5vSpRRZr8xUSCLW/view</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>HTML URL Encoding Reference</string>
-                                    <key>url</key>
-                                    <string>https://www.w3schools.com/tags/ref_urlencode.ASP</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>URL Encode and Decode - Online</string>
-                                    <key>url</key>
-                                    <string>https://www.urlencoder.org/</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>The 9 Enneagram Types — The Enneagram Institute</string>
-                                    <key>url</key>
-                                    <string>https://www.enneagraminstitute.com/type-descriptions</string>
-                                </dict>
-                            </array>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🛩️ Travel</string>
-                            <key>children</key>
-                            <array>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Google Flights - Find Cheap Flight Options &amp; Track Prices</string>
-                                    <key>url</key>
-                                    <string>https://www.google.com/travel/flights?tcfs&amp;ved=2ahUKEwjeorSB1O2IAxVYwvIHHV6QI0EQ0I8EegQIAxAJ&amp;ictx=2</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>United Airlines - Airline Tickets, Travel Deals and Flights</string>
-                                    <key>url</key>
-                                    <string>https://www.united.com/en/us/</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Southwest Airlines | Book Flights, Make Reservations &amp; Plan a Trip</string>
-                                    <key>url</key>
-                                    <string>https://www.southwest.com/</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Google Maps</string>
-                                    <key>url</key>
-                                    <string>https://www.google.com/maps/@30.660359,-97.71092,14z?entry=ttu</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Tips on Austin, Texas - Reed Haynes - 2022-03-08 - Google Docs</string>
-                                    <key>url</key>
-                                    <string>https://docs.google.com/document/d/1sj9JJRSm4QNgDILYzHurV2kmQv00uondpAJ5kL-0TZs/edit#heading=h.v2mvb727yfe2</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Travel locations and stuff - Google Sheets</string>
-                                    <key>url</key>
-                                    <string>https://docs.google.com/spreadsheets/d/1LLRZph-ctmqKFYPUWfZs8LI89CbKsxvEGEqWuiq_-iA/edit#gid=0</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Alaska Airlines - Flight Deals and Cheap Airline Tickets - Book Today</string>
-                                    <key>url</key>
-                                    <string>https://www.alaskaair.com/</string>
-                                </dict>
-                                <dict>
-                                    <key>name</key>
-                                    <string>Offsite budget [template] - Google Sheets</string>
-                                    <key>url</key>
-                                    <string>https://docs.google.com/spreadsheets/d/1oe1wAFzerXlKghZaZtdlA7QrWBv9iZmHThlFYqfVzRQ/edit?gid=0#gid=0</string>
-                                </dict>
-                            </array>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🧑‍🚀 Fleeties (🧬 org chart &amp; team info)</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/spreadsheets/d/1OSLn-ZCbGSjPusHPiR5dwQhheH1K8-xqyZdsOe9y7qc/edit#gid=0</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>📈 OKRs (quarterly goals) + KPIs (everyday metrics)</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🎐 Why Fleet?</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/document/d/1E0VU4AcB6UTVRd4JKD45Saxh9Gz-mkO3LnGSTBDLEZo/edit#heading=h.vfxwnwufxzzi</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>GitHub Projects · fleetdm</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects?query=is%3Aopen</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>My PRs</string>
-                            <key>url</key>
-                            <string>https://github.com/pulls</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>PRs waiting on me</string>
-                            <key>url</key>
-                            <string>https://github.com/pulls/review-requested</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Issue: 🦟Bug report</string>
-                            <key>url</key>
-                            <string>https://github.com/fleetdm/fleet/issues/new?template=bug-report.md</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Issue: +New public issue</string>
-                            <key>url</key>
-                            <string>https://github.com/fleetdm/fleet/issues/new/choose</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Issue: +New confidential issue</string>
-                            <key>url</key>
-                            <string>https://github.com/fleetdm/confidential/issues/new/choose</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Issues assigned to me</string>
-                            <key>url</key>
-                            <string>https://github.com/issues?q=is%3Aopen%20is%3Aissue%20archived%3Afalse%20org%3Afleetdm%20no%3Amilestone%20assignee%3A%40me%20%20sort%3Aupdated-desc</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>1Password for Fleet</string>
-                            <key>url</key>
-                            <string>https://fleetdevicemanagement.1password.com/home</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Gmail Inbox - Fleet</string>
-                            <key>url</key>
-                            <string>https://mail.google.com/mail/u/0/#inbox</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Google Calendar</string>
-                            <key>url</key>
-                            <string>https://calendar.google.com/calendar/u/0/r</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Google Docs - Template gallery</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/document/u/0/?tgif=d&amp;ftv=1</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Google Sheets</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/spreadsheets/u/0/?tgif=d&amp;ftv=1</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Brex</string>
-                            <key>url</key>
-                            <string>https://dashboard.brex.com/card/transactions/yours</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Planner | Reclaim</string>
-                            <key>url</key>
-                            <string>https://app.reclaim.ai/planner?range=WEEK</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>osquery | Schema :Tables</string>
-                            <key>url</key>
-                            <string>https://osquery.io/schema/5.8.2/</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>YouTube</string>
-                            <key>url</key>
-                            <string>https://www.youtube.com/</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>LinkedIn</string>
-                            <key>url</key>
-                            <string>https://www.linkedin.com/feed/</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Gong | Home</string>
-                            <key>url</key>
-                            <string>https://us-65885.app.gong.io/home</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Login | Slack</string>
-                            <key>url</key>
-                            <string>https://slack.com/get-started#/createnew</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Amazon.com</string>
-                            <key>url</key>
-                            <string>https://www.amazon.com/ref=nav_logo</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Account | Grammarly</string>
-                            <key>url</key>
-                            <string>https://account.grammarly.com/admin/home</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>🚀 Engineering</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🛩️ Product groups | Fleet handbook</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/product-groups</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🚀 Engineering (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/engineering</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🚀 Documentation for contributors</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/engineering#documentation-for-contributors</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🚀 Kanban board (~engineering-initiated)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/73</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🕸️ Kanban board (#g-website)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/92</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>💻 Current sprint (#g-mdm)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/58</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>📦 Current sprint (#g-software)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/70</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🪄 Current sprint (#g-orchestration)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/71</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🛡️ Current sprint (#g-security-compliance)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/97</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Training Videos - 🌈 Fleet - Google Drive</string>
-                            <key>url</key>
-                            <string>https://drive.google.com/drive/folders/1VO0YLrtq5e3Ju8xqUQOpUE_b4QP0pt5P</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>🦢 Product Design</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🦢 Product Design (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/product-design</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🦢 Kanban board (:help-design)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/93</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🦢 Drafting board (:product)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/67</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🎁 Feature fest board (~feature fest)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/72</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🗺️ Release planning</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/87</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Why There's No Such Thing As MDM for Linux, and What to Do About It</string>
-                            <key>url</key>
-                            <string>https://www.kolide.com/blog/why-there-s-no-such-thing-as-mdm-for-linux-and-what-to-do-about-it</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>🌦️ Customer Success</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🌦️ Customer Success (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/customer-success</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🌦️ Kanban board (:help-customers)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/79</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Customer codenames</string>
-                            <key>url</key>
-                            <string>https://github.com/fleetdm/confidential/labels?q=customer-</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Upgrade to Fleet Premium.mp4 - Google Drive</string>
-                            <key>url</key>
-                            <string>https://drive.google.com/file/d/1Up4XqtrPpYewwmCYVz4qBycd6alIsz7O/view</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Gong | Fleet @ Red Hat: Fleet + osquery 101</string>
-                            <key>url</key>
-                            <string>https://us-65885.app.gong.io/call?id=7669046288376668913</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Gong | Fleet @ Red Hat: Fleet 201 for Security</string>
-                            <key>url</key>
-                            <string>https://us-65885.app.gong.io/call?id=4778028065403913218</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Gong | Fleet @ Red Hat: MDM 101</string>
-                            <key>url</key>
-                            <string>https://us-65885.app.gong.io/call?id=2393880604319663645</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Gong | Fleet @ Red Hat: Fleet MDM 201</string>
-                            <key>url</key>
-                            <string>https://us-65885.app.gong.io/call?id=1767845845375937725</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Fleet usage statistics - Google Sheets</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/spreadsheets/d/1Mh7Vf4kJL8b5TWlHxcX7mYwaakZMg_ZGNLY3kl1VI-c/edit?gid=1797565811#gid=1797565811</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>🐋 Sales</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🐋 Sales (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/sales</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🚂 Go-To-Market operations (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/go-to-market-operations</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🚂 Kanban board (:help-gtm-ops)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/81</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Prospect codenames</string>
-                            <key>url</key>
-                            <string>https://github.com/fleetdm/confidential/labels?q=prospect-</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Sales playbook "One Pager" - Google Docs</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/document/d/1v5qEUH-aMxIQFQDIs6gdGorr8_iDD7f6/edit</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Fleet sales playbook/process overview</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/document/d/1xVmpCYoxWbOvzQdwGhf9xMQ6ZYoLVjsDA_cEeJb0mEE/edit?tab=t.0</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>confidential/linkedin-profile-best-practices.md at main · fleetdm/confidential</string>
-                            <key>url</key>
-                            <string>https://github.com/fleetdm/confidential/blob/main/linkedin-profile-best-practices.md</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>MAIN - Order form calculator - Google Sheets</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/spreadsheets/d/1LadGegF8JuzXLjcwmCQ_ZeTjqbux7Oz8jGhRLfspYCg/edit?gid=0#gid=0</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Home | Salesforce</string>
-                            <key>url</key>
-                            <string>https://fleetdm.lightning.force.com/lightning/page/home</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>🫧 Marketing</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🫧 Marketing (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/marketing</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🫧 Kanban board (:help-marketing)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/94</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🎪 Events</string>
-                            <key>url</key>
-                            <string>https://docs.google.com/spreadsheets/d/1YQXAX2Q_WnGkAwMYjMbQpV3nbCj7gOBbv7Y0u4twxzQ/edit#gid=1411322737</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>🌐 IT</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🌐 IT (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/it</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🌐 Kanban board (:help-it)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/101</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🍽️ Kanban board (:help-dogfooding)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/57</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Fleet's Trust Center</string>
-                            <key>url</key>
-                            <string>https://trust.fleetdm.com/</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Account recovery process | Security</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/it/security#account-recovery-process</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>periodic table - Google Search</string>
-                            <key>url</key>
-                            <string>https://www.google.com/search?q=periodic+table&amp;rlz=1C5CHFA_enUS1062US1063&amp;oq=Period&amp;gs_lcrp=EgZjaHJvbWUqDQgAEAAYgwEYsQMYgAQyDQgAEAAYgwEYsQMYgAQyDwgBEEUYORiDARixAxiABDIHCAIQABiABDIHCAMQABiABDINCAQQABiDARixAxiABDINCAUQABiDARixAxiABDIHCAYQABiABDIHCAcQABiABDIHCAgQABiABDIHCAkQABiABNIBCDM4MjRqMGo3qAIAsAIA&amp;sourceid=chrome&amp;ie=UTF-8</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>🧑‍🚀 People</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>🧑‍🚀 People (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/people</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>🧑‍🚀 Kanban board (:help-people)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/91</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>Hiring | 🛠️ Leadership</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/company/leadership#hiring</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>💸 Finance</string>
-                    <key>children</key>
-                    <array>
-                        <dict>
-                            <key>name</key>
-                            <string>Kanban board (:help-finance)</string>
-                            <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/80</string>
-                        </dict>
-                        <dict>
-                            <key>name</key>
-                            <string>💸 Finance (Handbook)</string>
-                            <key>url</key>
-                            <string>https://fleetdm.com/handbook/finance</string>
-                        </dict>
-                    </array>
-                </dict>
-                <dict>
-                    <key>name</key>
-                    <string>Fleet Dashboard</string>
-                    <key>url</key>
-                    <string>https://dogfood.fleetdm.com/dashboard</string>
-                </dict>
-            </array>
-        </dict>
-    </array>
-    <key>PayloadDescription</key>
-    <string>A collection of helpful bookmarks for Fleeties!</string>
-    <key>PayloadDisplayName</key>
-    <string>Google Chrome managed bookmarks</string>
-    <key>PayloadIdentifier</key>
-    <string>com.fleetdm.chrome.bookmarks</string>
-    <key>PayloadType</key>
-    <string>Configuration</string>
-    <key>PayloadUUID</key>
-    <string>C3EEFE41-1918-484B-9053-568399159951</string>
-    <key>PayloadVersion</key>
-    <integer>1</integer>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.chrome.bookmarks</string>
+	<key>PayloadUUID</key>
+	<string>F48FF6C6-CC0D-4D99-82FE-5DA275441FC7</string>
+	<key>PayloadDisplayName</key>
+	<string>Google Chrome managed bookmarks</string>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.google.Chrome</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.google.Chrome.Fleet.ManagedBookmarks</string>
+			<key>PayloadUUID</key>
+			<string>62BADA04-5FEC-48AE-B791-660889DBB5E7</string>
+			<key>ManagedBookmarks</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>👋 New Fleeties | Fleet handbook</string>
+					<key>url</key>
+					<string>https://fleetdm.com/handbook/company/communications#new-fleeties</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>📖 The handbook</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>📖 The handbook (fleetdm.com)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🔭 Values 🔴🟠🟢🔵🟣 (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company#values</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🔭 Org chart (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company#org-chart</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🔭 Company (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>💭 Why this way? (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/why-this-way</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🔐 Security (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/it/security#security</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🛰️ Communications (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/communications</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🛰️ Writing (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/communications#writing</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🛰️ Writing in Fleet-flavored markdown (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/communications#writing-in-fleet-flavored-markdown</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🛠️ Leadership (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/leadership</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🚂 Getting a contract reviewed (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/go-to-market-operations#getting-a-contract-reviewed</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🚂 Getting a contract signed (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/go-to-market-operations#getting-a-contract-signed</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>📓 Releases notes (Fleet Docs)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/releases</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>📓 Get started (Fleet Docs)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/docs/get-started/why-fleet</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>📓 Tutorials and guides (Fleet Docs)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/docs/get-started/tutorials-and-guides</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>The Handbook | The GitLab Handbook</string>
+							<key>url</key>
+							<string>https://handbook.gitlab.com/handbook/</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Security Tools Terms - Google Sheets</string>
+							<key>url</key>
+							<string>https://docs.google.com/spreadsheets/d/1bF7ct4Ibyo-GPaehFRwZrlN2PQqQmyi1D1gx-gqNlpc/edit?gid=0#gid=0</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>fleetdm.com</string>
+							<key>children</key>
+							<array>
+								<dict>
+									<key>name</key>
+									<string>Query generator</string>
+									<key>url</key>
+									<string>https://fleetdm.com/query-generator</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>License key tool</string>
+									<key>url</key>
+									<string>https://fleetdm.com/admin/generate-license#login</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>🏷️ Pricing (fleetdm.com)</string>
+									<key>url</key>
+									<string>https://fleetdm.com/pricing</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>🎙️ Announcements (fleetdm.com)</string>
+									<key>url</key>
+									<string>https://fleetdm.com/announcements</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>🧑‍🚀 Open positions (Handbook)</string>
+									<key>url</key>
+									<string>https://fleetdm.com/handbook/company#open-positions</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string> The ABCs</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🗂️</string>
+							<key>children</key>
+							<array>
+								<dict>
+									<key>name</key>
+									<string>All hands - ask me anything (AMA) - Google Docs</string>
+									<key>url</key>
+									<string>https://docs.google.com/document/d/1tKsaZmJ7BP8arWia_CUerbQY4p20O-oBABjG2aDmC0w/edit?tab=t.0</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>+new whiteboard</string>
+									<key>url</key>
+									<string>https://docs.google.com/document/create?usp=drive_web&amp;ouid=110737225569469728451&amp;folder=1prO98fmB2WKzpubZ2-z0sju9dQ4ijpNE</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>TEMPLATE - Meeting doc - Google Docs</string>
+									<key>url</key>
+									<string>https://docs.google.com/document/d/1TaZ654gTwadWGDYhP3zuAzWe0eiY0s9NhaU9KLCokgw/copy</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>⛵️ Cheat sheets and useful links</string>
+							<key>children</key>
+							<array>
+								<dict>
+									<key>name</key>
+									<string>git-cheat-sheet-education</string>
+									<key>url</key>
+									<string>https://education.github.com/git-cheat-sheet-education.pdf</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>GitHub Desktop keyboard shortcuts - GitHub Docs</string>
+									<key>url</key>
+									<string>https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/overview/github-desktop-keyboard-shortcuts</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Basic writing and formatting syntax - GitHub Docs</string>
+									<key>url</key>
+									<string>https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Keyboard shortcuts - GitHub Docs</string>
+									<key>url</key>
+									<string>https://docs.github.com/en/get-started/accessibility/keyboard-shortcuts#navigating-within-code-files</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>About code owners - GitHub Docs</string>
+									<key>url</key>
+									<string>https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string># Move this file into your user directory and rename this file to &quot;.zshrc&quot;.txt - Google Drive</string>
+									<key>url</key>
+									<string>https://drive.google.com/file/d/10MrYfln6srMhj09HE5vSpRRZr8xUSCLW/view</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>HTML URL Encoding Reference</string>
+									<key>url</key>
+									<string>https://www.w3schools.com/tags/ref_urlencode.ASP</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>URL Encode and Decode - Online</string>
+									<key>url</key>
+									<string>https://www.urlencoder.org/</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>The 9 Enneagram Types — The Enneagram Institute</string>
+									<key>url</key>
+									<string>https://www.enneagraminstitute.com/type-descriptions</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🛩️ Travel</string>
+							<key>children</key>
+							<array>
+								<dict>
+									<key>name</key>
+									<string>Google Flights - Find Cheap Flight Options &amp; Track Prices</string>
+									<key>url</key>
+									<string>https://www.google.com/travel/flights?tcfs&amp;ved=2ahUKEwjeorSB1O2IAxVYwvIHHV6QI0EQ0I8EegQIAxAJ&amp;ictx=2</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>United Airlines - Airline Tickets, Travel Deals and Flights</string>
+									<key>url</key>
+									<string>https://www.united.com/en/us/</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Southwest Airlines | Book Flights, Make Reservations &amp; Plan a Trip</string>
+									<key>url</key>
+									<string>https://www.southwest.com/</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Google Maps</string>
+									<key>url</key>
+									<string>https://www.google.com/maps/@30.660359,-97.71092,14z?entry=ttu</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Tips on Austin, Texas - Reed Haynes - 2022-03-08 - Google Docs</string>
+									<key>url</key>
+									<string>https://docs.google.com/document/d/1sj9JJRSm4QNgDILYzHurV2kmQv00uondpAJ5kL-0TZs/edit#heading=h.v2mvb727yfe2</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Travel locations and stuff - Google Sheets</string>
+									<key>url</key>
+									<string>https://docs.google.com/spreadsheets/d/1LLRZph-ctmqKFYPUWfZs8LI89CbKsxvEGEqWuiq_-iA/edit#gid=0</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Alaska Airlines - Flight Deals and Cheap Airline Tickets - Book Today</string>
+									<key>url</key>
+									<string>https://www.alaskaair.com/</string>
+								</dict>
+								<dict>
+									<key>name</key>
+									<string>Offsite budget [template] - Google Sheets</string>
+									<key>url</key>
+									<string>https://docs.google.com/spreadsheets/d/1oe1wAFzerXlKghZaZtdlA7QrWBv9iZmHThlFYqfVzRQ/edit?gid=0#gid=0</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🧑‍🚀 Fleeties (🧬 org chart &amp; team info)</string>
+							<key>url</key>
+							<string>https://docs.google.com/spreadsheets/d/1OSLn-ZCbGSjPusHPiR5dwQhheH1K8-xqyZdsOe9y7qc/edit#gid=0</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>📈 OKRs (quarterly goals) + KPIs (everyday metrics)</string>
+							<key>url</key>
+							<string>https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🎐 Why Fleet?</string>
+							<key>url</key>
+							<string>https://docs.google.com/document/d/1E0VU4AcB6UTVRd4JKD45Saxh9Gz-mkO3LnGSTBDLEZo/edit#heading=h.vfxwnwufxzzi</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>GitHub Projects · fleetdm</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects?query=is%3Aopen</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>My PRs</string>
+							<key>url</key>
+							<string>https://github.com/pulls</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>PRs waiting on me</string>
+							<key>url</key>
+							<string>https://github.com/pulls/review-requested</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Issue: 🦟Bug report</string>
+							<key>url</key>
+							<string>https://github.com/fleetdm/fleet/issues/new?template=bug-report.md</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Issue: +New public issue</string>
+							<key>url</key>
+							<string>https://github.com/fleetdm/fleet/issues/new/choose</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Issue: +New confidential issue</string>
+							<key>url</key>
+							<string>https://github.com/fleetdm/confidential/issues/new/choose</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Issues assigned to me</string>
+							<key>url</key>
+							<string>https://github.com/issues?q=is%3Aopen%20is%3Aissue%20archived%3Afalse%20org%3Afleetdm%20no%3Amilestone%20assignee%3A%40me%20%20sort%3Aupdated-desc</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>1Password for Fleet</string>
+							<key>url</key>
+							<string>https://fleetdevicemanagement.1password.com/home</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Gmail Inbox - Fleet</string>
+							<key>url</key>
+							<string>https://mail.google.com/mail/u/0/#inbox</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Google Calendar</string>
+							<key>url</key>
+							<string>https://calendar.google.com/calendar/u/0/r</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Google Docs - Template gallery</string>
+							<key>url</key>
+							<string>https://docs.google.com/document/u/0/?tgif=d&amp;ftv=1</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Google Sheets</string>
+							<key>url</key>
+							<string>https://docs.google.com/spreadsheets/u/0/?tgif=d&amp;ftv=1</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Brex</string>
+							<key>url</key>
+							<string>https://dashboard.brex.com/card/transactions/yours</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Planner | Reclaim</string>
+							<key>url</key>
+							<string>https://app.reclaim.ai/planner?range=WEEK</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>osquery | Schema :Tables</string>
+							<key>url</key>
+							<string>https://osquery.io/schema/5.8.2/</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>YouTube</string>
+							<key>url</key>
+							<string>https://www.youtube.com/</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>LinkedIn</string>
+							<key>url</key>
+							<string>https://www.linkedin.com/feed/</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Gong | Home</string>
+							<key>url</key>
+							<string>https://us-65885.app.gong.io/home</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Login | Slack</string>
+							<key>url</key>
+							<string>https://slack.com/get-started#/createnew</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Amazon.com</string>
+							<key>url</key>
+							<string>https://www.amazon.com/ref=nav_logo</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Account | Grammarly</string>
+							<key>url</key>
+							<string>https://account.grammarly.com/admin/home</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>🚀 Engineering</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🛩️ Product groups | Fleet handbook</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/product-groups</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🚀 Engineering (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/engineering</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🚀 Documentation for contributors</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/engineering#documentation-for-contributors</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🚀 Kanban board (~engineering-initiated)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/73</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🕸️ Kanban board (#g-website)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/92</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>💻 Current sprint (#g-mdm)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/58</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>📦 Current sprint (#g-software)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/70</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🪄 Current sprint (#g-orchestration)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/71</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🛡️ Current sprint (#g-security-compliance)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/97</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Training Videos - 🌈 Fleet - Google Drive</string>
+							<key>url</key>
+							<string>https://drive.google.com/drive/folders/1VO0YLrtq5e3Ju8xqUQOpUE_b4QP0pt5P</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>🦢 Product Design</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🦢 Product Design (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/product-design</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🦢 Kanban board (:help-design)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/93</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🦢 Drafting board (:product)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/67</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🎁 Feature fest board (~feature fest)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/72</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🗺️ Release planning</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/87</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Why There&apos;s No Such Thing As MDM for Linux, and What to Do About It</string>
+							<key>url</key>
+							<string>https://www.kolide.com/blog/why-there-s-no-such-thing-as-mdm-for-linux-and-what-to-do-about-it</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>🌦️ Customer Success</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🌦️ Customer Success (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/customer-success</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🌦️ Kanban board (:help-customers)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/79</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Customer codenames</string>
+							<key>url</key>
+							<string>https://github.com/fleetdm/confidential/labels?q=customer-</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Upgrade to Fleet Premium.mp4 - Google Drive</string>
+							<key>url</key>
+							<string>https://drive.google.com/file/d/1Up4XqtrPpYewwmCYVz4qBycd6alIsz7O/view</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Gong | Fleet @ Red Hat: Fleet + osquery 101</string>
+							<key>url</key>
+							<string>https://us-65885.app.gong.io/call?id=7669046288376668913</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Gong | Fleet @ Red Hat: Fleet 201 for Security</string>
+							<key>url</key>
+							<string>https://us-65885.app.gong.io/call?id=4778028065403913218</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Gong | Fleet @ Red Hat: MDM 101</string>
+							<key>url</key>
+							<string>https://us-65885.app.gong.io/call?id=2393880604319663645</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Gong | Fleet @ Red Hat: Fleet MDM 201</string>
+							<key>url</key>
+							<string>https://us-65885.app.gong.io/call?id=1767845845375937725</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Fleet usage statistics - Google Sheets</string>
+							<key>url</key>
+							<string>https://docs.google.com/spreadsheets/d/1Mh7Vf4kJL8b5TWlHxcX7mYwaakZMg_ZGNLY3kl1VI-c/edit?gid=1797565811#gid=1797565811</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>🐋 Sales</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🐋 Sales (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/sales</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🚂 Go-To-Market operations (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/go-to-market-operations</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🚂 Kanban board (:help-gtm-ops)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/81</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Prospect codenames</string>
+							<key>url</key>
+							<string>https://github.com/fleetdm/confidential/labels?q=prospect-</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Sales playbook &quot;One Pager&quot; - Google Docs</string>
+							<key>url</key>
+							<string>https://docs.google.com/document/d/1v5qEUH-aMxIQFQDIs6gdGorr8_iDD7f6/edit</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Fleet sales playbook/process overview</string>
+							<key>url</key>
+							<string>https://docs.google.com/document/d/1xVmpCYoxWbOvzQdwGhf9xMQ6ZYoLVjsDA_cEeJb0mEE/edit?tab=t.0</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>confidential/linkedin-profile-best-practices.md at main · fleetdm/confidential</string>
+							<key>url</key>
+							<string>https://github.com/fleetdm/confidential/blob/main/linkedin-profile-best-practices.md</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>MAIN - Order form calculator - Google Sheets</string>
+							<key>url</key>
+							<string>https://docs.google.com/spreadsheets/d/1LadGegF8JuzXLjcwmCQ_ZeTjqbux7Oz8jGhRLfspYCg/edit?gid=0#gid=0</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Home | Salesforce</string>
+							<key>url</key>
+							<string>https://fleetdm.lightning.force.com/lightning/page/home</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>🫧 Marketing</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🫧 Marketing (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/marketing</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🫧 Kanban board (:help-marketing)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/94</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🎪 Events</string>
+							<key>url</key>
+							<string>https://docs.google.com/spreadsheets/d/1YQXAX2Q_WnGkAwMYjMbQpV3nbCj7gOBbv7Y0u4twxzQ/edit#gid=1411322737</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>🌐 IT</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🌐 IT (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/it</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🌐 Kanban board (:help-it)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/101</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🍽️ Kanban board (:help-dogfooding)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/57</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Fleet&apos;s Trust Center</string>
+							<key>url</key>
+							<string>https://trust.fleetdm.com/</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Account recovery process | Security</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/it/security#account-recovery-process</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>periodic table - Google Search</string>
+							<key>url</key>
+							<string>https://www.google.com/search?q=periodic+table&amp;rlz=1C5CHFA_enUS1062US1063&amp;oq=Period&amp;gs_lcrp=EgZjaHJvbWUqDQgAEAAYgwEYsQMYgAQyDQgAEAAYgwEYsQMYgAQyDwgBEEUYORiDARixAxiABDIHCAIQABiABDIHCAMQABiABDINCAQQABiDARixAxiABDINCAUQABiDARixAxiABDIHCAYQABiABDIHCAcQABiABDIHCAgQABiABDIHCAkQABiABNIBCDM4MjRqMGo3qAIAsAIA&amp;sourceid=chrome&amp;ie=UTF-8</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>🧑‍🚀 People</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>🧑‍🚀 People (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/people</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>🧑‍🚀 Kanban board (:help-people)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/91</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>Hiring | 🛠️ Leadership</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/company/leadership#hiring</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>💸 Finance</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>Kanban board (:help-finance)</string>
+							<key>url</key>
+							<string>https://github.com/orgs/fleetdm/projects/80</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>💸 Finance (Handbook)</string>
+							<key>url</key>
+							<string>https://fleetdm.com/handbook/finance</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>Fleet Dashboard</string>
+					<key>url</key>
+					<string>https://dogfood.fleetdm.com/dashboard</string>
+				</dict>
+			</array>
+			<key>PayloadDisplayName</key>
+			<string>Google Chrome managed bookmarks</string>
+			<key>PayloadDescription</key>
+			<string>Google Chrome managed bookmarks</string>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>A collection of helpful bookmarks for Fleeties!</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.chrome.bookmarks</string>
 	<key>PayloadUUID</key>
-	<string>F48FF6C6-CC0D-4D99-82FE-5DA275441FC7</string>
+	<string>C3EEFE41-1918-484B-9053-568399159951</string>
 	<key>PayloadDisplayName</key>
 	<string>Google Chrome managed bookmarks</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.google.Chrome.Fleet.ManagedBookmarks</string>
 			<key>PayloadUUID</key>
-			<string>62BADA04-5FEC-48AE-B791-660889DBB5E7</string>
+			<string>BCEC63A3-F17A-4F73-8521-6E54927B3537</string>
 			<key>ManagedBookmarks</key>
 			<array>
 				<dict>

--- a/it-and-security/lib/macos/configuration-profiles/google-updater-background-task.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-updater-background-task.mobileconfig
@@ -2,19 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.google.updater.70FE5A48-1035-49FE-84E4-93E0416666D4</string>
+	<key>PayloadUUID</key>
+	<string>844C2040-516F-4AAD-BDD2-99890C01E1EC</string>
+	<key>PayloadDisplayName</key>
+	<string>Google Updater background task</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Background Apps</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.servicemanagement.673823C3-5AE5-4339-A36A-ECA3BBA25D24</string>
 			<key>PayloadType</key>
 			<string>com.apple.servicemanagement</string>
-			<key>PayloadUUID</key>
-			<string>673823C3-5AE5-4339-A36A-ECA3BBA25D24</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.servicemanagement.673823C3-5AE5-4339-A36A-ECA3BBA25D24</string>
+			<key>PayloadUUID</key>
+			<string>CFA0989D-D5BD-4A20-A7A4-44A4D161F520</string>
 			<key>Rules</key>
 			<array>
 				<dict>
@@ -24,21 +32,13 @@
 					<string>EQHXZ8M8AV</string>
 				</dict>
 			</array>
+			<key>PayloadDisplayName</key>
+			<string>Background Apps</string>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>Google Updater background task</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.google.updater.70FE5A48-1035-49FE-84E4-93E0416666D4</string>
-	<key>PayloadOrganization</key>
-	<string>Fleet</string>
 	<key>PayloadRemovalDisallowed</key>
 	<true/>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>A2EC78CA-5E19-4531-BE46-D0D722C6070A</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
+	<key>PayloadOrganization</key>
+	<string>Fleet</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/google-updater-background-task.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-updater-background-task.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.google.updater.70FE5A48-1035-49FE-84E4-93E0416666D4</string>
 	<key>PayloadUUID</key>
-	<string>844C2040-516F-4AAD-BDD2-99890C01E1EC</string>
+	<string>A2EC78CA-5E19-4531-BE46-D0D722C6070A</string>
 	<key>PayloadDisplayName</key>
 	<string>Google Updater background task</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.servicemanagement.673823C3-5AE5-4339-A36A-ECA3BBA25D24</string>
 			<key>PayloadUUID</key>
-			<string>CFA0989D-D5BD-4A20-A7A4-44A4D161F520</string>
+			<string>673823C3-5AE5-4339-A36A-ECA3BBA25D24</string>
 			<key>Rules</key>
 			<array>
 				<dict>

--- a/it-and-security/lib/macos/configuration-profiles/limit-ad-tracking.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/limit-ad-tracking.mobileconfig
@@ -2,44 +2,44 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn off ad tracking and personalized ads</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section2.LimitAdTracking</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>5C19E95A-31C7-4E0D-BC46-C343A0CB01DF</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section2.LimitAdTracking</string>
+	<key>PayloadUUID</key>
+	<string>8223865C-5A6F-455D-B258-67F88A0719B1</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn off ad tracking and personalized ads</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>2.5.6 - Ensure Limit Ad Tracking and Personalized Ads is Enabled</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.AdLib</string>
 			<key>PayloadType</key>
 			<string>com.apple.AdLib</string>
-			<key>PayloadUUID</key>
-			<string>B46A5A38-4BB0-49E6-AC28-F4EB426774E8</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
-			<key>allowApplePersonalizedAdvertising</key>
-			<false/>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.AdLib</string>
+			<key>PayloadUUID</key>
+			<string>FD399306-3C57-4C2B-91BC-0FFE613147A5</string>
 			<key>forceLimitAdTracking</key>
 			<true/>
+			<key>PayloadDisplayName</key>
+			<string>2.5.6 - Ensure Limit Ad Tracking and Personalized Ads is Enabled</string>
+			<key>allowApplePersonalizedAdvertising</key>
+			<false/>
 		</dict>
 	</array>
+	<key>PayloadOrganization</key>
+	<string>Center for Internet Security</string>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadScope</key>
+	<string>System</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/limit-ad-tracking.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/limit-ad-tracking.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.LimitAdTracking</string>
 	<key>PayloadUUID</key>
-	<string>8223865C-5A6F-455D-B258-67F88A0719B1</string>
+	<string>5C19E95A-31C7-4E0D-BC46-C343A0CB01DF</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn off ad tracking and personalized ads</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.AdLib</string>
 			<key>PayloadUUID</key>
-			<string>FD399306-3C57-4C2B-91BC-0FFE613147A5</string>
+			<string>B46A5A38-4BB0-49E6-AC28-F4EB426774E8</string>
 			<key>forceLimitAdTracking</key>
 			<true/>
 			<key>PayloadDisplayName</key>

--- a/it-and-security/lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
@@ -2,42 +2,42 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.547B48AB-75CF-4BB2-BA78-76A291F0EC3E</string>
+	<key>PayloadUUID</key>
+	<string>7FF8C479-369A-4857-948F-990934ED290F</string>
+	<key>PayloadDisplayName</key>
+	<string>Microsoft AutoUpdate settings</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.microsoft.autoupdate2</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.microsoft.autoupdate2.DD5F294A-3B5C-48EA-AA0B-B17C8806667D</string>
+			<key>PayloadUUID</key>
+			<string>1352FE21-07FF-4307-BA4F-2262D97C850C</string>
 			<key>AcknowledgedDataCollectionPolicy</key>
 			<string>RequiredDataOnly</string>
 			<key>ChannelName</key>
 			<string>Current</string>
-			<key>HowToCheck</key>
-			<string>AutomaticDownload</string>
 			<key>IgnoreUIOpenAfterInstall</key>
 			<true/>
+			<key>HowToCheck</key>
+			<string>AutomaticDownload</string>
 			<key>PayloadDisplayName</key>
 			<string>Microsoft AutoUpdate</string>
-			<key>PayloadIdentifier</key>
-			<string>com.microsoft.autoupdate2.DD5F294A-3B5C-48EA-AA0B-B17C8806667D</string>
-			<key>PayloadType</key>
-			<string>com.microsoft.autoupdate2</string>
-			<key>PayloadUUID</key>
-			<string>DD5F294A-3B5C-48EA-AA0B-B17C8806667D</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>Microsoft AutoUpdate settings</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.547B48AB-75CF-4BB2-BA78-76A291F0EC3E</string>
-	<key>PayloadOrganization</key>
-	<string>Fleet</string>
 	<key>PayloadRemovalDisallowed</key>
 	<true/>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>348EF514-7155-415A-A7CC-EF276614EFE7</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
+	<key>PayloadOrganization</key>
+	<string>Fleet</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.547B48AB-75CF-4BB2-BA78-76A291F0EC3E</string>
 	<key>PayloadUUID</key>
-	<string>7FF8C479-369A-4857-948F-990934ED290F</string>
+	<string>348EF514-7155-415A-A7CC-EF276614EFE7</string>
 	<key>PayloadDisplayName</key>
 	<string>Microsoft AutoUpdate settings</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.microsoft.autoupdate2.DD5F294A-3B5C-48EA-AA0B-B17C8806667D</string>
 			<key>PayloadUUID</key>
-			<string>1352FE21-07FF-4307-BA4F-2262D97C850C</string>
+			<string>DD5F294A-3B5C-48EA-AA0B-B17C8806667D</string>
 			<key>AcknowledgedDataCollectionPolicy</key>
 			<string>RequiredDataOnly</string>
 			<key>ChannelName</key>

--- a/it-and-security/lib/macos/configuration-profiles/misc.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/misc.mobileconfig
@@ -2,74 +2,74 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.github.erikberglund.ProfileCreator.7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0</string>
+	<key>PayloadUUID</key>
+	<string>91486082-E68E-4D9C-889B-FA0BCC69482C</string>
+	<key>PayloadDisplayName</key>
+	<string>Various restriction settings</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Restrictions</string>
-			<key>PayloadIdentifier</key>
-			<string>com.github.erikberglund.ProfileCreator.7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0.com.apple.applicationaccess.722287B0-ADCF-418F-8F8F-F2B5DB977355</string>
 			<key>PayloadType</key>
 			<string>com.apple.applicationaccess</string>
-			<key>PayloadUUID</key>
-			<string>722287B0-ADCF-418F-8F8F-F2B5DB977355</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
-			<key>allowActivityContinuation</key>
+			<key>PayloadIdentifier</key>
+			<string>com.github.erikberglund.ProfileCreator.7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0.com.apple.applicationaccess.722287B0-ADCF-418F-8F8F-F2B5DB977355</string>
+			<key>PayloadUUID</key>
+			<string>218B8DA2-D761-4445-B8E0-60AF8FB6EE0E</string>
+			<key>allowCloudReminders</key>
 			<true/>
+			<key>PayloadDisplayName</key>
+			<string>Restrictions</string>
 			<key>allowAirDrop</key>
 			<true/>
-			<key>allowAutoUnlock</key>
+			<key>allowActivityContinuation</key>
 			<true/>
-			<key>allowCamera</key>
-			<true/>
-			<key>allowCloudBTMM</key>
+			<key>allowDiagnosticSubmission</key>
 			<false/>
 			<key>allowCloudDesktopAndDocuments</key>
 			<false/>
-			<key>allowCloudFMM</key>
-			<true/>
-			<key>allowCloudKeychainSync</key>
-			<true/>
-			<key>allowCloudMail</key>
-			<true/>
-			<key>allowCloudNotes</key>
-			<true/>
 			<key>allowCloudPhotoLibrary</key>
-			<true/>
-			<key>allowCloudPrivateRelay</key>
-			<true/>
-			<key>allowCloudReminders</key>
-			<true/>
-			<key>allowContentCaching</key>
-			<false/>
-			<key>allowDiagnosticSubmission</key>
-			<false/>
-			<key>allowFingerprintForUnlock</key>
 			<true/>
 			<key>allowMailPrivacyProtection</key>
 			<true/>
+			<key>allowAutoUnlock</key>
+			<true/>
+			<key>allowContentCaching</key>
+			<false/>
+			<key>allowCamera</key>
+			<true/>
+			<key>allowFingerprintForUnlock</key>
+			<true/>
+			<key>allowCloudPrivateRelay</key>
+			<true/>
+			<key>allowCloudMail</key>
+			<true/>
 			<key>allowScreenShot</key>
 			<true/>
-			<key>allowiTunesFileSharing</key>
+			<key>allowCloudNotes</key>
 			<true/>
 			<key>enforcedFingerprintTimeout</key>
 			<integer>172800</integer>
+			<key>allowCloudBTMM</key>
+			<false/>
+			<key>allowCloudKeychainSync</key>
+			<true/>
+			<key>allowiTunesFileSharing</key>
+			<true/>
+			<key>allowCloudFMM</key>
+			<true/>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>Various restriction settings</string>
-	<key>PayloadIdentifier</key>
-	<string>com.github.erikberglund.ProfileCreator.7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0</string>
 	<key>PayloadOrganization</key>
 	<string>FleetDM</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/misc.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/misc.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0</string>
 	<key>PayloadUUID</key>
-	<string>91486082-E68E-4D9C-889B-FA0BCC69482C</string>
+	<string>7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0</string>
 	<key>PayloadDisplayName</key>
 	<string>Various restriction settings</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.github.erikberglund.ProfileCreator.7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0.com.apple.applicationaccess.722287B0-ADCF-418F-8F8F-F2B5DB977355</string>
 			<key>PayloadUUID</key>
-			<string>218B8DA2-D761-4445-B8E0-60AF8FB6EE0E</string>
+			<string>722287B0-ADCF-418F-8F8F-F2B5DB977355</string>
 			<key>allowCloudReminders</key>
 			<true/>
 			<key>PayloadDisplayName</key>

--- a/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
@@ -2,46 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.nudge.managed</string>
+	<key>PayloadUUID</key>
+	<string>2F554729-CAAD-4F5F-A5FC-948D9DF8B443</string>
+	<key>PayloadDisplayName</key>
+	<string>Nudge settings</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Nudge Preferences</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.nudge.preferences</string>
 			<key>PayloadType</key>
 			<string>com.github.macadmins.Nudge</string>
-			<key>PayloadUUID</key>
-			<string>69B22694-8FF8-40A0-AEE6-D5385BBF765D</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
-			<key>optionalFeatures</key>
-			<dict>
-				<key>acceptableApplicationBundleIDs</key>
-				<array>
-					<string>us.zoom.xos</string>
-				</array>
-				<key>acceptableCameraUsage</key>
-				<true/>
-				<key>acceptableScreenSharingUsage</key>
-				<true/>
-				<key>aggressiveUserExperience</key>
-				<false/>
-				<key>asynchronousSoftwareUpdate</key>
-				<true/>
-				<key>attemptToFetchMajorUpgrade</key>
-				<true/>
-				<key>disableNudgeForStandardInstalls</key>
-				<false/>
-				<key>disableSoftwareUpdateWorkflow</key>
-				<false/>
-				<key>enforceMinorUpdates</key>
-				<true/>
-				<key>utilizeSOFAFeed</key>
-				<true/>
-				<key>refreshSOFAFeedTime</key>
-				<string>300</string>
-			</dict>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.nudge.preferences</string>
+			<key>PayloadUUID</key>
+			<string>75E35729-7B1B-4B35-8604-F6AFDCB6E443</string>
 			<key>osVersionRequirements</key>
 			<array>
 				<dict>
@@ -61,41 +42,6 @@
 					<string>26</string>
 				</dict>
 			</array>
-			<key>userExperience</key>
-			<dict>
-				<key>allowGracePeriods</key>
-				<true/>
-				<key>allowLaterDeferralButton</key>
-				<true/>
-				<key>allowMovableWindow</key>
-				<false/>
-				<key>allowUserQuitDeferrals</key>
-				<true/>
-				<key>allowedDeferrals</key>
-				<integer>1000000</integer>
-				<key>approachingRefreshCycle</key>
-				<integer>86400</integer>
-				<key>approachingWindowTime</key>
-				<integer>120</integer>
-				<key>elapsedRefreshCycle</key>
-				<integer>7200</integer>
-				<key>gracePeriodInstallDelay</key>
-				<integer>336</integer>
-				<key>gracePeriodLaunchDelay</key>
-				<integer>168</integer>
-				<key>imminentRefreshCycle</key>
-				<integer>86400</integer>
-				<key>imminentWindowTime</key>
-				<integer>0</integer>
-				<key>initialRefreshCycle</key>
-				<integer>259200</integer>
-				<key>nudgeMajorUpgradeEventLaunchDelay</key>
-				<integer>0</integer>
-				<key>nudgeMinorUpdateEventLaunchDelay</key>
-				<integer>0</integer>
-				<key>randomDelay</key>
-				<false/>
-			</dict>
 			<key>userInterface</key>
 			<dict>
 				<key>fallbackLanguage</key>
@@ -158,18 +104,80 @@ If you have any questions or need any assistance, please reach out via #help-it 
 					</dict>
 				</array>
 			</dict>
+			<key>userExperience</key>
+			<dict>
+				<key>allowGracePeriods</key>
+				<true/>
+				<key>allowLaterDeferralButton</key>
+				<true/>
+				<key>allowMovableWindow</key>
+				<false/>
+				<key>allowUserQuitDeferrals</key>
+				<true/>
+				<key>allowedDeferrals</key>
+				<integer>1000000</integer>
+				<key>approachingRefreshCycle</key>
+				<integer>86400</integer>
+				<key>approachingWindowTime</key>
+				<integer>120</integer>
+				<key>elapsedRefreshCycle</key>
+				<integer>7200</integer>
+				<key>gracePeriodInstallDelay</key>
+				<integer>336</integer>
+				<key>gracePeriodLaunchDelay</key>
+				<integer>168</integer>
+				<key>imminentRefreshCycle</key>
+				<integer>86400</integer>
+				<key>imminentWindowTime</key>
+				<integer>0</integer>
+				<key>initialRefreshCycle</key>
+				<integer>259200</integer>
+				<key>nudgeMajorUpgradeEventLaunchDelay</key>
+				<integer>0</integer>
+				<key>nudgeMinorUpdateEventLaunchDelay</key>
+				<integer>0</integer>
+				<key>randomDelay</key>
+				<false/>
+			</dict>
+			<key>PayloadDisplayName</key>
+			<string>Nudge Preferences</string>
+			<key>optionalFeatures</key>
+			<dict>
+				<key>acceptableApplicationBundleIDs</key>
+				<array>
+					<string>us.zoom.xos</string>
+				</array>
+				<key>acceptableCameraUsage</key>
+				<true/>
+				<key>acceptableScreenSharingUsage</key>
+				<true/>
+				<key>aggressiveUserExperience</key>
+				<false/>
+				<key>asynchronousSoftwareUpdate</key>
+				<true/>
+				<key>attemptToFetchMajorUpgrade</key>
+				<true/>
+				<key>disableNudgeForStandardInstalls</key>
+				<false/>
+				<key>disableSoftwareUpdateWorkflow</key>
+				<false/>
+				<key>enforceMinorUpdates</key>
+				<true/>
+				<key>utilizeSOFAFeed</key>
+				<true/>
+				<key>refreshSOFAFeedTime</key>
+				<string>300</string>
+			</dict>
 		</dict>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Allow Nudge background tasks</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.servicemanagement.9D50FED5-9183-456C-918F-51EBD9E4F95D</string>
 			<key>PayloadType</key>
 			<string>com.apple.servicemanagement</string>
-			<key>PayloadUUID</key>
-			<string>9D50FED5-9183-456C-918F-51EBD9E4F95D</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.servicemanagement.9D50FED5-9183-456C-918F-51EBD9E4F95D</string>
+			<key>PayloadUUID</key>
+			<string>BF921684-81A8-4429-95EB-79F5BD6F808E</string>
 			<key>Rules</key>
 			<array>
 				<dict>
@@ -179,21 +187,13 @@ If you have any questions or need any assistance, please reach out via #help-it 
 					<string>com.github.macadmins.Nudge</string>
 				</dict>
 			</array>
+			<key>PayloadDisplayName</key>
+			<string>Allow Nudge background tasks</string>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>Nudge settings</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.nudge.managed</string>
-	<key>PayloadOrganization</key>
-	<string>Fleet</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>4B4C950F-995A-4567-B0B2-9A34EB4C22AC</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
+	<key>PayloadOrganization</key>
+	<string>Fleet</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.nudge.managed</string>
 	<key>PayloadUUID</key>
-	<string>2F554729-CAAD-4F5F-A5FC-948D9DF8B443</string>
+	<string>4B4C950F-995A-4567-B0B2-9A34EB4C22AC</string>
 	<key>PayloadDisplayName</key>
 	<string>Nudge settings</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.nudge.preferences</string>
 			<key>PayloadUUID</key>
-			<string>75E35729-7B1B-4B35-8604-F6AFDCB6E443</string>
+			<string>69B22694-8FF8-40A0-AEE6-D5385BBF765D</string>
 			<key>osVersionRequirements</key>
 			<array>
 				<dict>
@@ -166,7 +166,7 @@ If you have any questions or need any assistance, please reach out via #help-it 
 				<key>utilizeSOFAFeed</key>
 				<true/>
 				<key>refreshSOFAFeedTime</key>
-				<string>300</string>
+				<integer>21600</integer>
 			</dict>
 		</dict>
 		<dict>
@@ -177,7 +177,7 @@ If you have any questions or need any assistance, please reach out via #help-it 
 			<key>PayloadIdentifier</key>
 			<string>com.apple.servicemanagement.9D50FED5-9183-456C-918F-51EBD9E4F95D</string>
 			<key>PayloadUUID</key>
-			<string>BF921684-81A8-4429-95EB-79F5BD6F808E</string>
+			<string>9D50FED5-9183-456C-918F-51EBD9E4F95D</string>
 			<key>Rules</key>
 			<array>
 				<dict>

--- a/it-and-security/lib/macos/configuration-profiles/okta-verify-settings.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/okta-verify-settings.mobileconfig
@@ -2,19 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.okta-verify.settings</string>
+	<key>PayloadUUID</key>
+	<string>F908093E-F3CD-4879-93D5-3545A4E9686B</string>
+	<key>PayloadDisplayName</key>
+	<string>Okta Verify settings</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Privacy Preferences Policy Control</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.TCC.configuration-profile-policy.DFBB4921-A766-42FE-AC3E-47150B51991F</string>
 			<key>PayloadType</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
-			<key>PayloadUUID</key>
-			<string>DFBB4921-A766-42FE-AC3E-47150B51991F</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.TCC.configuration-profile-policy.DFBB4921-A766-42FE-AC3E-47150B51991F</string>
+			<key>PayloadUUID</key>
+			<string>AC220167-D6BB-468E-950D-AA95884052A8</string>
 			<key>Services</key>
 			<dict>
 				<key>BluetoothAlways</key>
@@ -23,7 +31,7 @@
 						<key>Authorization</key>
 						<string>Allow</string>
 						<key>CodeRequirement</key>
-						<string>anchor apple generic and identifier "com.okta.mobile" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = B7F62B65BN)</string>
+						<string>anchor apple generic and identifier &quot;com.okta.mobile&quot; and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = B7F62B65BN)</string>
 						<key>Identifier</key>
 						<string>com.okta.mobile</string>
 						<key>IdentifierType</key>
@@ -33,31 +41,41 @@
 					</dict>
 				</array>
 			</dict>
+			<key>PayloadDisplayName</key>
+			<string>Privacy Preferences Policy Control</string>
 		</dict>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Service Management - Managed Login Items</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.servicemanagement.C06873D1-CEE5-4CBD-8C3B-EE96BAF487D1</string>
 			<key>PayloadType</key>
 			<string>com.apple.servicemanagement</string>
-			<key>PayloadUUID</key>
-			<string>C06873D1-CEE5-4CBD-8C3B-EE96BAF487D1</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.servicemanagement.C06873D1-CEE5-4CBD-8C3B-EE96BAF487D1</string>
+			<key>PayloadUUID</key>
+			<string>0ECC09F1-C21D-495D-A420-260D18F1E2D1</string>
 			<key>Rules</key>
 			<array>
 				<dict>
 					<key>RuleType</key>
-					<string>BundleIdentifier</string>
+					<string>BundleIdentifierPrefix</string>
 					<key>RuleValue</key>
-					<string>com.okta.mobile</string>
+					<string>com.okta.</string>
 					<key>TeamIdentifier</key>
 					<string>B7F62B65BN</string>
 				</dict>
 			</array>
+			<key>PayloadDisplayName</key>
+			<string>Service Management - Managed Login Items</string>
 		</dict>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.notificationsettings</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.notificationsettings.C2C42EC8-D883-4102-AD50-C7B03FDD6E01</string>
+			<key>PayloadUUID</key>
+			<string>C5BFFE2B-06E0-44F7-988A-271DF4FCC15F</string>
 			<key>NotificationSettings</key>
 			<array>
 				<dict>
@@ -71,59 +89,41 @@
 			</array>
 			<key>PayloadDisplayName</key>
 			<string>Notifications</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.notificationsettings.C2C42EC8-D883-4102-AD50-C7B03FDD6E01</string>
-			<key>PayloadType</key>
-			<string>com.apple.notificationsettings</string>
-			<key>PayloadUUID</key>
-			<string>C2C42EC8-D883-4102-AD50-C7B03FDD6E01</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Okta Verify</string>
-			<key>PayloadIdentifier</key>
-			<string>com.okta.mobile.025AA0BB-1D39-456C-BA51-7274DFD0C4F5</string>
 			<key>PayloadType</key>
 			<string>com.okta.mobile</string>
-			<key>PayloadUUID</key>
-			<string>025AA0BB-1D39-456C-BA51-7274DFD0C4F5</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.okta.mobile.025AA0BB-1D39-456C-BA51-7274DFD0C4F5</string>
+			<key>PayloadUUID</key>
+			<string>8C5C8025-B0D9-4C50-84EF-621848460B15</string>
+			<key>PayloadDisplayName</key>
+			<string>Okta Verify</string>
 			<key>OktaVerify.OrgUrl</key>
 			<string>fleetdm.okta.com</string>
 			<key>OktaVerify.LaunchOptions</key>
 			<string>HideMainWindow</string>
 		</dict>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Okta Verify Auth Service Extension</string>
-			<key>PayloadIdentifier</key>
-			<string>com.okta.mobile.auth-service-extension.F8A21C44-3E9B-4D5C-9F2A-1B8E7D4A9C3F</string>
 			<key>PayloadType</key>
 			<string>com.okta.mobile.auth-service-extension</string>
-			<key>PayloadUUID</key>
-			<string>F8A21C44-3E9B-4D5C-9F2A-1B8E7D4A9C3F</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.okta.mobile.auth-service-extension.F8A21C44-3E9B-4D5C-9F2A-1B8E7D4A9C3F</string>
+			<key>PayloadUUID</key>
+			<string>6119F3AF-DBB8-4B6B-95DD-E0FA24D82951</string>
+			<key>PayloadDisplayName</key>
+			<string>Okta Verify Auth Service Extension</string>
 			<key>OktaVerify.OrgUrl</key>
 			<string>fleetdm.okta.com</string>
 			<key>OktaVerify.LaunchOptions</key>
 			<string>HideMainWindow</string>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>Okta Verify settings</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.okta-verify.settings</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>078FDE56-2002-4189-AFE6-019167F0F9F9</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/okta-verify-settings.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/okta-verify-settings.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.okta-verify.settings</string>
 	<key>PayloadUUID</key>
-	<string>F908093E-F3CD-4879-93D5-3545A4E9686B</string>
+	<string>078FDE56-2002-4189-AFE6-019167F0F9F9</string>
 	<key>PayloadDisplayName</key>
 	<string>Okta Verify settings</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.TCC.configuration-profile-policy.DFBB4921-A766-42FE-AC3E-47150B51991F</string>
 			<key>PayloadUUID</key>
-			<string>AC220167-D6BB-468E-950D-AA95884052A8</string>
+			<string>DFBB4921-A766-42FE-AC3E-47150B51991F</string>
 			<key>Services</key>
 			<dict>
 				<key>BluetoothAlways</key>
@@ -52,7 +52,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.servicemanagement.C06873D1-CEE5-4CBD-8C3B-EE96BAF487D1</string>
 			<key>PayloadUUID</key>
-			<string>0ECC09F1-C21D-495D-A420-260D18F1E2D1</string>
+			<string>C06873D1-CEE5-4CBD-8C3B-EE96BAF487D1</string>
 			<key>Rules</key>
 			<array>
 				<dict>
@@ -75,7 +75,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.notificationsettings.C2C42EC8-D883-4102-AD50-C7B03FDD6E01</string>
 			<key>PayloadUUID</key>
-			<string>C5BFFE2B-06E0-44F7-988A-271DF4FCC15F</string>
+			<string>C2C42EC8-D883-4102-AD50-C7B03FDD6E01</string>
 			<key>NotificationSettings</key>
 			<array>
 				<dict>
@@ -98,7 +98,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.okta.mobile.025AA0BB-1D39-456C-BA51-7274DFD0C4F5</string>
 			<key>PayloadUUID</key>
-			<string>8C5C8025-B0D9-4C50-84EF-621848460B15</string>
+			<string>025AA0BB-1D39-456C-BA51-7274DFD0C4F5</string>
 			<key>PayloadDisplayName</key>
 			<string>Okta Verify</string>
 			<key>OktaVerify.OrgUrl</key>
@@ -114,7 +114,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.okta.mobile.auth-service-extension.F8A21C44-3E9B-4D5C-9F2A-1B8E7D4A9C3F</string>
 			<key>PayloadUUID</key>
-			<string>6119F3AF-DBB8-4B6B-95DD-E0FA24D82951</string>
+			<string>F8A21C44-3E9B-4D5C-9F2A-1B8E7D4A9C3F</string>
 			<key>PayloadDisplayName</key>
 			<string>Okta Verify Auth Service Extension</string>
 			<key>OktaVerify.OrgUrl</key>

--- a/it-and-security/lib/macos/configuration-profiles/prevent-autologon.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/prevent-autologon.mobileconfig
@@ -2,42 +2,42 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn off automatic login</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section5.AutoLogin</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>60A76297-E69F-4A31-838F-6FCCE793F57B</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
+	<key>PayloadIdentifier</key>
+	<string>cis.macOSBenchmark.section5.AutoLogin</string>
+	<key>PayloadUUID</key>
+	<string>E0E5DADC-5243-4783-90E4-EBEC6972B7E3</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn off automatic login</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>5.8 - Ensure Automatic Login Is Disabled</string>
-			<key>PayloadIdentifier</key>
-			<string>CIS.macOS.autologin</string>
 			<key>PayloadType</key>
 			<string>com.apple.loginwindow</string>
-			<key>PayloadUUID</key>
-			<string>8C8382A1-04FF-48BE-8DE5-FF919836E0D4</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>CIS.macOS.autologin</string>
+			<key>PayloadUUID</key>
+			<string>348A1761-7CF5-471B-A704-BA886F858BC7</string>
 			<key>com.apple.login.mcx.DisableAutoLoginClient</key>
 			<true/>
+			<key>PayloadDisplayName</key>
+			<string>5.8 - Ensure Automatic Login Is Disabled</string>
 		</dict>
 	</array>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
+	<key>PayloadOrganization</key>
+	<string>Center for Internet Security</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/prevent-autologon.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/prevent-autologon.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section5.AutoLogin</string>
 	<key>PayloadUUID</key>
-	<string>E0E5DADC-5243-4783-90E4-EBEC6972B7E3</string>
+	<string>60A76297-E69F-4A31-838F-6FCCE793F57B</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn off automatic login</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>CIS.macOS.autologin</string>
 			<key>PayloadUUID</key>
-			<string>348A1761-7CF5-471B-A704-BA886F858BC7</string>
+			<string>8C8382A1-04FF-48BE-8DE5-FF919836E0D4</string>
 			<key>com.apple.login.mcx.DisableAutoLoginClient</key>
 			<true/>
 			<key>PayloadDisplayName</key>

--- a/it-and-security/lib/macos/configuration-profiles/santa-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/santa-configuration.mobileconfig
@@ -2,23 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.santa.configuration</string>
+	<key>PayloadUUID</key>
+	<string>8F06A206-9393-4798-B439-A9E6382529B8</string>
+	<key>PayloadDisplayName</key>
+	<string>Santa configuration</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDescription</key>
-			<string>Allows Santa background tasks without notifications</string>
-			<key>PayloadDisplayName</key>
-			<string>Background Apps</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.santa.servicemanagement</string>
-			<key>PayloadOrganization</key>
-			<string>Fleet</string>
 			<key>PayloadType</key>
 			<string>com.apple.servicemanagement</string>
-			<key>PayloadUUID</key>
-			<string>1161A7ED-2E7B-4744-B933-D3B9F58A1AAE</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.santa.servicemanagement</string>
+			<key>PayloadUUID</key>
+			<string>CF1F18D8-ACB3-40A6-8340-85C7B2C5B076</string>
+			<key>PayloadDescription</key>
+			<string>Allows Santa background tasks without notifications</string>
 			<key>Rules</key>
 			<array>
 				<dict>
@@ -28,8 +34,20 @@
 					<string>ZMCG7MLDV9</string>
 				</dict>
 			</array>
+			<key>PayloadDisplayName</key>
+			<string>Background Apps</string>
+			<key>PayloadOrganization</key>
+			<string>Fleet</string>
 		</dict>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.santa.preferences</string>
+			<key>PayloadUUID</key>
+			<string>384CE88D-DF7E-4F8B-91C2-03037C496796</string>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.northpolesec.santa</key>
@@ -66,24 +84,28 @@
 					</array>
 				</dict>
 			</dict>
-			<key>PayloadDescription</key>
-			<string>Manages Santa's configuration settings</string>
-			<key>PayloadDisplayName</key>
-			<string>Santa Configuration</string>
-			<key>PayloadEnabled</key>
-			<true/>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.santa.preferences</string>
 			<key>PayloadOrganization</key>
 			<string>Fleet</string>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadUUID</key>
-			<string>359E3C7D-396F-4C45-99E7-F429620B9B21</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadDescription</key>
+			<string>Manages Santa&apos;s configuration settings</string>
+			<key>PayloadDisplayName</key>
+			<string>Santa Configuration</string>
 		</dict>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.notificationsettings</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.santa.notificationsettings</string>
+			<key>PayloadUUID</key>
+			<string>3080FF9D-9ED9-41CC-8D67-6F22C1771E89</string>
+			<key>PayloadDescription</key>
+			<string>Configures notification settings for Santa</string>
+			<key>PayloadOrganization</key>
+			<string>Fleet</string>
 			<key>NotificationSettings</key>
 			<array>
 				<dict>
@@ -105,34 +127,23 @@
 					<false/>
 				</dict>
 			</array>
-			<key>PayloadDescription</key>
-			<string>Configures notification settings for Santa</string>
 			<key>PayloadDisplayName</key>
 			<string>Notifications Settings</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.santa.notificationsettings</string>
-			<key>PayloadOrganization</key>
-			<string>Fleet</string>
-			<key>PayloadType</key>
-			<string>com.apple.notificationsettings</string>
-			<key>PayloadUUID</key>
-			<string>510236AE-D7F8-4131-A4CA-5CC930C51866</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.system-extension-policy</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.santa.system-extension</string>
+			<key>PayloadUUID</key>
+			<string>FFEE1028-C42B-4D57-A1AE-03307340FD9E</string>
 			<key>AllowedSystemExtensionTypes</key>
 			<dict>
 				<key>ZMCG7MLDV9</key>
 				<array>
 					<string>EndpointSecurityExtension</string>
-				</array>
-			</dict>
-			<key>AllowedSystemExtensions</key>
-			<dict>
-				<key>ZMCG7MLDV9</key>
-				<array>
-					<string>com.northpolesec.santa.daemon</string>
 				</array>
 			</dict>
 			<key>NonRemovableSystemExtensions</key>
@@ -142,36 +153,33 @@
 					<string>com.northpolesec.santa.daemon</string>
 				</array>
 			</dict>
+			<key>AllowedSystemExtensions</key>
+			<dict>
+				<key>ZMCG7MLDV9</key>
+				<array>
+					<string>com.northpolesec.santa.daemon</string>
+				</array>
+			</dict>
 			<key>PayloadDescription</key>
-			<string>Allow Santa's system extension and prevent removal</string>
+			<string>Allow Santa&apos;s system extension and prevent removal</string>
+			<key>PayloadOrganization</key>
+			<string>Fleet</string>
 			<key>PayloadDisplayName</key>
 			<string>System Extension</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.santa.system-extension</string>
-			<key>PayloadOrganization</key>
-			<string>Fleet</string>
-			<key>PayloadType</key>
-			<string>com.apple.system-extension-policy</string>
-			<key>PayloadUUID</key>
-			<string>67EF74B6-F4FB-49FC-A086-5DE3E61B838A</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 		<dict>
-			<key>PayloadDescription</key>
-			<string>Allows full-disk access for Santa</string>
-			<key>PayloadDisplayName</key>
-			<string>TCC Permissions</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.santa.tcc</string>
-			<key>PayloadOrganization</key>
-			<string>Fleet</string>
 			<key>PayloadType</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
-			<key>PayloadUUID</key>
-			<string>8339162A-75E7-4E07-91DC-45DC939A4764</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.santa.tcc</string>
+			<key>PayloadUUID</key>
+			<string>0A4D0AFF-7A3F-44AE-8120-3E6CC3CD1DE7</string>
+			<key>PayloadDisplayName</key>
+			<string>TCC Permissions</string>
+			<key>PayloadDescription</key>
+			<string>Allows full-disk access for Santa</string>
 			<key>Services</key>
 			<dict>
 				<key>SystemPolicyAllFiles</key>
@@ -180,7 +188,7 @@
 						<key>Allowed</key>
 						<true/>
 						<key>CodeRequirement</key>
-						<string>identifier "com.northpolesec.santa.daemon" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZMCG7MLDV9</string>
+						<string>identifier &quot;com.northpolesec.santa.daemon&quot; and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZMCG7MLDV9</string>
 						<key>Comment</key>
 						<string></string>
 						<key>Identifier</key>
@@ -194,7 +202,7 @@
 						<key>Allowed</key>
 						<true/>
 						<key>CodeRequirement</key>
-						<string>identifier "com.northpolesec.santa.bundleservice" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZMCG7MLDV9</string>
+						<string>identifier &quot;com.northpolesec.santa.bundleservice&quot; and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZMCG7MLDV9</string>
 						<key>Comment</key>
 						<string></string>
 						<key>Identifier</key>
@@ -206,27 +214,19 @@
 					</dict>
 				</array>
 			</dict>
+			<key>PayloadOrganization</key>
+			<string>Fleet</string>
 		</dict>
 	</array>
-	<key>PayloadDescription</key>
-	<string>Santa configuration including background apps, settings, notifications, system extension, and TCC permissions</string>
-	<key>PayloadDisplayName</key>
-	<string>Santa configuration</string>
-	<key>PayloadEnabled</key>
-	<true/>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.santa.configuration</string>
-	<key>PayloadOrganization</key>
-	<string>Fleet</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
+	<key>PayloadEnabled</key>
+	<true/>
+	<key>PayloadDescription</key>
+	<string>Santa configuration including background apps, settings, notifications, system extension, and TCC permissions</string>
+	<key>PayloadOrganization</key>
+	<string>Fleet</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>BBA4AD4E-9A70-4EF7-B33A-072D05B128C0</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/santa-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/santa-configuration.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.santa.configuration</string>
 	<key>PayloadUUID</key>
-	<string>8F06A206-9393-4798-B439-A9E6382529B8</string>
+	<string>BBA4AD4E-9A70-4EF7-B33A-072D05B128C0</string>
 	<key>PayloadDisplayName</key>
 	<string>Santa configuration</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.santa.servicemanagement</string>
 			<key>PayloadUUID</key>
-			<string>CF1F18D8-ACB3-40A6-8340-85C7B2C5B076</string>
+			<string>1161A7ED-2E7B-4744-B933-D3B9F58A1AAE</string>
 			<key>PayloadDescription</key>
 			<string>Allows Santa background tasks without notifications</string>
 			<key>Rules</key>
@@ -47,7 +47,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.santa.preferences</string>
 			<key>PayloadUUID</key>
-			<string>384CE88D-DF7E-4F8B-91C2-03037C496796</string>
+			<string>359E3C7D-396F-4C45-99E7-F429620B9B21</string>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.northpolesec.santa</key>
@@ -101,7 +101,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.santa.notificationsettings</string>
 			<key>PayloadUUID</key>
-			<string>3080FF9D-9ED9-41CC-8D67-6F22C1771E89</string>
+			<string>510236AE-D7F8-4131-A4CA-5CC930C51866</string>
 			<key>PayloadDescription</key>
 			<string>Configures notification settings for Santa</string>
 			<key>PayloadOrganization</key>
@@ -138,7 +138,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.santa.system-extension</string>
 			<key>PayloadUUID</key>
-			<string>FFEE1028-C42B-4D57-A1AE-03307340FD9E</string>
+			<string>67EF74B6-F4FB-49FC-A086-5DE3E61B838A</string>
 			<key>AllowedSystemExtensionTypes</key>
 			<dict>
 				<key>ZMCG7MLDV9</key>
@@ -175,7 +175,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.santa.tcc</string>
 			<key>PayloadUUID</key>
-			<string>0A4D0AFF-7A3F-44AE-8120-3E6CC3CD1DE7</string>
+			<string>8339162A-75E7-4E07-91DC-45DC939A4764</string>
 			<key>PayloadDisplayName</key>
 			<string>TCC Permissions</string>
 			<key>PayloadDescription</key>

--- a/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
@@ -2,9 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.santa.rules</string>
+	<key>PayloadUUID</key>
+	<string>274C8541-158A-4BCE-9288-30E8922A4DF1</string>
+	<key>PayloadDisplayName</key>
+	<string>Santa rules</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.santa.359E3C7D-396F-4C45-99E7-F429620B9B21</string>
+			<key>PayloadUUID</key>
+			<string>256488D5-A23B-4015-8F1D-9C4CA3B0D486</string>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.northpolesec.santa</key>
@@ -42,33 +60,15 @@
 			</dict>
 			<key>PayloadEnabled</key>
 			<true/>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.santa.359E3C7D-396F-4C45-99E7-F429620B9B21</string>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadUUID</key>
-			<string>359E3C7D-396F-4C45-99E7-F429620B9B21</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
 		</dict>
 	</array>
-	<key>PayloadDescription</key>
-	<string>Santa rules</string>
-	<key>PayloadDisplayName</key>
-	<string>Santa rules</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.santa.rules</string>
-	<key>PayloadOrganization</key>
-	<string>Fleet</string>
 	<key>PayloadRemovalDisallowed</key>
 	<true/>
+	<key>PayloadDescription</key>
+	<string>Santa rules</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>AFA02DE3-ACA6-49C4-9980-A3664E22E446</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
+	<key>PayloadOrganization</key>
+	<string>Fleet</string>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.santa.rules</string>
 	<key>PayloadUUID</key>
-	<string>274C8541-158A-4BCE-9288-30E8922A4DF1</string>
+	<string>AFA02DE3-ACA6-49C4-9980-A3664E22E446</string>
 	<key>PayloadDisplayName</key>
 	<string>Santa rules</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.santa.359E3C7D-396F-4C45-99E7-F429620B9B21</string>
 			<key>PayloadUUID</key>
-			<string>256488D5-A23B-4015-8F1D-9C4CA3B0D486</string>
+			<string>359E3C7D-396F-4C45-99E7-F429620B9B21</string>
 			<key>PayloadContent</key>
 			<dict>
 				<key>com.northpolesec.santa</key>

--- a/it-and-security/lib/macos/configuration-profiles/screen-lock-inactivity.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/screen-lock-inactivity.mobileconfig
@@ -2,49 +2,51 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>Starts the screen saver after 15 minutes of inactivity. A password is required to unlock after a one-minute grace period once the screen saver has started or the display has slept.</string>
-	<key>PayloadDisplayName</key>
-	<string>Screen lock after inactivity</string>
-	<key>PayloadIdentifier</key>
-	<string>com.fleetdm.screen-lock-inactivity</string>
-	<key>PayloadOrganization</key>
-	<string>Fleet Device Management</string>
-	<key>PayloadScope</key>
-	<string>System</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>AB1372A9-6297-4108-85C7-0CE557A507AE</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-	<key>PayloadRemovalDisallowed</key>
-	<true/>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.screen-lock-inactivity</string>
+	<key>PayloadUUID</key>
+	<string>BE2E4980-67E1-4FD0-89CB-47DB6FFAD4BF</string>
+	<key>PayloadDisplayName</key>
+	<string>Screen lock after inactivity</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Screen lock after inactivity</string>
-			<key>PayloadIdentifier</key>
-			<string>com.fleetdm.screen-lock-inactivity.screensaver</string>
 			<key>PayloadType</key>
 			<string>com.apple.screensaver</string>
-			<key>PayloadUUID</key>
-			<string>0D9BCBE2-DA7A-40CD-9FCD-743F322677C2</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.screen-lock-inactivity.screensaver</string>
+			<key>PayloadUUID</key>
+			<string>85B7D157-0A46-42C3-9F93-3FD704454963</string>
 			<!-- Start the screen saver after 15 minutes of inactivity (must be <= 900 to satisfy the policy). -->
 			<key>idleTime</key>
 			<integer>900</integer>
+			<key>PayloadDisplayName</key>
+			<string>Screen lock after inactivity</string>
 			<!-- Require a password to wake from the screen saver or sleep. -->
 			<key>askForPassword</key>
 			<true/>
+			<key>moduleName</key>
+			<string>Lock Screen settings</string>
 			<!-- Seconds after screen saver or display sleep before a password is required (60 = 1 minute; must be <= 60 to satisfy the policy). -->
 			<key>askForPasswordDelay</key>
 			<integer>60</integer>
 		</dict>
 	</array>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadDescription</key>
+	<string>Starts the screen saver after 15 minutes of inactivity. A password is required to unlock after a one-minute grace period once the screen saver has started or the display has slept.</string>
+	<key>PayloadOrganization</key>
+	<string>Fleet Device Management</string>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/screen-lock-inactivity.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/screen-lock-inactivity.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.screen-lock-inactivity</string>
 	<key>PayloadUUID</key>
-	<string>BE2E4980-67E1-4FD0-89CB-47DB6FFAD4BF</string>
+	<string>AB1372A9-6297-4108-85C7-0CE557A507AE</string>
 	<key>PayloadDisplayName</key>
 	<string>Screen lock after inactivity</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.fleetdm.screen-lock-inactivity.screensaver</string>
 			<key>PayloadUUID</key>
-			<string>85B7D157-0A46-42C3-9F93-3FD704454963</string>
+			<string>0D9BCBE2-DA7A-40CD-9FCD-743F322677C2</string>
 			<!-- Start the screen saver after 15 minutes of inactivity (must be <= 900 to satisfy the policy). -->
 			<key>idleTime</key>
 			<integer>900</integer>

--- a/it-and-security/lib/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
@@ -2,42 +2,42 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Turn on secure keyboard entry in Terminal</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.SecureKeyboard</string>
+	<key>PayloadUUID</key>
+	<string>9D77EB80-1CAC-4772-95C1-F5DAE55E76BB</string>
+	<key>PayloadDisplayName</key>
+	<string>Turn on secure keyboard entry in Terminal</string>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.Terminal</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.Terminal</string>
+			<key>PayloadUUID</key>
+			<string>25DF37AF-EB5C-455C-A5B8-CF8D2960AA4F</string>
+			<key>SecureKeyboardEntry</key>
+			<true/>
+			<key>PayloadDisplayName</key>
+			<string>2.10 - Ensure Secure Keyboard Entry terminal.app is Enabled</string>
+		</dict>
+	</array>
+	<key>TargetDeviceType</key>
+	<integer>5</integer>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadDescription</key>
+	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadOrganization</key>
 	<string>Center for Internet Security</string>
 	<key>PayloadScope</key>
 	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>00B46A57-12BF-4FC3-AE79-3E0BEA66A973</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadDisplayName</key>
-			<string>2.10 - Ensure Secure Keyboard Entry terminal.app is Enabled</string>
-			<key>PayloadIdentifier</key>
-			<string>com.apple.Terminal</string>
-			<key>PayloadType</key>
-			<string>com.apple.Terminal</string>
-			<key>PayloadUUID</key>
-			<string>1CBE65D6-6E5C-42C3-AA43-0AAAA64BA908</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
-			<key>SecureKeyboardEntry</key>
-			<true/>
-		</dict>
-	</array>
 </dict>
 </plist>

--- a/it-and-security/lib/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
@@ -9,7 +9,7 @@
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.SecureKeyboard</string>
 	<key>PayloadUUID</key>
-	<string>9D77EB80-1CAC-4772-95C1-F5DAE55E76BB</string>
+	<string>00B46A57-12BF-4FC3-AE79-3E0BEA66A973</string>
 	<key>PayloadDisplayName</key>
 	<string>Turn on secure keyboard entry in Terminal</string>
 	<key>PayloadContent</key>
@@ -22,7 +22,7 @@
 			<key>PayloadIdentifier</key>
 			<string>com.apple.Terminal</string>
 			<key>PayloadUUID</key>
-			<string>25DF37AF-EB5C-455C-A5B8-CF8D2960AA4F</string>
+			<string>1CBE65D6-6E5C-42C3-AA43-0AAAA64BA908</string>
 			<key>SecureKeyboardEntry</key>
 			<true/>
 			<key>PayloadDisplayName</key>


### PR DESCRIPTION
Normalize and reorganize .mobileconfig files in it-and-security/lib/macos/configuration-profiles. Added and updated top-level payload metadata (PayloadType, PayloadVersion, PayloadIdentifier, PayloadUUID, PayloadDisplayName), ensured PayloadContent entries include proper PayloadType/PayloadIdentifier/PayloadUUID and display names, and set consistent fields such as PayloadScope, PayloadOrganization, PayloadRemovalDisallowed, TargetDeviceType and PayloadEnabled. Also updated specific payload settings and UUIDs/identifiers (e.g. 1Password, App Store auto updates, DNS-over-HTTPS, firewall logging) to make the profiles consistent and conform to expected mobileconfig structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reordered and normalized metadata across 30+ macOS configuration profiles; regenerated internal identifiers for consistency (no intended change to enforcement settings).
* **Bug Fixes**
  * Minor behavior adjustments: Nudge refresh interval value standardized (may affect background refresh timing); Okta Verify login-item matching broadened to a prefix match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->