### PR TITLE
FE: Remove unused route params

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -318,13 +318,12 @@ const ManageHostsPage = ({
   const depAssignProfileResponse = queryParams?.dep_assign_profile_response?.toUpperCase();
 
   // ========= routeParams
-  const { active_label: activeLabel, label_id: labelID } = routeParams;
+  const { label_id: labelID } = routeParams;
   const selectedLabels = useMemo(() => {
     const filters: string[] = [];
     labelID && filters.push(`${LABEL_SLUG_PREFIX}${labelID}`);
-    activeLabel && filters.push(activeLabel);
     return filters;
-  }, [activeLabel, labelID]);
+  }, [labelID]);
 
   // All possible filter states - these align with ILoadHostsOptions, but state names here can
   // differ from param names there:

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -280,15 +280,6 @@ const routes = (
             <IndexRedirect to="manage" />
             <Route path="manage" component={ManageHostsPage} />
             <Route path="manage/labels/:label_id" component={ManageHostsPage} />
-            <Route path="manage/:active_label" component={ManageHostsPage} />
-            <Route
-              path="manage/labels/:label_id/:active_label"
-              component={ManageHostsPage}
-            />
-            <Route
-              path="manage/:active_label/labels/:label_id"
-              component={ManageHostsPage}
-            />
             <Route path=":host_id" component={HostDetailsPage}>
               <IndexRedirect to="details" />
               <Route path="details" component={HostDetailsPage} />


### PR DESCRIPTION
## Issue
Closes #45027

Found dead code in review of #44880 
Comment https://github.com/fleetdm/fleet/pull/44880#discussion_r3209074033

## Description
- These route params are dead code

>  Yes, 100%. Here's everything I checked:                                                                                               
>                                                                                                                                         
>   - activeLabel as a variable — only existed in ManageHostsPage.tsx (now removed) and unrelated activeLabels in policy/query forms      
>   - active_label as a route param — only the routes I removed and two comments in ManageHostsPage.tsx                                   
>   - params.active_label / routeParams.active_label — zero matches                                                                       
>   - Any URL containing /hosts/manage/ followed by a label name (macs, windows, etc.) — zero matches                                     
>   - PATHS constants — only hosts/manage/labels/${labelId}, nothing with active_label                                                    
>                                                                                                                                         
>   Nothing in the codebase constructs or navigates to these routes. They're dead.          

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized label filtering and routing in the hosts management interface by removing redundant route variants, streamlining the label selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->