### PR TITLE
Load test - Workflow guardrails and osquery perf updates

### DIFF
--- a/.github/workflows/loadtest-infra.yml
+++ b/.github/workflows/loadtest-infra.yml
@@ -184,15 +184,9 @@ jobs:
           echo "osquery_perf_block=false" >> $GITHUB_OUTPUT
           terraform init
           if terraform workspace list | sed 's/^[* ]*//' | grep -Fxq "${{ inputs.terraform_workspace }}"; then
-            terraform workspace select ${{ inputs.terraform_workspace }}
-            RESOURCE_COUNT=$(terraform state list | wc -l)
-            if [[ $RESOURCE_COUNT -gt 0 ]]; then
-              echo "BLOCK: osquery-perf workspace '${{ inputs.terraform_workspace }}' has $RESOURCE_COUNT resources deployed."
-              echo "Destroying infra would break the osquery-perf deployment. Destroy the osquery-perf workspace first."
-              echo "osquery_perf_block=true" >> $GITHUB_OUTPUT
-            else
-              echo "OK: osquery-perf workspace '${{ inputs.terraform_workspace }}' exists but has no resources."
-            fi
+            echo "BLOCK: matching osquery-perf workspace '${{ inputs.terraform_workspace }}' exists."
+            echo "Destroy the osquery-perf workspace first."
+            echo "osquery_perf_block=true" >> $GITHUB_OUTPUT
           else
             echo "OK: no matching osquery-perf workspace '${{ inputs.terraform_workspace }}' found."
           fi

--- a/.github/workflows/loadtest-infra.yml
+++ b/.github/workflows/loadtest-infra.yml
@@ -181,14 +181,14 @@ jobs:
         id: check-osquery-perf
         working-directory: infrastructure/loadtesting/terraform/osquery_perf
         run: |
-          echo "osquery_perf_block=false" >> $GITHUB_OUTPUT
+          echo "osquery_perf_block=true" >> $GITHUB_OUTPUT
           terraform init
           if terraform workspace list | sed 's/^[* ]*//' | grep -Fxq "${{ inputs.terraform_workspace }}"; then
             echo "BLOCK: matching osquery-perf workspace '${{ inputs.terraform_workspace }}' exists."
             echo "Destroy the osquery-perf workspace first."
-            echo "osquery_perf_block=true" >> $GITHUB_OUTPUT
           else
             echo "OK: no matching osquery-perf workspace '${{ inputs.terraform_workspace }}' found."
+            echo "osquery_perf_block=false" >> $GITHUB_OUTPUT
           fi
       - name: Terraform Destroy
         if: inputs.terraform_action == 'destroy' && steps.check-osquery-perf.outputs.osquery_perf_block == 'false'

--- a/.github/workflows/loadtest-infra.yml
+++ b/.github/workflows/loadtest-infra.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Terraform workspace
         id: workspace
         run: |
-          if terraform workspace list | grep -q ${{ inputs.terraform_workspace }};
+          if terraform workspace list | sed 's/^[* ]*//' | grep -Fxq "${{ inputs.terraform_workspace }}";
           then
             echo "MATCH - TF_WORKSPACE: ${{ inputs.terraform_workspace }}\n"
             
@@ -176,10 +176,30 @@ jobs:
           else
             echo "TERRAFORM WORKSPACE: DOES NOT MATCH INPUT - ${{ inputs.terraform_workspace }}"
           fi
-      - name: Terraform Destroy
+      - name: Check osquery-perf workspace
         if: inputs.terraform_action == 'destroy'
+        id: check-osquery-perf
+        working-directory: infrastructure/loadtesting/terraform/osquery_perf
+        run: |
+          echo "osquery_perf_block=false" >> $GITHUB_OUTPUT
+          terraform init
+          if terraform workspace list | sed 's/^[* ]*//' | grep -Fxq "${{ inputs.terraform_workspace }}"; then
+            terraform workspace select ${{ inputs.terraform_workspace }}
+            RESOURCE_COUNT=$(terraform state list | wc -l)
+            if [[ $RESOURCE_COUNT -gt 0 ]]; then
+              echo "BLOCK: osquery-perf workspace '${{ inputs.terraform_workspace }}' has $RESOURCE_COUNT resources deployed."
+              echo "Destroying infra would break the osquery-perf deployment. Destroy the osquery-perf workspace first."
+              echo "osquery_perf_block=true" >> $GITHUB_OUTPUT
+            else
+              echo "OK: osquery-perf workspace '${{ inputs.terraform_workspace }}' exists but has no resources."
+            fi
+          else
+            echo "OK: no matching osquery-perf workspace '${{ inputs.terraform_workspace }}' found."
+          fi
+      - name: Terraform Destroy
+        if: inputs.terraform_action == 'destroy' && steps.check-osquery-perf.outputs.osquery_perf_block == 'false'
         id: destroy
-        run: | 
+        run: |
           if [[ `terraform workspace show` = "${{ inputs.terraform_workspace }}" ]];
           then
             echo "TERRAFORM WORKSPACE: MATCHES - ${{ inputs.terraform_workspace }}"

--- a/.github/workflows/loadtest-infra.yml
+++ b/.github/workflows/loadtest-infra.yml
@@ -184,10 +184,10 @@ jobs:
           echo "osquery_perf_block=true" >> $GITHUB_OUTPUT
           terraform init
           if terraform workspace list | sed 's/^[* ]*//' | grep -Fxq "${{ inputs.terraform_workspace }}"; then
-            echo "BLOCK: matching osquery-perf workspace '${{ inputs.terraform_workspace }}' exists."
+            echo -e "\n\nBLOCK: matching osquery-perf workspace '${{ inputs.terraform_workspace }}' exists."
             echo "Destroy the osquery-perf workspace first."
           else
-            echo "OK: no matching osquery-perf workspace '${{ inputs.terraform_workspace }}' found."
+            echo -e "\n\nOK: no matching osquery-perf workspace '${{ inputs.terraform_workspace }}' found."
             echo "osquery_perf_block=false" >> $GITHUB_OUTPUT
           fi
       - name: Terraform Destroy

--- a/.github/workflows/loadtest-osquery-perf.yml
+++ b/.github/workflows/loadtest-osquery-perf.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Terraform workspace
         id: workspace
         run: |
-          if terraform workspace list | grep -q ${{ inputs.terraform_workspace }};
+          if terraform workspace list | sed 's/^[* ]*//' | grep -Fxq "${{ inputs.terraform_workspace }}";
           then
             echo "MATCH - TF_WORKSPACE: ${{ inputs.terraform_workspace }}\n"
             

--- a/.github/workflows/loadtest-osquery-perf.yml
+++ b/.github/workflows/loadtest-osquery-perf.yml
@@ -103,6 +103,20 @@ jobs:
       - name: Terraform Init
         id: init
         run: terraform init
+      - name: Check infra workspace exists
+        id: check-infra-workspace
+        working-directory: infrastructure/loadtesting/terraform/infra
+        run: |
+          echo "infra_workspace_missing=true" >> $GITHUB_OUTPUT
+          terraform init
+          if terraform workspace list | sed 's/^[* ]*//' | grep -Fxq "${{ inputs.terraform_workspace }}"; then
+            echo -e "\n\nOK: matching infra workspace '${{ inputs.terraform_workspace }}' exists."
+            echo "infra_workspace_missing=false" >> $GITHUB_OUTPUT
+          else
+            echo -e "\n\nBLOCK: infra workspace '${{ inputs.terraform_workspace }}' does not exist."
+            echo "Deploy the infra workspace first, then deploy osquery-perf."
+            exit 1
+          fi
       - name: Terraform workspace
         id: workspace
         run: |

--- a/.github/workflows/loadtest-osquery-perf.yml
+++ b/.github/workflows/loadtest-osquery-perf.yml
@@ -21,6 +21,11 @@ on:
         type: string
         default: 0
         required: true
+      loadtest_containers_increment:
+        description: "Increment for enroll.sh loop. (Default: 4)."
+        type: string
+        default: 4
+        required: true
       task_size:
         description: "CPU and Memory setting for osquery-perf containers. Example: {\"cpu\":\"4096\",\"memory\":\"8192\"}"
         type: string
@@ -156,7 +161,7 @@ jobs:
           if [[ `terraform workspace show` = "${{ inputs.terraform_workspace }}" ]];
           then
             echo "TERRAFORM WORKSPACE: MATCHES - ${{ inputs.terraform_workspace }}"
-            ./enroll.sh ${{ inputs.git_tag_branch }} "${{ inputs.task_size }}" ${{ inputs.loadtest_containers_starting_index}} ${{ inputs.loadtest_containers }} ${{ inputs.sleep_time }} 
+            ./enroll.sh ${{ inputs.git_tag_branch }} "${{ inputs.task_size }}" ${{ inputs.loadtest_containers_starting_index}} ${{ inputs.loadtest_containers }} ${{ inputs.sleep_time }} ${{ inputs.loadtest_containers_increment }}
           else
             echo "TERRAFORM WORKSPACE: DOES NOT MATCH INPUT - ${{ inputs.terraform_workspace }}"
           fi

--- a/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
+++ b/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-# Script for enrolling osquery-perf hosts by `terraform apply`ing in increments of 8 `loadtest` containers.
+# Script for enrolling osquery-perf hosts by `terraform apply`ing in increments of 4 `loadtest` containers.
 # NOTE(lucas): This is the currently known configuration that won't tip the loadtest environment,
 # but maybe in the future we can be more aggressive (and reduce enroll time).
 #
@@ -11,7 +11,7 @@ TASK_SIZE=${2:?}
 START_INDEX=$3
 END_INDEX=$4
 SLEEP_TIME_SECONDS=${5:-60}
-INCREMENT=${6:-8}
+INCREMENT=${6:-4}
 
 if [ -z "$BRANCH_NAME" ]; then
 	echo "Missing BRANCH_NAME"

--- a/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
+++ b/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
@@ -13,6 +13,10 @@ END_INDEX=$4
 SLEEP_TIME_SECONDS=${5:-60}
 INCREMENT=${6:-4}
 
+if ! [[ "$INCREMENT" =~ ^[0-9]+$ ]] || (( INCREMENT <= 0 )); then
+	echo "INCREMENT must be a positive integer, got: $INCREMENT"
+	exit 1
+fi
 if [ -z "$BRANCH_NAME" ]; then
 	echo "Missing BRANCH_NAME"
 fi


### PR DESCRIPTION
- Prevents `terraform destroy` from running against load test infrastructure, for a given workspace, if an identical osquery perf workspace exists.
- Adds a check to the osquery perf workflow, to fail fast, if the specified load test infrastructure workspace is not detected.
- Adds ability for users to configure the osquery perf (increment - `input.loadtest_containers_increment`) batch size that get deployed to an environment during every loop. Default: 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable load-test container increment input (default: 4) to control scaling increments.

* **Improvements**
  * Prevented destructive runs when an existing infra workspace matches the requested name.
  * Tightened workspace-existence checks to require exact name matching.

* **Chores**
  * Default load-test increment reduced from 8 to 4 and input validated as a positive integer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->