### PR TITLE
Fix missing deleted_policy activity for auto-cleaned patch policies

### DIFF
--- a/changes/44286-deleted-policy-activity-for-patch-policies
+++ b/changes/44286-deleted-policy-activity-for-patch-policies
@@ -1,0 +1,1 @@
+* Fixed missing `deleted_policy` activity when a patch policy is removed by gitops as a result of its underlying Fleet-maintained app installer being removed from the YAML.

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3810,39 +3810,6 @@ labels:
 	require.Contains(t, deletedNames, "lbl-host-vitals")
 }
 
-// captureDeletedPolicyActivities replaces the suite's activity mock with a
-// recorder for deleted_policy activities. Returns a flush function that
-// returns and resets the captured activities.
-func (s *enterpriseIntegrationGitopsTestSuite) captureDeletedPolicyActivities(t *testing.T) func() []fleet.ActivityTypeDeletedPolicy {
-	t.Helper()
-	require.NotNil(t, s.activityMock, "activity mock should be wired up via TestServerOpts.ActivityMock")
-	prev := s.activityMock.NewActivityFunc
-	var (
-		mu       sync.Mutex
-		captured []fleet.ActivityTypeDeletedPolicy
-	)
-	s.activityMock.NewActivityFunc = func(ctx context.Context, user *activity_api.User, a activity_api.ActivityDetails) error {
-		if d, ok := a.(fleet.ActivityTypeDeletedPolicy); ok {
-			mu.Lock()
-			captured = append(captured, d)
-			mu.Unlock()
-		}
-		if prev != nil {
-			return prev(ctx, user, a)
-		}
-		return nil
-	}
-	t.Cleanup(func() { s.activityMock.NewActivityFunc = prev })
-
-	return func() []fleet.ActivityTypeDeletedPolicy {
-		mu.Lock()
-		defer mu.Unlock()
-		out := captured
-		captured = nil
-		return out
-	}
-}
-
 // setupDarwinFMA inserts a darwin FMA record with a unique slug and starts a
 // manifest+installer server pair for it. Returns the slug to use in YAML.
 func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) string {
@@ -3976,7 +3943,21 @@ reports:
 
 	// Phase 2: re-apply with no FMA and no policies. All three should be
 	// removed and each should emit a deleted_policy activity.
-	flush := s.captureDeletedPolicyActivities(t)
+	//
+	// Capture deleted_policy activities by overriding the mock's callback.
+	// fleetctl gitops makes API calls sequentially, so the slice append runs
+	// from a single HTTP-handler goroutine at a time and the post-apply read
+	// is synchronized by the HTTP response.
+	deletedIDs := map[uint]bool{}
+	prev := s.activityMock.NewActivityFunc
+	s.activityMock.NewActivityFunc = func(ctx context.Context, user *activity_api.User, a activity_api.ActivityDetails) error {
+		if d, ok := a.(fleet.ActivityTypeDeletedPolicy); ok {
+			deletedIDs[d.ID] = true
+		}
+		return prev(ctx, user, a)
+	}
+	t.Cleanup(func() { s.activityMock.NewActivityFunc = prev })
+
 	require.NoError(t, os.WriteFile(teamFile, []byte(teamEmpty), 0o644))
 	s.assertRealRunOutput(t, fleetctl.RunAppForTest(t, []string{
 		"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
@@ -3986,10 +3967,6 @@ reports:
 	require.NoError(t, err)
 	require.Empty(t, pols, "all policies should be removed after FMA installer is removed")
 
-	deletedIDs := map[uint]bool{}
-	for _, d := range flush() {
-		deletedIDs[d.ID] = true
-	}
 	for _, name := range []string{"install-policy", "patch-policy", "patch-and-install-policy"} {
 		require.True(t, deletedIDs[policyIDsByName[name]],
 			"expected deleted_policy activity for %q (id=%d), got activities for IDs %v",

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3810,11 +3810,8 @@ labels:
 	require.Contains(t, deletedNames, "lbl-host-vitals")
 }
 
-// setupDarwinFMA inserts a darwin FMA record with a unique slug and starts a
-// manifest+installer server pair for it. Returns the slug to use in YAML.
 func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) string {
 	t.Helper()
-	// Slug must have the form "<name>/<platform>" — Platform() splits on "/".
 	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
 	slug := fmt.Sprintf("foo%s/darwin", suffix)
 	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
@@ -3848,13 +3845,6 @@ func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) stri
 	return slug
 }
 
-// TestGitOpsRemovedFMAEmitsPolicyDeletedActivities verifies that when an FMA
-// installer is removed from the YAML, gitops emits a deleted_policy activity
-// for every policy that referenced it — covering all three automation shapes:
-//
-//   - regular policy with install_software referencing an FMA
-//   - patch policy referencing an FMA
-//   - patch policy that also has install_software
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDeletedActivities() {
 	t := s.T()
 	ctx := context.Background()
@@ -3863,8 +3853,8 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDe
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 	t.Setenv("FLEET_URL", s.Server.URL)
 
-	sharedSlug := s.setupDarwinFMA(t)          // used by install-policy and patch-policy
-	patchAndInstallSlug := s.setupDarwinFMA(t) // own FMA so the two patch policies don't collide on the (team_id, patch_software_title_id) unique index
+	sharedSlug := s.setupDarwinFMA(t)
+	patchAndInstallSlug := s.setupDarwinFMA(t)
 	teamName := uuid.NewString()
 
 	const globalConfig = `
@@ -3919,7 +3909,6 @@ reports:
 	require.NoError(t, os.WriteFile(globalFile, []byte(globalConfig), 0o644))
 	teamFile := filepath.Join(t.TempDir(), "team.yml")
 
-	// Phase 1: apply with FMA installer + three policies referencing it.
 	require.NoError(t, os.WriteFile(teamFile, []byte(teamWithFMAAndPolicies), 0o644))
 	s.assertRealRunOutput(t, fleetctl.RunAppForTest(t, []string{
 		"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
@@ -3938,10 +3927,6 @@ reports:
 	require.Contains(t, policyIDsByName, "patch-policy")
 	require.Contains(t, policyIDsByName, "patch-and-install-policy")
 
-	// Phase 2: re-apply with no FMA and no policies. All three should be
-	// removed and each should emit a deleted_policy activity.
-	//
-	// Capture deleted_policy activities by overriding the mock's callback.
 	// Could race if any test in this suite ever runs in parallel.
 	deletedIDs := map[uint]bool{}
 	prev := s.activityMock.NewActivityFunc

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3837,7 +3837,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) stri
 				InstallerURL:       installerServer.URL + "/foo.pkg",
 				InstallScriptRef:   "fooscript",
 				UninstallScriptRef: "fooscript",
-				SHA256:             "no_check",
+				SHA256:             "no_check", // See ma.noCheckHash
 			}},
 			Refs: map[string]string{"fooscript": "echo hello"},
 		}
@@ -3852,9 +3852,9 @@ func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) stri
 // installer is removed from the YAML, gitops emits a deleted_policy activity
 // for every policy that referenced it — covering all three automation shapes:
 //
-//   - regular policy with install_software (type=dynamic, software_installer_id)
-//   - patch policy without install automation (type=patch, patch_software_title_id)
-//   - patch policy with install automation (type=patch, both fields set)
+//   - regular policy with install_software referencing an FMA
+//   - patch policy referencing an FMA
+//   - patch policy that also has install_software
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDeletedActivities() {
 	t := s.T()
 	ctx := context.Background()
@@ -3863,11 +3863,8 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDe
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 	t.Setenv("FLEET_URL", s.Server.URL)
 
-	// Two FMAs are needed because patch policies have a unique index on
-	// (team_id, patch_software_title_id) — patch-policy and
-	// patch-and-install-policy must reference different titles.
-	slugA := s.setupDarwinFMA(t)
-	slugB := s.setupDarwinFMA(t)
+	sharedSlug := s.setupDarwinFMA(t)         // used by install-policy and patch-policy
+	patchAndInstallSlug := s.setupDarwinFMA(t) // own FMA so the two patch policies don't collide on the (team_id, patch_software_title_id) unique index
 	teamName := uuid.NewString()
 
 	const globalConfig = `
@@ -3906,7 +3903,7 @@ name: %s
 settings:
   secrets: [{"secret":"enroll_secret"}]
 reports:
-`, slugA, slugB, slugA, slugA, slugB, slugB, teamName)
+`, sharedSlug, patchAndInstallSlug, sharedSlug, sharedSlug, patchAndInstallSlug, patchAndInstallSlug, teamName)
 	teamEmpty := fmt.Sprintf(`
 controls:
 software:
@@ -3945,16 +3942,17 @@ reports:
 	// removed and each should emit a deleted_policy activity.
 	//
 	// Capture deleted_policy activities by overriding the mock's callback.
-	// fleetctl gitops makes API calls sequentially, so the slice append runs
-	// from a single HTTP-handler goroutine at a time and the post-apply read
-	// is synchronized by the HTTP response.
+	// Could race if any test in this suite ever runs in parallel.
 	deletedIDs := map[uint]bool{}
 	prev := s.activityMock.NewActivityFunc
-	s.activityMock.NewActivityFunc = func(ctx context.Context, user *activity_api.User, a activity_api.ActivityDetails) error {
+	s.activityMock.NewActivityFunc = func(ctx context.Context, _ *activity_api.User, a activity_api.ActivityDetails) error {
 		if d, ok := a.(fleet.ActivityTypeDeletedPolicy); ok {
 			deletedIDs[d.ID] = true
 		}
-		return prev(ctx, user, a)
+		if prev != nil {
+			return prev(ctx, nil, a)
+		}
+		return nil
 	}
 	t.Cleanup(func() { s.activityMock.NewActivityFunc = prev })
 

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3841,7 +3841,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) stri
 			}},
 			Refs: map[string]string{"fooscript": "echo hello"},
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(manifest))
+		_ = json.NewEncoder(w).Encode(manifest)
 	}))
 	t.Cleanup(manifestServer.Close)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
@@ -3863,7 +3863,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDe
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 	t.Setenv("FLEET_URL", s.Server.URL)
 
-	sharedSlug := s.setupDarwinFMA(t)         // used by install-policy and patch-policy
+	sharedSlug := s.setupDarwinFMA(t)          // used by install-policy and patch-policy
 	patchAndInstallSlug := s.setupDarwinFMA(t) // own FMA so the two patch policies don't collide on the (team_id, patch_software_title_id) unique index
 	teamName := uuid.NewString()
 

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3810,6 +3810,193 @@ labels:
 	require.Contains(t, deletedNames, "lbl-host-vitals")
 }
 
+// captureDeletedPolicyActivities replaces the suite's activity mock with a
+// recorder for deleted_policy activities. Returns a flush function that
+// returns and resets the captured activities.
+func (s *enterpriseIntegrationGitopsTestSuite) captureDeletedPolicyActivities(t *testing.T) func() []fleet.ActivityTypeDeletedPolicy {
+	t.Helper()
+	require.NotNil(t, s.activityMock, "activity mock should be wired up via TestServerOpts.ActivityMock")
+	prev := s.activityMock.NewActivityFunc
+	var (
+		mu       sync.Mutex
+		captured []fleet.ActivityTypeDeletedPolicy
+	)
+	s.activityMock.NewActivityFunc = func(ctx context.Context, user *activity_api.User, a activity_api.ActivityDetails) error {
+		if d, ok := a.(fleet.ActivityTypeDeletedPolicy); ok {
+			mu.Lock()
+			captured = append(captured, d)
+			mu.Unlock()
+		}
+		if prev != nil {
+			return prev(ctx, user, a)
+		}
+		return nil
+	}
+	t.Cleanup(func() { s.activityMock.NewActivityFunc = prev })
+
+	return func() []fleet.ActivityTypeDeletedPolicy {
+		mu.Lock()
+		defer mu.Unlock()
+		out := captured
+		captured = nil
+		return out
+	}
+}
+
+// setupDarwinFMA inserts a darwin FMA record with a unique slug and starts a
+// manifest+installer server pair for it. Returns the slug to use in YAML.
+func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) string {
+	t.Helper()
+	// Slug must have the form "<name>/<platform>" — Platform() splits on "/".
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
+	slug := fmt.Sprintf("foo%s/darwin", suffix)
+	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(t.Context(),
+			`INSERT INTO fleet_maintained_apps (name, slug, platform, unique_identifier)
+			 VALUES (?, ?, 'darwin', ?)`, "foo"+suffix, slug, "com.example.foo"+suffix)
+		return err
+	})
+
+	installerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("foo"))
+	}))
+	t.Cleanup(installerServer.Close)
+
+	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		manifest := ma.FMAManifestFile{
+			Versions: []*ma.FMAManifestApp{{
+				Version:            "1.0",
+				Queries:            ma.FMAQueries{Exists: "SELECT 1 FROM osquery_info;"},
+				InstallerURL:       installerServer.URL + "/foo.pkg",
+				InstallScriptRef:   "fooscript",
+				UninstallScriptRef: "fooscript",
+				SHA256:             "no_check",
+			}},
+			Refs: map[string]string{"fooscript": "echo hello"},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(manifest))
+	}))
+	t.Cleanup(manifestServer.Close)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
+	return slug
+}
+
+// TestGitOpsRemovedFMAEmitsPolicyDeletedActivities verifies that when an FMA
+// installer is removed from the YAML, gitops emits a deleted_policy activity
+// for every policy that referenced it — covering all three automation shapes:
+//
+//   - regular policy with install_software (type=dynamic, software_installer_id)
+//   - patch policy without install automation (type=patch, patch_software_title_id)
+//   - patch policy with install automation (type=patch, both fields set)
+func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDeletedActivities() {
+	t := s.T()
+	ctx := context.Background()
+
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+	t.Setenv("FLEET_URL", s.Server.URL)
+
+	// Two FMAs are needed because patch policies have a unique index on
+	// (team_id, patch_software_title_id) — patch-policy and
+	// patch-and-install-policy must reference different titles.
+	slugA := s.setupDarwinFMA(t)
+	slugB := s.setupDarwinFMA(t)
+	teamName := uuid.NewString()
+
+	const globalConfig = `
+agent_options:
+controls:
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+policies:
+reports:
+`
+	teamWithFMAAndPolicies := fmt.Sprintf(`
+controls:
+software:
+  fleet_maintained_apps:
+    - slug: %s
+    - slug: %s
+policies:
+  - name: install-policy
+    query: SELECT 1
+    install_software:
+      fleet_maintained_app_slug: %s
+  - name: patch-policy
+    type: patch
+    fleet_maintained_app_slug: %s
+  - name: patch-and-install-policy
+    type: patch
+    fleet_maintained_app_slug: %s
+    install_software:
+      fleet_maintained_app_slug: %s
+agent_options:
+name: %s
+settings:
+  secrets: [{"secret":"enroll_secret"}]
+reports:
+`, slugA, slugB, slugA, slugA, slugB, slugB, teamName)
+	teamEmpty := fmt.Sprintf(`
+controls:
+software:
+policies:
+agent_options:
+name: %s
+settings:
+  secrets: [{"secret":"enroll_secret"}]
+reports:
+`, teamName)
+
+	globalFile := filepath.Join(t.TempDir(), "global.yml")
+	require.NoError(t, os.WriteFile(globalFile, []byte(globalConfig), 0o644))
+	teamFile := filepath.Join(t.TempDir(), "team.yml")
+
+	// Phase 1: apply with FMA installer + three policies referencing it.
+	require.NoError(t, os.WriteFile(teamFile, []byte(teamWithFMAAndPolicies), 0o644))
+	s.assertRealRunOutput(t, fleetctl.RunAppForTest(t, []string{
+		"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
+	}))
+
+	team, err := s.DS.TeamByName(ctx, teamName)
+	require.NoError(t, err)
+	pols, err := s.DS.ListMergedTeamPolicies(ctx, team.ID, fleet.ListOptions{}, "")
+	require.NoError(t, err)
+	require.Len(t, pols, 3)
+	policyIDsByName := map[string]uint{}
+	for _, p := range pols {
+		policyIDsByName[p.Name] = p.ID
+	}
+	require.Contains(t, policyIDsByName, "install-policy")
+	require.Contains(t, policyIDsByName, "patch-policy")
+	require.Contains(t, policyIDsByName, "patch-and-install-policy")
+
+	// Phase 2: re-apply with no FMA and no policies. All three should be
+	// removed and each should emit a deleted_policy activity.
+	flush := s.captureDeletedPolicyActivities(t)
+	require.NoError(t, os.WriteFile(teamFile, []byte(teamEmpty), 0o644))
+	s.assertRealRunOutput(t, fleetctl.RunAppForTest(t, []string{
+		"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
+	}))
+
+	pols, err = s.DS.ListMergedTeamPolicies(ctx, team.ID, fleet.ListOptions{}, "")
+	require.NoError(t, err)
+	require.Empty(t, pols, "all policies should be removed after FMA installer is removed")
+
+	deletedIDs := map[uint]bool{}
+	for _, d := range flush() {
+		deletedIDs[d.ID] = true
+	}
+	for _, name := range []string{"install-policy", "patch-policy", "patch-and-install-policy"} {
+		require.True(t, deletedIDs[policyIDsByName[name]],
+			"expected deleted_policy activity for %q (id=%d), got activities for IDs %v",
+			name, policyIDsByName[name], deletedIDs)
+	}
+}
+
 // TestGitOpsVPPAppAutoUpdate tests that auto-update settings for VPP apps (iOS/iPadOS)
 // are properly applied via GitOps.
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsVPPAppAutoUpdate() {

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3810,10 +3810,50 @@ labels:
 	require.Contains(t, deletedNames, "lbl-host-vitals")
 }
 
-func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) string {
+// captureDeletedPolicyActivities replaces the suite's activity mock with a
+// recorder for deleted_policy activities. It returns a function that returns
+// and resets the captured activities. Cleanup restores the previous
+// NewActivityFunc.
+func (s *enterpriseIntegrationGitopsTestSuite) captureDeletedPolicyActivities(t *testing.T) func() []fleet.ActivityTypeDeletedPolicy {
+	t.Helper()
+	require.NotNil(t, s.activityMock, "activity mock should be wired up via TestServerOpts.ActivityMock")
+	prev := s.activityMock.NewActivityFunc
+	var (
+		mu       sync.Mutex
+		captured []fleet.ActivityTypeDeletedPolicy
+	)
+	s.activityMock.NewActivityFunc = func(ctx context.Context, user *activity_api.User, a activity_api.ActivityDetails) error {
+		if d, ok := a.(fleet.ActivityTypeDeletedPolicy); ok {
+			mu.Lock()
+			captured = append(captured, d)
+			mu.Unlock()
+		}
+		if prev != nil {
+			return prev(ctx, user, a)
+		}
+		return nil
+	}
+	t.Cleanup(func() { s.activityMock.NewActivityFunc = prev })
+
+	return func() []fleet.ActivityTypeDeletedPolicy {
+		mu.Lock()
+		defer mu.Unlock()
+		out := captured
+		captured = nil
+		return out
+	}
+}
+
+// setupDarwinFMA inserts a darwin FMA record and starts a per-FMA installer
+// server. Returns the slug and the installer server URL. The caller is
+// responsible for wiring a manifest server (FLEET_DEV_MAINTAINED_APPS_BASE_URL)
+// that serves a manifest for /<slug>.json — calling this helper twice within
+// the same test requires a single combined manifest server because
+// dev_mode.SetOverride only supports one base URL at a time.
+func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) (slug, installerURL string) {
 	t.Helper()
 	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
-	slug := fmt.Sprintf("foo%s/darwin", suffix)
+	slug = fmt.Sprintf("foo%s/darwin", suffix)
 	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(t.Context(),
 			`INSERT INTO fleet_maintained_apps (name, slug, platform, unique_identifier)
@@ -3825,24 +3865,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) stri
 		_, _ = w.Write([]byte("foo"))
 	}))
 	t.Cleanup(installerServer.Close)
-
-	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		manifest := ma.FMAManifestFile{
-			Versions: []*ma.FMAManifestApp{{
-				Version:            "1.0",
-				Queries:            ma.FMAQueries{Exists: "SELECT 1 FROM osquery_info;"},
-				InstallerURL:       installerServer.URL + "/foo.pkg",
-				InstallScriptRef:   "fooscript",
-				UninstallScriptRef: "fooscript",
-				SHA256:             "no_check", // See ma.noCheckHash
-			}},
-			Refs: map[string]string{"fooscript": "echo hello"},
-		}
-		_ = json.NewEncoder(w).Encode(manifest)
-	}))
-	t.Cleanup(manifestServer.Close)
-	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
-	return slug
+	return slug, installerServer.URL
 }
 
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDeletedActivities() {
@@ -3853,9 +3876,38 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDe
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 	t.Setenv("FLEET_URL", s.Server.URL)
 
-	sharedSlug := s.setupDarwinFMA(t)
-	patchAndInstallSlug := s.setupDarwinFMA(t)
+	sharedSlug, sharedInstaller := s.setupDarwinFMA(t)
+	patchAndInstallSlug, patchAndInstallInstaller := s.setupDarwinFMA(t)
 	teamName := uuid.NewString()
+
+	manifestFor := func(installerURL string) ma.FMAManifestFile {
+		return ma.FMAManifestFile{
+			Versions: []*ma.FMAManifestApp{{
+				Version:            "1.0",
+				Queries:            ma.FMAQueries{Exists: "SELECT 1 FROM osquery_info;"},
+				InstallerURL:       installerURL + "/foo.pkg",
+				InstallScriptRef:   "fooscript",
+				UninstallScriptRef: "fooscript",
+				SHA256:             "no_check", // See ma.noCheckHash
+			}},
+			Refs: map[string]string{"fooscript": "echo hello"},
+		}
+	}
+	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var installerURL string
+		switch r.URL.Path {
+		case "/" + sharedSlug + ".json":
+			installerURL = sharedInstaller
+		case "/" + patchAndInstallSlug + ".json":
+			installerURL = patchAndInstallInstaller
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(manifestFor(installerURL))
+	}))
+	t.Cleanup(manifestServer.Close)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
 
 	const globalConfig = `
 agent_options:
@@ -3927,20 +3979,7 @@ reports:
 	require.Contains(t, policyIDsByName, "patch-policy")
 	require.Contains(t, policyIDsByName, "patch-and-install-policy")
 
-	// Could race if any test in this suite ever runs in parallel.
-	deletedIDs := map[uint]bool{}
-	prev := s.activityMock.NewActivityFunc
-	s.activityMock.NewActivityFunc = func(ctx context.Context, _ *activity_api.User, a activity_api.ActivityDetails) error {
-		if d, ok := a.(fleet.ActivityTypeDeletedPolicy); ok {
-			deletedIDs[d.ID] = true
-		}
-		if prev != nil {
-			return prev(ctx, nil, a)
-		}
-		return nil
-	}
-	t.Cleanup(func() { s.activityMock.NewActivityFunc = prev })
-
+	flush := s.captureDeletedPolicyActivities(t)
 	require.NoError(t, os.WriteFile(teamFile, []byte(teamEmpty), 0o644))
 	s.assertRealRunOutput(t, fleetctl.RunAppForTest(t, []string{
 		"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
@@ -3950,6 +3989,10 @@ reports:
 	require.NoError(t, err)
 	require.Empty(t, pols, "all policies should be removed after FMA installer is removed")
 
+	deletedIDs := map[uint]bool{}
+	for _, d := range flush() {
+		deletedIDs[d.ID] = true
+	}
 	for _, name := range []string{"install-policy", "patch-policy", "patch-and-install-policy"} {
 		require.True(t, deletedIDs[policyIDsByName[name]],
 			"expected deleted_policy activity for %q (id=%d), got activities for IDs %v",

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2114,9 +2114,11 @@ WHERE
   team_id = ?
 `
 
-	const deleteAllPatchPolicies = `
-DELETE FROM
+	const unsetAllPatchPolicies = `
+UPDATE
 	policies
+SET
+	patch_software_title_id = NULL
 WHERE
 	team_id = ? AND
 	type = 'patch'
@@ -2266,9 +2268,11 @@ WHERE
   )
 `
 
-	const deletePatchPoliciesWithInstallersNotInList = `
-DELETE FROM
+	const unsetPatchPoliciesWithInstallersNotInList = `
+UPDATE
 	policies
+SET
+	patch_software_title_id = NULL
 WHERE
 	team_id = ? AND
 	patch_software_title_id NOT IN (?)
@@ -2511,8 +2515,8 @@ WHERE
 				return ctxerr.Wrap(ctx, err, "unset all obsolete installers in policies")
 			}
 
-			if _, err := tx.ExecContext(ctx, deleteAllPatchPolicies, globalOrTeamID); err != nil {
-				return ctxerr.Wrap(ctx, err, "delete all obsolete patch policies")
+			if _, err := tx.ExecContext(ctx, unsetAllPatchPolicies, globalOrTeamID); err != nil {
+				return ctxerr.Wrap(ctx, err, "unset all obsolete patch policies")
 			}
 
 			if _, err := tx.ExecContext(ctx, deleteAllPendingUninstallScriptExecutions, globalOrTeamID); err != nil {
@@ -2615,12 +2619,12 @@ WHERE
 			return ctxerr.Wrap(ctx, err, "unset obsolete software installers from policies")
 		}
 
-		stmt, args, err = sqlx.In(deletePatchPoliciesWithInstallersNotInList, globalOrTeamID, titleIDs)
+		stmt, args, err = sqlx.In(unsetPatchPoliciesWithInstallersNotInList, globalOrTeamID, titleIDs)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "build statement to delete obsolete patch policies")
+			return ctxerr.Wrap(ctx, err, "build statement to unset obsolete patch policies")
 		}
 		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
-			return ctxerr.Wrap(ctx, err, "delete obsolete patch policies")
+			return ctxerr.Wrap(ctx, err, "unset obsolete patch policies")
 		}
 
 		// check if any in the list are install_during_setup, fail if there is one

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -28672,7 +28672,7 @@ func (s *integrationEnterpriseTestSuite) TestPinMajorVersion() {
 	})
 }
 
-func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersDeletesObsoletePatchPolicy() {
+func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersUnsetsObsoletePatchPolicy() {
 	t := s.T()
 
 	team, err := s.ds.NewTeam(context.Background(), &fleet.Team{Name: "team_" + t.Name()})
@@ -28729,8 +28729,11 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersDeletesOb
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), fleet.ListTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
 	require.Len(t, listPolResp.Policies, 1)
 	require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
+	require.NotNil(t, listPolResp.Policies[0].PatchSoftware)
 
-	// Batch set only zoom/windows — should not fail and should delete the obsolete patch policy.
+	// Batch set only zoom/windows — should not fail and should unset the obsolete patch policy's
+	// patch_software_title_id without deleting the policy. Gitops then deletes it via the policy
+	// delete API so the deletion produces a deleted_policy activity.
 	s.DoJSON("POST", "/api/latest/fleet/software/batch",
 		batchSetSoftwareInstallersRequest{Software: []*fleet.SoftwareInstallerPayload{{Slug: ptr.String("zoom/windows")}}, TeamName: team.Name},
 		http.StatusAccepted, &resp,
@@ -28738,10 +28741,12 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersDeletesOb
 	)
 	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, resp.RequestUUID)
 
-	// Verify the patch policy was deleted.
+	// Verify the patch policy still exists but no longer references a software title.
 	listPolResp = fleet.ListTeamPoliciesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), fleet.ListTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
-	require.Empty(t, listPolResp.Policies)
+	require.Len(t, listPolResp.Policies, 1)
+	require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
+	require.Nil(t, listPolResp.Policies[0].PatchSoftware)
 }
 
 func (s *integrationEnterpriseTestSuite) TestListAPIEndpoints() {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44286

Unset `patch_software_title_id` rather than deleting the policy in `BatchSetSoftwareInstallers`, so the orphaned policy gets picked up by the `policiesToDelete` loop in `server/service/client.go:3121`. As a result, the `deleted_policy` activity is now created properly, and gitops dry/real runs also report the deletion:

```
dry run:
[-] would've deleted policy macOS - 010 Editor up to date
[-] would've deleted 1 policy

real run:
[-] deleting policy macOS - 010 Editor up to date
[-] deleting 1 policy
[-] deleted 1 policy
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing deletion activity logs when patch policies are removed via GitOps so policy deletion events are now recorded.

* **Behavior Changes**
  * Batch-updating installers now retains obsolete patch policies but clears their patch installer reference instead of deleting the policy.

* **Tests**
  * Added integration coverage to verify deletion activities are emitted and installer batch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->