### PR TITLE
Fix get policy by id endpoint and unify access in UI

### DIFF
--- a/changes/fix-get-policy-id-endpoint-and-unify-access-in-ui
+++ b/changes/fix-get-policy-id-endpoint-and-unify-access-in-ui
@@ -1,5 +1,3 @@
-* Fixed `GET /api/v1/fleet/policies/:id` endpoint to return (and properly populate) team policies.
-
-* Fixed `GET /api/v1/fleet/policies/:id` to perform authz check on team policies before returning.
-
-* Unify access to policies in UI by using the now generic `GET /api/v1/fleet/policies/:id` endpoint.
+- Fixed `GET /api/latest/fleet/policies/:id` endpoint (and alias `GET /api/v1/fleet/global/policies/:id`) to return (and properly populate) team policies.
+- Fixed `GET /api/latest/fleet/policies/:id` endpoint (and alias `GET /api/v1/fleet/global/policies/:id`) to perform authorization check on team policies before returning.
+- Unify access to global and team policies in UI by using the now generic `GET /api/latest/fleet/policies/:id` endpoint.

--- a/changes/fix-get-policy-id-endpoint-and-unify-access-in-ui
+++ b/changes/fix-get-policy-id-endpoint-and-unify-access-in-ui
@@ -1,0 +1,5 @@
+* Fixed `GET /api/v1/fleet/policies/:id` endpoint to return (and properly populate) team policies.
+
+* Fixed `GET /api/v1/fleet/policies/:id` to perform authz check on team policies before returning.
+
+* Unify access to policies in UI by using the now generic `GET /api/v1/fleet/policies/:id` endpoint.

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -22,7 +22,7 @@ import enrollSecretsAPI from "services/entities/enroll_secret";
 import usersAPI from "services/entities/users";
 import labelsAPI, { ILabelsResponse } from "services/entities/labels";
 import teamsAPI, { ILoadTeamsResponse } from "services/entities/teams";
-import globalPoliciesAPI from "services/entities/global_policies";
+import policiesAPI from "services/entities/policies";
 import hostsAPI, {
   HOSTS_QUERY_PARAMS as PARAMS,
   ILoadHostsQueryKey,
@@ -479,7 +479,7 @@ const ManageHostsPage = ({
     error: errorPolicy,
   } = useQuery<IStoredPolicyResponse, Error, IPolicy>(
     ["policy", policyId],
-    () => globalPoliciesAPI.load(policyId),
+    () => policiesAPI.load(policyId),
     {
       enabled: isRouteOk && !!policyId,
       select: (data) => data.policy,

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -132,7 +132,11 @@ const generateTableHeaders = (
               </>
             }
             path={getPathWithQueryParams(PATHS.POLICY_DETAILS(id), {
-              fleet_id: team_id,
+              // Inherited policies show team_id === null; preserve the
+              // current team context so back nav returns to the same list
+              // instead of "All teams".
+              fleet_id:
+                team_id ?? (selectedTeamId !== -1 ? selectedTeamId : null),
             })}
           />
         );

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -46,6 +46,16 @@ interface IPolicyDetailsPageProps {
 
 const baseClass = "policy-details-page";
 
+const getPolicyFleetName = (
+  policy: IPolicy | undefined,
+  teamData: ILoadTeamResponse | undefined
+): string | null => {
+  if (!policy) return null;
+  if (policy.team_id === null) return APP_CONTEXT_ALL_TEAMS_SUMMARY.name;
+  if (policy.team_id === 0) return APP_CONTEXT_NO_TEAM_SUMMARY.name;
+  return teamData?.team?.name ?? null;
+};
+
 const PolicyDetailsPage = ({
   router,
   params: { id: paramsPolicyId },
@@ -112,56 +122,54 @@ const PolicyDetailsPage = ({
     IStoredPolicyResponse,
     Error,
     IPolicy
-  >(
-    ["policy", policyId, teamIdForApi],
-    () => policiesAPI.load(policyId as number),
-    {
-      enabled: isRouteOk && !!policyId,
-      refetchOnWindowFocus: false,
-      retry: false,
-      select: (data: IStoredPolicyResponse) => data.policy,
-      onSuccess: (returnedPolicy) => {
-        setLastEditedQueryId(returnedPolicy.id);
-        setLastEditedQueryName(returnedPolicy.name);
-        setLastEditedQueryDescription(returnedPolicy.description);
-        setLastEditedQueryBody(returnedPolicy.query);
-        setLastEditedQueryResolution(returnedPolicy.resolution);
-        setLastEditedQueryCritical(returnedPolicy.critical);
-        setLastEditedQueryPlatform(returnedPolicy.platform);
-        setLastEditedQueryLabelsIncludeAny(
-          returnedPolicy.labels_include_any || []
-        );
-        setLastEditedQueryLabelsIncludeAll(
-          returnedPolicy.labels_include_all || []
-        );
-        setLastEditedQueryLabelsExcludeAny(
-          returnedPolicy.labels_exclude_any || []
-        );
-        const deNulledTeamId = returnedPolicy.team_id ?? undefined;
-        setPolicyTeamId(
-          deNulledTeamId === API_ALL_TEAMS_ID
-            ? APP_CONTEXT_ALL_TEAMS_ID
-            : deNulledTeamId
-        );
-      },
-      onError: (error) => handlePageError(error),
-    }
-  );
+  >(["policy", policyId], () => policiesAPI.load(policyId as number), {
+    enabled: isRouteOk && !!policyId,
+    refetchOnWindowFocus: false,
+    retry: false,
+    select: (data: IStoredPolicyResponse) => data.policy,
+    onSuccess: (returnedPolicy) => {
+      setLastEditedQueryId(returnedPolicy.id);
+      setLastEditedQueryName(returnedPolicy.name);
+      setLastEditedQueryDescription(returnedPolicy.description);
+      setLastEditedQueryBody(returnedPolicy.query);
+      setLastEditedQueryResolution(returnedPolicy.resolution);
+      setLastEditedQueryCritical(returnedPolicy.critical);
+      setLastEditedQueryPlatform(returnedPolicy.platform);
+      setLastEditedQueryLabelsIncludeAny(
+        returnedPolicy.labels_include_any || []
+      );
+      setLastEditedQueryLabelsIncludeAll(
+        returnedPolicy.labels_include_all || []
+      );
+      setLastEditedQueryLabelsExcludeAny(
+        returnedPolicy.labels_exclude_any || []
+      );
+      const deNulledTeamId = returnedPolicy.team_id ?? undefined;
+      setPolicyTeamId(
+        deNulledTeamId === API_ALL_TEAMS_ID
+          ? APP_CONTEXT_ALL_TEAMS_ID
+          : deNulledTeamId
+      );
+    },
+    onError: (error) => handlePageError(error),
+  });
 
   // Drive the team display from the policy's own team_id rather than the URL's
   // fleet_id: a user can land here from another team's list (e.g. clicking an
   // inherited policy from team 42's view), and the displayed Fleet must reflect
   // the policy's owner, not the navigation context.
-  const policyTeamId = storedPolicy?.team_id ?? undefined;
+  const policyTeamId = storedPolicy?.team_id;
 
   const { data: teamData } = useQuery<ILoadTeamResponse>(
     ["team", policyTeamId],
     () => teamsAPI.load(policyTeamId as number),
     {
-      enabled: policyTeamId !== undefined && policyTeamId > 0,
+      enabled: !!policyTeamId && policyTeamId > 0,
       refetchOnWindowFocus: false,
     }
   );
+
+  const policyFleetName = getPolicyFleetName(storedPolicy, teamData);
 
   let currentAutomatedPolicies: number[] = [];
   if (teamData?.team) {
@@ -391,36 +399,13 @@ const PolicyDetailsPage = ({
               />
             )}
             {renderAuthor()}
-            {storedPolicy &&
-              (() => {
-                if (storedPolicy.team_id === null) {
-                  return (
-                    <DataSet
-                      className={`${baseClass}__fleet`}
-                      title="Fleet"
-                      value={APP_CONTEXT_ALL_TEAMS_SUMMARY.name}
-                    />
-                  );
-                }
-                if (storedPolicy.team_id === 0) {
-                  return (
-                    <DataSet
-                      className={`${baseClass}__fleet`}
-                      title="Fleet"
-                      value={APP_CONTEXT_NO_TEAM_SUMMARY.name}
-                    />
-                  );
-                }
-                return (
-                  teamData?.team && (
-                    <DataSet
-                      className={`${baseClass}__fleet`}
-                      title="Fleet"
-                      value={teamData.team.name}
-                    />
-                  )
-                );
-              })()}
+            {policyFleetName && (
+              <DataSet
+                className={`${baseClass}__fleet`}
+                title="Fleet"
+                value={policyFleetName}
+              />
+            )}
             {renderPlatforms()}
             {renderLabels()}
             {storedPolicy && (

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -8,10 +8,14 @@ import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";
 import { ILabelPolicy } from "interfaces/label";
-import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
+import {
+  API_ALL_TEAMS_ID,
+  APP_CONTEXT_ALL_TEAMS_ID,
+  APP_CONTEXT_ALL_TEAMS_SUMMARY,
+  APP_CONTEXT_NO_TEAM_SUMMARY,
+} from "interfaces/team";
 import { PLATFORM_DISPLAY_NAMES, Platform } from "interfaces/platform";
-import globalPoliciesAPI from "services/entities/global_policies";
-import teamPoliciesAPI from "services/entities/team_policies";
+import policiesAPI from "services/entities/policies";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { addGravatarUrlToResource } from "utilities/helpers";
 import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
@@ -57,7 +61,6 @@ const PolicyDetailsPage = ({
     isGlobalTechnician,
     isOnGlobalTeam,
     config,
-    currentTeam,
   } = useContext(AppContext);
 
   const {
@@ -111,10 +114,7 @@ const PolicyDetailsPage = ({
     IPolicy
   >(
     ["policy", policyId, teamIdForApi],
-    () =>
-      teamIdForApi && teamIdForApi > 0
-        ? teamPoliciesAPI.load(teamIdForApi, policyId as number)
-        : globalPoliciesAPI.load(policyId as number),
+    () => policiesAPI.load(policyId as number),
     {
       enabled: isRouteOk && !!policyId,
       refetchOnWindowFocus: false,
@@ -148,11 +148,17 @@ const PolicyDetailsPage = ({
     }
   );
 
+  // Drive the team display from the policy's own team_id rather than the URL's
+  // fleet_id: a user can land here from another team's list (e.g. clicking an
+  // inherited policy from team 42's view), and the displayed Fleet must reflect
+  // the policy's owner, not the navigation context.
+  const policyTeamId = storedPolicy?.team_id ?? undefined;
+
   const { data: teamData } = useQuery<ILoadTeamResponse>(
-    ["team", teamIdForApi],
-    () => teamsAPI.load(teamIdForApi as number),
+    ["team", policyTeamId],
+    () => teamsAPI.load(policyTeamId as number),
     {
-      enabled: !!teamIdForApi && teamIdForApi > 0,
+      enabled: policyTeamId !== undefined && policyTeamId > 0,
       refetchOnWindowFocus: false,
     }
   );
@@ -385,13 +391,36 @@ const PolicyDetailsPage = ({
               />
             )}
             {renderAuthor()}
-            {currentTeam && (
-              <DataSet
-                className={`${baseClass}__fleet`}
-                title="Fleet"
-                value={currentTeam.name}
-              />
-            )}
+            {storedPolicy &&
+              (() => {
+                if (storedPolicy.team_id === null) {
+                  return (
+                    <DataSet
+                      className={`${baseClass}__fleet`}
+                      title="Fleet"
+                      value={APP_CONTEXT_ALL_TEAMS_SUMMARY.name}
+                    />
+                  );
+                }
+                if (storedPolicy.team_id === 0) {
+                  return (
+                    <DataSet
+                      className={`${baseClass}__fleet`}
+                      title="Fleet"
+                      value={APP_CONTEXT_NO_TEAM_SUMMARY.name}
+                    />
+                  );
+                }
+                return (
+                  teamData?.team && (
+                    <DataSet
+                      className={`${baseClass}__fleet`}
+                      title="Fleet"
+                      value={teamData.team.name}
+                    />
+                  )
+                );
+              })()}
             {renderPlatforms()}
             {renderLabels()}
             {storedPolicy && (

--- a/frontend/pages/policies/edit/EditPolicyPage.tsx
+++ b/frontend/pages/policies/edit/EditPolicyPage.tsx
@@ -14,6 +14,7 @@ import {
 import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import globalPoliciesAPI from "services/entities/global_policies";
 import teamPoliciesAPI from "services/entities/team_policies";
+import policiesAPI from "services/entities/policies";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import statusAPI from "services/entities/status";
 import PATHS from "router/paths";
@@ -141,18 +142,13 @@ const PolicyPage = ({
     false
   );
 
-  // TODO: Remove team endpoint workaround once global policy endpoint populates patch_software.
-  // The global endpoint does not return patch_software for patch policies, but the team endpoint does.
   const {
     isLoading: isStoredPolicyLoading,
     data: storedPolicy,
     error: storedPolicyError,
   } = useQuery<IStoredPolicyResponse, Error, IPolicy>(
     ["policy", policyId, teamIdForApi],
-    () =>
-      teamIdForApi && teamIdForApi > 0
-        ? teamPoliciesAPI.load(teamIdForApi, policyId as number)
-        : globalPoliciesAPI.load(policyId as number),
+    () => policiesAPI.load(policyId as number),
     {
       enabled: isRouteOk && !!policyId,
       refetchOnWindowFocus: false,

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
@@ -878,12 +878,78 @@ describe("PolicyForm - component", () => {
         },
       });
 
-      render(<PolicyForm {...defaultProps} />);
+      render(
+        <PolicyForm
+          {...defaultProps}
+          storedPolicy={createMockPolicy({
+            name: "Foo",
+            team_id: createMockTeamSummary().id,
+          })}
+        />
+      );
 
       expect(screen.getByText(/Editing policy for/i)).toBeInTheDocument();
       expect(
         screen.getByText(createMockTeamSummary().name)
       ).toBeInTheDocument();
+    });
+
+    it("shows 'Editing policy for All fleets' when editing an inherited (global) policy from a team's view", () => {
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            currentUser: createMockUser(),
+            // currentTeam reflects the URL (the team whose policy list the
+            // user came from), not the policy's true Fleet.
+            currentTeam: createMockTeamSummary(),
+            isGlobalObserver: false,
+            isGlobalAdmin: true,
+            isGlobalMaintainer: false,
+            isTeamMaintainerOrTeamAdmin: false,
+            isOnGlobalTeam: true,
+            isPremiumTier: true,
+            isSandboxMode: false,
+            isFreeTier: false,
+            config: createMockConfig(),
+          },
+          policy: {
+            policyTeamId: undefined,
+            lastEditedQueryId: mockPolicy.id,
+            lastEditedQueryName: mockPolicy.name,
+            lastEditedQueryDescription: mockPolicy.description,
+            lastEditedQueryBody: mockPolicy.query,
+            lastEditedQueryResolution: mockPolicy.resolution,
+            lastEditedQueryCritical: mockPolicy.critical,
+            lastEditedQueryPlatform: mockPolicy.platform,
+            lastEditedQueryLabelsIncludeAny: [],
+            lastEditedQueryLabelsIncludeAll: [],
+            lastEditedQueryLabelsExcludeAny: [],
+            defaultPolicy: false,
+            setLastEditedQueryName: jest.fn(),
+            setLastEditedQueryDescription: jest.fn(),
+            setLastEditedQueryBody: jest.fn(),
+            setLastEditedQueryResolution: jest.fn(),
+            setLastEditedQueryCritical: jest.fn(),
+            setLastEditedQueryPlatform: jest.fn(),
+          },
+        },
+      });
+
+      // The stored policy is global (team_id === null) — the form must show
+      // "All fleets", not the URL team's name.
+      render(
+        <PolicyForm
+          {...defaultProps}
+          storedPolicy={createMockPolicy({ name: "Foo", team_id: null })}
+        />
+      );
+
+      expect(screen.getByText(/Editing policy for/i)).toBeInTheDocument();
+      expect(screen.getByText("All fleets")).toBeInTheDocument();
+      expect(
+        screen.queryByText(createMockTeamSummary().name)
+      ).not.toBeInTheDocument();
     });
 
     it("shows 'Creating a new policy' when there is no existing policy", () => {

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -21,6 +21,10 @@ import {
 import { getPathWithQueryParams } from "utilities/url";
 
 import { IPolicy, IPolicyFormData } from "interfaces/policy";
+import {
+  APP_CONTEXT_ALL_TEAMS_SUMMARY,
+  APP_CONTEXT_NO_TEAM_SUMMARY,
+} from "interfaces/team";
 import { CommaSeparatedPlatformString } from "interfaces/platform";
 import { DEFAULT_POLICIES } from "pages/policies/constants";
 
@@ -603,15 +607,34 @@ const PolicyForm = ({
   };
 
   const renderPolicyFleetName = () => {
-    if (isFreeTier || !currentTeam?.name) return null;
+    if (isFreeTier) return null;
+
+    // In edit mode, the displayed Fleet must reflect the policy's actual
+    // owner, not the URL/navigation context: a user can land here by clicking
+    // an inherited (global) policy from a team's policy list, in which case
+    // currentTeam reflects the team URL, not the policy's true Fleet.
+    let fleetName: string | undefined;
+    if (isEditMode) {
+      if (storedPolicy?.team_id === null) {
+        fleetName = APP_CONTEXT_ALL_TEAMS_SUMMARY.name;
+      } else if (storedPolicy?.team_id === 0) {
+        fleetName = APP_CONTEXT_NO_TEAM_SUMMARY.name;
+      } else {
+        fleetName = currentTeam?.name;
+      }
+    } else {
+      fleetName = currentTeam?.name;
+    }
+
+    if (!fleetName) return null;
 
     return isEditMode ? (
       <p>
-        Editing policy for <strong>{currentTeam?.name}</strong>.
+        Editing policy for <strong>{fleetName}</strong>.
       </p>
     ) : (
       <p>
-        Creating a new policy for <strong>{currentTeam?.name}</strong>.
+        Creating a new policy for <strong>{fleetName}</strong>.
       </p>
     );
   };

--- a/frontend/pages/policies/live/LivePolicyPage/LivePolicyPage.tsx
+++ b/frontend/pages/policies/live/LivePolicyPage/LivePolicyPage.tsx
@@ -9,8 +9,7 @@ import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import { LIVE_QUERY_STEPS, DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
-import globalPoliciesAPI from "services/entities/global_policies";
-import teamPoliciesAPI from "services/entities/team_policies";
+import policiesAPI from "services/entities/policies";
 import hostAPI from "services/entities/hosts";
 import { IHost, IHostResponse } from "interfaces/host";
 import { ILabel } from "interfaces/label";
@@ -93,10 +92,7 @@ const LivePolicyPage = ({
     IPolicy
   >(
     ["policy", policyId, teamIdForApi],
-    () =>
-      teamIdForApi && teamIdForApi > 0
-        ? teamPoliciesAPI.load(teamIdForApi, policyId as number)
-        : globalPoliciesAPI.load(policyId as number),
+    () => policiesAPI.load(policyId as number),
     {
       enabled: !!policyId,
       refetchOnWindowFocus: false,

--- a/frontend/services/entities/policies.ts
+++ b/frontend/services/entities/policies.ts
@@ -1,0 +1,14 @@
+/* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
+
+import sendRequest from "services";
+import endpoints from "utilities/endpoints";
+import { IStoredPolicyResponse } from "interfaces/policy";
+
+export default {
+  load: (id: number): Promise<IStoredPolicyResponse> => {
+    const { GLOBAL_POLICIES } = endpoints;
+    const path = `${GLOBAL_POLICIES}/${id}`;
+
+    return sendRequest("GET", path);
+  },
+};

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -733,7 +733,7 @@ type Service interface {
 	ListGlobalPolicies(ctx context.Context, opts ListOptions) ([]*Policy, error)
 	DeleteGlobalPolicies(ctx context.Context, ids []uint) ([]uint, error)
 	ModifyGlobalPolicy(ctx context.Context, id uint, p ModifyPolicyPayload) (*Policy, error)
-	GetPolicyByIDQueries(ctx context.Context, policyID uint) (*Policy, error)
+	GetPolicyByID(ctx context.Context, policyID uint) (*Policy, error)
 	ApplyPolicySpecs(ctx context.Context, policies []*PolicySpec) error
 	CountGlobalPolicies(ctx context.Context, matchQuery string) (int, error)
 	AutofillPolicySql(ctx context.Context, sql string) (description string, resolution string, err error)
@@ -851,7 +851,7 @@ type Service interface {
 	ListTeamPolicies(ctx context.Context, teamID uint, opts ListOptions, iopts ListOptions, mergeInherited bool, automationType string) (teamPolicies, inheritedPolicies []*Policy, err error)
 	DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error)
 	ModifyTeamPolicy(ctx context.Context, teamID uint, id uint, p ModifyPolicyPayload) (*Policy, error)
-	GetTeamPolicyByIDQueries(ctx context.Context, teamID uint, policyID uint) (*Policy, error)
+	GetTeamPolicyByID(ctx context.Context, teamID uint, policyID uint) (*Policy, error)
 	CountTeamPolicies(ctx context.Context, teamID uint, matchQuery string, mergeInherited bool, automationType string) (int, int, error)
 
 	// /////////////////////////////////////////////////////////////////////////////

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -458,7 +458,7 @@ type DeleteGlobalPoliciesFunc func(ctx context.Context, ids []uint) ([]uint, err
 
 type ModifyGlobalPolicyFunc func(ctx context.Context, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error)
 
-type GetPolicyByIDQueriesFunc func(ctx context.Context, policyID uint) (*fleet.Policy, error)
+type GetPolicyByIDFunc func(ctx context.Context, policyID uint) (*fleet.Policy, error)
 
 type ApplyPolicySpecsFunc func(ctx context.Context, policies []*fleet.PolicySpec) error
 
@@ -532,7 +532,7 @@ type DeleteTeamPoliciesFunc func(ctx context.Context, teamID uint, ids []uint) (
 
 type ModifyTeamPolicyFunc func(ctx context.Context, teamID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error)
 
-type GetTeamPolicyByIDQueriesFunc func(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error)
+type GetTeamPolicyByIDFunc func(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error)
 
 type CountTeamPoliciesFunc func(ctx context.Context, teamID uint, matchQuery string, mergeInherited bool, automationType string) (int, int, error)
 
@@ -1584,8 +1584,8 @@ type Service struct {
 	ModifyGlobalPolicyFunc        ModifyGlobalPolicyFunc
 	ModifyGlobalPolicyFuncInvoked bool
 
-	GetPolicyByIDQueriesFunc        GetPolicyByIDQueriesFunc
-	GetPolicyByIDQueriesFuncInvoked bool
+	GetPolicyByIDFunc        GetPolicyByIDFunc
+	GetPolicyByIDFuncInvoked bool
 
 	ApplyPolicySpecsFunc        ApplyPolicySpecsFunc
 	ApplyPolicySpecsFuncInvoked bool
@@ -1695,8 +1695,8 @@ type Service struct {
 	ModifyTeamPolicyFunc        ModifyTeamPolicyFunc
 	ModifyTeamPolicyFuncInvoked bool
 
-	GetTeamPolicyByIDQueriesFunc        GetTeamPolicyByIDQueriesFunc
-	GetTeamPolicyByIDQueriesFuncInvoked bool
+	GetTeamPolicyByIDFunc        GetTeamPolicyByIDFunc
+	GetTeamPolicyByIDFuncInvoked bool
 
 	CountTeamPoliciesFunc        CountTeamPoliciesFunc
 	CountTeamPoliciesFuncInvoked bool
@@ -3822,11 +3822,11 @@ func (s *Service) ModifyGlobalPolicy(ctx context.Context, id uint, p fleet.Modif
 	return s.ModifyGlobalPolicyFunc(ctx, id, p)
 }
 
-func (s *Service) GetPolicyByIDQueries(ctx context.Context, policyID uint) (*fleet.Policy, error) {
+func (s *Service) GetPolicyByID(ctx context.Context, policyID uint) (*fleet.Policy, error) {
 	s.mu.Lock()
-	s.GetPolicyByIDQueriesFuncInvoked = true
+	s.GetPolicyByIDFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetPolicyByIDQueriesFunc(ctx, policyID)
+	return s.GetPolicyByIDFunc(ctx, policyID)
 }
 
 func (s *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.PolicySpec) error {
@@ -4081,11 +4081,11 @@ func (s *Service) ModifyTeamPolicy(ctx context.Context, teamID uint, id uint, p 
 	return s.ModifyTeamPolicyFunc(ctx, teamID, id, p)
 }
 
-func (s *Service) GetTeamPolicyByIDQueries(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error) {
+func (s *Service) GetTeamPolicyByID(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error) {
 	s.mu.Lock()
-	s.GetTeamPolicyByIDQueriesFuncInvoked = true
+	s.GetTeamPolicyByIDFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetTeamPolicyByIDQueriesFunc(ctx, teamID, policyID)
+	return s.GetTeamPolicyByIDFunc(ctx, teamID, policyID)
 }
 
 func (s *Service) CountTeamPolicies(ctx context.Context, teamID uint, matchQuery string, mergeInherited bool, automationType string) (int, int, error) {

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -112,38 +112,6 @@ func (svc Service) ListGlobalPolicies(ctx context.Context, opts fleet.ListOption
 	return svc.ds.ListGlobalPolicies(ctx, opts)
 }
 
-/////////////////////////////////////////////////////////////////////////////////
-// Get by id
-/////////////////////////////////////////////////////////////////////////////////
-
-func getPolicyByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
-	req := request.(*fleet.GetPolicyByIDRequest)
-	policy, err := svc.GetPolicyByIDQueries(ctx, req.PolicyID)
-	if err != nil {
-		return fleet.GetPolicyByIDResponse{Err: err}, nil
-	}
-	return fleet.GetPolicyByIDResponse{Policy: policy}, nil
-}
-
-func (svc Service) GetPolicyByIDQueries(ctx context.Context, policyID uint) (*fleet.Policy, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.Policy{}, fleet.ActionRead); err != nil {
-		return nil, err
-	}
-
-	policy, err := svc.ds.Policy(ctx, policyID)
-	if err != nil {
-		return nil, err
-	}
-	if err := svc.populatePolicyInstallSoftware(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate install_software")
-	}
-	if err := svc.populatePolicyRunScript(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
-	}
-
-	return policy, nil
-}
-
 // ///////////////////////////////////////////////////////////////////////////////
 // Count
 // ///////////////////////////////////////////////////////////////////////////////

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -135,7 +135,7 @@ func TestGlobalPoliciesAuth(t *testing.T) {
 			_, err = svc.ListGlobalPolicies(ctx, fleet.ListOptions{})
 			checkAuthErr(t, tt.shouldFailRead, err)
 
-			_, err = svc.GetPolicyByIDQueries(ctx, 1)
+			_, err = svc.GetPolicyByID(ctx, 1)
 			checkAuthErr(t, tt.shouldFailRead, err)
 
 			_, err = svc.ModifyGlobalPolicy(ctx, 1, fleet.ModifyPolicyPayload{})
@@ -151,6 +151,66 @@ func TestGlobalPoliciesAuth(t *testing.T) {
 				},
 			})
 			checkAuthErr(t, tt.shouldFailWrite, err)
+		})
+	}
+}
+
+// TestGetPolicyByIDCrossTeamAuth verifies that the global "get policy
+// by ID" endpoint refuses to return a team policy to a user who has no role
+// on that team. This guards against the regression described in the
+// "Cross-Team Policy Data Exposure" disclosure.
+func TestGetPolicyByIDCrossTeamAuth(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	// The fetched policy belongs to team 2.
+	const policyTeamID = uint(2)
+	ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+		teamID := policyTeamID
+		return &fleet.Policy{
+			PolicyData: fleet.PolicyData{
+				ID:     id,
+				TeamID: &teamID,
+			},
+		}, nil
+	}
+
+	testCases := []struct {
+		name           string
+		user           *fleet.User
+		shouldFailRead bool
+	}{
+		{
+			"global admin can read any team policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			false,
+		},
+		{
+			"global observer can read any team policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)},
+			false,
+		},
+		{
+			"team observer of the policy's team can read it",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: policyTeamID}, Role: fleet.RoleObserver}}},
+			false,
+		},
+		{
+			"team observer of a different team cannot read it",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}},
+			true,
+		},
+		{
+			"team admin of a different team cannot read it",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}},
+			true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
+			_, err := svc.GetPolicyByID(ctx, 1)
+			checkAuthErr(t, tt.shouldFailRead, err)
 		})
 	}
 }

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -196,6 +196,11 @@ func TestGetPolicyByIDCrossTeamAuth(t *testing.T) {
 			false,
 		},
 		{
+			"team gitops of the policy's team can read it",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: policyTeamID}, Role: fleet.RoleGitOps}}},
+			false,
+		},
+		{
 			"team observer of a different team cannot read it",
 			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}},
 			true,
@@ -203,6 +208,149 @@ func TestGetPolicyByIDCrossTeamAuth(t *testing.T) {
 		{
 			"team admin of a different team cannot read it",
 			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}},
+			true,
+		},
+		{
+			"team gitops of a different team cannot read it",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}},
+			true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
+			_, err := svc.GetPolicyByID(ctx, 1)
+			checkAuthErr(t, tt.shouldFailRead, err)
+		})
+	}
+}
+
+// TestGetPolicyByIDGlobalPolicyAuth verifies authorization for reading a
+// global policy (TeamID == nil) via the "get policy by ID" endpoint.
+func TestGetPolicyByIDGlobalPolicyAuth(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	// The fetched policy is global (TeamID is nil).
+	ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+		return &fleet.Policy{
+			PolicyData: fleet.PolicyData{
+				ID:     id,
+				TeamID: nil,
+			},
+		}, nil
+	}
+
+	testCases := []struct {
+		name           string
+		user           *fleet.User
+		shouldFailRead bool
+	}{
+		{
+			"global admin can read a global policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			false,
+		},
+		{
+			"global maintainer can read a global policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)},
+			false,
+		},
+		{
+			"global observer can read a global policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)},
+			false,
+		},
+		{
+			"global gitops can read a global policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
+			false,
+		},
+		{
+			"team admin can read a global policy",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}},
+			false,
+		},
+		{
+			"team observer can read a global policy",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}},
+			false,
+		},
+		{
+			"team gitops cannot read a global policy",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}},
+			true,
+		},
+		{
+			"user with no role cannot read a global policy",
+			&fleet.User{ID: 999},
+			true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
+			_, err := svc.GetPolicyByID(ctx, 1)
+			checkAuthErr(t, tt.shouldFailRead, err)
+		})
+	}
+}
+
+// TestGetPolicyByIDNoTeamPolicyAuth verifies authorization for reading a
+// "No team" policy (TeamID == 0) via the "get policy by ID" endpoint. Team-only
+// users without a role on team 0 must not be able to read it.
+func TestGetPolicyByIDNoTeamPolicyAuth(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	// The fetched policy belongs to "No team" (TeamID == 0).
+	ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+		return &fleet.Policy{
+			PolicyData: fleet.PolicyData{
+				ID:     id,
+				TeamID: ptr.Uint(0),
+			},
+		}, nil
+	}
+
+	testCases := []struct {
+		name           string
+		user           *fleet.User
+		shouldFailRead bool
+	}{
+		{
+			"global admin can read a no-team policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			false,
+		},
+		{
+			"global maintainer can read a no-team policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)},
+			false,
+		},
+		{
+			"global observer can read a no-team policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)},
+			false,
+		},
+		{
+			"global gitops can read a no-team policy",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
+			false,
+		},
+		{
+			"team admin of a regular team cannot read a no-team policy",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}},
+			true,
+		},
+		{
+			"team observer of a regular team cannot read a no-team policy",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}},
+			true,
+		},
+		{
+			"user with no role cannot read a no-team policy",
+			&fleet.User{ID: 999},
 			true,
 		},
 	}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8433,6 +8433,61 @@ func (s *integrationTestSuite) TestGlobalPoliciesBrowsing() {
 	assert.Equal(t, "select * from osquery;", policiesResponse.Policies[0].Query)
 }
 
+// TestGetPolicyByIDCrossTeamAccess verifies that GET /api/latest/fleet/policies/{id}
+// returns a team policy to a user that has access to the team it belongs to and
+// rejects the request with 403 when the requesting user has no role on that team.
+// This guards the security fix for the "Cross-Team Policy Data Exposure" disclosure.
+func (s *integrationTestSuite) TestGetPolicyByIDCrossTeamAccess() {
+	t := s.T()
+	ctx := context.Background()
+
+	team1, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "_team1"})
+	require.NoError(t, err)
+	team2, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "_team2"})
+	require.NoError(t, err)
+
+	policy, err := s.ds.NewTeamPolicy(ctx, team1.ID, nil, fleet.PolicyPayload{
+		Name:  t.Name() + "_team1_policy",
+		Query: "SELECT 1;",
+	})
+	require.NoError(t, err)
+
+	password := test.GoodPassword
+
+	team1Observer := &fleet.User{
+		Name:  "team1 observer",
+		Email: t.Name() + "_team1_observer@example.com",
+		Teams: []fleet.UserTeam{{Team: *team1, Role: fleet.RoleObserver}},
+	}
+	require.NoError(t, team1Observer.SetPassword(password, 10, 10))
+	_, err = s.ds.NewUser(ctx, team1Observer)
+	require.NoError(t, err)
+
+	team2Observer := &fleet.User{
+		Name:  "team2 observer",
+		Email: t.Name() + "_team2_observer@example.com",
+		Teams: []fleet.UserTeam{{Team: *team2, Role: fleet.RoleObserver}},
+	}
+	require.NoError(t, team2Observer.SetPassword(password, 10, 10))
+	_, err = s.ds.NewUser(ctx, team2Observer)
+	require.NoError(t, err)
+
+	policyURL := fmt.Sprintf("/api/latest/fleet/policies/%d", policy.ID)
+
+	// A user with access to the policy's team can read it.
+	s.setTokenForTest(t, team1Observer.Email, password)
+	var okResp fleet.GetPolicyByIDResponse
+	s.DoJSON("GET", policyURL, fleet.GetPolicyByIDRequest{}, http.StatusOK, &okResp)
+	require.NotNil(t, okResp.Policy)
+	assert.Equal(t, policy.ID, okResp.Policy.ID)
+	require.NotNil(t, okResp.Policy.TeamID)
+	assert.Equal(t, team1.ID, *okResp.Policy.TeamID)
+
+	// A user with no role on the policy's team is forbidden from reading it.
+	s.setTokenForTest(t, team2Observer.Email, password)
+	s.Do("GET", policyURL, fleet.GetPolicyByIDRequest{}, http.StatusForbidden)
+}
+
 func (s *integrationTestSuite) TestTeamPoliciesTeamNotExists() {
 	t := s.T()
 

--- a/server/service/policies.go
+++ b/server/service/policies.go
@@ -21,24 +21,20 @@ func getPolicyByIDEndpoint(ctx context.Context, request any, svc fleet.Service) 
 }
 
 func (svc Service) GetPolicyByID(ctx context.Context, policyID uint) (*fleet.Policy, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.Policy{}, fleet.ActionRead); err != nil {
-		return nil, err
-	}
-
+	// First, fetch policy to extract team for authorization checks.
 	policy, err := svc.ds.Policy(ctx, policyID)
 	if err != nil {
+		svc.SkipAuth(ctx)
 		return nil, err
 	}
 
-	// Re-authorize against the fetched policy so that team-scoped users cannot
-	// read policies belonging to teams they have no role on. The initial
-	// authorization above runs against an empty Policy{} (nil TeamID), which
-	// permits any user with a team role to reach this point regardless of the
-	// fetched policy's actual team.
+	// Now, authorize against the fetched policy so that team-scoped users cannot
+	// read policies belonging to teams they have no role on.
 	if err := svc.authz.Authorize(ctx, policy, fleet.ActionRead); err != nil {
 		return nil, err
 	}
 
+	// If it's a team policy we populate the automations on the policy.
 	if err := svc.populateAutomationsForTeamPolicy(ctx, policy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate automations")
 	}

--- a/server/service/policies.go
+++ b/server/service/policies.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+/////////////////////////////////////////////////////////////////////////////////
+// Get policy by id.
+/////////////////////////////////////////////////////////////////////////////////
+
+func getPolicyByIDEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*fleet.GetPolicyByIDRequest)
+	policy, err := svc.GetPolicyByID(ctx, req.PolicyID)
+	if err != nil {
+		return fleet.GetPolicyByIDResponse{Err: err}, nil
+	}
+	return fleet.GetPolicyByIDResponse{Policy: policy}, nil
+}
+
+func (svc Service) GetPolicyByID(ctx context.Context, policyID uint) (*fleet.Policy, error) {
+	if err := svc.authz.Authorize(ctx, &fleet.Policy{}, fleet.ActionRead); err != nil {
+		return nil, err
+	}
+
+	policy, err := svc.ds.Policy(ctx, policyID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Re-authorize against the fetched policy so that team-scoped users cannot
+	// read policies belonging to teams they have no role on. The initial
+	// authorization above runs against an empty Policy{} (nil TeamID), which
+	// permits any user with a team role to reach this point regardless of the
+	// fetched policy's actual team.
+	if err := svc.authz.Authorize(ctx, policy, fleet.ActionRead); err != nil {
+		return nil, err
+	}
+
+	if err := svc.populateAutomationsForTeamPolicy(ctx, policy); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate automations")
+	}
+
+	return policy, nil
+}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -85,14 +85,8 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 		return nil, ctxerr.Wrap(ctx, err, "creating policy")
 	}
 
-	if err := svc.populatePolicyInstallSoftware(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate install_software")
-	}
-	if err := svc.populatePolicyRunScript(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
-	}
-	if err := svc.populatePolicyPatchSoftware(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate patch_software")
+	if err := svc.populateAutomationsForTeamPolicy(ctx, policy); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate automations")
 	}
 
 	if teamID == 0 {
@@ -140,6 +134,22 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 		return nil, ctxerr.Wrap(ctx, err, "create activity for team policy creation")
 	}
 	return policy, nil
+}
+
+func (svc *Service) populateAutomationsForTeamPolicy(ctx context.Context, policy *fleet.Policy) error {
+	if policy.TeamID == nil {
+		return nil
+	}
+	if err := svc.populatePolicyInstallSoftware(ctx, policy); err != nil {
+		return ctxerr.Wrap(ctx, err, "populate install_software")
+	}
+	if err := svc.populatePolicyRunScript(ctx, policy); err != nil {
+		return ctxerr.Wrap(ctx, err, "populate run_script")
+	}
+	if err := svc.populatePolicyPatchSoftware(ctx, policy); err != nil {
+		return ctxerr.Wrap(ctx, err, "populate patch_software")
+	}
+	return nil
 }
 
 func (svc *Service) populatePolicyInstallSoftware(ctx context.Context, p *fleet.Policy) error {
@@ -264,11 +274,8 @@ func (svc *Service) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 	if mergeInherited {
 		policies, err := svc.ds.ListMergedTeamPolicies(ctx, teamID, opts, automationFilter)
 		for i := range policies {
-			if err := svc.populatePolicyInstallSoftware(ctx, policies[i]); err != nil {
-				return nil, nil, ctxerr.Wrapf(ctx, err, "populate install_software for policy_id: %d", policies[i].ID)
-			}
-			if err := svc.populatePolicyRunScript(ctx, policies[i]); err != nil {
-				return nil, nil, ctxerr.Wrapf(ctx, err, "populate run_script for policy_id: %d", policies[i].ID)
+			if err := svc.populateAutomationsForTeamPolicy(ctx, policies[i]); err != nil {
+				return nil, nil, ctxerr.Wrapf(ctx, err, "populate automations for policy_id: %d", policies[i].ID)
 			}
 		}
 		return policies, nil, err
@@ -280,14 +287,8 @@ func (svc *Service) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 	}
 
 	for i := range teamPolicies {
-		if err := svc.populatePolicyInstallSoftware(ctx, teamPolicies[i]); err != nil {
-			return nil, nil, ctxerr.Wrapf(ctx, err, "populate install_software for policy_id: %d", teamPolicies[i].ID)
-		}
-		if err := svc.populatePolicyRunScript(ctx, teamPolicies[i]); err != nil {
-			return nil, nil, ctxerr.Wrapf(ctx, err, "populate run_script for policy_id: %d", teamPolicies[i].ID)
-		}
-		if err := svc.populatePolicyPatchSoftware(ctx, teamPolicies[i]); err != nil {
-			return nil, nil, ctxerr.Wrapf(ctx, err, "populate patch_software for policy_id: %d", teamPolicies[i].ID)
+		if err := svc.populateAutomationsForTeamPolicy(ctx, teamPolicies[i]); err != nil {
+			return nil, nil, ctxerr.Wrapf(ctx, err, "populate automations for policy_id: %d", teamPolicies[i].ID)
 		}
 	}
 
@@ -347,14 +348,14 @@ func (svc *Service) CountTeamPolicies(ctx context.Context, teamID uint, matchQue
 
 func getTeamPolicyByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*fleet.GetTeamPolicyByIDRequest)
-	teamPolicy, err := svc.GetTeamPolicyByIDQueries(ctx, req.TeamID, req.PolicyID)
+	teamPolicy, err := svc.GetTeamPolicyByID(ctx, req.TeamID, req.PolicyID)
 	if err != nil {
 		return fleet.GetTeamPolicyByIDResponse{Err: err}, nil
 	}
 	return fleet.GetTeamPolicyByIDResponse{Policy: teamPolicy}, nil
 }
 
-func (svc Service) GetTeamPolicyByIDQueries(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error) {
+func (svc Service) GetTeamPolicyByID(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Policy{
 		PolicyData: fleet.PolicyData{
 			TeamID: ptr.Uint(teamID),
@@ -368,14 +369,8 @@ func (svc Service) GetTeamPolicyByIDQueries(ctx context.Context, teamID uint, po
 		return nil, err
 	}
 
-	if err := svc.populatePolicyInstallSoftware(ctx, teamPolicy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate install_software")
-	}
-	if err := svc.populatePolicyRunScript(ctx, teamPolicy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
-	}
-	if err := svc.populatePolicyPatchSoftware(ctx, teamPolicy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate patch_software")
+	if err := svc.populateAutomationsForTeamPolicy(ctx, teamPolicy); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate automations")
 	}
 
 	return teamPolicy, nil
@@ -639,14 +634,8 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		return nil, ctxerr.Wrap(ctx, err, "saving policy")
 	}
 
-	if err := svc.populatePolicyInstallSoftware(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate install_software")
-	}
-	if err := svc.populatePolicyRunScript(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
-	}
-	if err := svc.populatePolicyPatchSoftware(ctx, policy); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "populate patch_software")
+	if err := svc.populateAutomationsForTeamPolicy(ctx, policy); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate automations")
 	}
 
 	if teamID == nil {

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"testing"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -155,7 +157,7 @@ func TestTeamPoliciesAuth(t *testing.T) {
 			_, _, err = svc.ListTeamPolicies(ctx, 1, fleet.ListOptions{}, fleet.ListOptions{}, false, "")
 			checkAuthErr(t, tt.shouldFailRead, err)
 
-			_, err = svc.GetTeamPolicyByIDQueries(ctx, 1, 1)
+			_, err = svc.GetTeamPolicyByID(ctx, 1, 1)
 			checkAuthErr(t, tt.shouldFailRead, err)
 
 			_, err = svc.ModifyTeamPolicy(ctx, 1, 1, fleet.ModifyPolicyPayload{})
@@ -199,6 +201,190 @@ func TestTeamPolicyVPPAutomationRejectsNonMacOS(t *testing.T) {
 		SoftwareTitleID: ptr.Uint(123),
 	})
 	require.ErrorContains(t, err, "is associated to an iOS or iPadOS VPP app")
+}
+
+// TestTeamPolicyAutomationsPopulated verifies that every endpoint that
+// returns a team policy populates the install_software, run_script, and
+// patch_software automation fields by exercising the
+// populateAutomationsForTeamPolicy helper.
+func TestTeamPolicyAutomationsPopulated(t *testing.T) {
+	const (
+		teamID                  = uint(1)
+		policyID                = uint(42)
+		softwareInstallerID     = uint(101)
+		softwareInstallerTitle  = uint(201)
+		scriptID                = uint(301)
+		patchSoftwareTitleID    = uint(401)
+		patchInstallerTitleID   = uint(501)
+		installerSoftwareTitle  = "Cool Installer"
+		installerDisplayName    = "Cool Installer.app"
+		scriptName              = "remediate.sh"
+		patchSoftwareTitleName  = "Patchable App"
+		patchSoftwareDisplay    = "Patchable App.app"
+	)
+
+	// Returns a fresh team-scoped policy with all three automation IDs set.
+	// Each test gets a separate copy to prevent cross-test mutation.
+	freshPolicy := func() *fleet.Policy {
+		tID := teamID
+		return &fleet.Policy{
+			PolicyData: fleet.PolicyData{
+				ID:                   policyID,
+				TeamID:               &tID,
+				Name:                 "policy-with-automations",
+				Query:                "SELECT 1;",
+				SoftwareInstallerID:  ptr.Uint(softwareInstallerID),
+				ScriptID:             ptr.Uint(scriptID),
+				PatchSoftwareTitleID: ptr.Uint(patchSoftwareTitleID),
+			},
+		}
+	}
+
+	setupDS := func() *mock.Store {
+		ds := new(mock.Store)
+		ds.NewTeamPolicyFunc = func(ctx context.Context, tID uint, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error) {
+			return freshPolicy(), nil
+		}
+		ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+			return freshPolicy(), nil
+		}
+		ds.TeamPolicyFunc = func(ctx context.Context, tID uint, id uint) (*fleet.Policy, error) {
+			return freshPolicy(), nil
+		}
+		ds.ListTeamPoliciesFunc = func(ctx context.Context, tID uint, opts fleet.ListOptions, iopts fleet.ListOptions, automationFilter string) ([]*fleet.Policy, []*fleet.Policy, error) {
+			return []*fleet.Policy{freshPolicy()}, nil, nil
+		}
+		ds.ListMergedTeamPoliciesFunc = func(ctx context.Context, tID uint, opts fleet.ListOptions, automationFilter string) ([]*fleet.Policy, error) {
+			return []*fleet.Policy{freshPolicy()}, nil
+		}
+		ds.SavePolicyFunc = func(ctx context.Context, p *fleet.Policy, _ bool, _ bool) error {
+			return nil
+		}
+		ds.TeamLiteFunc = func(ctx context.Context, tID uint) (*fleet.TeamLite, error) {
+			return &fleet.TeamLite{ID: tID}, nil
+		}
+		ds.GetSoftwareInstallerMetadataByIDFunc = func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+			require.Equal(t, softwareInstallerID, id)
+			return &fleet.SoftwareInstaller{
+				TitleID:       ptr.Uint(softwareInstallerTitle),
+				SoftwareTitle: installerSoftwareTitle,
+				DisplayName:   installerDisplayName,
+			}, nil
+		}
+		ds.ScriptFunc = func(ctx context.Context, id uint) (*fleet.Script, error) {
+			require.Equal(t, scriptID, id)
+			return &fleet.Script{ID: id, Name: scriptName}, nil
+		}
+		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+			require.Equal(t, patchSoftwareTitleID, titleID)
+			return &fleet.SoftwareInstaller{
+				TitleID:       ptr.Uint(patchInstallerTitleID),
+				SoftwareTitle: patchSoftwareTitleName,
+				DisplayName:   patchSoftwareDisplay,
+			}, nil
+		}
+		return ds
+	}
+
+	requireAutomationsPopulated := func(t *testing.T, p *fleet.Policy) {
+		t.Helper()
+		require.NotNil(t, p)
+		require.NotNil(t, p.InstallSoftware, "install_software should be populated")
+		assert.Equal(t, softwareInstallerTitle, p.InstallSoftware.SoftwareTitleID)
+		assert.Equal(t, installerSoftwareTitle, p.InstallSoftware.Name)
+		assert.Equal(t, installerDisplayName, p.InstallSoftware.DisplayName)
+
+		require.NotNil(t, p.RunScript, "run_script should be populated")
+		assert.Equal(t, scriptID, p.RunScript.ID)
+		assert.Equal(t, scriptName, p.RunScript.Name)
+
+		require.NotNil(t, p.PatchSoftware, "patch_software should be populated")
+		assert.Equal(t, patchInstallerTitleID, p.PatchSoftware.SoftwareTitleID)
+		assert.Equal(t, patchSoftwareTitleName, p.PatchSoftware.Name)
+		assert.Equal(t, patchSoftwareDisplay, p.PatchSoftware.DisplayName)
+	}
+
+	adminCtx := func(ctx context.Context) context.Context {
+		return viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			ID:         1,
+			GlobalRole: ptr.String(fleet.RoleAdmin),
+		}})
+	}
+
+	t.Run("NewTeamPolicy", func(t *testing.T) {
+		ds := setupDS()
+		opts := &TestServerOpts{}
+		svc, baseCtx := newTestService(t, ds, nil, nil, opts)
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+		ctx := adminCtx(baseCtx)
+
+		policy, err := svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
+			Name:  "policy-with-automations",
+			Query: "SELECT 1;",
+		})
+		require.NoError(t, err)
+		requireAutomationsPopulated(t, policy)
+	})
+
+	t.Run("GetTeamPolicyByID", func(t *testing.T) {
+		ds := setupDS()
+		svc, baseCtx := newTestService(t, ds, nil, nil)
+		ctx := adminCtx(baseCtx)
+
+		policy, err := svc.GetTeamPolicyByID(ctx, teamID, policyID)
+		require.NoError(t, err)
+		requireAutomationsPopulated(t, policy)
+	})
+
+	t.Run("GetPolicyByID", func(t *testing.T) {
+		ds := setupDS()
+		svc, baseCtx := newTestService(t, ds, nil, nil)
+		ctx := adminCtx(baseCtx)
+
+		policy, err := svc.GetPolicyByID(ctx, policyID)
+		require.NoError(t, err)
+		requireAutomationsPopulated(t, policy)
+	})
+
+	t.Run("ListTeamPolicies", func(t *testing.T) {
+		ds := setupDS()
+		svc, baseCtx := newTestService(t, ds, nil, nil)
+		ctx := adminCtx(baseCtx)
+
+		teamPols, _, err := svc.ListTeamPolicies(ctx, teamID, fleet.ListOptions{}, fleet.ListOptions{}, false, "")
+		require.NoError(t, err)
+		require.Len(t, teamPols, 1)
+		requireAutomationsPopulated(t, teamPols[0])
+	})
+
+	t.Run("ListTeamPolicies_mergeInherited", func(t *testing.T) {
+		ds := setupDS()
+		svc, baseCtx := newTestService(t, ds, nil, nil)
+		ctx := adminCtx(baseCtx)
+
+		merged, _, err := svc.ListTeamPolicies(ctx, teamID, fleet.ListOptions{}, fleet.ListOptions{}, true, "")
+		require.NoError(t, err)
+		require.Len(t, merged, 1)
+		requireAutomationsPopulated(t, merged[0])
+	})
+
+	t.Run("ModifyTeamPolicy", func(t *testing.T) {
+		ds := setupDS()
+		opts := &TestServerOpts{}
+		svc, baseCtx := newTestService(t, ds, nil, nil, opts)
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+		ctx := adminCtx(baseCtx)
+
+		// Empty payload — no field changes; we only care that the helper runs
+		// after SavePolicy and the returned policy has its automations populated.
+		policy, err := svc.ModifyTeamPolicy(ctx, teamID, policyID, fleet.ModifyPolicyPayload{})
+		require.NoError(t, err)
+		requireAutomationsPopulated(t, policy)
+	})
 }
 
 func checkAuthErr(t *testing.T, shouldFail bool, err error) {

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -209,18 +209,18 @@ func TestTeamPolicyVPPAutomationRejectsNonMacOS(t *testing.T) {
 // populateAutomationsForTeamPolicy helper.
 func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 	const (
-		teamID                  = uint(1)
-		policyID                = uint(42)
-		softwareInstallerID     = uint(101)
-		softwareInstallerTitle  = uint(201)
-		scriptID                = uint(301)
-		patchSoftwareTitleID    = uint(401)
-		patchInstallerTitleID   = uint(501)
-		installerSoftwareTitle  = "Cool Installer"
-		installerDisplayName    = "Cool Installer.app"
-		scriptName              = "remediate.sh"
-		patchSoftwareTitleName  = "Patchable App"
-		patchSoftwareDisplay    = "Patchable App.app"
+		teamID                 = uint(1)
+		policyID               = uint(42)
+		softwareInstallerID    = uint(101)
+		softwareInstallerTitle = uint(201)
+		scriptID               = uint(301)
+		patchSoftwareTitleID   = uint(401)
+		patchInstallerTitleID  = uint(501)
+		installerSoftwareTitle = "Cool Installer"
+		installerDisplayName   = "Cool Installer.app"
+		scriptName             = "remediate.sh"
+		patchSoftwareTitleName = "Patchable App"
+		patchSoftwareDisplay   = "Patchable App.app"
 	)
 
 	// Returns a fresh team-scoped policy with all three automation IDs set.


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/44949.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policy retrieval now correctly enforces team authorization, preventing unauthorized cross-team access and ensuring team policies are returned properly.

* **New Features**
  * UI uses a unified policy access path for viewing/editing policies, improving consistency for inherited/team-scoped policies, back-navigation, and fleet-name display (All fleets / No team).

* **Tests**
  * Added unit and integration tests covering cross-team access rules and that policy automation fields are populated when policies are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->