### PR TITLE
Don't wipe out dataset collection config when not provided in GitOps

### DIFF
--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -422,21 +422,6 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	// In Overwrite mode (gitops), default any absent
-	// `features.historical_data` sub-keys to `true` before unmarshaling.
-	// Older clients (e.g. fleetctl <=4.84 that predates this field) send
-	// payloads with historical_data missing; without this the Overwrite
-	// branch below wipes the previously-persisted values to false because
-	// Go's bool zero value is indistinguishable from "absent" once the
-	// payload is unmarshaled. Per policy, absent must always mean true.
-	if applyOpts.Overwrite {
-		rewritten, err := injectHistoricalDataDefaults(p)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "inject historical_data defaults")
-		}
-		p = rewritten
-	}
-
 	invalid := &fleet.InvalidArgumentError{}
 	var newAppConfig fleet.AppConfig
 	if err := json.Unmarshal(p, &newAppConfig); err != nil {
@@ -444,6 +429,15 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 			Message:     "failed to decode app config",
 			InternalErr: err,
 		})
+	}
+
+	// In Overwrite mode (gitops), older clients (e.g. fleetctl <=4.84
+	// predating the field) omit features.historical_data entirely.
+	// Without defaulting here, the Overwrite branch below would persist
+	// those sub-keys as false because Go's bool zero value is
+	// indistinguishable from "absent".
+	if applyOpts.Overwrite {
+		applyHistoricalDataOverwriteDefaults(p, &newAppConfig)
 	}
 
 	fleetDesktopSettingsInvalidErr := validateFleetDesktopSettings(newAppConfig, lic)
@@ -2033,58 +2027,46 @@ func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *
 	}
 }
 
-// injectHistoricalDataDefaults rewrites the raw app config payload to
-// populate `features.historical_data` sub-keys with their default
-// `true` values when absent from the incoming JSON. Operates on the
-// raw payload because Features.HistoricalData uses plain bool fields,
-// which cannot distinguish "absent" from "false" once unmarshaled.
+// gitopsHistoricalDataView is the narrow tri-state view of
+// features.historical_data used to detect which sub-keys were absent
+// from a gitops payload. Pointer fields distinguish "absent" from
+// "false" — something the fleet.HistoricalDataSettings plain bools
+// cannot do once unmarshaled.
 //
-// Mirrors the client-side defaulting in fleetctl gitops so any caller
-// (older fleetctl, third-party tooling, direct API hits) gets the
-// same upgrade-friendly default in Overwrite mode. PATCH mode does
-// not need this — absent fields preserve previously-persisted values
-// via the second json.Unmarshal in ModifyAppConfig.
-//
-// Returns the original payload unchanged when it isn't a JSON object,
-// doesn't contain `features`, or contains a malformed historical_data
-// value; the main decode path will surface those as typed errors.
-func injectHistoricalDataDefaults(p []byte) ([]byte, error) {
-	dec := json.NewDecoder(bytes.NewReader(p))
-	dec.UseNumber()
-	var top map[string]any
-	if err := dec.Decode(&top); err != nil {
-		return p, nil //nolint:nilerr // let the main decode path produce the typed error
-	}
+// Only used by applyHistoricalDataOverwriteDefaults below.
+type gitopsHistoricalDataView struct {
+	Features struct {
+		HistoricalData struct {
+			Uptime          *bool `json:"uptime"`
+			Vulnerabilities *bool `json:"vulnerabilities"`
+		} `json:"historical_data"`
+	} `json:"features"`
+}
 
-	rawFeatures, ok := top["features"]
-	if !ok || rawFeatures == nil {
-		return p, nil
+// applyHistoricalDataOverwriteDefaults defaults absent
+// features.historical_data sub-keys to true.
+// Older clients will not send values for these keys,
+// and in Overwrite mode we want to preserve the default
+// "enabled" state so that we don't disable data collection
+// and wipe data incorrectly.
+func applyHistoricalDataOverwriteDefaults(p []byte, cfg *fleet.AppConfig) {
+	var view gitopsHistoricalDataView
+	if err := json.Unmarshal(p, &view); err != nil {
+		return // main decode path will surface the typed error
 	}
-	features, ok := rawFeatures.(map[string]any)
-	if !ok {
-		return p, nil
-	}
-
-	rawHist, present := features["historical_data"]
-	historical, isMap := rawHist.(map[string]any)
-	switch {
-	case !present || rawHist == nil:
-		historical = map[string]any{}
-		features["historical_data"] = historical
-	case !isMap:
-		return p, nil
-	}
-
 	var defaults fleet.Features
 	defaults.ApplyDefaults()
-	if _, ok := historical["uptime"]; !ok {
-		historical["uptime"] = defaults.HistoricalData.Uptime
+	// For each sub-key, check if the incoming data provided a value (true or false).
+	// If not, then set the config to the default value we want rather than
+	// the Go default for bools (false).
+	cfg.Features.HistoricalData.Uptime = defaults.HistoricalData.Uptime
+	if v := view.Features.HistoricalData.Uptime; v != nil {
+		cfg.Features.HistoricalData.Uptime = *v
 	}
-	if _, ok := historical["vulnerabilities"]; !ok {
-		historical["vulnerabilities"] = defaults.HistoricalData.Vulnerabilities
+	cfg.Features.HistoricalData.Vulnerabilities = defaults.HistoricalData.Vulnerabilities
+	if v := view.Features.HistoricalData.Vulnerabilities; v != nil {
+		cfg.Features.HistoricalData.Vulnerabilities = *v
 	}
-
-	return json.Marshal(top)
 }
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -422,6 +422,21 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
+	// In Overwrite mode (gitops), default any absent
+	// `features.historical_data` sub-keys to `true` before unmarshaling.
+	// Older clients (e.g. fleetctl <=4.84 that predates this field) send
+	// payloads with historical_data missing; without this the Overwrite
+	// branch below wipes the previously-persisted values to false because
+	// Go's bool zero value is indistinguishable from "absent" once the
+	// payload is unmarshaled. Per policy, absent must always mean true.
+	if applyOpts.Overwrite {
+		rewritten, err := injectHistoricalDataDefaults(p)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "inject historical_data defaults")
+		}
+		p = rewritten
+	}
+
 	invalid := &fleet.InvalidArgumentError{}
 	var newAppConfig fleet.AppConfig
 	if err := json.Unmarshal(p, &newAppConfig); err != nil {
@@ -2016,6 +2031,60 @@ func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *
 			}
 		}
 	}
+}
+
+// injectHistoricalDataDefaults rewrites the raw app config payload to
+// populate `features.historical_data` sub-keys with their default
+// `true` values when absent from the incoming JSON. Operates on the
+// raw payload because Features.HistoricalData uses plain bool fields,
+// which cannot distinguish "absent" from "false" once unmarshaled.
+//
+// Mirrors the client-side defaulting in fleetctl gitops so any caller
+// (older fleetctl, third-party tooling, direct API hits) gets the
+// same upgrade-friendly default in Overwrite mode. PATCH mode does
+// not need this — absent fields preserve previously-persisted values
+// via the second json.Unmarshal in ModifyAppConfig.
+//
+// Returns the original payload unchanged when it isn't a JSON object,
+// doesn't contain `features`, or contains a malformed historical_data
+// value; the main decode path will surface those as typed errors.
+func injectHistoricalDataDefaults(p []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(p))
+	dec.UseNumber()
+	var top map[string]any
+	if err := dec.Decode(&top); err != nil {
+		return p, nil //nolint:nilerr // let the main decode path produce the typed error
+	}
+
+	rawFeatures, ok := top["features"]
+	if !ok || rawFeatures == nil {
+		return p, nil
+	}
+	features, ok := rawFeatures.(map[string]any)
+	if !ok {
+		return p, nil
+	}
+
+	rawHist, present := features["historical_data"]
+	historical, isMap := rawHist.(map[string]any)
+	switch {
+	case !present || rawHist == nil:
+		historical = map[string]any{}
+		features["historical_data"] = historical
+	case !isMap:
+		return p, nil
+	}
+
+	var defaults fleet.Features
+	defaults.ApplyDefaults()
+	if _, ok := historical["uptime"]; !ok {
+		historical["uptime"] = defaults.HistoricalData.Uptime
+	}
+	if _, ok := historical["vulnerabilities"]; !ok {
+		historical["vulnerabilities"] = defaults.HistoricalData.Vulnerabilities
+	}
+
+	return json.Marshal(top)
 }
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -2179,3 +2179,101 @@ func TestModifyAppConfigGitOpsExceptionActivities(t *testing.T) {
 		require.Empty(t, fired, "no exception activity should be emitted when SaveAppConfig fails")
 	})
 }
+
+// TestModifyAppConfigGitOpsHistoricalDataDefaults guards against the bug
+// where an older fleetctl (<=4.84) running gitops would wipe a deployment's
+// previously-persisted historical_data sub-keys to false because the field
+// was absent from its payload and the Overwrite branch couldn't tell
+// "absent" from "false". Per policy, absent must always mean true.
+func TestModifyAppConfigGitOpsHistoricalDataDefaults(t *testing.T) {
+	admin := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+
+	testCases := []struct {
+		name      string
+		initial   fleet.HistoricalDataSettings
+		payload   string
+		overwrite bool
+		expected  fleet.HistoricalDataSettings
+	}{
+		{
+			name:      "overwrite: payload omits historical_data entirely (old fleetctl)",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"enable_software_inventory":true}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload omits historical_data, prior values were false",
+			initial:   fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: false},
+			payload:   `{"features":{"enable_software_inventory":true}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload sets historical_data to empty map",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"historical_data":{}}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload partially specifies historical_data (uptime false)",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"historical_data":{"uptime":false}}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload fully specifies historical_data",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"historical_data":{"uptime":false,"vulnerabilities":false}}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: false},
+		},
+		{
+			name:      "patch (non-overwrite): payload omits historical_data, prior values preserved",
+			initial:   fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: true},
+			payload:   `{"org_info":{"org_name":"Renamed"}}`,
+			overwrite: false,
+			expected:  fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: true},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			opts := &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}}
+			svc, ctx := newTestService(t, ds, nil, nil, opts)
+			ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
+
+			dsAppConfig := &fleet.AppConfig{
+				OrgInfo:        fleet.OrgInfo{OrgName: "Test"},
+				ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+				Features: fleet.Features{
+					EnableHostUsers:         true,
+					EnableSoftwareInventory: true,
+					HistoricalData:          tt.initial,
+				},
+			}
+
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return dsAppConfig, nil }
+			ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+				*dsAppConfig = *conf
+				return nil
+			}
+			ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error { return nil }
+			ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return []*fleet.VPPTokenDB{}, nil }
+			ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return []*fleet.ABMToken{}, nil }
+			// historical_data disable flips enqueue a scrub job.
+			ds.HasQueuedJobWithArgsFunc = func(ctx context.Context, name string, args json.RawMessage) (bool, error) {
+				return false, nil
+			}
+			ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) { return job, nil }
+
+			updated, err := svc.ModifyAppConfig(ctx, []byte(tt.payload), fleet.ApplySpecOptions{Overwrite: tt.overwrite})
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, updated.Features.HistoricalData)
+			require.Equal(t, tt.expected, dsAppConfig.Features.HistoricalData)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45042

# Details

On Dogfood, we have v4.85.0 server running but we run our GitOps with the currently published fleetctl (4.84).  This mismatch caused us to disable (and therefore wipe out data for) both of our historical chart datasets.  This PR patches the "update app config" code so that when in "overwrite mode" (i.e. GitOps), it checks for empty `historical_data` keys in the incoming JSON and replaces them with the default values (currently `true`, i.e. "collect the data").  Tested manually (see testing below).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased

## Testing

- [X] Added/updated automated tests
- [X] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually
  - [X] reproduced issue on both current fleet v4.85 and main branch servers, using fleetctl v4.84
  - [X] on this branch, ran fleetctl v4.84 w/out `historical_data` in gitops and verified that charts were enabled.
  - [X] on branch applied to 4.85, ran fleetctl v4.84 w/out `historical_data` in gitops and verified that charts were enabled.
  - [X] disabled one chart in the UI, and verified that updating unrelated app config in the UI did not affect that config (PATCH still works)

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed GitOps configuration handling for historical data settings to properly apply default values when fields are omitted by clients. This ensures that previous configuration settings are preserved correctly in overwrite mode, preventing incorrect defaults from being inadvertently persisted when managing configurations with older clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->