### PR TITLE
Update get policy endpoint

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8325,7 +8325,7 @@ _Available in Fleet Premium_
 
 ### Get policy
 
-`GET /api/v1/fleet/global/policies/:id`
+`GET /api/v1/fleet/policies/:id`
 
 #### Parameters
 
@@ -8335,7 +8335,7 @@ _Available in Fleet Premium_
 
 #### Example
 
-`GET /api/v1/fleet/global/policies/1`
+`GET /api/v1/fleet/policies/1`
 
 ##### Default response
 

--- a/server/api_endpoints/api_endpoints.yml
+++ b/server/api_endpoints/api_endpoints.yml
@@ -349,7 +349,7 @@
   path: "/api/v1/fleet/fleets/:fleet_id/policies/count"
   display_name: "Get a fleet's policies count"
 - method: "GET"
-  path: "/api/v1/fleet/global/policies/:id"
+  path: "/api/v1/fleet/policies/:id"
   display_name: "Get policy"
 - method: "GET"
   path: "/api/v1/fleet/fleets/:fleet_id/policies/:policy_id"


### PR DESCRIPTION
`GET /api/v1/fleet/policies/:id` can return both global and team policies and has been used by the UI to fetch both global and team policies. The `GET /api/v1/fleet/global/policies/:id` is an alias (that we decided to deprecate).

PS: I'll cherry-pick into 4.85.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the fleet policy retrieval endpoint path from `/api/v1/fleet/global/policies/:id` to `/api/v1/fleet/policies/:id`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->