### PR TITLE
Lower CVE-2025-0938 spot-check threshold to 1

### DIFF
--- a/cmd/cve/validate/main.go
+++ b/cmd/cve/validate/main.go
@@ -50,7 +50,12 @@ func checkNVDVulnerabilities(vulnPath string, logger *slog.Logger) {
 	if !ok {
 		panic("failed to cast CVE-2025-0938 to a Vuln")
 	}
-	if len(vulnEntry.Schema().Configurations.Nodes) < 1 || len(vulnEntry.Schema().Configurations.Nodes[0].CPEMatch) < 6 {
+	// NVD lists CVE-2025-0938 as Deferred with no configurations, so any CPE match
+	// here proves VulnCheck enrichment ran. The threshold was previously the historical
+	// row count (6), which broke the daily release pipeline whenever VulnCheck dropped
+	// a row. Floor of 1 catches a complete enrichment failure for this CVE without
+	// breaking on per-CVE drift.
+	if len(vulnEntry.Schema().Configurations.Nodes) < 1 || len(vulnEntry.Schema().Configurations.Nodes[0].CPEMatch) < 1 {
 		panic(errors.New("enriched vulnerability spot-check failed for Python on CVE-2025-0938"))
 	}
 


### PR DESCRIPTION
**Related issue:** N/A — fixes scheduled \`Generate CVE\` workflow in \`fleetdm/vulnerabilities\` (e.g. https://github.com/fleetdm/vulnerabilities/actions/runs/25566931088/job/75052629063)

## Summary

\`cmd/cve/validate/main.go\` requires \`>= 6\` CPE matches in the first configurations node of CVE-2025-0938. NVD lists this CVE as \`Deferred\` with no \`configurations\` block, so the count comes entirely from VulnCheck enrichment. The historical threshold matched the row count exactly, with no margin — a single dropped row in VulnCheck data panics the daily \`Generate CVE\` workflow.

Every scheduled run since 2026-05-08T08:59Z fails at this line, blocking all \`fleetdm/vulnerabilities\` releases.

Drop the floor to 1. Any CPE match proves VulnCheck enrichment ran for this CVE, which is what the canary intends to verify.

# Checklist for submitter

- [x] Input data is properly validated, \`SELECT *\` is avoided, SQL injection is prevented, JS inline code is prevented, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CVE validation thresholds for improved data quality assurance in enrichment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->