### PR TITLE
Fix upcoming activity count not refreshing after host software install (#37012)

### DIFF
--- a/changes/37012-host-details-activity-upcoming-count
+++ b/changes/37012-host-details-activity-upcoming-count
@@ -1,0 +1,1 @@
+- Fixed an issue where the upcoming activity count on the host details page was not updated after installing or uninstalling software.

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -7,7 +7,7 @@ import React, {
   useEffect,
 } from "react";
 import { InjectedRouter } from "react-router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { AxiosError } from "axios";
 
 import hostAPI, {
@@ -138,6 +138,8 @@ const HostSoftwareLibrary = ({
     isGlobalTechnician,
     currentUser,
   } = useContext(AppContext);
+
+  const queryClient = useQueryClient();
 
   const isUnsupported = isAndroid(platform); // no Android software
   const isWindowsHost = platform === "windows";
@@ -500,6 +502,9 @@ const HostSoftwareLibrary = ({
         if (isMountedRef.current) {
           onInstallOrUninstall();
         }
+        queryClient.invalidateQueries({
+          queryKey: [{ scope: "upcoming-activities" }],
+        });
 
         const message = () => {
           switch (true) {
@@ -524,7 +529,7 @@ const HostSoftwareLibrary = ({
         renderFlash("error", getInstallErrorMessage(e));
       }
     },
-    [id, renderFlash, onInstallOrUninstall, isHostOnline]
+    [id, renderFlash, onInstallOrUninstall, isHostOnline, queryClient]
   );
 
   const onClickUninstallAction = useCallback(
@@ -534,6 +539,9 @@ const HostSoftwareLibrary = ({
         if (isMountedRef.current) {
           onInstallOrUninstall();
         }
+        queryClient.invalidateQueries({
+          queryKey: [{ scope: "upcoming-activities" }],
+        });
         renderFlash(
           "success",
           <>
@@ -548,7 +556,7 @@ const HostSoftwareLibrary = ({
         renderFlash("error", getUninstallErrorMessage(e));
       }
     },
-    [id, renderFlash, onInstallOrUninstall, isHostOnline]
+    [id, renderFlash, onInstallOrUninstall, isHostOnline, queryClient]
   );
 
   const tableConfig = useMemo(() => {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37012

Invalidate the upcoming-activities cache on software install/uninstall.

https://github.com/user-attachments/assets/344dc3a5-e871-4e53-97db-282ea85adeec

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the upcoming activity count on the host details page failed to refresh after installing or uninstalling software.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45059)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->