### PR TITLE
Cherry-pick #45049: Don't wipe out dataset collection config when not provided in GitOps

### DIFF
--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -397,6 +397,15 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		})
 	}
 
+	// In Overwrite mode (gitops), older clients (e.g. fleetctl <=4.84
+	// predating the field) omit features.historical_data entirely.
+	// Without defaulting here, the Overwrite branch below would persist
+	// those sub-keys as false because Go's bool zero value is
+	// indistinguishable from "absent".
+	if applyOpts.Overwrite {
+		applyHistoricalDataOverwriteDefaults(p, &newAppConfig)
+	}
+
 	fleetDesktopSettingsInvalidErr := validateFleetDesktopSettings(newAppConfig, lic)
 	if fleetDesktopSettingsInvalidErr.HasErrors() {
 		return nil, ctxerr.Wrap(ctx, fleetDesktopSettingsInvalidErr)
@@ -1947,6 +1956,48 @@ func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *
 				invalid.Append("enable_jit_provisioning", ErrMissingLicense.Error())
 			}
 		}
+	}
+}
+
+// gitopsHistoricalDataView is the narrow tri-state view of
+// features.historical_data used to detect which sub-keys were absent
+// from a gitops payload. Pointer fields distinguish "absent" from
+// "false" — something the fleet.HistoricalDataSettings plain bools
+// cannot do once unmarshaled.
+//
+// Only used by applyHistoricalDataOverwriteDefaults below.
+type gitopsHistoricalDataView struct {
+	Features struct {
+		HistoricalData struct {
+			Uptime          *bool `json:"uptime"`
+			Vulnerabilities *bool `json:"vulnerabilities"`
+		} `json:"historical_data"`
+	} `json:"features"`
+}
+
+// applyHistoricalDataOverwriteDefaults defaults absent
+// features.historical_data sub-keys to true.
+// Older clients will not send values for these keys,
+// and in Overwrite mode we want to preserve the default
+// "enabled" state so that we don't disable data collection
+// and wipe data incorrectly.
+func applyHistoricalDataOverwriteDefaults(p []byte, cfg *fleet.AppConfig) {
+	var view gitopsHistoricalDataView
+	if err := json.Unmarshal(p, &view); err != nil {
+		return // main decode path will surface the typed error
+	}
+	var defaults fleet.Features
+	defaults.ApplyDefaults()
+	// For each sub-key, check if the incoming data provided a value (true or false).
+	// If not, then set the config to the default value we want rather than
+	// the Go default for bools (false).
+	cfg.Features.HistoricalData.Uptime = defaults.HistoricalData.Uptime
+	if v := view.Features.HistoricalData.Uptime; v != nil {
+		cfg.Features.HistoricalData.Uptime = *v
+	}
+	cfg.Features.HistoricalData.Vulnerabilities = defaults.HistoricalData.Vulnerabilities
+	if v := view.Features.HistoricalData.Vulnerabilities; v != nil {
+		cfg.Features.HistoricalData.Vulnerabilities = *v
 	}
 }
 

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -2147,3 +2147,101 @@ func TestModifyAppConfigGitOpsExceptionActivities(t *testing.T) {
 		require.Empty(t, fired, "no exception activity should be emitted when SaveAppConfig fails")
 	})
 }
+
+// TestModifyAppConfigGitOpsHistoricalDataDefaults guards against the bug
+// where an older fleetctl (<=4.84) running gitops would wipe a deployment's
+// previously-persisted historical_data sub-keys to false because the field
+// was absent from its payload and the Overwrite branch couldn't tell
+// "absent" from "false". Per policy, absent must always mean true.
+func TestModifyAppConfigGitOpsHistoricalDataDefaults(t *testing.T) {
+	admin := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+
+	testCases := []struct {
+		name      string
+		initial   fleet.HistoricalDataSettings
+		payload   string
+		overwrite bool
+		expected  fleet.HistoricalDataSettings
+	}{
+		{
+			name:      "overwrite: payload omits historical_data entirely (old fleetctl)",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"enable_software_inventory":true}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload omits historical_data, prior values were false",
+			initial:   fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: false},
+			payload:   `{"features":{"enable_software_inventory":true}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload sets historical_data to empty map",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"historical_data":{}}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload partially specifies historical_data (uptime false)",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"historical_data":{"uptime":false}}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: true},
+		},
+		{
+			name:      "overwrite: payload fully specifies historical_data",
+			initial:   fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
+			payload:   `{"features":{"historical_data":{"uptime":false,"vulnerabilities":false}}}`,
+			overwrite: true,
+			expected:  fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: false},
+		},
+		{
+			name:      "patch (non-overwrite): payload omits historical_data, prior values preserved",
+			initial:   fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: true},
+			payload:   `{"org_info":{"org_name":"Renamed"}}`,
+			overwrite: false,
+			expected:  fleet.HistoricalDataSettings{Uptime: false, Vulnerabilities: true},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			opts := &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}}
+			svc, ctx := newTestService(t, ds, nil, nil, opts)
+			ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
+
+			dsAppConfig := &fleet.AppConfig{
+				OrgInfo:        fleet.OrgInfo{OrgName: "Test"},
+				ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+				Features: fleet.Features{
+					EnableHostUsers:         true,
+					EnableSoftwareInventory: true,
+					HistoricalData:          tt.initial,
+				},
+			}
+
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return dsAppConfig, nil }
+			ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+				*dsAppConfig = *conf
+				return nil
+			}
+			ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error { return nil }
+			ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return []*fleet.VPPTokenDB{}, nil }
+			ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return []*fleet.ABMToken{}, nil }
+			// historical_data disable flips enqueue a scrub job.
+			ds.HasQueuedJobWithArgsFunc = func(ctx context.Context, name string, args json.RawMessage) (bool, error) {
+				return false, nil
+			}
+			ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) { return job, nil }
+
+			updated, err := svc.ModifyAppConfig(ctx, []byte(tt.payload), fleet.ApplySpecOptions{Overwrite: tt.overwrite})
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, updated.Features.HistoricalData)
+			require.Equal(t, tt.expected, dsAppConfig.Features.HistoricalData)
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #45049 into the RC branch.