### PR TITLE
Fleet UI: Update report and policies empty states

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -976,8 +976,8 @@ const ManagePolicyPage = ({
     : globalPoliciesError;
 
   const policyResults = !isAllTeamsSelected
-    ? teamPolicies && teamPolicies.length > 0
-    : globalPolicies && globalPolicies.length > 0;
+    ? teamPolicies !== undefined
+    : globalPolicies !== undefined;
 
   // Show CTA buttons if there are no errors
   const showCtaButtons = !policiesErrors;
@@ -1142,6 +1142,7 @@ const ManagePolicyPage = ({
           policiesList={globalPolicies || []}
           isLoading={isFetchingGlobalPolicies || isFetchingGlobalConfig}
           onDeletePoliciesClick={onDeletePoliciesClick}
+          onAddPolicyClick={onAddPolicyClick}
           canAddOrDeletePolicies={canAddOrDeletePolicies}
           hasPoliciesToDelete={hasPoliciesToDelete}
           currentTeam={currentTeamSummary}
@@ -1181,6 +1182,7 @@ const ManagePolicyPage = ({
             isFetchingGlobalConfig
           }
           onDeletePoliciesClick={onDeletePoliciesClick}
+          onAddPolicyClick={onAddPolicyClick}
           canAddOrDeletePolicies={canAddOrDeletePolicies}
           hasPoliciesToDelete={hasPoliciesToDelete}
           currentTeam={currentTeamSummary}

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1097,14 +1097,16 @@ const ManagePolicyPage = ({
 
   const renderAutomationFilter = isPremiumTier
     ? () => {
-        // Hide dropdown if there are errors OR there are no policy results with no filters (search or automation dropdown)
-        const hide =
-          policiesErrors ||
-          (!policyResults && searchQuery === "" && !automationFilter);
-
-        if (hide) {
+        // Hide dropdown only on errors
+        if (policiesErrors) {
           return null;
         }
+
+        const policiesCount = isAllTeamsSelected
+          ? globalPoliciesCount
+          : teamPoliciesCountMergeInherited;
+        const isTrulyEmpty =
+          (policiesCount ?? 0) === 0 && searchQuery === "" && !automationFilter;
 
         // No team ID = All fleets → only show "all" and "other" options
         const optionsForTeam = teamIdForApi
@@ -1122,6 +1124,7 @@ const ManagePolicyPage = ({
             placeholder="Filter by automation"
             options={optionsForTeam}
             variant="table-filter"
+            isDisabled={isTrulyEmpty}
           />
         );
       }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -97,9 +97,7 @@ describe("Policies table", () => {
       />
     );
 
-    expect(
-      screen.getByText("No policies for this fleet")
-    ).toBeInTheDocument();
+    expect(screen.getByText("No policies for this fleet")).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
   });
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -23,6 +23,7 @@ describe("Policies table", () => {
         policiesList={[]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         searchQuery=""
         page={0}
@@ -32,7 +33,7 @@ describe("Policies table", () => {
       />
     );
 
-    expect(screen.getByText("You don't have any policies")).toBeInTheDocument();
+    expect(screen.getByText("No policies yet")).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
     expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
   });
@@ -52,6 +53,7 @@ describe("Policies table", () => {
         policiesList={[]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         isPremiumTier
         searchQuery=""
@@ -63,7 +65,7 @@ describe("Policies table", () => {
     );
 
     expect(
-      screen.getByText("You don't have any policies that apply to all fleets")
+      screen.getByText("No policies apply to all fleets")
     ).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
     expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
@@ -84,6 +86,7 @@ describe("Policies table", () => {
         policiesList={[]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: 1, name: "Some team" }}
         isPremiumTier
         searchQuery=""
@@ -95,7 +98,7 @@ describe("Policies table", () => {
     );
 
     expect(
-      screen.getByText("You don't have any policies that apply to this fleet")
+      screen.getByText("No policies for this fleet")
     ).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
   });
@@ -115,6 +118,7 @@ describe("Policies table", () => {
         policiesList={[]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         isPremiumTier
         searchQuery="shouldn't match anything"
@@ -147,6 +151,7 @@ describe("Policies table", () => {
         policiesList={[testCriticalPolicy]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         isPremiumTier
         searchQuery=""
@@ -185,6 +190,7 @@ describe("Policies table", () => {
         policiesList={[testInheritedPolicy]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: 2, name: "Team 2" }}
         isPremiumTier
         searchQuery=""
@@ -223,6 +229,7 @@ describe("Policies table", () => {
         policiesList={[testGlobalPolicy]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         isPremiumTier
         searchQuery=""
@@ -264,6 +271,7 @@ describe("Policies table", () => {
         policiesList={policiesList}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: 2, name: "Team 2" }}
         isPremiumTier
         searchQuery=""
@@ -311,6 +319,7 @@ describe("Policies table", () => {
         policiesList={[testPatchPolicy]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         isPremiumTier
         searchQuery=""
@@ -341,6 +350,7 @@ describe("Policies table", () => {
         policiesList={[testDynamicPolicy]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         isPremiumTier
         searchQuery=""
@@ -384,6 +394,7 @@ describe("Policies table", () => {
         policiesList={[policyWithAutomations, policyWithoutAutomations]}
         isLoading={false}
         onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
         currentTeam={{ id: -1, name: "All fleets" }}
         isPremiumTier
         searchQuery=""

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -34,7 +34,7 @@ describe("Policies table", () => {
 
     expect(screen.getByText("You don't have any policies")).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
-    expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+    expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
   });
 
   it("Renders the page-wide empty state when no policies are present (all teams)", async () => {
@@ -66,7 +66,7 @@ describe("Policies table", () => {
       screen.getByText("You don't have any policies that apply to all fleets")
     ).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
-    expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+    expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
   });
 
   it("Renders the page-wide empty state when no policies are present (specific team)", async () => {

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -101,6 +101,72 @@ describe("Policies table", () => {
     expect(screen.queryByText("Name")).toBeNull();
   });
 
+  it("Renders generic empty state header in Primo mode (all fleets)", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+          config: { partnerships: { enable_primo: true } },
+        },
+      },
+    });
+
+    render(
+      <PoliciesTable
+        policiesList={[]}
+        isLoading={false}
+        onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
+        currentTeam={{ id: -1, name: "All fleets" }}
+        isPremiumTier
+        searchQuery=""
+        page={0}
+        onQueryChange={noop}
+        renderPoliciesCount={() => null}
+        count={0}
+      />
+    );
+
+    expect(screen.getByText("No policies yet")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No policies apply to all fleets")
+    ).not.toBeInTheDocument();
+  });
+
+  it("Renders generic empty state header in Primo mode (specific team)", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+          config: { partnerships: { enable_primo: true } },
+        },
+      },
+    });
+
+    render(
+      <PoliciesTable
+        policiesList={[]}
+        isLoading={false}
+        onDeletePoliciesClick={noop}
+        onAddPolicyClick={noop}
+        currentTeam={{ id: 1, name: "Some team" }}
+        isPremiumTier
+        searchQuery=""
+        page={0}
+        onQueryChange={noop}
+        renderPoliciesCount={() => null}
+        count={0}
+      />
+    );
+
+    expect(screen.getByText("No policies yet")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No policies for this fleet")
+    ).not.toBeInTheDocument();
+  });
+
   it("Renders the empty search state when search query exists for server side search with no results", async () => {
     const render = createCustomRenderer({
       context: {

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -89,11 +89,8 @@ const PoliciesTable = ({
     emptyState.info = "No policies match the current filters.";
   }
 
-  const searchable = !(
-    policiesList?.length === 0 &&
-    searchQuery === "" &&
-    !isFiltered
-  );
+  const isTrulyEmpty =
+    policiesList?.length === 0 && searchQuery === "" && !isFiltered;
 
   const isPrimoMode = config?.partnerships?.enable_primo || false;
   const viewingTeamPolicies =
@@ -154,9 +151,10 @@ const PoliciesTable = ({
         renderCount={renderPoliciesCount}
         onQueryChange={onQueryChange}
         inputPlaceHolder="Search by name"
-        searchable={searchable}
-        disableTableHeader={!searchable}
-        customControl={customControl}
+        searchable
+        disableSearch={isTrulyEmpty}
+        disableActionButton={isTrulyEmpty}
+        customControl={!isTrulyEmpty ? customControl : undefined}
       />
     </div>
   );

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -4,6 +4,7 @@ import { AppContext } from "context/app";
 import { IPolicyStats } from "interfaces/policy";
 import { ITeamSummary, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import { IEmptyStateProps } from "interfaces/empty_state";
+import Button from "components/buttons/Button";
 import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import EmptyState from "components/EmptyState";
@@ -25,6 +26,7 @@ interface IPoliciesTableProps {
   policiesList: IPolicyStats[];
   isLoading: boolean;
   onDeletePoliciesClick: (selectedTableIds: number[]) => void;
+  onAddPolicyClick: () => void;
   canAddOrDeletePolicies?: boolean;
   hasPoliciesToDelete?: boolean;
   currentTeam: ITeamSummary | undefined;
@@ -45,6 +47,7 @@ const PoliciesTable = ({
   policiesList,
   isLoading,
   onDeletePoliciesClick,
+  onAddPolicyClick,
   canAddOrDeletePolicies,
   hasPoliciesToDelete,
   currentTeam,
@@ -62,26 +65,27 @@ const PoliciesTable = ({
 }: IPoliciesTableProps): JSX.Element => {
   const { config } = useContext(AppContext);
 
+  const isAllFleets =
+    isPremiumTier &&
+    (currentTeam?.id === null || currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID);
+
+  let emptyHeader = "No policies yet";
+  if (isPremiumTier) {
+    emptyHeader = isAllFleets
+      ? "No policies apply to all fleets"
+      : "No policies for this fleet";
+  }
+
   const emptyState: IEmptyStateProps = {
-    header: "You don't have any policies",
+    header: emptyHeader,
     info:
-      "Add policies to detect device health issues and trigger automations.",
+      "Policies are queries that return a pass or fail result. Failures trigger fixes or prompt end users to solve them on their own.",
+    primaryButton: canAddOrDeletePolicies ? (
+      <Button onClick={onAddPolicyClick} type="button">
+        Add policy
+      </Button>
+    ) : undefined,
   };
-
-  if (isPremiumTier && !config?.partnerships?.enable_primo) {
-    if (
-      currentTeam?.id === null ||
-      currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
-    ) {
-      emptyState.header += ` that apply to all fleets`;
-    } else {
-      emptyState.header += ` that apply to this fleet`;
-    }
-  }
-
-  if (!canAddOrDeletePolicies) {
-    emptyState.info = "";
-  }
 
   if (searchQuery || isFiltered) {
     delete emptyState.primaryButton;

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -158,7 +158,7 @@ const PoliciesTable = ({
         searchable
         disableSearch={isTrulyEmpty}
         disableActionButton={isTrulyEmpty}
-        customControl={!isTrulyEmpty ? customControl : undefined}
+        customControl={customControl}
       />
     </div>
   );

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -70,7 +70,8 @@ const PoliciesTable = ({
     (currentTeam?.id === null || currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID);
 
   let emptyHeader = "No policies yet";
-  if (isPremiumTier) {
+  // Primo mode uses a generic empty state header
+  if (isPremiumTier && !config?.partnerships?.enable_primo) {
     emptyHeader = isAllFleets
       ? "No policies apply to all fleets"
       : "No policies for this fleet";
@@ -157,7 +158,6 @@ const PoliciesTable = ({
         inputPlaceHolder="Search by name"
         searchable
         disableSearch={isTrulyEmpty}
-        disableActionButton={isTrulyEmpty}
         customControl={customControl}
       />
     </div>

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -281,6 +281,8 @@ const ManageQueriesPage = ({
         }
         isLoading={isLoadingQueries || isFetchingQueries}
         onDeleteQueryClick={onDeleteQueryClick}
+        onAddReportClick={onCreateQueryClick}
+        canAddReport={canCustomQuery}
         isOnlyObserver={isOnlyObserver}
         isObserverPlus={isObserverPlus}
         isAnyTeamObserverPlus={isAnyTeamObserverPlus || false}

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -265,6 +265,14 @@ const ManageQueriesPage = ({
     return <h1>Reports</h1>;
   };
 
+  // CTA button shows for all roles but global observers and current team's observers
+  const canCustomQuery =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isTeamAdmin ||
+    isTeamMaintainer ||
+    isObserverPlus; // isObserverPlus checks global and selected team
+
   const renderQueriesTable = () => {
     if (queriesError) {
       return <TableDataError verticalPaddingSize="pad-xxxlarge" />;
@@ -373,14 +381,6 @@ const ManageQueriesPage = ({
       </>
     );
   };
-
-  // CTA button shows for all roles but global observers and current team's observers
-  const canCustomQuery =
-    isGlobalAdmin ||
-    isGlobalMaintainer ||
-    isTeamAdmin ||
-    isTeamMaintainer ||
-    isObserverPlus; // isObserverPlus checks global and selected team
 
   const canManageAutomations = isGlobalAdmin || isTeamAdmin;
   const isManageAutomationsEnabled = isAnyTeamSelected

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -174,7 +174,7 @@ describe("QueriesTable", () => {
         screen.getByText("You don't have any reports")
       ).toBeInTheDocument();
       expect(screen.queryByText("Interval")).toBeNull();
-      expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+      expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
     });
   });
 
@@ -201,7 +201,7 @@ describe("QueriesTable", () => {
         screen.getByText("You don't have any reports that apply to all fleets")
       ).toBeInTheDocument();
       expect(screen.queryByText("Interval")).toBeNull();
-      expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+      expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
     });
   });
 
@@ -228,7 +228,7 @@ describe("QueriesTable", () => {
         screen.getByText("You don't have any reports that apply to this fleet")
       ).toBeInTheDocument();
       expect(screen.queryByText("Interval")).toBeNull();
-      expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+      expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
     });
   });
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -170,9 +170,7 @@ describe("QueriesTable", () => {
 
     testData.forEach((tableProps) => {
       render(<QueriesTable {...tableProps} />);
-      expect(
-        screen.getByText("You don't have any reports")
-      ).toBeInTheDocument();
+      expect(screen.getByText("No reports yet")).toBeInTheDocument();
       expect(screen.queryByText("Interval")).toBeNull();
       expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
     });
@@ -198,7 +196,7 @@ describe("QueriesTable", () => {
     testData.forEach((tableProps) => {
       renderAsPremiumGlobalAdmin(<QueriesTable {...tableProps} />);
       expect(
-        screen.getByText("You don't have any reports that apply to all fleets")
+        screen.getByText("No reports apply to all fleets")
       ).toBeInTheDocument();
       expect(screen.queryByText("Interval")).toBeNull();
       expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
@@ -225,7 +223,7 @@ describe("QueriesTable", () => {
     testData.forEach((tableProps) => {
       renderAsPremiumGlobalAdmin(<QueriesTable {...tableProps} />);
       expect(
-        screen.getByText("You don't have any reports that apply to this fleet")
+        screen.getByText("No reports for this fleet")
       ).toBeInTheDocument();
       expect(screen.queryByText("Interval")).toBeNull();
       expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -222,9 +222,7 @@ describe("QueriesTable", () => {
 
     testData.forEach((tableProps) => {
       renderAsPremiumGlobalAdmin(<QueriesTable {...tableProps} />);
-      expect(
-        screen.getByText("No reports for this fleet")
-      ).toBeInTheDocument();
+      expect(screen.getByText("No reports for this fleet")).toBeInTheDocument();
       expect(screen.queryByText("Interval")).toBeNull();
       expect(screen.getByPlaceholderText("Search by name")).toBeDisabled();
     });

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -228,6 +228,74 @@ describe("QueriesTable", () => {
     });
   });
 
+  it("Renders generic empty state header in Primo mode (all fleets)", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+          config: { partnerships: { enable_primo: true } },
+        },
+      },
+    });
+
+    render(
+      <QueriesTable
+        queries={[]}
+        totalQueriesCount={0}
+        hasNextResults={false}
+        curTeamScopeQueriesPresent={true}
+        isLoading={false}
+        onDeleteQueryClick={jest.fn()}
+        isOnlyObserver={false}
+        isObserverPlus={false}
+        isAnyTeamObserverPlus={false}
+        currentTeamId={undefined}
+        isPremiumTier
+      />
+    );
+
+    expect(screen.getByText("No reports yet")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No reports apply to all fleets")
+    ).not.toBeInTheDocument();
+  });
+
+  it("Renders generic empty state header in Primo mode (specific team)", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+          config: { partnerships: { enable_primo: true } },
+        },
+      },
+    });
+
+    render(
+      <QueriesTable
+        queries={[]}
+        totalQueriesCount={0}
+        hasNextResults={false}
+        curTeamScopeQueriesPresent={true}
+        isLoading={false}
+        onDeleteQueryClick={jest.fn()}
+        isOnlyObserver={false}
+        isObserverPlus={false}
+        isAnyTeamObserverPlus={false}
+        currentTeamId={1}
+        isPremiumTier
+      />
+    );
+
+    expect(screen.getByText("No reports yet")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No reports for this fleet")
+    ).not.toBeInTheDocument();
+  });
+
   it("Renders inherited global queries and team queries when viewing a team", async () => {
     const testData: IQueriesTableProps[] = [
       {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -245,7 +245,7 @@ describe("QueriesTable", () => {
         queries={[]}
         totalQueriesCount={0}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={true}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -279,7 +279,7 @@ describe("QueriesTable", () => {
         queries={[]}
         totalQueriesCount={0}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={true}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -16,6 +16,7 @@ import { getPathWithQueryParams } from "utilities/url";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import DropdownWrapper from "components/forms/fields/DropdownWrapper";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
+import Button from "components/buttons/Button";
 import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import CustomLink from "components/CustomLink";
@@ -31,6 +32,8 @@ export interface IQueriesTableProps {
   curTeamScopeQueriesPresent: boolean;
   isLoading: boolean;
   onDeleteQueryClick: (selectedTableQueryIds: number[]) => void;
+  onAddReportClick?: () => void;
+  canAddReport?: boolean;
   isOnlyObserver?: boolean;
   isObserverPlus?: boolean;
   isAnyTeamObserverPlus: boolean;
@@ -88,6 +91,8 @@ const QueriesTable = ({
   curTeamScopeQueriesPresent,
   isLoading,
   onDeleteQueryClick,
+  onAddReportClick,
+  canAddReport,
   isOnlyObserver,
   isObserverPlus,
   isAnyTeamObserverPlus,
@@ -177,36 +182,34 @@ const QueriesTable = ({
     ]
   );
 
-  const emptyParams: IEmptyStateProps = {
-    header: "You don't have any reports",
-  };
-
-  if (isPremiumTier && !config?.partnerships?.enable_primo) {
-    if (
-      typeof currentTeamId === "undefined" ||
+  const isAllFleets =
+    isPremiumTier &&
+    (typeof currentTeamId === "undefined" ||
       currentTeamId === null ||
-      currentTeamId === APP_CONTEXT_ALL_TEAMS_ID
-    ) {
-      emptyParams.header += " that apply to all fleets";
-    } else {
-      emptyParams.header += " that apply to this fleet";
-    }
+      currentTeamId === APP_CONTEXT_ALL_TEAMS_ID);
+
+  let emptyHeader = "No reports yet";
+  if (isPremiumTier) {
+    emptyHeader = isAllFleets
+      ? "No reports apply to all fleets"
+      : "No reports for this fleet";
   }
 
+  const emptyParams: IEmptyStateProps = {
+    header: emptyHeader,
+    info:
+      "Reports are queries that run on a schedule. Results are saved in Fleet.",
+    primaryButton: canAddReport ? (
+      <Button onClick={onAddReportClick} type="button">
+        Add report
+      </Button>
+    ) : undefined,
+  };
+
   if (searchQuery || curTargetedPlatformFilter !== "all") {
+    delete emptyParams.primaryButton;
     emptyParams.header = "No matching reports";
     emptyParams.info = "No reports match the current filters.";
-  } else if (!isOnlyObserver || isObserverPlus || isAnyTeamObserverPlus) {
-    emptyParams.additionalInfo = (
-      <>
-        Create a new report, or{" "}
-        <CustomLink
-          url="https://fleetdm.com/docs/using-fleet/standard-query-library"
-          text="import Fleet's standard query library"
-          newTab
-        />
-      </>
-    );
   }
 
   const handlePlatformFilterDropdownChange = useCallback(

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -264,8 +264,8 @@ const QueriesTable = ({
     [currentUser, currentTeamId, curTeamScopeQueriesPresent]
   );
 
-  const searchable =
-    (totalQueriesCount ?? 0) > 0 || !!targetedPlatformParam || !!searchQuery;
+  const isTrulyEmpty =
+    (totalQueriesCount ?? 0) === 0 && !targetedPlatformParam && !searchQuery;
 
   const trimmedSearchQuery = searchQuery.trim();
 
@@ -293,17 +293,15 @@ const QueriesTable = ({
             onClick: onDeleteQueryClick,
           }}
           emptyComponent={() => <EmptyState {...emptyParams} />}
-          renderCount={() =>
-            ((totalQueriesCount || searchQuery) && (
-              <TableCount name="reports" count={totalQueriesCount} />
-            )) ||
-            null
-          }
+          renderCount={() => (
+            <TableCount name="reports" count={totalQueriesCount} />
+          )}
           inputPlaceHolder="Search by name"
           onQueryChange={onQueryChange}
-          searchable={searchable}
-          disableTableHeader={!searchable}
-          customControl={searchable ? renderPlatformDropdown : undefined}
+          searchable
+          disableSearch={isTrulyEmpty}
+          disableActionButton={isTrulyEmpty}
+          customControl={!isTrulyEmpty ? renderPlatformDropdown : undefined}
           disableMultiRowSelect={!curTeamScopeQueriesPresent}
           onClickRow={handleRowSelect}
           selectedDropdownFilter={curTargetedPlatformFilter}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -19,7 +19,6 @@ import { CustomOptionType } from "components/forms/fields/DropdownWrapper/Dropdo
 import Button from "components/buttons/Button";
 import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
-import CustomLink from "components/CustomLink";
 import EmptyState from "components/EmptyState";
 
 import generateColumnConfigs from "./QueriesTableConfig";
@@ -243,19 +242,6 @@ const QueriesTable = ({
     }
   };
 
-  const renderPlatformDropdown = useCallback(() => {
-    return (
-      <DropdownWrapper
-        name="platform-dropdown"
-        value={curTargetedPlatformFilter}
-        className={`${baseClass}__platform-dropdown`}
-        options={PLATFORM_FILTER_OPTIONS}
-        onChange={handlePlatformFilterDropdownChange}
-        variant="table-filter"
-      />
-    );
-  }, [curTargetedPlatformFilter, handlePlatformFilterDropdownChange]);
-
   const columnConfigs = useMemo(
     () =>
       currentUser &&
@@ -269,6 +255,24 @@ const QueriesTable = ({
 
   const isTrulyEmpty =
     (totalQueriesCount ?? 0) === 0 && !targetedPlatformParam && !searchQuery;
+
+  const renderPlatformDropdown = useCallback(() => {
+    return (
+      <DropdownWrapper
+        name="platform-dropdown"
+        value={curTargetedPlatformFilter}
+        className={`${baseClass}__platform-dropdown`}
+        options={PLATFORM_FILTER_OPTIONS}
+        onChange={handlePlatformFilterDropdownChange}
+        variant="table-filter"
+        isDisabled={isTrulyEmpty}
+      />
+    );
+  }, [
+    curTargetedPlatformFilter,
+    handlePlatformFilterDropdownChange,
+    isTrulyEmpty,
+  ]);
 
   const trimmedSearchQuery = searchQuery.trim();
 
@@ -303,8 +307,7 @@ const QueriesTable = ({
           onQueryChange={onQueryChange}
           searchable
           disableSearch={isTrulyEmpty}
-          disableActionButton={isTrulyEmpty}
-          customControl={!isTrulyEmpty ? renderPlatformDropdown : undefined}
+          customControl={renderPlatformDropdown}
           disableMultiRowSelect={!curTeamScopeQueriesPresent}
           onClickRow={handleRowSelect}
           selectedDropdownFilter={curTargetedPlatformFilter}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -188,7 +188,8 @@ const QueriesTable = ({
       currentTeamId === APP_CONTEXT_ALL_TEAMS_ID);
 
   let emptyHeader = "No reports yet";
-  if (isPremiumTier) {
+  // Primo mode uses a generic empty state header
+  if (isPremiumTier && !config?.partnerships?.enable_primo) {
     emptyHeader = isAllFleets
       ? "No reports apply to all fleets"
       : "No reports for this fleet";

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -253,7 +253,7 @@ const QueryDetailsPage = ({
     (isTeamMaintainerOrTeamAdmin && storedQuery?.team_id);
 
   const renderHeader = () => {
-
+    // Function instead of constant eliminates race condition with filteredQueriesPath
     const backPath = () => {
       if (hostId)
         return getPathWithQueryParams(

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -235,21 +235,24 @@ const QueryDetailsPage = ({
   const isClipped = queryReport?.report_clipped;
   const isLiveQueryDisabled = config?.server_settings.live_query_disabled;
 
-  const renderHeader = () => {
-    // Team admins/maintainers can only edit queries assigned to a team
-    const canEditQuery =
-      isGlobalAdmin ||
-      isGlobalMaintainer ||
-      (isTeamMaintainerOrTeamAdmin && storedQuery?.team_id);
+  const canLiveQuery =
+    lastEditedQueryObserverCanRun ||
+    isObserverPlus ||
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isTeamMaintainerOrTeamAdmin ||
+    isGlobalTechnician ||
+    isTeamTechnician;
 
-    const canLiveQuery =
-      lastEditedQueryObserverCanRun ||
-      isObserverPlus ||
-      isGlobalAdmin ||
-      isGlobalMaintainer ||
-      isTeamMaintainerOrTeamAdmin ||
-      isGlobalTechnician ||
-      isTeamTechnician;
+  const canRunLiveReport = canLiveQuery && !isLiveQueryDisabled;
+
+  // Team admins/maintainers can only edit queries assigned to a team
+  const canEditQuery =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    (isTeamMaintainerOrTeamAdmin && storedQuery?.team_id);
+
+  const renderHeader = () => {
 
     const backPath = () => {
       if (hostId)
@@ -420,16 +423,26 @@ const QueryDetailsPage = ({
     if (emptyCache || lastEditedQueryDiscardData) {
       return (
         <NoResults
+          queryId={queryId}
           queryInterval={storedQuery?.interval}
           queryUpdatedAt={storedQuery?.updated_at}
           disabledCaching={disabledCaching}
           disabledCachingGlobally={disabledCachingGlobally}
           discardDataEnabled={lastEditedQueryDiscardData}
           loggingSnapshot={loggingSnapshot}
+          canLiveQuery={canRunLiveReport}
+          canEditQuery={!!canEditQuery}
         />
       );
     }
-    return <QueryReport {...{ queryReport, isClipped }} />;
+    return (
+      <QueryReport
+        queryReport={queryReport}
+        queryId={queryId}
+        isClipped={isClipped}
+        canLiveQuery={canRunLiveReport}
+      />
+    );
   };
 
   return (

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
@@ -15,21 +15,17 @@ describe("NoResults", () => {
   describe("no interval set", () => {
     it("shows interval and live report text when user can edit and run live", () => {
       render(
-        <NoResults
-          {...baseProps}
-          queryInterval={0}
-          canEditQuery
-          canLiveQuery
-        />
+        <NoResults {...baseProps} queryInterval={0} canEditQuery canLiveQuery />
       );
 
       expect(screen.getByText("Nothing to report")).toBeInTheDocument();
       expect(screen.getByText(/Add an/)).toBeInTheDocument();
       expect(screen.getByText("interval")).toBeInTheDocument();
       expect(screen.getByText("live report")).toBeInTheDocument();
-      expect(
-        screen.getByRole("link", { name: /live report/ })
-      ).toHaveAttribute("href", expect.stringContaining("/reports/42/live"));
+      expect(screen.getByRole("link", { name: /live report/ })).toHaveAttribute(
+        "href",
+        expect.stringContaining("/reports/42/live")
+      );
     });
 
     it("shows only interval text when user can edit but not run live", () => {

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import NoResults from "./NoResults";
+
+const baseProps = {
+  queryId: 42,
+  disabledCaching: false,
+  disabledCachingGlobally: false,
+  discardDataEnabled: false,
+  loggingSnapshot: true,
+};
+
+describe("NoResults", () => {
+  describe("no interval set", () => {
+    it("shows interval and live report text when user can edit and run live", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={0}
+          canEditQuery
+          canLiveQuery
+        />
+      );
+
+      expect(screen.getByText("Nothing to report")).toBeInTheDocument();
+      expect(screen.getByText(/Add an/)).toBeInTheDocument();
+      expect(screen.getByText("interval")).toBeInTheDocument();
+      expect(screen.getByText("live report")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /live report/ })
+      ).toHaveAttribute("href", expect.stringContaining("/reports/42/live"));
+    });
+
+    it("shows only interval text when user can edit but not run live", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={0}
+          canEditQuery
+          canLiveQuery={false}
+        />
+      );
+
+      expect(screen.getByText(/Add an/)).toBeInTheDocument();
+      expect(screen.getByText("interval")).toBeInTheDocument();
+      expect(screen.queryByText("live report")).not.toBeInTheDocument();
+    });
+
+    it("shows only live report link when user can run live but not edit", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={0}
+          canEditQuery={false}
+          canLiveQuery
+        />
+      );
+
+      expect(screen.queryByText(/Add an/)).not.toBeInTheDocument();
+      expect(screen.getByText("live report")).toBeInTheDocument();
+    });
+
+    it("shows no actionable text when user can neither edit nor run live", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={0}
+          canEditQuery={false}
+          canLiveQuery={false}
+        />
+      );
+
+      expect(
+        screen.getByText(/does not collect data on a schedule/)
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/Add an/)).not.toBeInTheDocument();
+      expect(screen.queryByText("live report")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("has interval but no results yet", () => {
+    it("shows live report link when user can run live", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={3600}
+          queryUpdatedAt={new Date(0).toISOString()}
+          canLiveQuery
+        />
+      );
+
+      expect(screen.getByText("Nothing to report yet")).toBeInTheDocument();
+      expect(screen.getByText("live report")).toBeInTheDocument();
+    });
+
+    it("does not show live report link when user cannot run live", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={3600}
+          queryUpdatedAt={new Date(0).toISOString()}
+          canLiveQuery={false}
+        />
+      );
+
+      expect(screen.getByText("Nothing to report yet")).toBeInTheDocument();
+      expect(screen.queryByText("live report")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -141,7 +141,7 @@ const NoResults = ({
               {canEditQuery && canLiveQuery && " or "}
               {canLiveQuery && (
                 <>
-                  run a{" "}
+                  {canEditQuery ? "run" : "Run"} a{" "}
                   <CustomLink
                     url={PATHS.LIVE_REPORT(queryId)}
                     text="live report"

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -2,27 +2,35 @@ import React from "react";
 
 import { add, differenceInSeconds, formatDistance } from "date-fns";
 
+import PATHS from "router/paths";
 import TooltipWrapper from "components/TooltipWrapper/TooltipWrapper";
 import EmptyState from "components/EmptyState";
+import CustomLink from "components/CustomLink";
 
 interface INoResultsProps {
+  queryId: number;
   queryInterval?: number;
   queryUpdatedAt?: string;
   disabledCaching: boolean;
   disabledCachingGlobally: boolean;
   discardDataEnabled: boolean;
   loggingSnapshot: boolean;
+  canLiveQuery?: boolean;
+  canEditQuery?: boolean;
 }
 
 const baseClass = "no-results";
 
 const NoResults = ({
+  queryId,
   queryInterval,
   queryUpdatedAt,
   disabledCaching,
   disabledCachingGlobally,
   discardDataEnabled,
   loggingSnapshot,
+  canLiveQuery,
+  canEditQuery,
 }: INoResultsProps): JSX.Element => {
   // Returns how many seconds it takes to expect a cached update
   const secondsCheckbackTime = () => {
@@ -121,9 +129,28 @@ const NoResults = ({
       return [
         "Nothing to report",
         <>
-          This report does not collect data on a schedule. Add <br />
-          an <strong>interval</strong> or run this as a live report to see
-          results.
+          This report does not collect data on a schedule.
+          {(canEditQuery || canLiveQuery) && (
+            <>
+              <br />
+              {canEditQuery && (
+                <>
+                  Add an <strong>interval</strong>
+                </>
+              )}
+              {canEditQuery && canLiveQuery && " or "}
+              {canLiveQuery && (
+                <>
+                  run a{" "}
+                  <CustomLink
+                    url={PATHS.LIVE_REPORT(queryId)}
+                    text="live report"
+                  />
+                </>
+              )}{" "}
+              to see results.
+            </>
+          )}
         </>,
       ];
     }
@@ -139,10 +166,18 @@ const NoResults = ({
     return [
       "Nothing to report yet",
       <>
-        This report has returned no data so far. If you&apos;re <br />
-        expecting to see results, try running a live report to
-        <br />
-        get diagnostics.
+        This report has returned no data so far.
+        {canLiveQuery && (
+          <>
+            <br />
+            Expecting to see results? Run a{" "}
+            <CustomLink
+              url={PATHS.LIVE_REPORT(queryId)}
+              text="live report"
+            />{" "}
+            to troubleshoot.
+          </>
+        )}
       </>,
     ];
   };

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tests.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tests.tsx
@@ -28,7 +28,7 @@ describe("QueryReport", () => {
         report_clipped: false,
       },
     ];
-    render(<QueryReport {...{ isClipped, queryReport }} />);
+    render(<QueryReport queryId={1} {...{ isClipped, queryReport }} />);
 
     expect(screen.getByText(/value2/)).toBeInTheDocument();
     expect(screen.queryByText("truncated")).not.toBeInTheDocument();
@@ -61,7 +61,7 @@ describe("QueryReport", () => {
         report_clipped: false,
       },
     ];
-    render(<QueryReport {...{ isClipped, queryReport }} />);
+    render(<QueryReport queryId={1} {...{ isClipped, queryReport }} />);
 
     expect(screen.getByText(/value2/)).toBeInTheDocument();
     expect(screen.getByText(/(truncated)/)).toBeInTheDocument();
@@ -90,7 +90,7 @@ describe("QueryReport", () => {
       },
     ];
     const { user } = renderWithSetup(
-      <QueryReport {...{ isClipped, queryReport }} />
+      <QueryReport queryId={1} {...{ isClipped, queryReport }} />
     );
 
     await user.hover(screen.getByText(/\d+ result/));

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -9,6 +9,7 @@ import {
   generateCSVQueryResults,
 } from "utilities/generate_csv";
 import { IQueryReport, IQueryReportResultRow } from "interfaces/query_report";
+import PATHS from "router/paths";
 
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
@@ -17,12 +18,15 @@ import TableCount from "components/TableContainer/TableCount";
 import { generateResultsCountText } from "components/TableContainer/utilities/TableContainerUtils";
 import TooltipWrapper from "components/TooltipWrapper";
 import EmptyState from "components/EmptyState";
+import CustomLink from "components/CustomLink";
 
 import generateReportColumnConfigsFromResults from "./QueryReportTableConfig";
 
 interface IQueryReportProps {
   queryReport?: IQueryReport;
+  queryId: number;
   isClipped?: boolean;
+  canLiveQuery?: boolean;
 }
 
 const baseClass = "query-report";
@@ -44,7 +48,9 @@ const flattenResults = (results: IQueryReportResultRow[]) => {
 
 const QueryReport = ({
   queryReport,
+  queryId,
   isClipped,
+  canLiveQuery,
 }: IQueryReportProps): JSX.Element => {
   const { lastEditedQueryName } = useContext(QueryContext);
 
@@ -128,7 +134,22 @@ const QueryReport = ({
               <EmptyState
                 className={baseClass}
                 header="Nothing to report yet"
-                info="This report has returned no data so far."
+                info={
+                  <>
+                    This report hasn&apos;t returned data yet.
+                    {canLiveQuery && (
+                      <>
+                        <br />
+                        Expecting to see results? Run a{" "}
+                        <CustomLink
+                          url={PATHS.LIVE_REPORT(queryId)}
+                          text="live report"
+                        />{" "}
+                        to troubleshoot.
+                      </>
+                    )}
+                  </>
+                }
               />
             );
           }}


### PR DESCRIPTION
## Issue
Closes #44326 4.86.0
Second half of #35483 from 4.85.0

## Description
- Updates empty states of reports and policies pages only

## Screenshots


https://github.com/user-attachments/assets/8afb9456-86a5-4d61-8530-f8bec802f075


<img width="1473" height="543" alt="Screenshot 2026-05-15 at 10 16 42 AM" src="https://github.com/user-attachments/assets/3b53b233-6174-472e-9bae-e91b162132eb" />



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add-policy and add-report CTAs can be triggered from table empty states; tables receive handlers to invoke those flows.
  * Conditional "live report" links appear when permitted.

* **Improvements**
  * Empty-state messaging updated for policies and reports across tiers and scopes.
  * Search input and filter controls are disabled (not removed) when a table is truly empty; dropdowns hide/disable appropriately.

* **Tests**
  * Updated and added tests for empty-state copy, control behavior, and live/report flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->