### PR TITLE
Fixing frontend issue displaying pending details.

### DIFF
--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
+import { createMockHostMdmProfile } from "__mocks__/hostMock";
 import {
   FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID,
   ProfileOperationType,
@@ -138,6 +139,41 @@ describe("OS setting status cell", () => {
       ).toBeInTheDocument();
     });
   });
+  it("Shows the profile detail in the tooltip when a pending Android profile is waiting for a certificate", async () => {
+    const customRender = createCustomRenderer();
+
+    const detailMessage =
+      'Waiting for certificate "WiFi-Cert" to be installed on the host before applying this profile.';
+
+    const profile = createMockHostMdmProfile({
+      profile_uuid: "gf6dc58e8-d4c7-4d4b-8fa1-47de2bcb162c",
+      name: "01-wifi-eap-tls-WiFi-Cert.onc",
+      platform: "android",
+      operation_type: "install",
+      status: "pending",
+      detail: detailMessage,
+    });
+
+    const { user } = customRender(
+      <OSSettingStatusCell
+        profileName={profile.name}
+        status="pending"
+        operationType="install"
+        hostPlatform="android"
+        profileUUID={profile.profile_uuid}
+        profile={profile}
+      />
+    );
+
+    const statusText = screen.getByText("Enforcing");
+    expect(statusText).toBeInTheDocument();
+
+    await user.hover(statusText);
+    await waitFor(() => {
+      expect(screen.getByText(detailMessage)).toBeInTheDocument();
+    });
+  });
+
   it("Displays Pending UI for 'delivered' status with optype 'remove'", async () => {
     const customRender = createCustomRenderer();
 

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
@@ -129,9 +129,18 @@ const OSSettingStatusCell = ({
 
     // For failed status, use the error detail as tooltip content
     const errorTooltip = profile ? generateErrorTooltip(profile) : null;
+    // For pending profiles, prefer a backend-provided detail message (e.g.
+    // Android Wi-Fi profiles waiting for their certificate) over the generic
+    // "Enforcing" tooltip.
+    const pendingDetailTooltip =
+      profile?.status === "pending" && profile.detail ? profile.detail : null;
 
     let tipContent: React.ReactNode;
-    if (tooltip) {
+    if (pendingDetailTooltip) {
+      tipContent = (
+        <span className="tooltip__tooltip-text">{pendingDetailTooltip}</span>
+      );
+    } else if (tooltip) {
       if (status !== "action_required") {
         tipContent = (
           <span className="tooltip__tooltip-text">


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42405

Addresses issue with wrong tooltip when enforcing ONC profile: https://github.com/fleetdm/fleet/issues/42405#issuecomment-4401634532

QA'd functionality with fake data, not with full Android workflow.
<img width="995" height="494" alt="image" src="https://github.com/user-attachments/assets/ecfa730d-16d6-4944-a960-41232491ea1b" />

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tooltip messaging for pending OS settings profiles. When device settings are awaiting actions such as certificate installation, the status indicator's tooltip now displays backend-provided detail messages instead of generic text, providing users with clearer context about pending status changes.

* **Tests**
  * Added test coverage for the improved tooltip behavior with pending profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->