### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cisco-jabber/windows.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "15.2.1.60627",
+      "version": "15.2.2.60904",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cisco Jabber' AND publisher = 'Cisco Systems, Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cisco Jabber' AND publisher = 'Cisco Systems, Inc' AND version_compare(version, '15.2.1.60627') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cisco Jabber' AND publisher = 'Cisco Systems, Inc' AND version_compare(version, '15.2.2.60904') < 0);"
       },
-      "installer_url": "https://binaries.webex.com/jabberclientwindows/20260121061957/CiscoJabberSetup.msi",
+      "installer_url": "https://binaries.webex.com/jabberclientwindows/20260429083041/CiscoJabberSetup.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "48ce752e",
-      "sha256": "0876a1028372762b4350ce126a67fec6ae93fff8e6756686ec994e2fb1758e81",
+      "sha256": "58190d3e65bc93671404933d95b2953f7b05a2b3688bbd5b2d4881d23e1ba0cd",
       "default_categories": [
         "Communication"
       ],

--- a/ee/maintained-apps/outputs/clickup/darwin.json
+++ b/ee/maintained-apps/outputs/clickup/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.185",
+      "version": "3.5.208",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.clickup.desktop-app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.clickup.desktop-app' AND version_compare(bundle_short_version, '3.5.185') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.clickup.desktop-app' AND version_compare(bundle_short_version, '3.5.208') < 0);"
       },
-      "installer_url": "https://download.todesktop.com/221003ra4tebclw/ClickUp%203.5.185%20-%20Build%202603135dev5rzzi-arm64.dmg",
+      "installer_url": "https://download.todesktop.com/221003ra4tebclw/ClickUp%203.5.208%20-%20Build%20260505zrf6t7imk-arm64.dmg",
       "install_script_ref": "4b21205a",
       "uninstall_script_ref": "f4e84ffe",
-      "sha256": "ce6ea48fb1b0461e66f833de1526dcc780362ecaf09e9566eb4055f71096c7ac",
+      "sha256": "aaeecdee1e6be0a304c00f0c09e958de4de5733420a0896c079c8a7409be4d16",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.104.15",
+      "version": "1.104.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.16') < 0);"
       },
-      "installer_url": "https://releases.raycast.com/releases/1.104.15/download?build=arm",
+      "installer_url": "https://releases.raycast.com/releases/1.104.16/download?build=arm",
       "install_script_ref": "8461608e",
       "uninstall_script_ref": "c3d6f210",
-      "sha256": "dd2cb1d20228688e5388aa000d59442a1686a72b02630dbff0ff8ffd2706233b",
+      "sha256": "cbf30f3a8e889257fd84e1ff4510433a3757ef1f2dbdf205f4d078da0adf3c2f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/thunderbird/darwin.json
+++ b/ee/maintained-apps/outputs/thunderbird/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.0.1",
+      "version": "150.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '150.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '150.0.2') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/150.0.1/mac/en-US/Thunderbird%20150.0.1.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/150.0.2/mac/en-US/Thunderbird%20150.0.2.dmg",
       "install_script_ref": "158d6bf3",
       "uninstall_script_ref": "2b20efbb",
-      "sha256": "38c04659881a190797864d5116f214f3722966ae95f1583cc0693dda675a383d",
+      "sha256": "6ae5c89ebe9aca4f896b0af5f160e45de99df8e12f3e7c7a51cd2d500f6528cb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/thunderbird/windows.json
+++ b/ee/maintained-apps/outputs/thunderbird/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.0.1",
+      "version": "150.0.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '150.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '150.0.2') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/150.0.1/win64/en-US/Thunderbird%20Setup%20150.0.1.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/150.0.2/win64/en-US/Thunderbird%20Setup%20150.0.2.exe",
       "install_script_ref": "26f2daf8",
       "uninstall_script_ref": "96113731",
-      "sha256": "5a3581a8fae3bccc4b6d62f53eb7d6a64e2edf74d2a57224ede9b79f122c76f0",
+      "sha256": "d2780ade9361ac1a5358c15a5e119f3a117cde6d185bde0476e0249c0ec16b0b",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Cisco Jabber Windows to version 15.2.2.60904
  * Updated ClickUp Desktop macOS to version 3.5.208
  * Updated Raycast macOS to version 1.104.16
  * Updated Thunderbird on macOS to version 150.0.2
  * Updated Thunderbird on Windows to version 150.0.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->