### PR TITLE
Cherrypick: Don't write the secret.txt when the secret is the dummy placeholder value (#45041) -> v4.85.0

### DIFF
--- a/changes/fleetd-base-windows-secret
+++ b/changes/fleetd-base-windows-secret
@@ -1,0 +1,1 @@
+* Modified the MSI builder to not package the unusable "dummy" secret value when building fleetd-base.msi for Autopilot installs

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -70,9 +70,6 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-// unusedFlagKeyword is used by the MSI installer to populate parameters, which cannot be empty
-const unusedFlagKeyword = "dummy"
-
 type logError string
 
 const (
@@ -441,7 +438,7 @@ func orbitAction(c *cli.Context) error {
 		return fmt.Errorf("--host-identifier=%s is not supported, currently supported values are 'uuid' and 'instance'", hostIdentifier)
 	}
 
-	if email := c.String("end-user-email"); email != "" && email != unusedFlagKeyword && !fleet.IsLooseEmail(email) {
+	if email := c.String("end-user-email"); email != "" && email != constant.UnusedFlagKeyword && !fleet.IsLooseEmail(email) {
 		return fmt.Errorf("the provided end-user email address %q is not a valid email address", email)
 	}
 
@@ -1158,7 +1155,7 @@ func orbitAction(c *cli.Context) error {
 
 	// Set the EUA token from the MSI installer (Windows MDM enrollment).
 	// Must be set before any authenticated request triggers enrollment.
-	if euaToken := c.String("eua-token"); euaToken != "" && euaToken != unusedFlagKeyword {
+	if euaToken := c.String("eua-token"); euaToken != "" && euaToken != constant.UnusedFlagKeyword {
 		orbitClient.SetEUAToken(euaToken)
 	}
 
@@ -1485,7 +1482,7 @@ func orbitAction(c *cli.Context) error {
 	// --end-user-email is only supported on Windows and Linux (for macOS it gets the
 	// email from the enrollment profile)
 	endUserEmail := c.String("end-user-email")
-	if (runtime.GOOS == "windows" || runtime.GOOS == "linux") && endUserEmail != "" && endUserEmail != unusedFlagKeyword {
+	if (runtime.GOOS == "windows" || runtime.GOOS == "linux") && endUserEmail != "" && endUserEmail != constant.UnusedFlagKeyword {
 		if orbitClient.GetServerCapabilities().Has(fleet.CapabilityEndUserEmail) {
 			log.Debug().Msg("sending end-user email to Fleet")
 			if err := orbitClient.SetOrUpdateDeviceMappingEmail(endUserEmail); err != nil {

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -86,4 +86,7 @@ const (
 	FleetHTTPSignatureTPMKeyFileName = "host_identity_tpm.pem"
 	// FleetHTTPSignatureTPMKeyBackupFileName is the filename for the backup of the TPM key during renewal
 	FleetHTTPSignatureTPMKeyBackupFileName = "host_identity_tpm.old.pem"
+
+	// UnusedFlagKeyword is used by the MSI builder and installer to populate parameters, which cannot be empty.
+	UnusedFlagKeyword = "dummy"
 )

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -111,8 +111,12 @@ func BuildMSI(opt Options) (string, error) {
 
 	// Write files
 
-	if err := writeSecret(opt, orbitRoot); err != nil {
-		return "", fmt.Errorf("write enroll secret: %w", err)
+	// Don't write the dummy enroll secret to secret.txt. The installer will supply it on install and writing it
+	// here can cause "dummy" to attempt to be used as the secret, which will of course fail
+	if opt.EnrollSecret != constant.UnusedFlagKeyword {
+		if err := writeSecret(opt, orbitRoot); err != nil {
+			return "", fmt.Errorf("write enroll secret: %w", err)
+		}
 	}
 
 	if err := writeOsqueryFlagfile(opt, orbitRoot); err != nil {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44826

Cherrypick of #45041

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host
isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must
rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
* Windows MSI builds now correctly exclude placeholder secret values during installation, preventing unnecessary dummy configuration files from being created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
