### PR TITLE
Dashboard charts: Tweak tooltips

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -160,12 +160,12 @@ const ChartCard = ({
         : undefined,
       include_host_ids:
         chartFilters.hostFilterMode === "include" &&
-          chartFilters.selectedHosts.length
+        chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
       exclude_host_ids:
         chartFilters.hostFilterMode === "exclude" &&
-          chartFilters.selectedHosts.length
+        chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
     };

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -160,7 +160,7 @@ const ChartCard = ({
         : undefined,
       include_host_ids:
         chartFilters.hostFilterMode === "include" &&
-          chartFilters.selectedHosts.length
+        chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
       exclude_host_ids:

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -160,8 +160,8 @@ const ChartCard = ({
         : undefined,
       include_host_ids:
         chartFilters.hostFilterMode === "include" &&
-          chartFilters.selectedHosts.length
-          ? chartFilters.selectedHosts.map((h) => h.id).join(",")
+        chartFilters.selectedHosts.length
+? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
       exclude_host_ids:
         chartFilters.hostFilterMode === "exclude" &&

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -17,6 +17,7 @@ import DropdownWrapper from "components/forms/fields/DropdownWrapper";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
+import CustomLink from "components/CustomLink";
 
 import {
   IDataSet,
@@ -46,6 +47,7 @@ const DATASETS: IDataSet[] = [
       <>
         The number of hosts detected online during a given hour.
         <br />
+        <br />
         A host is considered online if it&rsquo;s actively checking in to Fleet.
         <br />
         This includes sleeping hosts (e.g. lid closed).{" "}
@@ -61,29 +63,24 @@ const DATASETS: IDataSet[] = [
     defaultChartType: "checkerboard",
     description: (
       <>
-        Shows the number of hosts with{" "}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://github.com/fleetdm/fleet/blob/1ea1fddfd62f66fd14de65cbeceb4f7a9d0167ec/server/chart/internal/mysql/charts.go#L111-L138"
-        >
-          certain critical
-          <br />
-          vulnerabilities
-        </a>{" "}
-        during a given hour.
+        The number of hosts with critical vulnerabilities detected in browsers
+        and{" "}
+        <CustomLink
+          newTab
+          text="other common software "
+          variant="tooltip-link"
+          url="https://fleetdm.com/learn-more-about/vulnerability-exposure-cves"
+        />
         <br />
         <br />
-        Want more control over this chart? Comprehensive vulnerability filtering
+        Want more control? Comprehensive vulnerability filtering
         is{" "}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://github.com/fleetdm/fleet/issues/44746"
-        >
-          coming soon
-        </a>
-        .
+        <CustomLink
+          newTab
+          text="coming soon "
+          variant="tooltip-link"
+          url="https://github.com/fleetdm/fleet/issues/44746"
+        />
       </>
     ),
     tooltipFormatter: ({ value }: { value: number }) =>
@@ -163,12 +160,12 @@ const ChartCard = ({
         : undefined,
       include_host_ids:
         chartFilters.hostFilterMode === "include" &&
-        chartFilters.selectedHosts.length
+          chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
       exclude_host_ids:
         chartFilters.hostFilterMode === "exclude" &&
-        chartFilters.selectedHosts.length
+          chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
     };

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -73,8 +73,7 @@ const DATASETS: IDataSet[] = [
         />
         <br />
         <br />
-        Want more control? Comprehensive vulnerability filtering
-        is{" "}
+        Want more control? Comprehensive vulnerability filtering is{" "}
         <CustomLink
           newTab
           text="coming soon "

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -165,7 +165,7 @@ const ChartCard = ({
           : undefined,
       exclude_host_ids:
         chartFilters.hostFilterMode === "exclude" &&
-          chartFilters.selectedHosts.length
+        chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
     };

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1270,6 +1270,7 @@ module.exports.routes = {
   'GET /learn-more-about/enrollment-profiles': 'https://developer.apple.com/documentation/devicemanagement/profile?changes=l_11_5',
   'GET /learn-more-about/psso-local-account': '/guides/setup-experience',
   'GET /learn-more-about/deploy-fleet': '/docs/deploy/deploy-fleet',
+  'GET /learn-more-about/vulnerability-exposure-cves': 'https://github.com/fleetdm/fleet/blob/1ea1fddfd62f66fd14de65cbeceb4f7a9d0167ec/server/chart/internal/mysql/charts.go#L111-L138',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
- Also add /learn-more link so we can update the link w/o a Fleet release

Hosts online:
<img width="494" height="171" alt="Screenshot 2026-05-08 at 5 11 23 PM" src="https://github.com/user-attachments/assets/98e355d0-2253-426b-851b-494f40ed6e31" />

Vulnerability exposure:
<img width="569" height="191" alt="Screenshot 2026-05-08 at 5 11 18 PM" src="https://github.com/user-attachments/assets/c4d4a026-e365-4321-b79c-6e83581857cc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new learning resource link for vulnerability exposure (CVE) dataset information.

* **Style**
  * Updated tooltip link formatting and styling for improved presentation.
  * Minor formatting adjustments to dataset descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->