### PR TITLE
Style fixes: label form, empty-state spacing, registration dark mode

### DIFF
--- a/changes/44923-style-fixes
+++ b/changes/44923-style-fixes
@@ -1,3 +1,0 @@
-* Moved the "Save" button to the left of "Cancel" on the Add/edit label page.
-* Removed the empty filter row above the empty state on the Reports and Policies pages so the empty state sits closer to the page header.
-* Cleaned up dark-mode styling on the initial Fleet setup page (active breadcrumb, input field hover/active borders, and confirmation table row backgrounds).

--- a/changes/44923-style-fixes
+++ b/changes/44923-style-fixes
@@ -1,0 +1,3 @@
+* Moved the "Save" button to the left of "Cancel" on the Add/edit label page.
+* Removed the empty filter row above the empty state on the Reports and Policies pages so the empty state sits closer to the page header.
+* Cleaned up dark-mode styling on the initial Fleet setup page (active breadcrumb, input field hover/active borders, and confirmation table row backgrounds).

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
@@ -100,3 +100,7 @@
     }
   }
 }
+
+body.dark-mode .confirm-user-reg__table tbody tr {
+  background-color: transparent;
+}

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -16,12 +16,6 @@
     color: $ui-fleet-black-50;
   }
 
-  &:hover:not(.input-field--read-only) {
-    box-shadow: none;
-    border: 1px solid $ui-fleet-black-75-over;
-  }
-
-  &:active:not(.input-field--read-only),
   &:focus:not(.input-field--read-only),
   &:focus-visible:not(.input-field--read-only) {
     box-shadow: none;

--- a/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
@@ -65,14 +65,6 @@
       }
 
       &.registration-breadcrumbs__page--active {
-        &::before {
-          background: linear-gradient(
-            to right,
-            $ui-fleet-black-75 50%,
-            $ui-fleet-black-25 50%
-          );
-        }
-
         &::after {
           background-color: transparent;
           outline: 2px solid $ui-fleet-black-75;
@@ -101,14 +93,6 @@
       }
 
       &.registration-breadcrumbs__page--active {
-        &::before {
-          background: linear-gradient(
-            to right,
-            $ui-fleet-black-75 50%,
-            $ui-fleet-black-25 50%
-          );
-        }
-
         &::after {
           background-color: transparent;
           outline: 2px solid $ui-fleet-black-75;
@@ -140,14 +124,6 @@
       }
 
       &.registration-breadcrumbs__page--active {
-        &::before {
-          background: linear-gradient(
-            to right,
-            $ui-fleet-black-75 50%,
-            $ui-fleet-black-25 50%
-          );
-        }
-
         &::after {
           background-color: transparent;
           outline: 2px solid $ui-fleet-black-75;

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -594,15 +594,6 @@ const NewLabelPage = ({
       </div>
       {renderVariableFields()}
       <div className="button-wrap">
-        <Button
-          onClick={() => {
-            router.goBack();
-          }}
-          variant="inverse"
-          disabled={isUpdating}
-        >
-          Cancel
-        </Button>
         <GitOpsModeTooltipWrapper
           entityType="labels"
           renderChildren={(disableChildren) => (
@@ -615,6 +606,15 @@ const NewLabelPage = ({
             </Button>
           )}
         />
+        <Button
+          onClick={() => {
+            router.goBack();
+          }}
+          variant="inverse"
+          disabled={isUpdating}
+        >
+          Cancel
+        </Button>
       </div>
     </form>
   );

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tsx
@@ -171,9 +171,6 @@ const LabelForm = ({
       {teamName ? <TeamNameField name={teamName} /> : null}
       {additionalFields}
       <div className="button-wrap">
-        <Button onClick={onCancel} variant="inverse">
-          Cancel
-        </Button>
         <GitOpsModeTooltipWrapper
           entityType="labels"
           renderChildren={(disableChildren) => (
@@ -186,6 +183,9 @@ const LabelForm = ({
             </Button>
           )}
         />
+        <Button onClick={onCancel} variant="inverse">
+          Cancel
+        </Button>
       </div>
     </form>
   );

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -155,6 +155,7 @@ const PoliciesTable = ({
         onQueryChange={onQueryChange}
         inputPlaceHolder="Search by name"
         searchable={searchable}
+        disableTableHeader={!searchable}
         customControl={customControl}
       />
     </div>

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -302,6 +302,7 @@ const QueriesTable = ({
           inputPlaceHolder="Search by name"
           onQueryChange={onQueryChange}
           searchable={searchable}
+          disableTableHeader={!searchable}
           customControl={searchable ? renderPlatformDropdown : undefined}
           disableMultiRowSelect={!curTeamScopeQueriesPresent}
           onClickRow={handleRowSelect}


### PR DESCRIPTION
For #44923

## Summary
- Moved the "Save" button to the left of "Cancel" on the Add/edit label page.
- Hid the empty filter row that sat above the empty state on the Reports and Policies pages by passing `disableTableHeader={!searchable}` when there are no results, no search, and no active filters. The empty state now sits closer to the page header.
- Cleaned up dark-mode styling on the initial Fleet setup page: active breadcrumb gradient, input field hover/active black borders, and confirmation table row backgrounds.

## Test plan
- [ ] Open Add/edit label: confirm "Save" is on the left, "Cancel" on the right.
- [ ] On a fleet with no reports, visit Reports: confirm the empty state sits directly below the subtitle without an empty row above it.
- [ ] Add a report and visit Reports: confirm the count + filter + search row still renders normally.
- [ ] Same checks for Policies (empty vs populated).
- [ ] Walk through initial Fleet setup in dark mode: confirm breadcrumb active step, input field hover/active states, and confirmation table no longer have black boxes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced dark mode styling for table display
  * Removed hover and active visual effects from input fields
  * Removed gradient styling from breadcrumb navigation
  * Improved button layout in label creation form

* **Updates**
  * Table headers now conditionally display based on search functionality availability in policies and queries pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->