### PR TITLE
Website: bring back CTA buttons on homepage

### DIFF
--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -316,7 +316,14 @@
     }
 
   }
-
+  [purpose='platform-button'] {
+    .cta-button();
+    padding: 8px 16px;
+    height: 36px;
+    font-size: 14px;
+    width: fit-content;
+    margin-top: 32px;
+  }
 
 
   [purpose='feature-with-image'] {

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -888,9 +888,6 @@
     <script src="/js/components/parallax-city.component.js"></script>
     <script src="/js/components/rituals.component.js"></script>
     <script src="/js/components/scrollable-tweets.component.js"></script>
-    <script src="/js/components/stripe-card-element.component.js"></script>
-    <script src="/js/utilities/open-stripe-checkout.js"></script>
-    <script src="/js/pages/account/account-overview.page.js"></script>
     <script src="/js/pages/account/edit-password.page.js"></script>
     <script src="/js/pages/account/edit-profile.page.js"></script>
     <script src="/js/pages/admin/email-preview.page.js"></script>
@@ -947,7 +944,6 @@
     <script src="/js/pages/landing-pages/replace-jamf.page.js"></script>
     <script src="/js/pages/legal/privacy.page.js"></script>
     <script src="/js/pages/legal/terms.page.js"></script>
-    <script src="/js/pages/meetups.page.js"></script>
     <script src="/js/pages/microsoft-proxy/remediate.page.js"></script>
     <script src="/js/pages/microsoft-proxy/turn-on-mdm.page.js"></script>
     <script src="/js/pages/observability.page.js"></script>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -79,20 +79,23 @@
         <div purpose="feature-image">
           <video autoplay loop playsinline muted purpose="calendar-video"><source src="/videos/features-loop.mp4" type="video/mp4"></video>
         </div>
-        <div purpose="feature-text">
-          <div purpose="feature-block">
-            <h5>One platform for every OS — even Linux</h5>
-            <p>Manage macOS, Linux, Windows, iOS, and Android from a single console, without compromising management and security.</p>
+        <div purpose="feature-list">
+
+          <div purpose="feature-text">
+            <div purpose="feature-block">
+              <h5>One platform for every OS — even Linux</h5>
+              <p>Manage macOS, Linux, Windows, iOS, and Android from a single console, without compromising management and security.</p>
+            </div>
+            <div purpose="feature-block">
+              <h5>UI, API, or infrastructure as code</h5>
+              <p>Work in the UI, automate with the API, or manage settings as code.</p>
+            </div>
+            <div purpose="feature-block">
+              <h5>All features, flexible deployment</h5>
+              <p>Unlike other solutions, you can let us host Fleet for you or deploy it yourself. You get the same experience either way.</p>
+            </div>
           </div>
-          <div purpose="feature-block">
-            <h5>UI, API, or infrastructure as code</h5>
-            <p>Work in the UI, automate with the API, or manage settings as code.</p>
-          </div>
-          <div purpose="feature-block">
-            <h5>All features, flexible deployment</h5>
-            <p>Unlike other solutions, you can let us host Fleet for you or deploy it yourself. You get the same experience either way.</p>
-          </div>
-          <!-- <a purpose="cta-button" href="/device-management">Explore device management</a> -->
+          <a purpose="platform-button" href="/device-management">Explore device management</a>
         </div>
       </div>
       <div purpose="homepage-text-block">
@@ -103,50 +106,54 @@
         <div purpose="feature-image">
           <img alt="See reality clearly" src="/images/see-reality-clearly-688x516@2x.png">
         </div>
-        <div purpose="feature-text">
-          <div purpose="feature-block">
-            <h5>Cut the busywork</h5>
-            <p>Get answers instantly with live reports. No waiting hours for scripts or manual data collection.</p>
+        <div purpose="feature-list">
+          <div purpose="feature-text">
+            <div purpose="feature-block">
+              <h5>Cut the busywork</h5>
+              <p>Get answers instantly with live reports. No waiting hours for scripts or manual data collection.</p>
+            </div>
+            <div purpose="feature-block">
+              <h5>Enroll any device</h5>
+              <p>Get instant visibility into devices from subsidiaries, partners, or acquisitions. Enroll endpoints without forcing teams to migrate tools.</p>
+            </div>
+            <div purpose="feature-block">
+              <h5>Tell your story</h5>
+              <p>Track AI usage, shadow IT, vulnerabilities, patch SLAs, and security posture with clear reports.</p>
+            </div>
           </div>
-          <div purpose="feature-block">
-            <h5>Enroll any device</h5>
-            <p>Get instant visibility into devices from subsidiaries, partners, or acquisitions. Enroll endpoints without forcing teams to migrate tools.</p>
-          </div>
-          <div purpose="feature-block">
-            <h5>Tell your story</h5>
-            <p>Track AI usage, shadow IT, vulnerabilities, patch SLAs, and security posture with clear reports.</p>
-          </div>
-          <!-- <a purpose="cta-button" href="/orchestration">More about visibility</a> -->
+          <a purpose="platform-button" href="/orchestration">More about visibility</a>
         </div>
       </div>
       <div purpose="homepage-text-block">
         <h2>Get things done faster</h2>
         <p>The world is changing rapidly, and traditional device management systems were built for computer labs.  In Fleet, you can become a power user in the UI, manage infrastructure as code, or adopt new ways of working.  For example:</p>
       </div>
-      <div purpose="feature-with-image">
+      <div purpose="feature-with-image" class="reverse">
         <div purpose="feature-image">
           <img alt="Modern change management" src="/images/mdm-modern-change-management-600x435@2x.png">
         </div>
-        <div purpose="feature-text">
-          <div purpose="feature-list-block">
-            <div purpose="feature-text-content">
-              <h5>Propose a change</h5>
-              <p>Describe a configuration change, CVE fix, or other improvement in natural language using your existing AI.</p>
+        <div purpose="feature-list">
+          <div purpose="feature-text">
+            <div purpose="feature-block">
+              <div purpose="feature-text-content">
+                <h5>Propose a change</h5>
+                <p>Describe a configuration change, CVE fix, or other improvement in natural language using your existing AI.</p>
+              </div>
+            </div>
+            <div purpose="feature-block">
+              <div purpose="feature-text-content">
+                <h5>Human review</h5>
+                <p>Review changes from your team (or your bots) before they reach your devices. Inspect the configuration, make edits if needed, then approve it.</p>
+              </div>
+            </div>
+            <div purpose="feature-block">
+              <div purpose="feature-text-content">
+                <h5>Apply across your fleet</h5>
+                <p>Merge the change and let Fleet apply it across your devices. Roll back instantly if needed.</p>
+              </div>
             </div>
           </div>
-          <div purpose="feature-list-block">
-            <div purpose="feature-text-content">
-              <h5>Human review</h5>
-              <p>Review changes from your team (or your bots) before they reach your devices. Inspect the configuration, make edits if needed, then approve it.</p>
-            </div>
-          </div>
-          <div purpose="feature-list-block">
-            <div purpose="feature-text-content">
-              <h5>Apply across your fleet</h5>
-              <p>Merge the change and let Fleet apply it across your devices. Roll back instantly if needed.</p>
-            </div>
-          </div>
-          <!-- <a purpose="cta-button" href="/infrastructure-as-code">Manage devices as code</a> -->
+          <a purpose="platform-button" href="/infrastructure-as-code">Manage devices as code</a>
         </div>
       </div>
       <div purpose="testimonials-header">


### PR DESCRIPTION
Changes:
- Uncommented and updated the styles of the CTA buttons on the homepage, updated the order of the section added in https://github.com/fleetdm/fleet/pull/45001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined homepage button styling with improved padding, typography, height, and layout properties for a more polished visual presentation.

* **New Features**
  * Updated homepage feature section content with refreshed descriptions and newly activated call-to-action links directing users to detailed product information for device management, orchestration, and infrastructure-as-code features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->