### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "147.1.89.145",
+      "version": "148.1.90.121",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '147.1.89.145') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '148.1.90.121') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.89.145/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.90.121/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "9d33e7746fb718dfac4b8a16370c89da7cdf60e7d7a577652c3d350fc48f078a",
+      "sha256": "91c55fed6456aa21039a20b8c8f994cd23096abbdc157cc281d7daba408085e0",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.9.0",
+      "version": "8.9.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.9.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.9.1') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.9.0.zip",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.9.1.zip",
       "install_script_ref": "fac7f399",
       "uninstall_script_ref": "a39bd40e",
-      "sha256": "812db6a58590f912beb53bf6f4fffe8508155455d92676ab39a11df01f50e8ee",
+      "sha256": "2a6268bc5bb8c372a17635b441ea6c6a41b7b1ff0a577904f04955596a664987",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.04.29.08.57.01",
+      "version": "0.2026.05.06.15.42.02",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.04.29.08.57.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.05.06.15.42.02') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.04.29.08.57.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.05.06.15.42.stable_02/Warp.dmg",
       "install_script_ref": "4b1c0c37",
       "uninstall_script_ref": "bd923c6f",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.1.6",
+      "version": "1.1.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.1.7') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.1.6/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.1.7/Zed-aarch64.dmg",
       "install_script_ref": "7a64bca0",
       "uninstall_script_ref": "315158ff",
-      "sha256": "fa4bcb1b2ebadb808c9bc33f7d1543f14f611ba1c8dd08b21cd0ac4984cb1c89",
+      "sha256": "0638df9e22a3e704877d099feed0afac64d6f53e98bda4b01f5b402398cf2b3d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zotero/windows.json
+++ b/ee/maintained-apps/outputs/zotero/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '9.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '9.0.3') < 0);"
       },
-      "installer_url": "https://download.zotero.org/client/release/9.0.2/Zotero-9.0.2_x64_setup.exe",
+      "installer_url": "https://download.zotero.org/client/release/9.0.3/Zotero-9.0.3_x64_setup.exe",
       "install_script_ref": "d29b62d2",
       "uninstall_script_ref": "599566de",
-      "sha256": "cf311861ff1af3b42e0750b48090492c034a8ee614a77f9e9f12bf05e0de51a9",
+      "sha256": "3d3668869fd6f9d5b2f4de8c7f3955de77097924b7c5a8816db0425089c05fb8",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed installer configurations, URLs, and security checksums for Brave Browser (Windows to 148.1.90.121), Signal (macOS to 8.9.1), Warp (macOS to 0.2026.05.06.15.42.02), Zed (macOS to 1.1.7), and Zotero (Windows to 9.0.3) to maintain platform compatibility and ensure safe installations with verified builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->