### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "147.1.89.145",
+      "version": "148.1.90.121",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '147.1.89.145') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '148.1.90.121') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.89.145/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.90.121/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "9d33e7746fb718dfac4b8a16370c89da7cdf60e7d7a577652c3d350fc48f078a",
+      "sha256": "91c55fed6456aa21039a20b8c8f994cd23096abbdc157cc281d7daba408085e0",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.6608.0",
+      "version": "1.6608.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.6608.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.6608.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.6608.0/Claude-f65729daa9bbf1994963463204a556d0431e6054.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.6608.2/Claude-ebf1a166e82541b54229aa620d117c60923a939a.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "d857a128",
-      "sha256": "e991445d461687af523f62293764b0c6d740da53ae3c6a5659297016e4cc8c5a",
+      "sha256": "1e11b6b175750072123e837db8c2b06a337bee61fff4d570a03327245c4f5a90",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.6259.1",
+      "version": "1.6608.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.6259.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.6608.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.6259.1/Claude-5095e7dddcba4ca974d351ee397e17d204814f07.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.6608.0/Claude-f65729daa9bbf1994963463204a556d0431e6054.msix",
       "install_script_ref": "31a0b698",
       "uninstall_script_ref": "03f72055",
-      "sha256": "d4fcf67b2a02a340e2f855d13affe5f134c56214eb7fadcce9715f12a5cbc27e",
+      "sha256": "3068da39f2e068aef2c05fdd213f04213a353714988ccb06b80f840730fcb495",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/clickup/windows.json
+++ b/ee/maintained-apps/outputs/clickup/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.185",
+      "version": "3.5.208",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'ClickUp' AND publisher = 'ClickUp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ClickUp' AND publisher = 'ClickUp' AND version_compare(version, '3.5.185') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ClickUp' AND publisher = 'ClickUp' AND version_compare(version, '3.5.208') < 0);"
       },
-      "installer_url": "https://download.todesktop.com/221003ra4tebclw/ClickUp-3.5.185-build-2603135dev5rzzi-x64.msi",
+      "installer_url": "https://download.todesktop.com/221003ra4tebclw/ClickUp-3.5.208-build-260505zrf6t7imk-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e107a4f2",
-      "sha256": "081471c27c470d297cdd4ad1977af8fc50f9c2b2211c339d1ef616fb63ac14d2",
+      "sha256": "875f5da2e8a24366a642f8847d7471cb8f231554a795b93894ad6d9b9762c55a",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.3.16",
+      "version": "3.3.27",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.3.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.3.27') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/7f0f522221d0ba220e4edb766bb3c47c08c14ab7/win32/x64/system-setup/CursorSetup-x64-3.3.16.exe",
+      "installer_url": "https://downloads.cursor.com/production/80b138a7a0a948e1a798e9ed7867d76a1ba9a318/win32/x64/system-setup/CursorSetup-x64-3.3.27.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "c1d15a53839c79b6ca7fdf5b2bc46ab4892caa9a65a28f572a81edba1686bdfc",
+      "sha256": "67869beea73a634855d96615fceaa6fbaba5567536882994251a20b9664a844b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@esr/windows.json
+++ b/ee/maintained-apps/outputs/firefox@esr/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "140.10.1",
+      "version": "140.10.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla' AND version_compare(version, '140.10.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla' AND version_compare(version, '140.10.2') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.10.1esr/win64/en-US/Firefox%20Setup%20140.10.1esr.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.10.2esr/win64/en-US/Firefox%20Setup%20140.10.2esr.exe",
       "install_script_ref": "36995f4f",
       "uninstall_script_ref": "5dc712f7",
-      "sha256": "ef9b237e30a0c6d0e32ad92704875b49972ec734fff2e8cbba146d3c2e468184",
+      "sha256": "cbcb876cd0e781448307580c4342ba7675774b5f7b2a008b6e67ffef0f39d3f7",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.162.5",
+      "version": "7.162.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.162.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.162.6') < 0);"
       },
-      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.162.5-win-x64.exe",
+      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.162.6-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "a47361db025ac3c4c6eeb33c360adec84da7420c2949cae0ab5a2ae84ca1fd3c",
+      "sha256": "4278beed60334fbf7af830bea32eebbf5683c1888e2bcdcea9be4ee2a94cf3fe",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.9.0",
+      "version": "8.9.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.9.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.9.1') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.9.0.zip",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.9.1.zip",
       "install_script_ref": "fac7f399",
       "uninstall_script_ref": "a39bd40e",
-      "sha256": "812db6a58590f912beb53bf6f4fffe8508155455d92676ab39a11df01f50e8ee",
+      "sha256": "2a6268bc5bb8c372a17635b441ea6c6a41b7b1ff0a577904f04955596a664987",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/telegram/windows.json
+++ b/ee/maintained-apps/outputs/telegram/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.7.8",
+      "version": "6.8.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC' AND version_compare(version, '6.7.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC' AND version_compare(version, '6.8.1') < 0);"
       },
-      "installer_url": "https://github.com/telegramdesktop/tdesktop/releases/download/v6.7.8/tsetup-x64.6.7.8.exe",
+      "installer_url": "https://github.com/telegramdesktop/tdesktop/releases/download/v6.8.1/tsetup-x64.6.8.1.exe",
       "install_script_ref": "0b88a95e",
       "uninstall_script_ref": "42311f1b",
-      "sha256": "e8a45876b171a070606d82c2c0893a00aad25930a4c285abb9e5d40b8f9d0eb9",
+      "sha256": "6eeb821695537e49f760f51e7d1d1d8cdfe6c0015f5ac5a8ba7e77d37d3f66e9",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.04.29.08.57.01",
+      "version": "0.2026.05.06.15.42.03",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.04.29.08.57.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.05.06.15.42.03') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.04.29.08.57.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.05.06.15.42.stable_03/Warp.dmg",
       "install_script_ref": "4b1c0c37",
       "uninstall_script_ref": "bd923c6f",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.1.6",
+      "version": "1.1.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.1.7') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.1.6/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.1.7/Zed-aarch64.dmg",
       "install_script_ref": "7a64bca0",
       "uninstall_script_ref": "315158ff",
-      "sha256": "fa4bcb1b2ebadb808c9bc33f7d1543f14f611ba1c8dd08b21cd0ac4984cb1c89",
+      "sha256": "0638df9e22a3e704877d099feed0afac64d6f53e98bda4b01f5b402398cf2b3d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zen/darwin.json
+++ b/ee/maintained-apps/outputs/zen/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.19.11b",
+      "version": "1.19.12b",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.19.11b') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.19.12b') < 0);"
       },
-      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.19.11b/zen.macos-universal.dmg",
+      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.19.12b/zen.macos-universal.dmg",
       "install_script_ref": "6dc5817a",
       "uninstall_script_ref": "3b2420d9",
-      "sha256": "1929390d8254267603e4f32320cb40c1eec1d0a7411cc8e07d00e727fd3024e2",
+      "sha256": "5c564941d6117e87ac7eb4cfe11b0a1fad772be2e02d6f0af48d38f788bea012",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/zotero/windows.json
+++ b/ee/maintained-apps/outputs/zotero/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '9.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '9.0.3') < 0);"
       },
-      "installer_url": "https://download.zotero.org/client/release/9.0.2/Zotero-9.0.2_x64_setup.exe",
+      "installer_url": "https://download.zotero.org/client/release/9.0.3/Zotero-9.0.3_x64_setup.exe",
       "install_script_ref": "d29b62d2",
       "uninstall_script_ref": "599566de",
-      "sha256": "cf311861ff1af3b42e0750b48090492c034a8ee614a77f9e9f12bf05e0de51a9",
+      "sha256": "3d3668869fd6f9d5b2f4de8c7f3955de77097924b7c5a8816db0425089c05fb8",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for 13 maintained applications (Brave Browser, Claude, ClickUp, Cursor, Firefox ESR, Granola, Signal, Telegram, Warp, Zed, Zen Browser, and Zotero) to their latest versions with corresponding installer URLs and security checksums across Windows and macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->