### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.3.27",
+      "version": "3.3.30",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.3.27') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.3.30') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/80b138a7a0a948e1a798e9ed7867d76a1ba9a318/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/3dc559280adc5f931ade8e25c7b85393842acf34/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "a4458d81",
-      "sha256": "c4b3f9737d3136e653de2b1fa6f55b9d72ba45b20997d96aa304c3f0151217e8",
+      "sha256": "28df81e604e1955393d39d5eaaaa672d3926968af5e75be8e3b8b83e30ee33a3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.3.27",
+      "version": "3.3.30",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.3.27') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.3.30') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/80b138a7a0a948e1a798e9ed7867d76a1ba9a318/win32/x64/system-setup/CursorSetup-x64-3.3.27.exe",
+      "installer_url": "https://downloads.cursor.com/production/3dc559280adc5f931ade8e25c7b85393842acf34/win32/x64/system-setup/CursorSetup-x64-3.3.30.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "67869beea73a634855d96615fceaa6fbaba5567536882994251a20b9664a844b",
+      "sha256": "9218fd728d682bd8c57ee7c3c4609c0d09db7d3839f15e30d921c8cd43fea1a5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/drawio/darwin.json
+++ b/ee/maintained-apps/outputs/drawio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "29.7.9",
+      "version": "30.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '29.7.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '30.0.0') < 0);"
       },
-      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v29.7.9/draw.io-arm64-29.7.9.dmg",
+      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.0.0/draw.io-arm64-30.0.0.dmg",
       "install_script_ref": "c5526876",
       "uninstall_script_ref": "f7bbd18b",
-      "sha256": "ea26d21b6b5d47a1252ff396357b29982cb7ddebdbc6b559b68b6f6db79caaa3",
+      "sha256": "aafa7aa79d1bca0b5d2055ccefdb61873c1f63f68c8870b871e16d002c34e399",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/orbstack/darwin.json
+++ b/ee/maintained-apps/outputs/orbstack/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.1.1",
+      "version": "2.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.1.3') < 0);"
       },
-      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.1.1_20026_arm64.dmg",
+      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.1.3_20115_arm64.dmg",
       "install_script_ref": "1ca1398e",
       "uninstall_script_ref": "9210efcc",
-      "sha256": "18a41f759958e1fa0951696b820b5478d3ed7353f8ca486fe9d026a1a7d97207",
+      "sha256": "f494db804fc486ef2f88eab903d186a6987c786de39868ff883416a5eb9a7317",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cursor for macOS and Windows to version 3.3.30 with new installer URLs and verification checksums.
  * Updated Draw.io Desktop for macOS to version 30.0.0.
  * Updated OrbStack for macOS to version 2.1.3.
  * Refreshed package metadata and installation queries for all updated applications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->