### PR TITLE
Dashboard widgets empty state font size

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -380,7 +380,7 @@
 
   h3 {
     margin: 0;
-    font-size: $medium;
+    font-size: $small;
     color: var(--core-fleet-black);
   }
 


### PR DESCRIPTION
- Use 16px as per Figma: https://www.figma.com/design/mCPegRjoFdpMem1PLMF1BF/-41519----44591---43769-Dashboard-widgets?node-id=5665-14743&t=2qxb66rqk3J0eTld-1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted heading typography sizing in the disabled state of chart cards for improved visual hierarchy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45133)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->