### PR TITLE
Update desktop token even if fleet desktop is disabled

### DIFF
--- a/orbit/changes/44681-always-update-identifier
+++ b/orbit/changes/44681-always-update-identifier
@@ -1,0 +1,1 @@
+* Updated orbit to rotate desktop token ("identifier" file) even if Fleet Desktop is disabled.


### PR DESCRIPTION
Missing changes file for: https://github.com/fleetdm/fleet/pull/39533/changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop security token rotation for identity verification now occurs consistently, regardless of Fleet Desktop configuration status.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45140)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->