### PR TITLE
Dedupe network errors so usage_statistics cron stops failing

### DIFF
--- a/changes/42613-dedupe-network-errors-in-error-store
+++ b/changes/42613-dedupe-network-errors-in-error-store
@@ -1,0 +1,1 @@
+- Fixed the `usage_statistics` cron failing against fleetdm.com when a large number of near-identical network errors accumulated in the error store.

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -36,6 +36,14 @@ func maybeReplaceSocketAddr(s string) string {
 	return socketAddrPattern.ReplaceAllString(s, "<addr>")
 }
 
+// statusCoder duck-types errors that expose an HTTP status code (matches
+// service.OsqueryError.Status). Used below to limit the socket-address
+// normalization to request-timeout errors only, without introducing a
+// service -> errorstore import cycle.
+type statusCoder interface {
+	Status() int
+}
+
 // Handler defines an error handler. Call Handler.Store to handle an error, and
 // Handler.Retrieve to retrieve all stored errors and optionally clear them
 // from the store. It is safe to call those methods concurrently.
@@ -160,10 +168,14 @@ func hashError(err error) string {
 
 	var sb strings.Builder
 	// hash the cause type and message (it might not be a FleetError).
-	// Socket addresses are normalized away first so that errors which
-	// only differ by ephemeral TCP source port (e.g. *net.OpError
-	// "read tcp ...: i/o timeout") collapse into a single dedup entry.
-	fmt.Fprintf(&sb, "%T\n%s\n", cause, maybeReplaceSocketAddr(cause.Error()))
+	// For request-timeout errors only, socket addresses are normalized
+	// away first so that occurrences which differ only by ephemeral TCP
+	// source port collapse into a single dedup entry.
+	msg := cause.Error()
+	if sc, ok := cause.(statusCoder); ok && sc.Status() == http.StatusRequestTimeout {
+		msg = maybeReplaceSocketAddr(msg)
+	}
+	fmt.Fprintf(&sb, "%T\n%s\n", cause, msg)
 
 	// hash the stack trace of the root FleetError in the chain
 	if ferr != nil {

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -168,11 +168,13 @@ func hashError(err error) string {
 
 	var sb strings.Builder
 	// hash the cause type and message (it might not be a FleetError).
-	// For request-timeout errors only, socket addresses are normalized
-	// away first so that occurrences which differ only by ephemeral TCP
-	// source port collapse into a single dedup entry.
+	// For request-timeout errors only, all socket addresses in the
+	// message (both local and remote, IPs and ports) are normalized
+	// away so that occurrences differing only by those addresses
+	// collapse into a single dedup entry.
 	msg := cause.Error()
-	if sc, ok := cause.(statusCoder); ok && sc.Status() == http.StatusRequestTimeout {
+	var sc statusCoder
+	if errors.As(err, &sc) && sc.Status() == http.StatusRequestTimeout {
 		msg = maybeReplaceSocketAddr(msg)
 	}
 	fmt.Fprintf(&sb, "%T\n%s\n", cause, msg)

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -26,6 +27,14 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	redigo "github.com/gomodule/redigo/redis"
 )
+
+// matches IPv4 and IPv6 socket addresses
+var socketAddrPattern = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}:\d+|\[[0-9a-fA-F:]+\]:\d+`)
+
+// replaces TCP/UDP socket addresses (if present) with a fixed placeholder
+func maybeReplaceSocketAddr(s string) string {
+	return socketAddrPattern.ReplaceAllString(s, "<addr>")
+}
 
 // Handler defines an error handler. Call Handler.Store to handle an error, and
 // Handler.Retrieve to retrieve all stored errors and optionally clear them
@@ -150,8 +159,11 @@ func hashError(err error) string {
 	ferr := ctxerr.FleetCause(err)
 
 	var sb strings.Builder
-	// hash the cause type and message (it might not be a FleetError)
-	fmt.Fprintf(&sb, "%T\n%s\n", cause, cause.Error())
+	// hash the cause type and message (it might not be a FleetError).
+	// Socket addresses are normalized away first so that errors which
+	// only differ by ephemeral TCP source port (e.g. *net.OpError
+	// "read tcp ...: i/o timeout") collapse into a single dedup entry.
+	fmt.Fprintf(&sb, "%T\n%s\n", cause, maybeReplaceSocketAddr(cause.Error()))
 
 	// hash the stack trace of the root FleetError in the chain
 	if ferr != nil {

--- a/server/errorstore/errors_test.go
+++ b/server/errorstore/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -130,6 +131,28 @@ func TestHashErrFleetError(t *testing.T) {
 		assert.NotEqual(t, h1, h2)
 		assert.NotEqual(t, h1, h3)
 		assert.NotEqual(t, h2, h3)
+	})
+
+	t.Run("errors use the same hash if their content differs only by the socket address (IPv4)", func(t *testing.T) {
+		err1 := errors.New("read tcp 10.10.3.44:8080->10.10.11.251:55732: i/o timeout")
+		err2 := errors.New("read tcp 10.10.3.44:8080->10.10.11.251:61204: i/o timeout")
+		err3 := errors.New("read tcp 10.10.3.44:8080->10.10.11.251:38891: i/o timeout")
+
+		h1, h2, h3 := hashError(err1), hashError(err2), hashError(err3)
+		assert.Equal(t, h1, h2)
+		assert.Equal(t, h1, h3)
+	})
+
+	t.Run("errors use the same hash if their content differs only by the socket address (IPv6)", func(t *testing.T) {
+		err1 := errors.New("read tcp [::1]:8080->[fe80::1]:55732: i/o timeout")
+		err2 := errors.New("read tcp [::1]:8080->[fe80::1]:61204: i/o timeout")
+		assert.Equal(t, hashError(err1), hashError(err2))
+	})
+
+	t.Run("errors use different hashes if the non-socket-address content differs", func(t *testing.T) {
+		err1 := errors.New("read tcp 10.0.0.1:80->10.0.0.2:55732: i/o timeout")
+		err2 := errors.New("read tcp 10.0.0.1:80->10.0.0.2:55732: connection reset by peer")
+		assert.NotEqual(t, hashError(err1), hashError(err2))
 	})
 }
 

--- a/server/errorstore/errors_test.go
+++ b/server/errorstore/errors_test.go
@@ -164,7 +164,7 @@ func TestHashErrFleetError(t *testing.T) {
 
 	t.Run("request-timeout errors use different hashes if the non-socket-address content differs", func(t *testing.T) {
 		err1 := &statusErr{msg: "read tcp 10.0.0.1:80->10.0.0.2:55732: i/o timeout", status: http.StatusRequestTimeout}
-		err2 := &statusErr{msg: "read tcp 10.0.0.1:80->10.0.0.2:55732: connection reset by peer", status: http.StatusRequestTimeout}
+		err2 := &statusErr{msg: "read tcp 10.0.0.1:80->10.0.0.2:55732: context deadline exceeded", status: http.StatusRequestTimeout}
 		assert.NotEqual(t, hashError(err1), hashError(err2))
 	})
 

--- a/server/errorstore/errors_test.go
+++ b/server/errorstore/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"regexp"
@@ -50,6 +51,18 @@ func alwaysNewErrorTwo(eh *Handler) error {
 }
 
 func alwaysWrappedErr() error { return ctxerr.Wrap(ctx, io.EOF, "always EOF") }
+
+// statusErr is a test fixture that implements the statusCoder interface
+// hashError checks against, so we can exercise the request-timeout-only
+// normalization path without importing service.OsqueryError (which would
+// be a circular import).
+type statusErr struct {
+	msg    string
+	status int
+}
+
+func (e *statusErr) Error() string { return e.msg }
+func (e *statusErr) Status() int   { return e.status }
 
 func TestHashErr(t *testing.T) {
 	t.Run("without stack trace, same error is same hash", func(t *testing.T) {
@@ -133,25 +146,37 @@ func TestHashErrFleetError(t *testing.T) {
 		assert.NotEqual(t, h2, h3)
 	})
 
-	t.Run("errors use the same hash if their content differs only by the socket address (IPv4)", func(t *testing.T) {
-		err1 := errors.New("read tcp 10.10.3.44:8080->10.10.11.251:55732: i/o timeout")
-		err2 := errors.New("read tcp 10.10.3.44:8080->10.10.11.251:61204: i/o timeout")
-		err3 := errors.New("read tcp 10.10.3.44:8080->10.10.11.251:38891: i/o timeout")
+	t.Run("request-timeout errors use the same hash if their content differs only by the socket address (IPv4)", func(t *testing.T) {
+		err1 := &statusErr{msg: "read tcp 10.10.3.44:8080->10.10.11.251:55732: i/o timeout", status: http.StatusRequestTimeout}
+		err2 := &statusErr{msg: "read tcp 10.10.3.44:8080->10.10.11.251:61204: i/o timeout", status: http.StatusRequestTimeout}
+		err3 := &statusErr{msg: "read tcp 10.10.3.44:8080->10.10.11.251:38891: i/o timeout", status: http.StatusRequestTimeout}
 
 		h1, h2, h3 := hashError(err1), hashError(err2), hashError(err3)
 		assert.Equal(t, h1, h2)
 		assert.Equal(t, h1, h3)
 	})
 
-	t.Run("errors use the same hash if their content differs only by the socket address (IPv6)", func(t *testing.T) {
-		err1 := errors.New("read tcp [::1]:8080->[fe80::1]:55732: i/o timeout")
-		err2 := errors.New("read tcp [::1]:8080->[fe80::1]:61204: i/o timeout")
+	t.Run("request-timeout errors use the same hash if their content differs only by the socket address (IPv6)", func(t *testing.T) {
+		err1 := &statusErr{msg: "read tcp [::1]:8080->[fe80::1]:55732: i/o timeout", status: http.StatusRequestTimeout}
+		err2 := &statusErr{msg: "read tcp [::1]:8080->[fe80::1]:61204: i/o timeout", status: http.StatusRequestTimeout}
 		assert.Equal(t, hashError(err1), hashError(err2))
 	})
 
-	t.Run("errors use different hashes if the non-socket-address content differs", func(t *testing.T) {
+	t.Run("request-timeout errors use different hashes if the non-socket-address content differs", func(t *testing.T) {
+		err1 := &statusErr{msg: "read tcp 10.0.0.1:80->10.0.0.2:55732: i/o timeout", status: http.StatusRequestTimeout}
+		err2 := &statusErr{msg: "read tcp 10.0.0.1:80->10.0.0.2:55732: connection reset by peer", status: http.StatusRequestTimeout}
+		assert.NotEqual(t, hashError(err1), hashError(err2))
+	})
+
+	t.Run("non-timeout errors are NOT normalized by socket address", func(t *testing.T) {
+		err1 := &statusErr{msg: "read tcp 10.0.0.1:80->10.0.0.2:55732: connection refused", status: http.StatusInternalServerError}
+		err2 := &statusErr{msg: "read tcp 10.0.0.1:80->10.0.0.2:61204: connection refused", status: http.StatusInternalServerError}
+		assert.NotEqual(t, hashError(err1), hashError(err2))
+	})
+
+	t.Run("errors without a Status() method are NOT normalized by socket address", func(t *testing.T) {
 		err1 := errors.New("read tcp 10.0.0.1:80->10.0.0.2:55732: i/o timeout")
-		err2 := errors.New("read tcp 10.0.0.1:80->10.0.0.2:55732: connection reset by peer")
+		err2 := errors.New("read tcp 10.0.0.1:80->10.0.0.2:61204: i/o timeout")
 		assert.NotEqual(t, hashError(err1), hashError(err2))
 	})
 }


### PR DESCRIPTION
**Related issue:** Resolves #42613

Dedupes errors that report HTTP 408 (request timeouts). As of now, I believe this only fires for timeouts on the **/api/v1/osquery/distributed/write** endpoint.
This is so that we have a unique error hash with an incrementing count, instead of thousands of entries each with count: 1, which produces a huge JSON payload when passed to https://fleetdm.com/api/v1/webhooks/receive-usage-analytics for processing.

Trade-off:
- Before: every occurrence got its own Redis entry so thousands of near-identical examples coexisted.
- After: they collapse into one entry whose :json value still contains a representative example, but we'd only keep the last IP+Port instead of all of them.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Build a ~5 MB JSON body in a temporary file:

```bash
{ printf '{"node_key":"'; head -c 5000000 /dev/zero | tr '\0' 'x'; printf '"}'; } > /tmp/distwrite-body.json
```

Clear out redis:

```bash
docker exec fleet-redis-1 redis-cli FLUSHDB
```

Send a dummy request and throttle the upload at 100 KB/s → ~50s to send, read timeout fires at 25s.
I sent this 3 times and got the "request body read error" error back after each request.

```bash
curl -sk --limit-rate 100K -X POST -H 'Content-Type: application/json' --data-binary @/tmp/distwrite-body.json https://127.0.0.1:8080/api/v1/osquery/distributed/write

{
  "error": "request body read error: i/o timeout",
  "uuid": "95937f50-1008-4625-9423-bc19c7be6818"
}
```

Count the error keys containing "request body read error" as the value. 

```bash
docker exec fleet-redis-1 sh -c 'for k in $(redis-cli --scan --pattern "error:*:json"); do v=$(redis-cli GET "$k"); echo "$v" | grep -q "request body read error" && echo "$k count=$(redis-cli GET "${k%:json}:count")"; done'\

error:{Cco_JmAdBVVVJI9k0XjNNUCmG0z1IKguMQD4VDaejfc=}:json count=3
```

Notice the single entry and count=3 (since I ran the dummy request 3 times).

Running this on main outputs three entries each with count=1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network error deduplication for request-timeout errors now normalizes socket addresses, preventing the usage statistics cron from failing when many similar network errors accumulate.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45142)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->