### PR TITLE
Move Safari report to macOS and remove mappings

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -195,11 +195,11 @@ reports:
   - path: ../lib/macos/reports/collect-default-browser.yml
   - path: ../lib/macos/reports/collect-santa-denied-logs.yml
   - path: ../lib/macos/reports/collect-macos-27-incompatible-apps.yml
+  - path: ../lib/macos/reports/collect-safari-browser-extensions.yml
   - path: ../lib/all/reports/dex-queries.yml
   - path: ../lib/all/reports/collect-local-user-accounts.yml
   - path: ../lib/all/reports/collect-usb-devices.yml
   - path: ../lib/all/reports/collect-chromium-browser-extensions.yml
-  - path: ../lib/all/reports/collect-safari-browser-extensions.yml
   - path: ../lib/all/reports/collect-firefox-browser-extensions.yml
   - path: ../lib/all/reports/collect-listening-ports.yml
 software:

--- a/it-and-security/lib/all/reports/collect-chromium-browser-extensions.yml
+++ b/it-and-security/lib/all/reports/collect-chromium-browser-extensions.yml
@@ -1,8 +1,6 @@
 - name: Collect Chromium-family browser extensions
   description: |-
     Extension inventory across Chrome, Edge, Brave, and other Chromium-based profiles.
-
-    Supports **NET-94** / ISO **A.8.23** (web/content exposure), **VPM-75** / **A.8.8** (vulnerability management), and SOC2 **CC 7.1**.
   query: |-
     SELECT
       u.username,

--- a/it-and-security/lib/all/reports/collect-firefox-browser-extensions.yml
+++ b/it-and-security/lib/all/reports/collect-firefox-browser-extensions.yml
@@ -1,8 +1,6 @@
 - name: Collect Firefox browser extensions
   description: |-
     Add-on/extension inventory across Firefox profiles for all users.
-
-    Supports **NET-94** / ISO **A.8.23** (web/content exposure), **VPM-75** / **A.8.8** (vulnerability management), and SOC2 **CC 7.1**.
   query: |-
     SELECT
       u.username,

--- a/it-and-security/lib/all/reports/collect-listening-ports.yml
+++ b/it-and-security/lib/all/reports/collect-listening-ports.yml
@@ -1,8 +1,6 @@
 - name: Collect listening TCP/UDP ports
   description: |-
     Processes listening on network ports for anomaly detection and firewall reviews.
-
-    Maps to **NET-91** / ISO **A.8.20**, **MON-121** / **A.8.16**, and SOC2 **CC 6.6** / **CC 7.2**.
   query: |-
     SELECT
       lp.port,

--- a/it-and-security/lib/all/reports/collect-local-user-accounts.yml
+++ b/it-and-security/lib/all/reports/collect-local-user-accounts.yml
@@ -1,8 +1,6 @@
 - name: Collect local user accounts and admin membership
   description: |-
     Inventory of local user accounts with admin-equivalent membership for access reviews.
-
-    Maps to Vanta **AST-66** / ISO **A.5.9** (asset inventory), **IAC-200** / **A.5.18** (access rights), and **IAC-201** / **A.8.2** (privileged access).
   query: |-
     SELECT
       u.uid,

--- a/it-and-security/lib/all/reports/collect-usb-devices.yml
+++ b/it-and-security/lib/all/reports/collect-usb-devices.yml
@@ -2,8 +2,6 @@
   description: |-
     USB devices currently attached to the host (useful for removable media and exfiltration visibility).
 
-    Maps to Vanta **AST-70** / ISO **A.7.10** (storage media), **CRY-3** / SOC2 **CC 6.7**, and **DCH-112** / **A.8.12** (data leakage prevention).
-
     Note: `usb_devices` is available on macOS and Linux only in Fleet’s schema.
   query: |-
     SELECT

--- a/it-and-security/lib/macos/reports/collect-safari-browser-extensions.yml
+++ b/it-and-security/lib/macos/reports/collect-safari-browser-extensions.yml
@@ -2,8 +2,6 @@
   description: |-
     Extension inventory across Safari profiles for all macOS users.
 
-    Supports **NET-94** / ISO **A.8.23** (web/content exposure), **VPM-75** / **A.8.8** (vulnerability management), and SOC2 **CC 7.1**.
-
     Note: Safari data is isolated per macOS user, so osquery requires Full Disk Access to read it. See https://fleetdm.com/guides/enroll-hosts#grant-full-disk-access-to-osquery-on-macos.
   query: |-
     SELECT


### PR DESCRIPTION
Relocate the Safari extensions report to a macOS-specific directory and update the fleet manifest to reference the new path. Also clean up report descriptions by removing embedded compliance/mapping lines from multiple reports (Chromium, Firefox, listening ports, local user accounts, USB devices, and Safari) — queries and report logic unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered reports list in fleet configuration
  * Removed compliance mapping metadata from report definitions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->