### PR TITLE
Add PSSO simplified setup profiles for Entra/Okta

### DIFF
--- a/docs/solutions/macos/configuration-profiles/entra-sso-extension-example.mobileconfig
+++ b/docs/solutions/macos/configuration-profiles/entra-sso-extension-example.mobileconfig
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>ExtensionIdentifier</key>
+			<string>com.microsoft.CompanyPortalMac.ssoextension</string>
+			<key>PayloadDisplayName</key>
+			<string>Extensible Single Sign-On</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.extensiblesso.5F68D4CF-1250-4FF4-AFFB-1176DB539C49</string>
+			<key>PayloadType</key>
+			<string>com.apple.extensiblesso</string>
+			<key>PayloadUUID</key>
+			<string>5F68D4CF-1250-4FF4-AFFB-1176DB539C49</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PlatformSSO</key>
+			<dict>
+				<key>AuthenticationMethod</key>
+				<string>Password</string>
+				<key>UseSharedDeviceKeys</key>
+				<true/>
+				<key>TokenToUserMapping</key>
+				<dict>
+					<key>AccountName</key>
+					<string>preferred_username</string>
+					<key>FullName</key>
+					<string>name</string>
+				</dict>
+				<key>EnableRegistrationDuringSetup</key>
+				<true/>
+			</dict>
+			<key>ScreenLockedBehavior</key>
+			<string>DoNotHandle</string>
+			<key>TeamIdentifier</key>
+			<string>UBF8T346G9</string>
+			<key>Type</key>
+			<string>Redirect</string>
+			<key>URLs</key>
+			<array>
+				<string>https://login.microsoftonline.com</string>
+				<string>https://login.microsoft.com</string>
+				<string>https://sts.windows.net</string>
+				<string>https://login.partner.microsoftonline.cn</string>
+				<string>https://login.chinacloudapi.cn</string>
+				<string>https://login.microsoftonline.us</string>
+				<string>https://login-us.microsoftonline.com</string>
+			</array>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>PlatformSSO Entra</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.platformsso.entra.772B07D0-2E08-45CE-9423-1FCAFFAEC390</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>772B07D0-2E08-45CE-9423-1FCAFFAEC390</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/docs/solutions/macos/configuration-profiles/okta-sso-extension-simplified-setup-example.mobileconfig
+++ b/docs/solutions/macos/configuration-profiles/okta-sso-extension-simplified-setup-example.mobileconfig
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>ExtensionIdentifier</key>
+			<string>com.okta.mobile.auth-service-extension</string>
+			<key>PayloadDisplayName</key>
+			<string>Extensible Single Sign-On</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.extensiblesso.CE7041AB-13CD-4231-9315-8C9435FF2EC7</string>
+			<key>PayloadType</key>
+			<string>com.apple.extensiblesso</string>
+			<key>PayloadUUID</key>
+			<string>CE7041AB-13CD-4231-9315-8C9435FF2EC7</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PlatformSSO</key>
+			<dict>
+				<key>AccountDisplayName</key>
+				<string>Okta Verify</string>
+				<key>AuthenticationMethod</key>
+				<string>Password</string>
+				<key>UseSharedDeviceKeys</key>
+				<true/>
+				<key>EnableRegistrationDuringSetup</key>
+				<true/>
+			</dict>
+			<key>ScreenLockedBehavior</key>
+			<string>DoNotHandle</string>
+			<key>TeamIdentifier</key>
+			<string>B7F62B65BN</string>
+			<key>Type</key>
+			<string>Redirect</string>
+			<key>URLs</key>
+			<array>
+				<string>https://yourdomain.okta.com/device-access/api/v1/nonce</string>
+				<string>https://yourdomain.okta.com/oauth2/v1/token</string>
+				<string>https://yourdomain.okta.com/v1/auth/device-sign</string>
+			</array>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Okta SSO Extension</string>
+	<key>PayloadIdentifier</key>
+	<string>com.okta.device.access.0F08D9EE-1CAE-4AC4-9E24-53B56FA6A2B1</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>0F08D9EE-1CAE-4AC4-9E24-53B56FA6A2B1</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Adding documented profiles for PSSO simplified setup. These are specifically for the macOS 26+ feature, though most of what's in them is also applicable to lower versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added example configuration profiles for macOS SSO extension setup with Entra and Okta platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->