### PR TITLE
Website: update `<code>` styles on markdown article pages

### DIFF
--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -598,12 +598,14 @@
       text-decoration: inherit;
     }
     code:not(.bash):not(.hljs):not(.nohighlight):not(.mermaid) {
-      background: #F1F0FF;
-      padding: 4px 8px;
-      font-family: @code-font;
+      background-color: @ui-off-white;
+      border: 1px solid @border-lt-gray;
+      color: @core-fleet-black-75;
       font-size: 13px;
+      padding: 2px 6px;
       line-height: 16px;
-      color: @core-fleet-black;
+      font-weight: 400;
+      border-radius: 4px;
     }
     pre {
       code {

--- a/website/assets/styles/pages/articles/basic-webinar.less
+++ b/website/assets/styles/pages/articles/basic-webinar.less
@@ -410,12 +410,14 @@
       text-decoration: inherit;
     }
     code:not(.bash):not(.hljs):not(.nohighlight):not(.mermaid) {
-      background: #F1F0FF;
-      padding: 4px 8px;
-      font-family: @code-font;
+      background-color: @ui-off-white;
+      border: 1px solid @border-lt-gray;
+      color: @core-fleet-black-75;
       font-size: 13px;
+      padding: 2px 6px;
       line-height: 16px;
-      color: @core-fleet-black;
+      font-weight: 400;
+      border-radius: 4px;
     }
     pre {
       code {

--- a/website/assets/styles/pages/articles/basic-whitepaper.less
+++ b/website/assets/styles/pages/articles/basic-whitepaper.less
@@ -354,12 +354,14 @@
       text-decoration: inherit;
     }
     code:not(.bash):not(.hljs):not(.nohighlight):not(.mermaid) {
-      background: #F1F0FF;
-      padding: 4px 8px;
-      font-family: @code-font;
+      background-color: @ui-off-white;
+      border: 1px solid @border-lt-gray;
+      color: @core-fleet-black-75;
       font-size: 13px;
+      padding: 2px 6px;
       line-height: 16px;
-      color: @core-fleet-black;
+      font-weight: 400;
+      border-radius: 4px;
     }
     pre {
       code {

--- a/website/assets/styles/pages/articles/case-study.less
+++ b/website/assets/styles/pages/articles/case-study.less
@@ -421,12 +421,14 @@
       text-decoration: inherit;
     }
     code:not(.bash):not(.hljs):not(.nohighlight):not(.mermaid) {
-      background: #F1F0FF;
-      padding: 4px 8px;
-      font-family: @code-font;
+      background-color: @ui-off-white;
+      border: 1px solid @border-lt-gray;
+      color: @core-fleet-black-75;
       font-size: 13px;
+      padding: 2px 6px;
       line-height: 16px;
-      color: @core-fleet-black;
+      font-weight: 400;
+      border-radius: 4px;
     }
     pre {
       code {


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/42652

Changes:
- Updated the styles for `<code>` elements on Markdown article pages to match handbook and documentation pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refreshed the visual appearance of inline code blocks throughout article pages with a new off-white background and light gray border design for improved readability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->