### PR TITLE
CIS Benchmarks: Update Windows 11 to v5.0.1

### DIFF
--- a/ee/cis/win-11/README.md
+++ b/ee/cis/win-11/README.md
@@ -8,6 +8,11 @@ For requirements and usage details, see the [CIS Benchmarks](https://fleetdm.com
 
 > None. All items in this version of the benchmark are able to be automated.
 
+### Important: Group Policy removal does not clear registry values
+
+When a Group Policy entry is removed from `Registry.pol` and `gpupdate /force` is run, Windows does **not** clean up the registry value it previously wrote. This means the osquery-based policy check will continue to report the device as compliant even after the Group Policy is set back to "Not Configured."
+
+This is expected Windows behavior and is consistent with the CIS benchmark audit procedure, which checks the registry value regardless of how it was set. To truly revert a setting, the registry value must be explicitly deleted or changed — simply removing the Group Policy is not sufficient.
 
 ### Checks that require a Group Policy template
 

--- a/ee/cis/win-11/README.md
+++ b/ee/cis/win-11/README.md
@@ -1,6 +1,6 @@
 # Windows 11 Enterprise benchmarks
 
-Fleet's policies have been written against v4.0.0 of the benchmark. You can refer to the [CIS website](https://www.cisecurity.org/cis-benchmarks) for full details about this version.
+Fleet's policies have been written against v5.0.1 of the benchmark. You can refer to the [CIS website](https://www.cisecurity.org/cis-benchmarks) for full details about this version.
 
 For requirements and usage details, see the [CIS Benchmarks](https://fleetdm.com/docs/using-fleet/cis-benchmarks) documentation.
 

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -400,7 +400,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Create a token object' is set to an empty list
+  name: CIS - Ensure 'Create a token object' is set to 'No One'
   platforms: win11
   platform: windows
   description: |
@@ -436,7 +436,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Create permanent shared objects' is set to an empty list
+  name: CIS - Ensure 'Create permanent shared objects' is set to 'No One'
   platforms: win11
   platform: windows
   description: |
@@ -505,7 +505,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny access to this computer from the network' includes 'Guest'
+  name: CIS - Ensure 'Deny access to this computer from the network' to include 'Guests, Local account'
   platforms: win11
   platform: windows
   description: |
@@ -527,7 +527,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on as a batch job' includes 'Guests'
+  name: CIS - Ensure 'Deny log on as a batch job' to include 'Guests'
   platforms: win11
   platform: windows
   description: |
@@ -546,7 +546,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on as a service' includes 'Guests'
+  name: CIS - Ensure 'Deny log on as a service' to include 'Guests'
   platforms: win11
   platform: windows
   description: |
@@ -565,7 +565,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on locally' includes 'Guest'
+  name: CIS - Ensure 'Deny log on locally' to include 'Guests'
   platforms: win11
   platform: windows
   description: |
@@ -585,7 +585,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on through Remote Desktop Services' includes 'Guest'
+  name: CIS - Ensure 'Deny log on through Remote Desktop Services' to include 'Guests, Local account'
   platforms: win11
   platform: windows
   description: |
@@ -603,14 +603,14 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Enable computer and user accounts to be trusted for delegation' is set to an empty list
+  name: CIS - Ensure 'Enable computer and user accounts to be trusted for delegation' is set to 'No One'
   platforms: win11
   platform: windows
   description: |
     This policy setting allows users to change the Trusted for Delegation setting on a computer object in Active Directory. Abuse of this privilege could allow unauthorized users to impersonate other users on the network.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Enable computer and user accounts to be trusted for delegation'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/EnableDelegation</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -632,7 +632,7 @@ spec:
     right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Force shutdown from a remote system'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/RemoteShutdown</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -650,7 +650,7 @@ spec:
     This policy setting determines which users or processes can generate audit records in the Security log.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Generate security audits'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/GenerateSecurityAudits</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(LOCAL SERVICE|NETWORK SERVICE).*",0) is not null);
@@ -672,7 +672,7 @@ spec:
     they have created to impersonate that client, which could elevate the unauthorized user's permissions to administrative or system levels.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Impersonate a client after authentication'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ImpersonateClient</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Administrators|LOCAL SERVICE|NETWORK SERVICE|([^\w\s]SERVICE)).*",0) is not null);
@@ -692,7 +692,7 @@ spec:
     user right is not required by administrative tools that are supplied with the operating system but might be required by software development tools.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Increase scheduling priority'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/IncreaseSchedulingPriority</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Administrators|Window Manager Group).*",0) is not null);
@@ -713,7 +713,7 @@ spec:
     Windows.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Increase scheduling priority'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/LoadUnloadDeviceDrivers</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -724,14 +724,14 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Lock pages in memory' is set to an empty list
+  name: CIS - Ensure 'Lock pages in memory' is set to 'No One'
   platforms: win11
   platform: windows
   description: |
     This policy setting allows a process to keep data in physical memory, which prevents the system from paging the data to virtual memory on disk. If this user right is assigned, significant degradation of system performance can occur.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Lock pages in memory'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/LockMemory</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -753,7 +753,7 @@ spec:
     after gaining user level access to a computer.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Log on as a batch job'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.28" AND (regex_match(value,".*(?=.*Administrators).*",0) is not null);
@@ -775,7 +775,7 @@ spec:
     Vista-based (and newer) computers, no users or groups have this privilege by default.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Log on as a service'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.29" AND value = ",";
@@ -793,7 +793,7 @@ spec:
     This policy setting determines which users can change the auditing options for files and directories and clear the Security log.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Manage auditing and security log'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ManageAuditingAndSecurityLog</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -804,7 +804,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Modify an object label' is set to an empty list
+  name: CIS - Ensure 'Modify an object label' is set to 'No One'
   platforms: win11
   platform: windows
   description: |
@@ -813,7 +813,7 @@ spec:
     can modify the label of an object owned by that user to a lower level without this privilege.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Modify an object label'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ModifyObjectLabel</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -833,7 +833,7 @@ spec:
     Configuration. Modification of these values and could lead to a hardware failure that would result in a denial of service condition.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Modify firmware environment values'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ModifyFirmwareEnvironment</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -851,7 +851,7 @@ spec:
     This policy setting allows users to manage the system's volume or disk configuration, which could allow a user to delete a volume and cause data loss as well as a denial-ofservice condition.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Perform volume maintenance tasks'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.33" AND (regex_match(value,".*(?=.*Administrators).*",0) is not null);
@@ -874,7 +874,7 @@ spec:
     information that could be used to mount an attack on the system.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Profile single process'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ProfileSingleProcess</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -935,7 +935,7 @@ spec:
     directories user right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Restore files and directories'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/RestoreFilesAndDirectories</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -973,7 +973,7 @@ spec:
     or threads. This user right bypasses any permissions that are in place to protect objects to give ownership to the specified user.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Take ownership of files or other objects'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/TakeOwnership</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -1119,7 +1119,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
+  name: CIS - Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1144,7 +1144,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Digitally encrypt secure channel data (when possible)' is set to 'Enabled'
+  name: CIS - Ensure 'Domain member: Digitally encrypt secure channel data (when possible)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1169,7 +1169,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Digitally sign secure channel data (when possible)' is set to 'Enabled'
+  name: CIS - Ensure 'Domain member: Digitally sign secure channel data (when possible)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1195,7 +1195,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Disable machine account password changes' is set to 'Disabled'
+  name: CIS - Ensure 'Domain member: Disable machine account password changes' is set to 'Disabled'
   platforms: win11
   platform: windows
   description: |
@@ -1224,7 +1224,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Maximum machine account password age' is set to '30 or fewer days, but not 0'
+  name: CIS - Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'
   platforms: win11
   platform: windows
   description: |
@@ -1254,7 +1254,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Require strong (Windows 2000 or later) session key' is set to 'Enabled'
+  name: CIS - Ensure 'Domain member: Require strong (Windows 2000 or later) session key' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1440,7 +1440,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network client Digitally sign communications (always)' is set to 'Enabled'
+  name: CIS - Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1458,7 +1458,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network client Digitally sign communications (if server agrees)' is set to 'Enabled'
+  name: CIS - Ensure 'Microsoft network client: Digitally sign communications (if server agrees)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1476,7 +1476,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network client Send unencrypted password to third-party SMB servers' is set to 'Disabled'
+  name: CIS - Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'
   platforms: win11
   platform: windows
   description: |
@@ -1494,7 +1494,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'
+  name: CIS - Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'
   platforms: win11
   platform: windows
   description: |
@@ -1515,7 +1515,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Digitally sign communications (always)' is set to 'Enabled'
+  name: CIS - Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1535,7 +1535,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Digitally sign communications (if client agrees)' is set to 'Enabled'
+  name: CIS - Ensure 'Microsoft network server: Digitally sign communications (if client agrees)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1555,7 +1555,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Disconnect clients when logon hours expire' is set to 'Enabled'
+  name: CIS - Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1575,7 +1575,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Server SPN target name validation level' is set to 'Accept if provided by client'
+  name: CIS - Ensure 'Microsoft network server: Server SPN target name validation level' is set to 'Accept if provided by client'
   platforms: win11
   platform: windows
   description: |
@@ -1931,7 +1931,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Network security Do not store LAN Manager hash value on next password change' is set to 'Enabled'
+  name: CIS - Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -3878,7 +3878,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Audit PNP Activity' is set to 'Success'
+  name: CIS - Ensure 'Audit User Account Management' is set to 'Success and Failure'
   platforms: win11
   platform: windows
   description: |

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11613,3 +11613,57 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Prohibit installation and configuration of Network Bridge on your DNS domain network' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    You can use this procedure to control a user's ability to install and configure a Network Bridge. The Network Bridge setting, if enabled, allows users to create a Layer 2 Media Access Control (MAC) bridge, enabling them to connect two or more physical network segments together.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Network Connections\Prohibit installation and configuration of Network Bridge on your DNS domain network'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_AllowNetBridge_NLA' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Prohibit use of Internet Connection Sharing on your DNS domain network' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    Although this legacy setting traditionally applied to the use of Internet Connection Sharing (ICS), this setting now freshly applies to the Mobile Hotspot feature in Windows 10 and Server 2016.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Network Connections\Prohibit use of Internet Connection Sharing on your DNS domain network'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_ShowSharedAccessUI' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Require domain users to elevate when setting a network's location' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether to require domain users to elevate when setting a network's location. Allowing regular users to set a network location increases the risk and attack surface.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Network Connections\Require domain users to elevate when setting a network's location'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_StdDomainUserSetLocation' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -1119,7 +1119,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1144,7 +1145,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Domain member: Digitally encrypt secure channel data (when possible)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Digitally encrypt secure channel data (when possible)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1169,7 +1171,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Domain member: Digitally sign secure channel data (when possible)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Digitally sign secure channel data (when possible)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1195,7 +1198,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Domain member: Disable machine account password changes' is set to 'Disabled'
+  name: >
+    CIS - Ensure 'Domain member: Disable machine account password changes' is set to 'Disabled'
   platforms: win11
   platform: windows
   description: |
@@ -1224,7 +1228,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'
+  name: >
+    CIS - Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'
   platforms: win11
   platform: windows
   description: |
@@ -1254,7 +1259,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Domain member: Require strong (Windows 2000 or later) session key' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Require strong (Windows 2000 or later) session key' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1440,7 +1446,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1458,7 +1465,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network client: Digitally sign communications (if server agrees)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network client: Digitally sign communications (if server agrees)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1476,7 +1484,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'
+  name: >
+    CIS - Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'
   platforms: win11
   platform: windows
   description: |
@@ -1494,7 +1503,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'
+  name: >
+    CIS - Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'
   platforms: win11
   platform: windows
   description: |
@@ -1515,7 +1525,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1535,7 +1546,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network server: Digitally sign communications (if client agrees)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network server: Digitally sign communications (if client agrees)' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1555,7 +1567,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -1575,7 +1588,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Microsoft network server: Server SPN target name validation level' is set to 'Accept if provided by client'
+  name: >
+    CIS - Ensure 'Microsoft network server: Server SPN target name validation level' is set to 'Accept if provided by client'
   platforms: win11
   platform: windows
   description: |
@@ -1931,7 +1945,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'
   platforms: win11
   platform: windows
   description: |
@@ -11185,43 +11200,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'WDigest Authentication' is set to 'Disabled'
-  platforms: win11
-  platform: windows
-  description: |
-    When WDigest authentication is enabled, Lsass.exe retains a copy of the user's plaintext password in memory, where it can be at risk of theft.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
-    'Computer Configuration\Policies\Administrative Templates\MS Security Guide\WDigest Authentication'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest\UseLogonCredential' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon' is set to 'Disabled'
-  platforms: win11
-  platform: windows
-  description: |
-    If you configure a computer for automatic logon, anyone who can physically gain access to the computer can also gain access to everything that is on the computer.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
-    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (AutoAdminLogon) Enable Automatic Logon'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon' AND data = '0';
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing protection level' is set to 'Enabled: Highest protection, source routing is completely disabled'
+  name: >
+    CIS - Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing protection level' is set to 'Enabled: Highest protection, source routing is completely disabled'
   platforms: win11
   platform: windows
   description: |
@@ -11239,7 +11219,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'MSS: (DisableIPSourceRouting) IP source routing protection level' is set to 'Enabled: Highest protection, source routing is completely disabled'
+  name: >
+    CIS - Ensure 'MSS: (DisableIPSourceRouting) IP source routing protection level' is set to 'Enabled: Highest protection, source routing is completely disabled'
   platforms: win11
   platform: windows
   description: |
@@ -11257,168 +11238,6 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes' is set to 'Disabled'
-  platforms: win11
-  platform: windows
-  description: |
-    Internet Control Message Protocol (ICMP) redirects cause the IPv4 stack to plumb host routes. These routes override the OSPF generated routes.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
-    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\EnableICMPRedirect' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    NetBIOS over TCP/IP is a network protocol that provides a way to resolve NetBIOS names. This setting determines whether the computer releases its NetBIOS name when it receives a name-release request.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
-    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetBT\Parameters\NoNameReleaseOnDemand' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'MSS: (SafeDllSearchMode) Enable Safe DLL search mode' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    The DLL search order can be configured to search for DLLs that are requested by running processes in one of two ways. When enabled, the system first searches folders specified in the system path and then searches the current working folder.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (SafeDllSearchMode) Enable Safe DLL search mode'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\SafeDllSearchMode' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'
-  platforms: win11
-  platform: windows
-  description: |
-    This setting can generate a security audit in the Security event log when the log reaches a user-defined threshold. If log settings are configured to Overwrite events as needed or Overwrite events older than x days, this event will not be generated.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: 90% or less:
-    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security\WarningLevel' AND CAST(data AS INTEGER) <= 90;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure multicast DNS (mDNS) protocol' is set to 'Disabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines if the DNS client will perform name resolution over Multicast DNS (mDNS). mDNS performs local network name and service discoveries without the need for central DNS.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\DNS Client\Configure multicast DNS (mDNS) protocol'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableMDNS' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure NetBIOS settings' is set to 'Enabled: Disable NetBIOS name resolution on public networks'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting specifies if the DNS client will perform name resolution over Network Basic Input/Output System (NetBIOS). NetBIOS is a legacy name resolution method for internal Microsoft networking that predates the use of DNS for that purpose.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Disable NetBIOS name resolution on public networks:
-    'Computer Configuration\Policies\Administrative Templates\Network\DNS Client\Configure NetBIOS settings'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableNetbios' AND (data = 0 OR data = 2);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Turn off multicast name resolution' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    Link-Local Multicast Name Resolution (LLMNR) is a secondary name resolution protocol. With LLMNR, queries are sent using multicast over a local network link on a single subnet. LLMNR does not require a DNS server or DNS client configuration and provides name resolution in scenarios in which conventional DNS name resolution is not possible.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\DNS Client\Turn off multicast name resolution'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableMulticast' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Audit client does not support encryption' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines whether the SMB server will log events when the SMB client doesn't support encryption. Organizations should be aware of all unencrypted SMB traffic in their environment.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Audit client does not support encryption'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\AuditClientDoesNotSupportEncryption' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Audit client does not support signing' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines whether the SMB server will log events when the SMB client doesn't support signing. Organizations should be aware of all unsigned SMB traffic in their environment.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Audit client does not support signing'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\AuditClientDoesNotSupportSigning' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
   name: CIS - Ensure 'Audit insecure guest logon' (Lanman Server) is set to 'Enabled'
   platforms: win11
   platform: windows
@@ -11430,24 +11249,6 @@ spec:
     'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Audit insecure guest logon'
   query: |
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\AuditInsecureGuestLogon' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Enable authentication rate limiter' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy settings configures the SMB server authentication rate limiter. The authentication rate limiter is a feature of SMB that is designed to address brute force attacks by implementing a 2-second delay between each failed NTLM or PKU2U-based authentication attempt.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Enable authentication rate limiter'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\EnableAuthRateLimiter' AND data = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
@@ -11473,7 +11274,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Mandate the minimum version of SMB' (Lanman Server) is set to 'Enabled: 3.1.1'
+  name: >
+    CIS - Ensure 'Mandate the minimum version of SMB' (Lanman Server) is set to 'Enabled: 3.1.1'
   platforms: win11
   platform: windows
   description: |
@@ -11509,60 +11311,6 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Audit server does not support encryption' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines whether the SMB client will log events when the SMB server doesn't support encryption. Organizations should be aware of all unencrypted SMB traffic in their environment.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Audit server does not support encryption'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AuditServerDoesNotSupportEncryption' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Audit server does not support signing' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines whether the SMB client will log events when the SMB server doesn't support signing. Organizations should be aware of all unsigned SMB traffic in their environment.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Audit server does not support signing'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AuditServerDoesNotSupportSigning' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Enable insecure guest logons' is set to 'Disabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines if the SMB client will allow insecure guest logons to an SMB server. Insecure guest logons are used by file servers to allow unauthenticated access to shared folders.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Enable insecure guest logons'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AllowInsecureGuestAuth' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
   name: CIS - Ensure 'Enable remote mailslots' (Lanman Workstation) is set to 'Disabled'
   platforms: win11
   platform: windows
@@ -11581,7 +11329,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Mandate the minimum version of SMB' (Lanman Workstation) is set to 'Enabled: 3.1.1'
+  name: >
+    CIS - Ensure 'Mandate the minimum version of SMB' (Lanman Workstation) is set to 'Enabled: 3.1.1'
   platforms: win11
   platform: windows
   description: |
@@ -11599,79 +11348,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Require Encryption' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls whether the SMB client will require encryption. The SMB server must support and have SMB encryption enabled (requires SMB v3.0 or later).
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Require Encryption'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\RequireEncryption' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Prohibit installation and configuration of Network Bridge on your DNS domain network' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    You can use this procedure to control a user's ability to install and configure a Network Bridge. The Network Bridge setting, if enabled, allows users to create a Layer 2 Media Access Control (MAC) bridge, enabling them to connect two or more physical network segments together.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Network Connections\Prohibit installation and configuration of Network Bridge on your DNS domain network'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_AllowNetBridge_NLA' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Prohibit use of Internet Connection Sharing on your DNS domain network' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    Although this legacy setting traditionally applied to the use of Internet Connection Sharing (ICS), this setting now freshly applies to the Mobile Hotspot feature in Windows 10 and Server 2016.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Network Connections\Prohibit use of Internet Connection Sharing on your DNS domain network'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_ShowSharedAccessUI' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Require domain users to elevate when setting a network's location' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines whether to require domain users to elevate when setting a network's location. Allowing regular users to set a network location increases the risk and attack surface.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Network\Network Connections\Require domain users to elevate when setting a network's location'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_StdDomainUserSetLocation' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled: 3 = Prevent Wi-Fi when on Ethernet'
+  name: >
+    CIS - Ensure 'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled: 3 = Prevent Wi-Fi when on Ethernet'
   platforms: win11
   platform: windows
   description: |
@@ -11725,97 +11403,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Allow Print Spooler to accept client connections' is set to 'Disabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls whether the Print Spooler service will accept client connections. Disabling this mitigates remote attacks against the PrintNightmare vulnerability (CVE-2021-34527) and other remote Print Spooler attacks.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Allow Print Spooler to accept client connections'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\RegisterSpoolerRemoteRpcEndPoint' AND CAST(data AS INTEGER) = 2;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure Redirection Guard' is set to 'Enabled: Redirection Guard Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting determines whether Redirection Guard is enabled for the print spooler. Redirection Guard can prevent file redirections from being used within the print spooler process.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Redirection Guard Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Configure Redirection Guard'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RedirectionguardPolicy' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure RPC connection settings: Protocol to use for outgoing RPC connections' is set to 'Enabled: RPC over TCP'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls which protocol and protocol settings to use for outgoing Remote Procedure Call (RPC) connections to a remote print spooler. This prevents the use of named pipes for RPC connections and forces the use of TCP which is a more secure communication method.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: RPC over TCP:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC connection settings: Protocol to use for outgoing RPC connections'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcUseNamedPipeProtocol' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure RPC connection settings: Use authentication for outgoing RPC connections' is set to 'Enabled: Default'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls which protocol and protocol settings to use for outgoing Remote Procedure Call (RPC) connections to a remote print spooler.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Default:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC connection settings: Use authentication for outgoing RPC connections'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcAuthentication' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure RPC listener settings: Protocols to allow for incoming RPC connections' is set to 'Enabled: RPC over TCP'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls which protocols incoming Remote Procedure Call (RPC) connections to the print spooler are allowed to use. This forces the use of TCP which is a more secure communication method.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: RPC over TCP:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC listener settings: Protocols to allow for incoming RPC connections'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcProtocols' AND CAST(data AS INTEGER) = 5;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure RPC listener settings: Authentication protocol to use for incoming RPC connections' is set to 'Enabled: Negotiate' or higher
+  name: >
+    CIS - Ensure 'Configure RPC listener settings: Authentication protocol to use for incoming RPC connections' is set to 'Enabled: Negotiate' or higher
   platforms: win11
   platform: windows
   description: |
@@ -11833,7 +11422,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Configure RPC over TCP port' is set to 'Enabled: 0'
+  name: >
+    CIS - Ensure 'Configure RPC over TCP port' is set to 'Enabled: 0'
   platforms: win11
   platform: windows
   description: |
@@ -11844,258 +11434,6 @@ spec:
     'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC over TCP port'
   query: |
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcTcpPort' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Configure RPC packet level privacy setting for incoming connections' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls packet level privacy for Remote Procedure Call (RPC) incoming connections. Enabling this enforces the server-side to increase the authentication level to minimize the Print Spooler Spoofing Vulnerability (CVE-2021-1678).
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\MS Security Guide\Configure RPC packet level privacy setting for incoming connections'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print\RpcAuthnLevelPrivacyEnabled' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Limits print driver installation to Administrators' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls whether users who aren't Administrators can install print drivers on the system. Restricting the installation of print drivers to Administrators can help mitigate the PrintNightmare vulnerability (CVE-2021-34527).
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Limits print driver installation to Administrators'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint\RestrictDriverInstallationToAdministrators' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Manage processing of Queue-specific files' is set to 'Enabled: Limit Queue-specific files to Color profiles'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting manages how queue-specific files are processed during printer installation. A Windows Print Spooler Remote Code Execution Vulnerability (CVE-2021-36958) exists when the service improperly performs privileged file operations.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Limit Queue-specific files to Color profiles:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Manage processing of Queue-specific files'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\CopyFilesPolicy' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Point and Print Restrictions: When installing drivers for a new connection' is set to 'Enabled: Show warning and elevation prompt'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls whether computers will show a warning and a security elevation prompt when users create a new printer connection using Point and Print. This helps mitigate the PrintNightmare vulnerability (CVE-2021-34527).
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Show warning and elevation prompt:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Point and Print Restrictions: When installing drivers for a new connection'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint\NoWarningNoElevationOnInstall' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Point and Print Restrictions: When updating drivers for an existing connection' is set to 'Enabled: Show warning and elevation prompt'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls whether computers will show a warning and a security elevation prompt when users are updating drivers for an existing connection using Point and Print. This helps mitigate the PrintNightmare vulnerability (CVE-2021-34527).
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Show warning and elevation prompt:
-    'Computer Configuration\Policies\Administrative Templates\Printers\Point and Print Restrictions: When updating drivers for an existing connection'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint\UpdatePromptSettings' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Include command line in process creation events' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting controls whether the process creation command line text is logged in security audit events when a new process has been created. Capturing process command line information in event logs can be very valuable when performing forensic investigations of attack incidents.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\System\Audit Process Creation\Include command line in process creation events'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Encryption Oracle Remediation' is set to 'Enabled: Force Updated Clients'
-  platforms: win11
-  platform: windows
-  description: |
-    Some versions of the CredSSP protocol that is used by some applications (such as Remote Desktop Connection) are vulnerable to an encryption oracle attack against the client. This policy controls compatibility with vulnerable clients and servers and allows you to set the level of protection desired for the encryption oracle vulnerability.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Force Updated Clients:
-    'Computer Configuration\Policies\Administrative Templates\System\Credentials Delegation\Encryption Oracle Remediation'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters\AllowEncryptionOracle' AND data = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    When using credential delegation, devices provide an exportable version of credentials to the remote host. This exposes users to the risk of credential theft from threat actors on the remote host. The Restricted Admin Mode and Windows Defender Remote Credential Guard features are two options to help protect against this risk.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\System\Credentials Delegation\Remote host allows delegation of non-exportable credentials'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowProtectedCreds' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Turn On Virtualization Based Security' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting specifies whether Virtualization Based Security is enabled. Virtualization Based Security uses the Windows Hypervisor to provide support for security services. This setting was moved from the Next Generation (NG) profile to L1 for Windows 11 only.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\EnableVirtualizationBasedSecurity' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Turn On Virtualization Based Security: Select Platform Security Level' is set to 'Secure Boot' or higher
-  platforms: win11
-  platform: windows
-  description: |
-    This policy setting specifies whether Virtualization Based Security (VBS) is enabled. VBS uses the Windows Hypervisor to provide support for security services. The recommended state is Secure Boot. Configuring this setting to Secure Boot and DMA Protection also conforms to the benchmark.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Secure Boot or Secure Boot and DMA Protection:
-    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Select Platform Security Level'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\RequirePlatformSecurityFeatures' AND (data = 1 OR data = 3);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Turn On Virtualization Based Security: Virtualization Based Protection of Code Integrity' is set to 'Enabled with UEFI lock'
-  platforms: win11
-  platform: windows
-  description: |
-    This setting enables virtualization based protection of Kernel Mode Code Integrity. When this is enabled, kernel mode memory protections are enforced and the Code Integrity validation path is protected by the Virtualization Based Security feature. This setting was moved from NG to L1 for Windows 11 only.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled with UEFI lock:
-    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Virtualization Based Protection of Code Integrity'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\HypervisorEnforcedCodeIntegrity' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Turn On Virtualization Based Security: Require UEFI Memory Attributes Table' is set to 'True (checked)'
-  platforms: win11
-  platform: windows
-  description: |
-    This option will only enable Virtualization Based Protection of Code Integrity on devices with UEFI firmware support for the Memory Attributes Table. Devices without the UEFI Memory Attributes Table may have firmware that is incompatible with Virtualization Based Protection of Code Integrity. This setting was moved from NG to L1 for Windows 11 only.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to TRUE:
-    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Require UEFI Memory Attributes Table'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\HVCIMATRequired' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Turn On Virtualization Based Security: Credential Guard Configuration' is set to 'Enabled with UEFI lock'
-  platforms: win11
-  platform: windows
-  description: |
-    This setting lets users turn on Credential Guard with virtualization-based security to help protect credentials. The Enabled with UEFI lock option ensures that Credential Guard cannot be disabled remotely. This setting was moved from NG to L1 for Windows 11 only.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled with UEFI lock:
-    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Credential Guard Configuration'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\LsaCfgFlags' AND data = 1;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: fleet
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure 'Turn On Virtualization Based Security: Secure Launch Configuration' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    Secure Launch protects the Virtualization Based Security environment from exploited vulnerabilities in device firmware. This setting was moved from NG to L1 for Windows 11 only.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Secure Launch Configuration'
-  query: |
-    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\ConfigureSystemGuardLaunch' AND data = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
@@ -12139,7 +11477,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Disable HTTP proxy features: Disable WPAD' is set to 'Enabled: Checked'
+  name: >
+    CIS - Ensure 'Disable HTTP proxy features: Disable WPAD' is set to 'Enabled: Checked'
   platforms: win11
   platform: windows
   description: |

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11937,3 +11937,39 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Include command line in process creation events' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls whether the process creation command line text is logged in security audit events when a new process has been created. Capturing process command line information in event logs can be very valuable when performing forensic investigations of attack incidents.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\System\Audit Process Creation\Include command line in process creation events'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Encryption Oracle Remediation' is set to 'Enabled: Force Updated Clients'
+  platforms: win11
+  platform: windows
+  description: |
+    Some versions of the CredSSP protocol that is used by some applications (such as Remote Desktop Connection) are vulnerable to an encryption oracle attack against the client. This policy controls compatibility with vulnerable clients and servers and allows you to set the level of protection desired for the encryption oracle vulnerability.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Force Updated Clients:
+    'Computer Configuration\Policies\Administrative Templates\System\Credentials Delegation\Encryption Oracle Remediation'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters\AllowEncryptionOracle' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -519,7 +519,7 @@ spec:
     Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny access to this computer from the network'
   query: |
-    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyAccessFromNetwork</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
+    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyAccessFromNetwork</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null) AND (regex_match(mdm_command_output,".*(Local account).*",0) is not null);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, english-support-only
   contributors: marcosd4h
@@ -595,7 +595,7 @@ spec:
     Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on through Remote Desktop Services'
   query: |
-    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyRemoteDesktopServicesLogOn</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
+    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyRemoteDesktopServicesLogOn</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null) AND (regex_match(mdm_command_output,".*(Local account).*",0) is not null);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, english-support-only
   contributors: marcosd4h

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11505,3 +11505,111 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Audit server does not support encryption' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether the SMB client will log events when the SMB server doesn't support encryption. Organizations should be aware of all unencrypted SMB traffic in their environment.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Audit server does not support encryption'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AuditServerDoesNotSupportEncryption' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Audit server does not support signing' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether the SMB client will log events when the SMB server doesn't support signing. Organizations should be aware of all unsigned SMB traffic in their environment.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Audit server does not support signing'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AuditServerDoesNotSupportSigning' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Enable insecure guest logons' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines if the SMB client will allow insecure guest logons to an SMB server. Insecure guest logons are used by file servers to allow unauthenticated access to shared folders.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Enable insecure guest logons'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AllowInsecureGuestAuth' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Enable remote mailslots' (Lanman Workstation) is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy settings controls whether the SMB client will use remote mailslots over Multiple UNC Provider (MUP). The remote mailslots protocol is an old, simple, unreliable, and insecure inter-process communication method.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Enable remote mailslots'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\EnableMailslots' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Mandate the minimum version of SMB' (Lanman Workstation) is set to 'Enabled: 3.1.1'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy settings controls the minimum version of Server Message Block (SMB) protocol that can be used on the system. The newer SMB v3 is supported on all currently supported Microsoft Windows OSes.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: 3.1.1:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Mandate the minimum version of SMB'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\MinSmb2Dialect' AND CAST(data AS INTEGER) = 785;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Require Encryption' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls whether the SMB client will require encryption. The SMB server must support and have SMB encryption enabled (requires SMB v3.0 or later).
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Require Encryption'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\RequireEncryption' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11667,3 +11667,147 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled: 3 = Prevent Wi-Fi when on Ethernet'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting prevents computers from establishing multiple simultaneous connections to either the Internet or to a Windows domain.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: 3 = Prevent Wi-Fi when on Ethernet:
+    'Computer Configuration\Policies\Administrative Templates\Network\Windows Connection Manager\Minimize the number of simultaneous connections to the Internet or a Windows Domain'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy\fMinimizeConnections' AND CAST(data AS INTEGER) = 3;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Prohibit connection to non-domain networks when connected to domain authenticated network' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting prevents computers from connecting to both a domain based network and a non-domain based network at the same time.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Windows Connection Manager\Prohibit connection to non-domain networks when connected to domain authenticated network'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy\fBlockNonDomain' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Allow Windows to automatically connect to suggested open hotspots, to networks shared by contacts, and to hotspots offering paid services' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether users can enable WLAN settings including Connect to suggested open hotspots, Connect to networks shared by my contacts, and Enable paid services. Automatically connecting to an open hotspot or network can introduce the system to a rogue network with malicious intent.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\WLAN Service\WLAN Settings\Allow Windows to automatically connect to suggested open hotspots, to networks shared by contacts, and to hotspots offering paid services'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WcmSvc\wifinetworkmanager\config\AutoConnectAllowedOEM' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Allow Print Spooler to accept client connections' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls whether the Print Spooler service will accept client connections. Disabling this mitigates remote attacks against the PrintNightmare vulnerability (CVE-2021-34527) and other remote Print Spooler attacks.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Allow Print Spooler to accept client connections'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\RegisterSpoolerRemoteRpcEndPoint' AND CAST(data AS INTEGER) = 2;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure Redirection Guard' is set to 'Enabled: Redirection Guard Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether Redirection Guard is enabled for the print spooler. Redirection Guard can prevent file redirections from being used within the print spooler process.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Redirection Guard Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Configure Redirection Guard'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RedirectionguardPolicy' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure RPC connection settings: Protocol to use for outgoing RPC connections' is set to 'Enabled: RPC over TCP'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls which protocol and protocol settings to use for outgoing Remote Procedure Call (RPC) connections to a remote print spooler. This prevents the use of named pipes for RPC connections and forces the use of TCP which is a more secure communication method.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: RPC over TCP:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC connection settings: Protocol to use for outgoing RPC connections'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcUseNamedPipeProtocol' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure RPC connection settings: Use authentication for outgoing RPC connections' is set to 'Enabled: Default'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls which protocol and protocol settings to use for outgoing Remote Procedure Call (RPC) connections to a remote print spooler.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Default:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC connection settings: Use authentication for outgoing RPC connections'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcAuthentication' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure RPC listener settings: Protocols to allow for incoming RPC connections' is set to 'Enabled: RPC over TCP'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls which protocols incoming Remote Procedure Call (RPC) connections to the print spooler are allowed to use. This forces the use of TCP which is a more secure communication method.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: RPC over TCP:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC listener settings: Protocols to allow for incoming RPC connections'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcProtocols' AND CAST(data AS INTEGER) = 5;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11973,3 +11973,129 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    When using credential delegation, devices provide an exportable version of credentials to the remote host. This exposes users to the risk of credential theft from threat actors on the remote host. The Restricted Admin Mode and Windows Defender Remote Credential Guard features are two options to help protect against this risk.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\System\Credentials Delegation\Remote host allows delegation of non-exportable credentials'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowProtectedCreds' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Turn On Virtualization Based Security' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting specifies whether Virtualization Based Security is enabled. Virtualization Based Security uses the Windows Hypervisor to provide support for security services. This setting was moved from the Next Generation (NG) profile to L1 for Windows 11 only.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\EnableVirtualizationBasedSecurity' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Turn On Virtualization Based Security: Select Platform Security Level' is set to 'Secure Boot' or higher
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting specifies whether Virtualization Based Security (VBS) is enabled. VBS uses the Windows Hypervisor to provide support for security services. The recommended state is Secure Boot. Configuring this setting to Secure Boot and DMA Protection also conforms to the benchmark.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Secure Boot or Secure Boot and DMA Protection:
+    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Select Platform Security Level'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\RequirePlatformSecurityFeatures' AND (data = 1 OR data = 3);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Turn On Virtualization Based Security: Virtualization Based Protection of Code Integrity' is set to 'Enabled with UEFI lock'
+  platforms: win11
+  platform: windows
+  description: |
+    This setting enables virtualization based protection of Kernel Mode Code Integrity. When this is enabled, kernel mode memory protections are enforced and the Code Integrity validation path is protected by the Virtualization Based Security feature. This setting was moved from NG to L1 for Windows 11 only.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled with UEFI lock:
+    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Virtualization Based Protection of Code Integrity'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\HypervisorEnforcedCodeIntegrity' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Turn On Virtualization Based Security: Require UEFI Memory Attributes Table' is set to 'True (checked)'
+  platforms: win11
+  platform: windows
+  description: |
+    This option will only enable Virtualization Based Protection of Code Integrity on devices with UEFI firmware support for the Memory Attributes Table. Devices without the UEFI Memory Attributes Table may have firmware that is incompatible with Virtualization Based Protection of Code Integrity. This setting was moved from NG to L1 for Windows 11 only.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to TRUE:
+    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Require UEFI Memory Attributes Table'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\HVCIMATRequired' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Turn On Virtualization Based Security: Credential Guard Configuration' is set to 'Enabled with UEFI lock'
+  platforms: win11
+  platform: windows
+  description: |
+    This setting lets users turn on Credential Guard with virtualization-based security to help protect credentials. The Enabled with UEFI lock option ensures that Credential Guard cannot be disabled remotely. This setting was moved from NG to L1 for Windows 11 only.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled with UEFI lock:
+    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Credential Guard Configuration'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\LsaCfgFlags' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Turn On Virtualization Based Security: Secure Launch Configuration' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    Secure Launch protects the Virtualization Based Security environment from exploited vulnerabilities in device firmware. This setting was moved from NG to L1 for Windows 11 only.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\System\Device Guard\Turn On Virtualization Based Security: Secure Launch Configuration'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard\ConfigureSystemGuardLaunch' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11811,3 +11811,129 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure RPC listener settings: Authentication protocol to use for incoming RPC connections' is set to 'Enabled: Negotiate' or higher
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls which protocols incoming Remote Procedure Call (RPC) connections to the print spooler are allowed to use. Configuring this setting to Enabled: Kerberos also conforms to the benchmark.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Negotiate or Enabled: Kerberos:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC listener settings: Configure protocol options for incoming RPC connections'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\ForceKerberosForRpc' AND (data = 0 OR data = 1);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure RPC over TCP port' is set to 'Enabled: 0'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls which port is used for RPC over TCP for incoming connections to the print spooler and outgoing connections to remote print spoolers. Using dynamic ports makes it more difficult for a threat actor to know which port is being used.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: 0:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Configure RPC over TCP port'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcTcpPort' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure RPC packet level privacy setting for incoming connections' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls packet level privacy for Remote Procedure Call (RPC) incoming connections. Enabling this enforces the server-side to increase the authentication level to minimize the Print Spooler Spoofing Vulnerability (CVE-2021-1678).
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\MS Security Guide\Configure RPC packet level privacy setting for incoming connections'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print\RpcAuthnLevelPrivacyEnabled' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Limits print driver installation to Administrators' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls whether users who aren't Administrators can install print drivers on the system. Restricting the installation of print drivers to Administrators can help mitigate the PrintNightmare vulnerability (CVE-2021-34527).
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Limits print driver installation to Administrators'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint\RestrictDriverInstallationToAdministrators' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Manage processing of Queue-specific files' is set to 'Enabled: Limit Queue-specific files to Color profiles'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting manages how queue-specific files are processed during printer installation. A Windows Print Spooler Remote Code Execution Vulnerability (CVE-2021-36958) exists when the service improperly performs privileged file operations.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Limit Queue-specific files to Color profiles:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Manage processing of Queue-specific files'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\CopyFilesPolicy' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Point and Print Restrictions: When installing drivers for a new connection' is set to 'Enabled: Show warning and elevation prompt'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls whether computers will show a warning and a security elevation prompt when users create a new printer connection using Point and Print. This helps mitigate the PrintNightmare vulnerability (CVE-2021-34527).
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Show warning and elevation prompt:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Point and Print Restrictions: When installing drivers for a new connection'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint\NoWarningNoElevationOnInstall' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Point and Print Restrictions: When updating drivers for an existing connection' is set to 'Enabled: Show warning and elevation prompt'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls whether computers will show a warning and a security elevation prompt when users are updating drivers for an existing connection using Point and Print. This helps mitigate the PrintNightmare vulnerability (CVE-2021-34527).
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Show warning and elevation prompt:
+    'Computer Configuration\Policies\Administrative Templates\Printers\Point and Print Restrictions: When updating drivers for an existing connection'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint\UpdatePromptSettings' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11181,3 +11181,111 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level2
   contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'WDigest Authentication' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    When WDigest authentication is enabled, Lsass.exe retains a copy of the user's plaintext password in memory, where it can be at risk of theft.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
+    'Computer Configuration\Policies\Administrative Templates\MS Security Guide\WDigest Authentication'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest\UseLogonCredential' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    If you configure a computer for automatic logon, anyone who can physically gain access to the computer can also gain access to everything that is on the computer.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
+    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (AutoAdminLogon) Enable Automatic Logon'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon' AND data = '0';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing protection level' is set to 'Enabled: Highest protection, source routing is completely disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    IP source routing is a mechanism that allows the sender to determine the IP route that a datagram should follow through the network.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
+    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (DisableIPSourceRouting IPv6) IP source routing protection level'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\DisableIPSourceRouting' AND CAST(data AS INTEGER) = 2;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'MSS: (DisableIPSourceRouting) IP source routing protection level' is set to 'Enabled: Highest protection, source routing is completely disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    IP source routing is a mechanism that allows the sender to determine the IP route that a datagram should follow through the network.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
+    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (DisableIPSourceRouting) IP source routing protection level'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\DisableIPSourceRouting' AND CAST(data AS INTEGER) = 2;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    Internet Control Message Protocol (ICMP) redirects cause the IPv4 stack to plumb host routes. These routes override the OSPF generated routes.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
+    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\EnableICMPRedirect' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    NetBIOS over TCP/IP is a network protocol that provides a way to resolve NetBIOS names. This setting determines whether the computer releases its NetBIOS name when it receives a name-release request.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path as prescribed:
+    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetBT\Parameters\NoNameReleaseOnDemand' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -407,7 +407,7 @@ spec:
     This policy setting allows a process to create an access token, which may provide elevated rights to access sensitive data.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to an empty list:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'No One':
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Create a token object'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/CreateToken</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -445,7 +445,7 @@ spec:
     not necessary to specifically assign this user right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to an empty list:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'No One':
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Create permanent shared objects'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/CreatePermanentSharedObjects</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -516,7 +516,7 @@ spec:
     this computer from the network user right if an account is subject to both policies.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guest'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny access to this computer from the network'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyAccessFromNetwork</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
@@ -592,7 +592,7 @@ spec:
     This policy setting determines whether users can log on as Remote Desktop clients. This user right supersedes the Allow log on through Remote Desktop Services user right if an account is subject to both policies.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on through Remote Desktop Services'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyRemoteDesktopServicesLogOn</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
@@ -632,7 +632,7 @@ spec:
     right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Force shutdown from a remote system'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/RemoteShutdown</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -650,7 +650,7 @@ spec:
     This policy setting determines which users or processes can generate audit records in the Security log.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'LOCAL SERVICE, NETWORK SERVICE'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Generate security audits'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/GenerateSecurityAudits</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(LOCAL SERVICE|NETWORK SERVICE).*",0) is not null);
@@ -672,7 +672,7 @@ spec:
     they have created to impersonate that client, which could elevate the unauthorized user's permissions to administrative or system levels.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Impersonate a client after authentication'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ImpersonateClient</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Administrators|LOCAL SERVICE|NETWORK SERVICE|([^\w\s]SERVICE)).*",0) is not null);
@@ -692,7 +692,7 @@ spec:
     user right is not required by administrative tools that are supplied with the operating system but might be required by software development tools.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators, Window Manager\Window Manager Group'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Increase scheduling priority'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/IncreaseSchedulingPriority</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Administrators|Window Manager Group).*",0) is not null);
@@ -713,8 +713,8 @@ spec:
     Windows.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Increase scheduling priority'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Load and unload device drivers'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/LoadUnloadDeviceDrivers</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
   purpose: Informational
@@ -753,7 +753,7 @@ spec:
     after gaining user level access to a computer.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Log on as a batch job'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.28" AND (regex_match(value,".*(?=.*Administrators).*",0) is not null);
@@ -793,7 +793,7 @@ spec:
     This policy setting determines which users can change the auditing options for files and directories and clear the Security log.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Manage auditing and security log'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ManageAuditingAndSecurityLog</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -833,7 +833,7 @@ spec:
     Configuration. Modification of these values and could lead to a hardware failure that would result in a denial of service condition.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Modify firmware environment values'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ModifyFirmwareEnvironment</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -851,7 +851,7 @@ spec:
     This policy setting allows users to manage the system's volume or disk configuration, which could allow a user to delete a volume and cause data loss as well as a denial-ofservice condition.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Perform volume maintenance tasks'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.33" AND (regex_match(value,".*(?=.*Administrators).*",0) is not null);
@@ -874,7 +874,7 @@ spec:
     information that could be used to mount an attack on the system.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Profile single process'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ProfileSingleProcess</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -935,7 +935,7 @@ spec:
     directories user right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Restore files and directories'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/RestoreFilesAndDirectories</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -973,7 +973,7 @@ spec:
     or threads. This user right bypasses any permissions that are in place to protect objects to give ownership to the specified user.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Take ownership of files or other objects'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/TakeOwnership</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -12099,3 +12099,76 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Enable / disable CLFS logfile authentication' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting configures Common Log File System (CLFS) logfile authentication. Logfile authentication provides the ability for the CLFS driver to detect malicious modifications made to logfiles. CLFS is a security feature which hardens logfile parsing. If modifications to logfiles are detected, CLFS will consider the logfile unsafe for parsing and return an error to the caller. It is also able to detect modifications by writing authentication codes to logfiles which combines file data with a system-unique cryptographic key.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\System\Filesystem\Enable / disable CLFS logfile authentication'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\ClfsAuthenticationChecking' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Allow Recall to be enabled' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting controls whether the Recall optional component is available for end users to enable on the system. Microsoft Recall periodically captures screenshots of the system display, creating a searchable timeline of activity including apps, documents, and websites. Saving snapshots of all user activity could result in sensitive information such as passwords or banking details being stored insecurely and making it easily accessible.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Administrative Templates\Windows Components\Windows AI\Allow Recall to be enabled'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsAI\AllowRecallEnablement' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Disable HTTP proxy features: Disable WPAD' is set to 'Enabled: Checked'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether Web Proxy Auto-Discovery protocol (WPAD) is disabled on the system. WPAD is used to discover Proxy Auto-Config (PAC) files from the local network. WPAD could expose the system to Man-In-The-Middle (MITM) attacks. If an organization depends on HTTP proxy configuration, it is recommended that other client configuration mechanisms be used instead, such as Group Policy.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Checked:
+    'Computer Configuration\Policies\Administrative Templates\Center for Internet Security (CIS)\Additional Benchmark Settings\Disable HTTP proxy features: Disable WPAD'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings\WinHttp\DisableWpad' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Disable HTTP proxy features: Disable proxy authentication' is set to 'Enabled: Disable authentication over loopback interfaces' or higher
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether Windows can authenticate over a loopback interface. It is best to limit the sign-in interface to only known and trusted services, so malicious actors can't impersonate them. Configuring this setting to 'Disable all authentication protocols and loopback authentication' also conforms to the benchmark.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Disable authentication over loopback interfaces or Disable all authentication protocols and loopback authentication:
+    'Computer Configuration\Policies\Administrative Templates\Center for Internet Security (CIS)\Additional Benchmark Settings\Disable HTTP proxy features: Disable proxy authentication'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings\DisableProxyAuthenticationSchemes' AND (data = 256 OR data = 287);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11289,3 +11289,219 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
   contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'MSS: (SafeDllSearchMode) Enable Safe DLL search mode' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    The DLL search order can be configured to search for DLLs that are requested by running processes in one of two ways. When enabled, the system first searches folders specified in the system path and then searches the current working folder.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (SafeDllSearchMode) Enable Safe DLL search mode'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\SafeDllSearchMode' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'
+  platforms: win11
+  platform: windows
+  description: |
+    This setting can generate a security audit in the Security event log when the log reaches a user-defined threshold. If log settings are configured to Overwrite events as needed or Overwrite events older than x days, this event will not be generated.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: 90% or less:
+    'Computer Configuration\Policies\Administrative Templates\MSS (Legacy)\MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security\WarningLevel' AND CAST(data AS INTEGER) <= 90;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure multicast DNS (mDNS) protocol' is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines if the DNS client will perform name resolution over Multicast DNS (mDNS). mDNS performs local network name and service discoveries without the need for central DNS.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\DNS Client\Configure multicast DNS (mDNS) protocol'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableMDNS' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Configure NetBIOS settings' is set to 'Enabled: Disable NetBIOS name resolution on public networks'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting specifies if the DNS client will perform name resolution over Network Basic Input/Output System (NetBIOS). NetBIOS is a legacy name resolution method for internal Microsoft networking that predates the use of DNS for that purpose.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: Disable NetBIOS name resolution on public networks:
+    'Computer Configuration\Policies\Administrative Templates\Network\DNS Client\Configure NetBIOS settings'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableNetbios' AND (data = 0 OR data = 2);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Turn off multicast name resolution' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    Link-Local Multicast Name Resolution (LLMNR) is a secondary name resolution protocol. With LLMNR, queries are sent using multicast over a local network link on a single subnet. LLMNR does not require a DNS server or DNS client configuration and provides name resolution in scenarios in which conventional DNS name resolution is not possible.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\DNS Client\Turn off multicast name resolution'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableMulticast' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Audit client does not support encryption' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether the SMB server will log events when the SMB client doesn't support encryption. Organizations should be aware of all unencrypted SMB traffic in their environment.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Audit client does not support encryption'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\AuditClientDoesNotSupportEncryption' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Audit client does not support signing' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy setting determines whether the SMB server will log events when the SMB client doesn't support signing. Organizations should be aware of all unsigned SMB traffic in their environment.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Audit client does not support signing'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\AuditClientDoesNotSupportSigning' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Audit insecure guest logon' (Lanman Server) is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy determines whether the SMB server will log events when the client is logged on as guest account. Insecure guest logons can be used by file servers to allow unauthenticated access to shared folders.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Audit insecure guest logon'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\AuditInsecureGuestLogon' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Enable authentication rate limiter' is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy settings configures the SMB server authentication rate limiter. The authentication rate limiter is a feature of SMB that is designed to address brute force attacks by implementing a 2-second delay between each failed NTLM or PKU2U-based authentication attempt.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Enable authentication rate limiter'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\EnableAuthRateLimiter' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Enable remote mailslots' (Lanman Server) is set to 'Disabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy settings controls whether the SMB server will use remote mailslots over the computer browser service. The remote mailslots protocol is an old, simple, unreliable, and insecure inter-process communication method.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Enable remote mailslots'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Bowser\EnableMailslots' AND data = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Mandate the minimum version of SMB' (Lanman Server) is set to 'Enabled: 3.1.1'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy settings controls the minimum version of Server Message Block (SMB) protocol that can be used on the system. SMBv1 is no longer enabled by default due to its security risks, and although SMBv2 is more robust than v1, it does not support encryption like its successor.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled: 3.1.1:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Server\Mandate the minimum version of SMB'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\MinSmb2Dialect' AND CAST(data AS INTEGER) = 785;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Audit insecure guest logon' (Lanman Workstation) is set to 'Enabled'
+  platforms: win11
+  platform: windows
+  description: |
+    This policy determines whether the SMB client will log events when the client is logged on as guest account. Insecure guest logons can be used by file servers to allow unauthenticated access to shared folders.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Administrative Templates\Network\Lanman Workstation\Audit insecure guest logon'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AuditInsecureGuestLogon' AND data = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: fleet

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -11214,7 +11214,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\DisableIPSourceRouting' AND CAST(data AS INTEGER) = 2;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11233,7 +11233,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\DisableIPSourceRouting' AND CAST(data AS INTEGER) = 2;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11251,7 +11251,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\AuditInsecureGuestLogon' AND data = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11269,7 +11269,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Bowser\EnableMailslots' AND data = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11288,7 +11288,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanServer\MinSmb2Dialect' AND CAST(data AS INTEGER) = 785;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11306,7 +11306,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\AuditInsecureGuestLogon' AND data = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11324,7 +11324,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\EnableMailslots' AND data = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11343,7 +11343,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation\MinSmb2Dialect' AND CAST(data AS INTEGER) = 785;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11362,7 +11362,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy\fMinimizeConnections' AND CAST(data AS INTEGER) = 3;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11380,7 +11380,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy\fBlockNonDomain' AND data = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11398,7 +11398,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WcmSvc\wifinetworkmanager\config\AutoConnectAllowedOEM' AND data = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11417,7 +11417,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\ForceKerberosForRpc' AND (data = 0 OR data = 1);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11436,7 +11436,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC\RpcTcpPort' AND data = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11454,7 +11454,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\ClfsAuthenticationChecking' AND data = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11472,7 +11472,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsAI\AllowRecallEnablement' AND data = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11491,7 +11491,7 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings\WinHttp\DisableWpad' AND data = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm
 ---
 apiVersion: v1
 kind: policy
@@ -11510,4 +11510,4 @@ spec:
     SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings\DisableProxyAuthenticationSchemes' AND (data = 256 OR data = 287);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: fleet
+  contributors: sharon-fdm


### PR DESCRIPTION
Closes #39096

## Summary

Updates the CIS Windows 11 Enterprise benchmark policies from v4.0.0 to v5.0.1.

### Phase 1 -- Title updates: 42 existing policy titles updated to match v5.0.1
### Phase 2 -- New L1 policies: 17 added

New policies added:
- 18.5.2 MSS: DisableIPSourceRouting IPv6
- 18.5.3 MSS: DisableIPSourceRouting
- 18.6.7.3 Audit insecure guest logon (Lanman Server)
- 18.6.7.5 Enable remote mailslots (Lanman Server)
- 18.6.7.6 Mandate the minimum version of SMB (Lanman Server)
- 18.6.8.1 Audit insecure guest logon (Lanman Workstation)
- 18.6.8.5 Enable remote mailslots (Lanman Workstation)
- 18.6.8.6 Mandate the minimum version of SMB (Lanman Workstation)
- 18.6.21.1 Minimize simultaneous connections
- 18.6.21.2 Prohibit non-domain connections
- 18.6.23.2.1 Auto-connect to hotspots
- 18.7.5 Configure RPC listener settings (auth)
- 18.7.7 Configure RPC over TCP port
- 18.9.17.1 Enable/disable CLFS logfile authentication
- 18.10.73.1 Allow Recall to be enabled
- 18.11.1 Disable HTTP proxy features: Disable WPAD
- 18.11.2 Disable HTTP proxy features: Disable proxy authentication

### Additional fixes
- Fixed 16 policies where resolution text was inconsistent with policy name/query
- Fixed YAML colon escaping for policy names containing colons (e.g. "Domain member:", "Microsoft network client:")
- Added GP removal behavior note to README
- Validated with fleetctl apply (572 policies, no errors)

### Policy count: 572 (was 555)

---

## Testing

### Methodology

New policies tested on **Windows 11 Enterprise 24H2** VM (DESKTOP-UUIQ1EM, build 10.0.26100.4349) via SSH + registry-direct testing.

Three test cases per policy:
- PASS value -> query returns result
- FAIL value -> query returns empty
- NOT SET (deleted) -> query returns empty

### Results: All new policies pass

| # | CIS | Policy | Registry Key | FAIL | PASS |
|---|-----|--------|--------------|------|------|
| 1 | 18.9.17.1 | CLFS logfile authentication | ClfsAuthenticationChecking=1 | PASS | PASS |
| 2 | 18.10.73.1 | Allow Recall to be enabled | AllowRecallEnablement=0 | PASS | PASS |
| 3 | 18.11.1 | Disable WPAD | DisableWpad=1 | PASS | PASS |
| 4 | 18.11.2 | Disable proxy authentication | DisableProxyAuthenticationSchemes=256or287 | PASS | PASS |

### Import validation

fleetctl apply confirms all 572 policies parse and import successfully.

Test environment: Windows 11 Enterprise 24H2 (10.0.26100.4349), osqueryd 5.23.0 via fleetd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Standardized many Windows 11 CIS policy names and UI text: explicit principals (e.g., "No One"), expanded denial/user-right lists, and normalized punctuation and prefixes (e.g., "Domain member:"). Renamed an audit entry and aligned expected outcomes.

* **New Features**
  * Added 30+ Windows CIS policies covering IP source routing protections, SMB/Lanman guest and dialect controls, Network/WLAN hardening, RPC/print mitigations, logfile/auth protections, Recall disablement, and proxy/WPAD restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45173)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->