### PR TITLE
Update Okta Verify policy resolution and install flag

### DIFF
--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -66,10 +66,10 @@
     - Macs with Zoom installed
 - name: macOS - Okta Verify up to date
   description: The host may have an outdated version of Okta Verify, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Okta Verify's built-in update functionality."
+  resolution: "Okta Verify is an app managed by IT and should be kept up to date automatically. If you are failing this policy, install the latest version from Self-service, then click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
   fleet_maintained_app_slug: okta-verify/darwin
-  install_software: false
+  install_software: true
   labels_include_any:
     - Macs with Okta Verify installed
 - name: macOS - Santa up to date


### PR DESCRIPTION
Clarify the user-facing resolution to instruct users to install Okta Verify from Self-service, click Refetch, and contact #help-it if issues persist. Also enable automatic installation by changing install_software to true so Fleet can install the managed app when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS Okta Verify update workflow to IT-managed process
  * Users can now install the latest version via Self-service and use the Refetch option
  * Enhanced support escalation pathway for update-related issues

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45185)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->