### PR TITLE
Fix homebrew package matching incorrect CPE

### DIFF
--- a/changes/35195-slate-homebrew-cpe-mismatch
+++ b/changes/35195-slate-homebrew-cpe-mismatch
@@ -1,0 +1,1 @@
+- Fixed incorrect CPE match on "slate" homebrew program

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -161,6 +161,15 @@
   },
   {
     "software": {
+      "name": ["slate"],
+      "source": ["homebrew_packages"]
+    },
+    "filter": {
+      "skip": true
+    }
+  },
+  {
+    "software": {
       "name": ["Flock.app"],
       "source": ["apps"]
     },


### PR DESCRIPTION
**Related issue:** Resolves #35195

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect CPE match for the Homebrew "slate" package to ensure accurate vulnerability identification and tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45186)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->