### PR TITLE
Add adobe_plugins osquery extension table

### DIFF
--- a/docs/Contributing/architecture/software/software-automations.md
+++ b/docs/Contributing/architecture/software/software-automations.md
@@ -4,18 +4,228 @@ This document provides an overview of Fleet's software automation architecture.
 
 ## Introduction
 
-Software automation in Fleet enable organizations automatically install or update software based on a [policy](https://fleetdm.com/securing/what-are-fleet-policies).
+Software automation in Fleet enables organizations to automatically install
+or update software based on a [policy](https://fleetdm.com/securing/what-are-fleet-policies).
+It shares its decision logic with the rest of Fleet's policy automations
+(webhook, Jira, Zendesk, script run, VPP install, calendar event, and
+conditional access), so this document describes the whole pipeline and
+calls out where the software-install branch fits in.
+
+The core gating rule: automations fire on the **pass to fail flip**, not on
+every fail. A host that has been failing the same policy for a week will not
+retrigger the automation on every check-in. A separate
+`fire_outdated_automations` cron is the only built-in mechanism to re-fire
+for a host that is continuously failing.
 
 ## Architecture overview
 
+The pipeline is split across four cooperating pieces:
+
+1. **Flip detector.** When a host posts policy results via osquery
+   `distributed/write`, `FlippingPoliciesForHost` compares the host's
+   previous pass/fail state in `policy_membership` against the incoming
+   results and returns `newFailing` and `newPassing` sets.
+2. **Real-time fan-out.** Inside `SubmitDistributedQueryResults`, the
+   `newFailing` set drives the per-host processors (script, software, VPP)
+   and seeds a Redis-backed `FailingPolicySet`. Calendar and
+   conditional-access processors also run here but with their own gating
+   (see "Things worth knowing" below).
+3. **Failing policy set.** Redis queue of (policy_id, host) pairs awaiting
+   delivery. Drained by the delivery cron, refilled by the real-time
+   fan-out and by the outdated automations cron.
+4. **Delivery cron.** Every `WebhookSettings.Interval`,
+   `triggerFailingPoliciesAutomation` walks the set, resolves each policy's
+   team automation config, and dispatches a webhook POST or queues a
+   Jira/Zendesk worker job.
+
+A second cron, `fire_outdated_automations`, re-injects still-failing hosts
+based on `policy_automation_iterations` so operators can bump an iteration
+counter to force a re-fire.
+
 ## Key components
+
+- `server/datastore/mysql/policies.go` - `FlippingPoliciesForHost`,
+  `flipping`, `OutdatedAutomationBatch`. The previously-vs-now decision.
+- `server/service/osquery.go` - `SubmitDistributedQueryResults`,
+  `registerFlippedPolicies`, `processScriptsForNewlyFailingPolicies`,
+  `processSoftwareForNewlyFailingPolicies`,
+  `processVPPForNewlyFailingPolicies`,
+  `processConditionalAccessForNewlyFailingPolicies`,
+  `processCalendarPolicies`. The real-time fan-out per host.
+- `server/policies/failing_policies.go` -
+  `TriggerFailingPoliciesAutomation`, `buildFailingPolicyAutomationConfig`,
+  `getActiveAutomation`. Per-team and global config resolution and
+  dispatch.
+- `cmd/fleet/cron.go` - `scheduleFailingPoliciesAutomation` (outdated
+  re-queue) and `triggerFailingPoliciesAutomation` (delivery cron).
+- `server/webhooks/failing_policies.go` - `SendFailingPoliciesBatchedPOSTs`.
+  Batches hosts, POSTs the webhook, and removes the batch from Redis only
+  on success.
+- `server/service/redis_policy_set/redis_policy_set.go` - Redis-backed
+  `FailingPolicySet` storage.
+
+## Decision rule
+
+The gate comes down to one function in `server/datastore/mysql/policies.go`:
+
+```go
+func flipping(prevResults map[uint]bool, incomingResults map[uint]bool) (newFailing, newPassing []uint) {
+    for policyID, incomingPasses := range incomingResults {
+        prevPasses, ok := prevResults[policyID]
+        if !ok { // first run for this (host, policy)
+            if !incomingPasses {
+                newFailing = append(newFailing, policyID)
+            }
+        } else { // ran previously
+            if !prevPasses && incomingPasses {
+                newPassing = append(newPassing, policyID)
+            } else if prevPasses && !incomingPasses {
+                newFailing = append(newFailing, policyID)
+            }
+        }
+    }
+    return newFailing, newPassing
+}
+```
+
+In English:
+
+- no previous result + incoming fail -> `newFailing`
+- previous pass     + incoming fail -> `newFailing`
+- previous fail     + incoming pass -> `newPassing`
+- previous fail     + incoming fail -> nothing (no event)
+- previous pass     + incoming pass -> nothing
 
 ## Architecture diagram
 
+### High-level
+
+```mermaid
+flowchart TD
+    A[Host submits policy results<br/>distributed/write] --> B{Any policy results?}
+    B -- no --> Z[Done]
+    B -- yes --> C[FlippingPoliciesForHost<br/>compare prev vs incoming]
+
+    C --> D{Per policy: did status flip?}
+    D -- prev=fail, now=fail --> E[Skip<br/>no event]
+    D -- prev=pass, now=pass --> E
+    D -- now=pass<br/>prev=fail --> F[newPassing<br/>remove host from set]
+    D -- now=fail<br/>prev=pass or no prev --> G[newFailing]
+
+    G --> H[Run per-host side effects<br/>script, software install, VPP,<br/>calendar, conditional access]
+    G --> I[Add host to Redis<br/>FailingPolicySet]
+
+    I -.cron tick.-> J[failing_policies_automation<br/>cron job]
+    J --> K{Automation type<br/>for this policy's team?}
+    K -- none --> L[Drop set, skip]
+    K -- webhook --> M[POST to webhook URL<br/>then remove batch from set]
+    K -- jira --> N[Queue Jira job<br/>then remove hosts]
+    K -- zendesk --> O[Queue Zendesk job<br/>then remove hosts]
+
+    P[fire_outdated_automations cron] -.re-queues still-failing hosts.-> I
 ```
-[Placeholder for Software Policies Architecture Diagram]
+
+### Detailed state machine
+
+Full lifecycle of a single (policy, host) pair, including retries and
+re-queue paths.
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoPriorResult
+
+    NoPriorResult --> Passing: incoming=pass
+    NoPriorResult --> NewlyFailing: incoming=fail
+
+    Passing --> Passing: incoming=pass<br/>no event
+    Passing --> NewlyFailing: incoming=fail<br/>(pass to fail flip)
+
+    Failing --> Failing: incoming=fail<br/>NOT re-fired
+    Failing --> NewlyPassing: incoming=pass<br/>(fail to pass flip)
+
+    NewlyFailing --> SideEffectsFanout: trigger inline processors
+    NewlyFailing --> EnqueuedInSet: add to FailingPolicySet (Redis)
+
+    state SideEffectsFanout {
+        [*] --> ScriptCheck
+        ScriptCheck --> ScriptQueued: gated on newFailingSet<br/>+ policy has script<br/>+ scripts enabled<br/>+ under pending limit
+        ScriptCheck --> ScriptSkipped: missing script,<br/>vanilla osquery,<br/>scripts disabled, etc.
+
+        [*] --> SoftwareCheck
+        SoftwareCheck --> SoftwareInstallQueued: gated on newFailingSet<br/>+ policy has installer<br/>+ platform match<br/>+ label scoped
+        SoftwareCheck --> SoftwareSkipped: out of scope<br/>or no installer
+
+        [*] --> VPPCheck
+        VPPCheck --> VPPInstallQueued: gated on newFailingSet<br/>+ darwin only<br/>+ policy has VPP app<br/>+ scoped
+        VPPCheck --> VPPSkipped: not darwin<br/>or not scoped
+
+        [*] --> CalendarCheck
+        CalendarCheck --> CalendarWebhookFired: not gated on newFailing<br/>fires if WebhookStatus=Pending<br/>+ any calendar policy failing<br/>+ inside event window
+        CalendarCheck --> CalendarSkipped: no event,<br/>too early/late,<br/>or not enabled
+
+        [*] --> CondAccessCheck
+        CondAccessCheck --> CondAccessTriggered: not gated on newFailing<br/>compliance recomputed from<br/>current results, pushed to Entra
+        CondAccessCheck --> CondAccessSkipped: vanilla osquery,<br/>not configured,<br/>or no Entra device id
+    }
+
+    EnqueuedInSet --> CronTrigger: failing_policies_automation cron tick<br/>(WebhookSettings.Interval)
+
+    state CronTrigger {
+        [*] --> ResolveTeamConfig
+        ResolveTeamConfig --> DropAutomationDisabled: no automation configured<br/>OR policy not in configured IDs<br/>OR team deleted
+        ResolveTeamConfig --> DispatchByType: automation enabled<br/>+ policy listed
+
+        DispatchByType --> WebhookSent: type=webhook<br/>POST + remove batch
+        DispatchByType --> JiraQueued: type=jira<br/>queue worker job + remove
+        DispatchByType --> ZendeskQueued: type=zendesk<br/>queue worker job + remove
+
+        WebhookSent --> WebhookRetry: HTTP error<br/>host stays in set
+        WebhookRetry --> [*]: picked up next tick
+    }
+
+    DropAutomationDisabled --> Failing: host stays failing<br/>but no delivery
+    WebhookSent --> Failing
+    JiraQueued --> Failing
+    ZendeskQueued --> Failing
+
+    NewlyPassing --> Passing: remove host from FailingPolicySet
+
+    Failing --> Requeued: fire_outdated_automations cron<br/>(iteration bump)
+    Requeued --> EnqueuedInSet: re-add to set for next trigger run
 ```
+
+## Things worth knowing
+
+1. **Fail to fail is silent by design.** A host that has been failing for
+   days will not retrigger the webhook or ticket flow unless
+   `fire_outdated_automations` bumps the iteration. See
+   [#42651](https://github.com/fleetdm/fleet/issues/42651) for the
+   "continuous retries" feature request.
+2. **Most per-host side effects gate on `newFailingSet`** (script run,
+   software install, VPP install) so they only fire on the pass-to-fail
+   flip. **Calendar and Conditional Access do not.** Despite their
+   function names (`processCalendarPolicies`,
+   `processConditionalAccessForNewlyFailingPolicies`), calendar fires
+   whenever the host's calendar event is in `Pending` status and any
+   calendar policy is currently failing, and conditional access recomputes
+   overall compliance from the full incoming result set and pushes it to
+   Entra.
+3. **Webhook removal is post-success.** If the POST fails, the host stays
+   in the Redis set and is retried on the next cron tick. Jira and Zendesk
+   hosts are removed as soon as the worker job is queued, not when the
+   ticket is actually created.
+4. **Team automation must be enabled AND the policy must be in
+   `PolicyIDs`.** If a policy is failing but not listed in the team's (or
+   global) configured policy IDs, the cron drops the whole set for that
+   policy via `failingPoliciesSet.RemoveSet`.
+5. **Global vs per-team config.** Global policies use
+   `appConfig.WebhookSettings.FailingPoliciesWebhook` and
+   `appConfig.Integrations`. Team policies use the team's own webhook
+   settings and integrations, with global integrations matched in via
+   `MatchWithIntegrations`. "No Team" policies (`TeamID == 0`) use the
+   default team config.
 
 ## Related resources
 
 - [Software Product Group Documentation](../../product-groups/software/) - Documentation for the Software product group
+- [Automations user guide](https://fleetdm.com/guides/automations) - user-facing configuration documentation

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins.go
@@ -1,0 +1,337 @@
+// Package adobe_plugins implements an osquery extension table that detects
+// Adobe plugins (CEP extensions, UXP extensions, and native plug-ins) on
+// macOS and Windows endpoints by scanning well-known directories and parsing
+// plugin manifests.
+//
+// The table supports a scan_level constraint in the WHERE clause:
+//
+//	SELECT * FROM adobe_plugins;                              -- standard (default)
+//	SELECT * FROM adobe_plugins WHERE scan_level = 'deep';    -- includes native plug-ins
+//
+// Standard: scans CEP and UXP extension directories only.
+// Deep: additionally scans application-specific native plug-in directories
+// (Photoshop, Premiere Pro, After Effects, Illustrator).
+package adobe_plugins
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/tablehelpers"
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/rs/zerolog"
+)
+
+const tableName = "adobe_plugins"
+
+const (
+	colPath            = "path"
+	colName            = "name"
+	colVersion         = "version"
+	colVendor          = "vendor"
+	colBundleID        = "bundle_id"
+	colHostApplication = "host_application"
+	colExtensionType   = "extension_type"
+	colUser            = "user"
+	colPlatform        = "platform"
+	colScanLevel       = "scan_level"
+)
+
+// scanPath describes a directory to scan for Adobe plugins.
+type scanPath struct {
+	basePath      string // directory path, may contain glob wildcards
+	extensionType string // "CEP", "UXP", or "native"
+	hostApp       string // known host application from path context
+	user          string // username for user-scoped installs, empty for system
+}
+
+// hostAppCodes maps Adobe host application codes found in manifests to
+// human-readable application names.
+var hostAppCodes = map[string]string{
+	"PHXS": "Photoshop",
+	"PHSP": "Photoshop",
+	"PS":   "Photoshop",
+	"ILST": "Illustrator",
+	"AI":   "Illustrator",
+	"PPRO": "Premiere Pro",
+	"AEFT": "After Effects",
+	"AE":   "After Effects",
+	"IDSN": "InDesign",
+	"ID":   "InDesign",
+	"FLPR": "Animate",
+	"DRWV": "Dreamweaver",
+	"AUDT": "Audition",
+	"AU":   "Audition",
+	"KBRG": "Bridge",
+	"LTRM": "Lightroom",
+	"LRCC": "Lightroom Classic",
+	"XD":   "XD",
+}
+
+type adobePluginsTable struct {
+	logger zerolog.Logger
+}
+
+// TablePlugin returns the osquery plugin for the adobe_plugins table.
+func TablePlugin(logger zerolog.Logger) *table.Plugin {
+	t := &adobePluginsTable{
+		logger: logger.With().Str("table", tableName).Logger(),
+	}
+	return table.NewPlugin(tableName, Columns(), t.generate)
+}
+
+// Columns defines the table schema.
+func Columns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn(colPath),
+		table.TextColumn(colName),
+		table.TextColumn(colVersion),
+		table.TextColumn(colVendor),
+		table.TextColumn(colBundleID),
+		table.TextColumn(colHostApplication),
+		table.TextColumn(colExtensionType),
+		table.TextColumn(colUser),
+		table.TextColumn(colPlatform),
+		// scan_level is a WHERE-clause-only constraint that controls scan depth.
+		// It is not populated in results.
+		table.TextColumn(colScanLevel),
+	}
+}
+
+func (t *adobePluginsTable) generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	scanLevels := tablehelpers.GetConstraints(queryContext, colScanLevel,
+		tablehelpers.WithDefaults("standard"),
+		tablehelpers.WithAllowedValues([]string{"standard", "deep"}),
+		tablehelpers.WithLogger(t.logger),
+	)
+
+	level := "standard"
+	for _, l := range scanLevels {
+		if l == "deep" {
+			level = "deep"
+			break
+		}
+	}
+
+	paths, err := getScanPaths(level)
+	if err != nil {
+		t.logger.Warn().Err(err).Msg("failed to build scan paths")
+		return nil, nil
+	}
+
+	var results []map[string]string
+	seen := make(map[string]struct{})
+
+	for _, sp := range paths {
+		matches, err := filepath.Glob(sp.basePath)
+		if err != nil {
+			t.logger.Debug().Err(err).Str("path", sp.basePath).Msg("glob error")
+			continue
+		}
+
+		for _, dir := range matches {
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.logger.Debug().Err(err).Str("dir", dir).Msg("cannot read directory")
+				continue
+			}
+
+			for _, entry := range entries {
+				pluginPath := filepath.Join(dir, entry.Name())
+
+				if _, ok := seen[pluginPath]; ok {
+					continue
+				}
+				seen[pluginPath] = struct{}{}
+
+				row := t.scanEntry(pluginPath, entry, sp)
+				if row != nil {
+					results = append(results, row)
+				}
+			}
+		}
+	}
+
+	return results, nil
+}
+
+func (t *adobePluginsTable) scanEntry(pluginPath string, entry os.DirEntry, sp scanPath) map[string]string {
+	switch sp.extensionType {
+	case "CEP":
+		if !entry.IsDir() {
+			return nil
+		}
+		return t.parseCEPPlugin(pluginPath, sp)
+	case "UXP":
+		if !entry.IsDir() {
+			return nil
+		}
+		return t.parseUXPPlugin(pluginPath, sp)
+	case "native":
+		if strings.HasPrefix(entry.Name(), ".") {
+			return nil
+		}
+		return parseNativePlugin(pluginPath, entry, sp)
+	}
+	return nil
+}
+
+// CEP manifest XML structures (CSXS/manifest.xml)
+
+type cepManifest struct {
+	XMLName  xml.Name `xml:"ExtensionManifest"`
+	BundleID string   `xml:"ExtensionBundleId,attr"`
+	Version  string   `xml:"ExtensionBundleVersion,attr"`
+	Author   struct {
+		Name string `xml:"Name,attr"`
+	} `xml:"Author"`
+	ExecutionEnvironment struct {
+		HostList struct {
+			Hosts []struct {
+				Name string `xml:"Name,attr"`
+			} `xml:"Host"`
+		} `xml:"HostList"`
+	} `xml:"ExecutionEnvironment"`
+}
+
+func (t *adobePluginsTable) parseCEPPlugin(pluginPath string, sp scanPath) map[string]string {
+	row := map[string]string{
+		colPath:          pluginPath,
+		colName:          filepath.Base(pluginPath),
+		colExtensionType: "CEP",
+		colUser:          sp.user,
+		colPlatform:      runtime.GOOS,
+	}
+
+	manifestPath := filepath.Join(pluginPath, "CSXS", "manifest.xml")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.logger.Debug().Err(err).Str("path", manifestPath).Msg("no CEP manifest found")
+		return row
+	}
+
+	var m cepManifest
+	if err := xml.Unmarshal(data, &m); err != nil {
+		t.logger.Debug().Err(err).Str("path", manifestPath).Msg("failed to parse CEP manifest")
+		return row
+	}
+
+	row[colVersion] = m.Version
+	row[colVendor] = m.Author.Name
+	row[colBundleID] = m.BundleID
+
+	var hostCodes []string
+	for _, h := range m.ExecutionEnvironment.HostList.Hosts {
+		hostCodes = append(hostCodes, h.Name)
+	}
+	hostApps := resolveHostApps(hostCodes)
+	if hostApps == "" {
+		hostApps = sp.hostApp
+	}
+	row[colHostApplication] = hostApps
+
+	return row
+}
+
+// UXP manifest JSON structures (manifest.json)
+
+type uxpManifest struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Host    []struct {
+		App string `json:"app"`
+	} `json:"host"`
+	Metadata struct {
+		Publisher string `json:"publisher"`
+	} `json:"metadata"`
+}
+
+func (t *adobePluginsTable) parseUXPPlugin(pluginPath string, sp scanPath) map[string]string {
+	row := map[string]string{
+		colPath:          pluginPath,
+		colName:          filepath.Base(pluginPath),
+		colExtensionType: "UXP",
+		colUser:          sp.user,
+		colPlatform:      runtime.GOOS,
+	}
+
+	manifestPath := filepath.Join(pluginPath, "manifest.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.logger.Debug().Err(err).Str("path", manifestPath).Msg("no UXP manifest found")
+		return row
+	}
+
+	var m uxpManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.logger.Debug().Err(err).Str("path", manifestPath).Msg("failed to parse UXP manifest")
+		return row
+	}
+
+	name := m.Name
+	if name == "" {
+		name = m.ID
+	}
+	if name == "" {
+		name = filepath.Base(pluginPath)
+	}
+	row[colName] = name
+	row[colVersion] = m.Version
+	row[colVendor] = m.Metadata.Publisher
+	row[colBundleID] = m.ID
+
+	var hostCodes []string
+	for _, h := range m.Host {
+		hostCodes = append(hostCodes, h.App)
+	}
+	hostApps := resolveHostApps(hostCodes)
+	if hostApps == "" {
+		hostApps = sp.hostApp
+	}
+	row[colHostApplication] = hostApps
+
+	return row
+}
+
+func parseNativePlugin(pluginPath string, entry os.DirEntry, sp scanPath) map[string]string {
+	name := entry.Name()
+	for _, ext := range []string{".plugin", ".bundle", ".8bf", ".8bi", ".dll", ".aex"} {
+		if strings.HasSuffix(strings.ToLower(name), ext) {
+			name = name[:len(name)-len(ext)]
+			break
+		}
+	}
+
+	return map[string]string{
+		colPath:            pluginPath,
+		colName:            name,
+		colHostApplication: sp.hostApp,
+		colExtensionType:   "native",
+		colUser:            sp.user,
+		colPlatform:        runtime.GOOS,
+	}
+}
+
+// resolveHostApps converts a list of Adobe host application codes to
+// human-readable names, deduplicating entries.
+func resolveHostApps(codes []string) string {
+	seen := make(map[string]struct{})
+	var apps []string
+	for _, code := range codes {
+		app := code
+		if resolved, ok := hostAppCodes[strings.ToUpper(code)]; ok {
+			app = resolved
+		}
+		if _, exists := seen[app]; !exists {
+			seen[app] = struct{}{}
+			apps = append(apps, app)
+		}
+	}
+	return strings.Join(apps, ", ")
+}

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -26,6 +28,10 @@ import (
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/rs/zerolog"
 )
+
+// maxManifestSize is the maximum size of a manifest file we'll read.
+// Prevents memory exhaustion from unexpectedly large files (orbit runs as root).
+const maxManifestSize = 1 << 20 // 1 MB
 
 const tableName = "adobe_plugins"
 
@@ -142,6 +148,11 @@ func (t *adobePluginsTable) generate(ctx context.Context, queryContext table.Que
 			}
 
 			for _, entry := range entries {
+				// Skip symlinks to avoid traversing outside intended scan dirs.
+				if entry.Type()&fs.ModeSymlink != 0 {
+					continue
+				}
+
 				pluginPath := filepath.Join(dir, entry.Name())
 
 				if _, ok := seen[pluginPath]; ok {
@@ -209,7 +220,7 @@ func (t *adobePluginsTable) parseCEPPlugin(pluginPath string, sp scanPath) map[s
 	}
 
 	manifestPath := filepath.Join(pluginPath, "CSXS", "manifest.xml")
-	data, err := os.ReadFile(manifestPath)
+	data, err := readFileCapped(manifestPath, maxManifestSize)
 	if err != nil {
 		t.logger.Debug().Err(err).Str("path", manifestPath).Msg("no CEP manifest found")
 		return row
@@ -262,7 +273,7 @@ func (t *adobePluginsTable) parseUXPPlugin(pluginPath string, sp scanPath) map[s
 	}
 
 	manifestPath := filepath.Join(pluginPath, "manifest.json")
-	data, err := os.ReadFile(manifestPath)
+	data, err := readFileCapped(manifestPath, maxManifestSize)
 	if err != nil {
 		t.logger.Debug().Err(err).Str("path", manifestPath).Msg("no UXP manifest found")
 		return row
@@ -316,6 +327,17 @@ func parseNativePlugin(pluginPath string, entry os.DirEntry, sp scanPath) map[st
 		colUser:            sp.user,
 		colPlatform:        runtime.GOOS,
 	}
+}
+
+// readFileCapped reads up to maxBytes from a file. This prevents memory
+// exhaustion from unexpectedly large files since orbit runs as root.
+func readFileCapped(path string, maxBytes int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(io.LimitReader(f, maxBytes))
 }
 
 // resolveHostApps converts a list of Adobe host application codes to

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins_darwin.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins_darwin.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 func getScanPaths(level string) ([]scanPath, error) {
@@ -24,19 +26,20 @@ func getScanPaths(level string) ([]scanPath, error) {
 
 	// Per-user CEP and UXP extensions
 	users, err := listLocalUsers()
-	if err == nil {
-		for _, u := range users {
-			paths = append(paths, scanPath{
-				basePath:      filepath.Join(u.homeDir, "Library", "Application Support", "Adobe", "CEP", "extensions"),
-				extensionType: "CEP",
-				user:          u.name,
-			})
-			paths = append(paths, scanPath{
-				basePath:      filepath.Join(u.homeDir, "Library", "Application Support", "Adobe", "UXP", "extensions"),
-				extensionType: "UXP",
-				user:          u.name,
-			})
-		}
+	if err != nil {
+		log.Warn().Err(err).Msg("adobe_plugins: failed to enumerate local users, skipping per-user paths")
+	}
+	for _, u := range users {
+		paths = append(paths, scanPath{
+			basePath:      filepath.Join(u.homeDir, "Library", "Application Support", "Adobe", "CEP", "extensions"),
+			extensionType: "CEP",
+			user:          u.name,
+		})
+		paths = append(paths, scanPath{
+			basePath:      filepath.Join(u.homeDir, "Library", "Application Support", "Adobe", "UXP", "extensions"),
+			extensionType: "UXP",
+			user:          u.name,
+		})
 	}
 
 	if level == "deep" {

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins_darwin.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins_darwin.go
@@ -1,0 +1,96 @@
+//go:build darwin
+
+package adobe_plugins
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func getScanPaths(level string) ([]scanPath, error) {
+	var paths []scanPath
+
+	// System-wide CEP extensions
+	paths = append(paths, scanPath{
+		basePath:      "/Library/Application Support/Adobe/CEP/extensions",
+		extensionType: "CEP",
+	})
+	// System-wide UXP extensions
+	paths = append(paths, scanPath{
+		basePath:      "/Library/Application Support/Adobe/UXP/extensions",
+		extensionType: "UXP",
+	})
+
+	// Per-user CEP and UXP extensions
+	users, err := listLocalUsers()
+	if err == nil {
+		for _, u := range users {
+			paths = append(paths, scanPath{
+				basePath:      filepath.Join(u.homeDir, "Library", "Application Support", "Adobe", "CEP", "extensions"),
+				extensionType: "CEP",
+				user:          u.name,
+			})
+			paths = append(paths, scanPath{
+				basePath:      filepath.Join(u.homeDir, "Library", "Application Support", "Adobe", "UXP", "extensions"),
+				extensionType: "UXP",
+				user:          u.name,
+			})
+		}
+	}
+
+	if level == "deep" {
+		paths = append(paths,
+			scanPath{
+				basePath:      "/Applications/Adobe Photoshop */Plug-ins",
+				extensionType: "native",
+				hostApp:       "Photoshop",
+			},
+			scanPath{
+				basePath:      "/Applications/Adobe Premiere Pro */Plug-ins",
+				extensionType: "native",
+				hostApp:       "Premiere Pro",
+			},
+			scanPath{
+				basePath:      "/Applications/Adobe After Effects */Plug-ins",
+				extensionType: "native",
+				hostApp:       "After Effects",
+			},
+			scanPath{
+				basePath:      "/Applications/Adobe Illustrator */Plug-ins",
+				extensionType: "native",
+				hostApp:       "Illustrator",
+			},
+		)
+	}
+
+	return paths, nil
+}
+
+type localUser struct {
+	name    string
+	homeDir string
+}
+
+func listLocalUsers() ([]localUser, error) {
+	entries, err := os.ReadDir("/Users")
+	if err != nil {
+		return nil, err
+	}
+
+	var users []localUser
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") || name == "Shared" {
+			continue
+		}
+		users = append(users, localUser{
+			name:    name,
+			homeDir: filepath.Join("/Users", name),
+		})
+	}
+	return users, nil
+}

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins_stub.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins_stub.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !windows
+
+package adobe_plugins
+
+// getScanPaths returns nil on unsupported platforms (Linux, etc.).
+// Adobe Creative Cloud does not run on Linux.
+func getScanPaths(_ string) ([]scanPath, error) {
+	return nil, nil
+}

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins_test.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins_test.go
@@ -1,0 +1,233 @@
+package adobe_plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCEPPlugin(t *testing.T) {
+	t.Parallel()
+
+	tbl := &adobePluginsTable{logger: zerolog.Nop()}
+
+	t.Run("valid manifest", func(t *testing.T) {
+		t.Parallel()
+		pluginPath := filepath.Join("testdata", "cep_plugin")
+		sp := scanPath{extensionType: "CEP"}
+
+		row := tbl.parseCEPPlugin(pluginPath, sp)
+		require.NotNil(t, row)
+
+		assert.Equal(t, pluginPath, row[colPath])
+		assert.Equal(t, "cep_plugin", row[colName])
+		assert.Equal(t, "2.1.0", row[colVersion])
+		assert.Equal(t, "Test Vendor", row[colVendor])
+		assert.Equal(t, "com.example.test.plugin", row[colBundleID])
+		assert.Contains(t, row[colHostApplication], "Photoshop")
+		assert.Contains(t, row[colHostApplication], "Illustrator")
+		assert.Equal(t, "CEP", row[colExtensionType])
+	})
+
+	t.Run("missing manifest falls back to dir name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		pluginPath := filepath.Join(dir, "no_manifest_plugin")
+		require.NoError(t, os.MkdirAll(pluginPath, 0o755))
+
+		sp := scanPath{extensionType: "CEP", user: "testuser"}
+		row := tbl.parseCEPPlugin(pluginPath, sp)
+		require.NotNil(t, row)
+
+		assert.Equal(t, "no_manifest_plugin", row[colName])
+		assert.Equal(t, "CEP", row[colExtensionType])
+		assert.Equal(t, "testuser", row[colUser])
+		assert.Empty(t, row[colVersion])
+		assert.Empty(t, row[colBundleID])
+	})
+
+	t.Run("malformed manifest falls back to dir name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		pluginPath := filepath.Join(dir, "bad_manifest")
+		require.NoError(t, os.MkdirAll(filepath.Join(pluginPath, "CSXS"), 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(pluginPath, "CSXS", "manifest.xml"),
+			[]byte("not valid xml {{{"),
+			0o644,
+		))
+
+		sp := scanPath{extensionType: "CEP"}
+		row := tbl.parseCEPPlugin(pluginPath, sp)
+		require.NotNil(t, row)
+
+		assert.Equal(t, "bad_manifest", row[colName])
+		assert.Equal(t, "CEP", row[colExtensionType])
+		assert.Empty(t, row[colVersion])
+	})
+}
+
+func TestParseUXPPlugin(t *testing.T) {
+	t.Parallel()
+
+	tbl := &adobePluginsTable{logger: zerolog.Nop()}
+
+	t.Run("valid manifest", func(t *testing.T) {
+		t.Parallel()
+		pluginPath := filepath.Join("testdata", "uxp_plugin")
+		sp := scanPath{extensionType: "UXP"}
+
+		row := tbl.parseUXPPlugin(pluginPath, sp)
+		require.NotNil(t, row)
+
+		assert.Equal(t, pluginPath, row[colPath])
+		assert.Equal(t, "Test UXP Plugin", row[colName])
+		assert.Equal(t, "3.0.1", row[colVersion])
+		assert.Equal(t, "UXP Test Vendor", row[colVendor])
+		assert.Equal(t, "com.example.uxp.plugin", row[colBundleID])
+		assert.Contains(t, row[colHostApplication], "Photoshop")
+		assert.Contains(t, row[colHostApplication], "XD")
+		assert.Equal(t, "UXP", row[colExtensionType])
+	})
+
+	t.Run("missing manifest falls back to dir name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		pluginPath := filepath.Join(dir, "some_uxp_ext")
+		require.NoError(t, os.MkdirAll(pluginPath, 0o755))
+
+		sp := scanPath{extensionType: "UXP", user: "alice"}
+		row := tbl.parseUXPPlugin(pluginPath, sp)
+		require.NotNil(t, row)
+
+		assert.Equal(t, "some_uxp_ext", row[colName])
+		assert.Equal(t, "alice", row[colUser])
+		assert.Empty(t, row[colVersion])
+	})
+
+	t.Run("manifest with id but no name uses id", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		pluginPath := filepath.Join(dir, "id_only")
+		require.NoError(t, os.MkdirAll(pluginPath, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(pluginPath, "manifest.json"),
+			[]byte(`{"id": "com.vendor.idonly", "version": "1.0"}`),
+			0o644,
+		))
+
+		sp := scanPath{extensionType: "UXP"}
+		row := tbl.parseUXPPlugin(pluginPath, sp)
+		require.NotNil(t, row)
+
+		assert.Equal(t, "com.vendor.idonly", row[colName])
+		assert.Equal(t, "com.vendor.idonly", row[colBundleID])
+		assert.Equal(t, "1.0", row[colVersion])
+	})
+}
+
+func TestParseNativePlugin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fileName     string
+		expectedName string
+	}{
+		{"macOS plugin bundle", "MyPlugin.plugin", "MyPlugin"},
+		{"Photoshop filter 8bf", "CoolFilter.8bf", "CoolFilter"},
+		{"After Effects plugin", "Effect.aex", "Effect"},
+		{"Windows DLL plugin", "Plugin.dll", "Plugin"},
+		{"no extension", "SomePlugin", "SomePlugin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			pluginPath := filepath.Join(dir, tt.fileName)
+
+			f, err := os.Create(pluginPath)
+			require.NoError(t, err)
+			f.Close()
+
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+
+			sp := scanPath{extensionType: "native", hostApp: "Photoshop"}
+			row := parseNativePlugin(pluginPath, entries[0], sp)
+			require.NotNil(t, row)
+
+			assert.Equal(t, tt.expectedName, row[colName])
+			assert.Equal(t, "Photoshop", row[colHostApplication])
+			assert.Equal(t, "native", row[colExtensionType])
+		})
+	}
+}
+
+func TestResolveHostApps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		codes    []string
+		expected string
+	}{
+		{"single known code", []string{"PHXS"}, "Photoshop"},
+		{"multiple codes", []string{"PHXS", "ILST"}, "Photoshop, Illustrator"},
+		{"deduplicates same app", []string{"PHXS", "PHSP"}, "Photoshop"},
+		{"unknown code passes through", []string{"UNKNOWN"}, "UNKNOWN"},
+		{"mixed known and unknown", []string{"PPRO", "CUSTOM"}, "Premiere Pro, CUSTOM"},
+		{"empty list", nil, ""},
+		{"case insensitive", []string{"phxs"}, "Photoshop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := resolveHostApps(tt.codes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestScanEntry(t *testing.T) {
+	t.Parallel()
+
+	tbl := &adobePluginsTable{logger: zerolog.Nop()}
+
+	t.Run("CEP skips non-directory entries", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		f, err := os.Create(filepath.Join(dir, "notadir.txt"))
+		require.NoError(t, err)
+		f.Close()
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+
+		sp := scanPath{extensionType: "CEP"}
+		row := tbl.scanEntry(filepath.Join(dir, "notadir.txt"), entries[0], sp)
+		assert.Nil(t, row)
+	})
+
+	t.Run("native skips hidden files", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		f, err := os.Create(filepath.Join(dir, ".DS_Store"))
+		require.NoError(t, err)
+		f.Close()
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+
+		sp := scanPath{extensionType: "native", hostApp: "Photoshop"}
+		row := tbl.scanEntry(filepath.Join(dir, ".DS_Store"), entries[0], sp)
+		assert.Nil(t, row)
+	})
+}

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins_windows.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins_windows.go
@@ -1,0 +1,106 @@
+//go:build windows
+
+package adobe_plugins
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func getScanPaths(level string) ([]scanPath, error) {
+	var paths []scanPath
+
+	// System-wide CEP extensions
+	paths = append(paths, scanPath{
+		basePath:      `C:\Program Files\Common Files\Adobe\CEP\extensions`,
+		extensionType: "CEP",
+	})
+	paths = append(paths, scanPath{
+		basePath:      `C:\Program Files (x86)\Common Files\Adobe\CEP\extensions`,
+		extensionType: "CEP",
+	})
+
+	// System-wide UXP extensions
+	paths = append(paths, scanPath{
+		basePath:      `C:\Program Files\Common Files\Adobe\UXP\extensions`,
+		extensionType: "UXP",
+	})
+
+	// Per-user CEP and UXP extensions
+	users, err := listLocalUsers()
+	if err == nil {
+		for _, u := range users {
+			paths = append(paths, scanPath{
+				basePath:      filepath.Join(u.homeDir, "AppData", "Roaming", "Adobe", "CEP", "extensions"),
+				extensionType: "CEP",
+				user:          u.name,
+			})
+			paths = append(paths, scanPath{
+				basePath:      filepath.Join(u.homeDir, "AppData", "Roaming", "Adobe", "UXP", "extensions"),
+				extensionType: "UXP",
+				user:          u.name,
+			})
+		}
+	}
+
+	if level == "deep" {
+		paths = append(paths,
+			scanPath{
+				basePath:      `C:\Program Files\Adobe\Adobe Photoshop *\Plug-ins`,
+				extensionType: "native",
+				hostApp:       "Photoshop",
+			},
+			scanPath{
+				basePath:      `C:\Program Files\Adobe\Adobe Premiere Pro *\Plug-ins`,
+				extensionType: "native",
+				hostApp:       "Premiere Pro",
+			},
+			scanPath{
+				basePath:      `C:\Program Files\Adobe\Adobe After Effects *\Plug-ins`,
+				extensionType: "native",
+				hostApp:       "After Effects",
+			},
+		)
+	}
+
+	return paths, nil
+}
+
+type localUser struct {
+	name    string
+	homeDir string
+}
+
+func listLocalUsers() ([]localUser, error) {
+	entries, err := os.ReadDir(`C:\Users`)
+	if err != nil {
+		return nil, err
+	}
+
+	skipNames := map[string]struct{}{
+		"public":       {},
+		"default":      {},
+		"default user": {},
+		"all users":    {},
+	}
+
+	var users []localUser
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if _, skip := skipNames[strings.ToLower(name)]; skip {
+			continue
+		}
+		users = append(users, localUser{
+			name:    name,
+			homeDir: filepath.Join(`C:\Users`, name),
+		})
+	}
+	return users, nil
+}

--- a/orbit/pkg/table/adobe_plugins/adobe_plugins_windows.go
+++ b/orbit/pkg/table/adobe_plugins/adobe_plugins_windows.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 func getScanPaths(level string) ([]scanPath, error) {
@@ -29,19 +31,20 @@ func getScanPaths(level string) ([]scanPath, error) {
 
 	// Per-user CEP and UXP extensions
 	users, err := listLocalUsers()
-	if err == nil {
-		for _, u := range users {
-			paths = append(paths, scanPath{
-				basePath:      filepath.Join(u.homeDir, "AppData", "Roaming", "Adobe", "CEP", "extensions"),
-				extensionType: "CEP",
-				user:          u.name,
-			})
-			paths = append(paths, scanPath{
-				basePath:      filepath.Join(u.homeDir, "AppData", "Roaming", "Adobe", "UXP", "extensions"),
-				extensionType: "UXP",
-				user:          u.name,
-			})
-		}
+	if err != nil {
+		log.Warn().Err(err).Msg("adobe_plugins: failed to enumerate local users, skipping per-user paths")
+	}
+	for _, u := range users {
+		paths = append(paths, scanPath{
+			basePath:      filepath.Join(u.homeDir, "AppData", "Roaming", "Adobe", "CEP", "extensions"),
+			extensionType: "CEP",
+			user:          u.name,
+		})
+		paths = append(paths, scanPath{
+			basePath:      filepath.Join(u.homeDir, "AppData", "Roaming", "Adobe", "UXP", "extensions"),
+			extensionType: "UXP",
+			user:          u.name,
+		})
 	}
 
 	if level == "deep" {

--- a/orbit/pkg/table/adobe_plugins/testdata/cep_plugin/CSXS/manifest.xml
+++ b/orbit/pkg/table/adobe_plugins/testdata/cep_plugin/CSXS/manifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    ExtensionBundleId="com.example.test.plugin"
+    ExtensionBundleVersion="2.1.0"
+    Version="7.0">
+    <Author Name="Test Vendor"/>
+    <ExtensionList>
+        <Extension Id="com.example.test.plugin.panel" Version="2.1.0"/>
+    </ExtensionList>
+    <ExecutionEnvironment>
+        <HostList>
+            <Host Name="PHXS" Version="[15.0,99.9]"/>
+            <Host Name="ILST" Version="[19.0,99.9]"/>
+        </HostList>
+    </ExecutionEnvironment>
+</ExtensionManifest>

--- a/orbit/pkg/table/adobe_plugins/testdata/uxp_plugin/manifest.json
+++ b/orbit/pkg/table/adobe_plugins/testdata/uxp_plugin/manifest.json
@@ -1,0 +1,12 @@
+{
+    "id": "com.example.uxp.plugin",
+    "name": "Test UXP Plugin",
+    "version": "3.0.1",
+    "host": [
+        {"app": "PS", "minVersion": "22.0.0"},
+        {"app": "XD", "minVersion": "36.0.0"}
+    ],
+    "metadata": {
+        "publisher": "UXP Test Vendor"
+    }
+}

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/adobe_plugins"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/cryptoinfotable"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dataflattentable"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/filecontents"
@@ -153,6 +154,7 @@ func OrbitDefaultTables(opts PluginOpts) []osquery.OsqueryPlugin {
 		// Note: the logger passed here and to all other tables is the global logger from zerolog.
 		// This logger has already been configured with some required settings in
 		// orbit/cmd/orbit/orbit.go.
+		adobe_plugins.TablePlugin(log.Logger),
 		firefox_preferences.TablePlugin(log.Logger),
 		cryptoinfotable.TablePlugin(log.Logger),
 


### PR DESCRIPTION

## Summary

- Adds a new `adobe_plugins` osquery extension table to fleetd (macOS + Windows)
- Parses CEP (`CSXS/manifest.xml`) and UXP (`manifest.json`) manifests for rich metadata
- Falls back to filesystem info for native plug-ins where no manifest exists
- Supports a `scan_level` WHERE constraint: `standard` (default) or `deep`

## Table schema

| Column | Type | Description |
| --- | --- | --- |
| `path` | TEXT | Full path to the plugin directory or file |
| `name` | TEXT | Plugin display name (from manifest or directory name) |
| `version` | TEXT | Plugin version (from manifest) |
| `vendor` | TEXT | Plugin author/publisher (from manifest) |
| `bundle_id` | TEXT | Plugin bundle identifier (from manifest) |
| `host_application` | TEXT | Target app(s): Photoshop, Illustrator, Premiere Pro, etc. |
| `extension_type` | TEXT | `CEP`, `UXP`, or `native` |
| `user` | TEXT | Username for user-scoped installs; empty for system-wide |
| `platform` | TEXT | `darwin` or `windows` |
| `scan_level` | TEXT | WHERE constraint only — `standard` (default) or `deep` |

## How I tested it (macOS)

### Unit tests — 22 passing

```
$ go test ./orbit/pkg/table/adobe_plugins/... -v
--- PASS: TestParseCEPPlugin/valid_manifest
--- PASS: TestParseCEPPlugin/missing_manifest_falls_back_to_dir_name
--- PASS: TestParseCEPPlugin/malformed_manifest_falls_back_to_dir_name
--- PASS: TestParseUXPPlugin/valid_manifest
--- PASS: TestParseUXPPlugin/missing_manifest_falls_back_to_dir_name
--- PASS: TestParseUXPPlugin/manifest_with_id_but_no_name_uses_id
--- PASS: TestParseNativePlugin/* (5 subtests)
--- PASS: TestResolveHostApps/* (7 subtests)
--- PASS: TestScanEntry/* (2 subtests)
PASS
```

### Cross-platform compilation

```
$ go build ./orbit/pkg/table/adobe_plugins/...                  # macOS ✅
$ GOOS=windows go build ./orbit/pkg/table/adobe_plugins/...     # Windows ✅
$ GOOS=linux go build ./orbit/pkg/table/adobe_plugins/...       # Linux stub ✅
$ go build ./orbit/cmd/fleetd_tables/                           # Full fleetd binary ✅
$ go vet ./orbit/pkg/table/adobe_plugins/...                    # Clean ✅
```

### Manual testing on macOS via osqueryi

Built the extension and ran it against osquery 5.23.0:

```bash
go build -o build/fleetd-tables-test ./orbit/cmd/fleetd_tables/
OSQUERYD="/opt/orbit/bin/osqueryd/macos-app/stable/osquery.app/Contents/MacOS/osqueryd"
$OSQUERYD -S --allow_unsafe --extensions_timeout=10 \
  --extensions_require=com.fleetdm.fleetd_tables.osquery_extension.v1 \
  --extension build/fleetd-tables-test
```

**1. Schema registered correctly:**
```
osquery> .schema adobe_plugins
CREATE TABLE adobe_plugins(`path` TEXT, `name` TEXT, `version` TEXT,
  `vendor` TEXT, `bundle_id` TEXT, `host_application` TEXT,
  `extension_type` TEXT, `user` TEXT, `platform` TEXT, `scan_level` TEXT);
```

**2. CEP extension with manifest** — placed a test plugin at `~/Library/Application Support/Adobe/CEP/extensions/com.test.photoshop.tool/CSXS/manifest.xml`:

```json
{
  "bundle_id": "com.test.photoshop.tool",
  "extension_type": "CEP",
  "host_application": "Photoshop, Premiere Pro",
  "name": "com.test.photoshop.tool",
  "path": "/Users/sharonkatz/Library/Application Support/Adobe/CEP/extensions/com.test.photoshop.tool",
  "platform": "darwin",
  "user": "sharonkatz",
  "vendor": "Test Author Inc",
  "version": "1.5.0"
}
```
✅ All manifest fields parsed correctly. Host codes `PHXS` → `Photoshop`, `PPRO` → `Premiere Pro`.

**3. CEP extension with no manifest** (fallback) — empty directory `orphan-extension`:

```json
{
  "extension_type": "CEP",
  "name": "orphan-extension",
  "path": "...extensions/orphan-extension",
  "platform": "darwin",
  "user": "sharonkatz",
  "vendor": "",
  "version": ""
}
```
✅ Falls back to directory name. Empty version/vendor, no error.

**4. UXP extension with JSON manifest** — `~/Library/Application Support/Adobe/UXP/extensions/cool-plugin/manifest.json`:

```json
{
  "bundle_id": "com.test.cool-plugin",
  "extension_type": "UXP",
  "host_application": "Photoshop",
  "name": "Cool Plugin",
  "path": "...extensions/cool-plugin",
  "platform": "darwin",
  "user": "sharonkatz",
  "vendor": "Cool Corp",
  "version": "2.0.0"
}
```
✅ JSON manifest parsed. `name` from manifest (not directory name). `PS` → `Photoshop`.

**5. No Adobe installed** → `SELECT * FROM adobe_plugins` returns 0 rows, no error. ✅

**6. Deep scan** → `SELECT * FROM adobe_plugins WHERE scan_level = 'deep'` returns 0 additional rows (no Photoshop app bundle on this machine), no error. ✅

### Windows

Not tested yet — Windows paths are implemented and cross-compile, but need manual verification on a Windows host with Adobe CC.