### PR TITLE
Fix custom org logo delete for external URLs (#45213)

### DIFF
--- a/changes/45213-custom-logo-delete-fails-if-external-url
+++ b/changes/45213-custom-logo-delete-fails-if-external-url
@@ -1,0 +1,1 @@
+* Fixed custom org logo delete failing when the configured logo URL pointed at an external host.

--- a/changes/45213-custom-logo-delete-fails-if-external-url
+++ b/changes/45213-custom-logo-delete-fails-if-external-url
@@ -1,1 +1,0 @@
-* Fixed custom org logo delete failing when the configured logo URL pointed at an external host.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -17022,4 +17022,28 @@ func (s *integrationTestSuite) TestOrgLogoUpload() {
 
 	res = s.DoRawNoAuth("GET", "/api/latest/fleet/logo?mode=light", nil, http.StatusNotFound)
 	require.NoError(t, res.Body.Close())
+
+	// 6. DELETE for an external URL: customer sets a logo URL pointing at
+	// an external host, then deletes via the UI. The endpoint must clear
+	// the URL field without touching any store (#45213).
+	s.DoRaw("PATCH", "/api/latest/fleet/config", []byte(`{
+		"org_info": {
+			"org_logo_url": "https://placehold.co/100",
+			"org_logo_url_light_mode": "https://placehold.co/200"
+		}
+	}`), http.StatusOK)
+
+	s.Do("DELETE", "/api/v1/fleet/logo", nil, http.StatusOK, "mode", "dark")
+	s.DoJSON("GET", "/api/v1/fleet/config", nil, http.StatusOK, &acResp)
+	require.Empty(t, acResp.OrgInfo.OrgLogoURLDarkMode)
+	require.Empty(t, acResp.OrgInfo.OrgLogoURL)
+	require.Equal(t, "https://placehold.co/200", acResp.OrgInfo.OrgLogoURLLightMode)
+
+	s.Do("DELETE", "/api/v1/fleet/logo", nil, http.StatusOK, "mode", "light")
+	s.DoJSON("GET", "/api/v1/fleet/config", nil, http.StatusOK, &acResp)
+	require.Empty(t, acResp.OrgInfo.OrgLogoURLLightMode)
+	require.Empty(t, acResp.OrgInfo.OrgLogoURLLightBackground)
+
+	// 7. DELETE when no logo is set returns 400 (existing behavior preserved).
+	s.Do("DELETE", "/api/v1/fleet/logo", nil, http.StatusBadRequest, "mode", "dark")
 }

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -17025,10 +17025,14 @@ func (s *integrationTestSuite) TestOrgLogoUpload() {
 
 	// 6. DELETE for an external URL: customer sets a logo URL pointing at
 	// an external host, then deletes via the UI. The endpoint must clear
-	// the URL field without touching any store (#45213).
+	// the URL field without touching any store (#45213). The dark side
+	// still has a Fleet-hosted URL from step 2, so we replace both keys
+	// for each pair to keep NormalizeLogoFields happy.
 	s.DoRaw("PATCH", "/api/latest/fleet/config", []byte(`{
 		"org_info": {
 			"org_logo_url": "https://placehold.co/100",
+			"org_logo_url_dark_mode": "https://placehold.co/100",
+			"org_logo_url_light_background": "https://placehold.co/200",
 			"org_logo_url_light_mode": "https://placehold.co/200"
 		}
 	}`), http.StatusOK)
@@ -17038,6 +17042,7 @@ func (s *integrationTestSuite) TestOrgLogoUpload() {
 	require.Empty(t, acResp.OrgInfo.OrgLogoURLDarkMode)
 	require.Empty(t, acResp.OrgInfo.OrgLogoURL)
 	require.Equal(t, "https://placehold.co/200", acResp.OrgInfo.OrgLogoURLLightMode)
+	require.Equal(t, "https://placehold.co/200", acResp.OrgInfo.OrgLogoURLLightBackground)
 
 	s.Do("DELETE", "/api/v1/fleet/logo", nil, http.StatusOK, "mode", "light")
 	s.DoJSON("GET", "/api/v1/fleet/config", nil, http.StatusOK, &acResp)

--- a/server/service/org_logo.go
+++ b/server/service/org_logo.go
@@ -239,10 +239,10 @@ func (svc *Service) DeleteOrgLogo(ctx context.Context, mode fleet.OrgLogoMode) e
 		return ctxerr.New(ctx, "org logo store not configured")
 	}
 
-	// Read AppConfig up front so we can distinguish Fleet-hosted URLs (which
-	// also have a blob in the store) from external URLs (which don't). For
-	// external URLs there's nothing to delete from the store — we just clear
-	// the URL field. Bypass the cache so we see any concurrent write.
+	// Read AppConfig so we can clear the URL fields even when there's no
+	// backing blob in the store (e.g. the URL was set to an external host
+	// like https://example.com/logo.png). Bypass the cache so we see any
+	// concurrent write.
 	ctx = ctxdb.BypassCachedMysql(ctx, true)
 	ac, err := svc.ds.AppConfig(ctx)
 	if err != nil {
@@ -251,27 +251,24 @@ func (svc *Service) DeleteOrgLogo(ctx context.Context, mode fleet.OrgLogoMode) e
 
 	// toDelete: modes whose blob lives in the store and must be removed.
 	// toClear: modes whose URL field is non-empty and must be cleared.
-	// The two sets can diverge:
-	//   - External URL → toClear only (no blob backs an external URL).
-	//   - Empty URL + lingering blob → toDelete only. Happens in the
-	//     GitOps flow, which PATCHes the URL to "" before calling
-	//     DeleteOrgLogo to drop the blob (see doGitOpsOrgLogos).
-	//   - Fleet-hosted URL + blob → both.
+	// The two sets are computed independently because they can diverge:
+	//   - External URL with no blob → toClear only.
+	//   - Empty URL with orphan blob → toDelete only. Happens in the GitOps
+	//     flow (doGitOpsOrgLogos PATCHes the URL to "" before calling
+	//     DeleteOrgLogo) or after a PATCH overwrites a Fleet-hosted URL
+	//     with an external one without clearing the previously stored blob.
+	//   - Fleet-hosted URL with blob → both.
 	modes := mode.Modes()
 	var toDelete, toClear []fleet.OrgLogoMode
 	for _, m := range modes {
-		currentURL := orgLogoURLForMode(&ac.OrgInfo, m)
-		if currentURL != "" {
+		if orgLogoURLForMode(&ac.OrgInfo, m) != "" {
 			toClear = append(toClear, m)
 		}
-		// External URLs never have a backing blob — skip the Exists check.
-		// For empty or Fleet-hosted URLs the blob may exist.
-		if currentURL != "" && !fleet.IsFleetHostedLogoURL(currentURL) {
-			continue
-		}
-		// The S3 store's Delete is silent on missing keys, so check Exists
-		// first — otherwise we'd persist a misleading "logo deleted" activity
-		// when there was nothing to delete.
+		// Always check Exists: a blob may live in the store independent of
+		// what the URL field currently says (orphan from a prior partial
+		// state). The S3 store's Delete is silent on missing keys, so
+		// without this check we'd persist a misleading "logo deleted"
+		// activity when there was nothing to delete.
 		exists, err := svc.orgLogoStore.Exists(ctx, m)
 		if err != nil {
 			return ctxerr.Wrapf(ctx, err, "checking org logo exists (%s)", m)

--- a/server/service/org_logo.go
+++ b/server/service/org_logo.go
@@ -239,12 +239,39 @@ func (svc *Service) DeleteOrgLogo(ctx context.Context, mode fleet.OrgLogoMode) e
 		return ctxerr.New(ctx, "org logo store not configured")
 	}
 
-	// Filter to modes that actually have something to delete.
-	// (The S3 store's Delete is silent on missing keys, so without this check
-	// we'd persist a "logo deleted" activity.)
+	// Read AppConfig up front so we can distinguish Fleet-hosted URLs (which
+	// also have a blob in the store) from external URLs (which don't). For
+	// external URLs there's nothing to delete from the store — we just clear
+	// the URL field. Bypass the cache so we see any concurrent write.
+	ctx = ctxdb.BypassCachedMysql(ctx, true)
+	ac, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "loading app config")
+	}
+
+	// toDelete: modes whose blob lives in the store and must be removed.
+	// toClear: modes whose URL field is non-empty and must be cleared.
+	// The two sets can diverge:
+	//   - External URL → toClear only (no blob backs an external URL).
+	//   - Empty URL + lingering blob → toDelete only. Happens in the
+	//     GitOps flow, which PATCHes the URL to "" before calling
+	//     DeleteOrgLogo to drop the blob (see doGitOpsOrgLogos).
+	//   - Fleet-hosted URL + blob → both.
 	modes := mode.Modes()
-	toDelete := modes[:0:0]
+	var toDelete, toClear []fleet.OrgLogoMode
 	for _, m := range modes {
+		currentURL := orgLogoURLForMode(&ac.OrgInfo, m)
+		if currentURL != "" {
+			toClear = append(toClear, m)
+		}
+		// External URLs never have a backing blob — skip the Exists check.
+		// For empty or Fleet-hosted URLs the blob may exist.
+		if currentURL != "" && !fleet.IsFleetHostedLogoURL(currentURL) {
+			continue
+		}
+		// The S3 store's Delete is silent on missing keys, so check Exists
+		// first — otherwise we'd persist a misleading "logo deleted" activity
+		// when there was nothing to delete.
 		exists, err := svc.orgLogoStore.Exists(ctx, m)
 		if err != nil {
 			return ctxerr.Wrapf(ctx, err, "checking org logo exists (%s)", m)
@@ -253,7 +280,7 @@ func (svc *Service) DeleteOrgLogo(ctx context.Context, mode fleet.OrgLogoMode) e
 			toDelete = append(toDelete, m)
 		}
 	}
-	if len(toDelete) == 0 {
+	if len(toClear) == 0 && len(toDelete) == 0 {
 		return &fleet.BadRequestError{Message: "no org logo to delete for the given mode"}
 	}
 
@@ -271,8 +298,12 @@ func (svc *Service) DeleteOrgLogo(ctx context.Context, mode fleet.OrgLogoMode) e
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
-	if err := svc.updateOrgLogoURLs(ctx, toDelete, false); err != nil {
-		return err
+	// Skip the SaveAppConfig round-trip when there are no URLs to clear
+	// (e.g. the GitOps flow already PATCHed them to "" before calling us).
+	if len(toClear) > 0 {
+		if err := svc.updateOrgLogoURLs(ctx, toClear, false); err != nil {
+			return err
+		}
 	}
 
 	if vc, ok := viewer.FromContext(ctx); ok {
@@ -321,6 +352,26 @@ func (svc *Service) GetOrgLogo(ctx context.Context, mode fleet.OrgLogoMode) ([]b
 // orgLogoServingURL builds the URL persisted in AppConfig after an upload. The `v` param is a cache-buster (ignored server-side; only `mode` is read).
 func orgLogoServingURL(mode fleet.OrgLogoMode) string {
 	return fmt.Sprintf("/api/latest/fleet/logo?mode=%s&v=%d", mode, time.Now().UnixNano())
+}
+
+// orgLogoURLForMode returns the currently-configured URL for the given mode,
+// preferring the new field but falling back to the deprecated one when only
+// the legacy field is populated (e.g. a value written directly to the DB
+// before NormalizeLogoFields could mirror it).
+func orgLogoURLForMode(o *fleet.OrgInfo, mode fleet.OrgLogoMode) string {
+	switch mode {
+	case fleet.OrgLogoModeLight:
+		if o.OrgLogoURLLightMode != "" {
+			return o.OrgLogoURLLightMode
+		}
+		return o.OrgLogoURLLightBackground
+	case fleet.OrgLogoModeDark:
+		if o.OrgLogoURLDarkMode != "" {
+			return o.OrgLogoURLDarkMode
+		}
+		return o.OrgLogoURL
+	}
+	return ""
 }
 
 // updateOrgLogoURLs sets (uploaded=true) or clears (uploaded=false) the

--- a/server/service/org_logo_test.go
+++ b/server/service/org_logo_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
-	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,22 +34,22 @@ func TestOrgLogoAuth(t *testing.T) {
 	}{
 		{
 			"global admin",
-			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			&fleet.User{GlobalRole: new(fleet.RoleAdmin)},
 			false,
 		},
 		{
 			"global maintainer",
-			&fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)},
+			&fleet.User{GlobalRole: new(fleet.RoleMaintainer)},
 			true,
 		},
 		{
 			"global observer",
-			&fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)},
+			&fleet.User{GlobalRole: new(fleet.RoleObserver)},
 			true,
 		},
 		{
 			"global observer+",
-			&fleet.User{GlobalRole: ptr.String(fleet.RoleObserverPlus)},
+			&fleet.User{GlobalRole: new(fleet.RoleObserverPlus)},
 			true,
 		},
 		{
@@ -58,7 +57,7 @@ func TestOrgLogoAuth(t *testing.T) {
 			// which is what fleetctl gitops uses to upload custom org
 			// logos via the new org_logo_path_*_mode keys.
 			"global gitops",
-			&fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
+			&fleet.User{GlobalRole: new(fleet.RoleGitOps)},
 			false,
 		},
 		{
@@ -128,7 +127,7 @@ func TestDeleteOrgLogoExternalURL(t *testing.T) {
 		opts := &TestServerOpts{}
 		svc, ctx := newTestService(t, ds, nil, nil, opts)
 		ctx = viewer.NewContext(ctx, viewer.Viewer{
-			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+			User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)},
 		})
 
 		dsAppConfig := &fleet.AppConfig{
@@ -166,7 +165,7 @@ func TestDeleteOrgLogoExternalURL(t *testing.T) {
 		opts := &TestServerOpts{}
 		svc, ctx := newTestService(t, ds, nil, nil, opts)
 		ctx = viewer.NewContext(ctx, viewer.Viewer{
-			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+			User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)},
 		})
 
 		// Light mode has a Fleet-hosted URL (would normally have a blob in
@@ -210,7 +209,7 @@ func TestDeleteOrgLogoExternalURL(t *testing.T) {
 		opts := &TestServerOpts{}
 		svc, ctx := newTestService(t, ds, nil, nil, opts)
 		ctx = viewer.NewContext(ctx, viewer.Viewer{
-			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+			User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)},
 		})
 
 		dsAppConfig := &fleet.AppConfig{}
@@ -245,7 +244,7 @@ func TestDeleteOrgLogoExternalURL(t *testing.T) {
 		opts := &TestServerOpts{}
 		svc, ctx := newTestService(t, ds, nil, nil, opts)
 		ctx = viewer.NewContext(ctx, viewer.Viewer{
-			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+			User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)},
 		})
 
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -269,7 +268,7 @@ func TestDeleteOrgLogoExternalURL(t *testing.T) {
 		opts := &TestServerOpts{}
 		svc, ctx := newTestService(t, ds, nil, nil, opts)
 		ctx = viewer.NewContext(ctx, viewer.Viewer{
-			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+			User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)},
 		})
 
 		dsAppConfig := &fleet.AppConfig{

--- a/server/service/org_logo_test.go
+++ b/server/service/org_logo_test.go
@@ -3,8 +3,12 @@ package service
 import (
 	"bytes"
 	"context"
+	"image"
+	"image/color"
+	"image/png"
 	"testing"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -111,6 +115,185 @@ func TestOrgLogoAuth(t *testing.T) {
 	t.Run("public GET without viewer", func(t *testing.T) {
 		_, _, err := svc.GetOrgLogo(ctx, fleet.OrgLogoModeLight)
 		checkOrgLogoAuth(t, false, err)
+	})
+}
+
+// TestDeleteOrgLogoExternalURL covers the case where the configured logo URL
+// points at an external host (e.g. https://placehold.co/100) — the legacy
+// behavior errored because nothing exists in the store to delete, but the
+// user still needs the URL field cleared.
+func TestDeleteOrgLogoExternalURL(t *testing.T) {
+	t.Run("dark mode only, external URL", func(t *testing.T) {
+		ds := new(mock.Store)
+		opts := &TestServerOpts{}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = viewer.NewContext(ctx, viewer.Viewer{
+			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+		})
+
+		dsAppConfig := &fleet.AppConfig{
+			OrgInfo: fleet.OrgInfo{
+				OrgLogoURL:         "https://placehold.co/100",
+				OrgLogoURLDarkMode: "https://placehold.co/100",
+			},
+		}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return dsAppConfig, nil
+		}
+		var saved *fleet.AppConfig
+		ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+			saved = conf
+			return nil
+		}
+
+		var activityFired bool
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, act activity_api.ActivityDetails) error {
+			if _, ok := act.(fleet.ActivityTypeDeletedOrgLogo); ok {
+				activityFired = true
+			}
+			return nil
+		}
+
+		require.NoError(t, svc.DeleteOrgLogo(ctx, fleet.OrgLogoModeDark))
+		require.True(t, activityFired)
+		require.NotNil(t, saved)
+		require.Empty(t, saved.OrgInfo.OrgLogoURL)
+		require.Empty(t, saved.OrgInfo.OrgLogoURLDarkMode)
+	})
+
+	t.Run("mode=all with mixed Fleet-hosted and external URLs", func(t *testing.T) {
+		ds := new(mock.Store)
+		opts := &TestServerOpts{}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = viewer.NewContext(ctx, viewer.Viewer{
+			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+		})
+
+		// Light mode has a Fleet-hosted URL (would normally have a blob in
+		// the store — we leave the store empty so Exists returns false,
+		// which is treated the same as "already deleted" by the existing
+		// idempotency path). Dark mode is external.
+		dsAppConfig := &fleet.AppConfig{
+			OrgInfo: fleet.OrgInfo{
+				OrgLogoURLLightMode:       "/api/latest/fleet/logo?mode=light&v=123",
+				OrgLogoURLLightBackground: "/api/latest/fleet/logo?mode=light&v=123",
+				OrgLogoURL:                "https://placehold.co/100",
+				OrgLogoURLDarkMode:        "https://placehold.co/100",
+			},
+		}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return dsAppConfig, nil
+		}
+		var saved *fleet.AppConfig
+		ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+			saved = conf
+			return nil
+		}
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		require.NoError(t, svc.DeleteOrgLogo(ctx, fleet.OrgLogoModeAll))
+		require.NotNil(t, saved)
+		require.Empty(t, saved.OrgInfo.OrgLogoURLLightMode)
+		require.Empty(t, saved.OrgInfo.OrgLogoURLLightBackground)
+		require.Empty(t, saved.OrgInfo.OrgLogoURLDarkMode)
+		require.Empty(t, saved.OrgInfo.OrgLogoURL)
+	})
+
+	t.Run("URL already empty but blob remains (gitops PATCH-then-delete flow)", func(t *testing.T) {
+		// In the GitOps clearing path, doGitOpsOrgLogos PATCHes the URL to ""
+		// first, then calls DeleteOrgLogo to drop the blob. DeleteOrgLogo
+		// must still find and remove the blob even though the URL is
+		// already empty.
+		ds := new(mock.Store)
+		opts := &TestServerOpts{}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = viewer.NewContext(ctx, viewer.Viewer{
+			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+		})
+
+		dsAppConfig := &fleet.AppConfig{}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return dsAppConfig, nil
+		}
+		ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+			*dsAppConfig = *conf
+			return nil
+		}
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		// Plant a blob in the store for dark mode via UploadOrgLogo so the
+		// real filesystem store wired by newTestService has something to
+		// delete. Then zero out the URL fields to simulate the
+		// post-PATCH state GitOps lands in before invoking DeleteOrgLogo.
+		pngImg := image.NewRGBA(image.Rect(0, 0, 1, 1))
+		pngImg.Set(0, 0, color.RGBA{R: 0, G: 128, B: 0, A: 255})
+		var pngBuf bytes.Buffer
+		require.NoError(t, png.Encode(&pngBuf, pngImg))
+		require.NoError(t, svc.UploadOrgLogo(ctx, fleet.OrgLogoModeDark, bytes.NewReader(pngBuf.Bytes())))
+		dsAppConfig.OrgInfo.OrgLogoURL = ""
+		dsAppConfig.OrgInfo.OrgLogoURLDarkMode = ""
+
+		require.NoError(t, svc.DeleteOrgLogo(ctx, fleet.OrgLogoModeDark))
+	})
+
+	t.Run("nothing to clear returns BadRequest", func(t *testing.T) {
+		ds := new(mock.Store)
+		opts := &TestServerOpts{}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = viewer.NewContext(ctx, viewer.Viewer{
+			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+		})
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil
+		}
+		ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+			return nil
+		}
+
+		err := svc.DeleteOrgLogo(ctx, fleet.OrgLogoModeDark)
+		require.Error(t, err)
+		var br *fleet.BadRequestError
+		require.ErrorAs(t, err, &br)
+	})
+
+	t.Run("legacy deprecated field only", func(t *testing.T) {
+		// Mirrors the issue's repro: an external URL is written directly to
+		// the DB under the deprecated org_logo_url field (so the new
+		// mode-aware field is empty until NormalizeLogoFields runs). DELETE
+		// must still clear it.
+		ds := new(mock.Store)
+		opts := &TestServerOpts{}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = viewer.NewContext(ctx, viewer.Viewer{
+			User: &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)},
+		})
+
+		dsAppConfig := &fleet.AppConfig{
+			OrgInfo: fleet.OrgInfo{
+				OrgLogoURL: "https://placehold.co/100",
+			},
+		}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return dsAppConfig, nil
+		}
+		var saved *fleet.AppConfig
+		ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+			saved = conf
+			return nil
+		}
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		require.NoError(t, svc.DeleteOrgLogo(ctx, fleet.OrgLogoModeDark))
+		require.NotNil(t, saved)
+		require.Empty(t, saved.OrgInfo.OrgLogoURL)
+		require.Empty(t, saved.OrgInfo.OrgLogoURLDarkMode)
 	})
 }
 

--- a/server/service/org_logo_test.go
+++ b/server/service/org_logo_test.go
@@ -262,10 +262,9 @@ func TestDeleteOrgLogoExternalURL(t *testing.T) {
 	})
 
 	t.Run("legacy deprecated field only", func(t *testing.T) {
-		// Mirrors the issue's repro: an external URL is written directly to
-		// the DB under the deprecated org_logo_url field (so the new
-		// mode-aware field is empty until NormalizeLogoFields runs). DELETE
-		// must still clear it.
+		// an external URL is written directly to the DB under the deprecated org_logo_url field
+		// (so the new mode-aware field is empty until NormalizeLogoFields runs).
+		// DELETE must still clear it.
 		ds := new(mock.Store)
 		opts := &TestServerOpts{}
 		svc, ctx := newTestService(t, ds, nil, nil, opts)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45213 (issue created while I was running the test plan for the parent issue: https://github.com/fleetdm/fleet/issues/39016)

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Did a gitops run to apply external URLs as logos:

<img width="395" height="122" alt="Screenshot 2026-05-12 at 10 52 25 AM" src="https://github.com/user-attachments/assets/a1fea9ce-7a3d-419b-8c56-68568dcc704e" />

Command: `./build/fleetctl gitops -f /Users/nico/dev/gitops-output-test/default.yml` (**gitops-output-test** is where I usually have my gitops outputs).

Then I deleted both from the UI:


https://github.com/user-attachments/assets/03899795-7cda-485d-b87e-25f829b928b7



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom organization logo deletion when the configured logo URL points to an external host; deletion now correctly clears external and internal logo entries and records the deletion activity.

* **Tests**
  * Added tests covering deletion behavior for external URLs, legacy/mixed URL states, idempotent deletions, and activity recording.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45215)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->