### PR TITLE
Improve Slack notification for docker image trivy CVE detection

### DIFF
--- a/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
@@ -81,7 +81,33 @@ jobs:
             --pkg-types=os,library \
             --severity=HIGH,CRITICAL \
             --vex="${{ steps.generate_vex_files.outputs.VEX_FILES }}" \
-            fleetdm/fleetctl
+            --format=json \
+            --output=trivy-results.json \
+            fleetdm/fleetctl || trivy_exit_code=$?
+          # Print a human-readable table to the job log for debugging.
+          ./trivy convert --format table trivy-results.json
+          exit "${trivy_exit_code:-0}"
+
+      - name: Extract CVE list for Slack notification
+        id: extract_cves
+        if: failure()
+        run: |
+          if [ -f trivy-results.json ]; then
+            # `safe` JSON-escapes string fields so they can be embedded inline in
+            # the Slack payload JSON (titles can contain quotes, backslashes, etc.).
+            # `\\n` (literal backslash-n) is used as the separator so the value
+            # stays on a single line in $GITHUB_OUTPUT and Slack renders it as a
+            # newline when parsing the JSON payload.
+            cve_list=$(jq -r '
+              def safe(s): (s // "") | tojson | .[1:-1];
+              [.Results[]?.Vulnerabilities[]?]
+              | unique_by(.VulnerabilityID + "|" + (.PkgName // ""))
+              | sort_by(.Severity, .VulnerabilityID)
+              | map("• *\(.VulnerabilityID)* (\(.Severity // "UNKNOWN")) — \(safe(.PkgName // "?")) \(safe(.InstalledVersion // "?")) → \(safe(.FixedVersion // "?"))\\n    _\(safe(.Title // "(no title)"))_")
+              | join("\\n")
+            ' trivy-results.json)
+          fi
+          echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
         if: github.event.schedule == '0 6 * * *' && failure()
@@ -95,7 +121,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "⚠️ Build fleetdm/fleetctl and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                    "text": "⚠️ Build fleetdm/fleetctl and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n\n*Detected CVEs:*\n${{ steps.extract_cves.outputs.cve_list }}"
                   }
                 }
               ]

--- a/.github/workflows/check-bomutils-vulnerabilities.yml
+++ b/.github/workflows/check-bomutils-vulnerabilities.yml
@@ -93,7 +93,19 @@ jobs:
         if: failure()
         run: |
           if [ -f trivy-results.json ]; then
-            cve_list=$(jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | map("• " + .) | join("\\n")' trivy-results.json)
+            # `safe` JSON-escapes string fields so they can be embedded inline in
+            # the Slack payload JSON (titles can contain quotes, backslashes, etc.).
+            # `\\n` (literal backslash-n) is used as the separator so the value
+            # stays on a single line in $GITHUB_OUTPUT and Slack renders it as a
+            # newline when parsing the JSON payload.
+            cve_list=$(jq -r '
+              def safe(s): (s // "") | tojson | .[1:-1];
+              [.Results[]?.Vulnerabilities[]?]
+              | unique_by(.VulnerabilityID + "|" + (.PkgName // ""))
+              | sort_by(.Severity, .VulnerabilityID)
+              | map("• *\(.VulnerabilityID)* (\(.Severity // "UNKNOWN")) — \(safe(.PkgName // "?")) \(safe(.InstalledVersion // "?")) → \(safe(.FixedVersion // "?"))\\n    _\(safe(.Title // "(no title)"))_")
+              | join("\\n")
+            ' trivy-results.json)
           fi
           echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/check-bomutils-vulnerabilities.yml
+++ b/.github/workflows/check-bomutils-vulnerabilities.yml
@@ -81,7 +81,21 @@ jobs:
             --pkg-types=os,library \
             --severity=HIGH,CRITICAL \
             --vex="${{ steps.generate_vex_files.outputs.VEX_FILES }}" \
-            fleetdm/bomutils
+            --format=json \
+            --output=trivy-results.json \
+            fleetdm/bomutils || trivy_exit_code=$?
+          # Print a human-readable table to the job log for debugging.
+          ./trivy convert --format table trivy-results.json
+          exit "${trivy_exit_code:-0}"
+
+      - name: Extract CVE list for Slack notification
+        id: extract_cves
+        if: failure()
+        run: |
+          if [ -f trivy-results.json ]; then
+            cve_list=$(jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | map("• " + .) | join("\\n")' trivy-results.json)
+          fi
+          echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
         if: github.event.schedule == '0 6 * * *' && failure()
@@ -95,7 +109,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "⚠️ Build fleetdm/bomutils and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                    "text": "⚠️ Build fleetdm/bomutils and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n\n*Detected CVEs:*\n${{ steps.extract_cves.outputs.cve_list }}"
                   }
                 }
               ]

--- a/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
+++ b/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
@@ -146,7 +146,7 @@ jobs:
           echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
-        if: github.event.schedule == '0 6 * * *' && failure()
+        if: failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           payload: |

--- a/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
+++ b/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
@@ -146,7 +146,7 @@ jobs:
           echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
-        if: failure()
+        if: github.event.schedule == '0 6 * * *' && failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           payload: |

--- a/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
+++ b/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
@@ -77,12 +77,20 @@ jobs:
           chmod +x ./trivy
           RELEASES="${{ steps.get_latest_releases.outputs.FLEET_LATEST_RELEASES }}"
           for version in $RELEASES; do
+            unset trivy_exit_code
             ./trivy image \
               --exit-code=1 \
               --pkg-types=os,library \
               --severity=CRITICAL \
               --vex="${{ steps.generate_fleet_vex_files.outputs.FLEET_VEX_FILES }}" \
-              fleetdm/fleet:$version
+              --format=json \
+              --output=trivy-results-fleet-$version.json \
+              fleetdm/fleet:$version || trivy_exit_code=$?
+            # Print a human-readable table to the job log for debugging.
+            ./trivy convert --format table trivy-results-fleet-$version.json
+            if [ -n "${trivy_exit_code:-}" ]; then
+              exit "$trivy_exit_code"
+            fi
           done
 
       - name: List fleetctl VEX files
@@ -103,7 +111,39 @@ jobs:
             --pkg-types=os,library \
             --severity=CRITICAL \
             --vex="${{ steps.generate_fleetctl_vex_files.outputs.FLEETCTL_VEX_FILES }}" \
-            fleetdm/fleetctl:latest
+            --format=json \
+            --output=trivy-results-fleetctl.json \
+            fleetdm/fleetctl:latest || trivy_exit_code=$?
+          # Print a human-readable table to the job log for debugging.
+          ./trivy convert --format table trivy-results-fleetctl.json
+          exit "${trivy_exit_code:-0}"
+
+      - name: Extract CVE list for Slack notification
+        id: extract_cves
+        if: failure()
+        run: |
+          # Aggregate CVEs across every trivy result file produced above. With
+          # `--exit-code=1` fail-fast, only the first failing scan's file will
+          # exist, but we still scoop up whatever's there.
+          shopt -s nullglob
+          files=(trivy-results-*.json)
+          shopt -u nullglob
+          if [ ${#files[@]} -gt 0 ]; then
+            # `safe` JSON-escapes string fields so they can be embedded inline in
+            # the Slack payload JSON (titles can contain quotes, backslashes, etc.).
+            # `\\n` (literal backslash-n) is used as the separator so the value
+            # stays on a single line in $GITHUB_OUTPUT and Slack renders it as a
+            # newline when parsing the JSON payload.
+            cve_list=$(jq -r -s '
+              def safe(s): (s // "") | tojson | .[1:-1];
+              [.[] | (.ArtifactName // "?") as $image | .Results[]?.Vulnerabilities[]? | . + {image: $image}]
+              | unique_by(.VulnerabilityID + "|" + (.PkgName // "") + "|" + .image)
+              | sort_by(.Severity, .VulnerabilityID, .image)
+              | map("• *\(.VulnerabilityID)* (\(.Severity // "UNKNOWN")) in `\(safe(.image))` — \(safe(.PkgName // "?")) \(safe(.InstalledVersion // "?")) → \(safe(.FixedVersion // "?"))\\n    _\(safe(.Title // "(no title)"))_")
+              | join("\\n")
+            ' "${files[@]}")
+          fi
+          echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
         if: github.event.schedule == '0 6 * * *' && failure()
@@ -117,7 +157,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "⚠️ Check vulnerabilities in released docker images failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                    "text": "⚠️ Check vulnerabilities in released docker images failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n\n*Detected CVEs:*\n${{ steps.extract_cves.outputs.cve_list }}"
                   }
                 }
               ]

--- a/.github/workflows/check-wix-vulnerabilities.yml
+++ b/.github/workflows/check-wix-vulnerabilities.yml
@@ -93,7 +93,19 @@ jobs:
         if: failure()
         run: |
           if [ -f trivy-results.json ]; then
-            cve_list=$(jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | map("• " + .) | join("\\n")' trivy-results.json)
+            # `safe` JSON-escapes string fields so they can be embedded inline in
+            # the Slack payload JSON (titles can contain quotes, backslashes, etc.).
+            # `\\n` (literal backslash-n) is used as the separator so the value
+            # stays on a single line in $GITHUB_OUTPUT and Slack renders it as a
+            # newline when parsing the JSON payload.
+            cve_list=$(jq -r '
+              def safe(s): (s // "") | tojson | .[1:-1];
+              [.Results[]?.Vulnerabilities[]?]
+              | unique_by(.VulnerabilityID + "|" + (.PkgName // ""))
+              | sort_by(.Severity, .VulnerabilityID)
+              | map("• *\(.VulnerabilityID)* (\(.Severity // "UNKNOWN")) — \(safe(.PkgName // "?")) \(safe(.InstalledVersion // "?")) → \(safe(.FixedVersion // "?"))\\n    _\(safe(.Title // "(no title)"))_")
+              | join("\\n")
+            ' trivy-results.json)
           fi
           echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/check-wix-vulnerabilities.yml
+++ b/.github/workflows/check-wix-vulnerabilities.yml
@@ -98,7 +98,7 @@ jobs:
           echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
-        if: github.event.schedule == '0 6 * * *' && failure()
+        if: failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           payload: |

--- a/.github/workflows/check-wix-vulnerabilities.yml
+++ b/.github/workflows/check-wix-vulnerabilities.yml
@@ -81,7 +81,21 @@ jobs:
             --pkg-types=os,library \
             --severity=HIGH,CRITICAL \
             --vex="${{ steps.generate_vex_files.outputs.VEX_FILES }}" \
-            fleetdm/wix
+            --format=json \
+            --output=trivy-results.json \
+            fleetdm/wix || trivy_exit_code=$?
+          # Print a human-readable table to the job log for debugging.
+          ./trivy convert --format table trivy-results.json
+          exit "${trivy_exit_code:-0}"
+
+      - name: Extract CVE list for Slack notification
+        id: extract_cves
+        if: failure()
+        run: |
+          if [ -f trivy-results.json ]; then
+            cve_list=$(jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | map("• " + .) | join("\\n")' trivy-results.json)
+          fi
+          echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
         if: github.event.schedule == '0 6 * * *' && failure()
@@ -95,7 +109,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "⚠️ Build fleetdm/wix and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                    "text": "⚠️ Build fleetdm/wix and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n\n*Detected CVEs:*\n${{ steps.extract_cves.outputs.cve_list }}"
                   }
                 }
               ]

--- a/.github/workflows/check-wix-vulnerabilities.yml
+++ b/.github/workflows/check-wix-vulnerabilities.yml
@@ -110,7 +110,7 @@ jobs:
           echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
-        if: failure()
+        if: github.event.schedule == '0 6 * * *' && failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           payload: |

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -126,7 +126,12 @@ jobs:
             --pkg-types=os,library \
             --severity=HIGH,CRITICAL \
             --vex="${{ steps.generate_vex_files.outputs.VEX_FILES }}" \
-            fleetdm/fleet:${{ steps.sanitize_branch.outputs.DOCKER_IMAGE_TAG }}
+            --format=json \
+            --output=trivy-results.json \
+            fleetdm/fleet:${{ steps.sanitize_branch.outputs.DOCKER_IMAGE_TAG }} || trivy_exit_code=$?
+          # Print a human-readable table to the job log for debugging.
+          ./trivy convert --format table trivy-results.json
+          exit "${trivy_exit_code:-0}"
 
       - name: Check high/critical vulnerabilities before publishing (docker scout)
         # Only run this when tagging RCs.
@@ -166,6 +171,27 @@ jobs:
             docker push quay.io/fleetdm/fleet:${TAG} && break || sleep 10
           done
 
+      - name: Extract CVE list for Slack notification
+        id: extract_cves
+        if: (startsWith(github.ref, 'rc-minor-') || startsWith(github.ref, 'rc-patch-')) && failure()
+        run: |
+          if [ -f trivy-results.json ]; then
+            # `safe` JSON-escapes string fields so they can be embedded inline in
+            # the Slack payload JSON (titles can contain quotes, backslashes, etc.).
+            # `\\n` (literal backslash-n) is used as the separator so the value
+            # stays on a single line in $GITHUB_OUTPUT and Slack renders it as a
+            # newline when parsing the JSON payload.
+            cve_list=$(jq -r '
+              def safe(s): (s // "") | tojson | .[1:-1];
+              [.Results[]?.Vulnerabilities[]?]
+              | unique_by(.VulnerabilityID + "|" + (.PkgName // ""))
+              | sort_by(.Severity, .VulnerabilityID)
+              | map("• *\(.VulnerabilityID)* (\(.Severity // "UNKNOWN")) — \(safe(.PkgName // "?")) \(safe(.InstalledVersion // "?")) → \(safe(.FixedVersion // "?"))\\n    _\(safe(.Title // "(no title)"))_")
+              | join("\\n")
+            ' trivy-results.json)
+          fi
+          echo "cve_list=${cve_list:-(no CVE list available — check job logs)}" >> "$GITHUB_OUTPUT"
+
       - name: Slack notification
         if: startsWith(github.ref, 'rc-minor-') || startsWith(github.ref, 'rc-patch-') && failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
@@ -178,7 +204,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "⚠️ Docker publish failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                    "text": "⚠️ Docker publish failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n\n*Detected CVEs:*\n${{ steps.extract_cves.outputs.cve_list }}"
                   }
                 }
               ]


### PR DESCRIPTION
Current messages looks like this:

<img width="650" height="310" alt="Screenshot 2026-05-12 at 11 14 28 AM" src="https://github.com/user-attachments/assets/5c85b3e5-f2bf-47f5-8f15-568fac4fd808" />

New messages:

<img width="1063" height="464" alt="Screenshot 2026-05-12 at 11 56 45 AM" src="https://github.com/user-attachments/assets/be728115-4cee-433f-ac4f-2c3eddb1e3e0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Slack failure notifications now include a deduplicated, formatted "Detected CVEs" list to speed triage.
  * Vulnerability scans emit machine-readable JSON results while still converting them to human-readable tables for logs.
  * Workflows preserve scanner exit codes, add failure-only steps to extract and aggregate CVEs (including across multiple scan outputs), and expose a single Slack-ready CVE list.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45232)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->