### PR TITLE
Fix back-to-host-details button on report details page (#39727)

### DIFF
--- a/changes/39727-creating-queries-back-to-hosts-bug
+++ b/changes/39727-creating-queries-back-to-hosts-bug
@@ -1,0 +1,1 @@
+* Fixed an issue where the "Back to host details" button on a report's details page navigated to the reports list instead of the host's details page after creating a report from a host.

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tests.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tests.tsx
@@ -28,6 +28,7 @@ jest.mock("components/BackButton", () => ({
 
 const QUERY_ID = 1;
 const HOST_ID = 42;
+const FILTERED_QUERIES_PATH = "/queries/manage?fleet_id=1";
 
 const setupQueryHandlers = () => {
   mockServer.use(
@@ -66,67 +67,47 @@ const baseAppContext = {
   availableTeams: [],
 };
 
+const renderPage = (
+  appOverrides: { filteredQueriesPath?: string } = {},
+  hostId?: number
+) => {
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: { app: { ...baseAppContext, ...appOverrides } },
+  });
+  render(<QueryDetailsPage {...(createProps(hostId) as any)} />);
+  return screen.findByTestId("back-button");
+};
+
 describe("QueryDetailsPage - back navigation", () => {
-  it("'Back to host details' returns to the host's details page even when filteredQueriesPath is set in AppContext", async () => {
-    setupQueryHandlers();
+  beforeEach(() => setupQueryHandlers());
 
-    const render = createCustomRenderer({
-      withBackendMock: true,
-      context: {
-        app: {
-          ...baseAppContext,
-          // Simulates the user having visited the Queries (Reports) list earlier
-          // in the session, populating filteredQueriesPath on AppContext.
-          filteredQueriesPath: "/queries/manage?fleet_id=1",
-        },
-      },
-    });
-
-    render(<QueryDetailsPage {...(createProps(HOST_ID) as any)} />);
-
-    const backButton = await screen.findByTestId("back-button");
-
-    expect(backButton).toHaveTextContent("Back to host details");
-    expect(backButton.getAttribute("data-path")).toContain(
-      `/hosts/${HOST_ID}/details`
-    );
-    expect(backButton.getAttribute("data-path")).not.toBe(
-      "/queries/manage?fleet_id=1"
-    );
-  });
-
-  it("'Back to reports' returns to filteredQueriesPath when no hostId is present", async () => {
-    setupQueryHandlers();
-
-    const filteredPath = "/queries/manage?fleet_id=1";
-    const render = createCustomRenderer({
-      withBackendMock: true,
-      context: {
-        app: { ...baseAppContext, filteredQueriesPath: filteredPath },
-      },
-    });
-
-    render(<QueryDetailsPage {...(createProps() as any)} />);
-
-    const backButton = await screen.findByTestId("back-button");
-
-    expect(backButton).toHaveTextContent("Back to reports");
-    expect(backButton.getAttribute("data-path")).toBe(filteredPath);
-  });
-
-  it("'Back to reports' falls back to the manage reports page when neither hostId nor filteredQueriesPath is set", async () => {
-    setupQueryHandlers();
-
-    const render = createCustomRenderer({
-      withBackendMock: true,
-      context: { app: baseAppContext },
-    });
-
-    render(<QueryDetailsPage {...(createProps() as any)} />);
-
-    const backButton = await screen.findByTestId("back-button");
-
-    expect(backButton).toHaveTextContent("Back to reports");
-    expect(backButton.getAttribute("data-path")).toContain("/reports/manage");
+  it.each([
+    {
+      name: "hostId wins over filteredQueriesPath",
+      app: { filteredQueriesPath: FILTERED_QUERIES_PATH },
+      hostId: HOST_ID,
+      expectText: "Back to host details",
+      expectPathContains: `/hosts/${HOST_ID}/details`,
+    },
+    {
+      name: "falls back to filteredQueriesPath when no hostId",
+      app: { filteredQueriesPath: FILTERED_QUERIES_PATH },
+      hostId: undefined,
+      expectText: "Back to reports",
+      expectPathContains: FILTERED_QUERIES_PATH,
+    },
+    {
+      name:
+        "falls back to manage reports when neither hostId nor filteredQueriesPath is set",
+      app: {},
+      hostId: undefined,
+      expectText: "Back to reports",
+      expectPathContains: "/reports/manage",
+    },
+  ])("$name", async ({ app, hostId, expectText, expectPathContains }) => {
+    const back = await renderPage(app, hostId);
+    expect(back).toHaveTextContent(expectText);
+    expect(back.getAttribute("data-path")).toContain(expectPathContains);
   });
 });

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tests.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tests.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import {
+  createCustomRenderer,
+  baseUrl,
+  createMockRouter,
+} from "test/test-utils";
+import mockServer from "test/mock-server";
+import createMockUser from "__mocks__/userMock";
+import createMockConfig from "__mocks__/configMock";
+import createMockSchedulableQuery from "__mocks__/scheduleableQueryMock";
+import createMockQueryReport from "__mocks__/queryReportMock";
+
+import QueryDetailsPage from "./QueryDetailsPage";
+
+// Render BackButton as a button exposing its `path` prop so we can assert on the
+// computed back URL without depending on react-router's browserHistory.
+jest.mock("components/BackButton", () => ({
+  __esModule: true,
+  default: ({ text, path }: { text: string; path?: string }) => (
+    <button type="button" data-testid="back-button" data-path={path ?? ""}>
+      {text}
+    </button>
+  ),
+}));
+
+const QUERY_ID = 1;
+const HOST_ID = 42;
+
+const setupQueryHandlers = () => {
+  mockServer.use(
+    http.get(baseUrl(`/reports/${QUERY_ID}`), () =>
+      HttpResponse.json({
+        query: createMockSchedulableQuery({ id: QUERY_ID, team_id: null }),
+      })
+    ),
+    http.get(baseUrl(`/reports/${QUERY_ID}/report`), () =>
+      HttpResponse.json(
+        createMockQueryReport({ query_id: QUERY_ID, results: [] })
+      )
+    )
+  );
+};
+
+const createProps = (hostId?: number) => ({
+  router: createMockRouter(),
+  params: { id: String(QUERY_ID) },
+  location: {
+    pathname: `/reports/${QUERY_ID}`,
+    search: hostId !== undefined ? `?host_id=${hostId}` : "",
+    query: hostId !== undefined ? { host_id: String(hostId) } : {},
+  },
+});
+
+const baseAppContext = {
+  isGlobalAdmin: true,
+  isOnGlobalTeam: true,
+  // Free tier short-circuits useTeamIdParam's redirect logic when no fleet_id is set,
+  // keeping the test focused on backPath() rather than team reconciliation.
+  isFreeTier: true,
+  isPremiumTier: false,
+  currentUser: createMockUser({ global_role: "admin" }),
+  config: createMockConfig(),
+  availableTeams: [],
+};
+
+describe("QueryDetailsPage - back navigation", () => {
+  it("'Back to host details' returns to the host's details page even when filteredQueriesPath is set in AppContext", async () => {
+    setupQueryHandlers();
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          ...baseAppContext,
+          // Simulates the user having visited the Queries (Reports) list earlier
+          // in the session, populating filteredQueriesPath on AppContext.
+          filteredQueriesPath: "/queries/manage?fleet_id=1",
+        },
+      },
+    });
+
+    render(<QueryDetailsPage {...(createProps(HOST_ID) as any)} />);
+
+    const backButton = await screen.findByTestId("back-button");
+
+    expect(backButton).toHaveTextContent("Back to host details");
+    expect(backButton.getAttribute("data-path")).toContain(
+      `/hosts/${HOST_ID}/details`
+    );
+    expect(backButton.getAttribute("data-path")).not.toBe(
+      "/queries/manage?fleet_id=1"
+    );
+  });
+
+  it("'Back to reports' returns to filteredQueriesPath when no hostId is present", async () => {
+    setupQueryHandlers();
+
+    const filteredPath = "/queries/manage?fleet_id=1";
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: { ...baseAppContext, filteredQueriesPath: filteredPath },
+      },
+    });
+
+    render(<QueryDetailsPage {...(createProps() as any)} />);
+
+    const backButton = await screen.findByTestId("back-button");
+
+    expect(backButton).toHaveTextContent("Back to reports");
+    expect(backButton.getAttribute("data-path")).toBe(filteredPath);
+  });
+
+  it("'Back to reports' falls back to the manage reports page when neither hostId nor filteredQueriesPath is set", async () => {
+    setupQueryHandlers();
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: { app: baseAppContext },
+    });
+
+    render(<QueryDetailsPage {...(createProps() as any)} />);
+
+    const backButton = await screen.findByTestId("back-button");
+
+    expect(backButton).toHaveTextContent("Back to reports");
+    expect(backButton.getAttribute("data-path")).toContain("/reports/manage");
+  });
+});

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -251,14 +251,13 @@ const QueryDetailsPage = ({
       isGlobalTechnician ||
       isTeamTechnician;
 
-    // Function instead of constant eliminates race condition with filteredQueriesPath
     const backPath = () => {
-      if (filteredQueriesPath) return filteredQueriesPath;
-
       if (hostId)
         return getPathWithQueryParams(
           PATHS.HOST_DETAILS(hostId, currentTeamId)
         );
+
+      if (filteredQueriesPath) return filteredQueriesPath;
 
       return getPathWithQueryParams(PATHS.MANAGE_REPORTS, {
         fleet_id: currentTeamId,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39727 

Fixed bug on QueryDetailsPage's backPath() implementation, so the "Back to host details" button does not followed the stale filteredQueriesPath set when the user previously visited the reports page.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the "Back to host details" button so it navigates to the host details page when returning from a report created from a host.

* **Tests**
  * Added tests covering back-navigation behavior on the query details page across hostId and filtered path scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45238)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->