### PR TITLE
Fleet UI: Allow users with edit access to add automation from policy details page

### DIFF
--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -439,9 +439,8 @@ const PolicyDetailsPage = ({
               <PolicyAutomations
                 storedPolicy={storedPolicy}
                 currentAutomatedPolicies={currentAutomatedPolicies}
-                onAddAutomation={
-                  canEditPolicy ? onAddPatchAutomation : undefined
-                }
+                canEditPolicy={canEditPolicy}
+                onAddAutomation={onAddPatchAutomation}
                 isAddingAutomation={isAddingAutomation}
               />
             )}

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -1,10 +1,10 @@
 import React, { useContext, useEffect, useState } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useErrorHandler } from "react-error-boundary";
-import { noop } from "lodash";
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
+import { NotificationContext } from "context/notification";
 import { PolicyContext } from "context/policy";
 import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";
 import { ILabelPolicy } from "interfaces/label";
@@ -16,6 +16,7 @@ import {
 } from "interfaces/team";
 import { PLATFORM_DISPLAY_NAMES, Platform } from "interfaces/platform";
 import policiesAPI from "services/entities/policies";
+import teamPoliciesAPI from "services/entities/team_policies";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { addGravatarUrlToResource } from "utilities/helpers";
 import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
@@ -63,6 +64,7 @@ const PolicyDetailsPage = ({
 }: IPolicyDetailsPageProps): JSX.Element => {
   const policyId = paramsPolicyId ? parseInt(paramsPolicyId, 10) : null;
   const handlePageError = useErrorHandler();
+  const queryClient = useQueryClient();
 
   const {
     currentUser,
@@ -112,7 +114,10 @@ const PolicyDetailsPage = ({
     },
   });
 
+  const { renderFlash } = useContext(NotificationContext);
+
   const [showQueryModal, setShowQueryModal] = useState(false);
+  const [isAddingAutomation, setIsAddingAutomation] = useState(false);
 
   if (policyId === null || isNaN(policyId)) {
     router.push(PATHS.MANAGE_POLICIES);
@@ -210,6 +215,28 @@ const PolicyDetailsPage = ({
     isTeamTechnician;
 
   const disabledLiveQuery = config?.server_settings.live_query_disabled;
+
+  const onAddPatchAutomation = async () => {
+    if (
+      !storedPolicy?.patch_software?.software_title_id ||
+      !storedPolicy?.team_id
+    ) {
+      return;
+    }
+    setIsAddingAutomation(true);
+    try {
+      await teamPoliciesAPI.update(policyId as number, {
+        team_id: storedPolicy.team_id,
+        software_title_id: storedPolicy.patch_software.software_title_id,
+      });
+      queryClient.invalidateQueries(["policy", policyId]);
+      renderFlash("success", "Automation added.");
+    } catch {
+      renderFlash("error", "Couldn't set automation. Please try again.");
+    } finally {
+      setIsAddingAutomation(false);
+    }
+  };
 
   const backToPoliciesPath = getPathWithQueryParams(PATHS.MANAGE_POLICIES, {
     fleet_id: teamIdForApi,
@@ -412,8 +439,10 @@ const PolicyDetailsPage = ({
               <PolicyAutomations
                 storedPolicy={storedPolicy}
                 currentAutomatedPolicies={currentAutomatedPolicies}
-                onAddAutomation={noop}
-                isAddingAutomation={false}
+                onAddAutomation={
+                  canEditPolicy ? onAddPatchAutomation : undefined
+                }
+                isAddingAutomation={isAddingAutomation}
               />
             )}
           </>

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -219,7 +219,7 @@ const PolicyDetailsPage = ({
   const onAddPatchAutomation = async () => {
     if (
       !storedPolicy?.patch_software?.software_title_id ||
-      !storedPolicy?.team_id
+      storedPolicy?.team_id == null
     ) {
       return;
     }

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AppContext, initialState } from "context/app";
+import { IPolicy } from "interfaces/policy";
+import createMockConfig from "__mocks__/configMock";
+import PolicyAutomations from "./PolicyAutomations";
+
+// Stub SoftwareIcon to avoid asset resolution in tests
+jest.mock("pages/SoftwarePage/components/icons/SoftwareIcon", () => {
+  return () => <span data-testid="software-icon" />;
+});
+
+const createMockPatchPolicy = (overrides?: Partial<IPolicy>): IPolicy => ({
+  id: 10,
+  name: "macOS - Zoom up to date",
+  query: "SELECT 1;",
+  description: "Checks Zoom is up to date",
+  author_id: 1,
+  author_name: "Admin",
+  author_email: "admin@example.com",
+  resolution: "Install the latest version from self-service.",
+  platform: "darwin",
+  team_id: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  critical: false,
+  calendar_events_enabled: false,
+  conditional_access_enabled: false,
+  type: "patch",
+  patch_software: {
+    name: "Zoom",
+    display_name: "Zoom",
+    software_title_id: 42,
+  },
+  ...overrides,
+});
+
+// Wrap with AppContext so GitOpsModeTooltipWrapper's useGitOpsMode hook works
+const renderWithAppContext = (ui: React.ReactElement) => {
+  return render(
+    <AppContext.Provider
+      value={{ ...initialState, config: createMockConfig() }}
+    >
+      {ui}
+    </AppContext.Provider>
+  );
+};
+
+describe("PolicyAutomations", () => {
+  describe("CTA card (patch policy with patch_software, no install_software)", () => {
+    it("shows the CTA card and Add automation button when onAddAutomation is provided", () => {
+      const onAddAutomation = jest.fn();
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy()}
+          currentAutomatedPolicies={[]}
+          onAddAutomation={onAddAutomation}
+        />
+      );
+
+      expect(
+        screen.getByText(/Automatically patch Zoom/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Add automation/ })
+      ).toBeInTheDocument();
+    });
+
+    it("calls onAddAutomation when the button is clicked", async () => {
+      const user = userEvent.setup();
+      const onAddAutomation = jest.fn();
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy()}
+          currentAutomatedPolicies={[]}
+          onAddAutomation={onAddAutomation}
+        />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /Add automation/ })
+      );
+      expect(onAddAutomation).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT show the CTA card when onAddAutomation is undefined (no edit access)", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy()}
+          currentAutomatedPolicies={[]}
+        />
+      );
+
+      expect(
+        screen.queryByText(/Automatically patch Zoom/)
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /Add automation/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows 'Adding...' text when isAddingAutomation is true", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy()}
+          currentAutomatedPolicies={[]}
+          onAddAutomation={jest.fn()}
+          isAddingAutomation
+        />
+      );
+
+      expect(screen.getByText("Adding...")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /Add automation/ })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("CTA card is hidden when conditions are not met", () => {
+    it("hides the CTA card for a dynamic (non-patch) policy", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy({ type: "dynamic" })}
+          currentAutomatedPolicies={[]}
+          onAddAutomation={jest.fn()}
+        />
+      );
+
+      expect(
+        screen.queryByText(/Automatically patch/)
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides the CTA card when patch_software is not set", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy({ patch_software: undefined })}
+          currentAutomatedPolicies={[]}
+          onAddAutomation={jest.fn()}
+        />
+      );
+
+      expect(
+        screen.queryByText(/Automatically patch/)
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides the CTA card when install_software is already set", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy({
+            install_software: {
+              name: "Zoom",
+              software_title_id: 42,
+            },
+          })}
+          currentAutomatedPolicies={[]}
+          onAddAutomation={jest.fn()}
+        />
+      );
+
+      expect(
+        screen.queryByText(/Automatically patch/)
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
@@ -60,9 +60,7 @@ describe("PolicyAutomations", () => {
         />
       );
 
-      expect(
-        screen.getByText(/Automatically patch Zoom/)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Automatically patch Zoom/)).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /Add automation/ })
       ).toBeInTheDocument();
@@ -79,9 +77,7 @@ describe("PolicyAutomations", () => {
         />
       );
 
-      await user.click(
-        screen.getByRole("button", { name: /Add automation/ })
-      );
+      await user.click(screen.getByRole("button", { name: /Add automation/ }));
       expect(onAddAutomation).toHaveBeenCalledTimes(1);
     });
 
@@ -128,9 +124,7 @@ describe("PolicyAutomations", () => {
         />
       );
 
-      expect(
-        screen.queryByText(/Automatically patch/)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Automatically patch/)).not.toBeInTheDocument();
     });
 
     it("hides the CTA card when patch_software is not set", () => {
@@ -142,9 +136,7 @@ describe("PolicyAutomations", () => {
         />
       );
 
-      expect(
-        screen.queryByText(/Automatically patch/)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Automatically patch/)).not.toBeInTheDocument();
     });
 
     it("hides the CTA card when install_software is already set", () => {
@@ -161,9 +153,7 @@ describe("PolicyAutomations", () => {
         />
       );
 
-      expect(
-        screen.queryByText(/Automatically patch/)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Automatically patch/)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
@@ -48,15 +48,19 @@ const renderWithAppContext = (ui: React.ReactElement) => {
   );
 };
 
+const defaultProps = {
+  onAddAutomation: jest.fn(),
+  currentAutomatedPolicies: [] as number[],
+};
+
 describe("PolicyAutomations", () => {
   describe("CTA card (patch policy with patch_software, no install_software)", () => {
-    it("shows the CTA card and Add automation button when onAddAutomation is provided", () => {
-      const onAddAutomation = jest.fn();
+    it("shows the CTA card and Add automation button when canEditPolicy is true", () => {
       renderWithAppContext(
         <PolicyAutomations
           storedPolicy={createMockPatchPolicy()}
-          currentAutomatedPolicies={[]}
-          onAddAutomation={onAddAutomation}
+          canEditPolicy
+          {...defaultProps}
         />
       );
 
@@ -73,6 +77,7 @@ describe("PolicyAutomations", () => {
         <PolicyAutomations
           storedPolicy={createMockPatchPolicy()}
           currentAutomatedPolicies={[]}
+          canEditPolicy
           onAddAutomation={onAddAutomation}
         />
       );
@@ -81,11 +86,12 @@ describe("PolicyAutomations", () => {
       expect(onAddAutomation).toHaveBeenCalledTimes(1);
     });
 
-    it("does NOT show the CTA card when onAddAutomation is undefined (no edit access)", () => {
+    it("does NOT show the CTA card when canEditPolicy is false", () => {
       renderWithAppContext(
         <PolicyAutomations
           storedPolicy={createMockPatchPolicy()}
-          currentAutomatedPolicies={[]}
+          canEditPolicy={false}
+          {...defaultProps}
         />
       );
 
@@ -101,8 +107,8 @@ describe("PolicyAutomations", () => {
       renderWithAppContext(
         <PolicyAutomations
           storedPolicy={createMockPatchPolicy()}
-          currentAutomatedPolicies={[]}
-          onAddAutomation={jest.fn()}
+          canEditPolicy
+          {...defaultProps}
           isAddingAutomation
         />
       );
@@ -119,8 +125,8 @@ describe("PolicyAutomations", () => {
       renderWithAppContext(
         <PolicyAutomations
           storedPolicy={createMockPatchPolicy({ type: "dynamic" })}
-          currentAutomatedPolicies={[]}
-          onAddAutomation={jest.fn()}
+          canEditPolicy
+          {...defaultProps}
         />
       );
 
@@ -131,8 +137,8 @@ describe("PolicyAutomations", () => {
       renderWithAppContext(
         <PolicyAutomations
           storedPolicy={createMockPatchPolicy({ patch_software: undefined })}
-          currentAutomatedPolicies={[]}
-          onAddAutomation={jest.fn()}
+          canEditPolicy
+          {...defaultProps}
         />
       );
 
@@ -143,8 +149,8 @@ describe("PolicyAutomations", () => {
       renderWithAppContext(
         <PolicyAutomations
           storedPolicy={createMockPatchPolicy({ team_id: 0 })}
-          currentAutomatedPolicies={[]}
-          onAddAutomation={jest.fn()}
+          canEditPolicy
+          {...defaultProps}
         />
       );
 
@@ -163,8 +169,8 @@ describe("PolicyAutomations", () => {
               software_title_id: 42,
             },
           })}
-          currentAutomatedPolicies={[]}
-          onAddAutomation={jest.fn()}
+          canEditPolicy
+          {...defaultProps}
         />
       );
 

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
@@ -139,6 +139,21 @@ describe("PolicyAutomations", () => {
       expect(screen.queryByText(/Automatically patch/)).not.toBeInTheDocument();
     });
 
+    it("shows the CTA card for a no-team policy (team_id === 0)", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPatchPolicy({ team_id: 0 })}
+          currentAutomatedPolicies={[]}
+          onAddAutomation={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText(/Automatically patch Zoom/)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Add automation/ })
+      ).toBeInTheDocument();
+    });
+
     it("hides the CTA card when install_software is already set", () => {
       renderWithAppContext(
         <PolicyAutomations

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
@@ -17,7 +17,9 @@ const baseClass = "policy-automations";
 interface IPolicyAutomationsProps {
   storedPolicy: IPolicy;
   currentAutomatedPolicies: number[];
-  onAddAutomation?: () => void;
+  /** Some users only have access to read-only view */
+  canEditPolicy: boolean;
+  onAddAutomation: () => void;
   isAddingAutomation?: boolean;
 }
 
@@ -34,6 +36,7 @@ interface IAutomationRow {
 const PolicyAutomations = ({
   storedPolicy,
   currentAutomatedPolicies,
+  canEditPolicy,
   onAddAutomation,
   isAddingAutomation,
 }: IPolicyAutomationsProps): JSX.Element => {
@@ -44,7 +47,7 @@ const PolicyAutomations = ({
     isPatchPolicy &&
     hasPatchSoftware &&
     !hasSoftwareAutomation &&
-    onAddAutomation;
+    canEditPolicy;
 
   const automationRows: IAutomationRow[] = [];
 

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
@@ -17,8 +17,8 @@ const baseClass = "policy-automations";
 interface IPolicyAutomationsProps {
   storedPolicy: IPolicy;
   currentAutomatedPolicies: number[];
-  onAddAutomation: () => void;
-  isAddingAutomation: boolean;
+  onAddAutomation?: () => void;
+  isAddingAutomation?: boolean;
 }
 
 interface IAutomationRow {
@@ -41,7 +41,7 @@ const PolicyAutomations = ({
   const hasPatchSoftware = !!storedPolicy.patch_software;
   const hasSoftwareAutomation = !!storedPolicy.install_software;
   const showCtaCard =
-    isPatchPolicy && hasPatchSoftware && !hasSoftwareAutomation;
+    isPatchPolicy && hasPatchSoftware && !hasSoftwareAutomation && onAddAutomation;
 
   const automationRows: IAutomationRow[] = [];
 

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
@@ -41,7 +41,10 @@ const PolicyAutomations = ({
   const hasPatchSoftware = !!storedPolicy.patch_software;
   const hasSoftwareAutomation = !!storedPolicy.install_software;
   const showCtaCard =
-    isPatchPolicy && hasPatchSoftware && !hasSoftwareAutomation && onAddAutomation;
+    isPatchPolicy &&
+    hasPatchSoftware &&
+    !hasSoftwareAutomation &&
+    onAddAutomation;
 
   const automationRows: IAutomationRow[] = [];
 

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -693,6 +693,7 @@ const PolicyForm = ({
             <PolicyAutomations
               storedPolicy={storedPolicy}
               currentAutomatedPolicies={currentAutomatedPolicies}
+              canEditPolicy={isEditMode}
               onAddAutomation={onAddPatchAutomation}
               isAddingAutomation={isAddingAutomation}
             />

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -378,7 +378,7 @@ const PolicyForm = ({
   const onAddPatchAutomation = async () => {
     if (
       !storedPolicy?.patch_software?.software_title_id ||
-      !storedPolicy?.team_id
+      storedPolicy?.team_id == null
     ) {
       return;
     }


### PR DESCRIPTION
## Issue
Closes #44379 (and duplicate #44891 )

## Description

## Screenrecordings

### Before behavior

https://fleetdm.zoom.us/clips/share/QqoTqDvgQEeg2pQSBCX6Og

### After fix behavior

https://fleetdm.zoom.us/clips/share/xBwNYndgRiO2FiaHao4ABQ


- Update: Confirmed gitops mode still works

<img width="1163" height="546" alt="Screenshot 2026-05-12 at 2 42 29 PM" src="https://github.com/user-attachments/assets/e83d39a3-9e3e-46de-8e84-d5e46c54aa49" />

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add patch automations from the policy details page with loading state and success/error notifications.

* **UI**
  * “Add automation” CTA appears only when allowed; shows “Adding...” and hides/disables the button during operation.
  * CTA hidden when the action handler isn't available and gated by eligibility rules.

* **Bug Fixes**
  * Allow adding automations for policies tied to a team with ID zero.

* **Tests**
  * Added tests for CTA visibility, click behavior, loading state, and eligibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45239)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->