### PR TITLE
Fix Location and MDM status vitals looking clickable on My device page (#43279)

### DIFF
--- a/changes/43279-my-device-page-location-vital-looks-clickable
+++ b/changes/43279-my-device-page-location-vital-looks-clickable
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed the Location and MDM status vitals on the My device page rendering as clickable links even though they had no associated modal, by rendering them as plain text in read-only contexts.

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
-import createMockHost from "__mocks__/hostMock";
+import createMockHost, { createMockHostGeolocation } from "__mocks__/hostMock";
 import { createMockHostMdmData } from "__mocks__/mdmMock";
 
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
@@ -237,6 +237,153 @@ describe("Vitals Card component", () => {
     expect(screen.getByText("Serial number")).toBeInTheDocument();
     expect(screen.getAllByText("test-serial-number")[0]).toBeInTheDocument();
     expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+  });
+});
+
+describe("Location vital", () => {
+  // ADE = iOS/iPadOS host with mdm.enrollment_status === "On (automatic)";
+  // matches the definition in Vitals.tsx.
+  const renderLocationVital = ({
+    ade = false,
+    withToggle = false,
+    hostOverrides,
+  }: {
+    ade?: boolean;
+    withToggle?: boolean;
+    hostOverrides?: Parameters<typeof createMockHost>[0];
+  } = {}) => {
+    const baseOverrides = ade
+      ? {
+          platform: "ios" as const,
+          mdm: createMockHostMdmData({ enrollment_status: "On (automatic)" }),
+        }
+      : {
+          platform: "darwin" as const,
+          geolocation: createMockHostGeolocation(),
+        };
+
+    const mockHost = createMockHost({ ...baseOverrides, ...hostOverrides });
+    const toggleLocationModal = withToggle ? jest.fn() : undefined;
+
+    const utils = render(
+      <Vitals
+        vitalsData={mockHost}
+        mdm={mockHost.mdm}
+        toggleLocationModal={toggleLocationModal}
+      />
+    );
+
+    return { ...utils, toggleLocationModal };
+  };
+
+  it("renders city/country as a clickable button when toggleLocationModal is provided", () => {
+    renderLocationVital({ withToggle: true });
+
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Minneapolis, US" })
+    ).toBeInTheDocument();
+  });
+
+  it("invokes toggleLocationModal when the city/country button is clicked", () => {
+    const { toggleLocationModal } = renderLocationVital({ withToggle: true });
+
+    screen.getByRole("button", { name: "Minneapolis, US" }).click();
+
+    expect(toggleLocationModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders city/country as plain text when toggleLocationModal is not provided (e.g., My device page)", () => {
+    renderLocationVital();
+
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Minneapolis, US")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Minneapolis, US" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders 'Show location' button for ADE-enrolled iDevices when toggleLocationModal is provided", () => {
+    renderLocationVital({ ade: true, withToggle: true });
+
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show location" })
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Location row for ADE-enrolled iDevices when toggleLocationModal is not provided", () => {
+    renderLocationVital({ ade: true });
+
+    expect(screen.queryByText("Location")).not.toBeInTheDocument();
+    expect(screen.queryByText("Show location")).not.toBeInTheDocument();
+  });
+
+  it("hides the Location row when the host has no geolocation", () => {
+    renderLocationVital({ hostOverrides: { geolocation: undefined } });
+
+    expect(screen.queryByText("Location")).not.toBeInTheDocument();
+  });
+
+  it("renders an empty Location value when geolocation is present but city/country are empty strings", () => {
+    renderLocationVital({
+      hostOverrides: {
+        geolocation: createMockHostGeolocation({
+          city_name: "",
+          country_iso: "",
+        }),
+      },
+    });
+
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("MDM status vital", () => {
+  const renderMDMStatusVital = ({ withToggle = false } = {}) => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      mdm: createMockHostMdmData({ enrollment_status: "On (manual)" }),
+    });
+    const toggleMDMStatusModal = withToggle ? jest.fn() : undefined;
+
+    const utils = render(
+      <Vitals
+        vitalsData={mockHost}
+        mdm={mockHost.mdm}
+        toggleMDMStatusModal={toggleMDMStatusModal}
+      />
+    );
+
+    return { ...utils, toggleMDMStatusModal };
+  };
+
+  it("renders the MDM status as a clickable button when toggleMDMStatusModal is provided", () => {
+    renderMDMStatusVital({ withToggle: true });
+
+    expect(screen.getByText("MDM status")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "On (manual)" })
+    ).toBeInTheDocument();
+  });
+
+  it("invokes toggleMDMStatusModal when the status button is clicked", () => {
+    const { toggleMDMStatusModal } = renderMDMStatusVital({ withToggle: true });
+
+    screen.getByRole("button", { name: "On (manual)" }).click();
+
+    expect(toggleMDMStatusModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the MDM status as plain text when toggleMDMStatusModal is not provided (e.g., My device page)", () => {
+    renderMDMStatusVital();
+
+    expect(screen.getByText("MDM status")).toBeInTheDocument();
+    expect(screen.getByText("On (manual)")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "On (manual)" })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -42,7 +42,17 @@ interface IVitalsProps {
   mdm?: IHostMdmData;
   osVersionRequirement?: IAppleDeviceUpdates;
   className?: string;
+  /**
+   * Opens the Location modal. Presence of this handler also makes the
+   * Location row interactive — omit it for read-only contexts (e.g., the
+   * My device page) so the row renders as plain text instead of a link.
+   */
   toggleLocationModal?: () => void;
+  /**
+   * Opens the MDM status modal. Presence of this handler also makes the
+   * MDM status row interactive — omit it for read-only contexts (e.g.,
+   * the My device page) so the row renders as plain text instead of a link.
+   */
   toggleMDMStatusModal?: () => void;
 }
 
@@ -364,11 +374,16 @@ const Vitals = ({
     const isAdeIDevice =
       isIosOrIpadosHost && mdm?.enrollment_status === "On (automatic)";
 
-    if (isAdeIDevice || geolocation) {
-      const geoLocationButton = (
+    if (isAdeIDevice ? toggleLocationModal : geolocation) {
+      const label = isAdeIDevice
+        ? "Show location"
+        : getCityCountryLocation(geolocation);
+      const locationValue = toggleLocationModal ? (
         <Button variant="link" onClick={toggleLocationModal}>
-          {isAdeIDevice ? "Show location" : getCityCountryLocation(geolocation)}
+          {label}
         </Button>
+      ) : (
+        label
       );
       vitals.push({
         sortKey: "Location",
@@ -377,7 +392,7 @@ const Vitals = ({
             className={`${baseClass}__location`}
             key="location"
             title="Location"
-            value={geoLocationButton}
+            value={locationValue}
           />
         ),
       });
@@ -403,6 +418,8 @@ const Vitals = ({
 
     // MDM
     if (mdm?.enrollment_status) {
+      const mdmStatusLabel =
+        MDM_ENROLLMENT_STATUS_UI_MAP[mdm.enrollment_status].displayName;
       vitals.push(
         {
           sortKey: "MDM status",
@@ -414,12 +431,13 @@ const Vitals = ({
               value={
                 <>
                   {mdm.dep_profile_error && <Icon name="error" />}
-                  <Button variant="link" onClick={toggleMDMStatusModal}>
-                    {
-                      MDM_ENROLLMENT_STATUS_UI_MAP[mdm.enrollment_status]
-                        .displayName
-                    }
-                  </Button>
+                  {toggleMDMStatusModal ? (
+                    <Button variant="link" onClick={toggleMDMStatusModal}>
+                      {mdmStatusLabel}
+                    </Button>
+                  ) : (
+                    mdmStatusLabel
+                  )}
                 </>
               }
             />


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #43279 

On the My device page (DeviceUserPage), the Location and MDM status rows in the Vitals card rendered as <Button variant="link"> even though no modal was wired up, so clicking did nothing while the link styling implied otherwise.

<img width="814" height="743" alt="Screenshot 2026-05-12 at 12 12 02 PM" src="https://github.com/user-attachments/assets/12b884bf-f455-41f7-98d9-501072d30350" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Location and MDM status vitals on "My device" page now display as plain text in read-only contexts instead of appearing as clickable links when no corresponding modal exists.

* **Tests**
  * Expanded test coverage for Location and MDM status vital rendering behavior in different scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45246)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->