### PR TITLE
Reject null name on POST /packs (#43032)

### DIFF
--- a/changes/43032-post-packs-null-name
+++ b/changes/43032-post-packs-null-name
@@ -1,0 +1,1 @@
+- Fixed an issue where `POST /packs` with a JSON null name silently created a pack with an empty name; the endpoint now returns a 400 Bad Request, matching the behavior for an empty-string name.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8117,6 +8117,11 @@ func (s *integrationTestSuite) TestPacksBadRequests() {
 			s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/packs/%d", existingPackID), &payload, http.StatusBadRequest, &mResp)
 		})
 	}
+
+	t.Run("null name on create", func(t *testing.T) {
+		res := s.Do("POST", "/api/latest/fleet/packs", json.RawMessage(`{"name": null}`), http.StatusBadRequest)
+		assertBodyContains(t, res, "pack name cannot be empty")
+	})
 }
 
 func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {

--- a/server/service/packs.go
+++ b/server/service/packs.go
@@ -173,6 +173,12 @@ func (svc *Service) NewPack(ctx context.Context, p fleet.PackPayload) (*fleet.Pa
 		return nil, err
 	}
 
+	if p.Name == nil {
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: "pack payload verification: pack name cannot be empty",
+		})
+	}
+
 	if err := p.Verify(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("pack payload verification: %s", err),

--- a/server/service/packs_test.go
+++ b/server/service/packs_test.go
@@ -65,6 +65,33 @@ func TestNewPackSavesTargets(t *testing.T) {
 	assert.True(t, opts.ActivityMock.NewActivityFuncInvoked)
 }
 
+func TestNewPackRejectsMissingName(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload fleet.PackPayload
+	}{
+		{name: "nil name", payload: fleet.PackPayload{}},
+		{name: "empty string name", payload: fleet.PackPayload{Name: ptr.String("")}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			svc, ctx := newTestService(t, ds, nil, nil)
+
+			ds.NewPackFunc = func(ctx context.Context, pack *fleet.Pack, opts ...fleet.OptionalArg) (*fleet.Pack, error) {
+				return pack, nil
+			}
+
+			_, err := svc.NewPack(test.UserContext(ctx, test.UserAdmin), c.payload)
+			require.Error(t, err)
+			var badReqErr *fleet.BadRequestError
+			require.ErrorAs(t, err, &badReqErr)
+			assert.Contains(t, badReqErr.Message, "pack name cannot be empty")
+			assert.False(t, ds.NewPackFuncInvoked, "datastore should not be called when name is missing")
+		})
+	}
+}
+
 func TestPacksWithDS(t *testing.T) {
 	ds := mysql.CreateMySQLDS(t)
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #43032 

Added a nil-check in NewPack so a missing/null name returns the same BadRequestError as an empty-string name.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The POST /packs endpoint now properly rejects requests with null pack names, returning a 400 Bad Request error with clear validation messaging instead of silently creating packs with empty names. This improves data integrity by aligning null-name handling with existing empty-string validation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45259)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->