### PR TITLE
Reduce `fleet` and `fleetctl` binary sizes by removing debug symbols

### DIFF
--- a/.goreleaser-snapshot.yml
+++ b/.goreleaser-snapshot.yml
@@ -31,6 +31,9 @@ builds:
       - -tags=full,fts5,netgo
       - -trimpath
     ldflags:
+      # Reduce binary size by stripping debug symbols.
+      - -s
+      - -w
       - -extldflags "-static"
       - -X github.com/fleetdm/fleet/v4/server/version.appName={{ .ArtifactName }}
       - -X github.com/fleetdm/fleet/v4/server/version.version={{ .Version }}
@@ -51,6 +54,9 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      # Reduce binary size by stripping debug symbols.
+      - -s
+      - -w
       - -X github.com/fleetdm/fleet/v4/server/version.appName={{ .ArtifactName }}
       - -X github.com/fleetdm/fleet/v4/server/version.version={{ .Version }}
       - -X github.com/fleetdm/fleet/v4/server/version.branch={{ .Branch }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,9 @@ builds:
       - -tags=full,fts5,netgo
       - -trimpath
     ldflags:
+      # Reduce binary size by stripping debug symbols.
+      - -s
+      - -w
       - -extldflags "-static"
       - -X github.com/fleetdm/fleet/v4/server/version.appName={{ .ArtifactName }}
       - -X github.com/fleetdm/fleet/v4/server/version.version={{ .Version }}
@@ -50,6 +53,9 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      # Reduce binary size by stripping debug symbols.
+      - -s
+      - -w
       - -X github.com/fleetdm/fleet/v4/server/version.appName={{ .ArtifactName }}
       - -X github.com/fleetdm/fleet/v4/server/version.version={{ .Version }}
       - -X github.com/fleetdm/fleet/v4/server/version.branch={{ .Branch }}
@@ -70,6 +76,9 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      # Reduce binary size by stripping debug symbols.
+      - -s
+      - -w
       - -X github.com/fleetdm/fleet/v4/server/version.appName={{ .ArtifactName }}
       - -X github.com/fleetdm/fleet/v4/server/version.version={{ .Version }}
       - -X github.com/fleetdm/fleet/v4/server/version.branch={{ .Branch }}

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ ifdef CIRCLE_TAG
 	DOCKER_IMAGE_TAG = ${CIRCLE_TAG}
 endif
 
+# -s and -w reduce binary size by stripping debug symbols.
 LDFLAGS_VERSION_RAW = \
+	-s -w \
 	-X github.com/fleetdm/fleet/v4/server/version.appName=${APP_NAME} \
 	-X github.com/fleetdm/fleet/v4/server/version.version=${VERSION} \
 	-X github.com/fleetdm/fleet/v4/server/version.branch=${BRANCH} \

--- a/changes/45256-reduce-fleet-and-fleetctl-binary-sizes
+++ b/changes/45256-reduce-fleet-and-fleetctl-binary-sizes
@@ -1,0 +1,1 @@
+* Removed debug symbols from fleet and fleetctl executables to reduce binary size.


### PR DESCRIPTION
Resolves #45256

In macOS:
before: 129 MB build/fleet, 58 MB build/fleetctl.
after: 86 MB build/fleet, 42 MB build/fleetctl.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] QA'd all new/changed functionality manually. (Basic smoke testing of the binaries in macOS.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized binary sizes for fleet and fleetctl releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45260)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->