### PR TITLE
Build mdmproxy and osquery-perf images by module tag

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.26.2-alpine3.23@sha256:80fbb8f9b2fa541a7d34378f1ad10f4f1c433817c4ed39ddb3e2f3ec3e961271
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
-RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
+RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git
+RUN go install github.com/fleetdm/fleet/v4/cmd/osquery-perf@${TAG}
 
 # Generate software database from SQL file
 RUN cd /go/fleet/cmd/osquery-perf/software-library && \
@@ -27,7 +28,7 @@ LABEL maintainer="Fleet Developers"
 # Create FleetDM group and user
 RUN addgroup -S osquery-perf && adduser -S osquery-perf -G osquery-perf
 
-COPY --from=0 /go/fleet/cmd/osquery-perf/osquery-perf /go/osquery-perf
+COPY --from=0 /go/bin/osquery-perf /go/osquery-perf
 COPY --from=0 /go/fleet/server/vulnerabilities/testdata/ /go/fleet/server/vulnerabilities/testdata/
 # Copy software database (generated in builder stage)
 COPY --from=0 /go/fleet/cmd/osquery-perf/software-library/ /go/software-library/

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,13 +1,12 @@
 FROM golang:1.26.2-alpine3.23@sha256:80fbb8f9b2fa541a7d34378f1ad10f4f1c433817c4ed39ddb3e2f3ec3e961271
 ARG TAG
-RUN apk update && apk add --no-cache git
-RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .
+RUN go install github.com/fleetdm/fleet/v4/tools/mdm/migration/mdmproxy@${TAG}
 
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 LABEL maintainer="Fleet Developers"
 
 RUN apk update && apk add --no-cache tini
-COPY --from=0 /go/fleet/tools/mdm/migration/mdmproxy/mdmproxy /usr/bin/mdmproxy
+COPY --from=0 /go/bin/mdmproxy /usr/bin/mdmproxy
 ADD --chmod=0755 ./entrypoint.sh /usr/bin/entrypoint.sh
 
 # Create mdmproxy group and user


### PR DESCRIPTION
## Summary

Switch the `mdmproxy` and `osquery-perf` (loadtest) Dockerfiles to build via `go install github.com/fleetdm/fleet/v4/...@${TAG}` instead of `go build .` from an untagged in-repo checkout.

### Why
AWS ECR Inspector matches Fleet's own published security advisories (e.g. CVE-2026-23999, CVE-2026-22808) against the binary's Go module BuildInfo. Today both images embed a Go pseudo-version like `v4.0.0-20260506231109-39503ff99947` because the binary is built from a clone of the repo, not by module version. SemVer comparison treats `v4.0.0-...` as less than `4.80.1` (etc.), so every advisory lights up even on builds well past the fix. Building by module tag makes BuildInfo record `v4.84.0` and the scanner resolves cleanly.

See fleetdm/confidential#15628 for the originating Vanta finding.

### Changes
- `tools/mdm/migration/mdmproxy/Dockerfile`: drop the clone + `git` apk install (nothing else from the repo is used in the final stage); switch to `go install ...@${TAG}`; update binary COPY path from `/go/fleet/.../mdmproxy` to `/go/bin/mdmproxy`.
- `infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile`: keep the clone (still needed for `server/vulnerabilities/testdata/` and `cmd/osquery-perf/software-library/`), but switch the binary line to `go install ...@${TAG}`; update binary COPY path to `/go/bin/osquery-perf`.

## Test plan
- [ ] Build each image locally with a real release tag, e.g. `docker build --build-arg TAG=v4.84.0 ...`
- [ ] Inspect the built binary's BuildInfo: `docker run --rm <image> sh -c 'go version -m /usr/bin/mdmproxy 2>/dev/null || /usr/bin/mdmproxy --version'`. The Fleet module version should read `v4.84.0`, not a pseudo-version.
- [ ] After deploy, confirm in Vanta / AWS Inspector that Fleet self-references against fixed CVEs no longer appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configurations for internal infrastructure and tooling. Build processes for load testing and migration tools have been updated to use `go install` based binary compilation workflows, replacing previous repository cloning and local build methods. This results in improved build efficiency, better consistency across container images, and a more streamlined containerization pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45274)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->