### PR TITLE
Recovery Key can be viewed after team transfer if still present

### DIFF
--- a/changes/44459-recovery-password-key-team-transfer
+++ b/changes/44459-recovery-password-key-team-transfer
@@ -1,0 +1,1 @@
+- Fixed recovery lock password not being retrievable for hosts transferred to a team with recovery lock disabled.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -1604,7 +1604,7 @@ describe("Host Actions Dropdown", () => {
       ).toBeInTheDocument();
     });
 
-    it("hides the action when recovery lock is not enabled", async () => {
+    it("hides the action when recovery lock is not enabled and no password is available", async () => {
       const render = createCustomRenderer({
         context: {
           app: {
@@ -1626,6 +1626,7 @@ describe("Host Actions Dropdown", () => {
           isConnectedToFleetMdm
           hostPlatform="darwin"
           isRecoveryLockPasswordEnabled={false}
+          recoveryLockPasswordAvailable={false}
         />
       );
 
@@ -1634,6 +1635,39 @@ describe("Host Actions Dropdown", () => {
       expect(
         screen.queryByText("Show Recovery Lock password")
       ).not.toBeInTheDocument();
+    });
+
+    it("renders the action when a recovery lock password is available even if the team setting is disabled", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            isPremiumTier: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+          isConnectedToFleetMdm
+          hostPlatform="darwin"
+          isRecoveryLockPasswordEnabled={false}
+          recoveryLockPasswordAvailable
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      const option = screen.getByText("Show Recovery Lock password");
+      expect(option).toBeInTheDocument();
+      expect(option).not.toHaveAttribute("aria-disabled", "true");
     });
 
     it("hides the action for non-macOS hosts", async () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -308,6 +308,7 @@ const canShowRecoveryLockPassword = (config: IHostActionConfigOptions) => {
     hostPlatform,
     hostCpuType,
     isRecoveryLockPasswordEnabled,
+    recoveryLockPasswordAvailable,
   } = config;
   if (!isPremiumTier) {
     return false;
@@ -322,7 +323,10 @@ const canShowRecoveryLockPassword = (config: IHostActionConfigOptions) => {
   if (!isConnectedToFleetMdm) {
     return false;
   }
-  return isRecoveryLockPasswordEnabled;
+  // A password may exist on a host whose current team has the setting
+  // disabled (e.g., the host was locked under a different team's policy).
+  // Don't hide an existing password just because the team setting flipped.
+  return isRecoveryLockPasswordEnabled || recoveryLockPasswordAvailable;
 };
 
 const canShowManagedAccount = (config: IHostActionConfigOptions) => {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -7969,9 +7969,13 @@ func (ds *Datastore) ClaimHostsForRecoveryLockClear(ctx context.Context) ([]stri
 	`, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerified, fleet.MDMOperationTypeRemove)
 
 	// Update all claimed hosts to remove/pending
+	// auto_rotate_at is also nulled: it's meaningful only for install-state
+	// rows (see GetHostsForAutoRotation), so leaving a stale view-deadline on
+	// a row pending removal would cause the read API to report a rotation
+	// time that auto-rotation will never honor.
 	updateStmt := fmt.Sprintf(`
 		UPDATE host_recovery_key_passwords
-		SET operation_type = '%s', status = '%s'
+		SET operation_type = '%s', status = '%s', auto_rotate_at = NULL
 		WHERE host_uuid IN (?)
 	`, fleet.MDMOperationTypeRemove, fleet.MDMDeliveryPending)
 
@@ -8291,9 +8295,19 @@ func (ds *Datastore) HasPendingRecoveryLockRotation(ctx context.Context, hostUUI
 	return hasPending, nil
 }
 
+// MarkRecoveryLockPasswordViewed schedules auto-rotation by setting
+// auto_rotate_at to 1 hour from now on the host's install-state recovery lock
+// row, overwriting any prior deadline. Returns the scheduled rotation time.
+//
+// If the row is missing or not in install state (e.g.,
+// ClaimHostsForRecoveryLockClear has flipped it to operation_type='remove'
+// because the host's current team has the feature disabled), returns a zero
+// time and no error: the password is still readable until the device confirms
+// ClearRecoveryLock, but auto-rotation does not apply and would be undone by
+// the clear anyway. Callers should treat zero as "no rotation scheduled" and
+// omit auto_rotate_at from the response rather than reporting a deadline the
+// auto-rotation cron (filtered on operation_type='install') will never honor.
 func (ds *Datastore) MarkRecoveryLockPasswordViewed(ctx context.Context, hostUUID string) (time.Time, error) {
-	// Set auto_rotate_at to 1 hour from now when password is viewed.
-	// This always updates (even if pending rotation exists) so the API always returns a valid rotation time.
 	rotateAt := time.Now().Add(1 * time.Hour)
 
 	stmt := fmt.Sprintf(`
@@ -8311,12 +8325,6 @@ func (ds *Datastore) MarkRecoveryLockPasswordViewed(ctx context.Context, hostUUI
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		// Row is not in install state (e.g., ClaimHostsForRecoveryLockClear has
-		// flipped it to operation_type='remove' because the host's current team
-		// has the feature disabled). The password is still readable until the
-		// device confirms ClearRecoveryLock; auto-rotation does not apply and
-		// would be undone by the clear anyway. Return zero time so the caller
-		// can omit auto_rotate_at from the response.
 		return time.Time{}, nil
 	}
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8311,8 +8311,13 @@ func (ds *Datastore) MarkRecoveryLockPasswordViewed(ctx context.Context, hostUUI
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return time.Time{}, ctxerr.Wrap(ctx, notFound("HostRecoveryLockPassword").
-			WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+		// Row is not in install state (e.g., ClaimHostsForRecoveryLockClear has
+		// flipped it to operation_type='remove' because the host's current team
+		// has the feature disabled). The password is still readable until the
+		// device confirms ClearRecoveryLock; auto-rotation does not apply and
+		// would be undone by the clear anyway. Return zero time so the caller
+		// can omit auto_rotate_at from the response.
+		return time.Time{}, nil
 	}
 
 	return rotateAt, nil

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -11322,6 +11322,44 @@ func testClaimHostsForRecoveryLockClear(t *testing.T, ds *Datastore) {
 		assert.Equal(t, "pending", status)
 	})
 
+	t.Run("clears stale auto_rotate_at when flipping to remove", func(t *testing.T) {
+		team := createTeamWithRecoveryLock(t, "stale-rotation-team", true)
+		host := test.NewHost(t, ds, "stale-rotation-host", "1.2.6.7", "stalerotkey", "stalerotuuid", time.Now(),
+			test.WithPlatform("darwin"), test.WithTeamID(team.ID))
+		setHostCPUType(t, host.ID, "arm64")
+		nanoEnrollAndSetHostMDMData(t, ds, host, false)
+
+		pw := apple_mdm.GenerateRecoveryLockPassword()
+		err := ds.SetHostsRecoveryLockPasswords(ctx, []fleet.HostRecoveryLockPasswordPayload{{HostUUID: host.UUID, Password: pw}})
+		require.NoError(t, err)
+		err = ds.SetRecoveryLockVerified(ctx, host.UUID)
+		require.NoError(t, err)
+
+		// Simulate the user viewing the password under the install-state row,
+		// which schedules a rotation.
+		priorRotateAt, err := ds.MarkRecoveryLockPasswordViewed(ctx, host.UUID)
+		require.NoError(t, err)
+		require.False(t, priorRotateAt.IsZero())
+
+		// Disabling the team's setting and running the clear claim must wipe
+		// the stale view-deadline — auto_rotate_at is meaningful only for
+		// install-state rows, and leaving it would cause a subsequent view to
+		// return a rotation time the cron will never honor.
+		team.Config.MDM.EnableRecoveryLockPassword = false
+		_, err = ds.SaveTeam(ctx, team)
+		require.NoError(t, err)
+
+		uuids, err := ds.ClaimHostsForRecoveryLockClear(ctx)
+		require.NoError(t, err)
+		require.Contains(t, uuids, host.UUID)
+
+		var autoRotateAt *time.Time
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &autoRotateAt,
+			`SELECT auto_rotate_at FROM host_recovery_key_passwords WHERE host_uuid = ?`, host.UUID)
+		require.NoError(t, err)
+		assert.Nil(t, autoRotateAt, "auto_rotate_at should be cleared when flipping operation_type to remove")
+	})
+
 	t.Run("returns pending when operation_type is install and status is NULL", func(t *testing.T) {
 		host := test.NewHost(t, ds, "install-null-host", "1.2.6.5", "installnullkey", "installnulluuid", time.Now())
 
@@ -12251,27 +12289,36 @@ func testRecoveryLockAutoRotation(t *testing.T, ds *Datastore) {
 	t.Run("MarkRecoveryLockPasswordViewed returns zero time for remove operation", func(t *testing.T) {
 		host := setupHostWithVerifiedPassword(t, "view-host-remove", "viewuuidremove1")
 
-		// Flip to remove operation type — what ClaimHostsForRecoveryLockClear
-		// would do when the host's team has the feature disabled.
-		_, err := ds.writer(ctx).ExecContext(ctx, `
+		// Realistic sequence: password is viewed under install state (sets
+		// auto_rotate_at), then the row is flipped to remove by the cleanup
+		// path. A second view must not fail and must not (re-)schedule a
+		// rotation that the auto-rotation cron won't honor.
+		priorRotateAt, err := ds.MarkRecoveryLockPasswordViewed(ctx, host.UUID)
+		require.NoError(t, err)
+		require.False(t, priorRotateAt.IsZero(), "view under install state should schedule rotation")
+
+		_, err = ds.writer(ctx).ExecContext(ctx, `
 			UPDATE host_recovery_key_passwords
 			SET operation_type = 'remove'
 			WHERE host_uuid = ?`, host.UUID)
 		require.NoError(t, err)
 
-		// View must not fail just because the row is pending removal; the
-		// password is still valid on the device until the clear is confirmed.
 		rotateAt, err := ds.MarkRecoveryLockPasswordViewed(ctx, host.UUID)
 		require.NoError(t, err)
 		assert.True(t, rotateAt.IsZero(), "expected zero rotateAt for remove-state row")
 
-		// auto_rotate_at must not have been written to a row that is pending
-		// removal — otherwise a later restore to install state would surprise-rotate.
+		// MarkRecoveryLockPasswordViewed itself must not touch a remove-state
+		// row's auto_rotate_at — clearing that stale deadline is the
+		// responsibility of ClaimHostsForRecoveryLockClear (covered in
+		// testClaimHostsForRecoveryLockClear) so this assertion pins the
+		// no-op contract.
 		var autoRotateAt *time.Time
 		err = sqlx.GetContext(ctx, ds.reader(ctx), &autoRotateAt,
 			`SELECT auto_rotate_at FROM host_recovery_key_passwords WHERE host_uuid = ?`, host.UUID)
 		require.NoError(t, err)
-		assert.Nil(t, autoRotateAt, "auto_rotate_at should not be set on a remove-state row")
+		require.NotNil(t, autoRotateAt)
+		assert.WithinDuration(t, priorRotateAt, *autoRotateAt, time.Second,
+			"MarkRecoveryLockPasswordViewed must not modify auto_rotate_at on a remove-state row")
 	})
 
 	// Helper to check if a host UUID is in the rotation info list

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -12239,26 +12239,39 @@ func testRecoveryLockAutoRotation(t *testing.T, ds *Datastore) {
 		assert.True(t, pw.AutoRotateAt.After(firstRotateAt), "persisted auto_rotate_at should be after first rotation time")
 	})
 
-	t.Run("MarkRecoveryLockPasswordViewed fails for non-existent host", func(t *testing.T) {
-		_, err := ds.MarkRecoveryLockPasswordViewed(ctx, "non-existent-uuid")
-		require.Error(t, err)
-		assert.True(t, fleet.IsNotFound(err))
+	t.Run("MarkRecoveryLockPasswordViewed returns zero time for non-existent host", func(t *testing.T) {
+		// Callers are expected to verify existence via GetHostRecoveryLockPassword
+		// before scheduling rotation, so a missing row here is treated the same
+		// as a non-install-state row: skip scheduling without erroring.
+		rotateAt, err := ds.MarkRecoveryLockPasswordViewed(ctx, "non-existent-uuid")
+		require.NoError(t, err)
+		assert.True(t, rotateAt.IsZero())
 	})
 
-	t.Run("MarkRecoveryLockPasswordViewed fails for remove operation", func(t *testing.T) {
-		host := setupHostWithVerifiedPassword(t, "view-host3", "viewuuid0003")
+	t.Run("MarkRecoveryLockPasswordViewed returns zero time for remove operation", func(t *testing.T) {
+		host := setupHostWithVerifiedPassword(t, "view-host-remove", "viewuuidremove1")
 
-		// Change to remove operation type
+		// Flip to remove operation type — what ClaimHostsForRecoveryLockClear
+		// would do when the host's team has the feature disabled.
 		_, err := ds.writer(ctx).ExecContext(ctx, `
 			UPDATE host_recovery_key_passwords
 			SET operation_type = 'remove'
 			WHERE host_uuid = ?`, host.UUID)
 		require.NoError(t, err)
 
-		// Should fail because operation_type is not 'install'
-		_, err = ds.MarkRecoveryLockPasswordViewed(ctx, host.UUID)
-		require.Error(t, err)
-		assert.True(t, fleet.IsNotFound(err))
+		// View must not fail just because the row is pending removal; the
+		// password is still valid on the device until the clear is confirmed.
+		rotateAt, err := ds.MarkRecoveryLockPasswordViewed(ctx, host.UUID)
+		require.NoError(t, err)
+		assert.True(t, rotateAt.IsZero(), "expected zero rotateAt for remove-state row")
+
+		// auto_rotate_at must not have been written to a row that is pending
+		// removal — otherwise a later restore to install state would surprise-rotate.
+		var autoRotateAt *time.Time
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &autoRotateAt,
+			`SELECT auto_rotate_at FROM host_recovery_key_passwords WHERE host_uuid = ?`, host.UUID)
+		require.NoError(t, err)
+		assert.Nil(t, autoRotateAt, "auto_rotate_at should not be set on a remove-state row")
 	})
 
 	// Helper to check if a host UUID is in the rotation info list

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1652,8 +1652,11 @@ type Datastore interface {
 	// This is used when a clear command fails with a transient error (not password mismatch).
 	ResetRecoveryLockForRetry(ctx context.Context, hostUUID string) error
 
-	// MarkRecoveryLockPasswordViewed sets auto_rotate_at to 1 hour from now.
-	// Called when the password is viewed and returns the scheduled rotation time.
+	// MarkRecoveryLockPasswordViewed sets auto_rotate_at to 1 hour from now on
+	// the host's install-state recovery lock row and returns the scheduled
+	// rotation time. If the row is missing or in a state where rotation does
+	// not apply (e.g., operation_type='remove'), returns a zero time and no
+	// error so callers that have already retrieved the password do not 404.
 	MarkRecoveryLockPasswordViewed(ctx context.Context, hostUUID string) (time.Time, error)
 
 	// GetHostsForAutoRotation returns hosts where auto_rotate_at <= now

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -4066,11 +4066,14 @@ func (svc *Service) GetHostRecoveryLockPassword(ctx context.Context, hostID uint
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "mark recovery lock password viewed")
 	}
-	// Zero time means rotation does not apply to this row's current state
-	// (e.g., it's pending removal). Leave AutoRotateAt nil so the response
-	// omits the field rather than reporting a rotation that won't happen.
 	if !rotateAt.IsZero() {
 		password.AutoRotateAt = &rotateAt
+	} else {
+		// Rotation does not apply to this row's current state (e.g., it's
+		// pending removal). Discard any stale auto_rotate_at loaded from the
+		// DB — auto-rotation is gated on operation_type='install' and won't
+		// actually fire, so reporting a rotation time would mislead the UI.
+		password.AutoRotateAt = nil
 	}
 
 	return password, nil

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -4066,7 +4066,12 @@ func (svc *Service) GetHostRecoveryLockPassword(ctx context.Context, hostID uint
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "mark recovery lock password viewed")
 	}
-	password.AutoRotateAt = &rotateAt
+	// Zero time means rotation does not apply to this row's current state
+	// (e.g., it's pending removal). Leave AutoRotateAt nil so the response
+	// omits the field rather than reporting a rotation that won't happen.
+	if !rotateAt.IsZero() {
+		password.AutoRotateAt = &rotateAt
+	}
 
 	return password, nil
 }


### PR DESCRIPTION
**Related issue:** Resolves #44459
## Summary

Fixed an issue where the recovery lock password for a macOS host could become unretrievable via the UI and API after the host was transferred to a team with recovery lock disabled, even though the password was
still stored in the database.

## Root causes

Three bugs combined to produce the symptom:

- **Frontend visibility**: `canShowRecoveryLockPassword` gated the "Show Recovery Lock password" action on the current team's `enable_recovery_lock_password` setting and ignored the `recoveryLockPasswordAvailable`
 signal, so the UI option vanished whenever the host's new team had the feature off.
- **API 404 on view**: `MarkRecoveryLockPasswordViewed` returned a `notFound` error when its UPDATE matched zero rows. This happened as soon as the `ClaimHostsForRecoveryLockClear` cron flipped the password row's
`operation_type` from `install` to `remove` — causing `GET /hosts/:id/recovery_lock_password` to 404 even though the password had already been successfully retrieved and decrypted moments earlier in the same
request.
- **Stale rotation deadline**: `ClaimHostsForRecoveryLockClear` left the row's `auto_rotate_at` untouched when flipping to `remove`, so subsequent reads still surfaced the pre-transfer view-deadline and the UI
rendered a rotation banner promising an auto-rotation that the cron (filtered on `operation_type='install'`) would never honor.

## Fix

- **Frontend**: updated `canShowRecoveryLockPassword` to also show the action when a password is available, regardless of the team setting.
- **API**: changed `MarkRecoveryLockPasswordViewed` to return a zero `time.Time` with no error when no install-state row exists. The service skips the `AutoRotateAt` assignment in that case and explicitly nulls
any stale value loaded from the DB, so the response's `auto_rotate_at` is omitted.
- **Data hygiene**: updated `ClaimHostsForRecoveryLockClear` to also set `auto_rotate_at = NULL` when flipping a row to `remove`, since the rotation deadline is meaningful only for install-state rows.
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recovery lock password retrieval for hosts transferred to teams with recovery lock disabled; the "Show Recovery Lock password" option appears when a host password is available regardless of the team's setting.
* **Tests**
  * Added and updated tests to cover password visibility and auto-rotation/remove transitions.
* **Documentation**
  * Clarified behavior and return contract for marking recovery-lock passwords as viewed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45280)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->