### PR TITLE
 Dashboard widget: Hosts online: For first pass, drop mobile support

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -45,8 +45,8 @@ const DATASETS: IDataSet[] = [
     defaultChartType: "checkerboard",
     description: (
       <>
-        The number of hosts detected online (checking in to Fleet) during 
-        a given hour.
+        The number of hosts detected online (checking in to Fleet) during a 
+        given hour.
         <br />
         <br />
         Currently, only macOS, Windows, Linux, and ChromeOS are supported.

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -45,8 +45,8 @@ const DATASETS: IDataSet[] = [
     defaultChartType: "checkerboard",
     description: (
       <>
-        The number of hosts detected online (checking in to Fleet) during a given 
-        hour.
+        The number of hosts detected online (checking in to Fleet) during 
+        a given hour.
         <br />
         <br />
         Currently, only macOS, Windows, Linux, and ChromeOS are supported.

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -45,7 +45,8 @@ const DATASETS: IDataSet[] = [
     defaultChartType: "checkerboard",
     description: (
       <>
-        The number of hosts detected online (checking in to Fleet) during a given hour.
+        The number of hosts detected online (checking in to Fleet) during a given 
+        hour.
         <br />
         <br />
         Currently, only macOS, Windows, Linux, and ChromeOS are supported.

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -45,12 +45,10 @@ const DATASETS: IDataSet[] = [
     defaultChartType: "checkerboard",
     description: (
       <>
-        The number of hosts detected online during a given hour.
+        The number of hosts detected online (checking in to Fleet) during a given hour.
         <br />
         <br />
-        A host is considered online if it&rsquo;s actively checking in to Fleet.
-        <br />
-        This includes sleeping hosts (e.g. lid closed).{" "}
+        Currently, only macOS, Windows, Linux, and ChromeOS are supported.
       </>
     ),
     tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -45,7 +45,7 @@ const DATASETS: IDataSet[] = [
     defaultChartType: "checkerboard",
     description: (
       <>
-        The number of hosts detected online (checking in to Fleet) during a 
+        The number of hosts detected online (checking in to Fleet) during a
         given hour.
         <br />
         <br />


### PR DESCRIPTION
Tooltip copy update for this issue:
- https://github.com/fleetdm/fleet/issues/45290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "Hosts online" metric tooltip to clarify that online hosts are counted when they check in within a given hour (removing the prior reference to sleeping hosts) and to list supported OSes: macOS, Windows, Linux, and ChromeOS. This improves clarity around how the metric is measured.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45292)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->