### PR TITLE
Update data collection interval and strategy

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1562,7 +1562,7 @@ func newChartDataCollectionSchedule(
 ) (*schedule.Schedule, error) {
 	const (
 		name            = string(fleet.CronChartDataCollection)
-		defaultInterval = 10 * time.Minute
+		defaultInterval = 1 * time.Hour
 	)
 	s := schedule.New(
 		ctx, name, instanceID, defaultInterval, ds, ds,

--- a/server/chart/api/chart.go
+++ b/server/chart/api/chart.go
@@ -69,10 +69,12 @@ type Dataset interface {
 // method. It is satisfied by the chart internal Datastore, keeping dataset
 // implementations decoupled from internals.
 type DatasetStore interface {
-	// FindRecentlySeenHostIDs returns host IDs that have reported since the
-	// given cutoff. Used by datasets like uptime that derive their sample from
-	// recent host activity.
-	FindRecentlySeenHostIDs(ctx context.Context, since time.Time, disabledFleetIDs []uint) ([]uint, error)
+	// FindOnlineHostIDs returns host IDs that are "online right now" per the
+	// product's standard online predicate (host_seen_times.seen_time within
+	// the host's own check-in interval). MDM-only mobile devices (iOS,
+	// iPadOS, Android) are excluded by design — they don't have
+	// host_seen_times rows. Used by datasets like uptime.
+	FindOnlineHostIDs(ctx context.Context, now time.Time, disabledFleetIDs []uint) ([]uint, error)
 
 	// AffectedHostIDsByCVE returns host IDs grouped by CVE, scoped to the given
 	// cves set. nil or empty cves returns an empty map — callers must pass the

--- a/server/chart/datasets.go
+++ b/server/chart/datasets.go
@@ -7,10 +7,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/chart/api"
 )
 
-// uptimeRecentlySeenWindow must match the cron schedule cadence so each sample
-// reflects activity since the last run.
-const uptimeRecentlySeenWindow = 10 * time.Minute
-
 // UptimeDataset implements api.Dataset for host uptime tracking.
 type UptimeDataset struct{}
 
@@ -20,7 +16,7 @@ func (u *UptimeDataset) SampleStrategy() api.SampleStrategy { return api.SampleS
 func (u *UptimeDataset) DefaultVisualization() string       { return "checkerboard" }
 
 func (u *UptimeDataset) Collect(ctx context.Context, store api.DatasetStore, now time.Time, disabledFleetIDs []uint) error {
-	hostIDs, err := store.FindRecentlySeenHostIDs(ctx, now.Add(-uptimeRecentlySeenWindow), disabledFleetIDs)
+	hostIDs, err := store.FindOnlineHostIDs(ctx, now, disabledFleetIDs)
 	if err != nil {
 		return err
 	}

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -11,10 +11,15 @@ import (
 	"github.com/fleetdm/fleet/v4/server/chart/internal/types"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
 )
+
+// onlineIntervalBufferSeconds mirrors fleet.OnlineIntervalBuffer (the grace
+// period added on top of a host's own check-in interval before it's
+// considered offline). Duplicated rather than imported because the chart
+// bounded context must not depend on server/fleet — arch test enforced.
+const onlineIntervalBufferSeconds = 60
 
 // Datastore is the MySQL implementation of the chart datastore.
 type Datastore struct {
@@ -81,7 +86,7 @@ func (ds *Datastore) FindOnlineHostIDs(ctx context.Context, now time.Time, disab
 		JOIN host_seen_times hst ON h.id = hst.host_id
 		WHERE DATE_ADD(hst.seen_time,
 			INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND
-		) > ?`, fleet.OnlineIntervalBuffer)
+		) > ?`, onlineIntervalBufferSeconds)
 	args := []any{now.UTC()}
 
 	if len(disabledFleetIDs) > 0 {

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/chart/internal/types"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
 )
@@ -64,25 +65,24 @@ func (ds *Datastore) GetHostIDsForFilter(ctx context.Context, hostFilter *types.
 	return ids, nil
 }
 
-// FindRecentlySeenHostIDs returns host IDs with any activity signal at or after `since`.
-// "Activity signal" is the most recent of host_seen_times.seen_time, nano_enrollments.last_seen_at,
-// or host details/creation timestamps.
-func (ds *Datastore) FindRecentlySeenHostIDs(ctx context.Context, since time.Time, disabledFleetIDs []uint) ([]uint, error) {
-	query := `
+// FindOnlineHostIDs returns host IDs that are "online" at `now` per the same
+// per-host predicate used by the hosts list status=online filter
+// (filterHostsByStatus in server/datastore/mysql/hosts.go): the host has a
+// host_seen_times row whose seen_time falls within the host's own check-in
+// interval (LEAST of distributed_interval and config_tls_refresh) plus the
+// OnlineIntervalBuffer grace period.
+//
+// Because host_seen_times is updated only by osquery check-ins, MDM-only
+// mobile devices (iOS, iPadOS, Android) are currently excluded by design.
+func (ds *Datastore) FindOnlineHostIDs(ctx context.Context, now time.Time, disabledFleetIDs []uint) ([]uint, error) {
+	query := fmt.Sprintf(`
 		SELECT h.id
 		FROM hosts h
-			LEFT JOIN host_seen_times hst ON h.id = hst.host_id
-			LEFT JOIN nano_enrollments ne ON ne.id = h.uuid
-				AND ne.type IN ('Device', 'User Enrollment (Device)')
-		WHERE COALESCE(
-			GREATEST(
-				COALESCE(hst.seen_time, ne.last_seen_at),
-				COALESCE(ne.last_seen_at, hst.seen_time)
-			),
-			NULLIF(h.detail_updated_at, '2000-01-01 00:00:00'),
-			h.created_at
-		) >= ?`
-	args := []any{since.UTC()}
+		JOIN host_seen_times hst ON h.id = hst.host_id
+		WHERE DATE_ADD(hst.seen_time,
+			INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND
+		) > ?`, fleet.OnlineIntervalBuffer)
+	args := []any{now.UTC()}
 
 	if len(disabledFleetIDs) > 0 {
 		query += ` AND (h.team_id IS NULL OR h.team_id NOT IN (?))`
@@ -91,13 +91,13 @@ func (ds *Datastore) FindRecentlySeenHostIDs(ctx context.Context, since time.Tim
 
 	expanded, expandedArgs, err := sqlx.In(query, args...)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "expand recently-seen host args")
+		return nil, ctxerr.Wrap(ctx, err, "expand online host args")
 	}
 	expanded = ds.rebind(expanded)
 
 	var ids []uint
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &ids, expanded, expandedArgs...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "find recently seen host IDs")
+		return nil, ctxerr.Wrap(ctx, err, "find online host IDs")
 	}
 	return ids, nil
 }

--- a/server/chart/internal/mysql/charts_test.go
+++ b/server/chart/internal/mysql/charts_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFindRecentlySeenHostIDs covers the disabledFleetIDs filter on the
-// recently-seen query: that NULL team_id hosts are always retained, that hosts
-// in disabled fleets are excluded, and that the activity-signal cutoff still
-// applies regardless of fleet membership.
-func TestFindRecentlySeenHostIDs(t *testing.T) {
+// TestFindOnlineHostIDs covers the per-host online predicate and the
+// disabledFleetIDs filter: NULL team_id hosts are always retained, hosts in
+// disabled fleets are excluded, hosts whose seen_time falls outside their own
+// check-in interval are excluded, and hosts without a host_seen_times row at
+// all (mobile devices) are excluded.
+func TestFindOnlineHostIDs(t *testing.T) {
 	tdb := testutils.SetupTestDB(t, "chart_mysql")
 	ds := NewDatastore(tdb.Conns(), tdb.Logger)
 
@@ -21,11 +22,12 @@ func TestFindRecentlySeenHostIDs(t *testing.T) {
 		name string
 		fn   func(t *testing.T, tdb *testutils.TestDB, ds *Datastore)
 	}{
-		{"NoFilter", testFindRecentEmptyDisabled},
-		{"SingleDisabledFleet", testFindRecentSingleDisabled},
-		{"MultipleDisabledFleets", testFindRecentMultipleDisabled},
-		{"NullTeamHostsAlwaysIncluded", testFindRecentNullTeamRetained},
-		{"OldHostsExcludedRegardlessOfFleet", testFindRecentOldHostsFiltered},
+		{"NoFilter", testFindOnlineEmptyDisabled},
+		{"SingleDisabledFleet", testFindOnlineSingleDisabled},
+		{"MultipleDisabledFleets", testFindOnlineMultipleDisabled},
+		{"NullTeamHostsAlwaysIncluded", testFindOnlineNullTeamRetained},
+		{"OfflineHostsExcluded", testFindOnlineOfflineExcluded},
+		{"MobileHostsWithoutSeenTimeExcluded", testFindOnlineMobileExcluded},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -35,8 +37,20 @@ func TestFindRecentlySeenHostIDs(t *testing.T) {
 	}
 }
 
-// seedHosts inserts a host per (teamID, lastSeen) entry and returns the
-// auto-assigned host ids in input order. teamID == 0 is treated as NULL.
+// hostSeed describes one row to insert into hosts (and optionally host_seen_times).
+// distributedInterval is in seconds; when 0, the table defaults apply (which means
+// the effective online window collapses to fleet.OnlineIntervalBuffer alone).
+// When omitSeenTime is true, no host_seen_times row is inserted — simulating an
+// MDM-only mobile device.
+type hostSeed struct {
+	teamID              uint // 0 means NULL
+	seenTime            time.Time
+	distributedInterval int
+	omitSeenTime        bool
+}
+
+// seedHosts inserts a host per entry and returns the auto-assigned host ids in
+// input order. teamID == 0 is treated as NULL.
 func seedHosts(t *testing.T, tdb *testutils.TestDB, entries []hostSeed) []uint {
 	t.Helper()
 	ctx := t.Context()
@@ -60,29 +74,26 @@ func seedHosts(t *testing.T, tdb *testutils.TestDB, entries []hostSeed) []uint {
 		if e.teamID != 0 {
 			teamArg = e.teamID
 		}
-		// detail_updated_at is set to the sentinel so the WHERE clause's
-		// COALESCE falls through to either host_seen_times or created_at.
+		// detail_updated_at is set to the sentinel so it never spuriously
+		// makes a host look freshly active to anyone reading from hosts.
 		res, err := tdb.DB.ExecContext(ctx, `
-			INSERT INTO hosts (osquery_host_id, node_key, uuid, hostname, detail_updated_at, created_at, team_id)
-			VALUES (?, ?, ?, ?, '2000-01-01 00:00:00', ?, ?)
+			INSERT INTO hosts (osquery_host_id, node_key, uuid, hostname, detail_updated_at, created_at, team_id, distributed_interval, config_tls_refresh)
+			VALUES (?, ?, ?, ?, '2000-01-01 00:00:00', ?, ?, ?, ?)
 		`, "ohid-"+itoa(uint(i+1)), "nk-"+itoa(uint(i+1)), "uuid-"+itoa(uint(i+1)),
-			"host-"+itoa(uint(i+1)), e.lastSeen, teamArg)
+			"host-"+itoa(uint(i+1)), e.seenTime, teamArg, e.distributedInterval, e.distributedInterval)
 		require.NoError(t, err)
 		raw, err := res.LastInsertId()
 		require.NoError(t, err)
 		hostID := uint(raw) //nolint:gosec // G115: AUTO_INCREMENT primary key
-		_, err = tdb.DB.ExecContext(ctx,
-			`INSERT INTO host_seen_times (host_id, seen_time) VALUES (?, ?)`,
-			hostID, e.lastSeen)
-		require.NoError(t, err)
+		if !e.omitSeenTime {
+			_, err = tdb.DB.ExecContext(ctx,
+				`INSERT INTO host_seen_times (host_id, seen_time) VALUES (?, ?)`,
+				hostID, e.seenTime)
+			require.NoError(t, err)
+		}
 		ids = append(ids, hostID)
 	}
 	return ids
-}
-
-type hostSeed struct {
-	teamID   uint // 0 means NULL
-	lastSeen time.Time
 }
 
 func itoa(u uint) string {
@@ -100,74 +111,99 @@ func itoa(u uint) string {
 	return string(b[i:])
 }
 
-func testFindRecentEmptyDisabled(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
+// onlineSeen is a seen_time recent enough that the host should be considered
+// online given the default test distributedInterval below.
+func onlineSeen(now time.Time) time.Time { return now.Add(-1 * time.Minute) }
+
+// defaultInterval gives every online test host a 10-minute check-in interval,
+// so the predicate's effective window is 10m + OnlineIntervalBuffer (60s).
+const defaultInterval = 600
+
+func testFindOnlineEmptyDisabled(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
 	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
 	ids := seedHosts(t, tdb, []hostSeed{
-		{teamID: 1, lastSeen: now.Add(-1 * time.Hour)},
-		{teamID: 2, lastSeen: now.Add(-1 * time.Hour)},
-		{teamID: 0, lastSeen: now.Add(-1 * time.Hour)},
+		{teamID: 1, seenTime: onlineSeen(now), distributedInterval: defaultInterval},
+		{teamID: 2, seenTime: onlineSeen(now), distributedInterval: defaultInterval},
+		{teamID: 0, seenTime: onlineSeen(now), distributedInterval: defaultInterval},
 	})
 
-	got, err := ds.FindRecentlySeenHostIDs(ctx, now.Add(-24*time.Hour), nil)
+	got, err := ds.FindOnlineHostIDs(ctx, now, nil)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, ids, got, "with no fleet filter all recently-seen hosts are returned")
+	assert.ElementsMatch(t, ids, got, "with no fleet filter all online hosts are returned")
 }
 
-func testFindRecentSingleDisabled(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
+func testFindOnlineSingleDisabled(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
 	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
 	ids := seedHosts(t, tdb, []hostSeed{
-		{teamID: 1, lastSeen: now.Add(-1 * time.Hour)}, // 0: excluded
-		{teamID: 2, lastSeen: now.Add(-1 * time.Hour)}, // 1: kept
-		{teamID: 0, lastSeen: now.Add(-1 * time.Hour)}, // 2: kept (no team)
+		{teamID: 1, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 0: excluded
+		{teamID: 2, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 1: kept
+		{teamID: 0, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 2: kept (no team)
 	})
 
-	got, err := ds.FindRecentlySeenHostIDs(ctx, now.Add(-24*time.Hour), []uint{1})
+	got, err := ds.FindOnlineHostIDs(ctx, now, []uint{1})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint{ids[1], ids[2]}, got)
 }
 
-func testFindRecentMultipleDisabled(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
+func testFindOnlineMultipleDisabled(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
 	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
 	ids := seedHosts(t, tdb, []hostSeed{
-		{teamID: 1, lastSeen: now.Add(-1 * time.Hour)}, // 0: excluded
-		{teamID: 2, lastSeen: now.Add(-1 * time.Hour)}, // 1: excluded
-		{teamID: 3, lastSeen: now.Add(-1 * time.Hour)}, // 2: kept
-		{teamID: 0, lastSeen: now.Add(-1 * time.Hour)}, // 3: kept (no team)
+		{teamID: 1, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 0: excluded
+		{teamID: 2, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 1: excluded
+		{teamID: 3, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 2: kept
+		{teamID: 0, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 3: kept (no team)
 	})
 
-	got, err := ds.FindRecentlySeenHostIDs(ctx, now.Add(-24*time.Hour), []uint{1, 2})
+	got, err := ds.FindOnlineHostIDs(ctx, now, []uint{1, 2})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint{ids[2], ids[3]}, got)
 }
 
-func testFindRecentNullTeamRetained(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
+func testFindOnlineNullTeamRetained(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
 	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
 	ids := seedHosts(t, tdb, []hostSeed{
-		{teamID: 0, lastSeen: now.Add(-1 * time.Hour)}, // 0: kept (NULL team)
-		{teamID: 1, lastSeen: now.Add(-1 * time.Hour)}, // 1: excluded
+		{teamID: 0, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 0: kept (NULL team)
+		{teamID: 1, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 1: excluded
 	})
 
 	// Disabling every fleet that exists must still return the NULL-team host.
-	got, err := ds.FindRecentlySeenHostIDs(ctx, now.Add(-24*time.Hour), []uint{1})
+	got, err := ds.FindOnlineHostIDs(ctx, now, []uint{1})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint{ids[0]}, got)
 }
 
-func testFindRecentOldHostsFiltered(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
+func testFindOnlineOfflineExcluded(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
 	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
+	// All three hosts have a 10-min check-in interval (effective online
+	// window: 660s). Only host 0 is within that window.
 	ids := seedHosts(t, tdb, []hostSeed{
-		{teamID: 2, lastSeen: now.Add(-1 * time.Hour)},  // 0: kept (recent, not disabled)
-		{teamID: 2, lastSeen: now.Add(-48 * time.Hour)}, // 1: excluded by recency
-		{teamID: 0, lastSeen: now.Add(-48 * time.Hour)}, // 2: excluded by recency (NULL team doesn't bypass `since`)
+		{teamID: 2, seenTime: onlineSeen(now), distributedInterval: defaultInterval},      // 0: online
+		{teamID: 2, seenTime: now.Add(-1 * time.Hour), distributedInterval: defaultInterval},  // 1: offline (well past its window)
+		{teamID: 0, seenTime: now.Add(-48 * time.Hour), distributedInterval: defaultInterval}, // 2: offline even though NULL team
 	})
-	_ = ids
 
-	got, err := ds.FindRecentlySeenHostIDs(ctx, now.Add(-24*time.Hour), []uint{1})
+	got, err := ds.FindOnlineHostIDs(ctx, now, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{ids[0]}, got)
+}
+
+func testFindOnlineMobileExcluded(t *testing.T, tdb *testutils.TestDB, ds *Datastore) {
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	// Host 0 is an osquery host, online. Host 1 has no host_seen_times row —
+	// representing an MDM-only mobile device — and must be excluded by the
+	// INNER JOIN regardless of how recently it might have checked in via MDM.
+	ids := seedHosts(t, tdb, []hostSeed{
+		{teamID: 1, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 0: osquery online
+		{teamID: 1, seenTime: now, omitSeenTime: true},                                // 1: mobile (no hst row)
+	})
+
+	got, err := ds.FindOnlineHostIDs(ctx, now, nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint{ids[0]}, got)
 }

--- a/server/chart/internal/mysql/charts_test.go
+++ b/server/chart/internal/mysql/charts_test.go
@@ -182,7 +182,7 @@ func testFindOnlineOfflineExcluded(t *testing.T, tdb *testutils.TestDB, ds *Data
 	// All three hosts have a 10-min check-in interval (effective online
 	// window: 660s). Only host 0 is within that window.
 	ids := seedHosts(t, tdb, []hostSeed{
-		{teamID: 2, seenTime: onlineSeen(now), distributedInterval: defaultInterval},      // 0: online
+		{teamID: 2, seenTime: onlineSeen(now), distributedInterval: defaultInterval},          // 0: online
 		{teamID: 2, seenTime: now.Add(-1 * time.Hour), distributedInterval: defaultInterval},  // 1: offline (well past its window)
 		{teamID: 0, seenTime: now.Add(-48 * time.Hour), distributedInterval: defaultInterval}, // 2: offline even though NULL team
 	})
@@ -200,7 +200,7 @@ func testFindOnlineMobileExcluded(t *testing.T, tdb *testutils.TestDB, ds *Datas
 	// INNER JOIN regardless of how recently it might have checked in via MDM.
 	ids := seedHosts(t, tdb, []hostSeed{
 		{teamID: 1, seenTime: onlineSeen(now), distributedInterval: defaultInterval}, // 0: osquery online
-		{teamID: 1, seenTime: now, omitSeenTime: true},                                // 1: mobile (no hst row)
+		{teamID: 1, seenTime: now, omitSeenTime: true},                               // 1: mobile (no hst row)
 	})
 
 	got, err := ds.FindOnlineHostIDs(ctx, now, nil)

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -56,21 +56,21 @@ func globalViewer() *mockViewerProvider { return &mockViewerProvider{isGlobal: t
 
 // mockDatastore implements types.Datastore for unit tests.
 type mockDatastore struct {
-	getSCDDataFunc            func(ctx context.Context, dataset string, startDate, endDate time.Time, bucketSize time.Duration, strategy api.SampleStrategy, filterMask []byte, entityIDs []string) ([]api.DataPoint, error)
-	getHostIDsForFilterFunc   func(ctx context.Context, hostFilter *types.HostFilter) ([]uint, error)
-	findRecentlySeenHostIDsFn func(ctx context.Context, since time.Time, disabledFleetIDs []uint) ([]uint, error)
-	affectedHostIDsByCVEFn    func(ctx context.Context, disabledFleetIDs []uint, cves []string) (map[string][]uint, error)
-	trackedCriticalCVEsFn     func(ctx context.Context) ([]string, error)
-	recordBucketDataFn        func(ctx context.Context, dataset string, bucketStart time.Time, bucketSize time.Duration, strategy api.SampleStrategy, entityBitmaps map[string][]byte) error
-	recordBucketDataInvoked   bool
-	deleteAllForDatasetFn     func(ctx context.Context, dataset string, batchSize int) error
-	hostIDsInFleetsFn         func(ctx context.Context, fleetIDs []uint) ([]uint, error)
-	applyScrubMaskFn          func(ctx context.Context, dataset string, mask []byte, batchSize int) error
+	getSCDDataFunc          func(ctx context.Context, dataset string, startDate, endDate time.Time, bucketSize time.Duration, strategy api.SampleStrategy, filterMask []byte, entityIDs []string) ([]api.DataPoint, error)
+	getHostIDsForFilterFunc func(ctx context.Context, hostFilter *types.HostFilter) ([]uint, error)
+	findOnlineHostIDsFn     func(ctx context.Context, now time.Time, disabledFleetIDs []uint) ([]uint, error)
+	affectedHostIDsByCVEFn  func(ctx context.Context, disabledFleetIDs []uint, cves []string) (map[string][]uint, error)
+	trackedCriticalCVEsFn   func(ctx context.Context) ([]string, error)
+	recordBucketDataFn      func(ctx context.Context, dataset string, bucketStart time.Time, bucketSize time.Duration, strategy api.SampleStrategy, entityBitmaps map[string][]byte) error
+	recordBucketDataInvoked bool
+	deleteAllForDatasetFn   func(ctx context.Context, dataset string, batchSize int) error
+	hostIDsInFleetsFn       func(ctx context.Context, fleetIDs []uint) ([]uint, error)
+	applyScrubMaskFn        func(ctx context.Context, dataset string, mask []byte, batchSize int) error
 }
 
-func (m *mockDatastore) FindRecentlySeenHostIDs(ctx context.Context, since time.Time, disabledFleetIDs []uint) ([]uint, error) {
-	if m.findRecentlySeenHostIDsFn != nil {
-		return m.findRecentlySeenHostIDsFn(ctx, since, disabledFleetIDs)
+func (m *mockDatastore) FindOnlineHostIDs(ctx context.Context, now time.Time, disabledFleetIDs []uint) ([]uint, error) {
+	if m.findOnlineHostIDsFn != nil {
+		return m.findOnlineHostIDsFn(ctx, now, disabledFleetIDs)
 	}
 	return nil, nil
 }
@@ -573,8 +573,8 @@ func TestCollectDatasetsUptime(t *testing.T) {
 	now := time.Date(2026, 4, 8, 14, 37, 0, 0, time.UTC)
 	wantBucketStart := time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC)
 
-	ds.findRecentlySeenHostIDsFn = func(_ context.Context, since time.Time, _ []uint) ([]uint, error) {
-		assert.Equal(t, now.Add(-10*time.Minute), since)
+	ds.findOnlineHostIDsFn = func(_ context.Context, gotNow time.Time, _ []uint) ([]uint, error) {
+		assert.Equal(t, now, gotNow)
 		return []uint{1, 2, 3}, nil
 	}
 	ds.recordBucketDataFn = func(_ context.Context, dataset string, bucketStart time.Time, bucketSize time.Duration, strategy api.SampleStrategy, entityBitmaps map[string][]byte) error {
@@ -669,8 +669,8 @@ func TestCollectDatasetsForwardsScope(t *testing.T) {
 		ds := &mockDatastore{}
 		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
 		svc.RegisterDataset(&chart.UptimeDataset{})
-		ds.findRecentlySeenHostIDsFn = func(_ context.Context, _ time.Time, _ []uint) ([]uint, error) {
-			t.Fatal("FindRecentlySeenHostIDs should not have been called when scope returned skip=true")
+		ds.findOnlineHostIDsFn = func(_ context.Context, _ time.Time, _ []uint) ([]uint, error) {
+			t.Fatal("FindOnlineHostIDs should not have been called when scope returned skip=true")
 			return nil, nil
 		}
 		err := svc.CollectDatasets(t.Context(), now, func(name string) (bool, []uint) {
@@ -681,13 +681,13 @@ func TestCollectDatasetsForwardsScope(t *testing.T) {
 		assert.False(t, ds.recordBucketDataInvoked)
 	})
 
-	t.Run("disabledFleetIDs forwarded to FindRecentlySeenHostIDs", func(t *testing.T) {
+	t.Run("disabledFleetIDs forwarded to FindOnlineHostIDs", func(t *testing.T) {
 		ds := &mockDatastore{}
 		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
 		svc.RegisterDataset(&chart.UptimeDataset{})
 
 		var gotDisabled []uint
-		ds.findRecentlySeenHostIDsFn = func(_ context.Context, _ time.Time, disabled []uint) ([]uint, error) {
+		ds.findOnlineHostIDsFn = func(_ context.Context, _ time.Time, disabled []uint) ([]uint, error) {
 			gotDisabled = disabled
 			return []uint{1}, nil
 		}
@@ -730,7 +730,7 @@ func TestCollectDatasetsForwardsScope(t *testing.T) {
 		svc.RegisterDataset(&chart.UptimeDataset{})
 
 		gotDisabled := []uint{0xDEADBEEF} // sentinel — should be replaced with nil
-		ds.findRecentlySeenHostIDsFn = func(_ context.Context, _ time.Time, disabled []uint) ([]uint, error) {
+		ds.findOnlineHostIDsFn = func(_ context.Context, _ time.Time, disabled []uint) ([]uint, error) {
 			gotDisabled = disabled
 			return []uint{1}, nil
 		}

--- a/server/chart/internal/types/chart.go
+++ b/server/chart/internal/types/chart.go
@@ -32,9 +32,10 @@ type Datastore interface {
 	// FindOnlineHostIDs returns host IDs that are "online right now" per the
 	// product's standard online predicate: host_seen_times.seen_time falls
 	// within the host's own check-in interval (LEAST of distributed_interval
-	// and config_tls_refresh, plus fleet.OnlineIntervalBuffer). Hosts without
-	// a host_seen_times row — iOS, iPadOS, and Android devices, which only
-	// check in via MDM — are excluded. Used by datasets like uptime.
+	// and config_tls_refresh, plus a 60-second grace period that mirrors
+	// fleet.OnlineIntervalBuffer). Hosts without a host_seen_times row —
+	// iOS, iPadOS, and Android devices, which only check in via MDM — are
+	// excluded. Used by datasets like uptime.
 	FindOnlineHostIDs(ctx context.Context, now time.Time, disabledFleetIDs []uint) ([]uint, error)
 
 	// AffectedHostIDsByCVE returns host IDs grouped by CVE, scoped to the given

--- a/server/chart/internal/types/chart.go
+++ b/server/chart/internal/types/chart.go
@@ -29,10 +29,13 @@ type HostFilter struct {
 
 // Datastore is the internal datastore interface for the chart bounded context.
 type Datastore interface {
-	// FindRecentlySeenHostIDs returns host IDs that have reported since the
-	// given cutoff. Used by datasets like uptime that derive their sample from
-	// recent host activity.
-	FindRecentlySeenHostIDs(ctx context.Context, since time.Time, disabledFleetIDs []uint) ([]uint, error)
+	// FindOnlineHostIDs returns host IDs that are "online right now" per the
+	// product's standard online predicate: host_seen_times.seen_time falls
+	// within the host's own check-in interval (LEAST of distributed_interval
+	// and config_tls_refresh, plus fleet.OnlineIntervalBuffer). Hosts without
+	// a host_seen_times row — iOS, iPadOS, and Android devices, which only
+	// check in via MDM — are excluded. Used by datasets like uptime.
+	FindOnlineHostIDs(ctx context.Context, now time.Time, disabledFleetIDs []uint) ([]uint, error)
 
 	// AffectedHostIDsByCVE returns host IDs grouped by CVE, scoped to the given
 	// cves set. nil or empty cves returns an empty map. Unresolved-only is


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45241 

# Details

After looking at the "Hosts online" chart with data gathered from a couple of different sources, it was decided that the chart that took sampled data from the "list hosts" API with "status=online" hourly looked more familiar than the one that generated data by looking directly in the `hosts_seen` table every 10 minutes.  The former had a reasonable pattern of "online during the day on weekdays, mostly offline at night and on weekends" where the latter had devices online almost constantly, due to checkins happening via "wake on network access" features (i.e. while idle or asleep).  This PR updates the `uptime` chart dataset collection to use the same query that the "list hosts with status online" API uses, and sets the cron to collect data hourly rather than every 10 minutes.

This schedule is used by the CVE dataset collector as well, which just means that some updates about CVE exposure may be delayed for up to an hour.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
the query plan is the same (slightly better since we're dropping a join), and we're doing it far less often
- [ ] Alerted the release DRI if additional load testing is needed


## Summary by CodeRabbit

* **Changes**
  * Chart data collection frequency updated from every 10 minutes to hourly intervals.
  * Host online status for charts now determined using device check-in intervals (distributed interval, TLS refresh) plus an online buffer, replacing the previous time-window approach. Mobile/MDM-only devices excluded from online status.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45293)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->