### PR TITLE
Fix more unreleased dark mode contrast bugs

### DIFF
--- a/changes/dark-mode-tweaks
+++ b/changes/dark-mode-tweaks
@@ -1,3 +1,0 @@
-* Improved dark mode contrast on error pages.
-* Added borders to dropdowns.
-* Fixed bottom-right rounded corners of data tables being cut.

--- a/frontend/components/Avatar/Avatar.tsx
+++ b/frontend/components/Avatar/Avatar.tsx
@@ -93,7 +93,7 @@ const APIOnlyAvatar = ({ className }: IAPIOnlyAvatar) => {
         cx="16"
         cy="16"
         r="15"
-        fill="white"
+        fill="none"
         stroke={COLORS["ui-fleet-black-50"]}
         strokeWidth="2"
       />

--- a/frontend/components/Avatar/Avatar.tsx
+++ b/frontend/components/Avatar/Avatar.tsx
@@ -196,7 +196,7 @@ const Avatar = ({
 
   const avatarClasses = classnames(baseClass, className, {
     [`${baseClass}--${size?.toLowerCase()}`]: !!size,
-    "has-white-background": !!hasWhiteBackground,
+    "has-white-background": !!hasWhiteBackground && !useApiOnlyAvatar,
   });
   const { gravatar_url } = user;
 

--- a/frontend/components/TableContainer/DataTable/HeaderCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/HeaderCell/_styles.scss
@@ -17,14 +17,14 @@
     height: 0;
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
-    border-bottom: 5px solid $ui-fleet-black-25;
+    border-bottom: 5px solid $ui-fleet-black-50;
   }
   .descending-arrow {
     width: 0;
     height: 0;
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
-    border-top: 5px solid $ui-fleet-black-25;
+    border-top: 5px solid $ui-fleet-black-50;
   }
 
   &.ascending {

--- a/frontend/components/TableContainer/DataTable/PerformanceImpactCell/PerformanceImpactCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PerformanceImpactCell/PerformanceImpactCell.tsx
@@ -64,8 +64,7 @@ const PerformanceImpactCell = ({
         disableTooltip={disableTooltip}
         underline={false}
         showArrow
-        // Pills require more gap from text to tooltip
-        tipOffset={indicatorValue === "Undetermined" ? 8 : 12}
+        tipOffset={8}
       >
         <span className={pillClassName}>{indicatorValue}</span>
       </TooltipWrapper>

--- a/frontend/components/TableContainer/DataTable/PerformanceImpactCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/PerformanceImpactCell/_styles.scss
@@ -6,28 +6,9 @@
 
 .data-table__pill {
   color: $core-fleet-black;
-  font-weight: $bold;
-  padding: 4px 12px;
-  border-radius: 29px;
 
-  span {
-    border-radius: 29px;
-    background-color: $core-fleet-purple;
-  }
   &--undetermined {
     color: $ui-fleet-black-50;
     font-style: italic;
-    font-weight: 400;
-    padding: 0;
-    border-radius: 0;
-  }
-  &--minimal {
-    background-color: $ui-fleet-black-10;
-  }
-  &--considerable {
-    background-color: $ui-fleet-black-25;
-  }
-  &--excessive {
-    background-color: $ui-fleet-black-50;
   }
 }

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -453,7 +453,7 @@ $shadow-transition-width: 16px;
           }
         }
         .grey-cell {
-          color: $ui-fleet-black-50;
+          color: $ui-fleet-black-75;
         }
       }
 

--- a/frontend/components/YamlAce/YamlAce.jsx
+++ b/frontend/components/YamlAce/YamlAce.jsx
@@ -64,7 +64,6 @@ class YamlAce extends Component {
 
     const wrapperClass = classnames(wrapperClassName, "form-field", {
       [`${baseClass}__wrapper--error`]: error,
-      [`${baseClass}__wrapper--disabled`]: disabled,
     });
 
     return (
@@ -72,6 +71,7 @@ class YamlAce extends Component {
         {renderLabel()}
         <AceEditor
           readOnly={disabled}
+          showGutter={!disabled}
           className={baseClass}
           mode="yaml"
           theme="fleet"

--- a/frontend/components/YamlAce/_styles.scss
+++ b/frontend/components/YamlAce/_styles.scss
@@ -6,9 +6,6 @@
         border: 1px solid $ui-error;
       }
     }
-    &--disabled {
-      @include disabled($allow-pointer-events: true);
-    }
   }
 
   // Added to remove the "popping" effect when the editor first loads.

--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -14,12 +14,7 @@ import CustomLink from "components/CustomLink";
 import Radio from "components/forms/fields/Radio";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
-import {
-  generateRole,
-  generateTeam,
-  greyCell,
-  readableDate,
-} from "utilities/helpers";
+import { generateRole, generateTeam, readableDate } from "utilities/helpers";
 import { getThemeMode, setThemeMode, ThemeMode } from "utilities/theme";
 
 interface IAccountSidePanelProps {
@@ -115,20 +110,7 @@ const AccountSidePanel = ({
           onChange={onThemeSelect}
         />
       </div>
-      {isPremiumTier && (
-        <DataSet
-          title="Fleets"
-          value={
-            <span
-              className={`${
-                greyCell(teamsText) ? `${baseClass}__grey-text` : ""
-              }`}
-            >
-              {teamsText}
-            </span>
-          }
-        />
-      )}
+      {isPremiumTier && <DataSet title="Fleets" value={teamsText} />}
       <DataSet title="Role" value={roleText} />
       {isPremiumTier && config && (
         <DataSet

--- a/frontend/pages/AccountPage/AccountSidePanel/_styles.scss
+++ b/frontend/pages/AccountPage/AccountSidePanel/_styles.scss
@@ -17,10 +17,6 @@
     width: 100%;
   }
 
-  &__grey-text {
-    @include grey-text;
-  }
-
   &__password-info {
     display: flex;
     flex-direction: column;

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -216,9 +216,14 @@ const HostsEnrolledCard = ({
             margin={{ top: 0, right: 20, bottom: 0, left: 0 }}
             barCategoryGap="25%"
           >
-            <CartesianGrid horizontal={false} strokeDasharray="3 3" />
+            <CartesianGrid
+              horizontal={false}
+              strokeDasharray="3 3"
+              stroke="var(--ui-fleet-black-10)"
+            />
             <CartesianGrid
               vertical={false}
+              stroke="var(--ui-fleet-black-10)"
               horizontalCoordinatesGenerator={({ offset }) => {
                 const { top, height } = offset;
                 const bandHeight = height / data.length;

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -23,7 +23,7 @@
   // Note: recharts portals tick labels out of .recharts-cartesian-axis into a
   // .recharts-zIndex-layer_* group, so we target via .recharts-wrapper.
   .recharts-wrapper text {
-    fill: $ui-fleet-black-75;
+    fill: $ui-fleet-black-50;
   }
 
   // Pointer cursor only on rows with hosts. The component adds these classes

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -135,6 +135,7 @@ const generateTableHeaders = (
         return (
           <TextCell
             value={cellProps.cell.value}
+            grey={greyCell(cellProps.cell.value)}
             italic={greyCell(cellProps.cell.value)}
           />
         );

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -132,12 +132,10 @@ const generateTableHeaders = (
             </TooltipWrapper>
           );
         }
-        const greyAndItalic = greyCell(cellProps.cell.value);
         return (
           <TextCell
             value={cellProps.cell.value}
-            grey={greyAndItalic}
-            italic={greyAndItalic}
+            italic={greyCell(cellProps.cell.value)}
           />
         );
       },

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -26,6 +26,10 @@
     border-radius: $border-radius;
     height: 36px;
 
+    body.dark-mode & {
+      background-color: #25272d;
+    }
+
     &:hover {
       cursor: pointer;
       border: 1px solid $ui-fleet-black-50;
@@ -101,6 +105,10 @@
     z-index: 2;
     animation: fade-in 150ms ease-out;
     background-color: $core-fleet-white;
+
+    body.dark-mode & {
+      background-color: #25272d;
+    }
   }
 
   .label-filter-select__menu-list {

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -27,7 +27,7 @@
     height: 36px;
 
     body.dark-mode & {
-      background-color: #25272d;
+      background-color: $ui-fleet-black-5;
     }
 
     &:hover {
@@ -107,7 +107,7 @@
     background-color: $core-fleet-white;
 
     body.dark-mode & {
-      background-color: #25272d;
+      background-color: $ui-fleet-black-5;
     }
   }
 

--- a/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
@@ -12,7 +12,8 @@
     background-color: $ui-warning;
     padding: $pad-xsmall;
     font-size: $xx-small;
-    // Surface stays yellow in both themes; text must stay dark for contrast.
+    // Warning + error surfaces shift between themes; text stays dark so the
+    // badge reads cleanly in both modes without glare in dark mode.
     color: $static-black;
     font-weight: $bold;
     border-radius: $border-radius;
@@ -23,8 +24,8 @@
     }
 
     &.error {
-      color: $static-white;
       background-color: $core-vibrant-red;
+      color: $static-black;
     }
   }
 

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -143,10 +143,10 @@ body.dark-mode {
   --ui-gray: #32363e;
   --ui-light-grey: #1e2128;
   --ui-off-white: #1e2128;
-  --ui-shadow: #32363e;
+  --ui-shadow: #000000;
   --ui-vibrant-blue-50: rgba(123, 121, 255, 0.3);
   --ui-vibrant-blue-25: #282736;
-  --ui-vibrant-blue-10: #2c2f37;
+  --ui-vibrant-blue-10: #2d2e4d;
   --tooltip-bg: #353940;
 
   // Notifications & status — slightly brighter


### PR DESCRIPTION
## Summary

Address dark mode design feedback from head of design plus a handful of additional unreleased contrast bugs.

Resolves fleetdm/confidential#15823.
Closes #44864.
Closes #45117.
Closes #44239.
Closes #44899.

Two commits:

**1) Initial unreleased dark mode fixes**
- Resolves #44864. The "Wiped" / "Wipe pending" badge on host details was white text on a red surface, failing contrast in both themes (and harsh in dark mode). Switched to `$static-black`, matching the warning ("Locked") badge.
- "Various" role label and "Fleets" value on My account had a dimmed grey treatment that was unreadable in dark mode. First commit stripped it entirely; second commit re-introduces grey for the user roles column at fleet-black-75 (see below). Closes #45117.
- Removed `changes/dark-mode-tweaks`. Dark mode is unreleased.

**2) Design tweaks from head of design (fleetdm/confidential#15823)**

Global
- Table sort icons use `fleet-black-50` for the unsorted state (was -25, near-invisible in dark mode).
- API-user avatar circle is transparent (was hardcoded `fill="white"`); also drop `has-white-background` when rendering it so the activity-feed circle stops painting `#1a1c21` behind the icon.
- Dropdown selected-option background uses a clearly blue-tinted `ui-vibrant-blue-10` (`#2d2e4d`) in dark mode (was `#2c2f37`, indistinguishable from the menu surface). Closes #44239 and #44899.

Dashboard
- Hosts-enrolled chart keylines use `fleet-black-10`.
- Hosts-enrolled chart labels use `fleet-black-50` (was -75).

Hosts
- LabelFilterSelect (Filter by platform or label) control + menu surfaces use `#25272d` in dark mode.

Reports
- Performance-impact cell renders as plain text; pill backgrounds removed.

Settings
- YAML editor in read-only stays at 100% opacity and hides the gutter (line numbers) instead of dimming.
- `.grey-cell` is now `fleet-black-75` (was -50). UsersTableConfig re-adds the `grey` prop so the user-roles column gets it.

Misc
- Scrollable-table edge shadow in dark mode uses `#000000` so the fade-to-shadow at the right edge is perceptible against the dark page bg.

## Test plan

Bug fixes
- [ ] Light & dark: Locked badge has dark text on yellow.
- [ ] Light & dark: Wiped badge has dark text on red.

Design tweaks (dark mode unless noted)
- [ ] Tables: sort arrows for non-active columns are visible (medium grey).
- [ ] Activity feed: API-user avatar has transparent center (no white blob).
- [ ] Dropdowns (All hosts, Newest results): the selected option has a clearly tinted background distinct from the menu surface.
- [ ] Dashboard: Hosts-enrolled chart shows gridlines and axis labels readably.
- [ ] Hosts: Filter dropdown control & menu surface match other dropdowns.
- [ ] Reports table: Performance impact column is plain text, no pills.
- [ ] Settings → GitOps / similar YAML preview in read-only: text at full opacity, no line numbers.
- [ ] Settings → Users → Role column: "Various" reads italic at fleet-black-75 (not the old very-dim treatment).
- [ ] Any horizontally-scrollable table: shadow on the right edge is visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-mode contrast across error pages, status tags, and theme variables
  * Dark-mode backgrounds added for dropdowns and label-filter controls
  * Adjusted table and header arrow contrast and fixed bottom-right rounded corners on data tables
  * Made avatar icon interior transparent for better visual consistency

* **Bug Fixes / UX**
  * Fixed tooltip spacing and ensured editor gutter hides when read-only

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45295)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->