### PR TITLE
Fix for ONC profiles losing their details when adding another profile

### DIFF
--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -1183,8 +1183,22 @@ func (ds *Datastore) GetMDMAndroidProfilesContents(ctx context.Context, uuids []
 }
 
 func (ds *Datastore) BulkUpsertMDMAndroidHostProfiles(ctx context.Context, payload []*fleet.MDMAndroidProfilePayload) error {
+	return ds.bulkUpsertMDMAndroidHostProfiles(ctx, payload, true)
+}
+
+// bulkUpsertMDMAndroidHostProfiles upserts host/profile rows.
+func (ds *Datastore) bulkUpsertMDMAndroidHostProfiles(ctx context.Context, payload []*fleet.MDMAndroidProfilePayload, updateDetail bool) error {
 	if len(payload) == 0 {
 		return nil
+	}
+
+	detailUpdate := "detail = VALUES(detail),"
+	if !updateDetail {
+		// detail intentionally omitted from the ON DUPLICATE KEY UPDATE clause:
+		// the reconciler owns this field and may carry a forward-looking message
+		// (e.g. "Waiting for certificate ..." on withheld ONC profiles) that
+		// must survive this state reset.
+		detailUpdate = ""
 	}
 
 	executeUpsertBatch := func(valuePart string, args []any) error {
@@ -1206,14 +1220,14 @@ func (ds *Datastore) BulkUpsertMDMAndroidHostProfiles(ctx context.Context, paylo
 			ON DUPLICATE KEY UPDATE
 				status = VALUES(status),
 				operation_type = VALUES(operation_type),
-				detail = VALUES(detail),
+				%s
 				profile_name = VALUES(profile_name),
 				policy_request_uuid = VALUES(policy_request_uuid),
 				device_request_uuid = VALUES(device_request_uuid),
 				request_fail_count = VALUES(request_fail_count),
 				included_in_policy_version = VALUES(included_in_policy_version),
 				can_reverify = VALUES(can_reverify)
-`, strings.TrimSuffix(valuePart, ","),
+`, strings.TrimSuffix(valuePart, ","), detailUpdate,
 		)
 
 		// Taken from BulkUpsertMDMAppleHostProfiles: We need to run with retry
@@ -1443,12 +1457,14 @@ WHERE
 		}
 	}
 
+	// Mark every row backing an incoming profile as needing reprocessing. We do NOT
+	// clear `detail` here: that column is owned by the reconciler and may carry a
+	// forward-looking message (e.g. "Waiting for certificate ..." on ONC profiles)
 	const updateIncludedInPolicyVersionStmt = `
 	UPDATE
 		host_mdm_android_profiles
 	SET
 		included_in_policy_version = NULL,
-		detail = NULL,
 		policy_request_uuid = NULL,
 		device_request_uuid = NULL,
 		status = NULL,
@@ -1532,7 +1548,12 @@ func cancelAndroidHostInstallsForDeletedMDMProfiles(ctx context.Context, tx sqlx
 	return nil
 }
 
-// For android we set the status to NIL
+// bulkSetPendingMDMAndroidHostProfilesDB resets the status of every applicable
+// Android host profile to NULL so the next reconciler tick picks them up. New
+// rows are inserted with an empty detail; for existing rows we deliberately
+// leave the detail column alone so that forward-looking messages (e.g. the
+// "Waiting for certificate ..." text on ONC profiles withheld pending a cert
+// install) are not wiped between this call and the next reconciler run.
 func (ds *Datastore) bulkSetPendingMDMAndroidHostProfilesDB(
 	ctx context.Context,
 	hostUUIDs []string,
@@ -1573,9 +1594,8 @@ func (ds *Datastore) bulkSetPendingMDMAndroidHostProfilesDB(
 		}
 	}
 
-	err = ds.BulkUpsertMDMAndroidHostProfiles(ctx, profilesToUpsert)
-	if err != nil {
-		return false, ctxerr.Wrap(ctx, err, "bulk upsert android host profiles")
+	if err := ds.bulkUpsertMDMAndroidHostProfiles(ctx, profilesToUpsert, false); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "bulk reset android host profiles to pending")
 	}
 
 	return true, nil

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -1183,17 +1183,17 @@ func (ds *Datastore) GetMDMAndroidProfilesContents(ctx context.Context, uuids []
 }
 
 func (ds *Datastore) BulkUpsertMDMAndroidHostProfiles(ctx context.Context, payload []*fleet.MDMAndroidProfilePayload) error {
-	return ds.bulkUpsertMDMAndroidHostProfiles(ctx, payload, true)
+	return ds.bulkUpsertMDMAndroidHostProfiles(ctx, payload, false)
 }
 
 // bulkUpsertMDMAndroidHostProfiles upserts host/profile rows.
-func (ds *Datastore) bulkUpsertMDMAndroidHostProfiles(ctx context.Context, payload []*fleet.MDMAndroidProfilePayload, updateDetail bool) error {
+func (ds *Datastore) bulkUpsertMDMAndroidHostProfiles(ctx context.Context, payload []*fleet.MDMAndroidProfilePayload, preserveExistingDetail bool) error {
 	if len(payload) == 0 {
 		return nil
 	}
 
 	detailUpdate := "detail = VALUES(detail),"
-	if !updateDetail {
+	if preserveExistingDetail {
 		// detail intentionally omitted from the ON DUPLICATE KEY UPDATE clause:
 		// the reconciler owns this field and may carry a forward-looking message
 		// (e.g. "Waiting for certificate ..." on withheld ONC profiles) that
@@ -1458,7 +1458,7 @@ WHERE
 	}
 
 	// Mark every row backing an incoming profile as needing reprocessing. We do NOT
-	// clear `detail` here: that column is owned by the reconciler and may carry a
+	// touch `detail` here: that column is owned by the reconciler and may carry a
 	// forward-looking message (e.g. "Waiting for certificate ..." on ONC profiles)
 	const updateIncludedInPolicyVersionStmt = `
 	UPDATE
@@ -1470,9 +1470,9 @@ WHERE
 		status = NULL,
 		request_fail_count = 0
 	WHERE
-		profile_uuid IN (SELECT profile_uuid FROM mdm_android_configuration_profiles WHERE name IN (?))
+		profile_uuid IN (SELECT profile_uuid FROM mdm_android_configuration_profiles WHERE team_id = ? AND name IN (?))
 	`
-	stmt, args, err = sqlx.In(updateIncludedInPolicyVersionStmt, incomingNames)
+	stmt, args, err = sqlx.In(updateIncludedInPolicyVersionStmt, profileTeamID, incomingNames)
 	if err != nil {
 		return false, ctxerr.Wrap(ctx, err, "build query to update included in policy version")
 	}
@@ -1551,7 +1551,7 @@ func cancelAndroidHostInstallsForDeletedMDMProfiles(ctx context.Context, tx sqlx
 // bulkSetPendingMDMAndroidHostProfilesDB resets the status of every applicable
 // Android host profile to NULL so the next reconciler tick picks them up. New
 // rows are inserted with an empty detail; for existing rows we deliberately
-// leave the detail column alone so that forward-looking messages (e.g. the
+// leave the detail column alone so forward-looking messages (e.g. the
 // "Waiting for certificate ..." text on ONC profiles withheld pending a cert
 // install) are not wiped between this call and the next reconciler run.
 func (ds *Datastore) bulkSetPendingMDMAndroidHostProfilesDB(
@@ -1594,7 +1594,7 @@ func (ds *Datastore) bulkSetPendingMDMAndroidHostProfilesDB(
 		}
 	}
 
-	if err := ds.bulkUpsertMDMAndroidHostProfiles(ctx, profilesToUpsert, false); err != nil {
+	if err := ds.bulkUpsertMDMAndroidHostProfiles(ctx, profilesToUpsert, true); err != nil {
 		return false, ctxerr.Wrap(ctx, err, "bulk reset android host profiles to pending")
 	}
 

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -1916,6 +1916,100 @@ func (s *integrationMDMTestSuite) TestONCProfileReleasedAfterCertTemplateDeleted
 	s.assertONCProfilesReleased(t, host.UUID, "cert template deleted")
 }
 
+// TestONCProfileDetailPreservedWhenAddingAnotherProfile guards against this
+// regression: once an ONC profile is withheld pending a cert install
+// ("Waiting for certificate ..."), adding any other Android configuration
+// profile to the same team must NOT wipe the withheld profile's `detail`.
+func (s *integrationMDMTestSuite) TestONCProfileDetailPreservedWhenAddingAnotherProfile() {
+	t := s.T()
+	ctx := t.Context()
+	s.enableAndroidMDM(t)
+	s.setSkipWorkerJobs(t)
+
+	const (
+		oncProfileName       = "onc-wifi"
+		cameraProfileName    = "camera-policy"
+		certTemplateName     = "wifi-cert"
+		expectedDetailSubstr = `Waiting for certificate "wifi-cert"`
+	)
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name(), Secrets: []*fleet.EnrollSecret{
+		{Secret: "secret-" + t.Name()},
+	}})
+	require.NoError(t, err)
+
+	caID, _ := s.createTestCertificateAuthority(t, ctx)
+	var certTemplateResp applyCertificateTemplateSpecsResponse
+	s.DoJSON("POST", "/api/latest/fleet/spec/certificates", applyCertificateTemplateSpecsRequest{
+		Specs: []*fleet.CertificateRequestSpec{{
+			Name:                   certTemplateName,
+			Team:                   team.Name,
+			CertificateAuthorityId: caID,
+			SubjectName:            "CN=WiFi Cert",
+		}},
+	}, http.StatusOK, &certTemplateResp)
+
+	host, _, _ := s.createAndEnrollAndroidDevice(t, "onc-detail-test", &team.ID, true)
+
+	// Apply the initial profile set and reconcile once so the ONC profile is
+	// in the withheld state we want to defend.
+	oncProfileJSON, cameraProfileJSON := s.oncWithholdingProfiles()
+	s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: oncProfileName, Contents: oncProfileJSON},
+		{Name: cameraProfileName, Contents: cameraProfileJSON},
+	}}, http.StatusNoContent, "team_id", fmt.Sprint(team.ID))
+	s.awaitTriggerAndroidProfileSchedule(t)
+	s.assertONCProfileWithheld(t, host.UUID)
+
+	fetchONCProfileRow := func(t *testing.T) (status, detail *string) {
+		t.Helper()
+		var row struct {
+			Status *string `db:"status"`
+			Detail *string `db:"detail"`
+		}
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(t.Context(), q, &row,
+				"SELECT status, detail FROM host_mdm_android_profiles WHERE host_uuid = ? AND profile_name = ?",
+				host.UUID, oncProfileName)
+		})
+		return row.Status, row.Detail
+	}
+
+	requireDetailPreservedAndStatusReset := func(t *testing.T, trigger string) {
+		t.Helper()
+		status, detail := fetchONCProfileRow(t)
+		require.Nil(t, status, "%s: status should be reset to NULL", trigger)
+		require.NotNil(t, detail, "%s: detail must not be nil", trigger)
+		require.Contains(t, *detail, expectedDetailSubstr, "%s: detail must not be wiped", trigger)
+	}
+
+	t.Run("single-profile upload", func(t *testing.T) {
+		// POST /configuration_profiles
+		body, headers := generateNewProfileMultipartRequest(
+			t,
+			"extra-single.json",
+			[]byte(`{"cameraDisabled": false}`),
+			s.token,
+			map[string][]string{"team_id": {fmt.Sprint(team.ID)}},
+		)
+		res := s.DoRawWithHeaders("POST", "/api/latest/fleet/configuration_profiles", body.Bytes(), http.StatusOK, headers)
+		defer res.Body.Close()
+
+		requireDetailPreservedAndStatusReset(t, "POST /configuration_profiles")
+	})
+
+	t.Run("batch profile set", func(t *testing.T) {
+		// POST /mdm/profiles/batch
+		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+			{Name: oncProfileName, Contents: oncProfileJSON},
+			{Name: cameraProfileName, Contents: cameraProfileJSON},
+			{Name: "extra-batch", Contents: []byte(`{"cameraDisabled": false}`)},
+		}}, http.StatusNoContent, "team_id", fmt.Sprint(team.ID))
+
+		requireDetailPreservedAndStatusReset(t, "POST /mdm/profiles/batch")
+	})
+}
+
 // oncWithholdingProfiles returns ONC and camera profile JSON payloads for ONC
 // withholding tests. The ONC profile references a "wifi-cert" certificate alias.
 func (s *integrationMDMTestSuite) oncWithholdingProfiles() (oncJSON, cameraJSON []byte) {

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -1927,11 +1927,11 @@ func (s *integrationMDMTestSuite) TestONCProfileDetailPreservedWhenAddingAnother
 	s.setSkipWorkerJobs(t)
 
 	const (
-		oncProfileName       = "onc-wifi"
-		cameraProfileName    = "camera-policy"
-		certTemplateName     = "wifi-cert"
-		expectedDetailSubstr = `Waiting for certificate "wifi-cert"`
+		oncProfileName    = "onc-wifi"
+		cameraProfileName = "camera-policy"
+		certTemplateName  = "wifi-cert"
 	)
+	expectedDetailSubstr := fmt.Sprintf(`Waiting for certificate %q`, certTemplateName)
 
 	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name(), Secrets: []*fleet.EnrollSecret{
 		{Secret: "secret-" + t.Name()},


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42405

Unreleased bug fix.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android MDM profile detail messages (e.g., certificate status) are preserved when adding additional profiles or marking profiles pending, preventing loss of important status information.

* **Tests**
  * Added an integration test verifying ONC/certificate detail is retained when additional Android MDM profiles are uploaded for the same team.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45299)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->