### PR TITLE
Updated color levels for dashboard charts to match Figma

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -317,11 +317,11 @@
 
     body.dark-mode & {
       --level-0: #515256;
-      --level-1: #5a2727;
-      --level-2: #7d2c2c;
-      --level-3: #a83232;
-      --level-4: #d04040;
-      --level-5: #ff5c5c;
+      --level-1: #512f34;
+      --level-2: #7c373a;
+      --level-3: #a83f41;
+      --level-4: #d34748;
+      --level-5: #ff4f4f;
     }
   }
 


### PR DESCRIPTION
Updated color levels for dashboard charts to match Figma.

https://www.figma.com/design/mCPegRjoFdpMem1PLMF1BF/-41519----44591---43769-Dashboard-widgets?node-id=2-130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark mode color palette for the red theme in chart cards to enhance visual consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45300)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->