### PR TITLE
New colors for success/fail notifications

### DIFF
--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -90,13 +90,6 @@ const SingleFlashMessage = ({
     return null;
   }
 
-  let iconColor = "ui-error";
-  if (alertType === "warning-filled") {
-    iconColor = "static-black";
-  } else if (alertType === "success") {
-    iconColor = "ui-success";
-  }
-
   return (
     <div className={baseClasses} id={baseClasses}>
       <div className={`${baseClass}__content`}>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -90,18 +90,23 @@ const SingleFlashMessage = ({
     return null;
   }
 
+  // Three cases needed here (warning-filled, success, error) so we can't use a
+  // simple ternary like the close button below — no-nested-ternary lint rule.
+  let iconColor: "static-black" | "ui-success" | "ui-error";
+  if (alertType === "warning-filled") {
+    iconColor = "static-black";
+  } else if (alertType === "success") {
+    iconColor = "ui-success";
+  } else {
+    iconColor = "ui-error";
+  }
+
   return (
     <div className={baseClasses} id={baseClasses}>
       <div className={`${baseClass}__content`}>
         <Icon
           name={alertType === "success" ? "success" : "error"}
-          color={
-            alertType === "warning-filled"
-              ? "static-black"
-              : alertType === "success"
-              ? "ui-success"
-              : "ui-error"
-          }
+          color={iconColor}
         />
         <span>{message}</span>
       </div>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -94,20 +94,8 @@ const SingleFlashMessage = ({
     <div className={baseClasses} id={baseClasses}>
       <div className={`${baseClass}__content`}>
         <Icon
-          name={
-            alertType === "success"
-              ? "success"
-              : alertType === "warning-filled"
-              ? "warning"
-              : "error"
-          }
-          color={
-            alertType === "success"
-              ? "ui-success"
-              : alertType === "warning-filled"
-              ? "ui-warning"
-              : "ui-error"
-          }
+          name={alertType === "success" ? "success" : "error"}
+          color={alertType === "success" ? "ui-success" : "ui-error"}
         />
         <span>{message}</span>
       </div>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -90,14 +90,18 @@ const SingleFlashMessage = ({
     return null;
   }
 
+  const iconColorByAlertType = {
+    success: "ui-success",
+    error: "ui-error",
+    "warning-filled": "static-black",
+  } as const;
+
   return (
     <div className={baseClasses} id={baseClasses}>
       <div className={`${baseClass}__content`}>
         <Icon
           name={alertType === "success" ? "success" : "error"}
-          color={
-            alertType === "warning-filled" ? "static-black" : "ui-success"
-          }
+          color={iconColorByAlertType[alertType]}
         />
         <span>{message}</span>
       </div>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -90,14 +90,19 @@ const SingleFlashMessage = ({
     return null;
   }
 
+  let iconColor = "ui-error";
+  if (alertType === "warning-filled") {
+    iconColor = "static-black";
+  } else if (alertType === "success") {
+    iconColor = "ui-success";
+  }
+
   return (
     <div className={baseClasses} id={baseClasses}>
       <div className={`${baseClass}__content`}>
         <Icon
           name={alertType === "success" ? "success" : "error"}
-          color={
-            alertType === "warning-filled" ? "static-black" : alertType === "success" ? "ui-success" : "ui-error"
-          }
+          color={iconColor}
         />
         <span>{message}</span>
       </div>
@@ -110,7 +115,9 @@ const SingleFlashMessage = ({
             <Icon
               name="close"
               color={
-                alertType === "warning-filled" ? "static-black" : "core-fleet-black"
+                alertType === "warning-filled"
+                  ? "static-black"
+                  : "core-fleet-black"
               }
             />
           </button>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -90,18 +90,18 @@ const SingleFlashMessage = ({
     return null;
   }
 
-  const iconColorByAlertType = {
-    success: "ui-success",
-    error: "ui-error",
-    "warning-filled": "static-black",
-  } as const;
-
   return (
     <div className={baseClasses} id={baseClasses}>
       <div className={`${baseClass}__content`}>
         <Icon
           name={alertType === "success" ? "success" : "error"}
-          color={iconColorByAlertType[alertType]}
+          color={
+            alertType === "warning-filled"
+              ? "static-black"
+              : alertType === "success"
+              ? "ui-success"
+              : "ui-error"
+          }
         />
         <span>{message}</span>
       </div>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -94,11 +94,19 @@ const SingleFlashMessage = ({
     <div className={baseClasses} id={baseClasses}>
       <div className={`${baseClass}__content`}>
         <Icon
-          name={alertType === "success" ? "success" : "error"}
-          // Static (un-themed) so icon stays light on the colored toast
-          // surface in both light and dark mode.
+          name={
+            alertType === "success"
+              ? "success"
+              : alertType === "warning-filled"
+              ? "warning"
+              : "error"
+          }
           color={
-            alertType === "warning-filled" ? "static-black" : "static-white"
+            alertType === "success"
+              ? "ui-success"
+              : alertType === "warning-filled"
+              ? "ui-warning"
+              : "ui-error"
           }
         />
         <span>{message}</span>
@@ -111,9 +119,7 @@ const SingleFlashMessage = ({
           >
             <Icon
               name="close"
-              color={
-                alertType === "warning-filled" ? "static-black" : "static-white"
-              }
+              color="core-fleet-black"
             />
           </button>
         </div>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -95,7 +95,9 @@ const SingleFlashMessage = ({
       <div className={`${baseClass}__content`}>
         <Icon
           name={alertType === "success" ? "success" : "error"}
-          color={iconColor}
+          color={
+            alertType === "warning-filled" ? "static-black" : "ui-success"
+          }
         />
         <span>{message}</span>
       </div>

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -95,7 +95,9 @@ const SingleFlashMessage = ({
       <div className={`${baseClass}__content`}>
         <Icon
           name={alertType === "success" ? "success" : "error"}
-          color={alertType === "success" ? "ui-success" : "ui-error"}
+          color={
+            alertType === "warning-filled" ? "static-black" : alertType === "success" ? "ui-success" : "ui-error"
+          }
         />
         <span>{message}</span>
       </div>
@@ -107,7 +109,9 @@ const SingleFlashMessage = ({
           >
             <Icon
               name="close"
-              color="core-fleet-black"
+              color={
+                alertType === "warning-filled" ? "static-black" : "core-fleet-black"
+              }
             />
           </button>
         </div>

--- a/frontend/components/FlashMessage/_styles.scss
+++ b/frontend/components/FlashMessage/_styles.scss
@@ -36,6 +36,29 @@
     border-color: $ui-error;
   }
 
+  &--warning-filled {
+    background-color: $ui-warning;
+    // Yellow is light enough that foreground should be dark in BOTH modes.
+    // Use static (un-themed) tokens so dark mode doesn't flip to light text.
+    color: $static-black;
+
+    span {
+      margin-left: 15px;
+      margin-right: 15px;
+      font-size: $x-small;
+      color: $static-black;
+    }
+
+    .flash-message__remove .fleeticon,
+    .flash-message__remove .fleeticon:hover {
+      color: $static-black;
+    }
+
+    .flash-message__undo {
+      color: $static-black;
+    }
+  }
+
   &__content {
     display: flex;
     align-items: center;

--- a/frontend/components/FlashMessage/_styles.scss
+++ b/frontend/components/FlashMessage/_styles.scss
@@ -36,11 +36,6 @@
     border-color: $ui-error;
   }
 
-  &--warning-filled {
-    background-color: $flash-warning-bkg;
-    border-color: $ui-warning;
-  }
-
   &__content {
     display: flex;
     align-items: center;

--- a/frontend/components/FlashMessage/_styles.scss
+++ b/frontend/components/FlashMessage/_styles.scss
@@ -17,48 +17,28 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  // Use static (un-themed) white: the flash toast is always a colored
-  // surface, so foreground should stay light regardless of dark mode.
-  color: $static-white;
+  color: $core-fleet-black;
   padding: $pad-small $pad-medium;
   z-index: 999;
-  background-color: $core-vibrant-blue;
-  border: 1px solid $ui-fleet-black-10;
+  border: 1px solid;
   box-sizing: border-box;
-  box-shadow: 0px 7px 3px -5px rgba(25, 33, 71, 0.1);
   border-radius: 8px;
   max-width: calc(100% - 64px); // Same horizontal margin as .main-content
   pointer-events: auto;
 
   &--success {
-    background-color: $ui-success-toast-bg;
+    background-color: $flash-success-bkg;
+    border-color: $ui-success;
   }
 
   &--error {
-    background-color: $ui-error-toast-bg;
+    background-color: $flash-error-bkg;
+    border-color: $ui-error;
   }
 
   &--warning-filled {
-    background-color: $ui-warning;
-    // Yellow is light enough that foreground should be dark in BOTH modes.
-    // Use static (un-themed) tokens so dark mode doesn't flip to light text.
-    color: $static-black;
-
-    span {
-      margin-left: 15px;
-      margin-right: 15px;
-      font-size: $x-small;
-      color: $static-black;
-    }
-
-    .flash-message__remove .fleeticon,
-    .flash-message__remove .fleeticon:hover {
-      color: $static-black;
-    }
-
-    .flash-message__undo {
-      color: $static-black;
-    }
+    background-color: $flash-warning-bkg;
+    border-color: $ui-warning;
   }
 
   &__content {
@@ -86,7 +66,7 @@
   }
 
   &__undo {
-    color: $static-white;
+    color: $core-fleet-black;
     cursor: pointer;
     font-size: $small;
     text-decoration: underline;
@@ -100,11 +80,11 @@
 
     .fleeticon {
       transition: color 150ms ease-in-out;
-      color: $static-white;
+      color: $core-fleet-black;
       font-size: $small;
 
       &:hover {
-        color: $static-white;
+        color: $core-fleet-black;
       }
     }
   }

--- a/frontend/components/FlashMessage/_styles.scss
+++ b/frontend/components/FlashMessage/_styles.scss
@@ -27,12 +27,12 @@
   pointer-events: auto;
 
   &--success {
-    background-color: $flash-success-bkg;
+    background-color: $ui-success-flash-bg;
     border-color: $ui-success;
   }
 
   &--error {
-    background-color: $flash-error-bkg;
+    background-color: $ui-error-flash-bg;
     border-color: $ui-error;
   }
 

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -62,8 +62,8 @@
   --ui-error-toast-bg: #d66c7b;
 
   // Flash message background surfaces (light mode)
-  --flash-success-bkg: #e2f4eb;
-  --flash-error-bkg: #f9e9eb;
+  --ui-success-flash-bg: #e2f4eb;
+  --ui-error-flash-bg: #f9e9eb;
 
   // TS COLORS aliases (match keys used in colors.ts for JS inline styles)
   --core-fleet-red: #ff5c83;
@@ -168,8 +168,8 @@ body.dark-mode {
   --ui-error-toast-bg: #a8525f;
 
   // Flash message background surfaces (dark mode)
-  --flash-success-bkg: #1f332e;
-  --flash-error-bkg: #36282e;
+  --ui-success-flash-bg: #1f332e;
+  --ui-error-flash-bg: #36282e;
 
   // TS COLORS aliases
   --core-fleet-red: #ff7a9a;
@@ -266,8 +266,8 @@ $ui-yellow-banner: var(--ui-yellow-banner);
 $ui-yellow-banner-outline: var(--ui-yellow-banner-outline);
 $ui-success-toast-bg: var(--ui-success-toast-bg);
 $ui-error-toast-bg: var(--ui-error-toast-bg);
-$flash-success-bkg: var(--flash-success-bkg);
-$flash-error-bkg: var(--flash-error-bkg);
+$ui-success-flash-bg: var(--ui-success-flash-bg);
+$ui-error-flash-bg: var(--ui-error-flash-bg);
 
 // Rainbow
 $rainbow-orange: var(--rainbow-orange);

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -63,7 +63,6 @@
 
   // Flash message background surfaces (light mode)
   --flash-success-bkg: #e2f4eb;
-  --flash-warning-bkg: #fefaf0;
   --flash-error-bkg: #f9e9eb;
 
   // TS COLORS aliases (match keys used in colors.ts for JS inline styles)
@@ -170,7 +169,6 @@ body.dark-mode {
 
   // Flash message background surfaces (dark mode)
   --flash-success-bkg: #1f332e;
-  --flash-warning-bkg: #3b372c;
   --flash-error-bkg: #36282e;
 
   // TS COLORS aliases
@@ -269,7 +267,6 @@ $ui-yellow-banner-outline: var(--ui-yellow-banner-outline);
 $ui-success-toast-bg: var(--ui-success-toast-bg);
 $ui-error-toast-bg: var(--ui-error-toast-bg);
 $flash-success-bkg: var(--flash-success-bkg);
-$flash-warning-bkg: var(--flash-warning-bkg);
 $flash-error-bkg: var(--flash-error-bkg);
 
 // Rainbow

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -61,6 +61,11 @@
   --ui-success-toast-bg: #3db67b;
   --ui-error-toast-bg: #d66c7b;
 
+  // Flash message background surfaces (light mode)
+  --flash-success-bkg: #e2f4eb;
+  --flash-warning-bkg: #fefaf0;
+  --flash-error-bkg: #f9e9eb;
+
   // TS COLORS aliases (match keys used in colors.ts for JS inline styles)
   --core-fleet-red: #ff5c83;
   --ui-blue-hover: #5d5ae7;
@@ -163,6 +168,11 @@ body.dark-mode {
   --ui-success-toast-bg: #2d8f5f;
   --ui-error-toast-bg: #a8525f;
 
+  // Flash message background surfaces (dark mode)
+  --flash-success-bkg: #1f332e;
+  --flash-warning-bkg: #3b372c;
+  --flash-error-bkg: #36282e;
+
   // TS COLORS aliases
   --core-fleet-red: #ff7a9a;
   --ui-blue-hover: #8c8aff;
@@ -258,6 +268,9 @@ $ui-yellow-banner: var(--ui-yellow-banner);
 $ui-yellow-banner-outline: var(--ui-yellow-banner-outline);
 $ui-success-toast-bg: var(--ui-success-toast-bg);
 $ui-error-toast-bg: var(--ui-error-toast-bg);
+$flash-success-bkg: var(--flash-success-bkg);
+$flash-warning-bkg: var(--flash-warning-bkg);
+$flash-error-bkg: var(--flash-error-bkg);
 
 // Rainbow
 $rainbow-orange: var(--rainbow-orange);

--- a/frontend/styles/var/colors.ts
+++ b/frontend/styles/var/colors.ts
@@ -33,6 +33,7 @@ const STATIC_COLORS = {
   "ui-blue-10": "#F1F0FF",
   "tooltip-bg": "#3E4771",
   "ui-light-grey": "#FAFAFA",
+  "ui-success": "#3db67b",
   "ui-error": "#d66c7b",
   "ui-warning": "#ebbc43",
   "ui-fleet-black-5-down": "#F0F1F4",


### PR DESCRIPTION
For the following quick win:
- https://github.com/fleetdm/fleet/issues/45304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Flash/toast visuals now use theme-aware success and error background colors (light/dark) and a new greener success color token.
  * Undo and close control colors updated to improve contrast and consistency.

* **Bug Fixes / Behavior**
  * The warning-filled toast variant has been removed; toast types simplified.
  * Icon and close button colors refined for clearer contrast across toast types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45302)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->