### PR TITLE
EUA (no Apple MDM) UI fix (#45212)

### DIFF
--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -219,8 +219,10 @@ func (svc *Service) updateAppConfigMDMAppleSetup(ctx context.Context, payload fl
 		}
 	}
 
-	// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA.
-	if didUpdateMacOSEndUserAuth && payload.LockEndUserInfo == nil {
+	// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA (Apple-only).
+	// Also sync when EUA was just disabled so the Lock-requires-EUA invariant stays satisfied.
+	if didUpdateMacOSEndUserAuth && payload.LockEndUserInfo == nil &&
+		(ac.MDM.EnabledAndConfigured || !ac.MDM.MacOSSetup.EnableEndUserAuthentication) {
 		ac.MDM.MacOSSetup.LockEndUserInfo = optjson.SetBool(ac.MDM.MacOSSetup.EnableEndUserAuthentication)
 	}
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -307,8 +307,10 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			}
 
 			team.Config.MDM.MacOSSetup.EnableEndUserAuthentication = payload.MDM.MacOSSetup.EnableEndUserAuthentication
-			// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA.
-			if macOSEnableEndUserAuthUpdated && !payload.MDM.MacOSSetup.LockEndUserInfo.Valid {
+			// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA (Apple-only).
+			// Also sync when EUA was just disabled so the Lock-requires-EUA invariant below stays satisfied.
+			if macOSEnableEndUserAuthUpdated && !payload.MDM.MacOSSetup.LockEndUserInfo.Valid &&
+				(appCfg.MDM.EnabledAndConfigured || !team.Config.MDM.MacOSSetup.EnableEndUserAuthentication) {
 				team.Config.MDM.MacOSSetup.LockEndUserInfo = optjson.SetBool(team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
 			}
 
@@ -2158,6 +2160,11 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 }
 
 func (svc *Service) updateTeamMDMAppleSetup(ctx context.Context, tm *fleet.Team, payload fleet.MDMAppleSetupPayload) error {
+	appCfg, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "fetch app config")
+	}
+
 	var didUpdate, didUpdateMacOSEndUserAuth, didUpdateManagedLocalAccount bool
 
 	if payload.EnableEndUserAuthentication != nil {
@@ -2175,8 +2182,10 @@ func (svc *Service) updateTeamMDMAppleSetup(ctx context.Context, tm *fleet.Team,
 		}
 	}
 
-	// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA.
-	if didUpdateMacOSEndUserAuth && payload.LockEndUserInfo == nil {
+	// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA (Apple-only).
+	// Also sync when EUA was just disabled so the Lock-requires-EUA invariant below stays satisfied.
+	if didUpdateMacOSEndUserAuth && payload.LockEndUserInfo == nil &&
+		(appCfg.MDM.EnabledAndConfigured || !tm.Config.MDM.MacOSSetup.EnableEndUserAuthentication) {
 		tm.Config.MDM.MacOSSetup.LockEndUserInfo = optjson.SetBool(tm.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
 	}
 

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -930,6 +930,10 @@ func TestUpdateTeamMDMAppleSetupManualAgent(t *testing.T) {
 		return &fleet.Team{}, nil
 	}
 
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+
 	authorizer, err := authz.NewAuthorizer()
 	require.NoError(t, err)
 

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
+import mdmAPI from "services/entities/mdm";
+
 import UsersForm from "./UsersForm";
 
 describe("UsersForm", () => {
@@ -74,6 +76,52 @@ describe("UsersForm", () => {
     expect(screen.getByText("Lock end user info")).toBeInTheDocument();
   });
 
+  it("auto-checks lock end user info on EUA toggle when Apple MDM is configured", async () => {
+    const { user } = renderWithMdmEnabled(<UsersForm {...defaultProps} />);
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "End user authentication" })
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: "Lock end user info" })
+    ).toBeChecked();
+  });
+
+  it("does not auto-check lock end user info on EUA toggle when Apple MDM is not configured", async () => {
+    const { user } = renderWithMdmDisabled(<UsersForm {...defaultProps} />);
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "End user authentication" })
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: "Lock end user info" })
+    ).not.toBeChecked();
+  });
+
+  it("preserves the backend lock end user info value on EUA toggle when Apple MDM is not configured", async () => {
+    // Simulates: Apple MDM was previously on with lock_end_user_info=true, then
+    // Apple MDM was turned off. Toggling EUA must not clobber the saved value.
+    const { user } = renderWithMdmDisabled(
+      <UsersForm
+        {...defaultProps}
+        defaultLockEndUserInfo
+        defaultIsEndUserAuthEnabled
+      />
+    );
+
+    const eua = screen.getByRole("checkbox", {
+      name: "End user authentication",
+    });
+    await user.click(eua); // toggle EUA off
+    await user.click(eua); // toggle EUA back on
+
+    expect(
+      screen.getByRole("checkbox", { name: "Lock end user info" })
+    ).toBeChecked();
+  });
+
   it("renders managed local account checkbox as unchecked by default", () => {
     render(<UsersForm {...defaultProps} />);
     expect(
@@ -127,6 +175,24 @@ describe("UsersForm", () => {
       ).toHaveAttribute("aria-disabled", "true");
     });
 
+    it("disables lock end user info when Apple MDM is not configured", () => {
+      renderWithMdmDisabled(
+        <UsersForm {...defaultProps} defaultIsEndUserAuthEnabled />
+      );
+      expect(
+        screen.getByRole("checkbox", { name: "Lock end user info" })
+      ).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("enables lock end user info when Apple MDM is configured", () => {
+      renderWithMdmEnabled(
+        <UsersForm {...defaultProps} defaultIsEndUserAuthEnabled />
+      );
+      expect(
+        screen.getByRole("checkbox", { name: "Lock end user info" })
+      ).toHaveAttribute("aria-disabled", "false");
+    });
+
     it("does not allow toggling end user auth when IdP is not configured", async () => {
       const { user } = render(
         <UsersForm {...defaultProps} isIdPConfigured={false} />
@@ -163,6 +229,44 @@ describe("UsersForm", () => {
       await user.click(checkbox);
 
       expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  describe("save payload", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("omits Apple-only fields when Apple MDM is not configured", async () => {
+      // The backend skips its EUA->Lock auto-sync when Apple MDM isn't configured, so the
+      // FE can safely omit lock_end_user_info; managed local account is rejected outright.
+      const updateSpy = jest
+        .spyOn(mdmAPI, "updateSetupExperienceSettings")
+        .mockResolvedValue({});
+
+      const { user } = renderWithMdmDisabled(<UsersForm {...defaultProps} />);
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(updateSpy).toHaveBeenCalledWith({
+        fleet_id: 0,
+        enable_end_user_authentication: false,
+      });
+    });
+
+    it("includes Apple-only fields when Apple MDM is configured", async () => {
+      const updateSpy = jest
+        .spyOn(mdmAPI, "updateSetupExperienceSettings")
+        .mockResolvedValue({});
+
+      const { user } = renderWithMdmEnabled(<UsersForm {...defaultProps} />);
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(updateSpy).toHaveBeenCalledWith({
+        fleet_id: 0,
+        enable_end_user_authentication: false,
+        lock_end_user_info: false,
+        enable_managed_local_account: false,
+      });
     });
   });
 });

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
@@ -58,8 +58,11 @@ const UsersForm = ({
 
   const onToggleEndUserAuth = (newCheckVal: boolean) => {
     setEndUserAuthEnabled(newCheckVal);
-    // Sync lock end user info with EUA: enabling EUA enables it, disabling EUA disables it.
-    setLockEndUserInfo(newCheckVal);
+    // Sync lock end user info with EUA only when Apple MDM is configured. Without
+    // Apple MDM the field is read-only, so we leave whatever value came from the backend untouched.
+    if (isMacMdmEnabledAndConfigured) {
+      setLockEndUserInfo(newCheckVal);
+    }
   };
 
   const onChangeLockEndUserInfo = (newCheckVal: boolean) => {
@@ -79,8 +82,11 @@ const UsersForm = ({
       await mdmAPI.updateSetupExperienceSettings({
         fleet_id: currentTeamId,
         enable_end_user_authentication: isEndUserAuthEnabled,
-        lock_end_user_info: canLockEndUserInfo,
-        enable_managed_local_account: enableManagedLocalAccount,
+        // Apple-only fields are omitted when Apple MDM isn't configured.
+        ...(isMacMdmEnabledAndConfigured && {
+          lock_end_user_info: canLockEndUserInfo,
+          enable_managed_local_account: enableManagedLocalAccount,
+        }),
       });
       renderFlash("success", "Successfully updated.");
     } catch {
@@ -88,7 +94,9 @@ const UsersForm = ({
     }
 
     setIsUpdating(false);
-    setLockEndUserInfo(canLockEndUserInfo);
+    if (isMacMdmEnabledAndConfigured) {
+      setLockEndUserInfo(canLockEndUserInfo);
+    }
   };
 
   return (
@@ -135,27 +143,51 @@ const UsersForm = ({
         </TooltipWrapper>
         {isEndUserAuthEnabled && (
           <div className={`${baseClass}__advanced-options`}>
-            <Checkbox
-              disabled={gitOpsModeEnabled || !isIdPConfigured}
-              onChange={onChangeLockEndUserInfo}
-              value={lockEndUserInfo}
-            >
-              <TooltipWrapper
-                tipContent={
+            <TooltipWrapper
+              tipContent={
+                !isMacMdmEnabledAndConfigured ? (
                   <span>
-                    End user can&apos;t edit the local account&apos;s{" "}
-                    <b>Account Name</b> and
-                    <br />
-                    <b>Full Name</b> in macOS Setup Assistant. These fields will
-                    be
-                    <br />
-                    locked to values from your IdP.
+                    To enable, first turn on{" "}
+                    <CustomLink
+                      url={PATHS.ADMIN_INTEGRATIONS_MDM_APPLE}
+                      text="Apple MDM"
+                      variant="tooltip-link"
+                    />
+                    .
                   </span>
+                ) : undefined
+              }
+              disableTooltip={!!isMacMdmEnabledAndConfigured}
+              underline={false}
+              position="left"
+              showArrow
+            >
+              <Checkbox
+                disabled={
+                  gitOpsModeEnabled ||
+                  !isIdPConfigured ||
+                  !isMacMdmEnabledAndConfigured
                 }
+                onChange={onChangeLockEndUserInfo}
+                value={lockEndUserInfo}
               >
-                Lock end user info
-              </TooltipWrapper>
-            </Checkbox>
+                <TooltipWrapper
+                  tipContent={
+                    <span>
+                      End user can&apos;t edit the local account&apos;s{" "}
+                      <b>Account Name</b> and
+                      <br />
+                      <b>Full Name</b> in macOS Setup Assistant. These fields
+                      will be
+                      <br />
+                      locked to values from your IdP.
+                    </span>
+                  }
+                >
+                  Lock end user info
+                </TooltipWrapper>
+              </Checkbox>
+            </TooltipWrapper>
           </div>
         )}
         <TooltipWrapper

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -513,9 +513,11 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.MDM.MacOSSetup.LockEndUserInfo = oldAppConfig.MDM.MacOSSetup.LockEndUserInfo
 	}
 
-	// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA.
+	// When EUA changes and LockEndUserInfo is not explicitly set, sync LockEndUserInfo to match EUA (Apple-only).
+	// Also sync when EUA was just disabled so the Lock-requires-EUA invariant stays satisfied.
 	if oldAppConfig.MDM.MacOSSetup.EnableEndUserAuthentication != appConfig.MDM.MacOSSetup.EnableEndUserAuthentication &&
-		!newAppConfig.MDM.MacOSSetup.LockEndUserInfo.Valid {
+		!newAppConfig.MDM.MacOSSetup.LockEndUserInfo.Valid &&
+		(oldAppConfig.MDM.EnabledAndConfigured || !appConfig.MDM.MacOSSetup.EnableEndUserAuthentication) {
 		appConfig.MDM.MacOSSetup.LockEndUserInfo = optjson.SetBool(appConfig.MDM.MacOSSetup.EnableEndUserAuthentication)
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44801

Fixed remaining issue setting end user authentication in the UI. The root cause was that the frontend was always sending `enable_managed_local_account : false` even when macOS MDM was disabled.

Fix:
<img width="756" height="363" alt="image"
src="https://github.com/user-attachments/assets/5f88797d-c5c3-4c03-9048-c8ee2981c374" />

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
* Automatic syncing of "Lock end user info" when toggling End User Authentication now only runs when Apple MDM is enabled and configured (with an exception when EUA is being disabled to preserve behavior).
  * Save payloads omit Apple-only fields unless Apple MDM is configured.

* **UI**
* "Lock end user info" checkbox shows an Apple MDM–gated tooltip and is disabled when Apple MDM is not configured.

* **Tests**
* Added coverage for Apple MDM–gated behaviors and saved-payload variations.

[![Review Change
Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit ca648e9c042aab2c32386c5b5c3673bd914e14c1)

