### PR TITLE
Remove mobile platforms from chart filter list

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
@@ -26,9 +26,6 @@ const PLATFORM_OPTIONS = [
   { label: "Windows", value: "windows" },
   { label: "Linux", value: "linux" },
   { label: "ChromeOS", value: "chrome" },
-  { label: "iOS", value: "ios" },
-  { label: "iPadOS", value: "ipados" },
-  { label: "Android", value: "android" },
 ];
 
 type HostFilterMode = "none" | "include" | "exclude";


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45290

Just drops the mobile platforms from the platform list in the chart filters modal.

You can still find mobile devices by searching for now, as filtering them out is a bigger change requiring either backend work or on-the-glass filtering + pagination which is bug-prone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated platform filter options in chart filters. iOS, iPadOS, and Android are no longer available as filter options; macOS, Windows, Linux, and ChromeOS remain supported.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45310)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->