### PR TITLE
Remove bad comma from connect CA example

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -728,7 +728,7 @@ Object with the following structure:
     "profile_id": "b416e058-1bdc-4844-9c3f-7c71d58d0eff",
     "certificate_common_name": "$FLEET_VAR_HOST_HARDWARE_SERIAL",
     "certificate_user_principal_names": [
-      "$FLEET_VAR_HOST_HARDWARE_SERIAL",
+      "$FLEET_VAR_HOST_HARDWARE_SERIAL"
     ],
     "certificate_seat_id": "$FLEET_VAR_HOST_END_USER_EMAIL_IDP"
   }


### PR DESCRIPTION
Documentation only change, removes comma that causes JSON decoder error.