### PR TITLE
Made host team assignment sticky across orbit and osquery re-enrollments

### DIFF
--- a/changes/43294-sticky-team-enrollment
+++ b/changes/43294-sticky-team-enrollment
@@ -1,0 +1,1 @@
+* Made host team assignment sticky across orbit and osquery re-enrollments

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2382,7 +2382,7 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
         hardware_serial = COALESCE(NULLIF(hardware_serial, ''), ?),
         computer_name = COALESCE(NULLIF(computer_name, ''), ?),
         hardware_model = COALESCE(NULLIF(hardware_model, ''), ?),
-        refetch_requested = ?%s
+        refetch_requested = ?
       WHERE id = ?`
 			args := []any{
 				orbitNodeKey,
@@ -2394,21 +2394,9 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 				refetchRequested,
 			}
 
-			if !enrollConfig.IgnoreTeamUpdate {
-				args = append(args, teamID)
-				sqlUpdate = fmt.Sprintf(sqlUpdate, ", team_id = ?")
-			} else {
-				ds.logger.InfoContext(ctx, "skipping team update on orbit enroll", "host_uuid", hostInfo.HardwareUUID)
-				sqlUpdate = fmt.Sprintf(sqlUpdate, "")
-			}
-
 			// WHERE attributes
 			args = append(args, enrolledHostInfo.ID)
-
-			_, err := tx.ExecContext(ctx, sqlUpdate,
-				args...,
-			)
-			if err != nil {
+			if _, err := tx.ExecContext(ctx, sqlUpdate, args...); err != nil {
 				return ctxerr.Wrap(ctx, err, "orbit enroll error updating host details")
 			}
 			host.ID = enrolledHostInfo.ID
@@ -2621,7 +2609,7 @@ func (ds *Datastore) EnrollOsquery(ctx context.Context, opts ...fleet.DatastoreE
 				osquery_host_id = ?,
 				uuid = COALESCE(NULLIF(uuid, ''), ?),
 				hardware_serial = COALESCE(NULLIF(hardware_serial, ''), ?),
-				refetch_requested = ?%s
+				refetch_requested = ?
 				WHERE id = ?
 			`
 			args := []any{
@@ -2632,17 +2620,8 @@ func (ds *Datastore) EnrollOsquery(ctx context.Context, opts ...fleet.DatastoreE
 				refetchRequested,
 			}
 
-			if !enrollConfig.IgnoreTeamUpdate {
-				args = append(args, teamID)
-				sqlUpdate = fmt.Sprintf(sqlUpdate, ", team_id = ?")
-			} else {
-				ds.logger.InfoContext(ctx, "skipping team update on osquery enroll", "host_uuid", hardwareUUID)
-				sqlUpdate = fmt.Sprintf(sqlUpdate, "")
-			}
-
 			// WHERE attributes
 			args = append(args, enrolledHostInfo.ID)
-
 			_, err := tx.ExecContext(ctx, sqlUpdate, args...)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "update host")

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -11415,28 +11415,30 @@ func testHostsEnrollUpdatesMissingInfo(t *testing.T, ds *Datastore) {
 	require.Equal(t, "foobar", got.Hostname)
 	require.Equal(t, "darwin", got.Platform)
 
-	// enroll with osquery using uuid identifier, team
+	// enroll with osquery using uuid identifier, team enroll secret
 	_, err = ds.EnrollOsquery(ctx,
 		fleet.WithEnrollOsqueryMDMEnabled(true),
 		fleet.WithEnrollOsqueryHostID("uuid"),
 		fleet.WithEnrollOsqueryHardwareUUID("uuid"),
 		fleet.WithEnrollOsqueryHardwareSerial("different-serial"),
 		fleet.WithEnrollOsqueryNodeKey("osquery"),
-		fleet.WithEnrollOsqueryTeamID(&tm.ID),
+		fleet.WithEnrollOsqueryTeamID(&tm.ID), // use team enroll secret
 	)
 	require.NoError(t, err)
 	got, err = ds.LoadHostByOrbitNodeKey(ctx, "orbit")
 	require.NoError(t, err)
+
+	// New osquery node key is set.
+	require.NotNil(t, got.NodeKey)
+	require.Equal(t, "osquery", *got.NodeKey)
+
+	// Verify that the orbit enroll didn't override these values set by the previous orbit enroll.
 	require.Equal(t, h.ID, got.ID)
-	require.Equal(t, "serial", got.HardwareSerial) // unchanged as it was already filled
 	require.Equal(t, "uuid", got.UUID)
 	require.NotNil(t, got.OsqueryHostID)
 	require.Equal(t, "uuid", *got.OsqueryHostID)
-	require.NotNil(t, got.NodeKey)
-	require.Equal(t, "osquery", *got.NodeKey)
-	require.NotNil(t, got.TeamID)
-	require.Equal(t, tm.ID, *got.TeamID)
-	// Verify that the orbit enroll didn't override these values set by a previous osquery enroll.
+	require.Equal(t, "serial", got.HardwareSerial) // unchanged as it was already filled
+	require.Nil(t, got.TeamID)                     // team is sticky
 	require.Equal(t, "foobar", got.Hostname)
 	require.Equal(t, "darwin", got.Platform)
 }

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -1751,21 +1751,24 @@ func testTeamPolicyTransfer(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	checkPassingCount(0, 0, 1, 1)
 
-	// team policies are removed if the host is enrolled in a different team
+	// all host policies are removed on re-enroll even when the enroll secret
+	// belongs to a different team — but team_id stays put (orbit/osquery
+	// re-enrollment no longer changes a host's team).
 	_, err = ds.EnrollOsquery(ctx,
 		fleet.WithEnrollOsqueryHostID("2"),
 		fleet.WithEnrollOsqueryNodeKey("2"),
 		fleet.WithEnrollOsqueryTeamID(&team2.ID),
 	)
 	require.NoError(t, err)
-	// both hosts are now in team2
+	// host1 is in team2, host2 stays in team1 (sticky)
 	checkPassingCount(0, 0, 1, 1)
 
-	// team policies are removed if the host is re-enrolled without a team
+	// Re-record policy executions for host2; host2 is still in team1.
 	require.NoError(t, ds.RecordPolicyQueryExecutions(ctx, host2, map[uint]*bool{team1Policy.ID: new(true), globalPolicy.ID: new(true)}, time.Now(), false, nil))
-	checkPassingCount(1, 0, 2, 2)
+	checkPassingCount(1, 1, 1, 2)
 
-	// all host policies are removed when a host is re-enrolled
+	// all host policies are removed when a host is re-enrolled. The host's
+	// team_id is unchanged even though the re-enroll specifies no team.
 	_, err = ds.EnrollOsquery(ctx,
 		fleet.WithEnrollOsqueryHostID("2"),
 		fleet.WithEnrollOsqueryNodeKey("2"),

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -29,9 +29,6 @@ const (
 	// third-party MDM solution to Fleet.
 	RefetchMDMUnenrollCriticalQueryDuration = 3 * time.Minute
 
-	StickyMDMEnrollmentKeyPrefix = "sticky_mdm_enrollment_" // + host UUID
-	StickyMDMEnrollmentTTL       = 30 * time.Minute
-
 	// MDMProfileProcessingKeyPrefix is used to indicate that a host is currently being processed for MDM profile installation.
 	// We wrap the key in braces to make Redis hash the keys to the same slot, avoiding CrossSlot errors.
 	MDMProfileProcessingKeyPrefix = "{mdm_profile_processing}" // + :hostUUID

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -117,12 +117,11 @@ type OrbitHostInfo struct {
 
 // DatastoreEnrollOrbitConfig holds the configuration for datastore Orbit enrollment
 type DatastoreEnrollOrbitConfig struct {
-	IsMDMEnabled     bool
-	HostInfo         OrbitHostInfo
-	OrbitNodeKey     string
-	TeamID           *uint
-	IdentityCert     *types.HostIdentityCertificate
-	IgnoreTeamUpdate bool // when true the host's team won't be updated on enrollment where an entry already exists.
+	IsMDMEnabled bool
+	HostInfo     OrbitHostInfo
+	OrbitNodeKey string
+	TeamID       *uint
+	IdentityCert *types.HostIdentityCertificate
 }
 
 // DatastoreEnrollOrbitOption is a functional option for configuring datastore Orbit enrollment
@@ -159,14 +158,6 @@ func WithEnrollOrbitTeamID(teamID *uint) DatastoreEnrollOrbitOption {
 func WithEnrollOrbitIdentityCert(identityCert *types.HostIdentityCertificate) DatastoreEnrollOrbitOption {
 	return func(c *DatastoreEnrollOrbitConfig) {
 		c.IdentityCert = identityCert
-	}
-}
-
-// WithEnrollOrbitIgnoreTeamUpdate sets whether to ignore team updates for datastore Orbit enrollment
-// it only acts on existing hosts (i.e. it won't ignore the team id on new hosts)
-func WithEnrollOrbitIgnoreTeamUpdate(ignore bool) DatastoreEnrollOrbitOption {
-	return func(c *DatastoreEnrollOrbitConfig) {
-		c.IgnoreTeamUpdate = ignore
 	}
 }
 

--- a/server/fleet/osquery.go
+++ b/server/fleet/osquery.go
@@ -77,15 +77,14 @@ type PermissivePacks map[string]PermissivePackContent
 
 // DatastoreEnrollOsqueryConfig holds the configuration for datastore Host enrollment
 type DatastoreEnrollOsqueryConfig struct {
-	IsMDMEnabled     bool
-	OsqueryHostID    string
-	HardwareUUID     string
-	HardwareSerial   string
-	NodeKey          string
-	TeamID           *uint
-	Cooldown         time.Duration
-	IdentityCert     *types.HostIdentityCertificate
-	IgnoreTeamUpdate bool // when true the host's team won't be updated on enrollment where an entry already exists.
+	IsMDMEnabled   bool
+	OsqueryHostID  string
+	HardwareUUID   string
+	HardwareSerial string
+	NodeKey        string
+	TeamID         *uint
+	Cooldown       time.Duration
+	IdentityCert   *types.HostIdentityCertificate
 }
 
 // DatastoreEnrollOsqueryOption is a functional option for configuring datastore Host enrollment
@@ -143,13 +142,5 @@ func WithEnrollOsqueryCooldown(cooldown time.Duration) DatastoreEnrollOsqueryOpt
 func WithEnrollOsqueryIdentityCert(identityCert *types.HostIdentityCertificate) DatastoreEnrollOsqueryOption {
 	return func(c *DatastoreEnrollOsqueryConfig) {
 		c.IdentityCert = identityCert
-	}
-}
-
-// WithEnrollOsqueryIgnoreTeamUpdate sets whether to ignore team updates for datastore Host enrollment
-// it only acts on existing hosts (i.e. it won't ignore the team id on new hosts)
-func WithEnrollOsqueryIgnoreTeamUpdate(ignore bool) DatastoreEnrollOsqueryOption {
-	return func(c *DatastoreEnrollOsqueryConfig) {
-		c.IgnoreTeamUpdate = ignore
 	}
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3750,15 +3750,6 @@ func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm
 	}
 
 	if svc.keyValueStore != nil {
-		if !scepRenewalInProgress {
-			// Set sticky key for MDM enrollments to avoid updating team id on orbit enrollments
-			err = svc.keyValueStore.Set(r.Context, fleet.StickyMDMEnrollmentKeyPrefix+r.ID, "1", fleet.StickyMDMEnrollmentTTL)
-			if err != nil {
-				// We do not want to fail here, just log the error to notify
-				svc.logger.ErrorContext(r.Context, "failed to set sticky mdm enrollment key", "err", err, "host_uuid", r.ID)
-			}
-		}
-
 		// Set profile processing flag, is being handled by the apple_mdm worker, it will be cleared later if it's a SCEP renewal.
 		if err := svc.keyValueStore.Set(r.Context, fleet.MDMProfileProcessingKeyPrefix+":"+r.ID, "1", fleet.MDMProfileProcessingTTL); err != nil {
 			svc.logger.ErrorContext(r.Context, "failed to set mdm profile processing key", "err", err, "host_uuid", r.ID)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/pubsub"
 	commonCalendar "github.com/fleetdm/fleet/v4/server/service/calendar"
 	"github.com/fleetdm/fleet/v4/server/service/conditional_access_microsoft_proxy"
+	"github.com/fleetdm/fleet/v4/server/service/contract"
 	"github.com/fleetdm/fleet/v4/server/service/osquery_utils"
 	"github.com/fleetdm/fleet/v4/server/service/redis_lock"
 	"github.com/fleetdm/fleet/v4/server/service/schedule"
@@ -30405,4 +30406,129 @@ func (s *integrationEnterpriseTestSuite) TestApplyPolicySpecsBatchMixedScopes() 
 	require.Len(t, byName[validAnyName].LabelsIncludeAny, 1)
 	require.Len(t, byName[validAllName].LabelsIncludeAll, 2)
 	require.Len(t, byName[validExclName].LabelsExcludeAny, 1)
+}
+
+// TestOrbitOsqueryReEnrollDoesNotChangeTeam verifies that re-enrolling a host
+// via orbit or osquery with an enroll secret belonging to a different team than
+// the host's current team does not change the host's team_id. This protects
+// against unintended team transfers when a host re-enrolls using a different
+// enroll secret than the one originally used to onboard it.
+func (s *integrationEnterpriseTestSuite) TestOrbitOsqueryReEnrollDoesNotChangeTeam() {
+	t := s.T()
+	ctx := context.Background()
+
+	teamASecret := "team-a-reenroll-secret" //nolint:gosec // G101: test value only
+	teamBSecret := "team-b-reenroll-secret" //nolint:gosec // G101: test value only
+
+	teamA, err := s.ds.NewTeam(ctx, &fleet.Team{
+		Name:    t.Name() + "_teamA",
+		Secrets: []*fleet.EnrollSecret{{Secret: teamASecret}},
+	})
+	require.NoError(t, err)
+
+	// Team B exists only to own teamBSecret. The host should never end up in it.
+	_, err = s.ds.NewTeam(ctx, &fleet.Team{
+		Name:    t.Name() + "_teamB",
+		Secrets: []*fleet.EnrollSecret{{Secret: teamBSecret}},
+	})
+	require.NoError(t, err)
+
+	t.Run("orbit", func(t *testing.T) {
+		hostUUID := uuid.New().String()
+		hostSerial := uuid.New().String()
+		hostName := t.Name() + ".local"
+
+		// Initial orbit enroll with team A's secret — host should be created in team A.
+		var orbitResp enrollOrbitResponse
+		s.DoJSON("POST", "/api/fleet/orbit/enroll", fleet.EnrollOrbitRequest{
+			EnrollSecret:   teamASecret,
+			HardwareUUID:   hostUUID,
+			HardwareSerial: hostSerial,
+			Hostname:       hostName,
+			Platform:       "darwin",
+			HardwareModel:  "MacBookPro16,1",
+		}, http.StatusOK, &orbitResp)
+		require.NotEmpty(t, orbitResp.OrbitNodeKey)
+
+		hostLite, err := s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.NoError(t, err)
+		require.NotNil(t, hostLite.TeamID)
+		require.Equal(t, teamA.ID, *hostLite.TeamID)
+
+		// Re-enroll the same host using team B's secret. team_id must not change.
+		var reorbitResp enrollOrbitResponse
+		s.DoJSON("POST", "/api/fleet/orbit/enroll", fleet.EnrollOrbitRequest{
+			EnrollSecret:   teamBSecret,
+			HardwareUUID:   hostUUID,
+			HardwareSerial: hostSerial,
+			Hostname:       hostName,
+			Platform:       "darwin",
+			HardwareModel:  "MacBookPro16,1",
+		}, http.StatusOK, &reorbitResp)
+		require.NotEmpty(t, reorbitResp.OrbitNodeKey)
+
+		hostLite, err = s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.NoError(t, err)
+		require.NotNil(t, hostLite.TeamID)
+		require.Equal(t, teamA.ID, *hostLite.TeamID)
+	})
+
+	t.Run("osquery", func(t *testing.T) {
+		hostUUID := uuid.New().String()
+		hostSerial := uuid.New().String()
+
+		// Initial osquery enroll with team A's secret — host should be created in team A.
+		var osqueryResp contract.EnrollOsqueryAgentResponse
+		s.DoJSON("POST", "/api/osquery/enroll", contract.EnrollOsqueryAgentRequest{
+			EnrollSecret:   teamASecret,
+			HostIdentifier: hostUUID,
+			HostDetails: map[string]map[string]string{
+				"osquery_info": {
+					"instance_id": hostUUID,
+				},
+				"system_info": {
+					"hardware_serial": hostSerial,
+					"uuid":            hostUUID,
+				},
+			},
+		}, http.StatusOK, &osqueryResp)
+		require.NotEmpty(t, osqueryResp.NodeKey)
+
+		hostLite, err := s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.NoError(t, err)
+		require.NotNil(t, hostLite.TeamID)
+		require.Equal(t, teamA.ID, *hostLite.TeamID)
+
+		// Age last_enrolled_at to bypass the osquery enroll cooldown (default 42m in tests).
+		mysql.ExecAdhocSQL(t, s.ds, func(db sqlx.ExtContext) error {
+			_, err := db.ExecContext(
+				ctx,
+				"UPDATE hosts SET last_enrolled_at = DATE_SUB(NOW(), INTERVAL '1' HOUR) WHERE id = ?",
+				hostLite.ID,
+			)
+			return err
+		})
+
+		// Re-enroll the same host using team B's secret. team_id must not change.
+		var reosqueryResp contract.EnrollOsqueryAgentResponse
+		s.DoJSON("POST", "/api/osquery/enroll", contract.EnrollOsqueryAgentRequest{
+			EnrollSecret:   teamBSecret,
+			HostIdentifier: hostUUID,
+			HostDetails: map[string]map[string]string{
+				"osquery_info": {
+					"instance_id": hostUUID,
+				},
+				"system_info": {
+					"hardware_serial": hostSerial,
+					"uuid":            hostUUID,
+				},
+			},
+		}, http.StatusOK, &reosqueryResp)
+		require.NotEmpty(t, reosqueryResp.NodeKey)
+
+		hostLite, err = s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.NoError(t, err)
+		require.NotNil(t, hostLite.TeamID)
+		require.Equal(t, teamA.ID, *hostLite.TeamID)
+	})
 }

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/mdm/mdmtest"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
-	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
@@ -31,10 +30,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/contract"
-	"github.com/fleetdm/fleet/v4/server/service/redis_key_value"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/fleetdm/fleet/v4/server/worker"
-	redigo "github.com/gomodule/redigo/redis"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	micromdm "github.com/micromdm/micromdm/mdm/mdm"
@@ -2926,108 +2923,89 @@ func (s *integrationMDMTestSuite) TestDeleteMultipleHostsPendingDEP() {
 }
 
 // This test case covers the bug https://github.com/fleetdm/fleet/issues/26879
+//
+// It simulates an automation transferring a host to a team after MDM enrollment,
+// then performs orbit and osquery enrollment for the host with an enroll secret
+// that does NOT belong to the automation team. The host must remain a member of
+// the team set by the automation — orbit/osquery re-enrollment must not change
+// the team_id of an existing host.
 func (s *integrationMDMTestSuite) TestStickyMDMTeamEnrollment() {
 	t := s.T()
 	ctx := t.Context()
 
-	teamEnrollSecret := "sticky-mdm-team-enroll-secret" //nolint:gosec // G101: false positive, test value only
-	// Create a single team with MDM enabled
-	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "mdm team", Secrets: []*fleet.EnrollSecret{{Secret: teamEnrollSecret}}})
+	automationTeamSecret := "automation-team-enroll-secret" //nolint:gosec // G101: test value only
+	differentTeamSecret := "different-team-enroll-secret"   //nolint:gosec // G101: test value only
+
+	// Team the automation will transfer the host to after MDM enroll.
+	automationTeam, err := s.ds.NewTeam(ctx, &fleet.Team{
+		Name:    "automation team",
+		Secrets: []*fleet.EnrollSecret{{Secret: automationTeamSecret}},
+	})
 	require.NoError(t, err)
 
-	// Enable MDM for appconfig
-	appConfig, err := s.ds.AppConfig(ctx)
-	require.NoError(t, err)
-	appConfig.MDM.EnabledAndConfigured = true
-	err = s.ds.SaveAppConfig(ctx, appConfig)
+	// A different team whose enroll secret will be used by orbit/osquery enroll.
+	_, err = s.ds.NewTeam(ctx, &fleet.Team{
+		Name:    "different team",
+		Secrets: []*fleet.EnrollSecret{{Secret: differentTeamSecret}},
+	})
 	require.NoError(t, err)
 
-	testCases := []struct {
-		name          string
-		enrollURL     string
-		enrollRequest func(*fleet.Host, *mdmtest.TestAppleMDMClient) any
-	}{
-		{
-			name:      "Orbit Enrollment",
-			enrollURL: "/api/fleet/orbit/enroll",
-			enrollRequest: func(host *fleet.Host, mdmDevice *mdmtest.TestAppleMDMClient) any {
-				return fleet.EnrollOrbitRequest{
-					EnrollSecret:   teamEnrollSecret,
-					HardwareUUID:   host.UUID,
-					HardwareSerial: mdmDevice.SerialNumber,
-					Hostname:       host.Hostname,
-					Platform:       host.Platform,
-					PlatformLike:   host.PlatformLike,
-					HardwareModel:  host.HardwareModel,
-				}
+	// MDM-enroll a new host. It lands in "no team".
+	host, mdmDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+
+	hostLite, err := s.ds.HostLiteByIdentifier(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, hostLite)
+	require.Nil(t, hostLite.TeamID)
+
+	// Simulate the automation: transfer the host to the automation team.
+	s.Do("POST", "/api/latest/fleet/hosts/transfer", &addHostsToTeamRequest{
+		HostIDs: []uint{hostLite.ID},
+		TeamID:  &automationTeam.ID,
+	}, http.StatusOK)
+
+	hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, hostLite.TeamID)
+	require.Equal(t, automationTeam.ID, *hostLite.TeamID)
+
+	// Orbit-enroll using a different team's secret. The host must remain in the automation team.
+	var orbitResp enrollOrbitResponse
+	s.DoJSON("POST", "/api/fleet/orbit/enroll", fleet.EnrollOrbitRequest{
+		EnrollSecret:   differentTeamSecret,
+		HardwareUUID:   host.UUID,
+		HardwareSerial: mdmDevice.SerialNumber,
+		Hostname:       host.Hostname,
+		Platform:       host.Platform,
+		PlatformLike:   host.PlatformLike,
+		HardwareModel:  host.HardwareModel,
+	}, http.StatusOK, &orbitResp)
+
+	hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, hostLite.TeamID)
+	require.Equal(t, automationTeam.ID, *hostLite.TeamID)
+
+	// Osquery-enroll using a different team's secret. The host must remain in the automation team.
+	var osqueryResp contract.EnrollOsqueryAgentResponse
+	s.DoJSON("POST", "/api/osquery/enroll", contract.EnrollOsqueryAgentRequest{
+		EnrollSecret:   differentTeamSecret,
+		HostIdentifier: host.UUID,
+		HostDetails: map[string]map[string]string{
+			"osquery_info": {
+				"instance_id": host.UUID,
+			},
+			"system_info": {
+				"hardware_serial": mdmDevice.SerialNumber,
+				"uuid":            host.UUID,
 			},
 		},
-		{
-			name:      "Osquery Enrollment",
-			enrollURL: "/api/osquery/enroll",
-			enrollRequest: func(host *fleet.Host, mdmDevice *mdmtest.TestAppleMDMClient) any {
-				return contract.EnrollOsqueryAgentRequest{
-					EnrollSecret:   teamEnrollSecret,
-					HostIdentifier: host.UUID,
-					HostDetails: map[string]map[string]string{
-						"osquery_info": {
-							"instance_id": host.UUID,
-						},
-						"system_info": {
-							"hardware_serial": mdmDevice.SerialNumber,
-							"uuid":            host.UUID,
-						},
-					},
-				}
-			},
-		},
-	}
+	}, http.StatusOK, &osqueryResp)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Create a MDM apple device
-			host, mdmDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
-
-			// Check that redis key was set
-			keyValueStore := redis_key_value.New(s.redisPool)
-			val, err := keyValueStore.Get(ctx, fleet.StickyMDMEnrollmentKeyPrefix+host.UUID)
-			require.NoError(t, err)
-			require.NotNil(t, val)
-
-			// Get the team to check that it enrolled into no-team
-			hostLite, err := s.ds.HostLiteByIdentifier(ctx, host.UUID)
-			require.NoError(t, err)
-			require.NotNil(t, hostLite)
-			require.Nil(t, hostLite.TeamID)
-
-			request := tc.enrollRequest(host, mdmDevice)
-			response := struct{}{}
-			s.DoJSON("POST", tc.enrollURL, request, http.StatusOK, &response)
-
-			// Check that the host is still in no-team
-			hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
-			require.NoError(t, err)
-			require.NotNil(t, hostLite)
-			require.Nil(t, hostLite.TeamID)
-
-			// Delete the key to re-enroll
-			conn := redis.ConfigureDoer(s.redisPool, s.redisPool.Get())
-			defer conn.Close()
-
-			_, err = redigo.Int64(conn.Do("DEL", "key_value_"+fleet.StickyMDMEnrollmentKeyPrefix+host.UUID))
-			require.NoError(t, err)
-
-			// RE-enroll and see team transfer
-			s.DoJSON("POST", tc.enrollURL, request, http.StatusOK, &response)
-
-			// Check that the host is now in the team
-			hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
-			require.NoError(t, err)
-			require.NotNil(t, hostLite)
-			require.NotNil(t, hostLite.TeamID)
-			require.Equal(t, team.ID, *hostLite.TeamID)
-		})
-	}
+	hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, hostLite.TeamID)
+	require.Equal(t, automationTeam.ID, *hostLite.TeamID)
 }
 
 // This test verifies the fix for https://github.com/fleetdm/fleet/issues/33815

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -266,26 +266,12 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 		}
 	}
 
-	var stickyEnrollment *string
-	if svc.keyValueStore != nil {
-		// Check for sticky MDM enrollment flag. When set (e.g., after a host transfer),
-		// this prevents enrollment-based team changes for a time window to avoid race conditions
-		// with MDM profile delivery.
-		stickyEnrollment, err = svc.keyValueStore.Get(ctx, fleet.StickyMDMEnrollmentKeyPrefix+hostInfo.HardwareUUID)
-		if err != nil {
-			// Log error but continue enrollment (fail-open approach). If Redis is unavailable,
-			// enrollment proceeds without sticky behavior rather than blocking.
-			svc.logger.ErrorContext(ctx, "failed to get sticky enrollment", "err", err, "host_uuid", hostInfo.HardwareUUID)
-		}
-	}
-
 	host, err := svc.ds.EnrollOrbit(ctx,
 		fleet.WithEnrollOrbitMDMEnabled(appConfig.MDM.EnabledAndConfigured),
 		fleet.WithEnrollOrbitHostInfo(hostInfo),
 		fleet.WithEnrollOrbitNodeKey(orbitNodeKey),
 		fleet.WithEnrollOrbitTeamID(secret.TeamID),
 		fleet.WithEnrollOrbitIdentityCert(identityCert),
-		fleet.WithEnrollOrbitIgnoreTeamUpdate(stickyEnrollment != nil),
 	)
 	if err != nil {
 		return "", fleet.OrbitError{Message: "failed to enroll " + err.Error()}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -161,19 +161,6 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 		return "", newOsqueryErrorWithInvalidNode("app config load failed: " + err.Error())
 	}
 
-	var stickyEnrollment *string
-	if svc.keyValueStore != nil {
-		// Check for sticky MDM enrollment flag. When set (e.g., after a host transfer),
-		// this prevents enrollment-based team changes for a time window to avoid race conditions
-		// with MDM profile delivery.
-		stickyEnrollment, err = svc.keyValueStore.Get(ctx, fleet.StickyMDMEnrollmentKeyPrefix+hardwareUUID)
-		if err != nil {
-			// Log error but continue enrollment (fail-open approach). If Redis is unavailable,
-			// enrollment proceeds without sticky behavior rather than blocking.
-			svc.logger.ErrorContext(ctx, "failed to get sticky enrollment", "err", err, "host_uuid", hardwareUUID)
-		}
-	}
-
 	host, err := svc.ds.EnrollOsquery(ctx,
 		fleet.WithEnrollOsqueryMDMEnabled(appConfig.MDM.EnabledAndConfigured),
 		fleet.WithEnrollOsqueryHostID(hostIdentifier),
@@ -183,7 +170,6 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 		fleet.WithEnrollOsqueryTeamID(secret.TeamID),
 		fleet.WithEnrollOsqueryCooldown(svc.config.Osquery.EnrollCooldown),
 		fleet.WithEnrollOsqueryIdentityCert(identityCert),
-		fleet.WithEnrollOsqueryIgnoreTeamUpdate(stickyEnrollment != nil),
 	)
 	if err != nil {
 		return "", newOsqueryErrorWithInvalidNode("save enroll failed: " + err.Error())


### PR DESCRIPTION
Resolves #43294.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where host team assignments were not persisting during re-enrollment. Team assignments are now sticky and remain unchanged when hosts re-enroll using a different team's enrollment secret, ensuring consistent team ownership across re-enrollments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->