### PR TITLE
Inject initFatal as a package-level var (#33370)

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -71,7 +71,10 @@ func main() {
 }
 
 // initFatal prints an error message and exits with a non-zero status.
-func initFatal(err error, message string) {
+//
+// It is declared as a var so tests can override the behavior without
+// terminating the test binary via os.Exit.
+var initFatal = func(err error, message string) {
 	fmt.Printf("Failed to start: %s: %v\n", message, err)
 	os.Exit(1)
 }

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -1441,6 +1441,27 @@ func TestGetTLSConfig(t *testing.T) {
 	})
 }
 
+// TestGetTLSConfigInvalidProfile covers the default case of getTLSConfig,
+// which calls initFatal. Not run in parallel because the test mutates the
+// package-level initFatal var.
+func TestGetTLSConfigInvalidProfile(t *testing.T) {
+	var capturedErr error
+	var capturedMsg string
+	orig := initFatal
+	initFatal = func(err error, msg string) {
+		capturedErr = err
+		capturedMsg = msg
+	}
+	t.Cleanup(func() { initFatal = orig })
+
+	getTLSConfig("not-a-real-profile")
+
+	require.Error(t, capturedErr)
+	require.Contains(t, capturedErr.Error(), "not-a-real-profile")
+	require.Contains(t, capturedErr.Error(), "is invalid")
+	require.Equal(t, "set TLS profile", capturedMsg)
+}
+
 func TestInitLicense(t *testing.T) {
 	t.Parallel()
 	t.Run("dev license", func(t *testing.T) {


### PR DESCRIPTION
Second PR in the staged plan from [#33370](https://github.com/fleetdm/fleet/issues/33370#issuecomment-4394807680). Per [@getvictor's confirmation](https://github.com/fleetdm/fleet/issues/33370#issuecomment-4421816049), takes the package-level var approach so tests can swap `initFatal` without terminating the test binary.

The new `TestGetTLSConfigInvalidProfile` covers `getTLSConfig`'s default case (previously unreachable in tests because it calls `initFatal`)

**Related issue:** Part of #33370.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests

## Database migrations

_N/A — no database migrations in this PR._

## New Fleet configuration settings

_N/A — no new configuration settings._

## fleetd/orbit/Fleet Desktop

_N/A — no agent code changes._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for TLS configuration error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->