### PR TITLE
fix Actions dropdown in Run script modal auto-closing

### DIFF
--- a/changes/43640-actions-dropdown-auto-closing
+++ b/changes/43640-actions-dropdown-auto-closing
@@ -1,0 +1,1 @@
+* Fixed an issue where the Actions dropdown in the Run script modal within the Host details page would automatically close after 2-3s.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ScriptModalGroup/ScriptModalGroup.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ScriptModalGroup/ScriptModalGroup.tsx
@@ -148,6 +148,24 @@ const ScriptModalGroup = ({
     [currentModal]
   );
 
+  const onClickViewScript = useCallback(
+    (script: IHostScript) => {
+      setPreviousModal(currentModal);
+      setCurrentModal(ModalGroupOption.ViewScriptDetails);
+      setSelectedScript(script);
+    },
+    [currentModal]
+  );
+
+  const onClickRunDetails = useCallback(
+    (scriptExecutionId: string) => {
+      setPreviousModal(currentModal);
+      setCurrentModal(ModalGroupOption.ViewRunDetails);
+      setSelectedExecutionId(scriptExecutionId);
+    },
+    [currentModal]
+  );
+
   return (
     <>
       <RunScriptModal
@@ -155,16 +173,8 @@ const ScriptModalGroup = ({
         hostTeamId={host.team_id}
         onClickRun={onClikRunBeforeConfirmation}
         onClose={onCloseScriptModalGroup}
-        onClickViewScript={(script: IHostScript) => {
-          setPreviousModal(currentModal);
-          setCurrentModal(ModalGroupOption.ViewScriptDetails);
-          setSelectedScript(script);
-        }}
-        onClickRunDetails={(scriptExecutionId: string) => {
-          setPreviousModal(currentModal);
-          setCurrentModal(ModalGroupOption.ViewRunDetails);
-          setSelectedExecutionId(scriptExecutionId);
-        }}
+        onClickViewScript={onClickViewScript}
+        onClickRunDetails={onClickRunDetails}
         page={runScriptTablePage}
         setPage={setRunScriptTablePage}
         hostScriptResponse={runScriptTableResponse}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43640

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

I figured out that the RunScriptModal was being re-rendered without any user events or network calls after the 2s mark.
At first I thought the parent (ScriptModalGroup.tsx) could have been the culprit since there's a lot going on there (lots of callback functions passed to multiple modals). 
It turns out that RunScriptModal is wrapped in React.memo to avoid re-rendering but since some of its props changed in the parent component, this caused it to re-render and close the Actions dropdown randomly.

To detect which where the problematic props changing, I threw this code at the top of RunScriptModal.tsx:

```react
const prev = useRef<any>({});
  useEffect(() => {
    const current = {
      currentUser,
      hostTeamId,
      onClose,
      page,
      setPage,
      hostScriptResponse,
      isFetchingHostScripts,
      isLoadingHostScripts,
      isError,
      onClickViewScript,
      onClickRunDetails,
      onClickRun,
      isRunningScript,
      isHidden,
    };
    const changed = Object.entries(current).filter(
      ([k, v]) => prev.current[k] !== v
    );
    console.log(
      "RunScriptModal re-render. Changed props:",
      changed.map(([k]) => k)
    );
    prev.current = current;
  });
```

and the output was:

```
RunScriptModal re-render. Changed props:                                                  
  (2) ['onClickViewScript', 'onClickRunDetails']
```

So I just wrapped those two in useCallback and that fixed the issue.


https://github.com/user-attachments/assets/f6eae13e-2a60-4fda-9468-2952acdedd58




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the Actions dropdown in the Run script modal on the Host details page auto-closing after 2-3 seconds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45349)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->