### PR TITLE
Skip policy_membership writes for unchanged values (#44191)

### DIFF
--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -649,19 +649,30 @@ func (ds *Datastore) RecordPolicyQueryExecutions(ctx context.Context, host *flee
 	if len(newPassing) > 0 {
 		slices.Sort(newPassing)
 	}
+
+	// To avoid redundant UPSERTs (#44191), fetch the existing policy_membership
+	// rows for the incoming policies and narrow the UPSERT batch to only the
+	// rows whose stored value differs from incoming. The read is a small
+	// indexed lookup on (host_id, policy_id); the savings are on the writer
+	// side, which is the loadtest bottleneck. policy_membership.updated_at
+	// therefore tracks "last state change" rather than "last reported";
+	// hosts.policy_updated_at remains the per-host "last reported" signal
+	// and is updated below regardless.
+	needsWrite, err := ds.policiesNeedingMembershipWrite(ctx, host.ID, results)
+	if err != nil {
+		return err
+	}
+
 	vals := []interface{}{}
 	bindvars := []string{}
-	var orderedIDs []uint
-	if len(results) > 0 {
-		// Sort the results to have generated SQL queries ordered to minimize
-		// deadlocks. See https://github.com/fleetdm/fleet/issues/1146.
-		orderedIDs = make([]uint, 0, len(results))
-		for policyID := range results {
+	if len(needsWrite) > 0 {
+		// Sort to keep generated SQL ordered and minimize deadlocks (see #1146).
+		orderedIDs := make([]uint, 0, len(needsWrite))
+		for policyID := range needsWrite {
 			orderedIDs = append(orderedIDs, policyID)
 		}
 		sort.Slice(orderedIDs, func(i, j int) bool { return orderedIDs[i] < orderedIDs[j] })
 
-		// Loop through results, collecting which labels we need to insert/update
 		for _, policyID := range orderedIDs {
 			matches := results[policyID]
 			bindvars = append(bindvars, "(?,?,?,?)")
@@ -669,15 +680,19 @@ func (ds *Datastore) RecordPolicyQueryExecutions(ctx context.Context, host *flee
 		}
 	}
 
-	// NOTE: the insert of policy membership that follows must be kept in sync
-	// with the async implementation in AsyncBatchInsertPolicyMembership, and the
-	// update of the policy_updated_at timestamp in sync with the
-	// AsyncBatchUpdatePolicyTimestamp method (that is, their processing must be
-	// semantically equivalent, even though here it processes a single host and
-	// in async mode it processes a batch of hosts).
+	// NOTE: as of #44191, the sync path here narrows the UPSERT batch to only
+	// rows whose stored value differs from incoming, while
+	// AsyncBatchInsertPolicyMembership still UPSERTs every incoming row. As a
+	// result, policy_membership.updated_at means "last state change" under
+	// sync processing and "last reported" under async. The
+	// hosts.policy_updated_at column remains the per-host "last reported"
+	// signal under both paths and is updated below regardless. Narrowing the
+	// async path is a natural follow-up; until then keep the two write paths
+	// aware of this divergence rather than treating them as semantically
+	// equivalent.
 
-	err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-		if len(results) > 0 {
+	err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		if len(vals) > 0 {
 			query := fmt.Sprintf(
 				`INSERT INTO policy_membership (updated_at, policy_id, host_id, passes)
 			VALUES %s ON DUPLICATE KEY UPDATE updated_at=VALUES(updated_at), passes=VALUES(passes)`,
@@ -686,26 +701,30 @@ func (ds *Datastore) RecordPolicyQueryExecutions(ctx context.Context, host *flee
 			if _, err := tx.ExecContext(ctx, query, vals...); err != nil {
 				return ctxerr.Wrapf(ctx, err, "insert policy_membership (%v)", vals)
 			}
+		}
 
-			// Reset attempt_number to 0 only for policies that flipped failing -> passing.
-			if len(newPassing) > 0 {
-				query, args, err := sqlx.In(resetScriptAttemptsStmt, host.ID, newPassing)
-				if err != nil {
-					return ctxerr.Wrap(ctx, err, "building reset script attempts query")
-				}
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-					return ctxerr.Wrap(ctx, err, "reset script attempt numbers")
-				}
+		// Reset attempt_number to 0 for policies that flipped failing -> passing.
+		// Independent of the UPSERT above; if a caller pre-computed this signal,
+		// retry resets fire even when no rows ended up needing writes (e.g. a
+		// stale flip that already matches stored state).
+		if len(newPassing) > 0 {
+			query, args, err := sqlx.In(resetScriptAttemptsStmt, host.ID, newPassing)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "building reset script attempts query")
+			}
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return ctxerr.Wrap(ctx, err, "reset script attempt numbers")
+			}
 
-				query, args, err = sqlx.In(resetInstallAttemptsStmt, host.ID, newPassing)
-				if err != nil {
-					return ctxerr.Wrap(ctx, err, "building reset install attempts query")
-				}
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-					return ctxerr.Wrap(ctx, err, "reset install attempt numbers")
-				}
+			query, args, err = sqlx.In(resetInstallAttemptsStmt, host.ID, newPassing)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "building reset install attempts query")
+			}
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return ctxerr.Wrap(ctx, err, "reset install attempt numbers")
 			}
 		}
+
 		// if we are deferring host updates, we return at this point and do the change outside of the tx
 		if !deferredSaveHost {
 			if _, err := tx.ExecContext(ctx, `UPDATE hosts SET policy_updated_at = ? WHERE id=?`, updated, host.ID); err != nil {
@@ -744,6 +763,65 @@ func (ds *Datastore) RecordPolicyQueryExecutions(ctx context.Context, host *flee
 		}
 	}
 	return nil
+}
+
+// policiesNeedingMembershipWrite returns the set of policy IDs whose stored
+// passes value in policy_membership differs from the incoming value. Rules:
+//   - No existing row + incoming non-nil: write (first-run anything).
+//   - No existing row + incoming nil: skip (nothing to record).
+//   - Existing row matches incoming (both NULL or same bool): skip (no-op).
+//   - Existing row differs from incoming (incl. transitions to/from NULL): write.
+//
+// The read is an indexed lookup on (host_id, policy_id) and is cheap relative
+// to the writes it lets us avoid; this is the optimization #44191 is about.
+func (ds *Datastore) policiesNeedingMembershipWrite(ctx context.Context, hostID uint, incoming map[uint]*bool) (map[uint]struct{}, error) {
+	needsWrite := make(map[uint]struct{}, len(incoming))
+	if len(incoming) == 0 {
+		return needsWrite, nil
+	}
+
+	ids := make([]uint, 0, len(incoming))
+	for id := range incoming {
+		ids = append(ids, id)
+	}
+
+	type membershipRow struct {
+		PolicyID uint         `db:"policy_id"`
+		Passes   sql.NullBool `db:"passes"`
+	}
+	selectQuery := `SELECT policy_id, passes FROM policy_membership WHERE host_id = ? AND policy_id IN (?)`
+	selectQuery, args, err := sqlx.In(selectQuery, hostID, ids)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build select policy_membership query for delta")
+	}
+	var stored []membershipRow
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &stored, selectQuery, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "select policy_membership for delta")
+	}
+	storedByID := make(map[uint]sql.NullBool, len(stored))
+	for _, r := range stored {
+		storedByID[r.PolicyID] = r.Passes
+	}
+
+	for policyID, incomingValue := range incoming {
+		storedValue, hasRow := storedByID[policyID]
+		switch {
+		case !hasRow && incomingValue != nil:
+			// First-run anything → write.
+			needsWrite[policyID] = struct{}{}
+		case !hasRow && incomingValue == nil:
+			// No existing row and no value to record → skip.
+		case incomingValue == nil && storedValue.Valid:
+			// Incoming "didn't execute" over an existing known value → write to clear.
+			needsWrite[policyID] = struct{}{}
+		case incomingValue == nil && !storedValue.Valid:
+			// Both are NULL → no-op.
+		case !storedValue.Valid || storedValue.Bool != *incomingValue:
+			// Real state flip or transition from NULL to a known value → write.
+			needsWrite[policyID] = struct{}{}
+		}
+	}
+	return needsWrite, nil
 }
 
 func (ds *Datastore) ClearSoftwareInstallerAutoInstallPolicyStatusForHosts(ctx context.Context, installerID uint, hostIDs []uint) error {

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"crypto/md5" //nolint:gosec // (only used for tests)
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -51,6 +52,7 @@ func TestPolicies(t *testing.T) {
 		{"Save", testPoliciesSave},
 		{"DelUser", testPoliciesDelUser},
 		{"FlippingPoliciesForHost", testFlippingPoliciesForHost},
+		{"NarrowedMembershipUpsert", testPoliciesNarrowedMembershipUpsert},
 		{"PlatformUpdate", testPolicyPlatformUpdate},
 		{"CleanupPolicyMembership", testPolicyCleanupPolicyMembership},
 		{"DeleteAllPolicyMemberships", testDeleteAllPolicyMemberships},
@@ -2913,6 +2915,101 @@ func testFlippingPoliciesForHost(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Empty(t, newFailing)
 	require.Empty(t, newPassing)
+}
+
+// testPoliciesNarrowedMembershipUpsert pins the five delta cases that
+// RecordPolicyQueryExecutions handles (via policiesNeedingMembershipWrite)
+// after the #44191 optimization: first-run-pass writes a row, steady-state
+// re-reports skip the UPSERT (preserving updated_at), real flips update the
+// row, nil-incoming clears existing rows to NULL, and first-run-nil does
+// not create a row.
+func testPoliciesNarrowedMembershipUpsert(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   ptr.String("narrowed-upsert-host"),
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		NodeKey:         ptr.String("narrowed-upsert-host"),
+		UUID:            "narrowed-upsert-host",
+		Hostname:        "narrowed-upsert-host.local",
+	})
+	require.NoError(t, err)
+
+	policyA, err := ds.NewGlobalPolicy(ctx, &user.ID, fleet.PolicyPayload{
+		Name:  "narrowed-upsert-policyA",
+		Query: "select 1;",
+	})
+	require.NoError(t, err)
+	policyB, err := ds.NewGlobalPolicy(ctx, &user.ID, fleet.PolicyPayload{
+		Name:  "narrowed-upsert-policyB",
+		Query: "select 2;",
+	})
+	require.NoError(t, err)
+
+	type membershipRow struct {
+		Passes    sql.NullBool `db:"passes"`
+		UpdatedAt time.Time    `db:"updated_at"`
+	}
+	getRow := func(t *testing.T, policyID uint) (membershipRow, bool) {
+		var row membershipRow
+		err := sqlx.GetContext(ctx, ds.writer(ctx), &row,
+			`SELECT passes, updated_at FROM policy_membership WHERE host_id = ? AND policy_id = ?`,
+			host.ID, policyID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return membershipRow{}, false
+		}
+		require.NoError(t, err)
+		return row, true
+	}
+
+	// 1. First-run passing → row created with passes=true.
+	t1 := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, ds.RecordPolicyQueryExecutions(ctx, host,
+		map[uint]*bool{policyA.ID: new(true)}, t1, false, nil))
+	row, ok := getRow(t, policyA.ID)
+	require.True(t, ok, "first-run passing should create the row")
+	require.True(t, row.Passes.Valid)
+	require.True(t, row.Passes.Bool)
+	originalUpdatedAt := row.UpdatedAt
+
+	// 2. Steady-state re-report → no UPSERT, updated_at unchanged. We pass a
+	// clearly different timestamp; if our optimization works, the stored
+	// updated_at should still match the original (not the new t2).
+	t2 := t1.Add(2 * time.Minute)
+	require.NoError(t, ds.RecordPolicyQueryExecutions(ctx, host,
+		map[uint]*bool{policyA.ID: new(true)}, t2, false, nil))
+	row, _ = getRow(t, policyA.ID)
+	require.True(t, row.Passes.Valid)
+	require.True(t, row.Passes.Bool)
+	require.Equal(t, originalUpdatedAt.Unix(), row.UpdatedAt.Unix(),
+		"steady-state re-report should not refresh updated_at")
+
+	// 3. Real flip (passing → failing) → row updated.
+	require.NoError(t, ds.RecordPolicyQueryExecutions(ctx, host,
+		map[uint]*bool{policyA.ID: new(false)}, time.Now(), false, nil))
+	row, ok = getRow(t, policyA.ID)
+	require.True(t, ok)
+	require.True(t, row.Passes.Valid)
+	require.False(t, row.Passes.Bool, "flip should update stored value to false")
+
+	// 4. Nil-incoming over existing known value → cleared to NULL.
+	require.NoError(t, ds.RecordPolicyQueryExecutions(ctx, host,
+		map[uint]*bool{policyA.ID: nil}, time.Now(), false, nil))
+	row, ok = getRow(t, policyA.ID)
+	require.True(t, ok, "row should still exist after nil-clear")
+	require.False(t, row.Passes.Valid, "passes should be NULL after nil-incoming clears it")
+
+	// 5. First-run nil → no row created (nothing to record).
+	_, exists := getRow(t, policyB.ID)
+	require.False(t, exists, "precondition: no row for policyB")
+	require.NoError(t, ds.RecordPolicyQueryExecutions(ctx, host,
+		map[uint]*bool{policyB.ID: nil}, time.Now(), false, nil))
+	_, exists = getRow(t, policyB.ID)
+	require.False(t, exists, "first-run nil should not create a row")
 }
 
 func testPolicyPlatformUpdate(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
Implements the optimization described in [#44191](https://github.com/fleetdm/fleet/issues/44191): inside `RecordPolicyQueryExecutions`, fetch the existing `policy_membership` rows for the incoming policies and narrow the UPSERT batch to only the rows whose stored value differs from incoming. Steady-state rows are skipped entirely.

The added SELECT is a small indexed lookup on `(host_id, policy_id)`; the savings are on the writer side, which is the loadtest bottleneck.

### What changed

- Inside `RecordPolicyQueryExecutions`, compute `needsWrite` from a comparison between incoming and stored values; UPSERT only that set.
- New unexported helper `policiesNeedingMembershipWrite` does the SELECT and applies the delta rules.
- No public-interface changes: `RecordPolicyQueryExecutions` signature unchanged, `FlippingPoliciesForHost` signature unchanged, no caller updates needed.

### Delta rules (pinned by `testPoliciesNarrowedMembershipUpsert`)

1. No existing row + incoming non-nil → write (first-run anything)
2. No existing row + incoming nil → skip (nothing to record)
3. Existing row matches incoming (both NULL or same bool) → skip (the perf win)
4. Existing row differs from incoming → write (real flip, transition from/to NULL)

### Semantic change

`policy_membership.updated_at` now reflects "last time this host's state for this policy changed" rather than "last time this host reported on this policy." Per the audit posted on the issue, every in-tree reader of `policy_membership` references only `passes`, `host_id`, and `policy_id` — never `updated_at` — so this shift is invisible to Fleet's own code. `hosts.policy_updated_at` remains the per-host "last reported" signal and is unchanged.

### Out of scope

`AsyncBatchInsertPolicyMembership` continues to UPSERT every incoming row. A NOTE in `RecordPolicyQueryExecutions` documents the resulting divergence. Narrowing the async path is a natural follow-up.

**Related issue:** Part of #44191.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests

## Database migrations

_N/A — no database migrations in this PR._

## New Fleet configuration settings

_N/A — no new configuration settings._

## fleetd/orbit/Fleet Desktop

_N/A — no agent code changes._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy execution recording to more efficiently track policy status changes, ensuring accurate handling of pass/fail transitions and preventing unnecessary database updates for unchanged results.

* **Tests**
  * Added comprehensive test coverage for policy membership state transition scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45357)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->