### PR TITLE
Fix link to static SCEP challenge guide

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -21,7 +21,7 @@ To deploy certificates on a self-hosted Fleet instance, you'll need to configure
 
 The following steps show how to deploy SCEP certificates from Okta's certificate authority (CA). 
 
-We'll deploy a certificate with a dynamic SCEP challenge. To deploy certificates with a static challenge, follow this [separate guide](https://fleetdm.com/guides/enable-okta-verify-on-macos-with-configuration-profile).
+We'll deploy a certificate with a dynamic SCEP challenge. To deploy certificates with a static challenge, follow this [separate guide](https://fleetdm.com/guides/deploying-okta-platform-sso-with-fleet#option-2-static-scep-challenge).
 
 ### Step 1: Get Okta credentials
 


### PR DESCRIPTION
Updated the link for the static SCEP challenge guide to the correct URL.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/30674