### PR TITLE
Github test fix: Fix SetupAssistant.tests.tsx failing in CI

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
@@ -41,7 +41,9 @@ describe("SetupAssistant", () => {
         return new HttpResponse("Not found", { status: 404 });
       }),
       http.get(defaultEnrollmentProfileUrl, () => {
-        return HttpResponse.json({});
+        return HttpResponse.json({
+          enrollment_profile: {},
+        });
       })
     );
     const render = createCustomRenderer({

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tests.tsx
@@ -39,6 +39,9 @@ describe("SetupAssistant", () => {
     mockServer.use(
       http.get(enrollmentProfileUrl, () => {
         return new HttpResponse("Not found", { status: 404 });
+      }),
+      http.get(defaultEnrollmentProfileUrl, () => {
+        return HttpResponse.json({});
       })
     );
     const render = createCustomRenderer({


### PR DESCRIPTION
## Description
- All 3 tests pass. The fix was adding a mock for the defaultEnrollmentProfileUrl endpoint — when the enrollment profile returns 404, the component triggers a follow-up fetch for the default profile. Without that mock, the request hung in CI, keeping the loading spinner visible.

### From Claude

- A flaky test on main that happens to surface more in CI due to slower execution
- A rebase timing issue — the test was written before #44253 added the default enrollment profile fetch, and the missing mock only manifests under 
  CI timing 

The most likely answer is that commit eb661f9e6b (which added the default enrollment profile fetch) introduced the potential for this test to fail, but it only flakes under slower CI conditions. The fix is correct either way — a test should mock everything its component fetches.


## Testing

- [x] Added/updated automated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced Setup Assistant tests: added a mock for the default enrollment profile endpoint returning an empty profile while keeping the primary enrollment-profile endpoint returning 404, improving scenario coverage for "MDM isn't configured."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45378)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->