### PR TITLE
Fixed cursor style on timestamps shown on host Vitals (#43645)

### DIFF
--- a/changes/43645-timestamps-are-not-consistently-styled-as-hoverable-missing-dotted-underlines
+++ b/changes/43645-timestamps-are-not-consistently-styled-as-hoverable-missing-dotted-underlines
@@ -1,0 +1,1 @@
+- Updated timestamps w/ tooltips on host's Vitals component to always have cursor: pointer.

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -1,6 +1,10 @@
 .vitals-card {
   @include vertical-card-layout;
 
+  .date-tooltip {
+    cursor: pointer;
+  }
+
   .truncated-tooltip {
     .vitals-card__device-mapping__source {
       color: inherit;


### PR DESCRIPTION
**Related issue:** Fixes #43645

Updated timestamps w/ tooltips on host's Vitals component to always have cursor: pointer.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent styling of timestamps on the Vitals component to ensure they consistently appear as interactive elements with proper hover indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45381)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->