### PR TITLE
Remove platform constraint from npm package label

### DIFF
--- a/it-and-security/lib/all/labels/hosts-with-npm-package-inventory.yml
+++ b/it-and-security/lib/all/labels/hosts-with-npm-package-inventory.yml
@@ -4,4 +4,3 @@
     visible to the agent inventory).
   query: SELECT 1 FROM npm_packages LIMIT 1;
   label_membership_type: dynamic
-  platform: darwin,linux,windows


### PR DESCRIPTION
Delete the explicit 'platform: darwin,linux,windows' line from the hosts-with-npm-package-inventory label so the dynamic label applies regardless of OS. The label still uses the same query (SELECT 1 FROM npm_packages LIMIT 1) and remains dynamic; this change prevents unintentionally excluding platforms.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the "Hosts with npm package inventory" label to apply across all supported platforms, removing previous platform-specific restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45382)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->