### PR TITLE
Cherry-pick #45277: Bump Go to 1.26.3 to clear stdlib CVEs

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.26.2-trixie@sha256:b53c282df83967299380adbd6a2dc67e750a58217f39285d6240f6f80b19eaad
+FROM --platform=linux/amd64 golang:1.26.3-trixie@sha256:6b3de2e6b4ccfc5fae404042cb1a025b1de13c73458e50455e3143bf12e98eae
 LABEL maintainer="Fleet Developers"
 
 RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*

--- a/changes/update-go-1.26.3
+++ b/changes/update-go-1.26.3
@@ -1,0 +1,1 @@
+* Updated go to 1.26.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/pubsub v1.50.1

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine3.23@sha256:80fbb8f9b2fa541a7d34378f1ad10f4f1c433817c4ed39ddb3e2f3ec3e961271
+FROM golang:1.26.3-alpine3.23@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .

--- a/orbit/changes/update-go-1.26.3
+++ b/orbit/changes/update-go-1.26.3
@@ -1,0 +1,1 @@
+* Updated go to 1.26.3

--- a/third_party/goval-dictionary/go.mod
+++ b/third_party/goval-dictionary/go.mod
@@ -1,6 +1,6 @@
 module github.com/vulsio/goval-dictionary
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7

--- a/third_party/vuln-check/go.mod
+++ b/third_party/vuln-check/go.mod
@@ -9,7 +9,7 @@
 
 module github.com/fleetdm/fleet/v4/third_party/vuln-check
 
-go 1.26.2
+go 1.26.3
 
 require (
 	// NanoMDM - Apple MDM server (server/mdm/nanomdm/)

--- a/tools/ci/setboolcheck/go.mod
+++ b/tools/ci/setboolcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/ci/setboolcheck
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/tools/fleet-mcp/go.mod
+++ b/tools/fleet-mcp/go.mod
@@ -1,6 +1,6 @@
 module fleet-mcp
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/tools/github-manage/go.mod
+++ b/tools/github-manage/go.mod
@@ -1,6 +1,6 @@
 module fleetdm/gm
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine3.23@sha256:80fbb8f9b2fa541a7d34378f1ad10f4f1c433817c4ed39ddb3e2f3ec3e961271
+FROM golang:1.26.3-alpine3.23@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.26.2
+go 1.26.3
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/qacheck/go.mod
+++ b/tools/qacheck/go.mod
@@ -1,6 +1,6 @@
 module qacheck
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Cherry-pick of #45277 into the RC branch.