### PR TITLE
Fix enable_host_users defaulting to false on fresh install

### DIFF
--- a/changes/44630-fix-enable-host-users-default
+++ b/changes/44630-fix-enable-host-users-default
@@ -1,0 +1,1 @@
+* Fixed a bug where `enable_host_users` defaulted to `false` on a fresh Fleet install instead of the documented default `true`, causing the host details page to show "User collection has been disabled."

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4533,7 +4533,7 @@ software:
 	_, err = RunAppNoChecks([]string{"gitops", "-f", globalFileBasic.Name()})
 	require.NoError(t, err)
 
-	require.False(t, appConfig.Features.EnableHostUsers)
+	require.True(t, appConfig.Features.EnableHostUsers)
 	require.True(t, appConfig.Features.EnableSoftwareInventory)
 	require.Nil(t, appConfig.Features.AdditionalQueries)
 	require.Nil(t, appConfig.Features.DetailQueryOverrides)

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2036,6 +2036,9 @@ func (c *Client) DoGitOps(
 		if enableSoftwareInventory, ok := features.(map[string]any)["enable_software_inventory"]; !ok || enableSoftwareInventory == nil {
 			features.(map[string]any)["enable_software_inventory"] = true
 		}
+		if enableHostUsers, ok := features.(map[string]any)["enable_host_users"]; !ok || enableHostUsers == nil {
+			features.(map[string]any)["enable_host_users"] = true
+		}
 		// historical_data sub-keys default to true on every gitops apply so a
 		// deployment that doesn't pin them in YAML keeps dashboard collection
 		// enabled. Mirrors the enable_software_inventory carve-out above.
@@ -2292,6 +2295,9 @@ func (c *Client) DoGitOps(
 		}
 		if enableSoftwareInventory, ok := features.(map[string]any)["enable_software_inventory"]; !ok || enableSoftwareInventory == nil {
 			features.(map[string]any)["enable_software_inventory"] = true
+		}
+		if enableHostUsers, ok := features.(map[string]any)["enable_host_users"]; !ok || enableHostUsers == nil {
+			features.(map[string]any)["enable_host_users"] = true
 		}
 		// historical_data sub-keys default to true on every gitops apply.
 		// See ensureHistoricalDataDefaults for the rationale.


### PR DESCRIPTION
Closes #44630

## Summary

- After a fresh Fleet install (`fleet prepare db` + `fleetctl setup`), `enable_host_users` persisted as `false` despite the documented and coded default being `true`.
- **Root cause**: During setup, `NewAppConfig` correctly saves `enable_host_users: true`. However, the starter library then runs `fleetctl gitops` with a template that has no `features` section. In `DoGitOps`, when `features` is absent, an empty features map is created. `enable_software_inventory` was explicitly defaulted to `true`, but `enable_host_users` was not. The overwrite-mode PATCH then reset `enable_host_users` to `false` (Go's bool zero value).
- Adds the same defaulting logic for `enable_host_users` as exists for `enable_software_inventory`, in both the global and team config paths in `DoGitOps`.

## Test plan

Reproduced locally before and after the fix with a Fleet server + osqueryd agent (osquery 5.23.0):

**Before fix:**
1. Created a fresh database, ran `fleet prepare db`, started `fleet serve --dev`, ran `fleetctl setup`.
2. Checked DB: `enable_host_users` was `false` (bug).
3. Enrolled a local osqueryd agent against the server.
4. Queried the host details API: `users` field was `null` (user collection disabled).
5. Confirmed `features.enable_host_users: false` via `GET /api/latest/fleet/config`.

**After fix:**
1. Same steps with the fixed binary.
2. Checked DB: `enable_host_users` was `true` (correct).
3. Enrolled a local osqueryd agent against the server.
4. Queried the host details API: `users` field contained 3 collected users (root, sharonkatz, testuser) -- user collection working.
5. Confirmed `features.enable_host_users: true` via `GET /api/latest/fleet/config`.

**Unit tests:**
- [x] `TestGitOpsFeatures` -- updated assertion to expect `enable_host_users: true` when features are omitted from GitOps YAML (was previously testing the broken behavior).
- [x] All `TestGitOps*` tests pass (`go test ./cmd/fleetctl/fleetctl/ -run TestGitOps`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed default host user collection behavior on fresh Fleet installs. Host user collection now correctly defaults to enabled, matching documented settings and ensuring the host details page displays accurate collection status information instead of incorrectly showing it as disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45393)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->