### PR TITLE
fix: close policy details modal when navigating back to host details

### DIFF
--- a/changes/43647-close-policy-details-modal-when-navigating-back-to-host-details
+++ b/changes/43647-close-policy-details-modal-when-navigating-back-to-host-details
@@ -1,0 +1,1 @@
+* Fixed an issue where the Policy details modal would not close when navigating back to the Host details page with the browser's back button.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -476,9 +476,9 @@ const DeviceUserPage = ({
   }, [showOSSettingsModal, setShowOSSettingsModal]);
 
   const onCancelPolicyDetailsModal = useCallback(() => {
-    setShowPolicyDetailsModal(!showPolicyDetailsModal);
+    setShowPolicyDetailsModal(false);
     setSelectedPolicy(null);
-  }, [showPolicyDetailsModal, setShowPolicyDetailsModal, setSelectedPolicy]);
+  }, [setShowPolicyDetailsModal, setSelectedPolicy]);
 
   // User-initiated refetch always starts a new timer!
   const onRefetchHost = useCallback(async () => {

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -825,6 +825,7 @@ const DeviceUserPage = ({
                     isLoading={isLoadingDupDetails}
                     deviceUser
                     togglePolicyDetailsModal={togglePolicyDetailsModal}
+                    closePolicyDetailsModal={onCancelPolicyDetailsModal}
                     hostPlatform={host?.platform || ""}
                     conditionalAccessEnabled={
                       globalConfig?.features?.enable_conditional_access

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -717,9 +717,9 @@ const HostDetailsPage = ({
   }, [showClearPasscodeModal, setShowClearPasscodeModal]);
 
   const onCancelPolicyDetailsModal = useCallback(() => {
-    setPolicyDetailsModal(!showPolicyDetailsModal);
+    setPolicyDetailsModal(false);
     setSelectedPolicy(null);
-  }, [showPolicyDetailsModal, setPolicyDetailsModal, setSelectedPolicy]);
+  }, [setPolicyDetailsModal, setSelectedPolicy]);
 
   const toggleUnenrollMdmModal = useCallback(() => {
     setShowUnenrollMdmModal(!showUnenrollMdmModal);
@@ -1599,6 +1599,7 @@ const HostDetailsPage = ({
                     policies={host?.policies || []}
                     isLoading={isLoadingHost}
                     togglePolicyDetailsModal={togglePolicyDetailsModal}
+                    closePolicyDetailsModal={onCancelPolicyDetailsModal}
                     hostPlatform={host.platform}
                     currentTeamId={currentTeam?.id}
                     canManagePolicies={canManagePolicies}

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { screen } from "@testing-library/react";
+import React, { useCallback, useState } from "react";
+import { fireEvent, screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 import { noop } from "lodash";
 import { IHostPolicy } from "interfaces/policy";
 
 import HostPolicies from "./HostPolicies";
+import PolicyDetailsModal from "./HostPoliciesTable/PolicyDetailsModal";
 
 const createMockHostPolicy = (
   overrides?: Partial<IHostPolicy>
@@ -33,6 +34,7 @@ const baseProps = {
   policies: [] as IHostPolicy[],
   isLoading: false,
   togglePolicyDetailsModal: noop,
+  closePolicyDetailsModal: noop,
   hostPlatform: "darwin",
 };
 
@@ -116,5 +118,57 @@ describe("HostPolicies", () => {
       screen.getByText(/policies are not supported for this host/i)
     ).toBeInTheDocument();
     expect(screen.queryByText("No policies checked")).not.toBeInTheDocument();
+  });
+
+  it("closes the policy details modal when HostPolicies unmounts", () => {
+    // Simulates the policies tab unmounting (e.g. the user presses the
+    // browser back button from /hosts/:id/policies to /hosts/:id, or
+    // switches to a different host details tab). The modal state lives
+    // in the parent (HostDetailsPage / DeviceUserPage), so the parent owns it here too.
+    const policy = createMockHostPolicy({ name: "Failing policy" });
+
+    const Wrapper = ({ showPolicies }: { showPolicies: boolean }) => {
+      const [isModalOpen, setIsModalOpen] = useState(false);
+      const [selectedPolicy, setSelectedPolicy] = useState<IHostPolicy | null>(
+        null
+      );
+
+      const openModal = useCallback((p: IHostPolicy) => {
+        setSelectedPolicy(p);
+        setIsModalOpen(true);
+      }, []);
+
+      const closeModal = useCallback(() => {
+        setSelectedPolicy(null);
+        setIsModalOpen(false);
+      }, []);
+
+      return (
+        <>
+          <button type="button" onClick={() => openModal(policy)}>
+            open modal
+          </button>
+          {showPolicies && (
+            <HostPolicies
+              {...baseProps}
+              policies={[policy]}
+              togglePolicyDetailsModal={openModal}
+              closePolicyDetailsModal={closeModal}
+            />
+          )}
+          {isModalOpen && selectedPolicy && (
+            <PolicyDetailsModal onCancel={closeModal} policy={selectedPolicy} />
+          )}
+        </>
+      );
+    };
+
+    const { rerender } = createCustomRenderer()(<Wrapper showPolicies />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open modal/i }));
+    // "Resolve:" only renders inside PolicyDetailsModal.
+    expect(screen.getByText("Resolve:")).toBeInTheDocument();
+    rerender(<Wrapper showPolicies={false} />);
+    expect(screen.queryByText("Resolve:")).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
-import { fireEvent, screen } from "@testing-library/react";
-import { createCustomRenderer } from "test/test-utils";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer, renderWithSetup } from "test/test-utils";
 import { noop } from "lodash";
 import { IHostPolicy } from "interfaces/policy";
 
@@ -120,7 +120,7 @@ describe("HostPolicies", () => {
     expect(screen.queryByText("No policies checked")).not.toBeInTheDocument();
   });
 
-  it("closes the policy details modal when HostPolicies unmounts", () => {
+  it("closes the policy details modal when HostPolicies unmounts", async () => {
     // Simulates the policies tab unmounting (e.g. the user presses the
     // browser back button from /hosts/:id/policies to /hosts/:id, or
     // switches to a different host details tab). The modal state lives
@@ -163,9 +163,9 @@ describe("HostPolicies", () => {
       );
     };
 
-    const { rerender } = createCustomRenderer()(<Wrapper showPolicies />);
+    const { user, rerender } = renderWithSetup(<Wrapper showPolicies />);
 
-    fireEvent.click(screen.getByRole("button", { name: /open modal/i }));
+    await user.click(screen.getByRole("button", { name: /open modal/i }));
     // "Resolve:" only renders inside PolicyDetailsModal.
     expect(screen.getByText("Resolve:")).toBeInTheDocument();
     rerender(<Wrapper showPolicies={false} />);

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 
 import { Row } from "react-table";
 
@@ -26,8 +26,8 @@ interface IPoliciesProps {
   isLoading: boolean;
   deviceUser?: boolean;
   togglePolicyDetailsModal: (policy: IHostPolicy) => void;
+  closePolicyDetailsModal: () => void;
   hostPlatform: string;
-
   currentTeamId?: number;
   conditionalAccessEnabled?: boolean;
   conditionalAccessBypassed?: boolean;
@@ -44,8 +44,8 @@ const Policies = ({
   isLoading,
   deviceUser,
   togglePolicyDetailsModal,
+  closePolicyDetailsModal,
   hostPlatform,
-
   currentTeamId,
   conditionalAccessEnabled,
   conditionalAccessBypassed,
@@ -59,6 +59,12 @@ const Policies = ({
   }
   const failingResponses: IHostPolicy[] =
     policies.filter((policy: IHostPolicy) => policy.response === "fail") || [];
+
+  useEffect(() => {
+    return () => {
+      closePolicyDetailsModal();
+    };
+  }, [closePolicyDetailsModal]);
 
   const onClickRow = useCallback(
     (row: IHostPoliciesRowProps) => {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43647 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/c8370a7b-4dad-41b4-bf0c-8b8bdedd3f9b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Policy details modal could remain open when navigating back or switching host/detail views; the modal now reliably closes and clears the selected policy when leaving the view or when the related card unmounts.

* **Tests**
  * Added a test to verify the policy details modal content is removed from the DOM when the policies card is unmounted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45394)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->