### PR TITLE
Set campaign member status for form-based contacts

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -200,6 +200,18 @@ module.exports = {
 
     let accountValuesToSet = {};
 
+    let formBasedContactSources = [
+      'Website - Contact forms',
+      'Website - Contact forms - Demo - ICP',
+      'Website - Contact forms - Demo',
+      'Website - GitOps',
+      'Webinar',
+      'Website - Gated document',
+    ];
+    if(contactSource && formBasedContactSources.includes(contactSource)) {
+      contactValuesToSet.Most_recent_campaign_member_status__c = 'Registered';// eslint-disable-line camelcase
+    }
+
     if(numberOfHostsDetails){
       accountValuesToSet.Total_macOS_hosts__c = numberOfHostsDetails.macosHosts;// eslint-disable-line camelcase
       accountValuesToSet.Total_Windows_hosts__c = numberOfHostsDetails.windowsHosts;// eslint-disable-line camelcase


### PR DESCRIPTION
Add a list of form-based contact sources and set Most_recent_campaign_member_status__c to 'Registered' when contactSource matches any of them. This marks contacts originating from website contact forms, webinars, gated docs, and related sources as registered. The change includes an eslint-disable-line camelcase comment for the Salesforce field name.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced contact registration tracking to automatically set appropriate campaign status when contacts are registered through form-based sources such as webinars.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45427)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->