### PR TITLE
Revert Android instrumented-tests job to ubuntu-latest

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -140,7 +140,7 @@ jobs:
 
   instrumented-tests:
     name: Instrumented tests
-    runs-on: ubuntu-8core
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary
- The `instrumented-tests` job in `.github/workflows/test-android.yml` has been failing since #45284 routed it to `ubuntu-8core`.
- Revert just that job back to `ubuntu-latest`. The `build` and `scep-integration-test` jobs stay on `ubuntu-8core`.
- Flagged by Victor in Slack (cc @konstantin-fleetdm).

## Test plan
- [ ] Confirm the `Instrumented tests` job passes on this PR's CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions test runner configuration for Android instrumented tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45428)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->