### PR TITLE
Move note about closing tab after enrolling above button

### DIFF
--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -219,8 +219,8 @@
       <section class="device-instructions-content">
         <h1>How to enroll your Android device to Fleet</h1>
         <div class="android-content">
-          <p>Select <b>Enroll</b> and follow the steps.</p>
           <p>After you finish, you can close this tab.</p>
+          <p>Select <b>Enroll</b> and follow the steps.</p>
           <a class="enroll-link" href="" target="_blank">Enroll</a>
         </div>
       </section>

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -220,8 +220,8 @@
         <h1>How to enroll your Android device to Fleet</h1>
         <div class="android-content">
           <p>Select <b>Enroll</b> and follow the steps.</p>
+          <p>After you finish, you can close this tab.</p>
           <a class="enroll-link" href="" target="_blank">Enroll</a>
-          <p>Already finished? You can close this tab.</p>
         </div>
       </section>
     </template>


### PR DESCRIPTION
cc @noahtalerman discussed here: https://fleetdm.slack.com/archives/C02A8BRABB5/p1778708722488109?thread_ts=1778698170.524509&cid=C02A8BRABB5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified post-enrollment messaging in the Android enrollment flow by updating the wording to "After you finish, you can close this tab." to reduce confusion for users.
  * Improved enrollment template layout by reordering elements so the completion message appears before the enroll link, making the next steps more visible and readable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45433)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->