### PR TITLE
Add Press Release to campaign naming table

### DIFF
--- a/handbook/marketing/marketing-ops.md
+++ b/handbook/marketing/marketing-ops.md
@@ -148,6 +148,7 @@ For all paid and owned online media and content.
 | Paid media | PM | 2025\_11-PM-riskybiz\_podcast |
 | Content syndication & 3rd-party | CS | 2025\_12-CS-techtarget\_survey |
 | Email marketing (owned list) | EM | 2025\_11-EM-newsletter\_promo |
+| Press Release | PR | 2025\_11-PR-Abc\_launch |  
 
 
 #### 🎯 Prospecting


### PR DESCRIPTION
Include a 'Press Release' (PR) row in the paid/owned media naming conventions table with example `2025_11-PR-Abc_launch`. This documents the campaign prefix for press releases alongside existing Paid media, Content syndication, and Email marketing entries.
