### PR TITLE
Add "Requested Fleet SWAG" to intent signals

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -69,7 +69,16 @@ module.exports = {
         'Forked the fleetdm/fleet repo on GitHub',
         'Contributed to the fleetdm/fleet repo on GitHub',
         'Subscribed to the Fleet newsletter',
-        'Attended a Fleet training course'
+        'Attended a Fleet training course',
+        'Submitted the "Send a message" form',
+        'Scheduled a "Talk to us" meeting',
+        'Scheduled a "Let\'s get you set up" meeting',
+        'Submitted the "GitOps workshop request" form',
+        'Signed up for a fleetdm.com account',
+        'Requested whitepaper download',
+        'Created a quote for a self-service Fleet Premium license',
+        'Requested webinar recording',
+        'Requested Fleet swag',
       ]
     },
     historicalContent: {

--- a/website/api/helpers/salesforce/create-historical-event.js
+++ b/website/api/helpers/salesforce/create-historical-event.js
@@ -67,6 +67,7 @@ module.exports = {
         'Requested whitepaper download',
         'Created a quote for a self-service Fleet Premium license',
         'Requested webinar recording',
+        'Requested Fleet swag',
       ]
     },
     eventContent: {


### PR DESCRIPTION
@eashaw, I also updated the intent signals for the receive-from-clay.js to match create-historical-event.js



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Expanded system support for tracking additional customer interaction types, including training attendance, meetings, forms, account updates, and marketing activities.
  * Added new event type for swag requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45443)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->