### PR TITLE
VPP/in-house app managed configuration bug fixes and integration test

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	maintained_apps "github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
@@ -1529,6 +1530,12 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 	cmdUUID := uuid.NewString()
 	err = svc.ds.InsertHostVPPSoftwareInstall(ctx, host.ID, vppApp.VPPAppID, cmdUUID, eventID, opts)
 	if err != nil {
+		if errors.Is(err, apple_mdm.ErrUnresolvableAppConfigVar) {
+			return "", &fleet.BadRequestError{
+				Message:     "Couldn't install. The managed app configuration references Fleet variables that can't be resolved for this host.",
+				InternalErr: err,
+			}
+		}
 		return "", ctxerr.Wrapf(ctx, err, "inserting host vpp software install for host with serial %s and app with adamID %s", host.HardwareSerial, vppApp.AdamID)
 	}
 

--- a/server/datastore/mysql/in_house_apps.go
+++ b/server/datastore/mysql/in_house_apps.go
@@ -336,27 +336,15 @@ func (ds *Datastore) SaveInHouseAppUpdates(ctx context.Context, payload *fleet.U
 			}
 		}
 
-		// nil = leave unchanged; empty = clear; non-empty = set. Apply the change
-		// to both the iOS and iPadOS rows so platform-specific installer-ID
-		// lookups stay in sync (a single .ipa upload created two rows).
+		// nil = leave unchanged; empty = clear; non-empty = set.
 		if payload.Configuration != nil {
-			ids, err := installerIDsForInHouseAppSibling(ctx, tx, payload.InstallerID)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "looking up sibling in-house app row")
-			}
 			if len(payload.Configuration) == 0 {
-				query, args, err := sqlx.In(`DELETE FROM in_house_app_configurations WHERE in_house_app_id IN (?)`, ids)
-				if err != nil {
-					return ctxerr.Wrap(ctx, err, "build clear in-house app configuration query")
-				}
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				if _, err := tx.ExecContext(ctx, `DELETE FROM in_house_app_configurations WHERE in_house_app_id = ?`, payload.InstallerID); err != nil {
 					return ctxerr.Wrap(ctx, err, "clearing in-house app configuration")
 				}
 			} else {
-				for _, id := range ids {
-					if err := ds.updateInHouseAppConfigurationTx(ctx, tx, id, payload.Configuration); err != nil {
-						return ctxerr.Wrap(ctx, err, "setting in-house app configuration")
-					}
+				if err := ds.updateInHouseAppConfigurationTx(ctx, tx, payload.InstallerID, payload.Configuration); err != nil {
+					return ctxerr.Wrap(ctx, err, "setting in-house app configuration")
 				}
 			}
 		}
@@ -1778,26 +1766,3 @@ ON DUPLICATE KEY UPDATE
 	return nil
 }
 
-// installerIDsForInHouseAppSibling returns the supplied in_house_apps.id along
-// with the row sharing its (global_or_team_id, bundle_identifier) pair on the
-// other Apple platform. A single .ipa upload always creates two rows (ios and
-// ipados); configuration changes need to land on both so platform-specific
-// installer-ID lookups always see the same content.
-func installerIDsForInHouseAppSibling(ctx context.Context, tx sqlx.ExtContext, installerID uint) ([]uint, error) {
-	const stmt = `
-SELECT id FROM in_house_apps
-WHERE (global_or_team_id, bundle_identifier) = (
-	SELECT global_or_team_id, bundle_identifier FROM in_house_apps WHERE id = ?
-)`
-
-	var ids []uint
-	if err := sqlx.SelectContext(ctx, tx, &ids, stmt, installerID); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "select sibling in-house app ids")
-	}
-	if len(ids) == 0 {
-		// Defensive: caller already verified the row exists. Fall back to the
-		// supplied id so we never write zero rows.
-		return []uint{installerID}, nil
-	}
-	return ids, nil
-}

--- a/server/datastore/mysql/in_house_apps.go
+++ b/server/datastore/mysql/in_house_apps.go
@@ -1765,4 +1765,3 @@ ON DUPLICATE KEY UPDATE
 	}
 	return nil
 }
-

--- a/server/datastore/mysql/in_house_apps_test.go
+++ b/server/datastore/mysql/in_house_apps_test.go
@@ -186,33 +186,22 @@ func testInHouseAppsCrud(t *testing.T, ds *Datastore) {
 	require.Equal(t, expectedLabels, newInstaller.LabelsIncludeAny)
 	require.True(t, newInstaller.SelfService)
 
-	// Configuration: non-empty = set on both the iOS row and its iPadOS sibling.
-	var ipadInstallerID uint
-	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &ipadInstallerID,
-		`SELECT id FROM in_house_apps WHERE bundle_identifier = ? AND platform = 'ipados'`, payload.BundleIdentifier))
-	gotIOS, err := ds.GetInHouseAppConfiguration(ctx, installerID)
+	// Configuration: non-empty = set on the targeted row only.
+	gotCfg, err := ds.GetInHouseAppConfiguration(ctx, installerID)
 	require.NoError(t, err)
-	require.Equal(t, cfg, gotIOS)
-	gotIPad, err := ds.GetInHouseAppConfiguration(ctx, ipadInstallerID)
-	require.NoError(t, err)
-	require.Equal(t, cfg, gotIPad)
+	require.Equal(t, cfg, gotCfg)
 
-	// Configuration: nil = leave unchanged on both rows.
+	// Configuration: nil = leave unchanged.
 	updatePayload.Configuration = nil
 	require.NoError(t, ds.SaveInHouseAppUpdates(ctx, &updatePayload))
-	gotIOS, err = ds.GetInHouseAppConfiguration(ctx, installerID)
+	gotCfg, err = ds.GetInHouseAppConfiguration(ctx, installerID)
 	require.NoError(t, err)
-	require.Equal(t, cfg, gotIOS)
-	gotIPad, err = ds.GetInHouseAppConfiguration(ctx, ipadInstallerID)
-	require.NoError(t, err)
-	require.Equal(t, cfg, gotIPad)
+	require.Equal(t, cfg, gotCfg)
 
-	// Configuration: empty = clear on both rows.
+	// Configuration: empty = clear.
 	updatePayload.Configuration = []byte{}
 	require.NoError(t, ds.SaveInHouseAppUpdates(ctx, &updatePayload))
 	_, err = ds.GetInHouseAppConfiguration(ctx, installerID)
-	require.ErrorContains(t, err, "not found")
-	_, err = ds.GetInHouseAppConfiguration(ctx, ipadInstallerID)
 	require.ErrorContains(t, err, "not found")
 
 	// Summary is unchanged?
@@ -1972,37 +1961,6 @@ func testInHouseAppConfigSiblingRows(t *testing.T, ds *Datastore) {
 	gotIPad, err := ds.GetInHouseAppConfiguration(ctx, ipadID)
 	require.NoError(t, err, "iPadOS row must also have the configuration set at upload time")
 	require.Equal(t, cfg, gotIPad)
-
-	// SaveInHouseAppUpdates with a new config (called against the iOS row's id)
-	// must propagate to the iPadOS sibling.
-	updated := []byte(`<dict><key>K</key><string>v2</string></dict>`)
-	require.NoError(t, ds.SaveInHouseAppUpdates(ctx, &fleet.UpdateSoftwareInstallerPayload{
-		InstallerID:   iosID,
-		Configuration: updated,
-		// Required passthrough fields for the UPDATE statement.
-		StorageID: uuid.NewString(),
-		Filename:  "siblings.ipa",
-		Version:   "1.0",
-	}))
-	gotIOS, err = ds.GetInHouseAppConfiguration(ctx, iosID)
-	require.NoError(t, err)
-	require.Equal(t, updated, gotIOS)
-	gotIPad, err = ds.GetInHouseAppConfiguration(ctx, ipadID)
-	require.NoError(t, err)
-	require.Equal(t, updated, gotIPad)
-
-	// Clear (empty bytes) must propagate to both rows.
-	require.NoError(t, ds.SaveInHouseAppUpdates(ctx, &fleet.UpdateSoftwareInstallerPayload{
-		InstallerID:   iosID,
-		Configuration: []byte{},
-		StorageID:     uuid.NewString(),
-		Filename:      "siblings.ipa",
-		Version:       "1.0",
-	}))
-	_, err = ds.GetInHouseAppConfiguration(ctx, iosID)
-	require.True(t, fleet.IsNotFound(err))
-	_, err = ds.GetInHouseAppConfiguration(ctx, ipadID)
-	require.True(t, fleet.IsNotFound(err), "iPadOS sibling row must also be cleared")
 }
 
 func testHasInHouseAppConfigurationChanged(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/in_house_apps_test.go
+++ b/server/datastore/mysql/in_house_apps_test.go
@@ -186,22 +186,33 @@ func testInHouseAppsCrud(t *testing.T, ds *Datastore) {
 	require.Equal(t, expectedLabels, newInstaller.LabelsIncludeAny)
 	require.True(t, newInstaller.SelfService)
 
-	// Configuration: non-empty = set on the targeted row only.
-	gotCfg, err := ds.GetInHouseAppConfiguration(ctx, installerID)
+	// Configuration: non-empty = set on both the iOS row and its iPadOS sibling.
+	var ipadInstallerID uint
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &ipadInstallerID,
+		`SELECT id FROM in_house_apps WHERE bundle_identifier = ? AND platform = 'ipados'`, payload.BundleIdentifier))
+	gotIOS, err := ds.GetInHouseAppConfiguration(ctx, installerID)
 	require.NoError(t, err)
-	require.Equal(t, cfg, gotCfg)
+	require.Equal(t, cfg, gotIOS)
+	gotIPad, err := ds.GetInHouseAppConfiguration(ctx, ipadInstallerID)
+	require.NoError(t, err)
+	require.Equal(t, cfg, gotIPad)
 
-	// Configuration: nil = leave unchanged.
+	// Configuration: nil = leave unchanged on both rows.
 	updatePayload.Configuration = nil
 	require.NoError(t, ds.SaveInHouseAppUpdates(ctx, &updatePayload))
-	gotCfg, err = ds.GetInHouseAppConfiguration(ctx, installerID)
+	gotIOS, err = ds.GetInHouseAppConfiguration(ctx, installerID)
 	require.NoError(t, err)
-	require.Equal(t, cfg, gotCfg)
+	require.Equal(t, cfg, gotIOS)
+	gotIPad, err = ds.GetInHouseAppConfiguration(ctx, ipadInstallerID)
+	require.NoError(t, err)
+	require.Equal(t, cfg, gotIPad)
 
-	// Configuration: empty = clear.
+	// Configuration: empty = clear on both rows.
 	updatePayload.Configuration = []byte{}
 	require.NoError(t, ds.SaveInHouseAppUpdates(ctx, &updatePayload))
 	_, err = ds.GetInHouseAppConfiguration(ctx, installerID)
+	require.ErrorContains(t, err, "not found")
+	_, err = ds.GetInHouseAppConfiguration(ctx, ipadInstallerID)
 	require.ErrorContains(t, err, "not found")
 
 	// Summary is unchanged?

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -146,6 +146,7 @@ var teamRefs = []string{
 	"certificate_templates",
 	"software_title_icons",
 	"software_title_display_names",
+	"vpp_app_configurations",
 }
 
 // teamLabelsRefs are the tables that could be referenced by team labels that

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -47,6 +47,7 @@ func TestVPP(t *testing.T) {
 		{"AndroidAppConfigs", testAndroidAppConfigs},
 		{"VPPAppConfigCRUDFlow", testVPPAppConfigCRUDFlow},
 		{"VPPAppConfigHasChanged", testHasVPPAppConfigurationChanged},
+		{"VPPAppConfigDeletedOnTeamDelete", testVPPAppConfigDeletedOnTeamDelete},
 		{"VPPInstallEnqueuesConfigurationDict", testVPPInstallEnqueuesConfigurationDict},
 		{"VPPInstallOmitsConfigurationOnMacOS", testVPPInstallOmitsConfigurationOnMacOS},
 		{"MapAdamIDsPendingInstallVerification", testMapAdamIDsPendingInstallVerification},
@@ -3222,6 +3223,42 @@ func testVPPAppConfigCRUDFlow(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	_, err = ds.GetVPPAppConfiguration(ctx, fleet.IPadOSPlatform, adamID, teamID)
 	require.ErrorContains(t, err, "not found")
+}
+
+// testVPPAppConfigDeletedOnTeamDelete guards against the orphan-on-team-delete
+// scenario for vpp_app_configurations. The table has no FK to teams (only the
+// (application_id, platform) -> vpp_apps cascade), and the vpp_apps row
+// usually outlives a single team because multiple teams can share an app.
+// DeleteTeam must therefore clear the configuration rows explicitly via the
+// teamRefs cleanup pass.
+func testVPPAppConfigDeletedOnTeamDelete(t *testing.T, ds *Datastore) {
+	ctx := testCtx()
+	const adamID = "vppcfg-team-delete"
+	test.CreateInsertGlobalVPPToken(t, ds)
+	setupTestVPPApp(t, ds, adamID, fleet.IOSPlatform)
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "vpp-cfg-team-delete"})
+	require.NoError(t, err)
+
+	// Seed the configuration row for the team.
+	require.NoError(t, ds.updateVPPAppConfigurationTx(ctx, ds.writer(ctx),
+		fleet.IOSPlatform, team.ID, adamID, []byte(`<dict/>`)))
+
+	// Sanity: row exists keyed on this team_id before delete.
+	var beforeCount int
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &beforeCount,
+		`SELECT COUNT(*) FROM vpp_app_configurations WHERE team_id = ?`, team.ID))
+	require.Equal(t, 1, beforeCount, "expected exactly one seeded config row before DeleteTeam")
+
+	require.NoError(t, ds.DeleteTeam(ctx, team.ID))
+
+	// The cleanup must have removed the row. We query against the still-live
+	// vpp_apps row so failure here means the row is orphaned (dangling
+	// team_id), not that the parent cascade fired.
+	var afterCount int
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &afterCount,
+		`SELECT COUNT(*) FROM vpp_app_configurations WHERE team_id = ?`, team.ID))
+	require.Zero(t, afterCount, "vpp_app_configurations rows orphaned after DeleteTeam")
 }
 
 // testVPPInstallEnqueuesConfigurationDict exercises the fan-in point that

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -3225,12 +3225,9 @@ func testVPPAppConfigCRUDFlow(t *testing.T, ds *Datastore) {
 	require.ErrorContains(t, err, "not found")
 }
 
-// testVPPAppConfigDeletedOnTeamDelete guards against the orphan-on-team-delete
-// scenario for vpp_app_configurations. The table has no FK to teams (only the
-// (application_id, platform) -> vpp_apps cascade), and the vpp_apps row
-// usually outlives a single team because multiple teams can share an app.
-// DeleteTeam must therefore clear the configuration rows explicitly via the
-// teamRefs cleanup pass.
+// testVPPAppConfigDeletedOnTeamDelete asserts DeleteTeam clears
+// vpp_app_configurations rows for the team (no FK to teams, parent vpp_apps
+// outlives the team, so the cleanup goes through teamRefs).
 func testVPPAppConfigDeletedOnTeamDelete(t *testing.T, ds *Datastore) {
 	ctx := testCtx()
 	const adamID = "vppcfg-team-delete"
@@ -3240,21 +3237,16 @@ func testVPPAppConfigDeletedOnTeamDelete(t *testing.T, ds *Datastore) {
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "vpp-cfg-team-delete"})
 	require.NoError(t, err)
 
-	// Seed the configuration row for the team.
 	require.NoError(t, ds.updateVPPAppConfigurationTx(ctx, ds.writer(ctx),
 		fleet.IOSPlatform, team.ID, adamID, []byte(`<dict/>`)))
 
-	// Sanity: row exists keyed on this team_id before delete.
 	var beforeCount int
 	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &beforeCount,
 		`SELECT COUNT(*) FROM vpp_app_configurations WHERE team_id = ?`, team.ID))
-	require.Equal(t, 1, beforeCount, "expected exactly one seeded config row before DeleteTeam")
+	require.Equal(t, 1, beforeCount)
 
 	require.NoError(t, ds.DeleteTeam(ctx, team.ID))
 
-	// The cleanup must have removed the row. We query against the still-live
-	// vpp_apps row so failure here means the row is orphaned (dangling
-	// team_id), not that the parent cascade fired.
 	var afterCount int
 	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &afterCount,
 		`SELECT COUNT(*) FROM vpp_app_configurations WHERE team_id = ?`, team.ID))

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"time"
@@ -140,7 +141,7 @@ type VPPAppStoreApp struct {
 	DisplayName string   `json:"display_name"`
 	// Configuration is the managed app configuration payload. JSON for Android,
 	// XML for iOS / iPadOS.
-	Configuration []byte `json:"configuration,omitempty"`
+	Configuration json.RawMessage `json:"configuration,omitempty"`
 }
 
 // VPPAppStatusSummary represents aggregated status metrics for a VPP app.

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -60,8 +60,8 @@ type VPPAppTeam struct {
 	// app creation if AddAutoInstallPolicy is true.
 	AddedAutomaticInstallPolicy *Policy `json:"-"`
 	DisplayName                 *string `json:"display_name"`
-	// Configuration is the managed app configuration payload. JSON for Android,
-	// XML for iOS / iPadOS.
+	// Configuration is the managed app configuration payload.
+	// JSON for Android, XML for iOS / iPadOS.
 	Configuration       []byte  `json:"configuration,omitempty"`
 	AutoUpdateEnabled   *bool   `json:"-"`
 	AutoUpdateStartTime *string `json:"-"`
@@ -139,8 +139,8 @@ type VPPAppStoreApp struct {
 	// "Browsers", etc.
 	Categories  []string `json:"categories"`
 	DisplayName string   `json:"display_name"`
-	// Configuration is the managed app configuration payload. JSON for Android,
-	// XML for iOS / iPadOS.
+	// Configuration is the managed app configuration payload.
+	// JSON for Android, XML for iOS / iPadOS.
 	Configuration json.RawMessage `json:"configuration,omitempty"`
 }
 

--- a/server/service/integration_android_software_test.go
+++ b/server/service/integration_android_software_test.go
@@ -773,7 +773,7 @@ func (s *integrationMDMTestSuite) TestBatchAndroidApps() {
 			TeamID: teamID,
 		}, http.StatusOK, &titleResp)
 		require.Equal(t, "app_1", *titleResp.SoftwareTitle.ApplicationID)
-		require.Equal(t, []byte(`{}`), titleResp.SoftwareTitle.AppStoreApp.Configuration)
+		require.JSONEq(t, `{}`, string(titleResp.SoftwareTitle.AppStoreApp.Configuration))
 
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleApp2), &getSoftwareTitleRequest{
 			ID:     titleApp2,
@@ -802,7 +802,7 @@ func (s *integrationMDMTestSuite) TestBatchAndroidApps() {
 			TeamID: teamID,
 		}, http.StatusOK, &titleResp)
 		require.Equal(t, "app_1", *titleResp.SoftwareTitle.ApplicationID)
-		require.Equal(t, []byte(`{}`), titleResp.SoftwareTitle.AppStoreApp.Configuration)
+		require.JSONEq(t, `{}`, string(titleResp.SoftwareTitle.AppStoreApp.Configuration))
 
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleApp2), &getSoftwareTitleRequest{
 			ID:     titleApp2,

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -307,7 +307,6 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 		resp = s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", addResp.TitleID), nil, http.StatusOK, "fleet_id", fmt.Sprint(team.ID))
 		body := readBody(resp)
 		require.Contains(t, body, `"configuration":"<dict><key>K</key><string>v</string></dict>"`)
-		require.NotContains(t, body, base64.StdEncoding.EncodeToString([]byte(`"<dict><key>K</key><string>v</string></dict>"`)))
 	})
 
 	t.Run("android wire format", func(t *testing.T) {
@@ -336,7 +335,6 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 		resp = s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", addResp.TitleID), nil, http.StatusOK, "fleet_id", fmt.Sprint(team.ID))
 		body := readBody(resp)
 		require.Contains(t, body, `"configuration":{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`)
-		require.NotContains(t, body, base64.StdEncoding.EncodeToString([]byte(`{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`)))
 	})
 }
 

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -12,7 +14,9 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android/service/androidmgmt"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/androidmanagement/v1"
 )
 
 func (s *integrationMDMTestSuite) TestVPPAppleManagedAppConfiguration() {
@@ -255,5 +259,112 @@ func (s *integrationMDMTestSuite) TestVPPAppleManagedAppConfiguration() {
 		require.NoError(t, err)
 		require.Equal(t, macosAdamID, macMeta.AdamID)
 		requireNoStoredConfig(fleet.MacOSPlatform, macosAdamID, batchTeam.ID)
+	})
+}
+
+// TestManagedAppConfigurationWireFormat builds request bodies by hand and
+// inspects raw HTTP response bytes — no Go struct marshalling — to lock in the
+// on-the-wire shape of VPPAppStoreApp.Configuration after the switch from
+// []byte (base64-encoded by encoding/json) to json.RawMessage (passed through
+// as raw JSON). iOS / iPadOS configurations are sent and returned as a
+// JSON-encoded string of XML; Android configurations are sent and returned as
+// a raw JSON object.
+func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
+	t := s.T()
+	s.setSkipWorkerJobs(t)
+	ctx := context.Background()
+
+	// VPP setup.
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "vpp-android-wire-team"})
+	require.NoError(t, err)
+
+	orgName := "Fleet Device Management Inc."
+	token := "applewiretoken"
+	expDate := time.Now().Add(200 * time.Hour).UTC().Round(time.Second).Format(fleet.VPPTimeFormat)
+	tokenJSON := fmt.Sprintf(`{"expDate":%q,"token":%q,"orgName":%q}`, expDate, token, orgName)
+	dev_mode.SetOverride("FLEET_DEV_VPP_URL", s.appleVPPConfigSrv.URL, t)
+
+	var validToken uploadVPPTokenResponse
+	s.uploadDataViaForm("/api/latest/fleet/vpp_tokens", "token", "token.vpptoken",
+		[]byte(base64.StdEncoding.EncodeToString([]byte(tokenJSON))), http.StatusAccepted, "", &validToken)
+
+	var getVPPTokenResp getVPPTokensResponse
+	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &getVPPTokenResp)
+
+	var resPatchVPP patchVPPTokensTeamsResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", getVPPTokenResp.Tokens[0].ID),
+		patchVPPTokensTeamsRequest{TeamIDs: []uint{team.ID}}, http.StatusOK, &resPatchVPP)
+
+	// readBody reads the response body and compacts it (collapses the
+	// pretty-printing the server applies) so assertions can be written against
+	// the unindented wire bytes.
+	readBody := func(resp *http.Response) string {
+		t.Helper()
+		raw, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		var compact bytes.Buffer
+		require.NoError(t, json.Compact(&compact, raw))
+		return compact.String()
+	}
+
+	t.Run("vpp ios wire format", func(t *testing.T) {
+		// Adam ID "2" is pre-registered as an iOS app by the mock VPP server.
+		const iosAdamID = "2"
+		// Hand-built JSON body. The configuration value is a JSON-encoded
+		// string whose content is XML.
+		reqBody := fmt.Appendf(nil,
+			`{"fleet_id":%d,"app_store_id":%q,"platform":"ios","configuration":"<dict><key>K</key><string>v</string></dict>"}`,
+			team.ID, iosAdamID)
+		resp := s.DoRaw("POST", "/api/latest/fleet/software/app_store_apps", reqBody, http.StatusOK)
+		var addResp addAppStoreAppResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&addResp))
+		require.NoError(t, resp.Body.Close())
+		require.NotZero(t, addResp.TitleID)
+
+		// Stored config is the raw XML (the JSON-string was unwrapped server-side).
+		stored, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true), fleet.IOSPlatform, iosAdamID, team.ID)
+		require.NoError(t, err)
+		require.Equal(t, `<dict><key>K</key><string>v</string></dict>`, string(stored))
+
+		// GET response — wire shape is a JSON-encoded string of XML (no base64).
+		resp = s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", addResp.TitleID), nil, http.StatusOK, "fleet_id", fmt.Sprint(team.ID))
+		body := readBody(resp)
+		require.Contains(t, body, `"configuration":"<dict><key>K</key><string>v</string></dict>"`)
+		// Confirm the value is not base64-encoded (which is what a []byte field would do).
+		require.NotContains(t, body, base64.StdEncoding.EncodeToString([]byte(`"<dict><key>K</key><string>v</string></dict>"`)))
+	})
+
+	t.Run("android wire format", func(t *testing.T) {
+		s.enableAndroidMDM(t)
+		const androidAdamID = "com.test.wireformat"
+		s.androidAPIClient.EnterprisesApplicationsFunc = func(_ context.Context, _, _ string) (*androidmanagement.Application, error) {
+			return &androidmanagement.Application{IconUrl: "https://example.com/icon.png", Title: "WireApp"}, nil
+		}
+		s.androidAPIClient.EnterprisesPoliciesPatchFunc = func(_ context.Context, _ string, policy *androidmanagement.Policy, _ androidmgmt.PoliciesPatchOpts) (*androidmanagement.Policy, error) {
+			return policy, nil
+		}
+
+		// Configuration is sent as a raw JSON object — not a JSON-encoded string.
+		reqBody := fmt.Appendf(nil,
+			`{"fleet_id":%d,"app_store_id":%q,"platform":"android","configuration":{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}}`,
+			team.ID, androidAdamID)
+		resp := s.DoRaw("POST", "/api/latest/fleet/software/app_store_apps", reqBody, http.StatusOK)
+		var addResp addAppStoreAppResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&addResp))
+		require.NoError(t, resp.Body.Close())
+		require.NotZero(t, addResp.TitleID)
+
+		// Stored config is the raw JSON object.
+		stored, err := s.ds.GetAndroidAppConfiguration(ctxdb.RequirePrimary(ctx, true), androidAdamID, team.ID)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`, string(stored))
+
+		// GET response — Android emits the configuration as a raw JSON object,
+		// passed through unchanged from storage (no base64, no JSON-string wrap).
+		resp = s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", addResp.TitleID), nil, http.StatusOK, "fleet_id", fmt.Sprint(team.ID))
+		body := readBody(resp)
+		require.Contains(t, body, `"configuration":{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`)
+		require.NotContains(t, body, base64.StdEncoding.EncodeToString([]byte(`{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`)))
 	})
 }

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service/androidmgmt"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/apple_apps"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/androidmanagement/v1"
@@ -348,6 +350,7 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "vpp-managedcfg-install-team"})
 	require.NoError(t, err)
 	s.setVPPTokenForTeam(team.ID)
+	s.registerResetVPPProxyData(t)
 
 	asJSONString := func(s string) json.RawMessage {
 		b, err := json.Marshal(s)
@@ -627,6 +630,119 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 		require.Contains(t, raw, fmt.Sprintf("<string>%s</string>", ssHost.UUID),
 			"self-service install must resolve $FLEET_VAR_HOST_UUID to this host's UUID")
 		_, err = ssDev.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+	})
+
+	t.Run("auto-update install carries the managed Configuration", func(t *testing.T) {
+		// adam "3" is unused by prior subtests; override its proxy metadata
+		// to declare iOS at v1.0.0 (default proxy data has it as iPadOS-only).
+		const cfgAdamID = "3"
+		s.appleVPPProxySrvData[cfgAdamID] = `{"id": "3", "attributes": {"name": "Config App", "platformAttributes": {"ios": {"bundleId": "app-cfg", "artwork": {"url": "https://example.com/images/3/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "1.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`
+
+		cfgHost, cfgDev := s.createAppleMobileHostThenEnrollMDM("ios")
+		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, cfgDev.SerialNumber)
+		s.Do("POST", "/api/latest/fleet/hosts/transfer",
+			&addHostsToTeamRequest{HostIDs: []uint{cfgHost.ID}, TeamID: &team.ID}, http.StatusOK)
+
+		var addResp addAppStoreAppResponse
+		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
+			TeamID: &team.ID, AppStoreID: cfgAdamID, Platform: fleet.IOSPlatform,
+			Configuration: json.RawMessage(`"<dict><key>auto</key><string>update</string></dict>"`),
+		}, http.StatusOK, &addResp)
+		appTitleID := addResp.TitleID
+		require.NotZero(t, appTitleID)
+
+		// First install.
+		s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", cfgHost.ID, appTitleID),
+			&installSoftwareRequest{}, http.StatusAccepted, &installSoftwareResponse{})
+		s.awaitRunAppleMDMWorkerSchedule()
+		s.runWorker()
+		cmd, err := cfgDev.Idle()
+		require.NoError(t, err)
+		require.Equal(t, "InstallApplication", cmd.Command.RequestType)
+		require.Contains(t, string(cmd.Raw), "<key>Configuration</key>")
+		require.Contains(t, string(cmd.Raw), "<string>update</string>")
+		_, err = cfgDev.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+		s.runWorker()
+		cmd, err = cfgDev.Idle()
+		require.NoError(t, err)
+		require.Equal(t, "InstalledApplicationList", cmd.Command.RequestType)
+		_, err = cfgDev.AcknowledgeInstalledApplicationList(cfgDev.UUID, cmd.CommandUUID, []fleet.Software{
+			{Name: "Config App", BundleIdentifier: "app-cfg", Version: "1.0.0", Installed: true},
+		})
+		require.NoError(t, err)
+
+		// handleRefetch processes the three commands a refetch queues:
+		// InstalledApplicationList, CertificateList, DeviceInformation.
+		handleRefetch := func(software []fleet.Software) {
+			s.runWorker()
+			c, err := cfgDev.Idle()
+			require.NoError(t, err)
+			require.Equal(t, "InstalledApplicationList", c.Command.RequestType)
+			_, err = cfgDev.AcknowledgeInstalledApplicationList(cfgDev.UUID, c.CommandUUID, software)
+			require.NoError(t, err)
+			c, err = cfgDev.Idle()
+			require.NoError(t, err)
+			require.Equal(t, "CertificateList", c.Command.RequestType)
+			_, err = cfgDev.AcknowledgeCertificateList(cfgDev.UUID, c.CommandUUID, nil)
+			require.NoError(t, err)
+			c, err = cfgDev.Idle()
+			require.NoError(t, err)
+			require.Equal(t, "DeviceInformation", c.Command.RequestType)
+			_, err = cfgDev.AcknowledgeDeviceInformation(cfgDev.UUID, c.CommandUUID, "iPhone 17", "iPhone", "America/Los_Angeles")
+			require.NoError(t, err)
+		}
+
+		// First refetch populates the host's timezone (DeviceInformation is sent last).
+		s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/refetch", cfgHost.ID), nil, http.StatusOK)
+		handleRefetch([]fleet.Software{
+			{Name: "Config App", BundleIdentifier: "app-cfg", Version: "1.0.0", Installed: true},
+		})
+
+		// Enable auto-update inside the current Los Angeles window.
+		nowInLA, err := getCurrentLocalTimeInHostTimeZone(ctx, "America/Los_Angeles")
+		require.NoError(t, err)
+		startHHMM := nowInLA.Add(-30 * time.Minute).Format("15:04")
+		endHHMM := nowInLA.Add(30 * time.Minute).Format("15:04")
+		s.DoJSON("PATCH", fmt.Sprintf("/api/v1/fleet/software/titles/%d/app_store_app", appTitleID),
+			updateAppStoreAppRequest{
+				TeamID:              &team.ID,
+				AutoUpdateEnabled:   new(true),
+				AutoUpdateStartTime: &startHHMM,
+				AutoUpdateEndTime:   &endHHMM,
+			}, http.StatusOK, &updateAppStoreAppResponse{})
+
+		// Bump latest version in proxy data, refresh, and bypass the 1-hour install filter.
+		s.appleVPPProxySrvData[cfgAdamID] = `{"id": "3", "attributes": {"name": "Config App", "platformAttributes": {"ios": {"bundleId": "app-cfg", "artwork": {"url": "https://example.com/images/3/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "2.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`
+		require.NoError(t, vpp.RefreshVersions(ctx, s.ds, apple_apps.StubbedConfig()))
+		mysql.ExecAdhocSQL(t, s.ds, func(db sqlx.ExtContext) error {
+			_, err := db.ExecContext(ctx,
+				`UPDATE host_vpp_software_installs SET created_at = DATE_SUB(NOW(), INTERVAL 2 HOUR) WHERE host_id = ?`, cfgHost.ID)
+			return err
+		})
+
+		// Refetch with the host still on v1.0.0 → auto-update kicks in.
+		s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/refetch", cfgHost.ID), nil, http.StatusOK)
+		handleRefetch([]fleet.Software{
+			{Name: "Config App", BundleIdentifier: "app-cfg", Version: "1.0.0", Installed: true},
+		})
+
+		s.runWorker()
+		cmd, err = cfgDev.Idle()
+		require.NoError(t, err)
+		require.NotNil(t, cmd, "expected an auto-update InstallApplication command")
+		require.Equal(t, "InstallApplication", cmd.Command.RequestType)
+		require.Contains(t, string(cmd.Raw), "<key>Configuration</key>",
+			"scheduled auto-update InstallApplication must carry Configuration")
+		require.Contains(t, string(cmd.Raw), "<string>update</string>",
+			"scheduled auto-update must use the latest stored config bytes")
+
+		isAuto, err := s.ds.IsAutoUpdateVPPInstall(ctx, cmd.CommandUUID)
+		require.NoError(t, err)
+		require.True(t, isAuto, "command must be recorded with from_auto_update=true")
+
+		_, err = cfgDev.Acknowledge(cmd.CommandUUID)
 		require.NoError(t, err)
 	})
 }

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -365,15 +365,17 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 		return id
 	}
 
-	// drainVerifyCmds acks any pending InstalledApplicationList commands as "installed".
-	drainVerifyCmds := func(t *testing.T, dev *mdmtest.TestAppleMDMClient, installed fleet.Software) {
+	// installAndCaptureCmd triggers an install and returns the InstallApplication bytes,
+	// then completes the verification so the host is ready for another install.
+	installAndCaptureCmd := func(t *testing.T, host *fleet.Host, dev *mdmtest.TestAppleMDMClient, titleID uint, installed fleet.Software) []byte {
 		t.Helper()
 		installed.Installed = true
+		// Drain any pending verification commands from prior installs.
 		for {
 			cmd, err := dev.Idle()
 			require.NoError(t, err)
 			if cmd == nil {
-				return
+				break
 			}
 			require.Equal(t, "InstalledApplicationList", cmd.Command.RequestType,
 				"unexpected pending command %q while draining verifications", cmd.Command.RequestType)
@@ -381,13 +383,6 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 				[]fleet.Software{installed})
 			require.NoError(t, err)
 		}
-	}
-
-	// installAndCaptureCmd triggers an install and returns the InstallApplication bytes,
-	// then completes the verification so the host is ready for another install.
-	installAndCaptureCmd := func(t *testing.T, host *fleet.Host, dev *mdmtest.TestAppleMDMClient, titleID uint, installed fleet.Software) []byte {
-		t.Helper()
-		drainVerifyCmds(t, dev, installed)
 
 		var installResp installSoftwareResponse
 		s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", host.ID, titleID),
@@ -608,8 +603,6 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 		headers := map[string]string{
 			"X-Client-Cert-Serial": fmt.Sprintf("%d", certSerial),
 		}
-
-		drainVerifyCmds(t, ssDev, app2Installed)
 
 		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
 		s.DoJSON("PATCH",

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -456,6 +456,8 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 			&updateAppStoreAppRequest{TeamID: &team.ID, Configuration: json.RawMessage(`null`)},
 			http.StatusOK, &updateAppStoreAppResponse{})
 
+		s.lastActivityMatches(fleet.ActivityEditedAppStoreApp{}.ActivityName(), "", 0)
+
 		_, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true), fleet.IOSPlatform, adamMulti, team.ID)
 		require.True(t, fleet.IsNotFound(err), "expected config row deleted")
 
@@ -565,6 +567,35 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 			"updated install should still carry a Configuration dict")
 		require.Contains(t, raw, "<string>updated</string>",
 			"updated install must carry the latest stored config bytes")
+
+		// Updating to a config that references an IDP variable the host hasn't
+		// been linked to → install POST fails 400 with a user-facing message
+		// (substitution error surfaces in the response because
+		// activateNextUpcomingActivity runs in-tx with the upcoming-activity insert).
+		s.DoJSON("PATCH",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
+			&updateAppStoreAppRequest{TeamID: &team.ID,
+				Configuration: asJSONString(`<dict><key>Email</key><string>$FLEET_VAR_HOST_END_USER_EMAIL_IDP</string></dict>`)},
+			http.StatusOK, &updateAppStoreAppResponse{})
+
+		var uaBefore int
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &uaBefore,
+				`SELECT COUNT(*) FROM upcoming_activities WHERE host_id = ?`, iosHost.ID)
+		})
+
+		res := s.Do("POST",
+			fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", iosHost.ID, titleID),
+			&installSoftwareRequest{}, http.StatusBadRequest)
+		require.Contains(t, extractServerErrorText(res.Body),
+			"managed app configuration references Fleet variables that can't be resolved")
+
+		var uaAfter int
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &uaAfter,
+				`SELECT COUNT(*) FROM upcoming_activities WHERE host_id = ?`, iosHost.ID)
+		})
+		require.Equal(t, uaBefore, uaAfter, "failed install must not leave a zombie upcoming_activity row")
 	})
 
 	t.Run("self-service install carries Configuration with $FLEET_VAR_HOST_UUID resolved", func(t *testing.T) {

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -265,42 +265,19 @@ func (s *integrationMDMTestSuite) TestVPPAppleManagedAppConfiguration() {
 	})
 }
 
-// TestManagedAppConfigurationWireFormat builds request bodies by hand and
-// inspects raw HTTP response bytes — no Go struct marshalling — to lock in the
-// on-the-wire shape of VPPAppStoreApp.Configuration after the switch from
-// []byte (base64-encoded by encoding/json) to json.RawMessage (passed through
-// as raw JSON). iOS / iPadOS configurations are sent and returned as a
-// JSON-encoded string of XML; Android configurations are sent and returned as
-// a raw JSON object.
+// TestManagedAppConfigurationWireFormat asserts the on-the-wire shape of
+// VPPAppStoreApp.Configuration using hand-built request bodies and raw
+// response bytes (no Go struct marshalling on either side).
 func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 	t := s.T()
 	s.setSkipWorkerJobs(t)
 	ctx := context.Background()
 
-	// VPP setup.
-	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "vpp-android-wire-team"})
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "vpp-config-wire-team"})
 	require.NoError(t, err)
+	s.setVPPTokenForTeam(team.ID)
 
-	orgName := "Fleet Device Management Inc."
-	token := "applewiretoken"
-	expDate := time.Now().Add(200 * time.Hour).UTC().Round(time.Second).Format(fleet.VPPTimeFormat)
-	tokenJSON := fmt.Sprintf(`{"expDate":%q,"token":%q,"orgName":%q}`, expDate, token, orgName)
-	dev_mode.SetOverride("FLEET_DEV_VPP_URL", s.appleVPPConfigSrv.URL, t)
-
-	var validToken uploadVPPTokenResponse
-	s.uploadDataViaForm("/api/latest/fleet/vpp_tokens", "token", "token.vpptoken",
-		[]byte(base64.StdEncoding.EncodeToString([]byte(tokenJSON))), http.StatusAccepted, "", &validToken)
-
-	var getVPPTokenResp getVPPTokensResponse
-	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &getVPPTokenResp)
-
-	var resPatchVPP patchVPPTokensTeamsResponse
-	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", getVPPTokenResp.Tokens[0].ID),
-		patchVPPTokensTeamsRequest{TeamIDs: []uint{team.ID}}, http.StatusOK, &resPatchVPP)
-
-	// readBody reads the response body and compacts it (collapses the
-	// pretty-printing the server applies) so assertions can be written against
-	// the unindented wire bytes.
+	// readBody compacts the pretty-printed JSON so assertions can match unindented wire bytes.
 	readBody := func(resp *http.Response) string {
 		t.Helper()
 		raw, err := io.ReadAll(resp.Body)
@@ -314,8 +291,6 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 	t.Run("vpp ios wire format", func(t *testing.T) {
 		// Adam ID "2" is pre-registered as an iOS app by the mock VPP server.
 		const iosAdamID = "2"
-		// Hand-built JSON body. The configuration value is a JSON-encoded
-		// string whose content is XML.
 		reqBody := fmt.Appendf(nil,
 			`{"fleet_id":%d,"app_store_id":%q,"platform":"ios","configuration":"<dict><key>K</key><string>v</string></dict>"}`,
 			team.ID, iosAdamID)
@@ -325,16 +300,13 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 		require.NoError(t, resp.Body.Close())
 		require.NotZero(t, addResp.TitleID)
 
-		// Stored config is the raw XML (the JSON-string was unwrapped server-side).
 		stored, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true), fleet.IOSPlatform, iosAdamID, team.ID)
 		require.NoError(t, err)
 		require.Equal(t, `<dict><key>K</key><string>v</string></dict>`, string(stored))
 
-		// GET response — wire shape is a JSON-encoded string of XML (no base64).
 		resp = s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", addResp.TitleID), nil, http.StatusOK, "fleet_id", fmt.Sprint(team.ID))
 		body := readBody(resp)
 		require.Contains(t, body, `"configuration":"<dict><key>K</key><string>v</string></dict>"`)
-		// Confirm the value is not base64-encoded (which is what a []byte field would do).
 		require.NotContains(t, body, base64.StdEncoding.EncodeToString([]byte(`"<dict><key>K</key><string>v</string></dict>"`)))
 	})
 
@@ -348,7 +320,6 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 			return policy, nil
 		}
 
-		// Configuration is sent as a raw JSON object — not a JSON-encoded string.
 		reqBody := fmt.Appendf(nil,
 			`{"fleet_id":%d,"app_store_id":%q,"platform":"android","configuration":{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}}`,
 			team.ID, androidAdamID)
@@ -358,13 +329,10 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 		require.NoError(t, resp.Body.Close())
 		require.NotZero(t, addResp.TitleID)
 
-		// Stored config is the raw JSON object.
 		stored, err := s.ds.GetAndroidAppConfiguration(ctxdb.RequirePrimary(ctx, true), androidAdamID, team.ID)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`, string(stored))
 
-		// GET response — Android emits the configuration as a raw JSON object,
-		// passed through unchanged from storage (no base64, no JSON-string wrap).
 		resp = s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", addResp.TitleID), nil, http.StatusOK, "fleet_id", fmt.Sprint(team.ID))
 		body := readBody(resp)
 		require.Contains(t, body, `"configuration":{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`)
@@ -372,13 +340,8 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 	})
 }
 
-// TestVPPManagedConfigurationOnInstallCommand drives the MDM-side
-// coverage from issue #43973: when a VPP app has a managed configuration,
-// the InstallApplication command sent to the device must include the
-// Configuration dict (with $FLEET_VAR_HOST_UUID substituted), macOS installs
-// must drop it, clearing the configuration must remove it from the next
-// install, per-host substitution must use each host's own UUID, and the
-// iOS / iPadOS rows of the same adam_id must keep their configs isolated.
+// TestVPPManagedConfigurationOnInstallCommand asserts the InstallApplication
+// MDM command bytes for the VPP managed-configuration paths.
 func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() {
 	t := s.T()
 	s.setSkipWorkerJobs(t)
@@ -387,7 +350,6 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "vpp-managedcfg-install-team"})
 	require.NoError(t, err)
 	s.setVPPTokenForTeam(team.ID)
-	dev_mode.SetOverride("FLEET_DEV_VPP_URL", s.appleVPPConfigSrv.URL, t)
 
 	asJSONString := func(s string) json.RawMessage {
 		b, err := json.Marshal(s)
@@ -405,10 +367,7 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 		return id
 	}
 
-	// drainVerifyCmds acks any InstalledApplicationList verification commands
-	// pending on the device queue (from prior install cycles) as "app
-	// installed" so the next install_application sits at the head of the
-	// queue. Returns when Idle reports no command.
+	// drainVerifyCmds acks any pending InstalledApplicationList commands as "installed".
 	drainVerifyCmds := func(t *testing.T, dev *mdmtest.TestAppleMDMClient, installed fleet.Software) {
 		t.Helper()
 		installed.Installed = true
@@ -426,17 +385,10 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 		}
 	}
 
-	// installAndCaptureCmd drives a complete install cycle on host: triggers
-	// the install, returns the raw bytes of the InstallApplication command,
-	// then acks the follow-up InstalledApplicationList verification with the
-	// app reported as installed. Completing the verification leaves the host
-	// in a clean state so a subsequent install on the same host queues
-	// immediately instead of waiting behind a pending activity.
+	// installAndCaptureCmd triggers an install and returns the InstallApplication bytes,
+	// then completes the verification so the host is ready for another install.
 	installAndCaptureCmd := func(t *testing.T, host *fleet.Host, dev *mdmtest.TestAppleMDMClient, titleID uint, installed fleet.Software) []byte {
 		t.Helper()
-		// Drain any leftover verification commands from earlier installs so
-		// the next Idle after the install POST reliably returns the new
-		// InstallApplication.
 		drainVerifyCmds(t, dev, installed)
 
 		var installResp installSoftwareResponse
@@ -453,8 +405,6 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 		_, err = dev.Acknowledge(cmd.CommandUUID)
 		require.NoError(t, err)
 
-		// Complete the verification step so the activity transitions to
-		// Installed; otherwise a follow-up install on this host stays queued.
 		s.runWorker()
 		cmd, err = dev.Idle()
 		require.NoError(t, err)
@@ -472,14 +422,12 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 	// Adam ID "1" is macOS-only.
 	const adamMac = "1"
 
-	// Enroll an iOS host and add it to the team.
 	iosHost, iosDev := s.createAppleMobileHostThenEnrollMDM("ios")
 	s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, iosDev.SerialNumber)
 	s.Do("POST", "/api/latest/fleet/hosts/transfer",
 		&addHostsToTeamRequest{HostIDs: []uint{iosHost.ID}, TeamID: &team.ID}, http.StatusOK)
 
-	// App-2 metadata as the mock proxy reports it for ios / ipados (same name,
-	// bundle and version for both Apple-mobile platforms in the default proxy).
+	// App-2 metadata as the mock proxy reports it for ios / ipados.
 	app2Installed := fleet.Software{Name: "App 2", BundleIdentifier: "b-2", Version: "2.0.0"}
 
 	t.Run("iOS install carries Configuration and resolves $FLEET_VAR_HOST_UUID", func(t *testing.T) {
@@ -490,40 +438,33 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 			Configuration: asJSONString(plistXML),
 		}, http.StatusOK, &addResp)
 
-		raw := installAndCaptureCmd(t, iosHost, iosDev, titleIDFor(adamMulti, fleet.IOSPlatform), app2Installed)
-		s := string(raw)
-		require.Contains(t, s, "<key>Configuration</key>",
+		raw := string(installAndCaptureCmd(t, iosHost, iosDev, titleIDFor(adamMulti, fleet.IOSPlatform), app2Installed))
+		require.Contains(t, raw, "<key>Configuration</key>",
 			"InstallApplication should include Configuration dict for iOS")
-		require.Contains(t, s, "<key>K</key>")
-		require.Contains(t, s, "<string>v</string>")
-		require.NotContains(t, s, "$FLEET_VAR_HOST_UUID",
+		require.Contains(t, raw, "<key>K</key>")
+		require.Contains(t, raw, "<string>v</string>")
+		require.NotContains(t, raw, "$FLEET_VAR_HOST_UUID",
 			"Fleet variable must be resolved before sending to device")
-		require.Contains(t, s, fmt.Sprintf("<string>%s</string>", iosHost.UUID),
+		require.Contains(t, raw, fmt.Sprintf("<string>%s</string>", iosHost.UUID),
 			"Resolved value should be the iOS host's own UUID")
 	})
 
 	t.Run("clearing configuration drops Configuration from the next install", func(t *testing.T) {
 		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
-		// PATCH with configuration:null deletes the stored row.
 		s.DoJSON("PATCH",
 			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
 			&updateAppStoreAppRequest{TeamID: &team.ID, Configuration: json.RawMessage(`null`)},
 			http.StatusOK, &updateAppStoreAppResponse{})
 
-		// Sanity: row gone.
 		_, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true), fleet.IOSPlatform, adamMulti, team.ID)
 		require.True(t, fleet.IsNotFound(err), "expected config row deleted")
 
-		// Reuse the same iOS host — the previous subtest completed its install
-		// cycle (verification acked) so this host is ready for a fresh install.
 		raw := string(installAndCaptureCmd(t, iosHost, iosDev, titleID, app2Installed))
 		require.NotContains(t, raw, "<key>Configuration</key>",
 			"InstallApplication should not include Configuration after clearing the stored config")
 	})
 
 	t.Run("second iOS host gets its own UUID substituted (per-host resolution)", func(t *testing.T) {
-		// Re-set a config that references HOST_UUID, then install on a SECOND
-		// host to confirm the substitution is per-host (no caching across hosts).
 		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
 		s.DoJSON("PATCH",
 			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
@@ -545,8 +486,6 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 	})
 
 	t.Run("macOS install drops Configuration even when one was sent on add", func(t *testing.T) {
-		// Configuration is sent on the add — service-layer policy must silently
-		// drop it for macOS so the device-bound command has no Configuration key.
 		plistXML := `<dict><key>K</key><string>v</string></dict>`
 		var addResp addAppStoreAppResponse
 		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
@@ -554,14 +493,13 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 			Configuration: asJSONString(plistXML),
 		}, http.StatusOK, &addResp)
 
-		// Enroll a macOS host (needs fleetd for the install path), add to team.
+		// macOS install path requires fleetd enrollment.
 		macHost, macDev := createHostThenEnrollMDM(s.ds, s.server.URL, t)
 		setOrbitEnrollment(t, macHost, s.ds)
 		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, macHost.HardwareSerial)
 		s.Do("POST", "/api/latest/fleet/hosts/transfer",
 			&addHostsToTeamRequest{HostIDs: []uint{macHost.ID}, TeamID: &team.ID}, http.StatusOK)
-		// Drain the InstallFleetd command that enrollment queues so subsequent
-		// installs see InstallApplication at the head of the queue.
+		// Drain the InstallFleetd command queued by enrollment.
 		s.awaitRunAppleMDMWorkerSchedule()
 		s.runWorker()
 		checkInstallFleetdCommandSent(t, macDev, true)
@@ -574,28 +512,21 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 	})
 
 	t.Run("same adam_id on iOS and iPadOS keep configs isolated", func(t *testing.T) {
-		// adamMulti ("2") is registered for both iOS and iPadOS in the mock
-		// proxy. Add it under both platforms with DIFFERENT configs and
-		// confirm each platform's stored bytes are independent and that the
-		// device install carries the platform-scoped bytes.
 		const iosCfg = `<dict><key>side</key><string>ios</string></dict>`
 		const ipadCfg = `<dict><key>side</key><string>ipados</string></dict>`
 
-		// Update the existing iOS row (configured a few subtests up) to a known value.
 		iosTitle := titleIDFor(adamMulti, fleet.IOSPlatform)
 		s.DoJSON("PATCH",
 			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", iosTitle),
 			&updateAppStoreAppRequest{TeamID: &team.ID, Configuration: asJSONString(iosCfg)},
 			http.StatusOK, &updateAppStoreAppResponse{})
 
-		// Add the iPadOS row with its own distinct config.
 		var addResp addAppStoreAppResponse
 		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
 			TeamID: &team.ID, AppStoreID: adamMulti, Platform: fleet.IPadOSPlatform,
 			Configuration: asJSONString(ipadCfg),
 		}, http.StatusOK, &addResp)
 
-		// Stored configs must be platform-scoped — same adam_id, different bytes.
 		storedIOS, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true),
 			fleet.IOSPlatform, adamMulti, team.ID)
 		require.NoError(t, err)
@@ -604,10 +535,8 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 			fleet.IPadOSPlatform, adamMulti, team.ID)
 		require.NoError(t, err)
 		require.Equal(t, ipadCfg, string(storedIPad))
-		require.NotEqual(t, string(storedIOS), string(storedIPad),
-			"same adam_id should be able to hold per-platform configs")
+		require.NotEqual(t, string(storedIOS), string(storedIPad))
 
-		// And the iPadOS install carries the iPadOS bytes (not the iOS ones).
 		ipadHost, ipadDev := s.createAppleMobileHostThenEnrollMDM("ipados")
 		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, ipadDev.SerialNumber)
 		s.Do("POST", "/api/latest/fleet/hosts/transfer",
@@ -621,12 +550,9 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 			"iPadOS install must not leak the iOS-scoped config bytes")
 	})
 
-	t.Run("updating configuration → next install carries the new bytes (auto-update guarantee proxy)", func(t *testing.T) {
-		// Per nanoEnqueueVPPInstall, every install path — manual reinstall,
-		// self-service, scheduled auto-update — re-reads the latest stored
-		// configuration at enqueue time. Editing the config between two
-		// installs on the same host is enough to prove the freshness
-		// guarantee without driving the proxy version-bump dance.
+	t.Run("updating configuration → next install carries the new bytes", func(t *testing.T) {
+		// Every install path re-reads the stored config at enqueue time
+		// (nanoEnqueueVPPInstall), so this also exercises the auto-update freshness path.
 		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
 		const updatedCfg = `<dict><key>K</key><string>updated</string></dict>`
 		s.DoJSON("PATCH",
@@ -642,37 +568,27 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 	})
 
 	t.Run("self-service install carries Configuration with $FLEET_VAR_HOST_UUID resolved", func(t *testing.T) {
-		// Self-service install hits a different entry endpoint
-		// (/api/latest/fleet/device/{uuid}/software/install/{title_id}) but
-		// goes through the same nanoEnqueueVPPInstall path, so the on-the-
-		// wire bytes should match the admin-install path.
-		// Add a fresh app marked self_service:true with a config that uses
-		// $FLEET_VAR_HOST_UUID; install on a host via the device endpoint.
 		ssHost, ssDev := s.createAppleMobileHostThenEnrollMDM("ios")
 		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, ssDev.SerialNumber)
 		s.Do("POST", "/api/latest/fleet/hosts/transfer",
 			&addHostsToTeamRequest{HostIDs: []uint{ssHost.ID}, TeamID: &team.ID}, http.StatusOK)
 
-		// Mint an identity cert so the device endpoint accepts the request.
+		// Self-service device endpoint requires cert auth.
 		const certSerial = uint64(987654321)
 		s.addHostIdentityCertificate(ssHost.UUID, certSerial)
 		headers := map[string]string{
 			"X-Client-Cert-Serial": fmt.Sprintf("%d", certSerial),
 		}
 
-		// Drain any leftover verification commands so the new
-		// InstallApplication sits at the head of the device queue.
 		drainVerifyCmds(t, ssDev, app2Installed)
 
 		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
-		// Make sure the app is marked self_service AND has a known config.
 		s.DoJSON("PATCH",
 			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
 			&updateAppStoreAppRequest{TeamID: &team.ID, SelfService: new(true),
 				Configuration: asJSONString(`<dict><key>UUID</key><string>$FLEET_VAR_HOST_UUID</string></dict>`)},
 			http.StatusOK, &updateAppStoreAppResponse{})
 
-		// Trigger self-service install via the device endpoint.
 		s.DoRawWithHeaders("POST",
 			fmt.Sprintf("/api/latest/fleet/device/%s/software/install/%d", ssHost.UUID, titleID),
 			nil, http.StatusAccepted, headers)

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -11,10 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/mdm/mdmtest"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service/androidmgmt"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/androidmanagement/v1"
 )
@@ -366,5 +369,326 @@ func (s *integrationMDMTestSuite) TestManagedAppConfigurationWireFormat() {
 		body := readBody(resp)
 		require.Contains(t, body, `"configuration":{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`)
 		require.NotContains(t, body, base64.StdEncoding.EncodeToString([]byte(`{"workProfileWidgets":"WORK_PROFILE_WIDGETS_ALLOWED"}`)))
+	})
+}
+
+// TestVPPManagedConfigurationOnInstallCommand drives the MDM-side
+// coverage from issue #43973: when a VPP app has a managed configuration,
+// the InstallApplication command sent to the device must include the
+// Configuration dict (with $FLEET_VAR_HOST_UUID substituted), macOS installs
+// must drop it, clearing the configuration must remove it from the next
+// install, per-host substitution must use each host's own UUID, and the
+// iOS / iPadOS rows of the same adam_id must keep their configs isolated.
+func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() {
+	t := s.T()
+	s.setSkipWorkerJobs(t)
+	ctx := context.Background()
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "vpp-managedcfg-install-team"})
+	require.NoError(t, err)
+	s.setVPPTokenForTeam(team.ID)
+	dev_mode.SetOverride("FLEET_DEV_VPP_URL", s.appleVPPConfigSrv.URL, t)
+
+	asJSONString := func(s string) json.RawMessage {
+		b, err := json.Marshal(s)
+		require.NoError(t, err)
+		return json.RawMessage(b)
+	}
+
+	titleIDFor := func(adamID string, platform fleet.InstallableDevicePlatform) uint {
+		var id uint
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &id,
+				`SELECT title_id FROM vpp_apps WHERE adam_id = ? AND platform = ?`, adamID, platform)
+		})
+		require.NotZero(t, id, "title_id for adam=%s platform=%s", adamID, platform)
+		return id
+	}
+
+	// drainVerifyCmds acks any InstalledApplicationList verification commands
+	// pending on the device queue (from prior install cycles) as "app
+	// installed" so the next install_application sits at the head of the
+	// queue. Returns when Idle reports no command.
+	drainVerifyCmds := func(t *testing.T, dev *mdmtest.TestAppleMDMClient, installed fleet.Software) {
+		t.Helper()
+		installed.Installed = true
+		for {
+			cmd, err := dev.Idle()
+			require.NoError(t, err)
+			if cmd == nil {
+				return
+			}
+			require.Equal(t, "InstalledApplicationList", cmd.Command.RequestType,
+				"unexpected pending command %q while draining verifications", cmd.Command.RequestType)
+			_, err = dev.AcknowledgeInstalledApplicationList(dev.UUID, cmd.CommandUUID,
+				[]fleet.Software{installed})
+			require.NoError(t, err)
+		}
+	}
+
+	// installAndCaptureCmd drives a complete install cycle on host: triggers
+	// the install, returns the raw bytes of the InstallApplication command,
+	// then acks the follow-up InstalledApplicationList verification with the
+	// app reported as installed. Completing the verification leaves the host
+	// in a clean state so a subsequent install on the same host queues
+	// immediately instead of waiting behind a pending activity.
+	installAndCaptureCmd := func(t *testing.T, host *fleet.Host, dev *mdmtest.TestAppleMDMClient, titleID uint, installed fleet.Software) []byte {
+		t.Helper()
+		// Drain any leftover verification commands from earlier installs so
+		// the next Idle after the install POST reliably returns the new
+		// InstallApplication.
+		drainVerifyCmds(t, dev, installed)
+
+		var installResp installSoftwareResponse
+		s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", host.ID, titleID),
+			&installSoftwareRequest{}, http.StatusAccepted, &installResp)
+
+		s.awaitRunAppleMDMWorkerSchedule()
+		s.runWorker()
+		cmd, err := dev.Idle()
+		require.NoError(t, err)
+		require.NotNil(t, cmd, "expected an MDM command after install trigger but device went idle")
+		require.Equal(t, "InstallApplication", cmd.Command.RequestType)
+		raw := append([]byte(nil), cmd.Raw...)
+		_, err = dev.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+
+		// Complete the verification step so the activity transitions to
+		// Installed; otherwise a follow-up install on this host stays queued.
+		s.runWorker()
+		cmd, err = dev.Idle()
+		require.NoError(t, err)
+		require.NotNil(t, cmd, "expected an InstalledApplicationList verification command")
+		require.Equal(t, "InstalledApplicationList", cmd.Command.RequestType)
+		installed.Installed = true
+		_, err = dev.AcknowledgeInstalledApplicationList(dev.UUID, cmd.CommandUUID,
+			[]fleet.Software{installed})
+		require.NoError(t, err)
+		return raw
+	}
+
+	// Adam ID "2" is registered for iOS + iPadOS + macOS in the mock proxy.
+	const adamMulti = "2"
+	// Adam ID "1" is macOS-only.
+	const adamMac = "1"
+
+	// Enroll an iOS host and add it to the team.
+	iosHost, iosDev := s.createAppleMobileHostThenEnrollMDM("ios")
+	s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, iosDev.SerialNumber)
+	s.Do("POST", "/api/latest/fleet/hosts/transfer",
+		&addHostsToTeamRequest{HostIDs: []uint{iosHost.ID}, TeamID: &team.ID}, http.StatusOK)
+
+	// App-2 metadata as the mock proxy reports it for ios / ipados (same name,
+	// bundle and version for both Apple-mobile platforms in the default proxy).
+	app2Installed := fleet.Software{Name: "App 2", BundleIdentifier: "b-2", Version: "2.0.0"}
+
+	t.Run("iOS install carries Configuration and resolves $FLEET_VAR_HOST_UUID", func(t *testing.T) {
+		plistXML := `<dict><key>K</key><string>v</string><key>UUID</key><string>$FLEET_VAR_HOST_UUID</string></dict>`
+		var addResp addAppStoreAppResponse
+		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
+			TeamID: &team.ID, AppStoreID: adamMulti, Platform: fleet.IOSPlatform,
+			Configuration: asJSONString(plistXML),
+		}, http.StatusOK, &addResp)
+
+		raw := installAndCaptureCmd(t, iosHost, iosDev, titleIDFor(adamMulti, fleet.IOSPlatform), app2Installed)
+		s := string(raw)
+		require.Contains(t, s, "<key>Configuration</key>",
+			"InstallApplication should include Configuration dict for iOS")
+		require.Contains(t, s, "<key>K</key>")
+		require.Contains(t, s, "<string>v</string>")
+		require.NotContains(t, s, "$FLEET_VAR_HOST_UUID",
+			"Fleet variable must be resolved before sending to device")
+		require.Contains(t, s, fmt.Sprintf("<string>%s</string>", iosHost.UUID),
+			"Resolved value should be the iOS host's own UUID")
+	})
+
+	t.Run("clearing configuration drops Configuration from the next install", func(t *testing.T) {
+		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
+		// PATCH with configuration:null deletes the stored row.
+		s.DoJSON("PATCH",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
+			&updateAppStoreAppRequest{TeamID: &team.ID, Configuration: json.RawMessage(`null`)},
+			http.StatusOK, &updateAppStoreAppResponse{})
+
+		// Sanity: row gone.
+		_, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true), fleet.IOSPlatform, adamMulti, team.ID)
+		require.True(t, fleet.IsNotFound(err), "expected config row deleted")
+
+		// Reuse the same iOS host — the previous subtest completed its install
+		// cycle (verification acked) so this host is ready for a fresh install.
+		raw := string(installAndCaptureCmd(t, iosHost, iosDev, titleID, app2Installed))
+		require.NotContains(t, raw, "<key>Configuration</key>",
+			"InstallApplication should not include Configuration after clearing the stored config")
+	})
+
+	t.Run("second iOS host gets its own UUID substituted (per-host resolution)", func(t *testing.T) {
+		// Re-set a config that references HOST_UUID, then install on a SECOND
+		// host to confirm the substitution is per-host (no caching across hosts).
+		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
+		s.DoJSON("PATCH",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
+			&updateAppStoreAppRequest{TeamID: &team.ID,
+				Configuration: asJSONString(`<dict><key>UUID</key><string>$FLEET_VAR_HOST_UUID</string></dict>`)},
+			http.StatusOK, &updateAppStoreAppResponse{})
+
+		ios2Host, ios2Dev := s.createAppleMobileHostThenEnrollMDM("ios")
+		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, ios2Dev.SerialNumber)
+		s.Do("POST", "/api/latest/fleet/hosts/transfer",
+			&addHostsToTeamRequest{HostIDs: []uint{ios2Host.ID}, TeamID: &team.ID}, http.StatusOK)
+		require.NotEqual(t, iosHost.UUID, ios2Host.UUID, "second host needs a distinct UUID for this test to be meaningful")
+
+		raw := string(installAndCaptureCmd(t, ios2Host, ios2Dev, titleID, app2Installed))
+		require.Contains(t, raw, fmt.Sprintf("<string>%s</string>", ios2Host.UUID),
+			"second host's command should carry its own UUID")
+		require.NotContains(t, raw, fmt.Sprintf("<string>%s</string>", iosHost.UUID),
+			"second host's command must not carry the first host's UUID")
+	})
+
+	t.Run("macOS install drops Configuration even when one was sent on add", func(t *testing.T) {
+		// Configuration is sent on the add — service-layer policy must silently
+		// drop it for macOS so the device-bound command has no Configuration key.
+		plistXML := `<dict><key>K</key><string>v</string></dict>`
+		var addResp addAppStoreAppResponse
+		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
+			TeamID: &team.ID, AppStoreID: adamMac, Platform: fleet.MacOSPlatform,
+			Configuration: asJSONString(plistXML),
+		}, http.StatusOK, &addResp)
+
+		// Enroll a macOS host (needs fleetd for the install path), add to team.
+		macHost, macDev := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+		setOrbitEnrollment(t, macHost, s.ds)
+		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, macHost.HardwareSerial)
+		s.Do("POST", "/api/latest/fleet/hosts/transfer",
+			&addHostsToTeamRequest{HostIDs: []uint{macHost.ID}, TeamID: &team.ID}, http.StatusOK)
+		// Drain the InstallFleetd command that enrollment queues so subsequent
+		// installs see InstallApplication at the head of the queue.
+		s.awaitRunAppleMDMWorkerSchedule()
+		s.runWorker()
+		checkInstallFleetdCommandSent(t, macDev, true)
+
+		raw := string(installAndCaptureCmd(t, macHost, macDev,
+			titleIDFor(adamMac, fleet.MacOSPlatform),
+			fleet.Software{Name: "App 1", BundleIdentifier: "a-1", Version: "1.0.0"}))
+		require.NotContains(t, raw, "<key>Configuration</key>",
+			"macOS InstallApplication must not carry Configuration even if one was POSTed")
+	})
+
+	t.Run("same adam_id on iOS and iPadOS keep configs isolated", func(t *testing.T) {
+		// adamMulti ("2") is registered for both iOS and iPadOS in the mock
+		// proxy. Add it under both platforms with DIFFERENT configs and
+		// confirm each platform's stored bytes are independent and that the
+		// device install carries the platform-scoped bytes.
+		const iosCfg = `<dict><key>side</key><string>ios</string></dict>`
+		const ipadCfg = `<dict><key>side</key><string>ipados</string></dict>`
+
+		// Update the existing iOS row (configured a few subtests up) to a known value.
+		iosTitle := titleIDFor(adamMulti, fleet.IOSPlatform)
+		s.DoJSON("PATCH",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", iosTitle),
+			&updateAppStoreAppRequest{TeamID: &team.ID, Configuration: asJSONString(iosCfg)},
+			http.StatusOK, &updateAppStoreAppResponse{})
+
+		// Add the iPadOS row with its own distinct config.
+		var addResp addAppStoreAppResponse
+		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
+			TeamID: &team.ID, AppStoreID: adamMulti, Platform: fleet.IPadOSPlatform,
+			Configuration: asJSONString(ipadCfg),
+		}, http.StatusOK, &addResp)
+
+		// Stored configs must be platform-scoped — same adam_id, different bytes.
+		storedIOS, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true),
+			fleet.IOSPlatform, adamMulti, team.ID)
+		require.NoError(t, err)
+		require.Equal(t, iosCfg, string(storedIOS))
+		storedIPad, err := s.ds.GetVPPAppConfiguration(ctxdb.RequirePrimary(ctx, true),
+			fleet.IPadOSPlatform, adamMulti, team.ID)
+		require.NoError(t, err)
+		require.Equal(t, ipadCfg, string(storedIPad))
+		require.NotEqual(t, string(storedIOS), string(storedIPad),
+			"same adam_id should be able to hold per-platform configs")
+
+		// And the iPadOS install carries the iPadOS bytes (not the iOS ones).
+		ipadHost, ipadDev := s.createAppleMobileHostThenEnrollMDM("ipados")
+		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, ipadDev.SerialNumber)
+		s.Do("POST", "/api/latest/fleet/hosts/transfer",
+			&addHostsToTeamRequest{HostIDs: []uint{ipadHost.ID}, TeamID: &team.ID}, http.StatusOK)
+
+		raw := string(installAndCaptureCmd(t, ipadHost, ipadDev,
+			titleIDFor(adamMulti, fleet.IPadOSPlatform), app2Installed))
+		require.Contains(t, raw, "<string>ipados</string>",
+			"iPadOS install must use the iPadOS-scoped config")
+		require.NotContains(t, raw, "<string>ios</string>",
+			"iPadOS install must not leak the iOS-scoped config bytes")
+	})
+
+	t.Run("updating configuration → next install carries the new bytes (auto-update guarantee proxy)", func(t *testing.T) {
+		// Per nanoEnqueueVPPInstall, every install path — manual reinstall,
+		// self-service, scheduled auto-update — re-reads the latest stored
+		// configuration at enqueue time. Editing the config between two
+		// installs on the same host is enough to prove the freshness
+		// guarantee without driving the proxy version-bump dance.
+		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
+		const updatedCfg = `<dict><key>K</key><string>updated</string></dict>`
+		s.DoJSON("PATCH",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
+			&updateAppStoreAppRequest{TeamID: &team.ID, Configuration: asJSONString(updatedCfg)},
+			http.StatusOK, &updateAppStoreAppResponse{})
+
+		raw := string(installAndCaptureCmd(t, iosHost, iosDev, titleID, app2Installed))
+		require.Contains(t, raw, "<key>Configuration</key>",
+			"updated install should still carry a Configuration dict")
+		require.Contains(t, raw, "<string>updated</string>",
+			"updated install must carry the latest stored config bytes")
+	})
+
+	t.Run("self-service install carries Configuration with $FLEET_VAR_HOST_UUID resolved", func(t *testing.T) {
+		// Self-service install hits a different entry endpoint
+		// (/api/latest/fleet/device/{uuid}/software/install/{title_id}) but
+		// goes through the same nanoEnqueueVPPInstall path, so the on-the-
+		// wire bytes should match the admin-install path.
+		// Add a fresh app marked self_service:true with a config that uses
+		// $FLEET_VAR_HOST_UUID; install on a host via the device endpoint.
+		ssHost, ssDev := s.createAppleMobileHostThenEnrollMDM("ios")
+		s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, ssDev.SerialNumber)
+		s.Do("POST", "/api/latest/fleet/hosts/transfer",
+			&addHostsToTeamRequest{HostIDs: []uint{ssHost.ID}, TeamID: &team.ID}, http.StatusOK)
+
+		// Mint an identity cert so the device endpoint accepts the request.
+		const certSerial = uint64(987654321)
+		s.addHostIdentityCertificate(ssHost.UUID, certSerial)
+		headers := map[string]string{
+			"X-Client-Cert-Serial": fmt.Sprintf("%d", certSerial),
+		}
+
+		// Drain any leftover verification commands so the new
+		// InstallApplication sits at the head of the device queue.
+		drainVerifyCmds(t, ssDev, app2Installed)
+
+		titleID := titleIDFor(adamMulti, fleet.IOSPlatform)
+		// Make sure the app is marked self_service AND has a known config.
+		s.DoJSON("PATCH",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID),
+			&updateAppStoreAppRequest{TeamID: &team.ID, SelfService: new(true),
+				Configuration: asJSONString(`<dict><key>UUID</key><string>$FLEET_VAR_HOST_UUID</string></dict>`)},
+			http.StatusOK, &updateAppStoreAppResponse{})
+
+		// Trigger self-service install via the device endpoint.
+		s.DoRawWithHeaders("POST",
+			fmt.Sprintf("/api/latest/fleet/device/%s/software/install/%d", ssHost.UUID, titleID),
+			nil, http.StatusAccepted, headers)
+
+		s.awaitRunAppleMDMWorkerSchedule()
+		s.runWorker()
+		cmd, err := ssDev.Idle()
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		require.Equal(t, "InstallApplication", cmd.Command.RequestType)
+		raw := string(cmd.Raw)
+		require.Contains(t, raw, "<key>Configuration</key>",
+			"self-service iOS install should still include Configuration")
+		require.Contains(t, raw, fmt.Sprintf("<string>%s</string>", ssHost.UUID),
+			"self-service install must resolve $FLEET_VAR_HOST_UUID to this host's UUID")
+		_, err = ssDev.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43973

Fixes a few bugs regarding managed app configurations. Includes a few cherry-picks for commits that were supposed to be merged, but got overwritten by subsequent PRs that didn't get pushed properly while working with the github stack.
Also includes some more integration test cases. 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling for VPP managed app configurations that reference unresolvable Fleet variables.

* **Bug Fixes**
  * Fixed cleanup of VPP app configuration data during team deletion.
  * In-house app configurations now apply only to their specific installer instead of sibling installers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45452)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->