### PR TITLE
Revert "[YAML/API/Guide] Self-service: Custom software categories + Install all in category (#45265)"

### DIFF
--- a/articles/software-self-service.md
+++ b/articles/software-self-service.md
@@ -30,36 +30,6 @@ You can also add the software and later make it available in self-service:
 
 If a software item isn't made available in self-service, end users will not see it in **Fleet Desktop > Self-service**. IT admins can still install, update, and uninstall the software from Fleet.
 
-## Manage self-service categories
-
-_Available in Fleet Premium_
-
-Self-service categories group software on each fleet so end users can browse and install software by category on the **My device > Self-service** page.
-
-When a new fleet is created, Fleet seeds it with the following default categories that you can rename or delete: **🌎 Browsers**, **👬 Communication**, **🧰 Developer tools**, **💻 Productivity**, **🔐 Security**, and **🛟 Support**. Category names support emojis (which become part of the name) and can be up to 255 characters long.
-
-To manage categories for a fleet:
-
-1. Select the fleet from the dropdown in the upper left corner of the page.
-2. Select **Software** in the main navigation menu.
-3. Select the self-service categories icon in the upper right corner of the page.
-4. Select **Add category** to create a new category, or use the pencil and trash icons in a row to rename or delete a category.
-
-To assign a software title to one or more categories, edit the software in **Software > Library**, enable **Self-service** in the **Options** section, and check the categories you want to assign.
-
-> Custom categories are managed per fleet. Renaming a category updates the label end users see; deleting a category removes the assignment from any software in it but does not affect the software itself.
-
-## Install all in a category
-
-_Available in Fleet Premium_
-
-End users can install every app in a category in one click from the **My device > Self-service** page:
-
-1. Select a category from the dropdown above the software table.
-2. Select **Install all (n)** to install every app in the category, or **Install missing (n)** to install only the apps that aren't yet installed. The button label and count adjusts based on what's already installed on the device.
-
-Fleet queues each install as a separate operation; end users can monitor progress in the **Status** column. Software is installed in alphabetical order.
-
 ## Deploy self-service on iOS and iPadOS
 
 Install this configuration profile to add the self-service web app to the home screen on iPhone and iPad.

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -541,15 +541,10 @@ Currently, when a `.ipa` file is added in `packages`, Fleet adds software for bo
 
 ```yaml
 software:
-  self_service_categories:
-    - "🌎 Browsers"
-    - "👬 Communication"
-    - "🧰 Developer tools"
-    - "💻 Productivity"
   packages:
     - path: ../lib/software-name.package.yml
       categories:
-        - "🌎 Browsers"
+        - Browsers
       self_service: true
       setup_experience: true
     - path: ../lib/software-name2.package.yml
@@ -560,7 +555,7 @@ software:
         - Product
         - Marketing
       categories:
-        - "👬 Communication"
+        - Communication
       setup_experience: true
       auto_update_enabled: true
       auto_update_window_start: "00:00"
@@ -588,24 +583,21 @@ software:
         - Design
         - Sales
       categories:
-        - "👬 Communication"
-        - "💻 Productivity"
+        - Communication
+        - Productivity
 ```
-
-#### self_service_categories
-
-_Available in Fleet Premium_
-
-- `self_service_categories` is a list of custom self-service category names available on this fleet. End users can browse and install self-service software by category on the **My device > Self-service** page. Custom categories replace Fleet's previous fixed list and are managed per fleet.
-- Each category name must be unique within the fleet (case-insensitive) and is limited to 255 characters. Emojis are supported and are part of the name (e.g. `"🌎 Browsers"`).
-- When a fleet is created, Fleet seeds the following default categories that admins can rename or delete: **🌎 Browsers**, **👬 Communication**, **🧰 Developer tools**, **💻 Productivity**, **🔐 Security**, and **🛟 Support**.
-- `self_service_categories` is an optional key. When the key is included, the listed categories fully replace the fleet's existing self-service categories — any category not listed is deleted. When the key is omitted, existing categories are left unchanged. Software assigned to a deleted category is removed from that category but otherwise unaffected.
 
 #### self_service, labels, categories, and setup_experience
   
 - `self_service` specifies whether end users can install from **Fleet Desktop > Self-service** (default: `false`) on macOS or [self-service web app](https://fleetdm.com/learn-more-about/deploy-self-service-to-ios) on iOS/iPadOS.
 - `labels_include_all` targets hosts that **have all** of the specified labels. `labels_include_any` targets hosts that **have any** of the specified labels. `labels_exclude_any` targets hosts that **have none** of the specified labels. Only one of these fields can be set. If none are set, all hosts are targeted.
-- `categories` is a list of [self-service category names](#self-service-categories) on the fleet. Categories group self-service software on your end users' **Fleet Desktop > My device** page so that end users can filter by category and install all software in a category at once. Each value must match a category defined in the fleet's `self_service_categories`. If `categories` is empty, Fleet-maintained apps get their [default categories](https://github.com/fleetdm/fleet/tree/main/ee/maintained-apps/outputs) (creating them on the fleet if needed) and all other software only appears in the **All** group.
+- `categories` groups self-service software on your end users' **Fleet Desktop > My device** page. If none are set, Fleet-maintained apps get their [default categories](https://github.com/fleetdm/fleet/tree/main/ee/maintained-apps/outputs) and all other software only appears in the **All** group. Supported values:
+  - `Browsers`: shown as **🌎 Browsers**
+  - `Communication`: shown as **👬 Communication**
+  - `Developer tools`: shown as **🧰 Developer tools**
+  - `Productivity`: shown as **🖥️ Productivity**
+  - `Security`: shown as **🔐 Security**
+  - `Utilities`: shown as **🛠️ Utilities**
 - `setup_experience` installs the software when hosts enroll (default: `false`). Learn more in the [setup experience guide](https://fleetdm.com/guides/setup-experience).
 
 ### packages
@@ -657,7 +649,7 @@ software:
          path: ../lib/icons/vpn-setup.png
       self_service: true
       categories:
-        - "🛟 Support"
+        - Utilities
       labels_include_any:
       - Engineering
       - Customer Support

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -11502,7 +11502,7 @@ Update a package to install on macOS, Windows, Linux, iOS, or iPadOS hosts.
 | software        | file    | body | Installer package file or custom script file. Supported packages are `.pkg`, `.msi`, `.exe`, `.deb`, `.rpm`, `.tar.gz`, `.ipa`, `.sh`, and `.ps1`.   |
 | fleet_id         | integer | body | **Required**. The fleet ID. Updates a software package in the specified fleet. |
 | display_name    | string  | body | Optional override for the default `name`. |
-| categories        | array | body | Zero or more [self-service category](#list-self-service-categories) names defined on the fleet, used to group self-service software on your end users' **Fleet Desktop > My device** page. Each value must match a category that exists on the fleet. Software with no categories will still be shown under **All**. |
+| categories        | array | body | Zero or more of the [supported categories](https://fleetdm.com/docs/configuration/yaml-files#supported-software-categories), used to group self-service software on your end users' **Fleet Desktop > My device** page. Software with no categories will be still be shown under **All**. |
 | install_script  | string | body | Command that Fleet runs to install software. If not specified Fleet runs the [default install command](https://github.com/fleetdm/fleet/tree/main/pkg/file/scripts) for each package type. Not supported for `.sh` and `.ps1`. |
 | pre_install_query  | string | body | Query that is pre-install condition. If the query doesn't return any result, the package will not be installed. Not supported for `.sh` and `.ps1`. |
 | post_install_script | string | body | The contents of the script to run after install. If the specified script fails (exit code non-zero) software install will be marked as failed and rolled back. Not supported for `.sh` and `.ps1`. |
@@ -11801,7 +11801,7 @@ Modify an Apple App Store (VPP) or a Google Play app's options.
 | fleet_id       | integer | body | **Required**. The fleet ID. Edits Apple App Store or Android Play store app from the specified fleet.  |
 | display_name    | string  | body | Optional override for the default `name`. |
 | self_service | boolean | body | **Required if platform is Android**. Currently supported for macOS and Android apps. Specifies whether the app shows up in self-service and is available for install by the end user. For macOS shows up on **Fleet Desktop > My device** page, and for Android in **Play Store** app in end user's work profile.  |
-| categories | array | body | Zero or more [self-service category](#list-self-service-categories) names defined on the fleet, used to group self-service software on your end users' **Fleet Desktop > My device** page. Each value must match a category that exists on the fleet. Software with no categories will still be shown under **All**. |
+| categories | array | body | Zero or more of the [supported categories](https://fleetdm.com/docs/configuration/yaml-files#supported-software-categories), used to group self-service software on your end users' **Fleet Desktop > My device** page. Software with no categories will be still be shown under **All**. |
 | auto_update_enabled | boolean | body | Whether to enable automatic updates for iOS/iPadOS App Store (VPP) apps. |
 | auto_update_window_start | string | body | Update window start time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM. Required if `auto_update_enabled` is `true`. |
 | auto_update_window_end | string | body | Update window end time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM. Required if `auto_update_enabled` is `true`. |
@@ -12244,163 +12244,6 @@ Deletes software that's available for install. This won't uninstall the software
 #### Example
 
 `DELETE /api/v1/fleet/software/titles/24/available_for_install?team_id=2`
-
-##### Default response
-
-`Status: 204`
-
-## Self-service categories
-
-_Available in Fleet Premium_
-
-Self-service categories let IT admins group self-service software on each fleet so end users can browse and install software by category on the **My device > Self-service** page.
-
-When a new fleet is created, Fleet seeds it with the following default categories that can be renamed or deleted: **🌎 Browsers**, **👬 Communication**, **🧰 Developer tools**, **💻 Productivity**, **🔐 Security**, and **🛟 Support**.
-
-- [List self-service categories](#list-self-service-categories)
-- [Add self-service category](#add-self-service-category)
-- [Update self-service category](#update-self-service-category)
-- [Delete self-service category](#delete-self-service-category)
-
-### List self-service categories
-
-Lists all self-service categories on the specified fleet.
-
-`GET /api/v1/fleet/software/self_service_categories`
-
-#### Parameters
-
-| Name     | Type    | In    | Description                                                                                                       |
-| -------- | ------- | ----- | ----------------------------------------------------------------------------------------------------------------- |
-| fleet_id | integer | query | **Required**. The fleet ID. Use `0` to list categories for "Unassigned" hosts.                                    |
-
-#### Example
-
-`GET /api/v1/fleet/software/self_service_categories?fleet_id=3`
-
-##### Default response
-
-`Status: 200`
-
-```json
-{
-  "self_service_categories": [
-    {
-      "id": 12,
-      "name": "🌎 Browsers",
-      "fleet_id": 3,
-      "created_at": "2026-05-01T14:22:58Z",
-      "updated_at": "2026-05-01T14:22:58Z"
-    },
-    {
-      "id": 13,
-      "name": "🧰 Developer tools",
-      "fleet_id": 3,
-      "created_at": "2026-05-01T14:22:58Z",
-      "updated_at": "2026-05-01T14:22:58Z"
-    }
-  ]
-}
-```
-
-### Add self-service category
-
-Creates a new self-service category on the specified fleet. Only global and fleet admins and maintainers can call this endpoint.
-
-`POST /api/v1/fleet/software/self_service_categories`
-
-#### Parameters
-
-| Name     | Type    | In   | Description                                                                                                                                                                                                                                                                                |
-| -------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| fleet_id | integer | body | **Required**. The fleet ID. Use `0` to add the category to "Unassigned" hosts.                                                                                                                                                                                                            |
-| name     | string  | body | **Required**. The category name. Must be unique within the fleet (case-insensitive) and at most 255 characters. Emojis are supported and are part of the name (e.g. `"🌎 Browsers"`).                                                                                                       |
-
-#### Example
-
-`POST /api/v1/fleet/software/self_service_categories`
-
-##### Request body
-
-```json
-{
-  "fleet_id": 3,
-  "name": "💼 Engineering"
-}
-```
-
-##### Default response
-
-`Status: 200`
-
-```json
-{
-  "self_service_category": {
-    "id": 42,
-    "name": "💼 Engineering",
-    "fleet_id": 3,
-    "created_at": "2026-05-12T18:45:00Z",
-    "updated_at": "2026-05-12T18:45:00Z"
-  }
-}
-```
-
-### Update self-service category
-
-Renames an existing self-service category. Only global and fleet admins and maintainers can call this endpoint.
-
-`PATCH /api/v1/fleet/software/self_service_categories/:id`
-
-#### Parameters
-
-| Name | Type    | In   | Description                                                                                                                                                |
-| ---- | ------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id   | integer | path | **Required**. The self-service category ID.                                                                                                                |
-| name | string  | body | **Required**. The new category name. Must be unique within the fleet (case-insensitive) and at most 255 characters. Emojis are supported and are part of the name. |
-
-#### Example
-
-`PATCH /api/v1/fleet/software/self_service_categories/42`
-
-##### Request body
-
-```json
-{
-  "name": "💼 Engineering tools"
-}
-```
-
-##### Default response
-
-`Status: 200`
-
-```json
-{
-  "self_service_category": {
-    "id": 42,
-    "name": "💼 Engineering tools",
-    "fleet_id": 3,
-    "created_at": "2026-05-12T18:45:00Z",
-    "updated_at": "2026-05-12T19:01:00Z"
-  }
-}
-```
-
-### Delete self-service category
-
-Deletes the specified self-service category. Software assigned to the deleted category is removed from that category but otherwise unaffected. Only global and fleet admins and maintainers can call this endpoint.
-
-`DELETE /api/v1/fleet/software/self_service_categories/:id`
-
-#### Parameters
-
-| Name | Type    | In   | Description                                  |
-| ---- | ------- | ---- | -------------------------------------------- |
-| id   | integer | path | **Required**. The self-service category ID.  |
-
-#### Example
-
-`DELETE /api/v1/fleet/software/self_service_categories/42`
 
 ##### Default response
 


### PR DESCRIPTION
Reverts #45265.

The original docs PR was merged into `docs-v4.86.0` by mistake. These changes belong on `docs-v4.87.0`. Reverting here so the v4.86 release docs match what's actually shipping in that version. A follow-up PR re-applies the same changes against `docs-v4.87.0`.

Related to: #39018