### PR TITLE
Override Granola Windows installer URL

### DIFF
--- a/ee/maintained-apps/ingesters/winget/external_refs/granola_installer_url.go
+++ b/ee/maintained-apps/ingesters/winget/external_refs/granola_installer_url.go
@@ -1,0 +1,18 @@
+package externalrefs
+
+import (
+	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
+)
+
+// GranolaWindowsInstallerURL overrides the installer URL for Granola on Windows
+// to always use Granola's "download-latest-windows" endpoint instead of the
+// versioned URL surfaced by the winget manifest.
+//
+// Version is kept from winget (not set to "latest") so patch policies still work.
+func GranolaWindowsInstallerURL(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {
+	app.InstallerURL = "https://api.granola.ai/v1/download-latest-windows"
+	// The URL is not pinned to a version, so we can't validate the hash.
+	app.SHA256 = "no_check"
+
+	return app, nil
+}

--- a/ee/maintained-apps/ingesters/winget/external_refs/granola_installer_url_test.go
+++ b/ee/maintained-apps/ingesters/winget/external_refs/granola_installer_url_test.go
@@ -1,0 +1,25 @@
+package externalrefs
+
+import (
+	"testing"
+
+	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGranolaWindowsInstallerURL(t *testing.T) {
+	t.Run("overrides installer URL and sha256, preserves version", func(t *testing.T) {
+		app := &maintained_apps.FMAManifestApp{
+			UniqueIdentifier: "Granola",
+			Slug:             "granola/windows",
+			Version:          "7.205.1",
+			InstallerURL:     "https://api.granola.ai/v1/check-for-update/Granola-7.205.1-win-x64.exe",
+			SHA256:           "c1b34c35fe83cc5852a2bdc9f079029368ed19be49ebffff2a7c965523ebe9cd",
+		}
+		result, err := GranolaWindowsInstallerURL(app)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://api.granola.ai/v1/download-latest-windows", result.InstallerURL)
+		assert.Equal(t, "no_check", result.SHA256)
+		assert.Equal(t, "7.205.1", result.Version)
+	})
+}

--- a/ee/maintained-apps/ingesters/winget/external_refs/main.go
+++ b/ee/maintained-apps/ingesters/winget/external_refs/main.go
@@ -10,6 +10,7 @@ import (
 // Each slug can have multiple enricher functions that run sequentially.
 var Funcs = map[string][]func(*maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error){
 	"1password/windows": {OnePasswordVersionShortener},
+	"granola/windows":   {GranolaWindowsInstallerURL},
 }
 
 // EnrichManifest applies all registered enrichment functions for the given app.

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.205.1') < 0);"
       },
-      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.205.1-win-x64.exe",
+      "installer_url": "https://api.granola.ai/v1/download-latest-windows",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "c1b34c35fe83cc5852a2bdc9f079029368ed19be49ebffff2a7c965523ebe9cd",
+      "sha256": "no_check",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Add an enricher that replaces Granola's Windows installer URL with the `download-latest-windows` endpoint and sets SHA256 to `no_check` while preserving the manifest Version. Register the enricher, add unit tests, and update the generated windows.json output to reflect the new installer_url and sha256. This ensures the ingester uses Granola's latest-download endpoint (the URL is unpinned so hash validation is disabled) while keeping version for patch policies.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45359

