### PR TITLE
bump node-sql-parser fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@sgress454/node-sql-parser": "5.4.0-fork.1",
+    "@sgress454/node-sql-parser": "5.4.0-fork.2",
     "@types/dompurify": "3.0.2",
     "ace-builds": "1.4.14",
     "axios": "1.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2241,10 +2241,10 @@
     redux-thunk "^3.1.0"
     reselect "^5.1.0"
 
-"@sgress454/node-sql-parser@5.4.0-fork.1":
-  version "5.4.0-fork.1"
-  resolved "https://registry.npmjs.org/@sgress454/node-sql-parser/-/node-sql-parser-5.4.0-fork.1.tgz"
-  integrity sha512-c8lAK4EYKYpEWkYeFbEpZP2LC0j4QmC8LX86tCV+ogPo8dsbYWW56VNQRZp7d0XvVbvtfo21rooy+wCI/YoGmg==
+"@sgress454/node-sql-parser@5.4.0-fork.2":
+  version "5.4.0-fork.2"
+  resolved "https://registry.yarnpkg.com/@sgress454/node-sql-parser/-/node-sql-parser-5.4.0-fork.2.tgz#d7977e03d48db2abe0a09b39f58a71cd5fd4c15f"
+  integrity sha512-Z1NIQ1wG8WOVaNfGOhoGEalnNvshooPP5cqB93y2MsDxK/Hpp1mRm1I2mcIUme+FhiRtkurlFQxfN3tZ7U3h3g==
   dependencies:
     "@types/pegjs" "^0.10.0"
     big-integer "^1.6.48"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33759 

Bumps Fleet's `@sgress454/node-sql-parser` to the version that includes https://github.com/sgress454/node-sql-parser/pull/8, with fixes for #33759.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal dependency version for improved compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45472)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->