### PR TITLE
`fleetctl get mdm-commands` now requires the `--host` flag

### DIFF
--- a/changes/44170-fleetctl-mdm-commands-require-host
+++ b/changes/44170-fleetctl-mdm-commands-require-host
@@ -1,0 +1,1 @@
+* `fleetctl get mdm-commands` now requires the `--host` flag. Using `GET /api/v1/fleet/commands` without a host_identifier has been deprecated.

--- a/cmd/fleetctl/fleetctl/get.go
+++ b/cmd/fleetctl/fleetctl/get.go
@@ -1631,12 +1631,16 @@ func getMDMCommandsCommand() *cli.Command {
 	return &cli.Command{
 		Name:    "mdm-commands",
 		Aliases: []string{"mdm_commands"},
-		Usage:   "List information about MDM commands that were run.",
+		Usage:   "List information about MDM commands that were run on a host.",
 		Flags: []cli.Flag{
 			configFlag(),
 			contextFlag(),
 			debugFlag(),
-			byHostIdentifier(),
+			&cli.StringFlag{
+				Name:     "host",
+				Usage:    "Filter MDM commands by host specified by hostname, UUID, or serial number.",
+				Required: true,
+			},
 			byMDMCommandRequestType(),
 			withMDMCommandStatusFilter(),
 		},
@@ -1675,12 +1679,7 @@ func getMDMCommandsCommand() *cli.Command {
 			}
 
 			if len(results) == 0 {
-				if opts.Filters.HostIdentifier != "" {
-					log(c, "No MDM commands have been run on this host.\n")
-					return nil
-				}
-
-				log(c, "You haven't run any MDM commands. Run MDM commands with the `fleetctl mdm run-command` command.\n")
+				log(c, "No MDM commands have been run on this host.\n")
 				return nil
 			}
 

--- a/cmd/fleetctl/fleetctl/get.go
+++ b/cmd/fleetctl/fleetctl/get.go
@@ -1645,6 +1645,11 @@ func getMDMCommandsCommand() *cli.Command {
 			withMDMCommandStatusFilter(),
 		},
 		Action: func(c *cli.Context) error {
+			hostIdent := c.String("host")
+			if hostIdent == "" {
+				return errors.New("No host targeted. Please provide --host.")
+			}
+
 			client, err := clientFromCLI(c)
 			if err != nil {
 				return err
@@ -1664,7 +1669,7 @@ func getMDMCommandsCommand() *cli.Command {
 
 			opts := fleet.MDMCommandListOptions{
 				Filters: fleet.MDMCommandFilters{
-					HostIdentifier:  c.String("host"),
+					HostIdentifier:  hostIdent,
 					RequestType:     c.String("type"),
 					CommandStatuses: commandStatuses,
 				},

--- a/cmd/fleetctl/fleetctl/get.go
+++ b/cmd/fleetctl/fleetctl/get.go
@@ -1638,7 +1638,7 @@ func getMDMCommandsCommand() *cli.Command {
 			debugFlag(),
 			&cli.StringFlag{
 				Name:     "host",
-				Usage:    "Filter MDM commands by host specified by hostname, UUID, or serial number.",
+				Usage:    "Filter MDM commands by host specified by hostname, UUID, or serial number. (required)",
 				Required: true,
 			},
 			byMDMCommandRequestType(),

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -3400,19 +3400,20 @@ func TestGetMDMCommands(t *testing.T) {
 		}, nil, nil, nil
 	}
 
-	listErr = io.ErrUnexpectedEOF
+	// --host is required
 	_, err := RunAppNoChecks([]string{"get", "mdm-commands"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `Required flag "host" not set`)
+
+	expectIdentifier = true
+	listErr = io.ErrUnexpectedEOF
+	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--host", "foo"})
 	require.Error(t, err)
 	require.ErrorContains(t, err, io.ErrUnexpectedEOF.Error())
 
 	listErr = nil
-	empty = true
-	buf, err := RunAppNoChecks([]string{"get", "mdm-commands"})
-	require.NoError(t, err)
-	require.Contains(t, buf.String(), "You haven't run any MDM commands. Run MDM commands with the `fleetctl mdm run-command` command.")
-
 	empty = false
-	buf, err = RunAppNoChecks([]string{"get", "mdm-commands"})
+	buf, err := RunAppNoChecks([]string{"get", "mdm-commands", "--host", "foo"})
 	require.NoError(t, err)
 	require.Contains(t, buf.String(), strings.TrimSpace(`
 
@@ -3430,23 +3431,8 @@ The list of 3 most recent commands:
 `))
 
 	// Test with invalid option
-	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--invalid", "foo"})
+	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--invalid", "foo", "--host", "foo"})
 	require.Error(t, err)
-
-	// Test with host identifier filter
-	listErr = nil
-	empty = false
-	expectIdentifier = true
-	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--host", "foo"})
-	require.NoError(t, err)
-
-	// Test with request type filter
-	listErr = nil
-	empty = false
-	expectRequestType = true
-	expectIdentifier = false
-	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--type", "foo"})
-	require.NoError(t, err)
 
 	// Test with request type and host identifier filter
 	listErr = nil
@@ -3474,11 +3460,6 @@ The list of 3 most recent commands:
 	buf, err = RunAppNoChecks([]string{"get", "mdm-commands", "--host", "foo"})
 	require.NoError(t, err)
 	require.Contains(t, buf.String(), "No MDM commands have been run on this host.")
-
-	// Command status no host
-	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--command_status", "ran"})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `"host_identifier" must be specified when filtering by "command_status"`)
 }
 
 func TestUserIsObserver(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -3405,6 +3405,11 @@ func TestGetMDMCommands(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, `Required flag "host" not set`)
 
+	// --host="" is rejected before any API call
+	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--host", ""})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "No host targeted. Please provide --host.")
+
 	expectIdentifier = true
 	listErr = io.ErrUnexpectedEOF
 	_, err = RunAppNoChecks([]string{"get", "mdm-commands", "--host", "foo"})


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44170 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The CLI command to list MDM commands now requires a --host flag; calling it without a host will error.
  * The API endpoint for listing commands now requires a host_identifier parameter; requests without it are deprecated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45476)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->