### PR TITLE
Added invariant that `MDMProfileSpecsMatch` cannot contain duplicate `path` entries

### DIFF
--- a/changes/45485-mdm-profile-specs-match-duplicate-paths
+++ b/changes/45485-mdm-profile-specs-match-duplicate-paths
@@ -1,1 +1,0 @@
-* Internal: hardened `MDMProfileSpecsMatch` to honor its multiset-equality contract on inputs with duplicate `path` entries. No user-facing behavior change.

--- a/changes/45485-mdm-profile-specs-match-duplicate-paths
+++ b/changes/45485-mdm-profile-specs-match-duplicate-paths
@@ -1,0 +1,1 @@
+* Fixed `MDMProfileSpecsMatch` to correctly compare MDM custom-settings lists that contain duplicate `path` entries. Previously, applying app config or team specs with duplicate paths was incorrectly detected as a change on every apply.

--- a/changes/45485-mdm-profile-specs-match-duplicate-paths
+++ b/changes/45485-mdm-profile-specs-match-duplicate-paths
@@ -1,1 +1,1 @@
-* Fixed `MDMProfileSpecsMatch` to correctly compare MDM custom-settings lists that contain duplicate `path` entries. Previously, applying app config or team specs with duplicate paths was incorrectly detected as a change on every apply.
+* Internal: hardened `MDMProfileSpecsMatch` to honor its multiset-equality contract on inputs with duplicate `path` entries. No user-facing behavior change.

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -836,98 +836,66 @@ func (p *MDMProfileSpec) Copy() *MDMProfileSpec {
 	return &clone
 }
 
-func labelCountMap(labels []string) map[string]int {
-	counts := make(map[string]int)
-	for _, label := range labels {
-		counts[label]++
-	}
-	return counts
-}
-
-// MDMProfileSpecsMatch match checks if two slices contain the same spec
-// elements, regardless of order.
+// MDMProfileSpecsMatch checks if two slices contain the same spec elements,
+// regardless of order. Two specs compare equal when their Path,
+// LabelsIncludeAll (or the deprecated Labels field when LabelsIncludeAll is
+// empty), LabelsIncludeAny, and LabelsExcludeAny fields agree, with each
+// labels list treated as an unordered multiset.
 func MDMProfileSpecsMatch(a, b []MDMProfileSpec) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	pathLabelIncludeCounts := make(map[string]map[string]int)
-	for _, v := range a {
-		// the deprecated Labels field is only relevant if LabelsIncludeAll is
-		// empty.
-		if len(v.LabelsIncludeAll) > 0 {
-			pathLabelIncludeCounts[v.Path] = labelCountMap(v.LabelsIncludeAll)
-		} else {
-			pathLabelIncludeCounts[v.Path] = labelCountMap(v.Labels)
-		}
+	counts := make(map[string]int, len(a))
+	for _, s := range a {
+		counts[mdmProfileSpecKey(s)]++
 	}
-	pathLabelsIncludeAnyCounts := make(map[string]map[string]int)
-	for _, v := range a {
-		pathLabelsIncludeAnyCounts[v.Path] = labelCountMap(v.LabelsIncludeAny)
-	}
-	pathLabelExcludeCounts := make(map[string]map[string]int)
-	for _, v := range a {
-		pathLabelExcludeCounts[v.Path] = labelCountMap(v.LabelsExcludeAny)
-	}
-
-	for _, v := range b {
-		includeLabels, okIncl := pathLabelIncludeCounts[v.Path]
-		includeAnyLabels, okInclAny := pathLabelsIncludeAnyCounts[v.Path]
-		excludeLabels, okExcl := pathLabelExcludeCounts[v.Path]
-		if !okIncl || !okExcl || !okInclAny {
+	for _, s := range b {
+		k := mdmProfileSpecKey(s)
+		counts[k]--
+		if counts[k] < 0 {
 			return false
 		}
+	}
+	return true
+}
 
-		var bLabelIncludeCounts map[string]int
-		if len(v.LabelsIncludeAll) > 0 {
-			bLabelIncludeCounts = labelCountMap(v.LabelsIncludeAll)
-		} else {
-			bLabelIncludeCounts = labelCountMap(v.Labels)
-		}
-		for label, count := range bLabelIncludeCounts {
-			if includeLabels[label] != count {
-				return false
-			}
-			includeLabels[label] -= count
-		}
-		for _, count := range includeLabels {
-			if count != 0 {
-				return false
-			}
-		}
-
-		bLabelIncludeAnyCounts := labelCountMap(v.LabelsIncludeAny)
-		for label, count := range bLabelIncludeAnyCounts {
-			if includeAnyLabels[label] != count {
-				return false
-			}
-			includeAnyLabels[label] -= count
-		}
-		for _, count := range includeAnyLabels {
-			if count != 0 {
-				return false
-			}
-		}
-
-		bLabelExcludeCounts := labelCountMap(v.LabelsExcludeAny)
-		for label, count := range bLabelExcludeCounts {
-			if excludeLabels[label] != count {
-				return false
-			}
-			excludeLabels[label] -= count
-		}
-		for _, count := range excludeLabels {
-			if count != 0 {
-				return false
-			}
-		}
-
-		delete(pathLabelIncludeCounts, v.Path)
-		delete(pathLabelsIncludeAnyCounts, v.Path)
-		delete(pathLabelExcludeCounts, v.Path)
+// mdmProfileSpecKey returns a canonical string representation of an
+// MDMProfileSpec used for multiset equality. Labels are sorted so the order
+// in the slice does not matter; duplicates within a labels list are
+// preserved so the labels themselves are also compared as multisets. NUL
+// separators are used to avoid collisions between fields.
+func mdmProfileSpecKey(s MDMProfileSpec) string {
+	// the deprecated Labels field is only relevant if LabelsIncludeAll is empty
+	include := s.LabelsIncludeAll
+	if len(include) == 0 {
+		include = s.Labels
 	}
 
-	return len(pathLabelIncludeCounts) == 0 && len(pathLabelsIncludeAnyCounts) == 0 && len(pathLabelExcludeCounts) == 0
+	var sb strings.Builder
+	sb.WriteString(s.Path)
+	sb.WriteByte(0)
+	writeSortedLabels(&sb, include)
+	sb.WriteByte(0)
+	writeSortedLabels(&sb, s.LabelsIncludeAny)
+	sb.WriteByte(0)
+	writeSortedLabels(&sb, s.LabelsExcludeAny)
+	return sb.String()
+}
+
+func writeSortedLabels(sb *strings.Builder, labels []string) {
+	if len(labels) == 0 {
+		return
+	}
+	sorted := make([]string, len(labels))
+	copy(sorted, labels)
+	slices.Sort(sorted)
+	for i, l := range sorted {
+		if i > 0 {
+			sb.WriteByte(1)
+		}
+		sb.WriteString(l)
+	}
 }
 
 type MDMLabelsMode string

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -3,7 +3,6 @@ package fleet
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -837,70 +836,123 @@ func (p *MDMProfileSpec) Copy() *MDMProfileSpec {
 	return &clone
 }
 
+func labelCountMap(labels []string) map[string]int {
+	counts := make(map[string]int)
+	for _, label := range labels {
+		counts[label]++
+	}
+	return counts
+}
+
 // MDMProfileSpecsMatch checks if two slices contain the same spec elements,
-// regardless of order. Two specs compare equal when their Path,
-// LabelsIncludeAll (or the deprecated Labels field when LabelsIncludeAll is
-// empty), LabelsIncludeAny, and LabelsExcludeAny fields agree, with each
-// labels list treated as an unordered multiset.
+// regardless of order.
+//
+// Precondition: each slice must contain at most one entry per Path. Upstream
+// validation (`getProfilesContents` in server/service/client.go and
+// `validateCrossPlatformProfileNames` in server/service/mdm.go) enforces this
+// invariant before specs reach storage, so callers always pass unique-Path
+// lists. As a guard, this function returns false if either slice violates
+// the precondition; multiset comparison across duplicate Paths is not
+// supported.
 func MDMProfileSpecsMatch(a, b []MDMProfileSpec) bool {
 	if len(a) != len(b) {
 		return false
 	}
-
-	counts := make(map[string]int, len(a))
-	for _, s := range a {
-		counts[mdmProfileSpecKey(s)]++
+	if hasDuplicatePaths(a) || hasDuplicatePaths(b) {
+		return false
 	}
-	for _, s := range b {
-		k := mdmProfileSpecKey(s)
-		counts[k]--
-		if counts[k] < 0 {
-			return false
+
+	pathLabelIncludeCounts := make(map[string]map[string]int)
+	for _, v := range a {
+		// the deprecated Labels field is only relevant if LabelsIncludeAll is
+		// empty.
+		if len(v.LabelsIncludeAll) > 0 {
+			pathLabelIncludeCounts[v.Path] = labelCountMap(v.LabelsIncludeAll)
+		} else {
+			pathLabelIncludeCounts[v.Path] = labelCountMap(v.Labels)
 		}
 	}
-	return true
-}
-
-// mdmProfileSpecKey returns a canonical string representation of an
-// MDMProfileSpec used for multiset equality. Labels are sorted so the order
-// in the slice does not matter; duplicates within a labels list are
-// preserved so the labels themselves are also compared as multisets. Each
-// field is length-prefixed with a varint so the encoding is collision-free
-// regardless of which bytes paths or label names contain.
-func mdmProfileSpecKey(s MDMProfileSpec) string {
-	// the deprecated Labels field is only relevant if LabelsIncludeAll is empty
-	include := s.LabelsIncludeAll
-	if len(include) == 0 {
-		include = s.Labels
+	pathLabelsIncludeAnyCounts := make(map[string]map[string]int)
+	for _, v := range a {
+		pathLabelsIncludeAnyCounts[v.Path] = labelCountMap(v.LabelsIncludeAny)
+	}
+	pathLabelExcludeCounts := make(map[string]map[string]int)
+	for _, v := range a {
+		pathLabelExcludeCounts[v.Path] = labelCountMap(v.LabelsExcludeAny)
 	}
 
-	var sb strings.Builder
-	writeLengthPrefixed(&sb, s.Path)
-	writeSortedLabels(&sb, include)
-	writeSortedLabels(&sb, s.LabelsIncludeAny)
-	writeSortedLabels(&sb, s.LabelsExcludeAny)
-	return sb.String()
-}
+	for _, v := range b {
+		includeLabels, okIncl := pathLabelIncludeCounts[v.Path]
+		includeAnyLabels, okInclAny := pathLabelsIncludeAnyCounts[v.Path]
+		excludeLabels, okExcl := pathLabelExcludeCounts[v.Path]
+		if !okIncl || !okExcl || !okInclAny {
+			return false
+		}
 
-func writeSortedLabels(sb *strings.Builder, labels []string) {
-	sorted := make([]string, len(labels))
-	copy(sorted, labels)
-	slices.Sort(sorted)
-	writeUvarint(sb, uint64(len(sorted)))
-	for _, l := range sorted {
-		writeLengthPrefixed(sb, l)
+		var bLabelIncludeCounts map[string]int
+		if len(v.LabelsIncludeAll) > 0 {
+			bLabelIncludeCounts = labelCountMap(v.LabelsIncludeAll)
+		} else {
+			bLabelIncludeCounts = labelCountMap(v.Labels)
+		}
+		for label, count := range bLabelIncludeCounts {
+			if includeLabels[label] != count {
+				return false
+			}
+			includeLabels[label] -= count
+		}
+		for _, count := range includeLabels {
+			if count != 0 {
+				return false
+			}
+		}
+
+		bLabelIncludeAnyCounts := labelCountMap(v.LabelsIncludeAny)
+		for label, count := range bLabelIncludeAnyCounts {
+			if includeAnyLabels[label] != count {
+				return false
+			}
+			includeAnyLabels[label] -= count
+		}
+		for _, count := range includeAnyLabels {
+			if count != 0 {
+				return false
+			}
+		}
+
+		bLabelExcludeCounts := labelCountMap(v.LabelsExcludeAny)
+		for label, count := range bLabelExcludeCounts {
+			if excludeLabels[label] != count {
+				return false
+			}
+			excludeLabels[label] -= count
+		}
+		for _, count := range excludeLabels {
+			if count != 0 {
+				return false
+			}
+		}
+
+		delete(pathLabelIncludeCounts, v.Path)
+		delete(pathLabelsIncludeAnyCounts, v.Path)
+		delete(pathLabelExcludeCounts, v.Path)
 	}
+
+	return len(pathLabelIncludeCounts) == 0 && len(pathLabelsIncludeAnyCounts) == 0 && len(pathLabelExcludeCounts) == 0
 }
 
-func writeLengthPrefixed(sb *strings.Builder, s string) {
-	writeUvarint(sb, uint64(len(s)))
-	sb.WriteString(s)
-}
-
-func writeUvarint(sb *strings.Builder, v uint64) {
-	var buf [binary.MaxVarintLen64]byte
-	n := binary.PutUvarint(buf[:], v)
-	sb.Write(buf[:n])
+func hasDuplicatePaths(specs []MDMProfileSpec) bool {
+	if len(specs) < 2 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(specs))
+	for _, s := range specs {
+		if _, dup := seen[s.Path]; dup {
+			return true
+		}
+		seen[s.Path] = struct{}{}
+	}
+	return false
 }
 
 type MDMLabelsMode string

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -863,8 +864,9 @@ func MDMProfileSpecsMatch(a, b []MDMProfileSpec) bool {
 // mdmProfileSpecKey returns a canonical string representation of an
 // MDMProfileSpec used for multiset equality. Labels are sorted so the order
 // in the slice does not matter; duplicates within a labels list are
-// preserved so the labels themselves are also compared as multisets. NUL
-// separators are used to avoid collisions between fields.
+// preserved so the labels themselves are also compared as multisets. Each
+// field is length-prefixed with a varint so the encoding is collision-free
+// regardless of which bytes paths or label names contain.
 func mdmProfileSpecKey(s MDMProfileSpec) string {
 	// the deprecated Labels field is only relevant if LabelsIncludeAll is empty
 	include := s.LabelsIncludeAll
@@ -873,29 +875,32 @@ func mdmProfileSpecKey(s MDMProfileSpec) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(s.Path)
-	sb.WriteByte(0)
+	writeLengthPrefixed(&sb, s.Path)
 	writeSortedLabels(&sb, include)
-	sb.WriteByte(0)
 	writeSortedLabels(&sb, s.LabelsIncludeAny)
-	sb.WriteByte(0)
 	writeSortedLabels(&sb, s.LabelsExcludeAny)
 	return sb.String()
 }
 
 func writeSortedLabels(sb *strings.Builder, labels []string) {
-	if len(labels) == 0 {
-		return
-	}
 	sorted := make([]string, len(labels))
 	copy(sorted, labels)
 	slices.Sort(sorted)
-	for i, l := range sorted {
-		if i > 0 {
-			sb.WriteByte(1)
-		}
-		sb.WriteString(l)
+	writeUvarint(sb, uint64(len(sorted)))
+	for _, l := range sorted {
+		writeLengthPrefixed(sb, l)
 	}
+}
+
+func writeLengthPrefixed(sb *strings.Builder, s string) {
+	writeUvarint(sb, uint64(len(s)))
+	sb.WriteString(s)
+}
+
+func writeUvarint(sb *strings.Builder, v uint64) {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], v)
+	sb.Write(buf[:n])
 }
 
 type MDMLabelsMode string

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -847,18 +847,11 @@ func labelCountMap(labels []string) map[string]int {
 // MDMProfileSpecsMatch checks if two slices contain the same spec elements,
 // regardless of order.
 //
-// Precondition: each slice must contain at most one entry per Path. Upstream
-// validation (`getProfilesContents` in server/service/client.go and
-// `validateCrossPlatformProfileNames` in server/service/mdm.go) enforces this
-// invariant before specs reach storage, so callers always pass unique-Path
-// lists. As a guard, this function returns false if either slice violates
-// the precondition; multiset comparison across duplicate Paths is not
-// supported.
+// Precondition: each slice must contain at most one entry per Path.
 func MDMProfileSpecsMatch(a, b []MDMProfileSpec) bool {
+	mustNotHaveDuplicatePaths("a", a)
+	mustNotHaveDuplicatePaths("b", b)
 	if len(a) != len(b) {
-		return false
-	}
-	if hasDuplicatePaths(a) || hasDuplicatePaths(b) {
 		return false
 	}
 
@@ -941,18 +934,17 @@ func MDMProfileSpecsMatch(a, b []MDMProfileSpec) bool {
 	return len(pathLabelIncludeCounts) == 0 && len(pathLabelsIncludeAnyCounts) == 0 && len(pathLabelExcludeCounts) == 0
 }
 
-func hasDuplicatePaths(specs []MDMProfileSpec) bool {
+func mustNotHaveDuplicatePaths(name string, specs []MDMProfileSpec) {
 	if len(specs) < 2 {
-		return false
+		return
 	}
 	seen := make(map[string]struct{}, len(specs))
 	for _, s := range specs {
 		if _, dup := seen[s.Path]; dup {
-			return true
+			panic(fmt.Sprintf("MDMProfileSpecsMatch: %s contains duplicate Path %q; upstream validation should have rejected this", name, s.Path))
 		}
 		seen[s.Path] = struct{}{}
 	}
-	return false
 }
 
 type MDMLabelsMode string

--- a/server/fleet/mdm_test.go
+++ b/server/fleet/mdm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	nanodep_mock "github.com/fleetdm/fleet/v4/server/mock/nanodep"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 )
 
 func TestDEPClient(t *testing.T) {
@@ -548,6 +550,33 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			// Regression for https://github.com/fleetdm/fleet/issues/45485 —
+			// duplicate Paths must be compared as a multiset, not via a
+			// path-keyed map that collapses duplicates.
+			name: "Duplicate Path Reflexive",
+			a: []fleet.MDMProfileSpec{
+				{Path: "/a"},
+				{Path: "/a"},
+			},
+			b: []fleet.MDMProfileSpec{
+				{Path: "/a"},
+				{Path: "/a"},
+			},
+			expected: true,
+		},
+		{
+			name: "Duplicate Path Mismatch",
+			a: []fleet.MDMProfileSpec{
+				{Path: "/a"},
+				{Path: "/a"},
+			},
+			b: []fleet.MDMProfileSpec{
+				{Path: "/a"},
+				{Path: "/b"},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -556,6 +585,92 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			require.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+// TestMDMProfileSpecsMatchProperties uses property-based testing to verify
+// the contract documented on MDMProfileSpecsMatch ("contain the same spec
+// elements, regardless of order") via invariants that don't depend on a
+// reference implementation:
+//   - Reflexivity: Match(a, a) is always true.
+//   - Symmetry: Match(a, b) == Match(b, a).
+//   - Permutation invariance on the slice: shuffling a does not change
+//     Match(a, b).
+//   - Permutation invariance on labels within a spec: shuffling any of a
+//     spec's labels fields does not change Match(a, b).
+//   - Sensitivity to length: appending an extra element makes Match false.
+//
+// Generators use narrow pools so duplicate Paths and duplicate labels are
+// likely, which is where the multiset semantics matter most.
+func TestMDMProfileSpecsMatchProperties(t *testing.T) {
+	labelGen := rapid.SliceOfN(rapid.SampledFrom([]string{"x", "y", "z"}), 0, 3)
+	pathGen := rapid.SampledFrom([]string{"/a", "/b"})
+	specGen := rapid.Custom(func(t *rapid.T) fleet.MDMProfileSpec {
+		return fleet.MDMProfileSpec{
+			Path:             pathGen.Draw(t, "Path"),
+			Labels:           labelGen.Draw(t, "Labels"),
+			LabelsIncludeAll: labelGen.Draw(t, "LabelsIncludeAll"),
+			LabelsIncludeAny: labelGen.Draw(t, "LabelsIncludeAny"),
+			LabelsExcludeAny: labelGen.Draw(t, "LabelsExcludeAny"),
+		}
+	})
+	sliceGen := rapid.SliceOfN(specGen, 0, 5)
+
+	t.Run("Reflexive", func(t *testing.T) {
+		rapid.Check(t, func(t *rapid.T) {
+			a := sliceGen.Draw(t, "a")
+			require.Truef(t, fleet.MDMProfileSpecsMatch(a, a),
+				"Match(a, a) should be true; a=%+v", a)
+		})
+	})
+
+	t.Run("Symmetric", func(t *testing.T) {
+		rapid.Check(t, func(t *rapid.T) {
+			a := sliceGen.Draw(t, "a")
+			b := sliceGen.Draw(t, "b")
+			require.Equalf(t, fleet.MDMProfileSpecsMatch(a, b), fleet.MDMProfileSpecsMatch(b, a),
+				"Match should be symmetric; a=%+v b=%+v", a, b)
+		})
+	})
+
+	t.Run("PermutationInvariantOnSlice", func(t *testing.T) {
+		rapid.Check(t, func(t *rapid.T) {
+			a := sliceGen.Draw(t, "a")
+			b := sliceGen.Draw(t, "b")
+			aShuf := rapid.Permutation(a).Draw(t, "permA")
+			require.Equalf(t, fleet.MDMProfileSpecsMatch(a, b), fleet.MDMProfileSpecsMatch(aShuf, b),
+				"Match changed after shuffling a; a=%+v aShuf=%+v b=%+v", a, aShuf, b)
+		})
+	})
+
+	t.Run("PermutationInvariantOnLabels", func(t *testing.T) {
+		rapid.Check(t, func(t *rapid.T) {
+			a := sliceGen.Draw(t, "a")
+			b := sliceGen.Draw(t, "b")
+			aShuf := make([]fleet.MDMProfileSpec, len(a))
+			for i, s := range a {
+				prefix := fmt.Sprintf("a[%d]", i)
+				aShuf[i] = fleet.MDMProfileSpec{
+					Path:             s.Path,
+					Labels:           rapid.Permutation(s.Labels).Draw(t, prefix+".Labels"),
+					LabelsIncludeAll: rapid.Permutation(s.LabelsIncludeAll).Draw(t, prefix+".LabelsIncludeAll"),
+					LabelsIncludeAny: rapid.Permutation(s.LabelsIncludeAny).Draw(t, prefix+".LabelsIncludeAny"),
+					LabelsExcludeAny: rapid.Permutation(s.LabelsExcludeAny).Draw(t, prefix+".LabelsExcludeAny"),
+				}
+			}
+			require.Equalf(t, fleet.MDMProfileSpecsMatch(a, b), fleet.MDMProfileSpecsMatch(aShuf, b),
+				"Match changed after shuffling labels inside a; a=%+v aShuf=%+v b=%+v", a, aShuf, b)
+		})
+	})
+
+	t.Run("SensitiveToLengthChange", func(t *testing.T) {
+		rapid.Check(t, func(t *rapid.T) {
+			a := sliceGen.Draw(t, "a")
+			extra := specGen.Draw(t, "extra")
+			aPlus := append(append([]fleet.MDMProfileSpec{}, a...), extra)
+			require.Falsef(t, fleet.MDMProfileSpecsMatch(aPlus, a),
+				"Match should reject slices of different lengths; a=%+v aPlus=%+v", a, aPlus)
+		})
+	})
 }
 
 func TestHasCAVariables(t *testing.T) {

--- a/server/fleet/mdm_test.go
+++ b/server/fleet/mdm_test.go
@@ -577,6 +577,19 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			// Guards the encoding used for multiset keys against control-byte
+			// collisions: a label list ["a","b"] must not collapse to the
+			// same key as a single label "a\x01b".
+			name: "Control Byte Labels Not Collapsed",
+			a: []fleet.MDMProfileSpec{
+				{Path: "/a", LabelsIncludeAll: []string{"a", "b"}},
+			},
+			b: []fleet.MDMProfileSpec{
+				{Path: "/a", LabelsIncludeAll: []string{"a\x01b"}},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -587,7 +600,7 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 	}
 }
 
-// TestMDMProfileSpecsMatchProperties uses property-based testing to verify
+// TestPBT_MDMProfileSpecsMatch uses property-based testing to verify
 // the contract documented on MDMProfileSpecsMatch ("contain the same spec
 // elements, regardless of order") via invariants that don't depend on a
 // reference implementation:
@@ -601,7 +614,7 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 //
 // Generators use narrow pools so duplicate Paths and duplicate labels are
 // likely, which is where the multiset semantics matter most.
-func TestMDMProfileSpecsMatchProperties(t *testing.T) {
+func TestPBT_MDMProfileSpecsMatch(t *testing.T) {
 	labelGen := rapid.SliceOfN(rapid.SampledFrom([]string{"x", "y", "z"}), 0, 3)
 	pathGen := rapid.SampledFrom([]string{"/a", "/b"})
 	specGen := rapid.Custom(func(t *rapid.T) fleet.MDMProfileSpec {

--- a/server/fleet/mdm_test.go
+++ b/server/fleet/mdm_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +19,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	nanodep_mock "github.com/fleetdm/fleet/v4/server/mock/nanodep"
 	"github.com/stretchr/testify/require"
-	"pgregory.net/rapid"
 )
 
 func TestDEPClient(t *testing.T) {
@@ -551,10 +549,13 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			expected: true,
 		},
 		{
-			// Regression for https://github.com/fleetdm/fleet/issues/45485 —
-			// duplicate Paths must be compared as a multiset, not via a
-			// path-keyed map that collapses duplicates.
-			name: "Duplicate Path Reflexive",
+			// Pins the precondition documented on MDMProfileSpecsMatch: duplicate
+			// Paths within a slice are unsupported and produce false, regardless
+			// of whether the other slice is identical. Upstream validation in
+			// client.go and mdm.go prevents duplicates from reaching storage; if
+			// a caller ever violates that invariant, the function fails closed
+			// rather than miscomparing. See issue #45485.
+			name: "Duplicate Paths In Either Slice Returns False",
 			a: []fleet.MDMProfileSpec{
 				{Path: "/a"},
 				{Path: "/a"},
@@ -562,31 +563,6 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			b: []fleet.MDMProfileSpec{
 				{Path: "/a"},
 				{Path: "/a"},
-			},
-			expected: true,
-		},
-		{
-			name: "Duplicate Path Mismatch",
-			a: []fleet.MDMProfileSpec{
-				{Path: "/a"},
-				{Path: "/a"},
-			},
-			b: []fleet.MDMProfileSpec{
-				{Path: "/a"},
-				{Path: "/b"},
-			},
-			expected: false,
-		},
-		{
-			// Guards the encoding used for multiset keys against control-byte
-			// collisions: a label list ["a","b"] must not collapse to the
-			// same key as a single label "a\x01b".
-			name: "Control Byte Labels Not Collapsed",
-			a: []fleet.MDMProfileSpec{
-				{Path: "/a", LabelsIncludeAll: []string{"a", "b"}},
-			},
-			b: []fleet.MDMProfileSpec{
-				{Path: "/a", LabelsIncludeAll: []string{"a\x01b"}},
 			},
 			expected: false,
 		},
@@ -598,92 +574,6 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			require.Equal(t, tc.expected, result)
 		})
 	}
-}
-
-// TestPBT_MDMProfileSpecsMatch uses property-based testing to verify
-// the contract documented on MDMProfileSpecsMatch ("contain the same spec
-// elements, regardless of order") via invariants that don't depend on a
-// reference implementation:
-//   - Reflexivity: Match(a, a) is always true.
-//   - Symmetry: Match(a, b) == Match(b, a).
-//   - Permutation invariance on the slice: shuffling a does not change
-//     Match(a, b).
-//   - Permutation invariance on labels within a spec: shuffling any of a
-//     spec's labels fields does not change Match(a, b).
-//   - Sensitivity to length: appending an extra element makes Match false.
-//
-// Generators use narrow pools so duplicate Paths and duplicate labels are
-// likely, which is where the multiset semantics matter most.
-func TestPBT_MDMProfileSpecsMatch(t *testing.T) {
-	labelGen := rapid.SliceOfN(rapid.SampledFrom([]string{"x", "y", "z"}), 0, 3)
-	pathGen := rapid.SampledFrom([]string{"/a", "/b"})
-	specGen := rapid.Custom(func(t *rapid.T) fleet.MDMProfileSpec {
-		return fleet.MDMProfileSpec{
-			Path:             pathGen.Draw(t, "Path"),
-			Labels:           labelGen.Draw(t, "Labels"),
-			LabelsIncludeAll: labelGen.Draw(t, "LabelsIncludeAll"),
-			LabelsIncludeAny: labelGen.Draw(t, "LabelsIncludeAny"),
-			LabelsExcludeAny: labelGen.Draw(t, "LabelsExcludeAny"),
-		}
-	})
-	sliceGen := rapid.SliceOfN(specGen, 0, 5)
-
-	t.Run("Reflexive", func(t *testing.T) {
-		rapid.Check(t, func(t *rapid.T) {
-			a := sliceGen.Draw(t, "a")
-			require.Truef(t, fleet.MDMProfileSpecsMatch(a, a),
-				"Match(a, a) should be true; a=%+v", a)
-		})
-	})
-
-	t.Run("Symmetric", func(t *testing.T) {
-		rapid.Check(t, func(t *rapid.T) {
-			a := sliceGen.Draw(t, "a")
-			b := sliceGen.Draw(t, "b")
-			require.Equalf(t, fleet.MDMProfileSpecsMatch(a, b), fleet.MDMProfileSpecsMatch(b, a),
-				"Match should be symmetric; a=%+v b=%+v", a, b)
-		})
-	})
-
-	t.Run("PermutationInvariantOnSlice", func(t *testing.T) {
-		rapid.Check(t, func(t *rapid.T) {
-			a := sliceGen.Draw(t, "a")
-			b := sliceGen.Draw(t, "b")
-			aShuf := rapid.Permutation(a).Draw(t, "permA")
-			require.Equalf(t, fleet.MDMProfileSpecsMatch(a, b), fleet.MDMProfileSpecsMatch(aShuf, b),
-				"Match changed after shuffling a; a=%+v aShuf=%+v b=%+v", a, aShuf, b)
-		})
-	})
-
-	t.Run("PermutationInvariantOnLabels", func(t *testing.T) {
-		rapid.Check(t, func(t *rapid.T) {
-			a := sliceGen.Draw(t, "a")
-			b := sliceGen.Draw(t, "b")
-			aShuf := make([]fleet.MDMProfileSpec, len(a))
-			for i, s := range a {
-				prefix := fmt.Sprintf("a[%d]", i)
-				aShuf[i] = fleet.MDMProfileSpec{
-					Path:             s.Path,
-					Labels:           rapid.Permutation(s.Labels).Draw(t, prefix+".Labels"),
-					LabelsIncludeAll: rapid.Permutation(s.LabelsIncludeAll).Draw(t, prefix+".LabelsIncludeAll"),
-					LabelsIncludeAny: rapid.Permutation(s.LabelsIncludeAny).Draw(t, prefix+".LabelsIncludeAny"),
-					LabelsExcludeAny: rapid.Permutation(s.LabelsExcludeAny).Draw(t, prefix+".LabelsExcludeAny"),
-				}
-			}
-			require.Equalf(t, fleet.MDMProfileSpecsMatch(a, b), fleet.MDMProfileSpecsMatch(aShuf, b),
-				"Match changed after shuffling labels inside a; a=%+v aShuf=%+v b=%+v", a, aShuf, b)
-		})
-	})
-
-	t.Run("SensitiveToLengthChange", func(t *testing.T) {
-		rapid.Check(t, func(t *rapid.T) {
-			a := sliceGen.Draw(t, "a")
-			extra := specGen.Draw(t, "extra")
-			aPlus := append(append([]fleet.MDMProfileSpec{}, a...), extra)
-			require.Falsef(t, fleet.MDMProfileSpecsMatch(aPlus, a),
-				"Match should reject slices of different lengths; a=%+v aPlus=%+v", a, aPlus)
-		})
-	})
 }
 
 func TestHasCAVariables(t *testing.T) {

--- a/server/fleet/mdm_test.go
+++ b/server/fleet/mdm_test.go
@@ -548,24 +548,6 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			},
 			expected: true,
 		},
-		{
-			// Pins the precondition documented on MDMProfileSpecsMatch: duplicate
-			// Paths within a slice are unsupported and produce false, regardless
-			// of whether the other slice is identical. Upstream validation in
-			// client.go and mdm.go prevents duplicates from reaching storage; if
-			// a caller ever violates that invariant, the function fails closed
-			// rather than miscomparing. See issue #45485.
-			name: "Duplicate Paths In Either Slice Returns False",
-			a: []fleet.MDMProfileSpec{
-				{Path: "/a"},
-				{Path: "/a"},
-			},
-			b: []fleet.MDMProfileSpec{
-				{Path: "/a"},
-				{Path: "/a"},
-			},
-			expected: false,
-		},
 	}
 
 	for _, tc := range tests {
@@ -574,6 +556,29 @@ func TestMDMProfileSpecsMatch(t *testing.T) {
 			require.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+// TestMDMProfileSpecsMatchPanicsOnDuplicatePaths pins the precondition
+// documented on MDMProfileSpecsMatch: duplicate Paths within a slice are a
+// programming-bug indicator (upstream validation in client.go and mdm.go
+// rejects them before they reach storage), so the function panics rather
+// than silently miscomparing. See issue #45485.
+func TestMDMProfileSpecsMatchPanicsOnDuplicatePaths(t *testing.T) {
+	dup := []fleet.MDMProfileSpec{{Path: "/a"}, {Path: "/a"}}
+	clean := []fleet.MDMProfileSpec{{Path: "/a"}, {Path: "/b"}}
+
+	t.Run("duplicates in a", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			`MDMProfileSpecsMatch: a contains duplicate Path "/a"; upstream validation should have rejected this`,
+			func() { fleet.MDMProfileSpecsMatch(dup, clean) },
+		)
+	})
+	t.Run("duplicates in b", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			`MDMProfileSpecsMatch: b contains duplicate Path "/a"; upstream validation should have rejected this`,
+			func() { fleet.MDMProfileSpecsMatch(clean, dup) },
+		)
+	})
 }
 
 func TestHasCAVariables(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45485 

Not a user-visible change.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to detect and prevent duplicate entries in profile specifications. Users now receive clear error messages when attempting to use invalid data.

* **Tests**
  * Added regression test to verify validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45489)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->