### PR TITLE
Fleet UI: Fix table styling nits

### DIFF
--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -35,6 +35,10 @@
     grid-column: 1 / -1; /* Span across all columns */
     grid-row: 1; /* Place in the first row */
 
+    .table-container__search {
+      flex: 1; // Fill remaining width when stacked
+    }
+
     .Select-multi-value-wrapper {
       height: 36px; // Fixes height issues
       width: 236px;
@@ -136,7 +140,7 @@
 
   &__results-count {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     font-size: $x-small;
     font-weight: $bold;
     color: $core-fleet-black;
@@ -145,8 +149,8 @@
     gap: $gap-table-elements;
 
     > span {
-      line-height: 36px; // Match other header components' height but still align text baseline
       min-width: fit-content;
+      line-height: 1; // Normalize line-height so different font sizes share a consistent center
     }
 
     .count-error {
@@ -197,6 +201,18 @@
       left: 12px;
       font-size: $medium;
       color: $core-fleet-black;
+    }
+  }
+
+  // Tooltip wrapper around search input needs full width so the input can
+  // expand to fill the available space (applies to both stacked and non-stacked layouts).
+  &__search {
+    .component__tooltip-wrapper {
+      width: 100%;
+
+      &__element {
+        width: 100%;
+      }
     }
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/_styles.scss
@@ -22,6 +22,7 @@
       width: 100%; // Search bar across entire table
 
       .input-icon-field__input {
+        width: 100%;
         min-width: 213px;
         height: 36px;
       }

--- a/frontend/pages/SoftwarePage/components/tables/VersionCell/VersionCell.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/VersionCell/VersionCell.tsx
@@ -27,6 +27,7 @@ const VersionCell = <T extends { version: string }>({
       position="top"
       showArrow
       underline={false}
+      fixedPositionStrategy
     >
       <TextCell value={`${versions.length} versions`} italic />
     </TooltipWrapper>

--- a/frontend/pages/SoftwarePage/components/tables/VulnerabilitiesCell/VulnerabilitiesCell.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/VulnerabilitiesCell/VulnerabilitiesCell.tsx
@@ -111,6 +111,7 @@ const VulnerabilitiesCell = ({
       position={tooltipPosition}
       underline={false}
       showArrow
+      fixedPositionStrategy
     >
       <div className={`${baseClass}__vulnerability-text-with-tooltip`}>
         {cell}

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -204,6 +204,7 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
             showArrow
             position="top"
             tipOffset={10}
+            fixedPositionStrategy
           >
             <TextCell italic value={`${numUsers} users`} />
           </TooltipWrapper>

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -60,6 +60,13 @@
           .name__cell {
             max-width: 250px;
           }
+
+          // Override DataTable's 10px vertical margin on tooltip wrappers
+          // to prevent the VulnerabilitiesCell tooltip from making the row
+          // taller than the container, which causes an unnecessary scrollbar.
+          .vulnerabilities-cell .component__tooltip-wrapper {
+            margin: 0;
+          }
         }
       }
 

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -61,12 +61,6 @@
             max-width: 250px;
           }
 
-          // Override DataTable's 10px vertical margin on tooltip wrappers
-          // to prevent the VulnerabilitiesCell tooltip from making the row
-          // taller than the container, which causes an unnecessary scrollbar.
-          .vulnerabilities-cell .component__tooltip-wrapper {
-            margin: 0;
-          }
         }
       }
 


### PR DESCRIPTION
## Issue
Closes #45197 

## Description

## Screenshots 

https://github.com/user-attachments/assets/93f3a33f-855a-4269-a252-7df1ac348620


<img width="1019" height="387" alt="Screenshot 2026-05-14 at 2 27 30 PM" src="https://github.com/user-attachments/assets/ffd25753-3dad-494d-90cd-f9db85897cf8" />
<img width="893" height="531" alt="Screenshot 2026-05-14 at 11 45 43 AM" src="https://github.com/user-attachments/assets/1b4bddc7-de5f-4984-be9e-35decf677885" />
<img width="893" height="650" alt="Screenshot 2026-05-14 at 11 45 48 AM" src="https://github.com/user-attachments/assets/b67a25b7-dd95-4dd6-987a-1e901f448f33" />
<img width="899" height="537" alt="Screenshot 2026-05-14 at 11 45 53 AM" src="https://github.com/user-attachments/assets/0fcc2601-3bca-4ca4-b062-53de4c720996" />


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search inputs now fill available width across table and header layouts.
  * Tooltips adjusted to avoid increasing row height or triggering unnecessary scrollbars.
  * Result counters and header elements vertically centered for consistent alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45495)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->