### PR TITLE
Fixed an issue where the MDM solution name reported for a host could flip between values across osquery ingestions

### DIFF
--- a/changes/45491-mdm-name-from-server-url-nondeterministic
+++ b/changes/45491-mdm-name-from-server-url-nondeterministic
@@ -1,0 +1,1 @@
+- Fixed an issue where the MDM solution name reported for a host could flip between values across osquery ingestions when the MDM server URL contained substrings matching multiple known MDM vendors.

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1298,27 +1298,37 @@ const (
 	WellKnownMDMMosyle    = "Mosyle"
 )
 
-var mdmNameFromServerURLChecks = map[string]string{
-	"kandji":    WellKnownMDMIru,
-	"iru.com":   WellKnownMDMIru, // inclue top-level domain to disabmiguate from other strings that may contain "iru"
-	"jamf":      WellKnownMDMJamf,
-	"jumpcloud": WellKnownMDMJumpCloud,
-	"airwatch":  WellKnownMDMVMWare,
-	"awmdm":     WellKnownMDMVMWare,
-	"microsoft": WellKnownMDMIntune,
-	"simplemdm": WellKnownMDMSimpleMDM,
-	"fleetdm":   WellKnownMDMFleet,
-	"mosyle":    WellKnownMDMMosyle,
+// mdmNameFromServerURLChecks maps URL substrings to well-known MDM solution names.
+// The first matching entry wins, so more-specific substrings must appear before
+// more-generic ones (e.g. "jumpcloud" before "awmdm", since JumpCloud's MDM is
+// hosted on AirWatch/awmdm.com infrastructure and "jumpcloud.awmdm.com" must
+// resolve to JumpCloud rather than VMware Workspace ONE).
+var mdmNameFromServerURLChecks = []struct {
+	substring string
+	name      string
+}{
+	{"kandji", WellKnownMDMIru},
+	{"iru.com", WellKnownMDMIru}, // include top-level domain to disambiguate from other strings that may contain "iru"
+	{"jamf", WellKnownMDMJamf},
+	{"jumpcloud", WellKnownMDMJumpCloud},
+	{"airwatch", WellKnownMDMVMWare},
+	{"awmdm", WellKnownMDMVMWare},
+	{"microsoft", WellKnownMDMIntune},
+	{"simplemdm", WellKnownMDMSimpleMDM},
+	{"fleetdm", WellKnownMDMFleet},
+	{"mosyle", WellKnownMDMMosyle},
 }
 
 // MDMNameFromServerURL returns the MDM solution name corresponding to the
 // given server URL. If no match is found, it returns the unknown MDM name.
+// The check order is deterministic: the first matching substring in
+// mdmNameFromServerURLChecks wins.
 func MDMNameFromServerURL(serverURL string) string {
 	serverURL = strings.ToLower(serverURL)
 
-	for check, name := range mdmNameFromServerURLChecks {
-		if strings.Contains(serverURL, check) {
-			return name
+	for _, check := range mdmNameFromServerURLChecks {
+		if strings.Contains(serverURL, check.substring) {
+			return check.name
 		}
 	}
 	return UnknownMDMName

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -417,3 +417,35 @@ func TestHasJSONProfileAssigned(t *testing.T) {
 		})
 	}
 }
+
+func TestMDMNameFromServerURL(t *testing.T) {
+	testCases := []struct {
+		name      string
+		serverURL string
+		expected  string
+	}{
+		{"empty", "", UnknownMDMName},
+		{"unknown", "https://example.com/mdm", UnknownMDMName},
+		{"kandji", "https://example.kandji.io", WellKnownMDMIru},
+		{"iru", "https://mdm.iru.com", WellKnownMDMIru},
+		{"jamf", "https://example.jamfcloud.com", WellKnownMDMJamf},
+		{"jumpcloud", "https://example.jumpcloud.com", WellKnownMDMJumpCloud},
+		{"airwatch", "https://example.airwatch.com", WellKnownMDMVMWare},
+		{"awmdm", "https://example.awmdm.com", WellKnownMDMVMWare},
+		{"microsoft intune", "https://manage.microsoft.com", WellKnownMDMIntune},
+		{"simplemdm", "https://example.simplemdm.com", WellKnownMDMSimpleMDM},
+		{"fleetdm", "https://example.fleetdm.com", WellKnownMDMFleet},
+		{"mosyle", "https://example.mosyle.com", WellKnownMDMMosyle},
+		{"mixed case is normalized", "https://Example.JumpCloud.com", WellKnownMDMJumpCloud},
+		// Ambiguous URLs must resolve deterministically. JumpCloud's MDM is hosted on
+		// AirWatch/awmdm.com infrastructure, so jumpcloud.awmdm.com must resolve to
+		// JumpCloud rather than VMware Workspace ONE.
+		{"jumpcloud on awmdm infrastructure", "https://jumpcloud.awmdm.com", WellKnownMDMJumpCloud},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, MDMNameFromServerURL(tc.serverURL))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45491 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deterministic MDM solution name reporting for osquery ingestions when server URLs match multiple vendor substrings; resolves ambiguous matches (e.g., jumpcloud.awmdm.com) and normalizes case.

* **Tests**
  * Added unit tests covering empty/unknown inputs, multiple vendor hostnames, case-insensitive URLs, and ambiguous-match resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45496)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->