### PR TITLE
Fix checkout action version in `fleetctl new` template

### DIFF
--- a/changes/fix-fleetctl-new-checkout-action
+++ b/changes/fix-fleetctl-new-checkout-action
@@ -1,0 +1,1 @@
+- Updated the version of the checkout action in the `fleetctl new` template to avoid Node warnings.

--- a/cmd/fleetctl/fleetctl/templates/new/.github/workflows/workflow.template.yml
+++ b/cmd/fleetctl/fleetctl/templates/new/.github/workflows/workflow.template.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Make github action script executable
         run: chmod +x ./.github/fleet-gitops/gitops.sh

--- a/cmd/fleetctl/fleetctl/templates/new/.github/workflows/workflow.template.yml
+++ b/cmd/fleetctl/fleetctl/templates/new/.github/workflows/workflow.template.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@v6
 
       - name: Make github action script executable
         run: chmod +x ./.github/fleet-gitops/gitops.sh


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/confidential/issues/15917

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
 - I didn't see any tests that checked the contents of the templates directly; will update if anything fails.
- [X] QA'd all new/changed functionality manually
 - Tested on my test gitops repo: https://github.com/sgress454/fleet-gitops-test/actions/runs/25875796027/job/76042556514


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Node-related warnings that appeared when using the Fleet "new" project and GitOps workflow templates, improving clarity during template execution and initial project setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45502)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->