### PR TITLE
Add Windows Secure Boot CA 2023 migration report and scripts

### DIFF
--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -77,6 +77,8 @@ controls:
     - path: ../lib/macos/scripts/uninstall-fleetd-macos.sh
     # Windows scripts
     - path: ../lib/windows/scripts/uninstall-fleetd-windows.ps1
+    - path: ../lib/windows/scripts/migrate-windows-ca-2023.ps1
+    - path: ../lib/windows/scripts/verify-windows-ca-2023.ps1
     # Linux scripts
     - path: ../lib/linux/scripts/uninstall-fleetd-linux.sh
     - path: ../lib/linux/scripts/install-fleet-desktop-required-extension.sh
@@ -85,6 +87,8 @@ policies:
   # Linux policies
   - path: ../lib/linux/policies/check-fleet-desktop-extension-enabled.yml
 reports:
+  # Windows reports
+ - path: ../lib/windows/reports/windows-ca-2023.yml
 software:
   packages:
     # Linux apps

--- a/it-and-security/lib/windows/reports/windows-ca-2023.yml
+++ b/it-and-security/lib/windows/reports/windows-ca-2023.yml
@@ -1,0 +1,61 @@
+- name: Windows Secure Boot CA 2023 migration state
+  automations_enabled: false
+  description: |
+    Detects per-host migration state for KB5025885 / CVE-2023-24932.
+    Combines file signatures on disk with the Microsoft servicing state
+    machine. One row per boot binary. compliance_verdict column gives
+    the per-row verdict (compliant_via_files, compliant_via_registry,
+    in_progress, errored, not_started).
+  discard_data: false
+  interval: 86400
+  logging: snapshot
+  observer_can_run: true
+  platform: windows
+  query: |
+    SELECT
+      a.path,
+      a.issuer_name,
+      a.result,
+      CASE
+        WHEN a.issuer_name LIKE '%Windows UEFI CA 2023%' THEN 'migrated'
+        WHEN a.issuer_name LIKE '%Production PCA 2011%' THEN 'not_migrated'
+        ELSE 'unknown'
+      END AS file_status,
+      (SELECT data FROM registry
+       WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+         AND name = 'UEFICA2023Status') AS reg_status,
+      (SELECT data FROM registry
+       WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+         AND name = 'WindowsUEFICA2023Capable') AS reg_capable,
+      (SELECT data FROM registry
+       WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+         AND name = 'UEFICA2023Error') AS reg_error,
+      CASE
+        WHEN a.issuer_name LIKE '%Windows UEFI CA 2023%'
+          THEN 'compliant_via_files'
+        WHEN (SELECT data FROM registry
+              WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+                AND name = 'UEFICA2023Status') = 'Updated'
+         AND (SELECT data FROM registry
+              WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+                AND name = 'WindowsUEFICA2023Capable') = '2'
+         AND IFNULL((SELECT data FROM registry
+                     WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+                       AND name = 'UEFICA2023Error'), '0') = '0'
+          THEN 'compliant_via_registry'
+        WHEN CAST(IFNULL((SELECT data FROM registry
+                          WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+                            AND name = 'UEFICA2023Error'), '0') AS INTEGER) > 0
+          THEN 'errored'
+        WHEN (SELECT data FROM registry
+              WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing'
+                AND name = 'UEFICA2023Status') = 'InProgress'
+          THEN 'in_progress'
+        ELSE 'not_started'
+      END AS compliance_verdict
+    FROM authenticode a
+    WHERE a.path IN (
+      'C:\Windows\Boot\EFI\bootmgfw.efi',
+      'C:\Windows\System32\winload.efi',
+      'C:\Windows\System32\winresume.efi'
+    );

--- a/it-and-security/lib/windows/reports/windows-ca-2023.yml
+++ b/it-and-security/lib/windows/reports/windows-ca-2023.yml
@@ -13,7 +13,7 @@
   platform: windows
   query: |
     SELECT
-      a.path,
+      expected_paths.path,
       a.issuer_name,
       a.result,
       CASE
@@ -53,9 +53,9 @@
           THEN 'in_progress'
         ELSE 'not_started'
       END AS compliance_verdict
-    FROM authenticode a
-    WHERE a.path IN (
-      'C:\Windows\Boot\EFI\bootmgfw.efi',
-      'C:\Windows\System32\winload.efi',
-      'C:\Windows\System32\winresume.efi'
-    );
+    FROM (
+      SELECT 'C:\Windows\Boot\EFI\bootmgfw.efi' AS path
+      UNION ALL SELECT 'C:\Windows\System32\winload.efi'
+      UNION ALL SELECT 'C:\Windows\System32\winresume.efi'
+    ) AS expected_paths
+    LEFT JOIN authenticode AS a ON expected_paths.path = a.path;

--- a/it-and-security/lib/windows/scripts/migrate-windows-ca-2023.ps1
+++ b/it-and-security/lib/windows/scripts/migrate-windows-ca-2023.ps1
@@ -26,6 +26,7 @@
       3 = Cumulative update too old (run Windows Update first)
       4 = Errored state (UEFICA2023Error != 0); manual investigation required
       5 = Reboot pending; reboot to advance migration
+      6 = Boot file missing or signature unreadable; cannot proceed with remediation
 
     References:
       KB5025885: https://support.microsoft.com/en-us/topic/41a975df-beb2-40c1-99a3-b3ff139f832d
@@ -53,7 +54,7 @@ if (-not $secureBootEnabled) {
 Write-State "Secure Boot" "enabled"
 
 # --- Preflight: cumulative update current enough ---
-$secBootTask = Get-ScheduledTask -TaskName "Secure-Boot-Update" -ErrorAction SilentlyContinue
+$secBootTask = Get-ScheduledTask -TaskPath "\Microsoft\Windows\PI\" -TaskName "Secure-Boot-Update" -ErrorAction SilentlyContinue
 if (-not $secBootTask) {
     Write-Output "FAIL: \Microsoft\Windows\PI\Secure-Boot-Update task missing."
     Write-Output "      Cumulative update too old. Install latest CU and retry."
@@ -82,7 +83,9 @@ foreach ($f in $bootFiles) {
     }
     $issuer = $null
     try { $issuer = (Get-AuthenticodeSignature $f).SignerCertificate.Issuer } catch {}
-    if ($issuer -match 'Windows UEFI CA 2023') {
+    if (-not $issuer) {
+        Write-State $name "signature unreadable"
+    } elseif ($issuer -match 'Windows UEFI CA 2023') {
         Write-State $name "CA 2023 (migrated)"
         $migratedCount++
     } elseif ($issuer -match 'Production PCA 2011') {
@@ -90,6 +93,32 @@ foreach ($f in $bootFiles) {
     } else {
         Write-State $name "unknown issuer: $issuer"
     }
+}
+
+# --- Early exit if inspection incomplete ---
+if ($missingCount -gt 0) {
+    Write-Output ""
+    Write-Output "FAIL: $missingCount boot file(s) missing. Cannot proceed with remediation."
+    Write-State "State" "inspection_incomplete_missing_files"
+    exit 6
+}
+
+# Check for any unreadable signatures
+$unreadableCount = 0
+foreach ($f in $bootFiles) {
+    if (Test-Path $f) {
+        $issuer = $null
+        try { $issuer = (Get-AuthenticodeSignature $f).SignerCertificate.Issuer } catch {}
+        if (-not $issuer) {
+            $unreadableCount++
+        }
+    }
+}
+if ($unreadableCount -gt 0) {
+    Write-Output ""
+    Write-Output "FAIL: $unreadableCount boot file(s) have unreadable signatures. Cannot proceed with remediation."
+    Write-State "State" "inspection_incomplete_unreadable_signatures"
+    exit 6
 }
 
 # --- Inspect registry servicing state machine ---
@@ -163,7 +192,15 @@ if ($migratedCount -gt 0) {
     Write-Output "Triggering CA 2023 migration (AvailableUpdates = 0x5944) ..."
 }
 Set-ItemProperty -Path $secureboot -Name "AvailableUpdates" -Value 0x5944 -Type DWord -Force
-Start-ScheduledTask -TaskName "\Microsoft\Windows\PI\Secure-Boot-Update"
+$taskStarted = $null
+try {
+    Start-ScheduledTask -TaskPath "\Microsoft\Windows\PI\" -TaskName "Secure-Boot-Update"
+    $taskStarted = Get-ScheduledTask -TaskPath "\Microsoft\Windows\PI\" -TaskName "Secure-Boot-Update" -ErrorAction SilentlyContinue
+} catch {}
+if (-not $taskStarted) {
+    Write-Output "FAIL: Could not start Secure-Boot-Update task."
+    exit 3
+}
 
 Write-Output "OK: Migration triggered. Reboot required (sometimes two)."
 Write-Output "    Re-run this script after each reboot to confirm progress."

--- a/it-and-security/lib/windows/scripts/migrate-windows-ca-2023.ps1
+++ b/it-and-security/lib/windows/scripts/migrate-windows-ca-2023.ps1
@@ -1,0 +1,170 @@
+<#
+.SYNOPSIS
+    Migrates a Windows host to Secure Boot CA 2023 trust chain (KB5025885).
+
+.DESCRIPTION
+    Closes CVE-2023-24932 / BlackLotus boot manager swap vulnerability and
+    ensures continued Secure Boot servicing past PCA 2011 expiry (June 2026).
+
+    Verifies completion by checking BOTH:
+      - File signatures on disk (bootmgfw.efi, winload.efi, winresume.efi)
+      - Registry servicing state machine (UEFICA2023Status, Error, Capable)
+
+    Idempotent and conservative:
+      - Skips if all 3 boot binaries are already signed by CA 2023
+      - Respects in-progress workflows (does not retrigger)
+      - Bails if errored state detected (does not retry blindly)
+      - Bails if prerequisites missing (Secure Boot off, CU too old)
+
+.OUTPUTS
+    Structured key:value output to stdout for log capture / parsing.
+
+.NOTES
+    Exit codes:
+      0 = Migration complete, in progress, or just triggered (no action needed)
+      2 = Secure Boot not enabled in firmware (firmware change required)
+      3 = Cumulative update too old (run Windows Update first)
+      4 = Errored state (UEFICA2023Error != 0); manual investigation required
+      5 = Reboot pending; reboot to advance migration
+
+    References:
+      KB5025885: https://support.microsoft.com/en-us/topic/41a975df-beb2-40c1-99a3-b3ff139f832d
+      MS Secure Boot Playbook (Feb 2026):
+      https://techcommunity.microsoft.com/blog/windows-itpro-blog/secure-boot-playbook-for-certificates-expiring-in-2026/4469235
+#>
+
+$ErrorActionPreference = 'Stop'
+
+function Write-State {
+    param([string]$Label, [string]$Value)
+    Write-Output ("{0,-30} : {1}" -f $Label, $Value)
+}
+
+Write-Output "=== Windows Secure Boot CA 2023 migration ==="
+Write-Output ""
+
+# --- Preflight: Secure Boot enabled ---
+$secureBootEnabled = $false
+try { $secureBootEnabled = Confirm-SecureBootUEFI } catch {}
+if (-not $secureBootEnabled) {
+    Write-Output "FAIL: Secure Boot not enabled in firmware. Enable before running."
+    exit 2
+}
+Write-State "Secure Boot" "enabled"
+
+# --- Preflight: cumulative update current enough ---
+$secBootTask = Get-ScheduledTask -TaskName "Secure-Boot-Update" -ErrorAction SilentlyContinue
+if (-not $secBootTask) {
+    Write-Output "FAIL: \Microsoft\Windows\PI\Secure-Boot-Update task missing."
+    Write-Output "      Cumulative update too old. Install latest CU and retry."
+    exit 3
+}
+Write-State "Secure-Boot-Update task" "present"
+
+# --- Inspect file signatures ---
+Write-Output ""
+Write-Output "--- File signatures ---"
+
+$bootFiles = @(
+    "$env:SystemRoot\Boot\EFI\bootmgfw.efi",
+    "$env:SystemRoot\System32\winload.efi",
+    "$env:SystemRoot\System32\winresume.efi"
+)
+
+$migratedCount = 0
+$missingCount  = 0
+foreach ($f in $bootFiles) {
+    $name = Split-Path $f -Leaf
+    if (-not (Test-Path $f)) {
+        Write-State $name "MISSING"
+        $missingCount++
+        continue
+    }
+    $issuer = $null
+    try { $issuer = (Get-AuthenticodeSignature $f).SignerCertificate.Issuer } catch {}
+    if ($issuer -match 'Windows UEFI CA 2023') {
+        Write-State $name "CA 2023 (migrated)"
+        $migratedCount++
+    } elseif ($issuer -match 'Production PCA 2011') {
+        Write-State $name "PCA 2011 (not migrated)"
+    } else {
+        Write-State $name "unknown issuer: $issuer"
+    }
+}
+
+# --- Inspect registry servicing state machine ---
+Write-Output ""
+Write-Output "--- Registry servicing state ---"
+
+$servicing  = "HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing"
+$secureboot = "HKLM:\SYSTEM\CurrentControlSet\Control\Secureboot"
+
+$regStatus    = (Get-ItemProperty -Path $servicing  -Name "UEFICA2023Status"         -ErrorAction SilentlyContinue).UEFICA2023Status
+$regCapable   = (Get-ItemProperty -Path $servicing  -Name "WindowsUEFICA2023Capable" -ErrorAction SilentlyContinue).WindowsUEFICA2023Capable
+$regError     = (Get-ItemProperty -Path $servicing  -Name "UEFICA2023Error"          -ErrorAction SilentlyContinue).UEFICA2023Error
+$regAvailable = (Get-ItemProperty -Path $secureboot -Name "AvailableUpdates"         -ErrorAction SilentlyContinue).AvailableUpdates
+
+$availableStr = if ($null -ne $regAvailable) { "0x{0:X4} ({1})" -f $regAvailable, $regAvailable } else { "(not set)" }
+
+$statusStr  = if ($regStatus)              { $regStatus }              else { "(not set)" }
+$capableStr = if ($null -ne $regCapable)   { $regCapable.ToString() }  else { "(not set)" }
+$errorStr   = if ($null -ne $regError)     { $regError.ToString() }    else { "(not set)" }
+
+Write-State "UEFICA2023Status"         $statusStr
+Write-State "WindowsUEFICA2023Capable" $capableStr
+Write-State "UEFICA2023Error"          $errorStr
+Write-State "AvailableUpdates"         $availableStr
+
+# --- Decision: idempotency, conservative paths ---
+Write-Output ""
+Write-Output "--- Decision ---"
+
+# Fully migrated: all 3 files on CA 2023, no error
+if ($migratedCount -eq 3 -and (-not $regError -or $regError -eq 0)) {
+    Write-Output "OK: Fully migrated. All boot binaries signed by CA 2023."
+    exit 0
+}
+
+# Errored state: do not retry
+if ($regError -and $regError -ne 0) {
+    Write-Output "FAIL: UEFICA2023Error = $regError. Manual investigation required."
+    Write-Output "      Check Event Viewer > System for Event ID 1801 (DB update blocked)"
+    Write-Output "      or 1803 (no PK-signed KEK)."
+    exit 4
+}
+
+# Firmware servicing reports Updated — done at firmware level even if OS-side files lag
+if ($regStatus -eq 'Updated') {
+    Write-Output "OK: Servicing reports Updated (capable = $regCapable)."
+    Write-Output "    Firmware-level migration complete. OS-side files may show PCA 2011"
+    Write-Output "    until the next Windows Update cycle refreshes the staging copy."
+    Write-Output "    Run verify-windows-ca-2023.ps1 to confirm firmware DB / ESP state."
+    exit 0
+}
+
+# In-flight: leave alone
+if ($regStatus -eq 'InProgress') {
+    Write-Output "OK: Migration in progress (UEFICA2023Status = InProgress)."
+    Write-Output "    Files migrated: $migratedCount / 3. Reboot may be required to advance."
+    exit 0
+}
+
+# Reboot pending
+if ($regAvailable -eq 0x4100) {
+    Write-Output "WAIT: Reboot pending (AvailableUpdates = 0x4100)."
+    Write-Output "      Reboot to advance migration. Re-run script after reboot."
+    exit 5
+}
+
+# Trigger full deployment
+if ($migratedCount -gt 0) {
+    Write-Output "Partial migration detected ($migratedCount / 3 files on CA 2023). Retriggering."
+} else {
+    Write-Output "Triggering CA 2023 migration (AvailableUpdates = 0x5944) ..."
+}
+Set-ItemProperty -Path $secureboot -Name "AvailableUpdates" -Value 0x5944 -Type DWord -Force
+Start-ScheduledTask -TaskName "\Microsoft\Windows\PI\Secure-Boot-Update"
+
+Write-Output "OK: Migration triggered. Reboot required (sometimes two)."
+Write-Output "    Re-run this script after each reboot to confirm progress."
+exit 0

--- a/it-and-security/lib/windows/scripts/verify-windows-ca-2023.ps1
+++ b/it-and-security/lib/windows/scripts/verify-windows-ca-2023.ps1
@@ -35,7 +35,11 @@ Write-Output ""
 
 # --- Secure Boot enabled ---
 $sb = $null
-try { $sb = Confirm-SecureBootUEFI } catch {}
+try {
+    $sb = Confirm-SecureBootUEFI
+} catch {
+    Write-State "Secure Boot check" "FAILED: $_"
+}
 Write-State "Secure Boot enabled" $sb
 
 # --- Firmware DB: is CA 2023 trusted? ---
@@ -79,7 +83,12 @@ foreach ($f in $bootFiles) {
         continue
     }
     $issuer = $null
-    try { $issuer = (Get-AuthenticodeSignature $f).SignerCertificate.Issuer } catch {}
+    try {
+        $issuer = (Get-AuthenticodeSignature $f).SignerCertificate.Issuer
+    } catch {
+        Write-State $name "signature read FAILED: $_"
+        continue
+    }
     $tag = if ($issuer -match 'Windows UEFI CA 2023')      { 'CA 2023' }
            elseif ($issuer -match 'Production PCA 2011')   { 'PCA 2011' }
            else { "unknown: $issuer" }
@@ -126,7 +135,7 @@ $capable   = (Get-ItemProperty -Path $servicing  -Name "WindowsUEFICA2023Capable
 $err       = (Get-ItemProperty -Path $servicing  -Name "UEFICA2023Error"          -ErrorAction SilentlyContinue).UEFICA2023Error
 $available = (Get-ItemProperty -Path $secureboot -Name "AvailableUpdates"         -ErrorAction SilentlyContinue).AvailableUpdates
 
-$statusStr  = if ($status)              { $status }              else { "(not set)" }
+$statusStr  = if ($null -ne $status)    { $status }              else { "(not set)" }
 $capableStr = if ($null -ne $capable)   { $capable.ToString() }  else { "(not set)" }
 $errStr     = if ($null -ne $err)       { $err.ToString() }      else { "(not set)" }
 $availStr   = if ($null -ne $available) { "0x{0:X4}" -f $available } else { "(not set)" }

--- a/it-and-security/lib/windows/scripts/verify-windows-ca-2023.ps1
+++ b/it-and-security/lib/windows/scripts/verify-windows-ca-2023.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+    Verifies Windows Secure Boot CA 2023 migration at firmware level.
+
+.DESCRIPTION
+    Reads firmware-level state that osquery cannot see:
+      - CA 2023 presence in firmware DB
+      - DBX (deny list) size as rough revocation indicator
+      - Boot manager signature on the EFI System Partition (the real one
+        firmware loads, not the OS-side staging copy)
+
+    Also reports OS-side file signatures and registry servicing state for
+    side-by-side comparison.
+
+    READ-ONLY. Makes no changes to the system.
+
+.NOTES
+    Intended use:
+      - Confirm hosts reported as `compliant_via_registry` in the Fleet
+        report are actually migrated at firmware level
+      - Diagnose hosts stuck in unusual servicing states
+
+    Exit code: always 0 unless PowerShell itself errors. Output is the deliverable.
+#>
+
+$ErrorActionPreference = 'Continue'
+
+function Write-State {
+    param([string]$Label, [string]$Value)
+    Write-Output ("{0,-32} : {1}" -f $Label, $Value)
+}
+
+Write-Output "=== Windows Secure Boot CA 2023 verification ==="
+Write-Output ""
+
+# --- Secure Boot enabled ---
+$sb = $null
+try { $sb = Confirm-SecureBootUEFI } catch {}
+Write-State "Secure Boot enabled" $sb
+
+# --- Firmware DB: is CA 2023 trusted? ---
+Write-Output ""
+Write-Output "--- Firmware DB ---"
+try {
+    $dbBytes = (Get-SecureBootUEFI db).bytes
+    $dbText  = [Text.Encoding]::ASCII.GetString($dbBytes)
+    Write-State "CA 2023 present"  ($dbText -match 'Windows UEFI CA 2023')
+    Write-State "PCA 2011 present" ($dbText -match 'Microsoft Windows Production PCA 2011')
+    Write-State "DB size (bytes)"  $dbBytes.Length
+} catch {
+    Write-State "DB read" "FAILED: $_"
+}
+
+# --- DBX (deny list) size as revocation indicator ---
+Write-Output ""
+Write-Output "--- DBX (deny list) ---"
+try {
+    $dbxBytes = (Get-SecureBootUEFI dbx).bytes
+    Write-State "DBX size (bytes)" $dbxBytes.Length
+    Write-Output "    Pre-revocation DBX is typically ~16-32 KB."
+    Write-Output "    Post-revocation DBX is much larger (often 100+ KB)."
+} catch {
+    Write-State "DBX read" "FAILED: $_"
+}
+
+# --- OS-side staging files ---
+Write-Output ""
+Write-Output "--- OS-side files (staging copies) ---"
+
+$bootFiles = @(
+    "$env:SystemRoot\Boot\EFI\bootmgfw.efi",
+    "$env:SystemRoot\System32\winload.efi",
+    "$env:SystemRoot\System32\winresume.efi"
+)
+foreach ($f in $bootFiles) {
+    $name = Split-Path $f -Leaf
+    if (-not (Test-Path $f)) {
+        Write-State $name "MISSING"
+        continue
+    }
+    $issuer = $null
+    try { $issuer = (Get-AuthenticodeSignature $f).SignerCertificate.Issuer } catch {}
+    $tag = if ($issuer -match 'Windows UEFI CA 2023')      { 'CA 2023' }
+           elseif ($issuer -match 'Production PCA 2011')   { 'PCA 2011' }
+           else { "unknown: $issuer" }
+    Write-State $name $tag
+}
+
+# --- ESP boot manager (the one firmware actually loads) ---
+Write-Output ""
+Write-Output "--- ESP boot manager (the real one firmware loads) ---"
+
+$mountLetter = "S"
+$mounted     = $false
+try {
+    mountvol "${mountLetter}:" /s 2>&1 | Out-Null
+    $mounted = ($LASTEXITCODE -eq 0)
+
+    $espPath = "${mountLetter}:\EFI\Microsoft\Boot\bootmgfw.efi"
+    if (Test-Path $espPath) {
+        $espSig    = Get-AuthenticodeSignature $espPath
+        $espIssuer = $espSig.SignerCertificate.Issuer
+        $tag = if ($espIssuer -match 'Windows UEFI CA 2023')    { 'CA 2023 (firmware MIGRATED)' }
+               elseif ($espIssuer -match 'Production PCA 2011') { 'PCA 2011 (firmware NOT migrated)' }
+               else { "unknown: $espIssuer" }
+        Write-State "ESP\EFI\...\bootmgfw.efi" $tag
+        Write-State "Signature status" $espSig.Status
+    } else {
+        Write-State "ESP boot manager" "MISSING at $espPath"
+    }
+} catch {
+    Write-State "ESP read" "FAILED: $_"
+} finally {
+    if ($mounted) { mountvol "${mountLetter}:" /d 2>&1 | Out-Null }
+}
+
+# --- Registry servicing state ---
+Write-Output ""
+Write-Output "--- Registry servicing state ---"
+
+$servicing  = "HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing"
+$secureboot = "HKLM:\SYSTEM\CurrentControlSet\Control\Secureboot"
+
+$status    = (Get-ItemProperty -Path $servicing  -Name "UEFICA2023Status"         -ErrorAction SilentlyContinue).UEFICA2023Status
+$capable   = (Get-ItemProperty -Path $servicing  -Name "WindowsUEFICA2023Capable" -ErrorAction SilentlyContinue).WindowsUEFICA2023Capable
+$err       = (Get-ItemProperty -Path $servicing  -Name "UEFICA2023Error"          -ErrorAction SilentlyContinue).UEFICA2023Error
+$available = (Get-ItemProperty -Path $secureboot -Name "AvailableUpdates"         -ErrorAction SilentlyContinue).AvailableUpdates
+
+$statusStr  = if ($status)              { $status }              else { "(not set)" }
+$capableStr = if ($null -ne $capable)   { $capable.ToString() }  else { "(not set)" }
+$errStr     = if ($null -ne $err)       { $err.ToString() }      else { "(not set)" }
+$availStr   = if ($null -ne $available) { "0x{0:X4}" -f $available } else { "(not set)" }
+
+Write-State "UEFICA2023Status"          $statusStr
+Write-State "WindowsUEFICA2023Capable"  $capableStr
+Write-State "UEFICA2023Error"           $errStr
+Write-State "AvailableUpdates"          $availStr
+
+Write-Output ""
+Write-Output "Done. No changes made."
+exit 0


### PR DESCRIPTION
For QA testing — adds detection report and remediation/verification scripts for the Windows Secure Boot CA 2023 migration (KB5025885 / CVE-2023-24932).

Part of CSA pattern work in fleetdm/fleet#45474.

## Files

- `report-windows-ca-2023.yml` — diagnostic report, daily snapshot. One row per boot binary; combines file signatures and the servicing state machine. `compliance_verdict` column gives per-row state (`compliant_via_files`, `compliant_via_registry`, `in_progress`, `errored`, `not_started`).
- `migrate-windows-ca-2023.ps1` — idempotent remediation. Preflight checks Secure Boot + `Secure-Boot-Update` task; respects in-progress / Updated / errored states; triggers `AvailableUpdates = 0x5944` only when needed.
- `verify-windows-ca-2023.ps1` — read-only. Reads firmware DB, ESP boot manager, DBX size, and registry servicing state side-by-side. For validating `compliant_via_registry` hosts.

## Tested

- Report query: live-run against dogfood. Returned three distinct migration states across responding hosts. See fleetdm/fleet#45474 for results table.
- Scripts: not yet run. QA testing is the purpose of this PR.

## QA test plan

1. Confirm report renders in Fleet UI with all columns populated.
2. Run `verify-windows-ca-2023.ps1` against a `compliant_via_registry` host (e.g. `WIN-EGSCS3UVTON`, `DESKTOP-ON4IEPD`). Output should show firmware DB and ESP boot manager signatures.
3. Run `migrate-windows-ca-2023.ps1` against `MISO` (`not_started`). Expect either preflight failure (exit 2 or 3) or migration triggered (exit 0).
4. Re-run report. Expect `MISO` to transition out of `not_started`.

Refs fleetdm/fleet#45474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows Secure Boot CA 2023 report for daily compliance monitoring (automation disabled by default), showing per-boot-binary status, registry-servicing state, and an overall compliance verdict.

* **Chores**
  * Added maintenance tools to migrate hosts to the Secure Boot CA 2023 trust chain and a read-only verifier to diagnose migration state and expected reboot requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45510)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->