### PR TITLE
Fix nil-pointer panic in Android Enterprise Pub/Sub endpoint (#45520)

### DIFF
--- a/changes/45520-nil-pointer-panic-in-android-enterprise-pubsub-endpoint
+++ b/changes/45520-nil-pointer-panic-in-android-enterprise-pubsub-endpoint
@@ -1,0 +1,1 @@
+- Fixed a nil-pointer panic in the Android Enterprise Pub/Sub endpoint that occurred when Google's Android Management API sent a device payload missing `hardwareInfo`, `softwareInfo`, or `memoryInfo`.

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -746,6 +746,14 @@ func (svc *Service) verifyDevicePolicy(ctx context.Context, hostUUID string, dev
 			}
 		}
 
+		// No pending profile matches the applied policy version, so there's nothing
+		// to map the non-compliance details back to. Skip the datastore lookup that
+		// would otherwise emit a spurious "policy request not found" error.
+		if policyRequestUUID == "" {
+			svc.logger.DebugContext(ctx, "no matching policy request for non-compliance evaluation", "host_uuid", hostUUID, "applied_policy_version", appliedPolicyVersion)
+			return
+		}
+
 		// Iterate over all policy request uuids, fetch them and unmarshal the payload into the type.
 		// Then re-use the map above, so we can iterate over it again, but now the payload is already unmarshalled.
 		policyRequest, err := svc.ds.GetAndroidPolicyRequestByUUID(ctx, policyRequestUUID)

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -128,6 +128,11 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 		return ctxerr.Wrap(ctx, err, "unmarshal Android status report message")
 	}
 
+	// Validate the device payload up front.
+	if err := svc.validateDevice(ctx, &device); err != nil {
+		return err
+	}
+
 	// NOTE: uncomment as needed, can be useful for debugging as the pubsub report
 	// can be very large - it is not practical to print so it saves it to a file,
 	// different names for all instances of the pubsub, and under an extension that
@@ -286,6 +291,12 @@ func (svc *Service) handlePubSubEnrollment(ctx context.Context, token string, ra
 		return ctxerr.Wrap(ctx, err, "unmarshal Android enrollment message")
 	}
 
+	// Validate up front so the DELETED branch below (getExistingHost/getComputerName)
+	// cannot dereference a nil *HardwareInfo before enrollHost's own validateDevice runs.
+	if err := svc.validateDevice(ctx, &device); err != nil {
+		return err
+	}
+
 	// Some deployments may report work profile removal under ENROLLMENT notifications.
 	// Detect DELETED here too and treat as unenrollment confirmation.
 	isDeleted := strings.ToUpper(device.AppliedState) == string(android.DeviceStateDeleted)
@@ -396,14 +407,31 @@ func (svc *Service) getExistingHost(ctx context.Context, device *androidmanageme
 }
 
 func (svc *Service) validateDevice(ctx context.Context, device *androidmanagement.Device) error {
+	// Validation errors are returned with HTTP 200 so Pub/Sub acks the delivery
+	// instead of retrying. The missing field is either a permanent payload shape
+	// issue or a policy setting (e.g. softwareInfoEnabled) — retrying the same
+	// message will not change either.
 	if device.HardwareInfo == nil {
-		return ctxerr.Errorf(ctx, "missing hardware info for Android device %s", device.Name)
+		svc.logger.WarnContext(ctx, "Android device payload missing hardwareInfo",
+			"device.name", device.Name,
+			"device.appliedState", device.AppliedState,
+			"device.state", device.State,
+		)
+		return fleet.NewInvalidArgumentError("device", fmt.Sprintf("missing hardware info for Android device %s", device.Name)).WithStatus(http.StatusOK)
 	}
 	if device.SoftwareInfo == nil {
-		return ctxerr.Errorf(ctx, "missing software info for Android device %s. Are policy statusReportingSettings set correctly?", device.Name)
+		svc.logger.WarnContext(ctx, "Android device payload missing softwareInfo",
+			"device.name", device.Name,
+			"device.enterpriseSpecificId", device.HardwareInfo.EnterpriseSpecificId,
+		)
+		return fleet.NewInvalidArgumentError("device", fmt.Sprintf("missing software info for Android device %s. Are policy statusReportingSettings set correctly?", device.Name)).WithStatus(http.StatusOK)
 	}
 	if device.MemoryInfo == nil {
-		return ctxerr.Errorf(ctx, "missing memory info for Android device %s", device.Name)
+		svc.logger.WarnContext(ctx, "Android device payload missing memoryInfo",
+			"device.name", device.Name,
+			"device.enterpriseSpecificId", device.HardwareInfo.EnterpriseSpecificId,
+		)
+		return fleet.NewInvalidArgumentError("device", fmt.Sprintf("missing memory info for Android device %s", device.Name)).WithStatus(http.StatusOK)
 	}
 	return nil
 }
@@ -710,6 +738,9 @@ func (svc *Service) verifyDevicePolicy(ctx context.Context, hostUUID string, dev
 		// Dedupe the policyRequestUUID across all pending install profiles
 		var policyRequestUUID string
 		for _, profile := range pendingInstallProfiles {
+			if profile.IncludedInPolicyVersion == nil {
+				continue
+			}
 			if int64(*profile.IncludedInPolicyVersion) == device.AppliedPolicyVersion && profile.PolicyRequestUUID != nil {
 				policyRequestUUID = *profile.PolicyRequestUUID
 			}

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -738,20 +738,9 @@ func (svc *Service) verifyDevicePolicy(ctx context.Context, hostUUID string, dev
 		// Dedupe the policyRequestUUID across all pending install profiles
 		var policyRequestUUID string
 		for _, profile := range pendingInstallProfiles {
-			if profile.IncludedInPolicyVersion == nil {
-				continue
-			}
 			if int64(*profile.IncludedInPolicyVersion) == device.AppliedPolicyVersion && profile.PolicyRequestUUID != nil {
 				policyRequestUUID = *profile.PolicyRequestUUID
 			}
-		}
-
-		// No pending profile matches the applied policy version, so there's nothing
-		// to map the non-compliance details back to. Skip the datastore lookup that
-		// would otherwise emit a spurious "policy request not found" error.
-		if policyRequestUUID == "" {
-			svc.logger.DebugContext(ctx, "no matching policy request for non-compliance evaluation", "host_uuid", hostUUID, "applied_policy_version", appliedPolicyVersion)
-			return
 		}
 
 		// Iterate over all policy request uuids, fetch them and unmarshal the payload into the type.

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -1762,3 +1762,43 @@ func TestPubSubStatusReportHostDeletedFromFleet(t *testing.T) {
 	require.True(t, mockDS.NewAndroidHostFuncInvoked, "re-enrollment should create the host")
 	require.True(t, mockDS.UpdateAndroidHostFuncInvoked, "status report update should run against the re-enrolled host")
 }
+
+func TestPubSubStatusReport_DoesNotPanicWhenHardwareInfoMissing(t *testing.T) {
+	svc, mockDS := createAndroidService(t)
+
+	mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{AndroidEnabledAndConfigured: true}}, nil
+	}
+
+	deviceJSON := `{"name":"enterprises/E1/devices/abc123","appliedState":"ACTIVE"}`
+	msg := &android.PubSubMessage{
+		Attributes: map[string]string{"notificationType": string(android.PubSubStatusReport)},
+		Data:       base64.StdEncoding.EncodeToString([]byte(deviceJSON)),
+	}
+
+	require.NotPanics(t, func() {
+		err := svc.ProcessPubSubPush(t.Context(), "value", msg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing hardware info")
+	})
+}
+
+func TestPubSubEnrollment_DoesNotPanicWhenHardwareInfoMissing(t *testing.T) {
+	svc, mockDS := createAndroidService(t)
+
+	mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{AndroidEnabledAndConfigured: true}}, nil
+	}
+
+	deviceJSON := `{"name":"enterprises/E1/devices/abc123","appliedState":"DELETED"}`
+	msg := &android.PubSubMessage{
+		Attributes: map[string]string{"notificationType": string(android.PubSubEnrollment)},
+		Data:       base64.StdEncoding.EncodeToString([]byte(deviceJSON)),
+	}
+
+	require.NotPanics(t, func() {
+		err := svc.ProcessPubSubPush(t.Context(), "value", msg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing hardware info")
+	})
+}

--- a/server/service/integration_android_software_test.go
+++ b/server/service/integration_android_software_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1400,4 +1401,25 @@ func (s *integrationMDMTestSuite) TestAndroidWebAppsDuplicateName() {
 	s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
 		AppStoreID: webAppID2, Platform: fleet.AndroidPlatform, TeamID: &tm2.ID,
 	}, http.StatusOK, &addResp2)
+}
+
+func (s *integrationMDMTestSuite) TestAndroidPubSubStatusReport_MissingHardwareInfo() {
+	ctx := context.Background()
+	t := s.T()
+
+	s.enableAndroidMDM(t)
+
+	assets, err := s.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetAndroidPubSubToken}, nil)
+	require.NoError(t, err)
+	pubsubToken := assets[fleet.MDMAssetAndroidPubSubToken]
+	require.NotEmpty(t, pubsubToken.Value)
+
+	deviceJSON := fmt.Sprintf(`{"name":%q,"appliedState":"ACTIVE"}`, createAndroidDeviceID("missing-hardware-info"))
+	req := android_service.PubSubPushRequest{
+		PubSubMessage: android.PubSubMessage{
+			Attributes: map[string]string{"notificationType": string(android.PubSubStatusReport)},
+			Data:       base64.StdEncoding.EncodeToString([]byte(deviceJSON)),
+		},
+	}
+	s.Do("POST", "/api/v1/fleet/android_enterprise/pubsub", &req, http.StatusOK, "token", string(pubsubToken.Value))
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #45520 

The Pub/Sub status-report and enrollment handlers dereferenced device.HardwareInfo before any nil check, so a payload from Google's Android Management API with hardwareInfo omitted panicked the request goroutine.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented panics when Android Enterprise Pub/Sub messages omit hardware, software, or memory details; such deliveries are now acknowledged (HTTP 200) and handled gracefully to avoid retries.

* **Tests**
  * Added unit tests verifying status and enrollment messages with missing hardware info do not cause panics and return appropriate errors.

* **Integration Tests**
  * Added an integration test confirming Pub/Sub status reports missing hardware info are accepted with HTTP 200.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->