### PR TITLE
allow gitops mode to be set in yaml

### DIFF
--- a/changes/45330-gitops-mode-from-yaml
+++ b/changes/45330-gitops-mode-from-yaml
@@ -1,0 +1,1 @@
+- Added support for setting `gitops_mode_enabled` and `repository_url` via GitOps.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/file"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/pkg/spec"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -7229,4 +7230,218 @@ software:
 	logs = RunAppForTest(t, []string{"gitops", "-f", globalPath, "-f", teamPath})
 	assert.Contains(t, logs, "[+] applied 1 script\n")
 	assert.Contains(t, logs, fmt.Sprintf("[+] applied 1 script for fleet %s\n", teamName))
+}
+
+// gitopsModeYamlSetup wires up the minimum-viable mocks needed to run the
+// gitops apply through the AppConfig PATCH path for the
+// `org_settings.gitops` YAML control tests. It seeds the existing AppConfig
+// (so PATCH-merge has something to merge against) and captures both the
+// saved AppConfig and the activities emitted.
+func gitopsModeYamlSetup(t *testing.T, tier string, seed fleet.GitOpsConfig) (savedAppConfig **fleet.AppConfig, activities *[]activity_api.ActivityDetails) {
+	t.Helper()
+	t.Setenv("FLEET_SERVER_URL", "https://fleet.example.com")
+	t.Setenv("ORG_NAME", "GitOps Mode YAML Test")
+
+	license := &fleet.LicenseInfo{Tier: tier}
+	if tier == fleet.TierPremium {
+		license.Expiration = time.Now().Add(24 * time.Hour)
+	}
+
+	opts := &service.TestServerOpts{
+		License:       license,
+		KeyValueStore: testing_utils.NewMemKeyValueStore(),
+	}
+	_, ds := testing_utils.RunServerWithMockedDS(t, opts)
+	setupEmptyGitOpsMocks(ds)
+
+	captured := &fleet.AppConfig{}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		cfg := &fleet.AppConfig{}
+		cfg.GitOpsConfig = seed
+		return cfg, nil
+	}
+	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error {
+		captured = config
+		return nil
+	}
+
+	var emitted []activity_api.ActivityDetails
+	var emittedMu sync.Mutex
+	opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+		emittedMu.Lock()
+		defer emittedMu.Unlock()
+		emitted = append(emitted, activity)
+		return nil
+	}
+
+	out := &captured
+	return out, &emitted
+}
+
+// writeGitOpsYamlWithGitops writes a minimal global gitops YAML to a temp
+// file and returns the path. The provided `gitopsBlock` is inserted under
+// `org_settings.gitops`. Pass an empty string to omit the block entirely.
+func writeGitOpsYamlWithGitops(t *testing.T, gitopsBlock string) string {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+
+	body := `
+controls:
+queries:
+policies:
+agent_options:
+org_settings:
+  server_settings:
+    server_url: $FLEET_SERVER_URL
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: ${ORG_NAME}
+  secrets:
+GITOPS_BLOCK_PLACEHOLDER
+software:
+`
+	if gitopsBlock != "" {
+		body = strings.Replace(body, "GITOPS_BLOCK_PLACEHOLDER\n", "  gitops:\n"+gitopsBlock, 1)
+	} else {
+		body = strings.Replace(body, "GITOPS_BLOCK_PLACEHOLDER\n", "", 1)
+	}
+	_, err = tmpFile.WriteString(body)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	return tmpFile.Name()
+}
+
+func TestGitOpsModeYamlAppliesAndPreserves(t *testing.T) {
+	// Cannot t.Parallel() — uses t.Setenv.
+
+	t.Run("YAML sets mode and url; server picks them up", func(t *testing.T) {
+		savedAppConfigPtr, _ := gitopsModeYamlSetup(t, fleet.TierPremium, fleet.GitOpsConfig{})
+		yml := writeGitOpsYamlWithGitops(t, "    gitops_mode_enabled: true\n    repository_url: https://github.com/example/fleet-config\n")
+
+		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
+
+		saved := *savedAppConfigPtr
+		assert.Equal(t, true, saved.GitOpsConfig.GitopsModeEnabled)
+		assert.Equal(t, "https://github.com/example/fleet-config", saved.GitOpsConfig.RepositoryURL)
+	})
+
+	t.Run("YAML omitting gitops preserves stored mode and url", func(t *testing.T) {
+		seed := fleet.GitOpsConfig{
+			GitopsModeEnabled: true,
+			RepositoryURL:     "https://prior.example.com",
+		}
+		savedAppConfigPtr, _ := gitopsModeYamlSetup(t, fleet.TierPremium, seed)
+		yml := writeGitOpsYamlWithGitops(t, "")
+
+		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
+
+		saved := *savedAppConfigPtr
+		assert.Equal(t, true, saved.GitOpsConfig.GitopsModeEnabled)
+		assert.Equal(t, "https://prior.example.com", saved.GitOpsConfig.RepositoryURL)
+	})
+
+	t.Run("YAML omitting gitops preserves exceptions", func(t *testing.T) {
+		seed := fleet.GitOpsConfig{
+			Exceptions: fleet.GitOpsExceptions{Labels: true, Software: true, Secrets: false},
+		}
+		savedAppConfigPtr, _ := gitopsModeYamlSetup(t, fleet.TierPremium, seed)
+		yml := writeGitOpsYamlWithGitops(t, "")
+
+		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
+
+		saved := *savedAppConfigPtr
+		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Labels)
+		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Software)
+		assert.Equal(t, false, saved.GitOpsConfig.Exceptions.Secrets)
+	})
+
+	t.Run("YAML setting mode and url does not clobber stored exceptions", func(t *testing.T) {
+		seed := fleet.GitOpsConfig{
+			Exceptions: fleet.GitOpsExceptions{Labels: true, Software: true, Secrets: false},
+		}
+		savedAppConfigPtr, _ := gitopsModeYamlSetup(t, fleet.TierPremium, seed)
+		yml := writeGitOpsYamlWithGitops(t, "    gitops_mode_enabled: true\n    repository_url: https://github.com/example/fleet-config\n")
+
+		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
+
+		saved := *savedAppConfigPtr
+		assert.Equal(t, true, saved.GitOpsConfig.GitopsModeEnabled)
+		assert.Equal(t, "https://github.com/example/fleet-config", saved.GitOpsConfig.RepositoryURL)
+		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Labels)
+		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Software)
+		assert.Equal(t, false, saved.GitOpsConfig.Exceptions.Secrets)
+	})
+}
+
+func TestGitOpsModeYamlActivityEmission(t *testing.T) {
+	// Cannot t.Parallel() — uses t.Setenv.
+
+	countActivities := func(emitted []activity_api.ActivityDetails) (enabled, disabled int) {
+		for _, a := range emitted {
+			switch a.(type) {
+			case fleet.ActivityTypeEnabledGitOpsMode:
+				enabled++
+			case fleet.ActivityTypeDisabledGitOpsMode:
+				disabled++
+			}
+		}
+		return
+	}
+
+	t.Run("flip false->true emits enabled_gitops_mode", func(t *testing.T) {
+		_, activitiesPtr := gitopsModeYamlSetup(t, fleet.TierPremium, fleet.GitOpsConfig{})
+		yml := writeGitOpsYamlWithGitops(t, "    gitops_mode_enabled: true\n    repository_url: https://github.com/example/fleet-config\n")
+
+		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
+
+		enabled, disabled := countActivities(*activitiesPtr)
+		assert.Equal(t, 1, enabled)
+		assert.Equal(t, 0, disabled)
+	})
+
+	t.Run("flip true->false emits disabled_gitops_mode", func(t *testing.T) {
+		seed := fleet.GitOpsConfig{
+			GitopsModeEnabled: true,
+			RepositoryURL:     "https://prior.example.com",
+		}
+		_, activitiesPtr := gitopsModeYamlSetup(t, fleet.TierPremium, seed)
+		yml := writeGitOpsYamlWithGitops(t, "    gitops_mode_enabled: false\n")
+
+		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
+
+		enabled, disabled := countActivities(*activitiesPtr)
+		assert.Equal(t, 0, enabled)
+		assert.Equal(t, 1, disabled)
+	})
+
+	t.Run("no-op YAML emits no gitops-mode activity", func(t *testing.T) {
+		seed := fleet.GitOpsConfig{
+			GitopsModeEnabled: true,
+			RepositoryURL:     "https://github.com/example/fleet-config",
+		}
+		_, activitiesPtr := gitopsModeYamlSetup(t, fleet.TierPremium, seed)
+		yml := writeGitOpsYamlWithGitops(t, "    gitops_mode_enabled: true\n    repository_url: https://github.com/example/fleet-config\n")
+
+		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
+
+		enabled, disabled := countActivities(*activitiesPtr)
+		assert.Equal(t, 0, enabled)
+		assert.Equal(t, 0, disabled)
+	})
+}
+
+func TestGitOpsModeYamlFreeTierRejected(t *testing.T) {
+	// Cannot t.Parallel() — uses t.Setenv.
+
+	savedAppConfigPtr, _ := gitopsModeYamlSetup(t, fleet.TierFree, fleet.GitOpsConfig{})
+	yml := writeGitOpsYamlWithGitops(t, "    gitops_mode_enabled: true\n    repository_url: https://github.com/example/fleet-config\n")
+
+	_, err := RunAppNoChecks([]string{"gitops", "-f", yml})
+	require.Error(t, err)
+	// The server-side validation in ModifyAppConfig is what flags this on free tier.
+	assert.ErrorContains(t, err, "missing or invalid license")
+	// Saved AppConfig should not have been mutated since the PATCH was rejected.
+	saved := *savedAppConfigPtr
+	assert.Equal(t, false, saved.GitOpsConfig.GitopsModeEnabled)
 }

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7322,7 +7322,7 @@ func TestGitOpsModeYamlAppliesAndPreserves(t *testing.T) {
 		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
 
 		saved := *savedAppConfigPtr
-		assert.Equal(t, true, saved.GitOpsConfig.GitopsModeEnabled)
+		assert.True(t, saved.GitOpsConfig.GitopsModeEnabled)
 		assert.Equal(t, "https://github.com/example/fleet-config", saved.GitOpsConfig.RepositoryURL)
 	})
 
@@ -7337,7 +7337,7 @@ func TestGitOpsModeYamlAppliesAndPreserves(t *testing.T) {
 		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
 
 		saved := *savedAppConfigPtr
-		assert.Equal(t, true, saved.GitOpsConfig.GitopsModeEnabled)
+		assert.True(t, saved.GitOpsConfig.GitopsModeEnabled)
 		assert.Equal(t, "https://prior.example.com", saved.GitOpsConfig.RepositoryURL)
 	})
 
@@ -7351,9 +7351,9 @@ func TestGitOpsModeYamlAppliesAndPreserves(t *testing.T) {
 		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
 
 		saved := *savedAppConfigPtr
-		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Labels)
-		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Software)
-		assert.Equal(t, false, saved.GitOpsConfig.Exceptions.Secrets)
+		assert.True(t, saved.GitOpsConfig.Exceptions.Labels)
+		assert.True(t, saved.GitOpsConfig.Exceptions.Software)
+		assert.False(t, saved.GitOpsConfig.Exceptions.Secrets)
 	})
 
 	t.Run("YAML setting mode and url does not clobber stored exceptions", func(t *testing.T) {
@@ -7366,11 +7366,11 @@ func TestGitOpsModeYamlAppliesAndPreserves(t *testing.T) {
 		_ = RunAppForTest(t, []string{"gitops", "-f", yml})
 
 		saved := *savedAppConfigPtr
-		assert.Equal(t, true, saved.GitOpsConfig.GitopsModeEnabled)
+		assert.True(t, saved.GitOpsConfig.GitopsModeEnabled)
 		assert.Equal(t, "https://github.com/example/fleet-config", saved.GitOpsConfig.RepositoryURL)
-		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Labels)
-		assert.Equal(t, true, saved.GitOpsConfig.Exceptions.Software)
-		assert.Equal(t, false, saved.GitOpsConfig.Exceptions.Secrets)
+		assert.True(t, saved.GitOpsConfig.Exceptions.Labels)
+		assert.True(t, saved.GitOpsConfig.Exceptions.Software)
+		assert.False(t, saved.GitOpsConfig.Exceptions.Secrets)
 	})
 }
 
@@ -7440,8 +7440,8 @@ func TestGitOpsModeYamlFreeTierRejected(t *testing.T) {
 	_, err := RunAppNoChecks([]string{"gitops", "-f", yml})
 	require.Error(t, err)
 	// The server-side validation in ModifyAppConfig is what flags this on free tier.
-	assert.ErrorContains(t, err, "missing or invalid license")
+	require.ErrorContains(t, err, "missing or invalid license")
 	// Saved AppConfig should not have been mutated since the PATCH was rejected.
 	saved := *savedAppConfigPtr
-	assert.Equal(t, false, saved.GitOpsConfig.GitopsModeEnabled)
+	assert.False(t, saved.GitOpsConfig.GitopsModeEnabled)
 }

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -652,6 +652,7 @@ func parseOrgSettings(raw json.RawMessage, result *GitOps, baseDir string, fileP
 		} else {
 			multiError = parseSecrets(result, multiError)
 			multiError = validateOrgInfoLogo(result.OrgSettings, multiError)
+			multiError = validateGitOpsConfig(result.OrgSettings, multiError)
 		}
 		// Validate unknown keys in org_settings section.
 		multiError = multierror.Append(multiError, validateYAMLKeys(raw, reflect.TypeFor[GitOpsOrgSettings](), settingsFilePath, []string{"org_settings"})...)
@@ -680,6 +681,47 @@ func validateOrgInfoLogo(orgSettings map[string]any, multiError *multierror.Erro
 	}
 	check("dark", "org_logo_path_dark_mode", "org_logo_url_dark_mode")
 	check("light", "org_logo_path_light_mode", "org_logo_url_light_mode")
+	return multiError
+}
+
+// validateGitOpsConfig validates the `org_settings.gitops` block at parse time
+// to mirror the server-side checks in ModifyAppConfig. The `exceptions`
+// sub-block is not yet supported via YAML and is rejected here; the
+// server-side strip in DoGitOps remains as defense in depth.
+func validateGitOpsConfig(orgSettings map[string]any, multiError *multierror.Error) *multierror.Error {
+	gitops, _ := orgSettings["gitops"].(map[string]any)
+	if gitops == nil {
+		return multiError
+	}
+
+	if _, ok := gitops["exceptions"]; ok {
+		multiError = multierror.Append(multiError, errors.New(
+			"org_settings.gitops.exceptions is not supported via GitOps; set exceptions in the Fleet UI",
+		))
+	}
+
+	modeEnabled, _ := gitops["gitops_mode_enabled"].(bool)
+	repoURL, _ := gitops["repository_url"].(string)
+
+	if modeEnabled && repoURL == "" {
+		multiError = multierror.Append(multiError, errors.New(
+			"org_settings.gitops.repository_url is required when gitops_mode_enabled is true",
+		))
+	}
+
+	if repoURL != "" {
+		parsed, err := url.Parse(repoURL)
+		if err != nil {
+			multiError = multierror.Append(multiError, fmt.Errorf(
+				"org_settings.gitops.repository_url is invalid: %v", err,
+			))
+		} else if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			multiError = multierror.Append(multiError, errors.New(
+				"org_settings.gitops.repository_url must include protocol (e.g. https://)",
+			))
+		}
+	}
+
 	return multiError
 }
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1363,6 +1363,79 @@ org_settings:
 	})
 }
 
+// TestGitOpsModeYaml exercises the parse-time validator for the
+// `org_settings.gitops` block: rejects `exceptions`, enforces the
+// repository_url requirement and scheme rules, and accepts well-formed
+// inputs.
+func TestGitOpsModeYaml(t *testing.T) {
+	t.Parallel()
+
+	withGitops := func(body string) string {
+		config := getGlobalConfig([]string{"org_settings"})
+		config += `
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: Test Org
+  secrets:
+  gitops:
+` + body
+		return config
+	}
+
+	t.Run("https URL with mode enabled is accepted", func(t *testing.T) {
+		config := withGitops("    gitops_mode_enabled: true\n    repository_url: https://github.com/example/fleet-config\n")
+		gitops, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+		gitopsBlock, _ := gitops.OrgSettings["gitops"].(map[string]any)
+		require.NotNil(t, gitopsBlock)
+		assert.Equal(t, true, gitopsBlock["gitops_mode_enabled"])
+		assert.Equal(t, "https://github.com/example/fleet-config", gitopsBlock["repository_url"])
+	})
+
+	t.Run("http URL with mode enabled is accepted", func(t *testing.T) {
+		config := withGitops("    gitops_mode_enabled: true\n    repository_url: http://internal.example.com/fleet-config\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("mode enabled without repository_url is rejected", func(t *testing.T) {
+		config := withGitops("    gitops_mode_enabled: true\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "repository_url is required when gitops_mode_enabled is true")
+	})
+
+	t.Run("mode enabled with empty repository_url is rejected", func(t *testing.T) {
+		config := withGitops("    gitops_mode_enabled: true\n    repository_url: \"\"\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "repository_url is required when gitops_mode_enabled is true")
+	})
+
+	t.Run("repository_url missing scheme is rejected", func(t *testing.T) {
+		config := withGitops("    gitops_mode_enabled: true\n    repository_url: github.com/example/fleet-config\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "must include protocol")
+	})
+
+	t.Run("exceptions block is rejected", func(t *testing.T) {
+		config := withGitops("    exceptions:\n      labels: true\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "org_settings.gitops.exceptions is not supported via GitOps")
+	})
+
+	t.Run("absent gitops block is accepted", func(t *testing.T) {
+		config := getGlobalConfig(nil)
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+}
+
 func TestGitOpsPaths(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -694,9 +694,13 @@ func (c *Client) ApplyGroup(
 			specs.AppConfig.(map[string]interface{})["yara_rules"] = rulePayloads
 		}
 
-		// GitOps mode config is managed server-side; remove it from the PATCH
-		// payload so the existing settings are preserved.
-		delete(specs.AppConfig.(map[string]any), "gitops")
+		// GitOps `exceptions` remain UI-only for now; strip them defense-in-depth
+		// in case the parse-time reject in pkg/spec is bypassed. The other
+		// `gitops` sub-keys (`gitops_mode_enabled`, `repository_url`) are
+		// settable via YAML and flow through to ModifyAppConfig.
+		if gitopsBlock, ok := specs.AppConfig.(map[string]any)["gitops"].(map[string]any); ok {
+			delete(gitopsBlock, "exceptions")
+		}
 
 		if err := c.ApplyAppConfig(specs.AppConfig, opts.ApplySpecOptions); err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("applying fleet config: %w", err)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45330

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
so many
- [X] QA'd all new/changed functionality manually
  - [X] was able to set gitops mode to enabled via `fleetctl gitops`
  - [X] attempting to set gitops mode w/out repository_url in `fleetctl gitops` failed w/ helpful error
  - [X] attempting to set gitops mode w/ invalid repository_url in `fleetctl gitops` failed w/ helpful error
  - [X] attempting to set gitops exceptions in `fleetctl gitops` failed w/ helpful error
  - [X] was able to unset gitops mode via `fleetctl gitops`
  - [X] leaving `gitops:` blank in `fleetctl gitops` left the mode untouched (it would retain its previous value)

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
it is not, but it's not a requirement here and leaving it out is a no-op
- [x] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
it is not, nor should it be, as that would clear gitops mode on every customer currently using it
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled
n/a, you still need to be able to do gitops mode in the UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitOps mode and repository URL can now be set via GitOps YAML.

* **Bug Fixes**
  * Server preserves existing GitOps settings during config updates; requires repository URL when enabling and rejects unsupported exceptions in GitOps YAML.

* **Tests**
  * Added tests covering apply behavior, YAML validation, activity emission on mode changes, and license-restricted rejection on free tier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45537)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->