### PR TITLE
Downsize 16-core CI runners to 8-core

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-16core
+    runs-on: ubuntu-8core
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-16core
+    runs-on: ubuntu-8core
     environment: Docker Hub
     outputs:
       binary_uploaded: ${{ steps.check_binary.outputs.exists }}

--- a/.github/workflows/test-go-suite.yaml
+++ b/.github/workflows/test-go-suite.yaml
@@ -43,7 +43,7 @@ jobs:
     # Don't cancel other jobs if one test suite fails. Since our product teams are tightly coupled, we never want to see our tests fail due
     # to an unrelated issue in another product area.
     continue-on-error: true
-    runs-on: ubuntu-16core
+    runs-on: ubuntu-8core
 
     env:
       RACE_ENABLED: false


### PR DESCRIPTION
## Summary
- Switch `codeql-analysis`, `test-go-suite`, and `goreleaser-fleet` from `ubuntu-16core` to `ubuntu-8core`.
- 16-core Linux minutes drove ~77% of GitHub Actions billed spend on May 13, 2026 ($403.79 of $522.57). The 8-core SKU is roughly half the per-minute cost and matches what the other Go-heavy workflows already use (`test-android`, `fleet-and-orbit`, `e2e-agent`, `goreleaser-snapshot-fleet`, `randokiller-go`).

## Test plan
- [ ] CI runs to completion on the three affected workflows
- [ ] Wall-clock duration on `test-go-suite` and `goreleaser-fleet` stays within acceptable range vs. 16-core baseline
- [ ] Revisit billing breakdown after a few days to confirm the daily spend drops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline configurations across build and test workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45547)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->