### PR TITLE
Move MySQL 9 Go test coverage from per-PR to nightly cron

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         suite: ["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]
-        mysql: ["mysql:8.0.44", "mysql:9.5.0"]
+        mysql: ["mysql:8.0.44"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: ${{ matrix.suite }}
@@ -82,14 +82,14 @@ jobs:
 
   # ──────────────────────────────────────────────────────────────────────────
   # Extended MySQL coverage: only on the nightly cron schedule.
-  # Tests the same DB-dependent suites against older/intermediate versions.
+  # Tests the same DB-dependent suites against the other supported versions.
   # ──────────────────────────────────────────────────────────────────────────
   test-go-extended-mysql:
     if: github.event_name == 'schedule'
     strategy:
       matrix:
         suite: ["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]
-        mysql: ["mysql:8.0.42", "mysql:8.4.8"]
+        mysql: ["mysql:8.0.42", "mysql:8.4.8", "mysql:9.5.0"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: ${{ matrix.suite }}


### PR DESCRIPTION
## Summary
- Per-PR `test-go` matrix now runs against MySQL 8.0.44 only, dropping the DB-dependent matrix from 16 → 8 jobs per push/PR.
- MySQL 9.5.0 joins `test-go-extended-mysql` alongside 8.0.42 and 8.4.8, so all non-primary supported versions are covered on the nightly cron.
- Motivation: GitHub Actions billing on May 13, 2026 showed the Go test matrix dominating CI minutes. Version-specific MySQL regressions are rare enough that nightly compat coverage is sufficient; per-PR runs can stay focused on the version most users run in production.

## Test plan
- [ ] Push/PR triggers `test-go` with 8 DB-dependent jobs (one per suite) plus the 2 no-db suites — 10 total instead of 18
- [ ] Nightly cron triggers `test-go-extended-mysql` across all three of 8.0.42, 8.4.8, and 9.5.0
- [ ] Watch the next nightly cron for any MySQL-9-only failures that would previously have been caught at PR time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configurations to optimize test matrix coverage for Go test suites.

---

**Note:** This release contains internal infrastructure updates with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45549)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->