### PR TITLE
CI: run golangci-lint Linux-only on PR; macOS/Windows on cron

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,8 @@ on:
       - '.golangci-incremental.yml'
       - '.custom-gcl.yml'
   workflow_dispatch: # Manual
+  schedule:
+    - cron: '0 4 * * *' # Daily 4 AM UTC, runs the full OS lint matrix
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -43,8 +45,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # See #9943, we just need to add windows-latest here once all issues are fixed.
-        os: [ubuntu-4core, macos-latest, windows-latest]
+        # PR/push runs Linux only for fast, cheap feedback. The full OS matrix
+        # (macOS + Windows) runs nightly via the schedule trigger and on manual dispatch.
+        os: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '["ubuntu-4core","macos-latest","windows-latest"]' || '["ubuntu-4core"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       # Tell git not to change line endings when checking out files on Windows. Without this gofmt
@@ -108,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-4core, macos-latest, windows-latest]
+        os: [ubuntu-4core]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Summary
- `golangci` job now runs on `ubuntu-4core` only for `pull_request` and `push` events; the full `[ubuntu-4core, macos-latest, windows-latest]` matrix runs on the new daily cron (4 AM UTC) and on `workflow_dispatch`.
- `golangci-incremental` (PR-only by design) is fixed to `ubuntu-4core`.
- Motivation: the May 13 billing breakdown showed CI runner spend dominated by per-PR work. macOS and Windows lint rarely catch issues the Linux pass misses, and the macOS/Windows runner SKUs cost ~2-3x per minute.

## Risk
- An OS-specific lint regression can land on `main` and not surface until the next nightly cron (worst case ~24h). The same pattern is already used by `test-go.yaml` for extended MySQL coverage, so the precedent exists.
- If cron starts flagging OS-specific issues regularly we can promote them back to per-PR.

## Test plan
- [ ] Open this draft PR → only the `lint (ubuntu-4core)` and `lint-incremental (ubuntu-4core)` jobs should run; macOS and Windows variants should not appear
- [ ] Trigger `workflow_dispatch` manually on `main` → full 3-OS matrix runs
- [ ] Confirm the next 4 AM UTC cron run produces 3 jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified GitHub Actions linting workflow to adjust OS-specific runner assignments based on event triggers and restrict incremental linting to a targeted platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45558)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->