### PR TITLE
CI: run native-tooling packaging tests on schedule only

### DIFF
--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -43,12 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-4core]
-        # build_type == 'remote' means this job will test the fleetdm/fleetctl:latest from Docker Hub.
-        # build_type == 'local' means this job will build the the image locally.
-        #
-        # TODO(lucas): We should only run 'remote' on schedule
-        # (adding conditionals to 'matrix' requires many tricks).
-        build_type: ["remote", "local"]
+        # build_type == 'remote' tests fleetdm/fleetctl:latest from Docker Hub (cheap).
+        # build_type == 'local' rebuilds the wix/bomutils/fleetctl Docker images from
+        # source (expensive — adds Go install + three docker image builds).
+        # PRs run only 'remote'; push, schedule, and workflow_dispatch run both.
+        build_type: ${{ fromJSON(github.event_name == 'pull_request' && '["remote"]' || '["remote","local"]') }}
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -3,6 +3,12 @@
 name: Test native tooling packaging
 
 on:
+  pull_request:
+    paths:
+      - 'tools/fleetctl-docker/**'
+      - 'tools/wix-docker/**'
+      - 'tools/bomutils-docker/**'
+      - '.github/workflows/test-native-tooling-packaging.yml'
   workflow_dispatch: # Manual
   schedule:
     - cron: "0 5 * * *"
@@ -28,7 +34,11 @@ jobs:
         os: [ubuntu-4core]
         # build_type == 'remote' means this job will test the fleetdm/fleetctl:latest from Docker Hub.
         # build_type == 'local' means this job will build the the image locally.
-        build_type: ["remote", "local"]
+        #
+        # On pull_request we only run 'local' (the PR's Dockerfile changes aren't
+        # in fleetdm/fleetctl:latest, so 'remote' has no signal). Schedule and
+        # workflow_dispatch run both.
+        build_type: ${{ fromJSON(github.event_name == 'pull_request' && '["local"]' || '["remote","local"]') }}
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -3,23 +3,6 @@
 name: Test native tooling packaging
 
 on:
-  push:
-    branches:
-      - main
-      - patch-*
-      - prepare-*
-  pull_request:
-    paths:
-      - 'cmd/fleetctl/**.go'
-      - 'pkg/**.go'
-      - 'server/service/**.go'
-      - 'server/context/**.go'
-      - 'orbit/**.go'
-      - 'ee/fleetctl/**.go'
-      - 'tools/fleetctl-docker/**'
-      - 'tools/wix-docker/**'
-      - 'tools/bomutils-docker/**'
-      - '.github/workflows/test-native-tooling-packaging.yml'
   workflow_dispatch: # Manual
   schedule:
     - cron: "0 5 * * *"
@@ -43,11 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-4core]
-        # build_type == 'remote' tests fleetdm/fleetctl:latest from Docker Hub (cheap).
-        # build_type == 'local' rebuilds the wix/bomutils/fleetctl Docker images from
-        # source (expensive — adds Go install + three docker image builds).
-        # PRs run only 'remote'; push, schedule, and workflow_dispatch run both.
-        build_type: ${{ fromJSON(github.event_name == 'pull_request' && '["remote"]' || '["remote","local"]') }}
+        # build_type == 'remote' means this job will test the fleetdm/fleetctl:latest from Docker Hub.
+        # build_type == 'local' means this job will build the the image locally.
+        build_type: ["remote", "local"]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
## Summary
- `test-native-tooling-packaging.yml` no longer runs on `push` or for unrelated `pull_request` paths. It runs on:
  - **`pull_request`** restricted to `tools/fleetctl-docker/**`, `tools/wix-docker/**`, `tools/bomutils-docker/**`, and the workflow file itself — and only the `local` build_type, since `remote` tests `fleetdm/fleetctl:latest` from Docker Hub and has no signal on a PR's Dockerfile changes.
  - **`workflow_dispatch`** (manual) and **`schedule`** (daily `0 5 * * *`) — both `remote` and `local`.
- Lucas's long-standing TODO about wanting matrix conditionals is removed.

## Why
Per [Lucas's feedback](https://github.com/fleetdm/fleet/pull/45559):
- `local` is too expensive (Go install + three docker image rebuilds) to run on every fleetctl PR. It only validates the docker image used to generate fleetd packages, which has no signal for non-Dockerfile PRs.
- `remote` doesn't make sense per-PR either: it tests `fleetdm/fleetctl:latest` from Docker Hub, which is independent of the PR's contents.

Auto-triggering `local` for PRs that actually touch the Dockerfiles keeps the relevant safety net without burdening unrelated PRs. The daily cron still exercises both build types and already alerts Slack on failure.

## Test plan
- [x] This PR modifies the workflow file itself, so it correctly triggers only the `local` matrix job (incidentally validating the matrix conditional syntax before merge)
- [ ] Open a follow-up PR touching a non-Dockerfile Go path (e.g., `cmd/fleetctl/**.go`) and confirm the workflow does **not** run
- [ ] Trigger `workflow_dispatch` on `main` after merge and confirm both `remote` and `local` jobs run
- [ ] Confirm next 5 AM UTC cron run produces both jobs