### PR TITLE
LOADTEST: Batch 2k host uuids, for profile reconciler.

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3441,6 +3441,296 @@ func (ds *Datastore) ListMDMAppleProfilesToInstallAndRemove(ctx context.Context)
 	return profilesToInstall, profilesToRemove, nil
 }
 
+// ListMDMAppleProfilesToInstallAndRemoveForHosts is the scoped variant of
+// ListMDMAppleProfilesToInstallAndRemove. Both lists are read in a single
+// read-only transaction so they reflect the same point-in-time system
+// state. See ReconcileAppleProfiles.
+func (ds *Datastore) ListMDMAppleProfilesToInstallAndRemoveForHosts(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
+	if len(hostUUIDs) == 0 {
+		return nil, nil, nil
+	}
+
+	var profilesToInstall []*fleet.MDMAppleProfilePayload
+	var profilesToRemove []*fleet.MDMAppleProfilePayload
+	err := ds.withReadTx(ctx, func(tx common_mysql.DBReadTx) error {
+		var err error
+		profilesToInstall, err = ds.listMDMAppleProfilesToInstallForHostsDB(ctx, tx, hostUUIDs)
+		if err != nil {
+			return err
+		}
+		profilesToRemove, err = ds.listMDMAppleProfilesToRemoveForHostsDB(ctx, tx, hostUUIDs)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "get Apple profiles to install and remove for hosts")
+	}
+
+	return profilesToInstall, profilesToRemove, nil
+}
+
+// listMDMAppleProfilesToInstallForHostsDB returns rows from the
+// ListMDMAppleProfilesToInstall set restricted to the given host UUIDs.
+// Uses the same conditions as listMDMAppleProfilesToInstallTransaction
+// (the authoritative reconciliation queries), not the subtly different
+// conditions in bulkSetPendingMDMAppleHostProfilesDB.
+func (ds *Datastore) listMDMAppleProfilesToInstallForHostsDB(ctx context.Context, tx common_mysql.DBReadTx, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, error) {
+	if len(hostUUIDs) == 0 {
+		return nil, nil
+	}
+
+	appleMDMProfilesDesiredStateQuery := generateDesiredStateQuery("profile")
+
+	// h.uuid IN (?) appears in all 4 UNION arms of the desired-state query
+	// so the optimizer filters early per branch. Pattern mirrors the
+	// Windows scoped variant in listMDMWindowsProfilesToInstallDB.
+	desiredStateFilter := "h.uuid IN (?)"
+
+	toInstallStmt := fmt.Sprintf(`
+	SELECT
+		ds.profile_uuid,
+		ds.host_uuid,
+		ds.host_platform,
+		ds.profile_identifier,
+		ds.profile_name,
+		ds.checksum,
+		ds.secrets_updated_at,
+		ds.scope,
+		ds.device_enrolled_at
+	FROM ( %s ) as ds
+		LEFT JOIN host_mdm_apple_profiles hmap
+			ON hmap.profile_uuid = ds.profile_uuid AND hmap.host_uuid = ds.host_uuid
+	WHERE
+		-- profile or secret variables have been updated
+		( hmap.checksum != ds.checksum ) OR IFNULL(hmap.secrets_updated_at < ds.secrets_updated_at, FALSE) OR
+		-- profiles in A but not in B
+		( hmap.profile_uuid IS NULL AND hmap.host_uuid IS NULL ) OR
+		-- profiles in A and B but with operation type "remove"
+		( hmap.host_uuid IS NOT NULL AND ( hmap.operation_type = ? OR hmap.operation_type IS NULL ) ) OR
+		-- profiles in A and B with operation type "install" and NULL status
+		( hmap.host_uuid IS NOT NULL AND hmap.operation_type = ? AND hmap.status IS NULL )
+`, fmt.Sprintf(appleMDMProfilesDesiredStateQuery, desiredStateFilter, desiredStateFilter, desiredStateFilter, desiredStateFilter))
+
+	// Mirror ListMDMAppleProfilesToInstall: a 10k host batch size matches
+	// what bulkSetPendingMDMAppleHostProfilesDB does for parameter-limit
+	// safety. In practice the reconciler caller passes <= batch size
+	// (typically 2000), so this loop runs once; the guard is here for
+	// safety in case the batch size is ever raised.
+	selectProfilesBatchSize := 10_000
+	if ds.testSelectMDMProfilesBatchSize > 0 {
+		selectProfilesBatchSize = ds.testSelectMDMProfilesBatchSize
+	}
+	selectProfilesTotalBatches := int(math.Ceil(float64(len(hostUUIDs)) / float64(selectProfilesBatchSize)))
+
+	var wantedProfiles []*fleet.MDMAppleProfilePayload
+	for i := 0; i < selectProfilesTotalBatches; i++ {
+		start := i * selectProfilesBatchSize
+		end := min(start+selectProfilesBatchSize, len(hostUUIDs))
+		batchUUIDs := hostUUIDs[start:end]
+
+		stmt, args, err := sqlx.In(toInstallStmt,
+			batchUUIDs, batchUUIDs, batchUUIDs, batchUUIDs,
+			fleet.MDMOperationTypeRemove, fleet.MDMOperationTypeInstall,
+		)
+		if err != nil {
+			return nil, ctxerr.Wrapf(ctx, err, "building statement to select Apple profiles to install for hosts, batch %d of %d", i, selectProfilesTotalBatches)
+		}
+
+		var partialResult []*fleet.MDMAppleProfilePayload
+		if err := sqlx.SelectContext(ctx, tx, &partialResult, stmt, args...); err != nil {
+			return nil, ctxerr.Wrapf(ctx, err, "selecting Apple profiles to install for hosts, batch %d of %d", i, selectProfilesTotalBatches)
+		}
+		wantedProfiles = append(wantedProfiles, partialResult...)
+	}
+
+	return wantedProfiles, nil
+}
+
+// listMDMAppleProfilesToRemoveForHostsDB returns rows from the
+// ListMDMAppleProfilesToRemove set restricted to the given host UUIDs.
+// Uses the same conditions as listMDMAppleProfilesToRemoveTransaction
+// (the authoritative reconciliation queries).
+func (ds *Datastore) listMDMAppleProfilesToRemoveForHostsDB(ctx context.Context, tx common_mysql.DBReadTx, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, error) {
+	if len(hostUUIDs) == 0 {
+		return nil, nil
+	}
+
+	appleMDMProfilesDesiredStateQuery := generateDesiredStateQuery("profile")
+
+	// The desired-state subquery is anti-joined ("ds.profile_uuid IS NULL
+	// AND ds.host_uuid IS NULL"), so the host filter applied inside the
+	// subquery does not prune rows from the remove set on its own; the
+	// outer hmap.host_uuid IN (?) is what actually scopes the result. We
+	// still push the filter into the desired-state UNION arms so the
+	// optimizer evaluates a much smaller ds. (Mirrors the Windows scoped
+	// variant.)
+	desiredStateFilter := "h.uuid IN (?)"
+
+	toRemoveStmt := fmt.Sprintf(`
+	SELECT
+		hmap.profile_uuid as profile_uuid,
+		hmap.host_uuid as host_uuid,
+		hmap.profile_identifier as profile_identifier,
+		hmap.profile_name as profile_name,
+		hmap.checksum as checksum,
+		hmap.status as status,
+		hmap.operation_type as operation_type,
+		COALESCE(hmap.detail, '') as detail,
+		hmap.command_uuid as command_uuid,
+		hmap.scope as scope
+	FROM ( %s ) as ds
+		RIGHT JOIN host_mdm_apple_profiles hmap
+			ON hmap.profile_uuid = ds.profile_uuid AND hmap.host_uuid = ds.host_uuid
+	WHERE
+		hmap.host_uuid IN (?) AND
+		-- profiles that are in B but not in A
+		ds.profile_uuid IS NULL AND ds.host_uuid IS NULL AND
+		-- except "remove" operations in a terminal state or already pending
+		( hmap.operation_type IS NULL OR hmap.operation_type != ? OR hmap.status IS NULL ) AND
+		-- except "would be removed" profiles if they are a broken label-based profile
+		-- (regardless of if it is an include-all or exclude-any label)
+		NOT EXISTS (
+			SELECT 1
+			FROM mdm_configuration_profile_labels mcpl
+			WHERE
+				mcpl.apple_profile_uuid = hmap.profile_uuid AND
+				mcpl.label_id IS NULL
+		)
+`, fmt.Sprintf(appleMDMProfilesDesiredStateQuery, desiredStateFilter, desiredStateFilter, desiredStateFilter, desiredStateFilter))
+
+	selectProfilesBatchSize := 10_000
+	if ds.testSelectMDMProfilesBatchSize > 0 {
+		selectProfilesBatchSize = ds.testSelectMDMProfilesBatchSize
+	}
+	selectProfilesTotalBatches := int(math.Ceil(float64(len(hostUUIDs)) / float64(selectProfilesBatchSize)))
+
+	var currentProfiles []*fleet.MDMAppleProfilePayload
+	for i := 0; i < selectProfilesTotalBatches; i++ {
+		start := i * selectProfilesBatchSize
+		end := min(start+selectProfilesBatchSize, len(hostUUIDs))
+		batchUUIDs := hostUUIDs[start:end]
+
+		stmt, args, err := sqlx.In(toRemoveStmt,
+			batchUUIDs, batchUUIDs, batchUUIDs, batchUUIDs, batchUUIDs,
+			fleet.MDMOperationTypeRemove,
+		)
+		if err != nil {
+			return nil, ctxerr.Wrapf(ctx, err, "building statement to select Apple profiles to remove for hosts, batch %d of %d", i, selectProfilesTotalBatches)
+		}
+
+		var partialResult []*fleet.MDMAppleProfilePayload
+		if err := sqlx.SelectContext(ctx, tx, &partialResult, stmt, args...); err != nil {
+			return nil, ctxerr.Wrapf(ctx, err, "selecting Apple profiles to remove for hosts, batch %d of %d", i, selectProfilesTotalBatches)
+		}
+		currentProfiles = append(currentProfiles, partialResult...)
+	}
+
+	return currentProfiles, nil
+}
+
+// ListNextPendingMDMAppleHostUUIDs returns up to batchSize host UUIDs
+// (sorted ascending, lexicographic) where host_uuid > afterHostUUID and
+// the host has any pending Apple MDM profile reconciliation work (install
+// or remove). If afterHostUUID is empty, scanning starts from the
+// beginning. The cron uses this to slice its per-tick work into a bounded
+// host window; see ReconcileAppleProfiles.
+func (ds *Datastore) ListNextPendingMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+	appleMDMProfilesDesiredStateQuery := generateDesiredStateQuery("profile")
+
+	// Push the cursor predicate (h.uuid > ?) into each branch of the UNION
+	// so the optimizer applies it before deduplication. Both the install
+	// and remove queries push the cursor into all 4 desired-state UNION
+	// arms; the remove query additionally gets the cursor in its outer
+	// WHERE on hmap.host_uuid for a clean PK range scan on
+	// host_mdm_apple_profiles. Mirrors the Windows pattern in
+	// ListNextPendingMDMWindowsHostUUIDs.
+	cursorPred := "h.uuid > ?"
+	desiredStateInstall := fmt.Sprintf(appleMDMProfilesDesiredStateQuery, cursorPred, cursorPred, cursorPred, cursorPred)
+	desiredStateRemove := fmt.Sprintf(appleMDMProfilesDesiredStateQuery, cursorPred, cursorPred, cursorPred, cursorPred)
+
+	// Note on what's distinct from the full install/remove queries: we
+	// project only host_uuid here, so we don't need to project profile
+	// content (checksum etc.). We still use the same join + WHERE shape
+	// so the planner picks the same indexes.
+	toInstall := fmt.Sprintf(`
+	SELECT ds.host_uuid
+	FROM ( %s ) as ds
+		LEFT JOIN host_mdm_apple_profiles hmap
+			ON hmap.profile_uuid = ds.profile_uuid AND hmap.host_uuid = ds.host_uuid
+	WHERE
+		( hmap.checksum != ds.checksum ) OR IFNULL(hmap.secrets_updated_at < ds.secrets_updated_at, FALSE) OR
+		( hmap.profile_uuid IS NULL AND hmap.host_uuid IS NULL ) OR
+		( hmap.host_uuid IS NOT NULL AND ( hmap.operation_type = ? OR hmap.operation_type IS NULL ) ) OR
+		( hmap.host_uuid IS NOT NULL AND hmap.operation_type = ? AND hmap.status IS NULL )
+`, desiredStateInstall)
+
+	toRemove := fmt.Sprintf(`
+	SELECT hmap.host_uuid
+	FROM ( %s ) as ds
+		RIGHT JOIN host_mdm_apple_profiles hmap
+			ON hmap.profile_uuid = ds.profile_uuid AND hmap.host_uuid = ds.host_uuid
+	WHERE
+		hmap.host_uuid > ? AND
+		ds.profile_uuid IS NULL AND ds.host_uuid IS NULL AND
+		( hmap.operation_type IS NULL OR hmap.operation_type != ? OR hmap.status IS NULL ) AND
+		NOT EXISTS (
+			SELECT 1
+			FROM mdm_configuration_profile_labels mcpl
+			WHERE
+				mcpl.apple_profile_uuid = hmap.profile_uuid AND
+				mcpl.label_id IS NULL
+		)
+`, desiredStateRemove)
+
+	stmt := fmt.Sprintf(`
+		SELECT host_uuid FROM (
+			SELECT host_uuid FROM (%s) AS install_set
+			UNION
+			SELECT host_uuid FROM (%s) AS remove_set
+		) AS combined
+		ORDER BY host_uuid
+		LIMIT %d
+	`, toInstall, toRemove, batchSize)
+
+	// Placeholder order in stmt:
+	//   install branches: 4 cursor (h.uuid > ?), 2 op-type (remove, install)
+	//   remove branches:  4 cursor (h.uuid > ?) for desired-state arms,
+	//                     1 cursor (hmap.host_uuid > ?) for outer WHERE,
+	//                     1 op-type (remove)
+	var hostUUIDs []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostUUIDs, stmt,
+		afterHostUUID, afterHostUUID, afterHostUUID, afterHostUUID,
+		fleet.MDMOperationTypeRemove, fleet.MDMOperationTypeInstall,
+		afterHostUUID, afterHostUUID, afterHostUUID, afterHostUUID,
+		afterHostUUID,
+		fleet.MDMOperationTypeRemove,
+	); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing next pending MDM apple host UUIDs")
+	}
+	return hostUUIDs, nil
+}
+
+// GetMDMAppleReconcileCursor returns the persisted host_uuid cursor used
+// by the Apple MDM reconciliation cron to bound per-tick work. Returns ""
+// if no cursor is set or if the underlying datastore does not support
+// cursor persistence (the bare mysql.Datastore in unit tests returns ""
+// here; the mysqlredis wrapper backs it with Redis).
+//
+// See ReconcileAppleProfiles.
+func (ds *Datastore) GetMDMAppleReconcileCursor(_ context.Context) (string, error) {
+	return "", nil
+}
+
+// SetMDMAppleReconcileCursor persists the host_uuid cursor used by the
+// Apple MDM reconciliation cron. The bare mysql.Datastore is a no-op
+// here; the mysqlredis wrapper writes to Redis. See
+// GetMDMAppleReconcileCursor.
+func (ds *Datastore) SetMDMAppleReconcileCursor(_ context.Context, _ string) error {
+	return nil
+}
+
 func (ds *Datastore) GetMDMAppleProfilesContents(ctx context.Context, uuids []string) (map[string]mobileconfig.Mobileconfig, error) {
 	if len(uuids) == 0 {
 		return nil, nil

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3630,84 +3630,46 @@ func (ds *Datastore) listMDMAppleProfilesToRemoveForHostsDB(ctx context.Context,
 	return currentProfiles, nil
 }
 
-// ListNextPendingMDMAppleHostUUIDs returns up to batchSize host UUIDs
-// (sorted ascending, lexicographic) where host_uuid > afterHostUUID and
-// the host has any pending Apple MDM profile reconciliation work (install
-// or remove). If afterHostUUID is empty, scanning starts from the
-// beginning. The cron uses this to slice its per-tick work into a bounded
-// host window; see ReconcileAppleProfiles.
-func (ds *Datastore) ListNextPendingMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
-	appleMDMProfilesDesiredStateQuery := generateDesiredStateQuery("profile")
-
-	// Push the cursor predicate (h.uuid > ?) into each branch of the UNION
-	// so the optimizer applies it before deduplication. Both the install
-	// and remove queries push the cursor into all 4 desired-state UNION
-	// arms; the remove query additionally gets the cursor in its outer
-	// WHERE on hmap.host_uuid for a clean PK range scan on
-	// host_mdm_apple_profiles. Mirrors the Windows pattern in
-	// ListNextPendingMDMWindowsHostUUIDs.
-	cursorPred := "h.uuid > ?"
-	desiredStateInstall := fmt.Sprintf(appleMDMProfilesDesiredStateQuery, cursorPred, cursorPred, cursorPred, cursorPred)
-	desiredStateRemove := fmt.Sprintf(appleMDMProfilesDesiredStateQuery, cursorPred, cursorPred, cursorPred, cursorPred)
-
-	// Note on what's distinct from the full install/remove queries: we
-	// project only host_uuid here, so we don't need to project profile
-	// content (checksum etc.). We still use the same join + WHERE shape
-	// so the planner picks the same indexes.
-	toInstall := fmt.Sprintf(`
-	SELECT ds.host_uuid
-	FROM ( %s ) as ds
-		LEFT JOIN host_mdm_apple_profiles hmap
-			ON hmap.profile_uuid = ds.profile_uuid AND hmap.host_uuid = ds.host_uuid
-	WHERE
-		( hmap.checksum != ds.checksum ) OR IFNULL(hmap.secrets_updated_at < ds.secrets_updated_at, FALSE) OR
-		( hmap.profile_uuid IS NULL AND hmap.host_uuid IS NULL ) OR
-		( hmap.host_uuid IS NOT NULL AND ( hmap.operation_type = ? OR hmap.operation_type IS NULL ) ) OR
-		( hmap.host_uuid IS NOT NULL AND hmap.operation_type = ? AND hmap.status IS NULL )
-`, desiredStateInstall)
-
-	toRemove := fmt.Sprintf(`
-	SELECT hmap.host_uuid
-	FROM ( %s ) as ds
-		RIGHT JOIN host_mdm_apple_profiles hmap
-			ON hmap.profile_uuid = ds.profile_uuid AND hmap.host_uuid = ds.host_uuid
-	WHERE
-		hmap.host_uuid > ? AND
-		ds.profile_uuid IS NULL AND ds.host_uuid IS NULL AND
-		( hmap.operation_type IS NULL OR hmap.operation_type != ? OR hmap.status IS NULL ) AND
-		NOT EXISTS (
-			SELECT 1
-			FROM mdm_configuration_profile_labels mcpl
-			WHERE
-				mcpl.apple_profile_uuid = hmap.profile_uuid AND
-				mcpl.label_id IS NULL
-		)
-`, desiredStateRemove)
-
-	stmt := fmt.Sprintf(`
-		SELECT host_uuid FROM (
-			SELECT host_uuid FROM (%s) AS install_set
-			UNION
-			SELECT host_uuid FROM (%s) AS remove_set
-		) AS combined
-		ORDER BY host_uuid
-		LIMIT %d
-	`, toInstall, toRemove, batchSize)
-
-	// Placeholder order in stmt:
-	//   install branches: 4 cursor (h.uuid > ?), 2 op-type (remove, install)
-	//   remove branches:  4 cursor (h.uuid > ?) for desired-state arms,
-	//                     1 cursor (hmap.host_uuid > ?) for outer WHERE,
-	//                     1 op-type (remove)
+// ListNextMDMAppleHostUUIDs returns up to batchSize Apple MDM host UUIDs
+// (sorted ascending, lexicographic) where host_uuid > afterHostUUID. If
+// afterHostUUID is empty, scanning starts from the beginning. The cron
+// uses this to slice its per-tick work into a bounded host window; see
+// ReconcileAppleProfiles.
+//
+// Intentionally does NOT pre-filter to hosts with pending work. The
+// scoped install/remove query that follows evaluates the full
+// desired-state UNION against this window and naturally returns only
+// the subset (often a small minority) that actually has changes. This
+// keeps the cursor scan dirt cheap (PK range scan on hosts.uuid + an
+// EXISTS lookup against nano_enrollments.device_id) and avoids running
+// the heavy desired-state query twice per tick. The trade is that
+// hosts without pending work still consume a slot in their tick's
+// batch — fine because the scoped UNION on 5000 hosts is much cheaper
+// than the full UNION across the universe.
+//
+// Diverges from ListNextPendingMDMWindowsHostUUIDs (which pushes the
+// cursor predicate into the desired-state UNION arms to filter to
+// hosts-with-work) on purpose. For Apple, the desired-state UNION is
+// expensive enough that running it twice — once to find work, once to
+// fetch it — is worse than running it once on a slightly larger window.
+func (ds *Datastore) ListNextMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+	const stmt = `
+		SELECT h.uuid
+		FROM hosts h
+		WHERE h.uuid > ?
+			AND h.platform IN ('darwin', 'ios', 'ipados')
+			AND EXISTS (
+				SELECT 1 FROM nano_enrollments ne
+				WHERE ne.device_id = h.uuid
+					AND ne.enabled = 1
+					AND ne.type IN ('Device', 'User Enrollment (Device)')
+			)
+		ORDER BY h.uuid
+		LIMIT ?
+	`
 	var hostUUIDs []string
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostUUIDs, stmt,
-		afterHostUUID, afterHostUUID, afterHostUUID, afterHostUUID,
-		fleet.MDMOperationTypeRemove, fleet.MDMOperationTypeInstall,
-		afterHostUUID, afterHostUUID, afterHostUUID, afterHostUUID,
-		afterHostUUID,
-		fleet.MDMOperationTypeRemove,
-	); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "listing next pending MDM apple host UUIDs")
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostUUIDs, stmt, afterHostUUID, batchSize); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing next MDM apple host UUIDs")
 	}
 	return hostUUIDs, nil
 }

--- a/server/datastore/mysqlredis/apple_recon_cursor.go
+++ b/server/datastore/mysqlredis/apple_recon_cursor.go
@@ -1,0 +1,53 @@
+package mysqlredis
+
+import (
+	"context"
+	"errors"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+// appleReconCursorKey is the Redis key holding the host_uuid cursor for
+// the mdm_apple_profile_manager cron's batched reconciliation.
+const appleReconCursorKey = "mdm:apple:recon_cursor"
+
+// GetMDMAppleReconcileCursor returns the persisted host_uuid cursor used
+// by the Apple MDM reconciliation cron to bound per-tick work.
+//
+// Returns "" if the key is unset (fresh deployment, Redis flushed, or full
+// pass complete). Loss of this key is harmless: the cron resumes from the
+// beginning, and the listing predicates filter out hosts whose state
+// already matches the desired state, so re-processing converges quickly.
+func (d *Datastore) GetMDMAppleReconcileCursor(ctx context.Context) (string, error) {
+	conn := redis.ConfigureDoer(d.pool, d.pool.Get())
+	defer conn.Close()
+
+	cursor, err := redigo.String(conn.Do("GET", appleReconCursorKey))
+	switch {
+	case err == nil:
+		return cursor, nil
+	case errors.Is(err, redigo.ErrNil):
+		return "", nil
+	default:
+		return "", ctxerr.Wrap(ctx, err, "get apple MDM reconcile cursor")
+	}
+}
+
+// SetMDMAppleReconcileCursor persists the host_uuid cursor used by the
+// Apple MDM reconciliation cron. An empty string indicates a full pass
+// has completed; the next tick will start from the beginning.
+//
+// No TTL: the cron writes this on every tick, so eviction by Redis would
+// only delay the next tick's read by the time it takes the cron to fire
+// again, and the worst-case effect is one redundant pass.
+func (d *Datastore) SetMDMAppleReconcileCursor(ctx context.Context, cursor string) error {
+	conn := redis.ConfigureDoer(d.pool, d.pool.Get())
+	defer conn.Close()
+
+	if _, err := conn.Do("SET", appleReconCursorKey, cursor); err != nil {
+		return ctxerr.Wrap(ctx, err, "set apple MDM reconcile cursor")
+	}
+	return nil
+}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1523,12 +1523,13 @@ type Datastore interface {
 	// reconciliation path; see ReconcileAppleProfiles.
 	ListMDMAppleProfilesToInstallAndRemoveForHosts(ctx context.Context, hostUUIDs []string) ([]*MDMAppleProfilePayload, []*MDMAppleProfilePayload, error)
 
-	// ListNextPendingMDMAppleHostUUIDs returns up to batchSize host UUIDs
-	// (sorted ascending, lexicographic) where host_uuid > afterHostUUID and
-	// the host has any pending Apple MDM profile reconciliation work
-	// (install or remove). Used by the cron's batched reconciliation path;
-	// see ReconcileAppleProfiles.
-	ListNextPendingMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error)
+	// ListNextMDMAppleHostUUIDs returns up to batchSize Apple MDM host
+	// UUIDs (sorted ascending, lexicographic) where host_uuid >
+	// afterHostUUID. Does NOT pre-filter by pending work — the scoped
+	// install/remove query that follows in the cron tick does that
+	// filtering. Used by the cron's batched reconciliation path; see
+	// ReconcileAppleProfiles.
+	ListNextMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error)
 
 	// GetMDMAppleReconcileCursor returns the persisted host_uuid cursor used
 	// by the Apple MDM reconciliation cron to bound per-tick work. Returns

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1516,6 +1516,31 @@ type Datastore interface {
 	// lists reflect the same system state and no changes can be introduced between the queries.
 	ListMDMAppleProfilesToInstallAndRemove(ctx context.Context) ([]*MDMAppleProfilePayload, []*MDMAppleProfilePayload, error)
 
+	// ListMDMAppleProfilesToInstallAndRemoveForHosts is the scoped variant of
+	// ListMDMAppleProfilesToInstallAndRemove: it returns rows only for the
+	// given host UUIDs. Both lists are still read in an isolated manner so
+	// they reflect the same system state. Used by the cron's batched
+	// reconciliation path; see ReconcileAppleProfiles.
+	ListMDMAppleProfilesToInstallAndRemoveForHosts(ctx context.Context, hostUUIDs []string) ([]*MDMAppleProfilePayload, []*MDMAppleProfilePayload, error)
+
+	// ListNextPendingMDMAppleHostUUIDs returns up to batchSize host UUIDs
+	// (sorted ascending, lexicographic) where host_uuid > afterHostUUID and
+	// the host has any pending Apple MDM profile reconciliation work
+	// (install or remove). Used by the cron's batched reconciliation path;
+	// see ReconcileAppleProfiles.
+	ListNextPendingMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error)
+
+	// GetMDMAppleReconcileCursor returns the persisted host_uuid cursor used
+	// by the Apple MDM reconciliation cron to bound per-tick work. Returns
+	// "" if no cursor is set or if the implementation does not support
+	// cursor persistence (the bare mysql.Datastore returns "" here; the
+	// mysqlredis wrapper backs it with Redis). See ReconcileAppleProfiles.
+	GetMDMAppleReconcileCursor(ctx context.Context) (string, error)
+
+	// SetMDMAppleReconcileCursor persists the host_uuid cursor used by the
+	// Apple MDM reconciliation cron. See GetMDMAppleReconcileCursor.
+	SetMDMAppleReconcileCursor(ctx context.Context, cursor string) error
+
 	// BulkUpsertMDMAppleHostProfiles bulk-adds/updates records to track the
 	// status of a profile in a host.
 	BulkUpsertMDMAppleHostProfiles(ctx context.Context, payload []*MDMAppleBulkUpsertHostProfilePayload) error

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1033,6 +1033,14 @@ type ListMDMAppleProfilesToRemoveFunc func(ctx context.Context) ([]*fleet.MDMApp
 
 type ListMDMAppleProfilesToInstallAndRemoveFunc func(ctx context.Context) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error)
 
+type ListMDMAppleProfilesToInstallAndRemoveForHostsFunc func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error)
+
+type ListNextPendingMDMAppleHostUUIDsFunc func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error)
+
+type GetMDMAppleReconcileCursorFunc func(ctx context.Context) (string, error)
+
+type SetMDMAppleReconcileCursorFunc func(ctx context.Context, cursor string) error
+
 type BulkUpsertMDMAppleHostProfilesFunc func(ctx context.Context, payload []*fleet.MDMAppleBulkUpsertHostProfilePayload) error
 
 type BulkSetPendingMDMHostProfilesFunc func(ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string) (updates fleet.MDMProfilesUpdates, err error)
@@ -3480,6 +3488,18 @@ type DataStore struct {
 
 	ListMDMAppleProfilesToInstallAndRemoveFunc        ListMDMAppleProfilesToInstallAndRemoveFunc
 	ListMDMAppleProfilesToInstallAndRemoveFuncInvoked bool
+
+	ListMDMAppleProfilesToInstallAndRemoveForHostsFunc        ListMDMAppleProfilesToInstallAndRemoveForHostsFunc
+	ListMDMAppleProfilesToInstallAndRemoveForHostsFuncInvoked bool
+
+	ListNextPendingMDMAppleHostUUIDsFunc        ListNextPendingMDMAppleHostUUIDsFunc
+	ListNextPendingMDMAppleHostUUIDsFuncInvoked bool
+
+	GetMDMAppleReconcileCursorFunc        GetMDMAppleReconcileCursorFunc
+	GetMDMAppleReconcileCursorFuncInvoked bool
+
+	SetMDMAppleReconcileCursorFunc        SetMDMAppleReconcileCursorFunc
+	SetMDMAppleReconcileCursorFuncInvoked bool
 
 	BulkUpsertMDMAppleHostProfilesFunc        BulkUpsertMDMAppleHostProfilesFunc
 	BulkUpsertMDMAppleHostProfilesFuncInvoked bool
@@ -8415,6 +8435,34 @@ func (s *DataStore) ListMDMAppleProfilesToInstallAndRemove(ctx context.Context) 
 	s.ListMDMAppleProfilesToInstallAndRemoveFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListMDMAppleProfilesToInstallAndRemoveFunc(ctx)
+}
+
+func (s *DataStore) ListMDMAppleProfilesToInstallAndRemoveForHosts(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
+	s.mu.Lock()
+	s.ListMDMAppleProfilesToInstallAndRemoveForHostsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc(ctx, hostUUIDs)
+}
+
+func (s *DataStore) ListNextPendingMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+	s.mu.Lock()
+	s.ListNextPendingMDMAppleHostUUIDsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListNextPendingMDMAppleHostUUIDsFunc(ctx, afterHostUUID, batchSize)
+}
+
+func (s *DataStore) GetMDMAppleReconcileCursor(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	s.GetMDMAppleReconcileCursorFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMAppleReconcileCursorFunc(ctx)
+}
+
+func (s *DataStore) SetMDMAppleReconcileCursor(ctx context.Context, cursor string) error {
+	s.mu.Lock()
+	s.SetMDMAppleReconcileCursorFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetMDMAppleReconcileCursorFunc(ctx, cursor)
 }
 
 func (s *DataStore) BulkUpsertMDMAppleHostProfiles(ctx context.Context, payload []*fleet.MDMAppleBulkUpsertHostProfilePayload) error {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1035,7 +1035,7 @@ type ListMDMAppleProfilesToInstallAndRemoveFunc func(ctx context.Context) ([]*fl
 
 type ListMDMAppleProfilesToInstallAndRemoveForHostsFunc func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error)
 
-type ListNextPendingMDMAppleHostUUIDsFunc func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error)
+type ListNextMDMAppleHostUUIDsFunc func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error)
 
 type GetMDMAppleReconcileCursorFunc func(ctx context.Context) (string, error)
 
@@ -3492,8 +3492,8 @@ type DataStore struct {
 	ListMDMAppleProfilesToInstallAndRemoveForHostsFunc        ListMDMAppleProfilesToInstallAndRemoveForHostsFunc
 	ListMDMAppleProfilesToInstallAndRemoveForHostsFuncInvoked bool
 
-	ListNextPendingMDMAppleHostUUIDsFunc        ListNextPendingMDMAppleHostUUIDsFunc
-	ListNextPendingMDMAppleHostUUIDsFuncInvoked bool
+	ListNextMDMAppleHostUUIDsFunc        ListNextMDMAppleHostUUIDsFunc
+	ListNextMDMAppleHostUUIDsFuncInvoked bool
 
 	GetMDMAppleReconcileCursorFunc        GetMDMAppleReconcileCursorFunc
 	GetMDMAppleReconcileCursorFuncInvoked bool
@@ -8444,11 +8444,11 @@ func (s *DataStore) ListMDMAppleProfilesToInstallAndRemoveForHosts(ctx context.C
 	return s.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc(ctx, hostUUIDs)
 }
 
-func (s *DataStore) ListNextPendingMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+func (s *DataStore) ListNextMDMAppleHostUUIDs(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
 	s.mu.Lock()
-	s.ListNextPendingMDMAppleHostUUIDsFuncInvoked = true
+	s.ListNextMDMAppleHostUUIDsFuncInvoked = true
 	s.mu.Unlock()
-	return s.ListNextPendingMDMAppleHostUUIDsFunc(ctx, afterHostUUID, batchSize)
+	return s.ListNextMDMAppleHostUUIDsFunc(ctx, afterHostUUID, batchSize)
 }
 
 func (s *DataStore) GetMDMAppleReconcileCursor(ctx context.Context) (string, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5489,15 +5489,19 @@ func ReconcileAppleDeclarations(
 // delivered to the device-channel.
 const hoursToWaitForUserEnrollmentAfterDeviceEnrollment = 2
 
-// reconcileAppleProfilesBatchSize bounds how many distinct hosts the Apple
-// MDM reconciliation cron processes per tick. The cron uses a host_uuid
-// cursor (persisted in Redis via the mysqlredis wrapper) to page through
-// the pending-work universe in batches, smoothing the writer pressure
-// that an unbounded reconciliation generates during bulk events like team
-// transfers. Mirrors reconcileWindowsProfilesBatchSize.
+// reconcileAppleProfilesBatchSize bounds how many distinct Apple MDM
+// hosts the reconciliation cron considers per tick. The cron uses a
+// host_uuid cursor (persisted in Redis via the mysqlredis wrapper) to
+// page through every Apple MDM host in batches, running the full
+// desired-state install/remove query scoped to each window. Only the
+// subset of hosts with actual changes gets written/enqueued, so the
+// writer load is bounded by real work and the reader load is bounded by
+// the per-tick window. Pass-through latency to detect a new change
+// (e.g. label drift) is total_apple_hosts / batchSize × tick_interval —
+// at 5000 hosts / tick on a 30s tick, that's <= 5 min for 50k hosts.
 //
-// var rather than const so it's tunable at runtime for load testing.
-var reconcileAppleProfilesBatchSize = 2000
+// var rather than const so tests can shrink the batch size.
+var reconcileAppleProfilesBatchSize = 5000
 
 // ReconcileAppleProfiles applies configuration profiles to Apple MDM hosts.
 // Named return so the deferred SetCursor block below sees the actual
@@ -5550,9 +5554,9 @@ func ReconcileAppleProfiles(
 		cursor = ""
 	}
 
-	hostUUIDs, err := ds.ListNextPendingMDMAppleHostUUIDs(ctx, cursor, reconcileAppleProfilesBatchSize)
+	hostUUIDs, err := ds.ListNextMDMAppleHostUUIDs(ctx, cursor, reconcileAppleProfilesBatchSize)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "listing next pending Apple MDM hosts")
+		return ctxerr.Wrap(ctx, err, "listing next Apple MDM host window")
 	}
 
 	if len(hostUUIDs) == 0 {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5489,6 +5489,21 @@ func ReconcileAppleDeclarations(
 // delivered to the device-channel.
 const hoursToWaitForUserEnrollmentAfterDeviceEnrollment = 2
 
+// reconcileAppleProfilesBatchSize bounds how many distinct hosts the Apple
+// MDM reconciliation cron processes per tick. The cron uses a host_uuid
+// cursor (persisted in Redis via the mysqlredis wrapper) to page through
+// the pending-work universe in batches, smoothing the writer pressure
+// that an unbounded reconciliation generates during bulk events like team
+// transfers. Mirrors reconcileWindowsProfilesBatchSize.
+//
+// var rather than const so it's tunable at runtime for load testing.
+var reconcileAppleProfilesBatchSize = 2000
+
+// ReconcileAppleProfiles applies configuration profiles to Apple MDM hosts.
+// Named return so the deferred SetCursor block below sees the actual
+// function exit error. With a named return, every `return X` assigns X to
+// the named err before the defer fires, so any failure path correctly
+// skips the cursor write.
 func ReconcileAppleProfiles(
 	ctx context.Context,
 	ds fleet.Datastore,
@@ -5496,7 +5511,7 @@ func ReconcileAppleProfiles(
 	redisKeyValue fleet.AdvancedKeyValueStore,
 	logger *slog.Logger,
 	certProfilesLimit int,
-) error {
+) (err error) {
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)
@@ -5525,8 +5540,82 @@ func ReconcileAppleProfiles(
 		logger.ErrorContext(ctx, "unable to ensure a fleetd configuration profiles are in place", "details", err)
 	}
 
-	// retrieve the profiles to install/remove.
-	toInstall, toRemove, err := ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
+	// Read the cursor; on error, treat as start-of-pass and continue. A
+	// stale or missing cursor is harmless because the listing predicates
+	// filter out hosts whose state already matches desired state.
+	cursor, err := ds.GetMDMAppleReconcileCursor(ctx)
+	if err != nil {
+		logger.WarnContext(ctx, "failed to read apple MDM reconcile cursor; starting from beginning",
+			"err", err)
+		cursor = ""
+	}
+
+	hostUUIDs, err := ds.ListNextPendingMDMAppleHostUUIDs(ctx, cursor, reconcileAppleProfilesBatchSize)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "listing next pending Apple MDM hosts")
+	}
+
+	if len(hostUUIDs) == 0 {
+		// Either no work, or we've reached the end of the cursor pass.
+		// Reset to "" so the next tick starts from the beginning.
+		//
+		// Decision: cursor write failures here (and in the deferred
+		// advance below) are logged-and-swallowed rather than returned
+		// as tick failures.
+		if cursor != "" {
+			logger.InfoContext(ctx, "apple MDM reconcile pass complete; resetting cursor",
+				"cursor", cursor)
+			if cerr := ds.SetMDMAppleReconcileCursor(ctx, ""); cerr != nil {
+				// We assume a transient Redis failure here.
+				logger.WarnContext(ctx, "failed to reset apple MDM reconcile cursor", "err", cerr)
+			}
+		}
+		return nil
+	}
+
+	// Compute the next cursor before processing so we can advance after a
+	// successful pass. If we got fewer than the batch size, the next tick
+	// should restart from the beginning.
+	var nextCursor string
+	if len(hostUUIDs) >= reconcileAppleProfilesBatchSize {
+		nextCursor = hostUUIDs[len(hostUUIDs)-1]
+	}
+
+	// Only log when the cursor is actually in play - i.e. the pending
+	// universe didn't fit in a single tick. The four state combos:
+	//   cursor=="", nextCursor!=""  - starting a multi-tick pass
+	//   cursor!="", nextCursor!=""  - continuing mid-pass
+	//   cursor!="", nextCursor==""  - completing the final tick of a pass
+	//   cursor=="", nextCursor==""  - silent: the entire universe fit in
+	//                                 this one tick, no cursor needed
+	if cursor != "" || nextCursor != "" {
+		logger.InfoContext(ctx, "apple MDM reconcile tick using cursor",
+			"cursor", cursor,
+			"next_cursor", nextCursor,
+			"batch_size", reconcileAppleProfilesBatchSize,
+			"hosts_in_batch", len(hostUUIDs),
+		)
+	}
+
+	// On any error during the body below, leave the cursor where it was.
+	// The next tick will retry the same host window. The body's writes
+	// flip status from NULL to 'pending' on success, which removes those
+	// rows from the listing on retry, so a partial failure converges.
+	//
+	// Skip the write when the cursor isn't changing (steady-state ticks
+	// where the entire pending universe fit in one batch: cursor="",
+	// nextCursor=""). Mirrors the empty-result branch's `cursor != ""`
+	// guard above.
+	defer func() {
+		if err == nil && cursor != nextCursor {
+			if cerr := ds.SetMDMAppleReconcileCursor(ctx, nextCursor); cerr != nil {
+				logger.WarnContext(ctx, "failed to advance apple MDM reconcile cursor", "err", cerr)
+			}
+		}
+	}()
+
+	// retrieve the profiles to install/remove, scoped to this tick's host window.
+	toInstall, toRemove, err := ds.ListMDMAppleProfilesToInstallAndRemoveForHosts(ctx, hostUUIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting profiles to install and remove")
 	}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5501,7 +5501,7 @@ const hoursToWaitForUserEnrollmentAfterDeviceEnrollment = 2
 // at 5000 hosts / tick on a 30s tick, that's <= 5 min for 50k hosts.
 //
 // var rather than const so tests can shrink the batch size.
-var reconcileAppleProfilesBatchSize = 5000
+var reconcileAppleProfilesBatchSize = 2000
 
 // ReconcileAppleProfiles applies configuration profiles to Apple MDM hosts.
 // Named return so the deferred SetCursor block below sees the actual

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -3168,7 +3168,7 @@ func TestMDMAppleReconcileAppleProfiles(t *testing.T) {
 	ds.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
 		return ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
 	}
-	ds.ListNextPendingMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+	ds.ListNextMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
 		return []string{hostUUID1, hostUUID2}, nil
 	}
 	ds.GetMDMAppleReconcileCursorFunc = func(ctx context.Context) (string, error) { return "", nil }
@@ -3931,7 +3931,7 @@ func TestReconcileAppleProfilesCAThrottle(t *testing.T) {
 	ds.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
 		return ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
 	}
-	ds.ListNextPendingMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+	ds.ListNextMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
 		return hostUUIDs, nil
 	}
 	ds.GetMDMAppleReconcileCursorFunc = func(ctx context.Context) (string, error) { return "", nil }
@@ -4183,7 +4183,7 @@ func TestReconcileAppleProfilesSkipsHostBeingProcessed(t *testing.T) {
 	ds.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
 		return ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
 	}
-	ds.ListNextPendingMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+	ds.ListNextMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
 		return []string{blockedHostUUID, nonSetupHostUUID}, nil
 	}
 	ds.GetMDMAppleReconcileCursorFunc = func(ctx context.Context) (string, error) { return "", nil }

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -3162,6 +3162,17 @@ func TestMDMAppleReconcileAppleProfiles(t *testing.T) {
 	ds.ListMDMAppleProfilesToInstallAndRemoveFunc = func(ctx context.Context) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
 		return baseProfilesToInstall, baseProfilesToRemove, nil
 	}
+	// Scoped variant proxies to the legacy mock so subtest overrides flow
+	// through. The cursor-related mocks are tick stubs: the test doesn't
+	// exercise multi-tick paging, just wants one batch covering all hosts.
+	ds.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
+		return ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
+	}
+	ds.ListNextPendingMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+		return []string{hostUUID1, hostUUID2}, nil
+	}
+	ds.GetMDMAppleReconcileCursorFunc = func(ctx context.Context) (string, error) { return "", nil }
+	ds.SetMDMAppleReconcileCursorFunc = func(ctx context.Context, cursor string) error { return nil }
 
 	kv.MGetFunc = func(ctx context.Context, keys []string) (map[string]*string, error) {
 		return map[string]*string{}, nil
@@ -3916,6 +3927,15 @@ func TestReconcileAppleProfilesCAThrottle(t *testing.T) {
 	ds.ListMDMAppleProfilesToInstallAndRemoveFunc = func(ctx context.Context) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
 		return profilesToInstall, nil, nil
 	}
+	// Scoped variant proxies to the legacy mock so subtest overrides flow through.
+	ds.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
+		return ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
+	}
+	ds.ListNextPendingMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+		return hostUUIDs, nil
+	}
+	ds.GetMDMAppleReconcileCursorFunc = func(ctx context.Context) (string, error) { return "", nil }
+	ds.SetMDMAppleReconcileCursorFunc = func(ctx context.Context, cursor string) error { return nil }
 
 	ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]mobileconfig.Mobileconfig, error) {
 		return map[string]mobileconfig.Mobileconfig{
@@ -4159,6 +4179,15 @@ func TestReconcileAppleProfilesSkipsHostBeingProcessed(t *testing.T) {
 			{ProfileUUID: profileUUID, ProfileIdentifier: "com.test.profile", ProfileName: "Test Profile", HostUUID: nonSetupHostUUID, Scope: fleet.PayloadScopeSystem},
 		}, nil, nil
 	}
+	// Scoped variant proxies to the legacy mock so subtest overrides flow through.
+	ds.ListMDMAppleProfilesToInstallAndRemoveForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMAppleProfilePayload, []*fleet.MDMAppleProfilePayload, error) {
+		return ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
+	}
+	ds.ListNextPendingMDMAppleHostUUIDsFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]string, error) {
+		return []string{blockedHostUUID, nonSetupHostUUID}, nil
+	}
+	ds.GetMDMAppleReconcileCursorFunc = func(ctx context.Context) (string, error) { return "", nil }
+	ds.SetMDMAppleReconcileCursorFunc = func(ctx context.Context, cursor string) error { return nil }
 	ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]mobileconfig.Mobileconfig, error) {
 		return map[string]mobileconfig.Mobileconfig{profileUUID: profileContent}, nil
 	}


### PR DESCRIPTION
Mirrors the Windows MDM reconciler pattern: each 30s tick picks up to 2000 distinct hosts with pending install/remove work, ordered by host_uuid ascending. The cursor is persisted in Redis (via the mysqlredis wrapper) so multi-tick passes converge over time without running the unbounded reconciliation in a single pass.

Intended for load testing: scopes per-tick writer pressure on host_mdm_apple_profiles and the nano command queue, which the current all-at-once reconciler can spike during bulk events (team transfer, profile add).

Key oddities mirrored from the Windows side:
- Named return on ReconcileAppleProfiles so the deferred cursor write observes the actual exit error and skips advancement on failure.
- Cursor write failures are logged-and-swallowed: a transient Redis blip should not poison the cron tick.
- Steady-state silence: when the entire pending universe fits in one tick (cursor=="" and nextCursor==""), no cursor write or info log.
- Bare mysql.Datastore returns "" for the cursor; only mysqlredis persists. Unit tests get the no-op stub.
- Listing predicates filter out hosts whose state already matches desired state, so stale cursors and partial-failure retries converge idempotently.
- Cursor predicate (h.uuid > ?) pushed into all 4 desired-state UNION arms (install + remove) for early per-branch filtering.

Test wiring: existing reconcile tests proxy the new scoped variant through the legacy ListMDMAppleProfilesToInstallAndRemove mock so subtest overrides flow through without per-subtest changes.

