### PR TITLE
Add missing header on Fleet free for Conditional Access (#43643)

### DIFF
--- a/changes/43643-conditional-access-header-fleet-free
+++ b/changes/43643-conditional-access-header-fleet-free
@@ -1,0 +1,1 @@
+- Fixed missing "Conditional access" section header on the Settings > Integrations > Conditional access page on Fleet Free.

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tests.tsx
@@ -471,5 +471,25 @@ BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
         screen.getByText(/This feature is included in Fleet Premium/i)
       ).toBeInTheDocument();
     });
+
+    it("Renders the 'Conditional access' section header on Fleet Free", () => {
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            isPremiumTier: false,
+          },
+        },
+      });
+
+      render(<ConditionalAccess />);
+
+      expect(
+        screen.getByRole("heading", {
+          level: 2,
+          name: /Conditional access/i,
+        })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
@@ -30,6 +30,8 @@ import TooltipWrapper from "components/TooltipWrapper";
 import { IConfig, isOktaConditionalAccessConfigured } from "interfaces/config";
 import { IInputFieldParseTarget } from "interfaces/form_field";
 
+import SettingsSection from "pages/admin/components/SettingsSection";
+
 import SectionCard from "../MdmSettings/components/SectionCard";
 import EntraConditionalAccessModal from "./components/EntraConditionalAccessModal";
 import OktaConditionalAccessModal from "./components/OktaConditionalAccessModal";
@@ -296,7 +298,11 @@ const ConditionalAccess = () => {
   }, [entraTenantId, entraConfigured, entraPhase]);
 
   if (!isPremiumTier) {
-    return <PremiumFeatureMessage />;
+    return (
+      <SettingsSection title="Conditional access">
+        <PremiumFeatureMessage />
+      </SettingsSection>
+    );
   }
 
   // HANDLERS


### PR DESCRIPTION

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #43643

Fixed missing "Conditional access" section header on the Settings > Integrations > Conditional access page on Fleet Free.

<img width="1090" height="494" alt="Screenshot 2026-05-15 at 7 43 58 AM" src="https://github.com/user-attachments/assets/00ef2a31-d7f0-4b49-9b1b-03eee0b7d948" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a display issue on the Settings > Integrations > Conditional access page where the "Conditional access" section header was not visible to Fleet Free users. The section header has been restored and now properly displays for all subscription levels, ensuring consistent visual organization and improving the overall user experience in the Integrations settings area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45576)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->