### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/betterdisplay/darwin.json
+++ b/ee/maintained-apps/outputs/betterdisplay/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.2.3",
+      "version": "4.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'pro.betterdisplay.BetterDisplay';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'pro.betterdisplay.BetterDisplay' AND version_compare(bundle_short_version, '4.2.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'pro.betterdisplay.BetterDisplay' AND version_compare(bundle_short_version, '4.3.3') < 0);"
       },
-      "installer_url": "https://github.com/waydabber/BetterDisplay/releases/download/v4.2.3/BetterDisplay-v4.2.3.dmg",
+      "installer_url": "https://github.com/waydabber/BetterDisplay/releases/download/v4.3.3/BetterDisplay-v4.3.3.dmg",
       "install_script_ref": "d892af0a",
       "uninstall_script_ref": "bbd5cfd3",
-      "sha256": "91e26474c0cedb5dc3525d8b015aadc758e8026714a54df7e938fc025742a0aa",
+      "sha256": "5e105e8eb17e3dfd8823573f6a6426930bfe9272b43e2ecf148a33c89a50d317",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/mattermost/darwin.json
+++ b/ee/maintained-apps/outputs/mattermost/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.1.2",
+      "version": "6.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop' AND version_compare(bundle_short_version, '6.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop' AND version_compare(bundle_short_version, '6.2.0') < 0);"
       },
-      "installer_url": "https://releases.mattermost.com/desktop/6.1.2/mattermost-desktop-6.1.2-mac-arm64.zip",
+      "installer_url": "https://releases.mattermost.com/desktop/6.2.0/mattermost-desktop-6.2.0-mac-arm64.zip",
       "install_script_ref": "b8367a3b",
       "uninstall_script_ref": "cb17ddbd",
-      "sha256": "bdfbf4d23de5b58c59904856ca74c7574e6b640ab36a1038d08ae4379169b98b",
+      "sha256": "8e8a8ff8d48e9173025c22b0862b7b28a670fdf562b81360b89acef6bde320b6",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/webstorm/darwin.json
+++ b/ee/maintained-apps/outputs/webstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.1",
+      "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.2-aarch64.dmg",
       "install_script_ref": "a0f305dd",
       "uninstall_script_ref": "fdc991f1",
-      "sha256": "fd6c065e7bd8673f0ccce39081fe0118c44fedc2c8bfc140d652bc36f220b68a",
+      "sha256": "d98c821e2ef23d79eae4a5a4a82f94a1d9dce318fe0e44ec2f5bd436a2cd98f8",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.2.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.2.5') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.2.4/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.2.5/Zed-aarch64.dmg",
       "install_script_ref": "7a64bca0",
       "uninstall_script_ref": "315158ff",
-      "sha256": "7d46c6eee95ff45506c2228b91cd38d74f4208fa5a9e446c4a186ccafd4aa38b",
+      "sha256": "19f844a14147fa2667a63da355a58dcdc9b9e9e0d1585ff2c9c5f0ddfe48ae89",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application metadata for four macOS tools: BetterDisplay (4.2.3 → 4.3.3), Mattermost (6.1.2 → 6.2.0), WebStorm (2026.1.1 → 2026.1.2), and Zed (1.2.4 → 1.2.5) with corresponding installer URLs and checksums.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45582)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->