### PR TITLE
Fix SAML JIT login failing when role attributes have empty values (#42874)

### DIFF
--- a/changes/42874-saml-jit-empty-role-values
+++ b/changes/42874-saml-jit-empty-role-values
@@ -1,0 +1,1 @@
+- Fixed SAML JIT provisioning so `FLEET_JIT_USER_ROLE_*` attributes with empty, whitespace-only, or missing values are treated as `null` and ignored instead of failing SSO login.

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -204,6 +204,7 @@ Fleet will attempt to parse SAML custom attributes with the following format:
 
 Currently supported values for the above attributes are: `admin`, `maintainer`, `observer`, `observer_plus`, `technician` and `null`.
 A role attribute with value `null` will be ignored by Fleet. (This is to support limitations on some IdPs which do not allow you to choose what keys are sent to Fleet when creating a new user.)
+Attribute values that are empty, whitespace-only, or omit the `<saml:AttributeValue>` element entirely are also treated as `null` and ignored.
 SAML supports multi-valued attributes, Fleet will always use the last value.
 
 NOTE: Setting both `FLEET_JIT_USER_ROLE_GLOBAL` and `FLEET_JIT_USER_ROLE_FLEET_<FLEET_ID>` will cause an error during login as users cannot be both global users and belong to fleets.

--- a/ee/server/service/users.go
+++ b/ee/server/service/users.go
@@ -39,9 +39,15 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 		}
 
 		// Load custom roles from SSO attributes.
-		ssoRolesInfo, err := fleet.RolesFromSSOAttributes(auth.AssertionAttributes())
+		ssoRolesInfo, coercedAttrs, err := fleet.RolesFromSSOAttributes(auth.AssertionAttributes())
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "invalid SSO attributes")
+		}
+		if len(coercedAttrs) > 0 {
+			svc.logger.WarnContext(ctx,
+				"SAML role attribute(s) coerced to null due to empty value",
+				"attributes", coercedAttrs,
+			)
 		}
 		if !ssoRolesInfo.IsSet() {
 			// If role attributes were not set, then there's nothing to do here.
@@ -92,9 +98,15 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 		teamRoles  []fleet.UserTeam
 	)
 	// Attempt to retrieve user roles from SAML custom attributes.
-	ssoRolesInfo, err := fleet.RolesFromSSOAttributes(auth.AssertionAttributes())
+	ssoRolesInfo, coercedAttrs, err := fleet.RolesFromSSOAttributes(auth.AssertionAttributes())
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "invalid SSO attributes")
+	}
+	if len(coercedAttrs) > 0 {
+		svc.logger.WarnContext(ctx,
+			"SAML role attribute(s) coerced to null due to empty value",
+			"attributes", coercedAttrs,
+		)
 	}
 	if ssoRolesInfo.IsSet() {
 		globalRole, teamRoles, err = svc.userRolesFromSSOAttributes(ctx, ssoRolesInfo)

--- a/server/fleet/sessions.go
+++ b/server/fleet/sessions.go
@@ -124,14 +124,19 @@ const (
 //
 // For both attributes currently supported values are `admin`, `maintainer`, `observer`,
 // `observer_plus`, `technician` and `null`. A `null` value is used to ignore the attribute.
-func RolesFromSSOAttributes(attributes []SAMLAttribute) (SSORolesInfo, error) {
-	ssoRolesInfo := SSORolesInfo{}
+// An empty or whitespace-only value (or an attribute with no value elements at all) is
+// also treated as `null` and ignored. The names of any such coerced attributes are
+// returned in `coercedAttrs`.
+func RolesFromSSOAttributes(attributes []SAMLAttribute) (ssoRolesInfo SSORolesInfo, coercedAttrs []string, err error) {
 	for _, attribute := range attributes {
 		switch {
 		case attribute.Name == globalUserRoleSSOAttrName:
-			role, err := parseRole(attribute.Values)
+			role, coerced, err := parseRole(attribute.Values)
 			if err != nil {
-				return SSORolesInfo{}, fmt.Errorf("parse global role: %w", err)
+				return SSORolesInfo{}, nil, fmt.Errorf("parse global role: %w", err)
+			}
+			if coerced {
+				coercedAttrs = append(coercedAttrs, attribute.Name)
 			}
 			if role == ssoAttrNullRoleValue {
 				// If the role is set to the null value then the attribute is ignored.
@@ -146,11 +151,14 @@ func RolesFromSSOAttributes(attributes []SAMLAttribute) (SSORolesInfo, error) {
 			// Parse the fleet ID from what's left.
 			teamID, err := strconv.ParseUint(teamIDSuffix, 10, 32)
 			if err != nil {
-				return SSORolesInfo{}, fmt.Errorf("parse team ID: %w", err)
+				return SSORolesInfo{}, nil, fmt.Errorf("parse team ID: %w", err)
 			}
-			teamRole, err := parseRole(attribute.Values)
+			teamRole, coerced, err := parseRole(attribute.Values)
 			if err != nil {
-				return SSORolesInfo{}, fmt.Errorf("parse team role: %w", err)
+				return SSORolesInfo{}, nil, fmt.Errorf("parse team role: %w", err)
+			}
+			if coerced {
+				coercedAttrs = append(coercedAttrs, attribute.Name)
 			}
 			if teamRole == ssoAttrNullRoleValue {
 				// If the role is set to the null value then the attribute is ignored.
@@ -165,24 +173,31 @@ func RolesFromSSOAttributes(attributes []SAMLAttribute) (SSORolesInfo, error) {
 		}
 	}
 	if err := ssoRolesInfo.verify(); err != nil {
-		return SSORolesInfo{}, err
+		return SSORolesInfo{}, nil, err
 	}
-	return ssoRolesInfo, nil
+	return ssoRolesInfo, coercedAttrs, nil
 }
 
-func parseRole(values []SAMLAttributeValue) (string, error) {
+// parseRole returns the role to apply for a SAML role attribute. The second
+// return value is true when the input was empty / missing / whitespace-only and
+// was therefore coerced to the `null` sentinel. Valid role values must match
+// exactly (no trimming) — e.g. " admin " is rejected as an invalid role.
+func parseRole(values []SAMLAttributeValue) (string, bool, error) {
 	if len(values) == 0 {
-		return "", errors.New("empty role")
+		return ssoAttrNullRoleValue, true, nil
 	}
 	// Using last value by default.
 	value := values[len(values)-1].Value
+	if strings.TrimSpace(value) == "" {
+		return ssoAttrNullRoleValue, true, nil
+	}
 	if value != RoleAdmin &&
 		value != RoleMaintainer &&
 		value != RoleObserver &&
 		value != RoleObserverPlus &&
 		value != RoleTechnician &&
 		value != ssoAttrNullRoleValue {
-		return "", fmt.Errorf("invalid role: %s", value)
+		return "", false, fmt.Errorf("invalid role: %s", value)
 	}
-	return value, nil
+	return value, false, nil
 }

--- a/server/fleet/sessions_test.go
+++ b/server/fleet/sessions_test.go
@@ -13,6 +13,7 @@ func TestRolesFromSSOAttributes(t *testing.T) {
 		attributes           []SAMLAttribute
 		shouldFail           bool
 		expectedSSORolesInfo SSORolesInfo
+		expectedCoerced      []string
 	}{
 		{
 			name:                 "nil",
@@ -305,11 +306,117 @@ func TestRolesFromSSOAttributes(t *testing.T) {
 			},
 		},
 		{
-			name: "attribute-with-no-values-should-fail",
+			name: "attribute-with-no-values-is-ignored",
 			attributes: []SAMLAttribute{
 				{
 					Name:   globalUserRoleSSOAttrName,
 					Values: []SAMLAttributeValue{},
+				},
+			},
+			shouldFail:           false,
+			expectedSSORolesInfo: SSORolesInfo{},
+			expectedCoerced:      []string{globalUserRoleSSOAttrName},
+		},
+		{
+			name: "empty-string-on-global-is-ignored",
+			attributes: []SAMLAttribute{
+				{
+					Name: globalUserRoleSSOAttrName,
+					Values: []SAMLAttributeValue{
+						{Value: ""},
+					},
+				},
+			},
+			shouldFail:           false,
+			expectedSSORolesInfo: SSORolesInfo{},
+			expectedCoerced:      []string{globalUserRoleSSOAttrName},
+		},
+		{
+			name: "whitespace-only-on-team-is-ignored",
+			attributes: []SAMLAttribute{
+				{
+					Name: teamUserRoleSSOAttrNamePrefix + "1",
+					Values: []SAMLAttributeValue{
+						{Value: "   "},
+					},
+				},
+			},
+			shouldFail:           false,
+			expectedSSORolesInfo: SSORolesInfo{},
+			expectedCoerced:      []string{teamUserRoleSSOAttrNamePrefix + "1"},
+		},
+		{
+			name: "empty-team-attribute-alongside-set-global-attribute",
+			attributes: []SAMLAttribute{
+				{
+					Name: globalUserRoleSSOAttrName,
+					Values: []SAMLAttributeValue{
+						{Value: "admin"},
+					},
+				},
+				{
+					Name:   teamUserRoleSSOAttrNamePrefix + "1",
+					Values: []SAMLAttributeValue{},
+				},
+				{
+					Name: teamUserRoleSSOAttrNamePrefix + "2",
+					Values: []SAMLAttributeValue{
+						{Value: ""},
+					},
+				},
+			},
+			shouldFail: false,
+			expectedSSORolesInfo: SSORolesInfo{
+				Global: ptr.String("admin"),
+			},
+			expectedCoerced: []string{
+				teamUserRoleSSOAttrNamePrefix + "1",
+				teamUserRoleSSOAttrNamePrefix + "2",
+			},
+		},
+		{
+			name: "v2-prefix-empty-value-ignored",
+			attributes: []SAMLAttribute{
+				{
+					Name: "FLEET_JIT_USER_ROLE_FLEET_1",
+					Values: []SAMLAttributeValue{
+						{Value: ""},
+					},
+				},
+			},
+			shouldFail:           false,
+			expectedSSORolesInfo: SSORolesInfo{},
+			expectedCoerced:      []string{"FLEET_JIT_USER_ROLE_FLEET_1"},
+		},
+		{
+			// Locks in "last value wins" semantics even when the last value is
+			// empty: the attribute is ignored rather than falling back to
+			// earlier non-empty values.
+			name: "multi-value-last-empty-ignored",
+			attributes: []SAMLAttribute{
+				{
+					Name: teamUserRoleSSOAttrNamePrefix + "1",
+					Values: []SAMLAttributeValue{
+						{Value: "admin"},
+						{Value: ""},
+					},
+				},
+			},
+			shouldFail:           false,
+			expectedSSORolesInfo: SSORolesInfo{},
+			expectedCoerced:      []string{teamUserRoleSSOAttrNamePrefix + "1"},
+		},
+		{
+			// Whitespace around a valid role is NOT trimmed for validation;
+			// the value is rejected. Only entirely empty/whitespace-only
+			// values are coerced to the null sentinel.
+			name: "whitespace-padded-valid-role-fails",
+			attributes: []SAMLAttribute{
+				{
+					Name: globalUserRoleSSOAttrName,
+					Values: []SAMLAttributeValue{
+						{Value: " admin "},
+					},
 				},
 			},
 			shouldFail: true,
@@ -502,13 +609,14 @@ func TestRolesFromSSOAttributes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ssoRolesInfo, err := RolesFromSSOAttributes(tc.attributes)
+			ssoRolesInfo, coerced, err := RolesFromSSOAttributes(tc.attributes)
 			if tc.shouldFail {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
 			require.Equal(t, tc.expectedSSORolesInfo, ssoRolesInfo)
+			require.Equal(t, tc.expectedCoerced, coerced)
 		})
 	}
 }


### PR DESCRIPTION

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #42874

Empty, whitespace-only, and missing `FLEET_JIT_USER_ROLE_*` SAML attribute values are now treated as `null` (ignored) instead of returning an error, matching the literal `"null"` workaround.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SAML Just-In-Time user provisioning to properly handle empty or whitespace-only role attributes during SSO login. Warning logs are now emitted when role attributes are adjusted due to invalid values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45589)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->