### PR TITLE
add doc that explains how to reset sync cursor

### DIFF
--- a/docs/Contributing/product-groups/mdm/mdm-overview.md
+++ b/docs/Contributing/product-groups/mdm/mdm-overview.md
@@ -190,6 +190,8 @@ On every run, we pull the list of added/modified/deleted devices and:
     1. Assign the corresponding JSON profile to each host using ABM's APIs.
 2. If the host was deleted, we soft delete the `host_dep_assignments` entry 
 
+Read [resetting Apple DEP sync cursor](./troubleshooting/resetting-apple-dep-sync-cursor.md) for how to reset the sync cursor.
+
 #### Special case: host in ABM is deleted in Fleet
 
 If an IT admin deletes a host in the UI/API, and we have a non-deleted entry in `host_dep_assignments` for the host, we immediately create a new host entry as if the device was just ingested from the ABM sync.

--- a/docs/Contributing/product-groups/mdm/troubleshooting/resetting-apple-dep-sync-cursor.md
+++ b/docs/Contributing/product-groups/mdm/troubleshooting/resetting-apple-dep-sync-cursor.md
@@ -32,6 +32,10 @@ Storage backend: [`server/mdm/nanodep/storage/mysql`](https://github.com/fleetdm
 A reset does **not** re-enroll devices, change ABM assignments, or re-push
 DEP profiles — it only re-baselines Fleet's assignment list.
 
+## Notes
+
+- We've seen cases of where devices hit the threshold for moving into a cooldown/throttled state, Apple stops returning them on the sync cursor requests.
+
 ## Reference
 
 - Apple ADE / DEP API:

--- a/docs/Contributing/product-groups/mdm/troubleshooting/resetting-apple-dep-sync-cursor.md
+++ b/docs/Contributing/product-groups/mdm/troubleshooting/resetting-apple-dep-sync-cursor.md
@@ -1,0 +1,42 @@
+# DEP/ADE device sync in Fleet
+
+## How it works
+
+Fleet syncs ABM-assigned devices via [NanoDEP](https://github.com/fleetdm/fleet/tree/main/server/mdm/nanodep),
+driven by a cursor persisted per ABM token.
+
+- **No cursor** → Fleet calls Apple's [`fetch-devices`](https://developer.apple.com/documentation/devicemanagement/fetch-devices) (full list).
+- **Cursor present** → Fleet calls [`sync-devices`](https://developer.apple.com/documentation/devicemanagement/sync-devices) (deltas only).
+
+Fleet pages at **200 devices per request** (`DEPSyncLimit` in
+[`server/mdm/apple/apple_mdm.go`](https://github.com/fleetdm/fleet/blob/main/server/mdm/apple/apple_mdm.go))
+and loops until Apple reports no more pages. Sync cadence is set by
+`mdm.apple_dep_sync_periodicity` (default 1 minute). Apple expires cursors
+after 7 days; Fleet recovers automatically by falling back to a full fetch.
+
+## Resetting the cursor
+
+A "reset" is just clearing the stored cursor — the next sync then uses
+`fetch-devices` and rebuilds Fleet's view from scratch.
+
+This is fine to do even in larger deployments.
+
+```sql
+UPDATE nano_dep_names
+SET    syncer_cursor = NULL
+WHERE  name = '<your-abm-token-name>';
+```
+
+Storage backend: [`server/mdm/nanodep/storage/mysql`](https://github.com/fleetdm/fleet/tree/main/server/mdm/nanodep/storage/mysql).
+
+A reset does **not** re-enroll devices, change ABM assignments, or re-push
+DEP profiles — it only re-baselines Fleet's assignment list.
+
+## Reference
+
+- Apple ADE / DEP API:
+  [`fetch-devices`](https://developer.apple.com/documentation/devicemanagement/fetch-devices),
+  [`sync-devices`](https://developer.apple.com/documentation/devicemanagement/sync-devices)
+- Fleet ADE integration: [`server/mdm/apple/apple_mdm.go`](https://github.com/fleetdm/fleet/blob/main/server/mdm/apple/apple_mdm.go)
+- DEP sync tests: [`server/service/integration_mdm_dep_test.go`](https://github.com/fleetdm/fleet/blob/main/server/service/integration_mdm_dep_test.go)
+- NanoDEP syncer: [`server/mdm/nanodep/sync`](https://github.com/fleetdm/fleet/tree/main/server/mdm/nanodep/sync)


### PR DESCRIPTION
Quick doc that should help how DEP sync works (We also have the general entry) and then how to reset, and a call out that it's okay to do even for larger deployments.