### PR TITLE
Fleet-maintained app rollbacks: Fix tooltips

### DIFF
--- a/frontend/components/FileDetails/FileDetails.tsx
+++ b/frontend/components/FileDetails/FileDetails.tsx
@@ -122,8 +122,8 @@ const FileDetails = ({
         onFileSelect &&
         (gitopsCompatible ? (
           <GitOpsModeTooltipWrapper
-            position="left"
-            tipOffset={4}
+            position={customEditor ? "top" : "left"}
+            tipOffset={customEditor ? 12 : 4}
             renderChildren={(disableChildren) =>
               renderEditButton(disableChildren)
             }

--- a/frontend/components/FileDetails/FileDetails.tsx
+++ b/frontend/components/FileDetails/FileDetails.tsx
@@ -122,8 +122,8 @@ const FileDetails = ({
         onFileSelect &&
         (gitopsCompatible ? (
           <GitOpsModeTooltipWrapper
-            position={customEditor ? "top" : "left"}
-            tipOffset={customEditor ? 12 : 4}
+            position="top"
+            tipOffset={8}
             renderChildren={(disableChildren) =>
               renderEditButton(disableChildren)
             }

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -465,6 +465,7 @@ const PackageForm = ({
         versionOptions={versionOptions}
         onSelectVersion={onSelectVersion}
         className={`${baseClass}__version-selector`}
+        isGitOpsMode={gitOpsModeEnabled}
       />
     );
   };

--- a/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tests.tsx
@@ -34,6 +34,11 @@ describe("PackageVersionSelector component", () => {
     expect(
       screen.queryByText("Latest (2.0.0)", { exact: false })
     ).not.toBeInTheDocument();
+
+    // No tooltip when there is only one version (nothing to roll back to)
+    expect(
+      document.querySelector(".component__tooltip-wrapper__element")
+    ).toBeNull();
   });
 
   it("renders the package version dropdown when there are package versions to choose from", () => {
@@ -134,7 +139,7 @@ describe("PackageVersionSelector component", () => {
     expect(latestOptionWrapper).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("shows the GitOps rollback tooltip text when the selected version is the first (latest) option", async () => {
+  it("shows the rollback tooltip when the latest version is selected and not in GitOps mode", async () => {
     const { user } = renderWithSetup(
       <PackageVersionSelector
         selectedVersion="2.0.0"
@@ -146,7 +151,6 @@ describe("PackageVersionSelector component", () => {
       />
     );
 
-    // TooltipWrapper attaches tooltip to this element:
     const tooltipAnchor = document.querySelector(
       ".component__tooltip-wrapper__element"
     ) as HTMLElement;
@@ -161,6 +165,24 @@ describe("PackageVersionSelector component", () => {
         screen.getByText("to roll back (UI coming soon).", { exact: false })
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows no tooltip when in GitOps mode (parent handles the GitOps tooltip)", () => {
+    render(
+      <PackageVersionSelector
+        selectedVersion="2.0.0"
+        versionOptions={[
+          { value: "2.0.0", label: "Latest (2.0.0)" },
+          { value: "1.0.0", label: "1.0.0" },
+        ]}
+        onSelectVersion={noop}
+        isGitOpsMode
+      />
+    );
+
+    expect(
+      document.querySelector(".component__tooltip-wrapper__element")
+    ).toBeNull();
   });
 
   it("shows the update-to-latest tooltip text when the selected version is not the first (latest) option", async () => {

--- a/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tsx
@@ -27,6 +27,7 @@ interface IPackageVersionSelectorProps {
   versionOptions: CustomOptionType[];
   selectedVersion: string;
   onSelectVersion: (version: string) => void;
+  isGitOpsMode?: boolean;
 }
 
 const PackageVersionSelector = ({
@@ -34,6 +35,7 @@ const PackageVersionSelector = ({
   versionOptions,
   selectedVersion,
   onSelectVersion,
+  isGitOpsMode = false,
 }: IPackageVersionSelectorProps) => {
   if (versionOptions.length === 0) {
     return null;
@@ -47,24 +49,30 @@ const PackageVersionSelector = ({
       onChange={(version) => onSelectVersion(version?.value || "")}
       options={disableAllUIOptions(versionOptions, selectedVersion)} // Replace with "versions" when we want to enable selecting versions in the UI
       placeholder="Select a version"
+      isDisabled={isGitOpsMode}
     />
   );
 
+  if (isGitOpsMode || versionOptions.length < 2) {
+    return renderDropdown();
+  }
+
+  const tipContent =
+    selectedVersion === versionOptions[0].value ? (
+      <>
+        Currently, you can only use GitOps <br />
+        to roll back (UI coming soon).
+      </>
+    ) : (
+      <>
+        Currently, to update to latest you have
+        <br /> to delete and re-add the software.
+      </>
+    );
+
   return (
     <TooltipWrapper
-      tipContent={
-        selectedVersion === versionOptions[0].value ? (
-          <>
-            Currently, you can only use GitOps <br />
-            to roll back (UI coming soon).
-          </>
-        ) : (
-          <>
-            Currently, to update to latest you have
-            <br /> to delete and re-add the software.
-          </>
-        )
-      }
+      tipContent={tipContent}
       position="top"
       showArrow
       underline={false}


### PR DESCRIPTION
For the following bug:
- https://github.com/fleetdm/fleet/issues/45597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Repositioned edit icon tooltip from left to top positioning for improved visibility.
  * Package version selector now properly handles GitOps mode, disabling the dropdown when GitOps is active with updated tooltip behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45599)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->