### PR TITLE
Skip website/config/custom.js in Trivy secret scan

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -129,13 +129,15 @@ jobs:
           # - tools/osquery/in-a-box/osquery/fleet.key: TLS key for the "Fleet in a box" demo
           # - tools/osquery/fleet.key: TLS key for the standalone osquery dev sandbox
           # - orbit/pkg/insecure/proxy.go: TLS key used when running orbit with `--insecure` mode for development/testing.
-          # - ee/orbit/pkg/httpsigproxy/httpsigproxy.go: TLS key only used for osquery to orbit _local_ communication 
+          # - ee/orbit/pkg/httpsigproxy/httpsigproxy.go: TLS key only used for osquery to orbit _local_ communication
           #   (for injection of HTTP signatures for the TPM-backed feature in Linux).
+          # - website/config/custom.js: commented-out Stripe test-mode placeholders shown as example config.
           skip-files: |
             tools/osquery/in-a-box/osquery/fleet.key
             tools/osquery/fleet.key
             orbit/pkg/insecure/proxy.go
             ee/orbit/pkg/httpsigproxy/httpsigproxy.go
+            website/config/custom.js
 
       - name: Upload Trivy scan results to GitHub Security tab
         # Only upload on schedule/manual runs. PR/push uploads register


### PR DESCRIPTION
## Summary

- `website/config/custom.js` contains commented-out Stripe test-mode placeholders (`pk_test_...` / `sk_test_...`) shown to developers as example billing config.
- Trivy's secret detector matches the Stripe regex regardless of comment syntax, so every push to `main` that touches a `.tf` file (e.g. the v4.85.0 release commit) trips the scan and fails CI: https://github.com/fleetdm/fleet/actions/runs/25920033570/job/76186369286
- Added the file to the existing `skip-files` block in `.github/workflows/trivy-scan.yml`, matching the pattern used for the demo/test TLS keys already listed there.

## Test plan

- [ ] Push triggers the workflow on this PR; confirm the Trivy job passes (no Stripe secret findings).
- [ ] Next push to `main` that touches a `.tf` file does not fail the Trivy scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration to refine file ignore patterns and improve scan coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45621)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->