### PR TITLE
Update patch policy logic when OR is used

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -158,7 +158,7 @@ func TestIngestValidations(t *testing.T) {
 				)
 			} else {
 				require.Equal(t,
-					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
+					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
 					out.Queries.Patched,
 				)
 			}

--- a/ee/maintained-apps/outputs/codex-cli/windows.json
+++ b/ee/maintained-apps/outputs/codex-cli/windows.json
@@ -4,7 +4,7 @@
       "version": "0.130.0",
       "queries": {
         "exists": "SELECT 1 FROM file WHERE path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe' AND version_compare(version, '0.130.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe') AND version_compare(version, '0.130.0') < 0);"
       },
       "installer_url": "https://github.com/openai/codex/releases/download/rust-v0.130.0/codex-x86_64-pc-windows-msvc.exe.zip",
       "install_script_ref": "8bb4b68b",

--- a/ee/maintained-apps/outputs/codex-cli/windows.json
+++ b/ee/maintained-apps/outputs/codex-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.116.0",
+      "version": "0.130.0",
       "queries": {
         "exists": "SELECT 1 FROM file WHERE path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe';",
-        "patch": ""
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe' AND version_compare(version, '0.130.0') < 0);"
       },
-      "installer_url": "https://github.com/openai/codex/releases/download/rust-v0.116.0/codex-x86_64-pc-windows-msvc.exe.zip",
+      "installer_url": "https://github.com/openai/codex/releases/download/rust-v0.130.0/codex-x86_64-pc-windows-msvc.exe.zip",
       "install_script_ref": "8bb4b68b",
       "uninstall_script_ref": "7e1fe544",
-      "sha256": "f3a64ca3d389224404c1eb654015a868247e4f59bd300e3cdc05f8933f667f8a",
+      "sha256": "1aa3b56bcc825c0425185c5a7c17166cd9d56de673def0b93d48815c867d6356",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.17",
+      "version": "3.4.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.4.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.4.20') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/93e603f703cd553a6bb3644711a3379bbbb3118f/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/0cf8b06883f54e26bb4f0fb8647c9500ccb4331f/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "a4458d81",
-      "sha256": "00a3f53183e1964b938b4abfc722d735613a15aa39546e1c072685e066ada30c",
+      "sha256": "c2f4d692edb29063f925ad81cd66084a1760ac470d71560ef775c4f05414851c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.16",
+      "version": "3.4.20",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.4.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.4.20') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/f736016b0aa20ba1f99b7eec1dda48579fa4c295/win32/x64/system-setup/CursorSetup-x64-3.4.16.exe",
+      "installer_url": "https://downloads.cursor.com/production/0cf8b06883f54e26bb4f0fb8647c9500ccb4331f/win32/x64/system-setup/CursorSetup-x64-3.4.20.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "f752c0465c2dbc226c6a674d9eb7831f6bf2988519f8678dfcb68017b7f6a1de",
+      "sha256": "e5219dba8d8c6bf7e4d95562875f0ba682a839771cb1ca048c54352fe08dca6d",
       "default_categories": [
         "Developer tools"
       ]

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -35,6 +35,14 @@ func GenerateQueryForManifest(p PolicyData) (string, error) {
 		return "", ErrNoExistsQuery
 	}
 	before, _ := strings.CutSuffix(p.ExistsQuery, ";")
+	// Wrap the WHERE clause body in parens so the appended `AND version_compare(...)`
+	// binds across the whole condition — protects against precedence bugs when
+	// the existing conditions contain OR.
+	const whereSep = " WHERE "
+	if idx := strings.Index(before, whereSep); idx >= 0 {
+		split := idx + len(whereSep)
+		before = before[:split] + "(" + before[split:] + ")"
+	}
 	// Escape any literal '%' in the exists query (e.g. SQL LIKE patterns)
 	// so fmt.Sprintf doesn't interpret them as format verbs.
 	before = strings.ReplaceAll(before, "%", "%%")

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -20,7 +20,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo' AND version_compare(bundle_short_version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query",
@@ -29,7 +29,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.' AND version_compare(version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query with LIKE percent wildcard",
@@ -38,7 +38,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "12.5.6",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.5.6') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
 		},
 		{
 			name: "windows from exists query with multiple LIKE percent wildcards",
@@ -47,7 +47,16 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "139.0.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla' AND version_compare(version, '139.0.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
+		},
+		{
+			name: "windows from exists query with OR conditions",
+			p: patch_policy.PolicyData{
+				Platform:    "windows",
+				Version:     "0.130.0",
+				ExistsQuery: "SELECT 1 FROM file WHERE path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe';",
+			},
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe') AND version_compare(version, '0.130.0') < 0);",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request improves the safety and correctness of SQL query generation for patch policies, particularly when handling complex `WHERE` clauses that include `OR` conditions. It also updates the application manifests for Cursor and Codex CLI to their latest versions.

**SQL Query Generation Improvements:**

* The logic for generating patch queries now wraps the body of the `WHERE` clause in parentheses when appending version checks. This ensures correct SQL operator precedence, especially when the original condition contains `OR`.
* Unit tests for query generation and ingester validation have been updated to expect the new parenthesized `WHERE` clause conditions, and a new test case was added for queries with `OR` conditions. [[1]](diffhunk://#diff-a770c8e2c3066123079c660322e318014a7c4870429e091a6e48d4acb222c340L23-R23) [[2]](diffhunk://#diff-a770c8e2c3066123079c660322e318014a7c4870429e091a6e48d4acb222c340L32-R32) [[3]](diffhunk://#diff-a770c8e2c3066123079c660322e318014a7c4870429e091a6e48d4acb222c340L41-R41) [[4]](diffhunk://#diff-a770c8e2c3066123079c660322e318014a7c4870429e091a6e48d4acb222c340L50-R59) [[5]](diffhunk://#diff-82958e1ecc7af4c2032fcb933320788e6f5e663eb18ee6cc83df106f4df960e0L161-R161)

**Application Manifest Updates:**

* Updated Cursor for macOS (`cursor/darwin.json`) and Windows (`cursor/windows.json`) to version 3.4.20, including new installer URLs, hashes, and patch queries. [[1]](diffhunk://#diff-9b2c1dd79187cceb6b65a32902bfdbee462fe2e4a3b738d9617e1fafb2b77d2dL4-R12) [[2]](diffhunk://#diff-98a7339e336a530430050323dadc8db70e07c2f62c70f988c8fdb06072ce8c7dL4-R12)
* Updated Codex CLI for Windows (`codex-cli/windows.json`) to version 0.130.0, with new installer URL, hash, and a corrected patch query that now uses the safer query generation logic.

These changes make the patch policy system more robust against SQL logic bugs and keep the application manifests up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Codex CLI Windows metadata to 0.130.0.
  * Updated Cursor macOS and Windows metadata to 3.4.20.

* **Bug Fixes**
  * Improved install/patch detection logic so version checks behave correctly for complex install conditions.

* **Tests**
  * Updated test expectations to reflect the new query formatting and version-check behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45622)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->