### PR TITLE
Revert Apple ACME and non-proxied SCEP validators — marker is opt-in (PR 2.3d)

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -511,16 +511,6 @@ func CheckProfileIsNotSigned(data []byte) error {
 }
 
 func validateConfigProfileFleetVariables(contents string, lic *fleet.LicenseInfo, groupedCAs *fleet.GroupedCertificateAuthorities) ([]string, error) {
-	// Run before the fleetVars early-return: ACME and raw-SCEP profiles
-	// may carry no Fleet variables besides the renewal-ID marker and would
-	// otherwise skip this check.
-	if err := additionalACMEValidation(contents); err != nil {
-		return nil, err
-	}
-	if err := additionalNonProxiedSCEPValidation(contents); err != nil {
-		return nil, err
-	}
-
 	fleetVars := variables.Find(contents)
 	if len(fleetVars) == 0 {
 		return nil, nil
@@ -720,97 +710,6 @@ func additionalSmallstepValidation(contents string, smallstepVars *SmallstepVars
 		for _, ca := range smallstepVars.CAs() {
 			if !slices.Contains(foundCAs, ca) {
 				return &fleet.BadRequestError{Message: fleet.SCEPVariablesNotInSCEPPayloadErrMsg}
-			}
-		}
-	}
-	return nil
-}
-
-// acmePayloadForValidation differs from SCEPPayloadContent because an ACME
-// payload's Subject is a sibling of PayloadType, not nested inside it.
-type acmePayloadForValidation struct {
-	PayloadType string       `plist:"PayloadType"`
-	Subject     [][][]string `plist:"Subject"`
-}
-
-type acmeProfileForValidation struct {
-	PayloadContent []acmePayloadForValidation `plist:"PayloadContent"`
-}
-
-// additionalACMEValidation rejects profiles whose com.apple.security.acme
-// payload Subject OU lacks $FLEET_VAR_CERTIFICATE_RENEWAL_ID. Without the
-// marker the cert can't be linked back to its profile and renewal won't
-// fire.
-func additionalACMEValidation(contents string) error {
-	if !strings.Contains(contents, mobileconfig.ACMEPayloadType) {
-		return nil
-	}
-	// Strip variables embedded in <data> elements so the plist unmarshal
-	// doesn't choke on them (consistent with unmarshalSCEPProfile).
-	contents = variables.ProfileDataVariableRegex.ReplaceAllString(contents, "")
-	var acmeProf acmeProfileForValidation
-	if err := plist.Unmarshal([]byte(contents), &acmeProf); err != nil {
-		return &fleet.BadRequestError{Message: fmt.Sprintf("Failed to parse ACME payload with Fleet variables: %s", err.Error())}
-	}
-	for _, payload := range acmeProf.PayloadContent {
-		if payload.PayloadType != mobileconfig.ACMEPayloadType {
-			continue
-		}
-		var orgUnit strings.Builder
-		for _, rdn := range payload.Subject {
-			for _, kv := range rdn {
-				if len(kv) != 2 || kv[0] != "OU" {
-					continue
-				}
-				if orgUnit.Len() > 0 {
-					orgUnit.WriteByte(',')
-				}
-				orgUnit.WriteString(kv[1])
-			}
-		}
-		if !fleet.FleetVarCertificateRenewalIDRegexp.MatchString(orgUnit.String()) {
-			return &fleet.BadRequestError{
-				Message: "Variable $FLEET_VAR_" + string(fleet.FleetVarCertificateRenewalID) +
-					" must be in the ACME certificate's organizational unit (OU).",
-			}
-		}
-	}
-	return nil
-}
-
-// additionalNonProxiedSCEPValidation rejects raw SCEP profiles (those not
-// using Fleet proxy CA variables) whose cert Subject OU lacks
-// $FLEET_VAR_CERTIFICATE_RENEWAL_ID. Profiles that use Fleet proxy
-// variables (NDES, Custom SCEP, Smallstep) are deferred to the per-CA
-// validators downstream, which enforce the same OU requirement.
-func additionalNonProxiedSCEPValidation(contents string) error {
-	if !strings.Contains(contents, mobileconfig.SCEPPayloadType) {
-		return nil
-	}
-	// If the profile uses any Fleet proxy CA variable, the per-CA
-	// validators handle it downstream.
-	for _, v := range variables.Find(contents) {
-		if v == string(fleet.FleetVarNDESSCEPChallenge) ||
-			v == string(fleet.FleetVarNDESSCEPProxyURL) ||
-			strings.HasPrefix(v, string(fleet.FleetVarCustomSCEPChallengePrefix)) ||
-			strings.HasPrefix(v, string(fleet.FleetVarCustomSCEPProxyURLPrefix)) ||
-			strings.HasPrefix(v, string(fleet.FleetVarSmallstepSCEPChallengePrefix)) ||
-			strings.HasPrefix(v, string(fleet.FleetVarSmallstepSCEPProxyURLPrefix)) {
-			return nil
-		}
-	}
-	scepProf, err := unmarshalSCEPProfile(contents)
-	if err != nil {
-		return err
-	}
-	for _, payload := range scepProf.PayloadContent {
-		if payload.PayloadType != mobileconfig.SCEPPayloadType {
-			continue
-		}
-		if !fleet.FleetVarCertificateRenewalIDRegexp.MatchString(payload.PayloadContent.OrganizationalUnit) {
-			return &fleet.BadRequestError{
-				Message: "Variable $FLEET_VAR_" + string(fleet.FleetVarCertificateRenewalID) +
-					" must be in the SCEP certificate's organizational unit (OU).",
 			}
 		}
 	}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -7370,16 +7370,76 @@ func TestApplePayloadValidatorsAreOptional(t *testing.T) {
 </dict>
 </plist>`
 
+	// Marker in CN, literal OU — confirms upload acceptance is independent
+	// of marker placement.
+	const acmeProfileCNMarker = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key><string>com.apple.security.acme</string>
+			<key>PayloadIdentifier</key><string>com.test.acme.cn</string>
+			<key>PayloadUUID</key><string>33333333-4444-5555-6666-777777777777</string>
+			<key>DirectoryURL</key><string>https://acme.example.com/directory</string>
+			<key>Subject</key>
+			<array>
+				<array><array><string>CN</string><string>%s</string></array></array>
+				<array><array><string>OU</string><string>static-ou-value</string></array></array>
+			</array>
+		</dict>
+	</array>
+	<key>PayloadIdentifier</key><string>com.test.profile.acme.cn</string>
+	<key>PayloadType</key><string>Configuration</string>
+	<key>PayloadUUID</key><string>cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa</string>
+	<key>PayloadVersion</key><integer>1</integer>
+</dict>
+</plist>`
+
+	const rawSCEPProfileCNMarker = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key><string>com.apple.security.scep</string>
+			<key>PayloadIdentifier</key><string>com.test.scep.cn</string>
+			<key>PayloadUUID</key><string>44444444-5555-6666-7777-888888888888</string>
+			<key>PayloadContent</key>
+			<dict>
+				<key>Challenge</key><string>static-challenge-value</string>
+				<key>URL</key><string>https://scep.example.com/scep</string>
+				<key>Subject</key>
+				<array>
+					<array><array><string>CN</string><string>%s</string></array></array>
+					<array><array><string>OU</string><string>static-ou-value</string></array></array>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>PayloadIdentifier</key><string>com.test.profile.rawscep.cn</string>
+	<key>PayloadType</key><string>Configuration</string>
+	<key>PayloadUUID</key><string>dddddddd-eeee-ffff-aaaa-bbbbbbbbbbbb</string>
+	<key>PayloadVersion</key><integer>1</integer>
+</dict>
+</plist>`
+
 	cases := []struct {
 		name    string
 		profile string
 	}{
-		{"ACME with preferred marker", fmt.Sprintf(acmeProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
-		{"ACME with legacy marker", fmt.Sprintf(acmeProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")},
+		{"ACME with preferred marker in OU", fmt.Sprintf(acmeProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
+		{"ACME with legacy marker in OU", fmt.Sprintf(acmeProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")},
 		{"ACME with no marker", fmt.Sprintf(acmeProfile, "static-ou-value")},
-		{"raw SCEP with preferred marker", fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
-		{"raw SCEP with legacy marker", fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")},
+		{"ACME with preferred marker in CN", fmt.Sprintf(acmeProfileCNMarker, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
+		{"ACME with legacy marker in CN", fmt.Sprintf(acmeProfileCNMarker, "$FLEET_VAR_SCEP_RENEWAL_ID")},
+		{"raw SCEP with preferred marker in OU", fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
+		{"raw SCEP with legacy marker in OU", fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")},
 		{"raw SCEP with no marker", fmt.Sprintf(rawSCEPProfile, "static-ou-value")},
+		{"raw SCEP with preferred marker in CN", fmt.Sprintf(rawSCEPProfileCNMarker, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
+		{"raw SCEP with legacy marker in CN", fmt.Sprintf(rawSCEPProfileCNMarker, "$FLEET_VAR_SCEP_RENEWAL_ID")},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -7187,14 +7187,13 @@ func TestValidateConfigProfileFleetVariables(t *testing.T) {
 			errMsg: "Variable \"$FLEET_VAR_NDES_SCEP_PROXY_URL\" must be in the SCEP certificate's \"URL\" field.",
 		},
 		{
-			// Raw SCEP fixture uses the legacy SCEP_RENEWAL_ID variable
-			// (baked into the embedded mobileconfig). The new non-proxied
-			// SCEP validator is a net-new surface that requires the
-			// preferred variable name only.
-			name: "raw SCEP with legacy variable name is rejected",
+			// Non-proxied SCEP: marker in CN won't trigger auto-renewal
+			// but upload is not blocked.
+			name: "raw SCEP with renewal-ID variable in CN uploads cleanly",
 			profile: customSCEPForValidation("challenge", "url",
 				"Name", "com.apple.security.scep"),
-			errMsg: "Variable $FLEET_VAR_CERTIFICATE_RENEWAL_ID must be in the SCEP certificate's organizational unit (OU).",
+			errMsg: "",
+			vars:   []string{"SCEP_RENEWAL_ID"},
 		},
 		{
 			name: "NDES happy path",
@@ -7310,7 +7309,9 @@ func TestValidateConfigProfileFleetVariables(t *testing.T) {
 	}
 }
 
-func TestValidateConfigProfileFleetVariablesACMEAndRenewalIDRename(t *testing.T) {
+// ACME and non-proxied SCEP profiles upload regardless of marker presence
+// or placement; the renewal-ID variable is opt-in only.
+func TestApplePayloadValidatorsAreOptional(t *testing.T) {
 	t.Parallel()
 	premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
 	groupedCAs := &fleet.GroupedCertificateAuthorities{}
@@ -7322,14 +7323,10 @@ func TestValidateConfigProfileFleetVariablesACMEAndRenewalIDRename(t *testing.T)
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadType</key>
-			<string>com.apple.security.acme</string>
-			<key>PayloadIdentifier</key>
-			<string>com.test.acme</string>
-			<key>PayloadUUID</key>
-			<string>11111111-2222-3333-4444-555555555555</string>
-			<key>DirectoryURL</key>
-			<string>https://acme.example.com/directory</string>
+			<key>PayloadType</key><string>com.apple.security.acme</string>
+			<key>PayloadIdentifier</key><string>com.test.acme</string>
+			<key>PayloadUUID</key><string>11111111-2222-3333-4444-555555555555</string>
+			<key>DirectoryURL</key><string>https://acme.example.com/directory</string>
 			<key>Subject</key>
 			<array>
 				<array><array><string>CN</string><string>device-cn</string></array></array>
@@ -7337,109 +7334,13 @@ func TestValidateConfigProfileFleetVariablesACMEAndRenewalIDRename(t *testing.T)
 			</array>
 		</dict>
 	</array>
-	<key>PayloadIdentifier</key>
-	<string>com.test.profile</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
-</dict>
-</plist>`
-
-	t.Run("ACME profile with preferred CERTIFICATE_RENEWAL_ID is accepted", func(t *testing.T) {
-		profile := fmt.Sprintf(acmeProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		_, err := validateConfigProfileFleetVariables(profile, premiumLic, groupedCAs)
-		require.NoError(t, err)
-	})
-
-	t.Run("ACME profile with legacy SCEP_RENEWAL_ID is rejected", func(t *testing.T) {
-		// ACME is a net-new validation surface; the legacy variable name
-		// is rejected even though SCEP profiles accept it.
-		profile := fmt.Sprintf(acmeProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")
-		_, err := validateConfigProfileFleetVariables(profile, premiumLic, groupedCAs)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		require.Contains(t, err.Error(), "ACME certificate")
-	})
-
-	t.Run("ACME profile missing renewal-ID marker is rejected", func(t *testing.T) {
-		profile := fmt.Sprintf(acmeProfile, "static-ou-value")
-		_, err := validateConfigProfileFleetVariables(profile, premiumLic, groupedCAs)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		require.Contains(t, err.Error(), "ACME certificate")
-		require.NotContains(t, err.Error(), "SCEP_RENEWAL_ID",
-			"error message must not advertise the legacy variable name")
-	})
-
-	t.Run("ACME profile with renewal-ID in CN only is rejected", func(t *testing.T) {
-		// ACME is a net-new validation surface; the marker must live in
-		// OU. Accepting CN placement perpetuates the bug-shaped "validator
-		// says OU, code accepts either" inconsistency inherited from
-		// pre-existing SCEP validators.
-		const cnOnlyProfile = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadType</key>
-			<string>com.apple.security.acme</string>
-			<key>PayloadIdentifier</key>
-			<string>com.test.acme</string>
-			<key>PayloadUUID</key>
-			<string>11111111-2222-3333-4444-555555555555</string>
-			<key>DirectoryURL</key>
-			<string>https://acme.example.com/directory</string>
-			<key>Subject</key>
-			<array>
-				<array><array><string>CN</string><string>$FLEET_VAR_CERTIFICATE_RENEWAL_ID</string></array></array>
-				<array><array><string>OU</string><string>static-ou-value</string></array></array>
-			</array>
-		</dict>
-	</array>
-	<key>PayloadIdentifier</key>
-	<string>com.test.profile</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
-</dict>
-</plist>`
-		_, err := validateConfigProfileFleetVariables(cnOnlyProfile, premiumLic, groupedCAs)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		require.Contains(t, err.Error(), "organizational unit (OU)")
-	})
-
-	t.Run("Non-ACME profile without Fleet vars is unaffected", func(t *testing.T) {
-		const wifiProfile = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
+	<key>PayloadIdentifier</key><string>com.test.profile.acme</string>
 	<key>PayloadType</key><string>Configuration</string>
-	<key>PayloadIdentifier</key><string>com.test.wifi</string>
 	<key>PayloadUUID</key><string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
 	<key>PayloadVersion</key><integer>1</integer>
 </dict>
 </plist>`
-		_, err := validateConfigProfileFleetVariables(wifiProfile, premiumLic, groupedCAs)
-		require.NoError(t, err)
-	})
-}
 
-func TestAdditionalNonProxiedSCEPValidation(t *testing.T) {
-	t.Parallel()
-	premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
-	groupedCAs := &fleet.GroupedCertificateAuthorities{}
-
-	// Raw SCEP profile template — literal Challenge/URL, marker variable
-	// in Subject OU. No Fleet proxy variables.
 	const rawSCEPProfile = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -7449,7 +7350,7 @@ func TestAdditionalNonProxiedSCEPValidation(t *testing.T) {
 		<dict>
 			<key>PayloadType</key><string>com.apple.security.scep</string>
 			<key>PayloadIdentifier</key><string>com.test.scep</string>
-			<key>PayloadUUID</key><string>11111111-2222-3333-4444-555555555555</string>
+			<key>PayloadUUID</key><string>22222222-3333-4444-5555-666666666666</string>
 			<key>PayloadContent</key>
 			<dict>
 				<key>Challenge</key><string>static-challenge-value</string>
@@ -7462,135 +7363,30 @@ func TestAdditionalNonProxiedSCEPValidation(t *testing.T) {
 			</dict>
 		</dict>
 	</array>
-	<key>PayloadIdentifier</key><string>com.test.profile</string>
+	<key>PayloadIdentifier</key><string>com.test.profile.rawscep</string>
 	<key>PayloadType</key><string>Configuration</string>
-	<key>PayloadUUID</key><string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
+	<key>PayloadUUID</key><string>bbbbbbbb-cccc-dddd-eeee-ffffffffffff</string>
 	<key>PayloadVersion</key><integer>1</integer>
 </dict>
 </plist>`
 
-	t.Run("raw SCEP with preferred CERTIFICATE_RENEWAL_ID is accepted", func(t *testing.T) {
-		profile := fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		_, err := validateConfigProfileFleetVariables(profile, premiumLic, groupedCAs)
-		require.NoError(t, err)
-	})
-
-	t.Run("raw SCEP with legacy SCEP_RENEWAL_ID is rejected", func(t *testing.T) {
-		// Raw-SCEP validation is a net-new surface; the legacy variable
-		// is rejected even though pre-existing SCEP validators (NDES,
-		// Custom SCEP, Smallstep) still accept it.
-		profile := fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")
-		_, err := validateConfigProfileFleetVariables(profile, premiumLic, groupedCAs)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		require.Contains(t, err.Error(), "SCEP certificate")
-	})
-
-	t.Run("raw SCEP missing renewal-ID marker is rejected", func(t *testing.T) {
-		profile := fmt.Sprintf(rawSCEPProfile, "static-ou-value")
-		_, err := validateConfigProfileFleetVariables(profile, premiumLic, groupedCAs)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		require.Contains(t, err.Error(), "SCEP certificate")
-		require.NotContains(t, err.Error(), "SCEP_RENEWAL_ID variables",
-			"error must not advertise the legacy name in the suggested-fix list")
-	})
-
-	t.Run("raw SCEP with renewal-ID in CN only is rejected", func(t *testing.T) {
-		// Raw SCEP validation is a net-new surface; the marker must live in
-		// the OU. Accepting CN placement would perpetuate the bug-shaped
-		// "validator says OU, code accepts either" inconsistency inherited
-		// from pre-existing validators.
-		const cnOnlyProfile = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadType</key><string>com.apple.security.scep</string>
-			<key>PayloadIdentifier</key><string>com.test.scep</string>
-			<key>PayloadUUID</key><string>11111111-2222-3333-4444-555555555555</string>
-			<key>PayloadContent</key>
-			<dict>
-				<key>Challenge</key><string>static-challenge-value</string>
-				<key>URL</key><string>https://scep.example.com/scep</string>
-				<key>Subject</key>
-				<array>
-					<array><array><string>CN</string><string>$FLEET_VAR_CERTIFICATE_RENEWAL_ID</string></array></array>
-					<array><array><string>OU</string><string>static-ou-value</string></array></array>
-				</array>
-			</dict>
-		</dict>
-	</array>
-	<key>PayloadIdentifier</key><string>com.test.profile</string>
-	<key>PayloadType</key><string>Configuration</string>
-	<key>PayloadUUID</key><string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
-	<key>PayloadVersion</key><integer>1</integer>
-</dict>
-</plist>`
-		_, err := validateConfigProfileFleetVariables(cnOnlyProfile, premiumLic, groupedCAs)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")
-		require.Contains(t, err.Error(), "organizational unit (OU)")
-	})
-
-	t.Run("SCEP profile using Fleet proxy vars defers to per-CA validator", func(t *testing.T) {
-		// This profile uses NDES proxy vars but lacks a SubjectName with
-		// the renewal-ID marker. additionalNonProxiedSCEPValidation should
-		// short-circuit (return nil) and let the per-CA NDES validator
-		// produce its own error downstream. The end result is still an
-		// error, but it should be the per-CA one (referencing the NDES
-		// variable triple), not the raw-SCEP one.
-		const ndesProfile = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadType</key><string>com.apple.security.scep</string>
-			<key>PayloadIdentifier</key><string>com.test.ndes</string>
-			<key>PayloadUUID</key><string>11111111-2222-3333-4444-555555555555</string>
-			<key>PayloadContent</key>
-			<dict>
-				<key>Challenge</key><string>$FLEET_VAR_NDES_SCEP_CHALLENGE</string>
-				<key>URL</key><string>$FLEET_VAR_NDES_SCEP_PROXY_URL</string>
-				<key>Subject</key>
-				<array>
-					<array><array><string>CN</string><string>device-cn</string></array></array>
-					<array><array><string>OU</string><string>static-ou</string></array></array>
-				</array>
-			</dict>
-		</dict>
-	</array>
-	<key>PayloadIdentifier</key><string>com.test.profile</string>
-	<key>PayloadType</key><string>Configuration</string>
-	<key>PayloadUUID</key><string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
-	<key>PayloadVersion</key><integer>1</integer>
-</dict>
-</plist>`
-		_, err := validateConfigProfileFleetVariables(ndesProfile, premiumLic, groupedCAs)
-		require.Error(t, err)
-		// The per-CA NDES validator's message — proves the raw-SCEP
-		// path short-circuited rather than producing its own error.
-		require.Contains(t, err.Error(), "NDES")
-	})
-
-	t.Run("non-SCEP profile is unaffected", func(t *testing.T) {
-		const wifiProfile = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadType</key><string>Configuration</string>
-	<key>PayloadIdentifier</key><string>com.test.wifi</string>
-	<key>PayloadUUID</key><string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
-	<key>PayloadVersion</key><integer>1</integer>
-</dict>
-</plist>`
-		_, err := validateConfigProfileFleetVariables(wifiProfile, premiumLic, groupedCAs)
-		require.NoError(t, err)
-	})
+	cases := []struct {
+		name    string
+		profile string
+	}{
+		{"ACME with preferred marker", fmt.Sprintf(acmeProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
+		{"ACME with legacy marker", fmt.Sprintf(acmeProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")},
+		{"ACME with no marker", fmt.Sprintf(acmeProfile, "static-ou-value")},
+		{"raw SCEP with preferred marker", fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_CERTIFICATE_RENEWAL_ID")},
+		{"raw SCEP with legacy marker", fmt.Sprintf(rawSCEPProfile, "$FLEET_VAR_SCEP_RENEWAL_ID")},
+		{"raw SCEP with no marker", fmt.Sprintf(rawSCEPProfile, "static-ou-value")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateConfigProfileFleetVariables(tc.profile, premiumLic, groupedCAs)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestValidateDeclarationFleetVariables(t *testing.T) {

--- a/server/service/mdm_profiles.go
+++ b/server/service/mdm_profiles.go
@@ -508,11 +508,10 @@ func validateProfileCertificateAuthorityVariables(profileContents string, lic *f
 		if smallstepVars.RenewalOnly() {
 			smallstepVars = nil
 		}
-		// ACME and raw-SCEP profiles legitimately have only the renewal-ID
-		// variable; bypass the "needs URL/Challenge" error for them. Marker
-		// presence is enforced upstream by additionalACMEValidation and
-		// additionalNonProxiedSCEPValidation. Non-mobileconfig content
-		// (Windows path) parses as no-payload, so the error fires normally.
+		// ACME and non-proxied SCEP profiles legitimately have only the
+		// renewal-ID variable; bypass the "needs URL/Challenge" error when
+		// such a payload is present. Windows profiles parse as no-payload
+		// and remain subject to the check.
 		hasRenewableCertPayload := false
 		mc := mobileconfig.Mobileconfig(profileContents)
 		for _, pt := range []string{mobileconfig.ACMEPayloadType, mobileconfig.SCEPPayloadType} {


### PR DESCRIPTION
**Related issue:** Resolves #45629

## What this PR does

Reverts the two Apple-side profile-upload validators that initially shipped in PR #45043 (ACME) and PR #45364 (raw SCEP). The `\$FLEET_VAR_CERTIFICATE_RENEWAL_ID` marker becomes purely opt-in: profiles upload regardless of marker presence or placement. Auto-renewal activates when the marker is in OU; otherwise the profile continues to work with manual renewal as in 4.85.

## Why

The hard-rejection behavior broke established customer workflows:

- **GitOps trap**: `fleetctl gitops apply` on existing customer profiles (Conditional Access, Okta Verify, ACME) would fail after upgrade because pre-4.86 profiles lack the marker.
- **UI-edit trap**: opening an existing profile and saving an unrelated change would be rejected.
- **Conditional Access self-rejection** (#45580): Fleet's own generated profile lacks the marker, so customers following the published guide can't deploy.

The silent-non-renewal protection from validation didn't outweigh the upgrade-day breakage cost for customers who don't even use auto-renewal.

## What's preserved

- **Pre-existing proxy SCEP validators** (NDES, Custom SCEP, Smallstep) — unchanged. These predate this story (since 4.65, PR #34403) and continue to enforce renewal-ID for profiles using Fleet proxy variables.
- **Variable rename + substitution** — `\$FLEET_VAR_CERTIFICATE_RENEWAL_ID` remains the preferred name; legacy name continues to substitute identically.
- **ACME/SCEP-with-only-renewal-ID bypass** in `mdm_profiles.go` — kept (correctly distinguishes legitimate ACME profiles from broken SCEP profiles).

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * ACME and raw SCEP configuration profiles no longer require the renewal-ID Fleet variable in certificate Subject fields. The renewal-ID variable validation is now optional, allowing more flexible certificate configuration.

* **Tests**
  * Updated configuration profile validation tests to reflect optional renewal-ID behavior for ACME and non-proxied SCEP profiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45643)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->