### PR TITLE
Hide "Rotate password" button for Observer role in Recovery Lock modal

### DIFF
--- a/changes/42249-hide-rotate-password-observer
+++ b/changes/42249-hide-rotate-password-observer
@@ -1,0 +1,1 @@
+* Hid the "Rotate password" button in the Recovery Lock password modal for users with the Observer role, instead of showing it as disabled.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tests.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+import { screen, waitFor } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+
+import hostAPI from "services/entities/hosts";
+
+import RecoveryLockPasswordModal from "./RecoveryLockPasswordModal";
+
+jest.mock("services/entities/hosts");
+
+const mockPasswordResponse = {
+  host_id: 7,
+  recovery_lock_password: {
+    password: "supersecret",
+    updated_at: "2026-04-30T13:00:00Z",
+  },
+};
+
+describe("RecoveryLockPasswordModal", () => {
+  const render = createCustomRenderer({ withBackendMock: true });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (hostAPI.getRecoveryLockPassword as jest.Mock).mockResolvedValue(
+      mockPasswordResponse
+    );
+  });
+
+  it("hides the rotate button when canRotatePassword is false", async () => {
+    render(
+      <RecoveryLockPasswordModal
+        hostId={7}
+        canRotatePassword={false}
+        onCancel={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Close")).toBeVisible();
+    });
+    expect(screen.queryByText("Rotate password")).not.toBeInTheDocument();
+  });
+
+  it("shows the rotate button when canRotatePassword is true", async () => {
+    render(
+      <RecoveryLockPasswordModal
+        hostId={7}
+        canRotatePassword
+        onCancel={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Rotate password")).toBeVisible();
+    });
+  });
+});

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
@@ -14,7 +14,6 @@ import Spinner from "components/Spinner";
 import CustomLink from "components/CustomLink";
 import Icon from "components/Icon";
 import InfoBanner from "components/InfoBanner";
-import TooltipWrapper from "components/TooltipWrapper";
 import {
   DEFAULT_USE_QUERY_OPTIONS,
   LEARN_MORE_ABOUT_BASE_LINK,
@@ -76,34 +75,20 @@ const RecoveryLockPasswordModal = ({
   };
 
   const renderRotateButton = () => {
-    if (canRotatePassword) {
-      return (
-        <Button
-          variant="inverse"
-          onClick={onRotatePassword}
-          disabled={isRotating}
-          className={`${baseClass}__rotate-button`}
-        >
-          <Icon name="refresh" />
-          {isRotating ? "Rotating..." : "Rotate password"}
-        </Button>
-      );
+    if (!canRotatePassword) {
+      return null;
     }
 
     return (
-      <span className={`${baseClass}__rotate-button--disabled`}>
-        <TooltipWrapper
-          underline={false}
-          showArrow
-          position="bottom"
-          tipContent="Only users with the maintainer role and above can rotate password."
-        >
-          <span className={`${baseClass}__rotate-button-content`}>
-            <Icon name="refresh" />
-            Rotate password
-          </span>
-        </TooltipWrapper>
-      </span>
+      <Button
+        variant="inverse"
+        onClick={onRotatePassword}
+        disabled={isRotating}
+        className={`${baseClass}__rotate-button`}
+      >
+        <Icon name="refresh" />
+        {isRotating ? "Rotating..." : "Rotate password"}
+      </Button>
     );
   };
 

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/_styles.scss
@@ -14,12 +14,4 @@
     gap: $pad-small;
   }
 
-  &__rotate-button--disabled {
-    color: $ui-fleet-black-50;
-    cursor: default;
-
-    .icon {
-      color: $ui-fleet-black-50;
-    }
-  }
 }


### PR DESCRIPTION
Closes #42249
Supersedes #42247 (stale draft with merge conflicts)

## Summary

- Hides the "Rotate password" button entirely in the Recovery Lock password modal when the user has the Observer role (`canRotatePassword` is false), instead of showing a disabled span with a tooltip
- Removes unused `TooltipWrapper` import and orphaned SCSS styles for the disabled state
- Consistent with the existing pattern in `ManagedAccountModal` which already hides the button for observers

## Changes

- `RecoveryLockPasswordModal.tsx`: Return `null` when `!canRotatePassword` instead of rendering disabled tooltip
- `_styles.scss`: Remove `__rotate-button--disabled` styles
- Added `RecoveryLockPasswordModal.tests.tsx` with two tests covering button visibility based on role

## How I tested

- Added unit tests (following the `ManagedAccountModal.tests.tsx` pattern) that verify:
  - The "Rotate password" button is **not rendered** when `canRotatePassword={false}` (Observer role)
  - The "Rotate password" button **is rendered** when `canRotatePassword={true}` (Admin/Maintainer role)
- Both tests pass locally
- ESLint passed clean on all changed files
- Webpack build succeeded; verified the built bundle no longer contains the old tooltip text or disabled-button CSS class

## Test plan

- [ ] Log in as an Observer, navigate to a macOS host with Recovery Lock, open the Recovery Lock password modal, and confirm the "Rotate password" button is not visible
- [ ] Log in as an Admin/Maintainer and confirm the "Rotate password" button still appears and works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Rotate password" control in the Recovery Lock Password modal is now hidden when password rotation is unavailable (e.g., for Observer role) instead of being shown as a disabled control.

* **Tests**
  * Added tests verifying the rotate-button visibility behavior based on rotation availability/permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->