### PR TITLE
Design proposal: Dismiss vulnerability (API + GitOps docs)

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -722,6 +722,89 @@ If the fields below are omitted, they default to values specified in [the app's 
 - `uninstall_script.path` is the script Fleet will run on hosts to uninstall software.
 - `categories` is an array of categories, from [supported categories](#labels-and-categories).
 
+## vulnerabilities
+ 
+The `vulnerabilities` section allows you to manage how Fleet handles vulnerability dismissals.
+ 
+A dismissal hides a CVE from active vulnerability reports across all hosts and fleets while preserving the audit trail. CVEs can be dismissed for a fixed window, until the CVSS score increases, or permanently.
+ 
+The `dismissed` list supports inline configuration and references to separate files in your `lib/` folder. Entries support `path:` (single file) and `paths:` (glob pattern) references. See [`path:` vs `paths:`](#path-vs-paths-glob-patterns) for details. Filenames must not contain `*`, `?`, `[`, or `{` when using `path:`.
+ 
+### Options
+ 
+For available options, see the parameters for the [Dismiss vulnerability](https://fleetdm.com/docs/rest-api/rest-api#dismiss-vulnerability) API endpoint.
+ 
+- `cve` specifies the CVE identifier (format must be CVE-YYYY-<4 or more digits>, case-insensitive). Required.
+- `reason` is free-text rationale visible in the activity log and on the dismissed view. Optional but recommended. Max 2,000 characters (default: `""`).
+- `re_evaluate.mode` specifies when the dismissal re-evaluates. Choices for mode are `after`, `on_cvss_increase`, and `never`. Required.
+- `re_evaluate.at` specifies the date the dismissal expires. Required when `re_evaluate.mode` is `after`. Accepts `YYYY-MM-DD` (interpreted as midnight UTC) or a full RFC3339 timestamp.
+- `re_evaluate.cvss_threshold` _Available in Fleet Premium._ Specifies the CVSS score delta that re-surfaces the CVE. Used when `re_evaluate.mode` is `on_cvss_increase` (default: `0.1`).
+- `scope` is reserved for future per-fleet scoping. Currently only `"global"` is supported (default: `"global"`).
+`re_evaluate.mode: never` requires the GitOps service account to have the admin role and emits a high-priority entry in the activity log.
+ 
+> `vulnerabilities` is an optional key: if included in `default.yml`, existing dismissals not listed will be removed. If the `vulnerabilities` key is omitted, existing dismissals will stay intact. For this reason, enabling [GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) _does not_ restrict creating/editing dismissals via the UI.
+>
+> Dismissals managed by GitOps cannot be restored from the UI — they must be removed from the YAML and re-synced. If a CVE is dismissed both via the UI and via GitOps, GitOps wins on the next sync.
+ 
+Can only be configured for "All fleets" (`default.yml`).
+ 
+### Example
+ 
+#### Inline
+ 
+`default.yml`
+ 
+```yaml
+vulnerabilities:
+  dismissed:
+    - cve: CVE-2024-5520
+      reason: "Mitigated by network segmentation; tracked in JIRA-3421."
+      re_evaluate:
+        mode: after
+        at: 2026-07-28
+    - cve: CVE-2024-1144
+      reason: "Linux-only CVE on a macOS-only fleet."
+      re_evaluate:
+        mode: on_cvss_increase
+        cvss_threshold: 0.5 # Available in Fleet Premium
+    - cve: CVE-2023-9982
+      reason: "Vendor end-of-life; replaced by alternative tooling Q1 2026."
+      re_evaluate:
+        mode: never
+```
+ 
+#### Separate file
+ 
+`lib/vulnerabilities-dismissed.yml`
+ 
+```yaml
+- cve: CVE-2024-5520
+  reason: "Mitigated by network segmentation; tracked in JIRA-3421."
+  re_evaluate:
+    mode: after
+    at: 2026-07-28
+- cve: CVE-2024-1144
+  reason: "Linux-only CVE on a macOS-only fleet."
+  re_evaluate:
+    mode: on_cvss_increase
+    cvss_threshold: 0.5
+- cve: CVE-2023-9982
+  reason: "Vendor end-of-life; replaced by alternative tooling Q1 2026."
+  re_evaluate:
+    mode: never
+```
+ 
+`default.yml`
+ 
+```yaml
+vulnerabilities:
+  dismissed:
+    - path: ../lib/vulnerabilities-dismissed.yml
+    - paths: ../lib/dismissed/*.yml
+```
+ 
+> Sync errors for unknown CVEs are logged as warnings, not fatal errors. A single invalid entry won't block the rest of the config from syncing.
+
 ## org_settings and settings
 
 Currently, managing users and ticket destinations (Jira and Zendesk) are only supported using Fleet's UI or [API](https://fleetdm.com/docs/rest-api/rest-api).

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -12019,18 +12019,18 @@ Deletes software that's available for install. This won't uninstall the software
 `Status: 204`
 
 ## Vulnerabilities
-
 - [List vulnerabilities](#list-vulnerabilities)
 - [Get vulnerability](#get-vulnerability)
-
+- [Dismiss vulnerability](#dismiss-vulnerability)
+- [Restore vulnerability](#restore-vulnerability)
 ### List vulnerabilities
-
+ 
 Retrieves a list of all CVEs affecting software and/or OS versions.
-
+ 
 `GET /api/v1/fleet/vulnerabilities`
-
+ 
 #### Parameters
-
+ 
 | Name                | Type     | In    | Description                                                                                                                          |
 | ---      | ---      | ---   | ---                                                                                                                                  |
 | fleet_id             | integer | query | _Available in Fleet Premium_. Filters only include vulnerabilities affecting the specified fleet. Use `0` to filter by "Unassigned" hosts.  |
@@ -12040,13 +12040,14 @@ Retrieves a list of all CVEs affecting software and/or OS versions.
 | order_direction | string | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
 | query | string | query | Search query keywords. Searchable fields include `cve`. |
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Otherwise, includes vulnerabilities with any `cisa_known_exploit` value.  |
+| status | string | query | Filter by dismissal state. Allowed values are `"active"`, `"dismissed"`, and `"all"`. Default is `"active"`. |
+| dismissed_by | integer | query | **Requires `status: "dismissed"` or `"all"`**. Filters to only include vulnerabilities dismissed by the specified user ID. |
 | after | string | query | The value to get results after. This needs `order_key` defined, as that's the column that would be used. |
-
-
+ 
 ##### Default response
-
+ 
 `Status: 200`
-
+ 
 ```json
 {
   "vulnerabilities": [
@@ -12061,6 +12062,8 @@ Retrieves a list of all CVEs affecting software and/or OS versions.
       "cisa_known_exploit": false,// Available in Fleet Premium
       "cve_published": "2022-06-01T00:15:00Z",// Available in Fleet Premium
       "cve_description": "Microsoft Windows Support Diagnostic Tool (MSDT) Remote Code Execution Vulnerability.",// Available in Fleet Premium
+      "dismissed": false,
+      "dismissal": null
     }
   ],
   "count": 123,
@@ -12071,31 +12074,32 @@ Retrieves a list of all CVEs affecting software and/or OS versions.
   }
 }
 ```
-
-
+ 
+When a vulnerability has been dismissed, `dismissed` is `true` and `dismissal` contains the full dismissal record (see [Dismiss vulnerability](#dismiss-vulnerability) for object shape).
+ 
 ### Get vulnerability
-
+ 
 Retrieve details about a vulnerability and its affected software and OS versions.
-
+ 
 If no vulnerable OS versions or software were found, but Fleet is aware of the vulnerability, a 204 status code is returned.
-
+ 
 #### Parameters
-
+ 
 | Name    | Type    | In    | Description                                                                                                                  |
 |---------|---------|-------|------------------------------------------------------------------------------------------------------------------------------|
 | cve     | string  | path  | The cve to get information about (format must be CVE-YYYY-<4 or more digits>, case-insensitive).                             |
 | fleet_id | integer | query | _Available in Fleet Premium_. Filters response data to the specified fleet. Use `0` to filter by "Unassigned" hosts. |
-
+ 
 `GET /api/v1/fleet/vulnerabilities/:cve`
-
+ 
 #### Example
-
+ 
 `GET /api/v1/fleet/vulnerabilities/cve-2022-30190`
-
+ 
 ##### Default response
-
+ 
 `Status: 200`
-
+ 
 ```json
 "vulnerability": {
   "cve": "CVE-2022-30190",
@@ -12108,6 +12112,8 @@ If no vulnerable OS versions or software were found, but Fleet is aware of the v
   "cisa_known_exploit": false,// Available in Fleet Premium
   "cve_published": "2022-06-01T00:15:00Z",// Available in Fleet Premium
   "cve_description": "Microsoft Windows Support Diagnostic Tool (MSDT) Remote Code Execution Vulnerability.",// Available in Fleet Premium
+  "dismissed": false,
+  "dismissal": null,
   "os_versions" : [
     {
       "os_version_id": 6,
@@ -12136,9 +12142,138 @@ If no vulnerable OS versions or software were found, but Fleet is aware of the v
   ]
 }
 ```
-
+ 
 The `extension_for` field is included when set and when empty, at the same level as `source`. `extension_for` will show the browser or Visual Studio Code fork associated with the extension, allowing for differentiation between e.g. an extension installed on Visual Studio Code and one installed on Cursor.
-
+ 
+When a vulnerability has been dismissed, `dismissed` is `true` and `dismissal` contains the full dismissal record (see [Dismiss vulnerability](#dismiss-vulnerability) for object shape).
+### Dismiss vulnerability
+ 
+Dismisses a vulnerability and hides it from active reports across all hosts and teams. Dismissals are recorded in the activity log and re-surface automatically based on the `re_evaluate` rule.
+ 
+`POST /api/v1/fleet/vulnerabilities/:cve/dismiss`
+ 
+#### Parameters
+ 
+| Name        | Type    | In   | Description                                                                                                                          |
+| ---         | ---     | ---  | ---                                                                                                                                  |
+| cve         | string  | path | The CVE to dismiss (format must be CVE-YYYY-<4 or more digits>, case-insensitive).                                                   |
+| reason      | string  | body | Free-text rationale. Optional but recommended; visible in the activity log and on the dismissed view. Max 2,000 characters.          |
+| re_evaluate | object  | body | Re-evaluation rule (see below). Required.                                                                                            |
+| scope       | string  | body | _Reserved for future use._ Defaults to `"global"`.                                                                                   |
+ 
+The `re_evaluate` object accepts the following fields:
+ 
+| Name           | Type    | Description                                                                                                                                            |
+| ---            | ---     | ---                                                                                                                                                    |
+| mode           | string  | One of `"after"`, `"on_cvss_increase"`, `"never"`. Required.                                                                                           |
+| at             | string  | RFC3339 timestamp. Required when `mode` is `"after"`. The CVE re-surfaces at this timestamp if still detected.                                         |
+| cvss_threshold | number  | _Available in Fleet Premium_. Used when `mode` is `"on_cvss_increase"`. The CVE re-surfaces when the NVD CVSS score rises by this delta. Default `0.1`. |
+ 
+`mode: "never"` requires admin role and creates a high-priority entry in the activity log.
+ 
+#### Example
+ 
+`POST /api/v1/fleet/vulnerabilities/CVE-2024-5520/dismiss`
+ 
+##### Request body
+ 
+```json
+{
+  "reason": "Mitigated by network segmentation; tracked in JIRA-3421.",
+  "re_evaluate": {
+    "mode": "after",
+    "at": "2026-07-28T00:00:00Z"
+  }
+}
+```
+ 
+##### Default response
+ 
+`Status: 201`
+ 
+```json
+{
+  "dismissal": {
+    "id": "dsm_8k4Jx2P9",
+    "cve": "CVE-2024-5520",
+    "scope": "global",
+    "reason": "Mitigated by network segmentation; tracked in JIRA-3421.",
+    "re_evaluate": {
+      "mode": "after",
+      "at": "2026-07-28T00:00:00Z"
+    },
+    "dismissed_by": {
+      "id": 412,
+      "email": "justine.hoang@example.com"
+    },
+    "managed_by": "ui",
+    "created_at": "2026-04-29T20:34:11Z"
+  }
+}
+```
+ 
+##### Errors
+ 
+| Status | Error                              | Meaning                                                                                  |
+| ---    | ---                                | ---                                                                                      |
+| 403    | `forbidden_permanent_dismiss`      | A non-admin user attempted `mode: "never"`.                                              |
+| 404    | `vulnerability_not_found`          | The CVE is not present in Fleet's vulnerability database.                                |
+| 409    | `already_dismissed`                | An active dismissal already exists for this CVE. Restore it before dismissing again.     |
+| 422    | `invalid_re_evaluate`              | The `re_evaluate` object is missing required fields or contains an invalid combination.  |
+ 
+### Restore vulnerability
+ 
+Restores a previously dismissed vulnerability and returns it to active reports immediately. The dismissal record is marked `restored` rather than deleted, preserving the audit trail.
+ 
+`POST /api/v1/fleet/vulnerabilities/:cve/restore`
+ 
+#### Parameters
+ 
+| Name   | Type   | In   | Description                                                                                                                  |
+| ---    | ---    | ---  | ---                                                                                                                          |
+| cve    | string | path | The CVE to restore (format must be CVE-YYYY-<4 or more digits>, case-insensitive).                                           |
+| reason | string | body | Free-text rationale for restoring. Optional; recommended for compliance.                                                     |
+ 
+If the dismissal is managed by GitOps (`managed_by: "gitops"`), this endpoint returns `409 managed_by_gitops`. The CVE must be removed from the YAML configuration and re-synced to restore.
+ 
+#### Example
+ 
+`POST /api/v1/fleet/vulnerabilities/CVE-2024-5520/restore`
+ 
+##### Request body
+ 
+```json
+{
+  "reason": "Network segmentation no longer mitigates after VLAN restructure."
+}
+```
+ 
+##### Default response
+ 
+`Status: 200`
+ 
+```json
+{
+  "dismissal": {
+    "id": "dsm_8k4Jx2P9",
+    "cve": "CVE-2024-5520",
+    "restored_at": "2026-05-02T14:11:09Z",
+    "restored_by": {
+      "id": 412,
+      "email": "justine.hoang@example.com"
+    },
+    "restore_reason": "Network segmentation no longer mitigates after VLAN restructure."
+  }
+}
+```
+ 
+##### Errors
+ 
+| Status | Error                  | Meaning                                                                          |
+| ---    | ---                    | ---                                                                              |
+| 404    | `dismissal_not_found`  | No active dismissal exists for this CVE.                                         |
+| 409    | `managed_by_gitops`    | This dismissal is managed by GitOps. Remove from YAML configuration to restore.  |
+ 
 ---
 
 ## Targets


### PR DESCRIPTION
> Design-stage draft PR. Submitted as part of the Product Designer design challenge.

Proposes the documentation for a new **dismiss vulnerability** feature: a way for security engineers to hide evaluated CVEs from active reports while preserving the audit trail.

The full design lives in the companion Figma file. This PR captures only the API + GitOps surface.

**Companion artifacts**
- [Figma flow link](https://www.figma.com/design/O3iUwuZBHiqDYbK0QkCMhz/Fleet---Dismiss-Vulnerabilities?node-id=12-2&t=4IVhM4uQjNV7qZyX-0)

## Changes

**`docs/REST API/rest-api.md`** — extends the existing `## Vulnerabilities` section:
- New `Dismiss vulnerability` endpoint (`POST /api/v1/fleet/vulnerabilities/:cve/dismiss`)
- New `Restore vulnerability` endpoint (`POST /api/v1/fleet/vulnerabilities/:cve/restore`)
- Adds `status` and `dismissed_by` query params to `List vulnerabilities`
- Adds `dismissed` and `dismissal` fields to `List` and `Get` response objects

**`docs/Configuration/yaml-files.md`** — adds new top-level `## vulnerabilities` section:
- `spec.vulnerabilities.dismissed[]` schema (mirrors the API one-to-one)
- GitOps conflict resolution (GitOps wins on next sync)
- Premium gating for `mode: on_cvss_increase`
- Admin role requirement for `mode: never`