### PR TITLE
Website: add article category page for webinars

### DIFF
--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -104,6 +104,10 @@ module.exports = {
         pageTitleForMeta = 'Whitepapers';
         pageDescriptionForMeta = 'Browse our whitepapers to learn how modern teams manage and secure their devices.';
         break;
+      case 'webinars':
+        pageTitleForMeta = 'Webinars';
+        pageDescriptionForMeta = 'Watch Fleet and industry practitioners discuss real-world device management and IT operations.';
+        break;
     }
 
 

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -34,9 +34,9 @@ module.exports = {
     let articles = [];
     let category = this.req.path.split('/')[1];
     if (category === 'articles') {
-      // If the category is `/articles` we'll show all articles
+      // If the category is `/articles` we'll show everything but guides, webinars and whitepaper articles.
       articles = sails.config.builtStaticContent.markdownPages.filter((page)=>{
-        if(_.startsWith(page.htmlId, 'articles') && !_.startsWith(page.url, '/guides') && !_.startsWith(page.url, '/whitepapers')) {
+        if(_.startsWith(page.htmlId, 'articles') && !_.startsWith(page.url, '/guides') && !_.startsWith(page.url, '/whitepapers') && !_.startsWith(page.url,  '/webinars')) {
           return page;
         }
       });

--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -54,6 +54,10 @@ parasails.registerPage('articles', {
         this.articleCategory = 'Whitepapers';
         this.categoryDescription = 'Browse our whitepapers to learn how modern teams manage and secure their devices.';
         break;
+      case 'webinars':
+        this.articleCategory = 'Webinars';
+        this.categoryDescription = 'Watch Fleet and industry practitioners discuss real-world device management and IT operations.';
+        break;
       case 'articles':
         this.articleCategory = 'Blog';
         this.categoryDescription = 'Read the latest articles from the Fleet team and community.';

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -612,6 +612,12 @@ module.exports.routes = {
     }
   },
 
+  'GET /webinars': {
+    action: 'articles/view-articles',
+    locals: {
+      currentSection: 'more'
+    }
+  },
 
   'GET /webinars/:slug': {
     action: 'articles/view-basic-webinar',

--- a/website/views/pages/articles/articles.ejs
+++ b/website/views/pages/articles/articles.ejs
@@ -38,6 +38,7 @@
           <a href="/customers">Case studies</a>
           <a href="/guides">Guides</a>
           <a href="/whitepapers">Whitepapers</a>
+          <a href="/webinars">Webinars</a>
           <a href="/releases">Releases</a>
         </div>
       </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/15702

Changes:
- Added /webinars, an article category page for webinar articles
- Added a link to the /webinars to the sidebar on the article category pages.
- Removed webinar articles from the "Blog" category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated Webinars section with a new navigation link in the articles sidebar.
  * Webinars are now displayed separately from other article content types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->