### PR TITLE
reassign dhruv articles to the security blog

### DIFF
--- a/articles/detecting-the-mini-shai-hulud-npm-supply-chain-worm-with-fleet.md
+++ b/articles/detecting-the-mini-shai-hulud-npm-supply-chain-worm-with-fleet.md
@@ -204,6 +204,6 @@ About the author: [Dhruv Majumdar](https://www.linkedin.com/in/neondhruv) is Fle
 <meta name="articleTitle" value="Detecting the Mini Shai-Hulud npm supply chain worm with Fleet">
 <meta name="authorFullName" value="Dhruv Majumdar">
 <meta name="authorGitHubUsername" value="drvcodenta">
-<meta name="category" value="articles">
+<meta name="category" value="security">
 <meta name="publishedOn" value="2026-05-13">
 <meta name="description" value="How we detected the Mini Shai-Hulud npm supply chain worm across our fleet using Fleet live queries and deep scan scripts.">

--- a/articles/natural-language-endpoint-security-fleet-mcp.md
+++ b/articles/natural-language-endpoint-security-fleet-mcp.md
@@ -173,6 +173,6 @@ About the author: [Dhruv Majumdar](https://www.linkedin.com/in/neondhruv) is Fle
 <meta name="articleTitle" value="Endpoint risk and threat hunting, in plain English: a Fleet MCP manifesto">
 <meta name="authorFullName" value="Dhruv Majumdar">
 <meta name="authorGitHubUsername" value="drvcodenta">
-<meta name="category" value="articles">
+<meta name="category" value="security">
 <meta name="publishedOn" value="2026-05-15">
 <meta name="description" value="A manifesto for natural-language endpoint security with Fleet's MCP server: ask in English, get an osquery scan, see the SQL.">


### PR DESCRIPTION
Also still shows in the main "all" articles.
