### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/camtasia/windows.json
+++ b/ee/maintained-apps/outputs/camtasia/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.1.16676",
+      "version": "26.1.2.16723",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation') AND version_compare(version, '26.1.1.16676') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation') AND version_compare(version, '26.1.2.16723') < 0);"
       },
-      "installer_url": "https://download.techsmith.com/camtasiastudio/releases/2611/camtasia.msi",
+      "installer_url": "https://download.techsmith.com/camtasiastudio/releases/2612/camtasia.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "424a13a0",
-      "sha256": "47d097868759b16494fb2579cd1a7d03ac2c1faede9c5bf71468ada7a713ad9d",
+      "sha256": "e0fc0054b3b51790f8155f7ad86696587b15615c86ec7a1ee9d9a13f9fd5fce7",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
         "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC') AND version_compare(version, '1.7196.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.7196.1/Claude-ddbeb72efde1b1de61380e139a06736428211d60.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.7196.1/Claude-abcd6556f79f4cca317ff02bfe0bedbeeb6e56a9.msix",
       "install_script_ref": "31a0b698",
       "uninstall_script_ref": "03f72055",
-      "sha256": "68ca22ebd01cf7cf708849a9e69bd4fa4fd1df5dc3032cc0000be96367ab1596",
+      "sha256": "6fac5d9622b1def773cc2162dbaa848573824de9782011cb8f20d1720381a1cc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/expressvpn/darwin.json
+++ b/ee/maintained-apps/outputs/expressvpn/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "14.1.0.13058",
+      "version": "14.1.1.13156",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.expressvpn.ExpressVPN';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.expressvpn.ExpressVPN') AND version_compare(bundle_short_version, '14.1.0.13058') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.expressvpn.ExpressVPN') AND version_compare(bundle_short_version, '14.1.1.13156') < 0);"
       },
-      "installer_url": "https://www.expressvpn.works/clients/mac/expressvpn-macos-universal-14.1.0.13058_release.zip",
+      "installer_url": "https://www.expressvpn.works/clients/mac/expressvpn-macos-universal-14.1.1.13156_release.zip",
       "install_script_ref": "c5afbbfa",
       "uninstall_script_ref": "185b88d3",
-      "sha256": "4395df575fd2282c345a436dbd11aa8399567768ad8d562de92f440d38c0f7e1",
+      "sha256": "b954a07bde7413436dfc38fe8dcc26e684dc0ed3fbc27e2bfcfae496019dd75d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/linear/darwin.json
+++ b/ee/maintained-apps/outputs/linear/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.30.0",
+      "version": "1.30.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear') AND version_compare(bundle_short_version, '1.30.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear') AND version_compare(bundle_short_version, '1.30.2') < 0);"
       },
-      "installer_url": "https://releases.linear.app/Linear-1.30.0-universal.dmg",
+      "installer_url": "https://releases.linear.app/Linear-1.30.2-universal.dmg",
       "install_script_ref": "a8868f79",
       "uninstall_script_ref": "86c828e9",
-      "sha256": "81802428822e83a10997f2b5545fc00102c9444ddb340d705754b3517c50fc86",
+      "sha256": "b9db4deec3a76d3d41ebce2afc984f146abc998be173909b4f1b898ba35815a7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.10.5",
+      "version": "12.10.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.10.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.10.6') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.10.5/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.10.6/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "219a06bef270b3f5b58bc165654b9e91664ab6158eacf7fdf2b7ad1cc2366df6",
+      "sha256": "7f25f88d9775d6f40dd5246b9d855056ff3a0ad6cf38ec83fa5f232f92dfd489",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated application version metadata for Camtasia (26.1.2.16723), Claude (1.7196.1), ExpressVPN (14.1.1.13156), Linear (1.30.2), and Postman (12.10.6).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->