### PR TITLE
feat: display activity log on device user page

### DIFF
--- a/changes/my-device-activity-panel
+++ b/changes/my-device-activity-panel
@@ -1,0 +1,1 @@
+- Added an Activity panel to the My Device page so end users can see past and upcoming activities run on their host.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -4,7 +4,11 @@ import { screen, waitFor } from "@testing-library/react";
 import { IDUPDetails, IHostDevice } from "interfaces/host";
 import createMockHost from "__mocks__/hostMock";
 import mockServer from "test/mock-server";
-import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import {
+  baseUrl,
+  createCustomRenderer,
+  createMockRouter,
+} from "test/test-utils";
 import createMockLicense from "__mocks__/licenseMock";
 
 import { IGetSetupExperienceStatusesResponse } from "services/entities/device_user";
@@ -13,11 +17,18 @@ import { IHostPolicy } from "interfaces/policy";
 
 import {
   customDeviceHandler,
+  customDevicePastActivitiesHandler,
+  customDeviceUpcomingActivitiesHandler,
   defaultDeviceCertificatesHandler,
   defaultDeviceHandler,
+  defaultDevicePastActivitiesHandler,
+  defaultDeviceUpcomingActivitiesHandler,
   deviceSetupExperienceHandler,
   emptySetupExperienceHandler,
 } from "test/handlers/device-handler";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+import { ActivityType } from "interfaces/activity";
+import { http, HttpResponse } from "msw";
 import DeviceUserPage from "./DeviceUserPage";
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
 
@@ -623,6 +634,227 @@ describe("Device User Page", () => {
       expect(
         screen.queryByRole("button", { name: "Resolve later" })
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Activity card", () => {
+    const detailsLocation = {
+      ...mockLocation,
+      pathname: "/device/testToken",
+    };
+
+    const setupActivityTest = () => {
+      mockServer.use(defaultDeviceHandler);
+      mockServer.use(defaultDeviceCertificatesHandler);
+      mockServer.use(emptySetupExperienceHandler);
+    };
+
+    it("renders the Activity card with Past and Upcoming tabs", async () => {
+      setupActivityTest();
+      mockServer.use(defaultDevicePastActivitiesHandler);
+      mockServer.use(defaultDeviceUpcomingActivitiesHandler);
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={detailsLocation}
+        />
+      );
+
+      // The activity card header is rendered inside the Details tab panel.
+      expect(await screen.findByText("Activity")).toBeInTheDocument();
+      // Both sub-tabs of the activity card are present.
+      expect(screen.getByText("Past")).toBeInTheDocument();
+      expect(screen.getByText("Upcoming")).toBeInTheDocument();
+    });
+
+    it("renders both Activity and User cards in the Details panel", async () => {
+      setupActivityTest();
+      mockServer.use(defaultDevicePastActivitiesHandler);
+      mockServer.use(defaultDeviceUpcomingActivitiesHandler);
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={detailsLocation}
+        />
+      );
+
+      expect(await screen.findByText("Activity")).toBeInTheDocument();
+      expect(await screen.findByText("User")).toBeInTheDocument();
+    });
+
+    it("renders past activity items returned by the device endpoint", async () => {
+      setupActivityTest();
+      mockServer.use(
+        customDevicePastActivitiesHandler({
+          activities: [
+            createMockHostPastActivity({
+              id: 101,
+              actor_full_name: "Admin User",
+            }),
+          ],
+        })
+      );
+      mockServer.use(defaultDeviceUpcomingActivitiesHandler);
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={detailsLocation}
+        />
+      );
+
+      // The past activity actor should appear inside the activity feed.
+      expect(await screen.findByText(/Admin User/)).toBeInTheDocument();
+    });
+
+    it("opens the software install details modal when clicking the info icon on an installed_software activity", async () => {
+      setupActivityTest();
+      mockServer.use(
+        customDevicePastActivitiesHandler({
+          activities: [
+            createMockHostPastActivity({
+              id: 202,
+              actor_full_name: "Admin User",
+              type: ActivityType.InstalledSoftware,
+              details: {
+                install_uuid: "test-install-uuid",
+                software_title: "Test Software",
+                status: "installed",
+              },
+            }),
+          ],
+        })
+      );
+      mockServer.use(defaultDeviceUpcomingActivitiesHandler);
+      // Stub the device install-result lookup the modal makes once opened, so
+      // the test isn't tripped by an unhandled request.
+      mockServer.use(
+        http.get(baseUrl("/device/:token/software/install/:uuid/results"), () =>
+          HttpResponse.json({ results: {} })
+        )
+      );
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      const { user } = render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={detailsLocation}
+        />
+      );
+
+      // Click the "show info" button on the activity item.
+      const infoButton = await screen.findByRole("button", {
+        name: /show info/i,
+      });
+      await user.click(infoButton);
+
+      // The modal opens with the software install details dialog.
+      expect(await screen.findByText("Install details")).toBeInTheDocument();
+    });
+
+    it("hides the show-info icon for ran_script activities (no device-mode modal)", async () => {
+      setupActivityTest();
+      mockServer.use(
+        customDevicePastActivitiesHandler({
+          activities: [
+            createMockHostPastActivity({
+              id: 303,
+              actor_full_name: "Admin User",
+              type: ActivityType.RanScript,
+              details: {
+                script_name: "noop.sh",
+                script_execution_id: "exec-noop",
+              },
+            }),
+          ],
+        })
+      );
+      mockServer.use(defaultDeviceUpcomingActivitiesHandler);
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={detailsLocation}
+        />
+      );
+
+      // The activity row renders, but the info button is hidden.
+      expect(await screen.findByText(/Admin User/)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /show info/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides the show-info icon for failed enrollment profile renewal activities", async () => {
+      setupActivityTest();
+      mockServer.use(
+        customDevicePastActivitiesHandler({
+          activities: [
+            createMockHostPastActivity({
+              id: 404,
+              actor_full_name: "Fleet",
+              type: ActivityType.FailedEnrollmentProfileRenewal,
+              details: { command_uuid: "cmd-fail" },
+            }),
+          ],
+        })
+      );
+      mockServer.use(defaultDeviceUpcomingActivitiesHandler);
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={detailsLocation}
+        />
+      );
+
+      expect(
+        await screen.findByText(/enrollment profile renewal failed/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /show info/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("disables the Upcoming tab on Android hosts", async () => {
+      const host = createMockHost() as IHostDevice;
+      host.platform = "android";
+
+      mockServer.use(customDeviceHandler({ host }));
+      mockServer.use(defaultDeviceCertificatesHandler);
+      mockServer.use(emptySetupExperienceHandler);
+      mockServer.use(defaultDevicePastActivitiesHandler);
+      mockServer.use(
+        customDeviceUpcomingActivitiesHandler({ activities: [], count: 0 })
+      );
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={detailsLocation}
+        />
+      );
+
+      await screen.findByText("Activity");
+      const upcomingTab = (await screen.findByText("Upcoming")).closest(
+        '[role="tab"]'
+      );
+      expect(upcomingTab).toHaveAttribute("aria-disabled", "true");
     });
   });
 });

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -15,6 +15,10 @@ import deviceUserAPI, {
   IGetDeviceCertificatesResponse,
   IGetSetupExperienceStatusesResponse,
 } from "services/entities/device_user";
+import activitiesAPI, {
+  IHostPastActivitiesResponse,
+  IHostUpcomingActivitiesResponse,
+} from "services/entities/activities";
 import diskEncryptionAPI from "services/entities/disk_encryption";
 import { IMacadminsResponse, IDUPDetails, IHostDevice } from "interfaces/host";
 import { IListSort } from "interfaces/list_options";
@@ -30,7 +34,12 @@ import {
   isLinuxLike,
   isWindows,
 } from "interfaces/platform";
-import { IHostSoftware } from "interfaces/software";
+import {
+  IHostSoftware,
+  resolveUninstallStatus,
+  SCRIPT_PACKAGE_SOURCES,
+  SoftwareInstallUninstallStatus,
+} from "interfaces/software";
 import { ISetupStep } from "interfaces/setup";
 
 import shouldShowUnsupportedScreen from "layouts/UnsupportedScreenSize/helpers";
@@ -54,6 +63,28 @@ import {
 } from "utilities/constants";
 
 import UnsupportedScreenSize from "layouts/UnsupportedScreenSize";
+
+import { IShowActivityDetailsData } from "components/ActivityItem/ActivityItem";
+import {
+  VppInstallDetailsModal,
+  IVppInstallDetails,
+} from "components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal";
+import {
+  SoftwareInstallDetailsModal,
+  IPackageInstallDetails,
+} from "components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal";
+import { SoftwareScriptDetailsModal } from "components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal";
+import {
+  SoftwareIpaInstallDetailsModal,
+  ISoftwareIpaInstallDetails,
+} from "components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal";
+import SoftwareUninstallDetailsModal, {
+  ISWUninstallDetailsParentState,
+} from "components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal";
+import CertificateInstallDetailsModal, {
+  ICertificateInstallDetails,
+} from "components/ActivityDetails/InstallDetails/CertificateInstallDetailsModal";
+import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
 import HostSummaryCard from "../cards/HostSummary";
 import VitalsCard from "../cards/Vitals";
@@ -80,6 +111,7 @@ import SelfService from "../cards/Software/SelfService";
 import DeviceUserBanners from "./components/DeviceUserBanners";
 import CertificateDetailsModal from "../modals/CertificateDetailsModal";
 import CertificatesCard from "../cards/Certificates";
+import ActivityCard from "../cards/Activity";
 import UserCard from "../cards/User";
 import HostHeader from "../cards/HostHeader/HostHeader";
 import InventoryVersionsModal from "../modals/InventoryVersionsModal";
@@ -177,6 +209,38 @@ const DeviceUserPage = ({
   const [refetchStartTime, setRefetchStartTime] = useState<number | null>(null);
   const [showRefetchSpinner, setShowRefetchSpinner] = useState(false);
 
+  // activity card states
+  const [activeActivityTab, setActiveActivityTab] = useState<
+    "past" | "upcoming"
+  >("past");
+  const [activityPage, setActivityPage] = useState(0);
+
+  // activity details modal states (info icon on an activity item)
+  const [
+    packageInstallDetails,
+    setPackageInstallDetails,
+  ] = useState<IPackageInstallDetails | null>(null);
+  const [
+    scriptPackageDetails,
+    setScriptPackageDetails,
+  ] = useState<IPackageInstallDetails | null>(null);
+  const [
+    ipaPackageInstallDetails,
+    setIpaPackageInstallDetails,
+  ] = useState<ISoftwareIpaInstallDetails | null>(null);
+  const [
+    packageUninstallDetails,
+    setPackageUninstallDetails,
+  ] = useState<ISWUninstallDetailsParentState | null>(null);
+  const [
+    activityVPPInstallDetails,
+    setActivityVPPInstallDetails,
+  ] = useState<IVppInstallDetails | null>(null);
+  const [
+    activityCertificateInstallDetails,
+    setActivityCertificateInstallDetails,
+  ] = useState<ICertificateInstallDetails | null>(null);
+
   const { data: deviceMacAdminsData } = useQuery(
     ["macadmins", deviceAuthToken],
     () => deviceUserAPI.loadHostDetailsExtension(deviceAuthToken, "macadmins"),
@@ -223,9 +287,62 @@ const DeviceUserPage = ({
     }
   );
 
+  const DEVICE_ACTIVITY_PAGE_SIZE = 8;
+
+  const {
+    data: pastActivities,
+    isFetching: pastActivitiesIsFetching,
+    isError: pastActivitiesIsError,
+    refetch: refetchPastActivities,
+  } = useQuery<IHostPastActivitiesResponse, Error, IHostPastActivitiesResponse>(
+    ["device-past-activities", deviceAuthToken, activityPage],
+    () =>
+      activitiesAPI.getDeviceHostPastActivities(
+        deviceAuthToken,
+        activityPage,
+        DEVICE_ACTIVITY_PAGE_SIZE
+      ),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: !!deviceAuthToken,
+      keepPreviousData: true,
+    }
+  );
+
+  const {
+    data: upcomingActivities,
+    isFetching: upcomingActivitiesIsFetching,
+    isError: upcomingActivitiesIsError,
+    refetch: refetchUpcomingActivities,
+  } = useQuery<
+    IHostUpcomingActivitiesResponse,
+    Error,
+    IHostUpcomingActivitiesResponse
+  >(
+    ["device-upcoming-activities", deviceAuthToken, activityPage],
+    () =>
+      activitiesAPI.getDeviceHostUpcomingActivities(
+        deviceAuthToken,
+        activityPage,
+        DEVICE_ACTIVITY_PAGE_SIZE
+      ),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: !!deviceAuthToken,
+      keepPreviousData: true,
+    }
+  );
+
   const refetchExtensions = useCallback(() => {
     deviceCertificates && refetchDeviceCertificates();
-  }, [deviceCertificates, refetchDeviceCertificates]);
+    refetchPastActivities();
+    refetchUpcomingActivities();
+  }, [
+    deviceCertificates,
+    refetchDeviceCertificates,
+    refetchPastActivities,
+    refetchUpcomingActivities,
+  ]);
 
   /**
    * Hides refetch spinner and resets refetch timer,
@@ -555,6 +672,82 @@ const DeviceUserPage = ({
     setSelectedCertificate(certificate);
   };
 
+  // Handler for the "info" icon on an activity item. Mirrors the admin host
+  // page handler (HostDetailsPage `onShowActivityDetails`) but only opens the
+  // detail modals whose underlying API supports the device auth token. Ran
+  // script details are not currently exposed to device-authenticated callers
+  // so we leave that activity type without a modal.
+  const onShowActivityDetails = useCallback(
+    ({ type, details }: IShowActivityDetailsData) => {
+      const hostDisplayName =
+        host?.display_name || details?.host_display_name || "";
+      switch (type) {
+        case "installed_software":
+          if (details?.command_uuid) {
+            setIpaPackageInstallDetails({
+              fleetInstallStatus: details?.status as SoftwareInstallUninstallStatus,
+              hostDisplayName,
+              appName: getDisplayedSoftwareName(
+                details.software_title,
+                details.software_display_name
+              ),
+              commandUuid: details?.command_uuid,
+            });
+          } else if (SCRIPT_PACKAGE_SOURCES.includes(details?.source || "")) {
+            setScriptPackageDetails({
+              ...details,
+              host_display_name: hostDisplayName,
+            });
+          } else {
+            setPackageInstallDetails({
+              ...details,
+              host_display_name: hostDisplayName,
+            });
+          }
+          break;
+        case "uninstalled_software":
+          setPackageUninstallDetails({
+            ...details,
+            softwareName: getDisplayedSoftwareName(
+              details?.software_title,
+              details?.software_display_name
+            ),
+            uninstallStatus: resolveUninstallStatus(details?.status),
+            scriptExecutionId: details?.script_execution_id || "",
+            hostDisplayName,
+          });
+          break;
+        case "installed_app_store_app":
+          setActivityVPPInstallDetails({
+            appName: getDisplayedSoftwareName(
+              details?.software_title,
+              details?.software_display_name
+            ),
+            fleetInstallStatus: (details?.status ||
+              "pending_install") as SoftwareInstallUninstallStatus,
+            commandUuid: details?.command_uuid || "",
+            hostDisplayName,
+            platform: details?.host_platform || host?.platform,
+          });
+          break;
+        case "installed_certificate":
+          setActivityCertificateInstallDetails({
+            certificateName: details?.certificate_name || "",
+            hostDisplayName,
+            status: details?.status || "",
+            detail: details?.detail || "",
+          });
+          break;
+        default:
+          // No device-mode modal for the remaining types. Items whose modal is
+          // admin-only (ran_script, FailedEnrollmentProfileRenewal) hide their
+          // show-info icon entirely via the ActivityCard's isMyDevicePage prop.
+          break;
+      }
+    },
+    [host?.display_name, host?.platform]
+  );
+
   const resendProfile = useCallback(
     (profileUUID: string): Promise<void> => {
       return deviceUserAPI.resendProfile(deviceAuthToken, profileUUID);
@@ -775,8 +968,42 @@ const DeviceUserPage = ({
                   vitalsData={vitalsData}
                   munki={deviceMacAdminsData?.munki}
                 />
+                <ActivityCard
+                  activeTab={activeActivityTab}
+                  activities={
+                    activeActivityTab === "past"
+                      ? pastActivities
+                      : upcomingActivities
+                  }
+                  isLoading={
+                    activeActivityTab === "past"
+                      ? pastActivitiesIsFetching
+                      : upcomingActivitiesIsFetching
+                  }
+                  isError={
+                    activeActivityTab === "past"
+                      ? pastActivitiesIsError
+                      : upcomingActivitiesIsError
+                  }
+                  upcomingCount={upcomingActivities?.count || 0}
+                  canCancelActivities={false}
+                  isUpcomingDisabled={host.platform === "android"}
+                  isMyDevicePage
+                  showMDMCommandsToggle={false}
+                  showMDMCommands={false}
+                  onChangeTab={(index: number) => {
+                    setActiveActivityTab(index === 0 ? "past" : "upcoming");
+                    setActivityPage(0);
+                  }}
+                  onNextPage={() => setActivityPage(activityPage + 1)}
+                  onPreviousPage={() => setActivityPage(activityPage - 1)}
+                  onShowDetails={onShowActivityDetails}
+                  onShowCommandDetails={() => undefined}
+                  onCancel={() => undefined}
+                  onShowMDMCommands={() => undefined}
+                  onHideMDMCommands={() => undefined}
+                />
                 <UserCard
-                  className={fullWidthCardClass}
                   canWriteEndUser={false}
                   endUsers={host.end_users ?? []}
                   disableFullNameTooltip
@@ -901,6 +1128,54 @@ const DeviceUserPage = ({
           <CertificateDetailsModal
             certificate={selectedCertificate}
             onExit={() => setSelectedCertificate(null)}
+          />
+        )}
+        {!!packageInstallDetails && (
+          <SoftwareInstallDetailsModal
+            details={packageInstallDetails}
+            deviceAuthToken={deviceAuthToken}
+            onCancel={() => setPackageInstallDetails(null)}
+          />
+        )}
+        {scriptPackageDetails && (
+          <SoftwareScriptDetailsModal
+            details={scriptPackageDetails}
+            deviceAuthToken={deviceAuthToken}
+            onCancel={() => setScriptPackageDetails(null)}
+          />
+        )}
+        {ipaPackageInstallDetails && (
+          <SoftwareIpaInstallDetailsModal
+            details={{
+              appName: ipaPackageInstallDetails.appName || "",
+              fleetInstallStatus: (ipaPackageInstallDetails.fleetInstallStatus ||
+                "pending_install") as SoftwareInstallUninstallStatus,
+              hostDisplayName: ipaPackageInstallDetails.hostDisplayName || "",
+              commandUuid: ipaPackageInstallDetails.commandUuid || "",
+            }}
+            deviceAuthToken={deviceAuthToken}
+            onCancel={() => setIpaPackageInstallDetails(null)}
+          />
+        )}
+        {packageUninstallDetails && (
+          <SoftwareUninstallDetailsModal
+            {...packageUninstallDetails}
+            hostDisplayName={packageUninstallDetails.hostDisplayName || ""}
+            deviceAuthToken={deviceAuthToken}
+            onCancel={() => setPackageUninstallDetails(null)}
+          />
+        )}
+        {!!activityVPPInstallDetails && (
+          <VppInstallDetailsModal
+            details={activityVPPInstallDetails}
+            deviceAuthToken={deviceAuthToken}
+            onCancel={() => setActivityVPPInstallDetails(null)}
+          />
+        )}
+        {!!activityCertificateInstallDetails && (
+          <CertificateInstallDetailsModal
+            details={activityCertificateInstallDetails}
+            onCancel={() => setActivityCertificateInstallDetails(null)}
           />
         )}
       </>

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -56,6 +56,9 @@ interface IActivityProps {
   canCancelActivities: boolean;
   /** When true, the Upcoming tab is disabled with a tooltip */
   isUpcomingDisabled?: boolean;
+  /** When true, hides the show-info icon on activity items whose details
+   * modal is admin-only (e.g. ran_script). Used by the My Device page. */
+  isMyDevicePage?: boolean;
   onChangeTab: (index: number, last: number, event: Event) => void;
   onNextPage: () => void;
   onPreviousPage: () => void;
@@ -78,6 +81,7 @@ const Activity = ({
   upcomingCount,
   canCancelActivities,
   isUpcomingDisabled = false,
+  isMyDevicePage = false,
   onChangeTab,
   onNextPage,
   onPreviousPage,
@@ -153,6 +157,7 @@ const Activity = ({
                 }
                 onShowDetails={onShowDetails}
                 isError={isError}
+                isMyDevicePage={isMyDevicePage}
                 onNextPage={onNextPage}
                 onPreviousPage={onPreviousPage}
               />
@@ -184,6 +189,7 @@ const Activity = ({
                 onShowDetails={onShowDetails}
                 onCancel={onCancel}
                 isError={isError}
+                isMyDevicePage={isMyDevicePage}
                 onNextPage={onNextPage}
                 onPreviousPage={onPreviousPage}
                 canCancelActivities={canCancelActivities}

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -45,6 +45,11 @@ export interface IHostActivityItemComponentProps {
    * @default false
    */
   hideCancel?: boolean;
+  /** Set this to `true` when rendering on the My Device page. Items whose
+   * details modal is admin-only use this to hide the show-info button.
+   * @default false
+   */
+  isMyDevicePage?: boolean;
 }
 
 /** Used for activity items component that need a show details handler */

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/FailedEnrollmentProfileRenewalActivityItem/FailedEnrollmentProfileRenewalActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/FailedEnrollmentProfileRenewalActivityItem/FailedEnrollmentProfileRenewalActivityItem.tsx
@@ -9,6 +9,7 @@ const FailedEnrollmentProfileRenewalActivityItem = ({
   activity,
   onShowDetails,
   isSoloActivity,
+  isMyDevicePage,
 }: IHostActivityItemComponentPropsWithShowDetails) => {
   return (
     <ActivityItem
@@ -17,6 +18,7 @@ const FailedEnrollmentProfileRenewalActivityItem = ({
       onShowDetails={onShowDetails}
       isSoloActivity={isSoloActivity}
       hideCancel
+      hideShowDetails={isMyDevicePage}
     >
       <span>
         <b>Fleet</b> enrollment profile renewal failed for this host.{" "}

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/RanScriptActivityItem/RanScriptActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/RanScriptActivityItem/RanScriptActivityItem.tsx
@@ -14,6 +14,7 @@ const RanScriptActivityItem = ({
   onCancel,
   isSoloActivity,
   hideCancel,
+  isMyDevicePage,
 }: IHostActivityItemComponentPropsWithShowDetails) => {
   let ranScriptPrefix = tab === "past" ? "ran" : "told Fleet to run";
   if (tab !== "past" && activity.fleet_initiated) {
@@ -28,6 +29,7 @@ const RanScriptActivityItem = ({
       onCancel={onCancel}
       isSoloActivity={isSoloActivity}
       hideCancel={hideCancel}
+      hideShowDetails={isMyDevicePage}
     >
       <b>{activity.actor_full_name ?? "Fleet"}</b>
       <>

--- a/frontend/pages/hosts/details/cards/Activity/PastActivityFeed/PastActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/PastActivityFeed/PastActivityFeed.tsx
@@ -17,6 +17,7 @@ const baseClass = "past-activity-feed";
 interface IPastActivityFeedProps {
   activities?: IHostPastActivitiesResponse;
   isError?: boolean;
+  isMyDevicePage?: boolean;
   onShowDetails: ShowActivityDetailsHandler;
   onNextPage: () => void;
   onPreviousPage: () => void;
@@ -25,6 +26,7 @@ interface IPastActivityFeedProps {
 const PastActivityFeed = ({
   activities,
   isError = false,
+  isMyDevicePage = false,
   onShowDetails,
   onNextPage,
   onPreviousPage,
@@ -66,6 +68,7 @@ const PastActivityFeed = ({
               tab="past"
               activity={activity}
               hideCancel
+              isMyDevicePage={isMyDevicePage}
               onShowDetails={onShowDetails}
             />
           );

--- a/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
@@ -17,6 +17,7 @@ interface IUpcomingActivityFeedProps {
   activities?: IHostUpcomingActivitiesResponse;
   isError?: boolean;
   canCancelActivities: boolean;
+  isMyDevicePage?: boolean;
   onShowDetails: ShowActivityDetailsHandler;
   onCancel: (activity: IHostUpcomingActivity) => void;
   onNextPage: () => void;
@@ -27,6 +28,7 @@ const UpcomingActivityFeed = ({
   activities,
   isError = false,
   canCancelActivities,
+  isMyDevicePage = false,
   onShowDetails,
   onCancel,
   onNextPage,
@@ -71,6 +73,7 @@ const UpcomingActivityFeed = ({
               activity={activity}
               onShowDetails={onShowDetails}
               hideCancel={!canCancelActivities}
+              isMyDevicePage={isMyDevicePage}
               onCancel={() => onCancel(activity)}
             />
           );

--- a/frontend/services/entities/activities.ts
+++ b/frontend/services/entities/activities.ts
@@ -110,4 +110,40 @@ export default {
     const { HOST_CANCEL_ACTIVITY } = endpoints;
     return sendRequest("DELETE", HOST_CANCEL_ACTIVITY(hostId, uuid));
   },
+
+  getDeviceHostPastActivities: (
+    token: string,
+    page = DEFAULT_PAGE,
+    perPage = DEFAULT_PAGE_SIZE
+  ): Promise<IHostPastActivitiesResponse> => {
+    const { DEVICE_HOST_PAST_ACTIVITIES } = endpoints;
+
+    const queryParams = {
+      page,
+      per_page: perPage,
+    };
+
+    const queryString = buildQueryStringFromParams(queryParams);
+    const path = `${DEVICE_HOST_PAST_ACTIVITIES(token)}?${queryString}`;
+
+    return sendRequest("GET", path);
+  },
+
+  getDeviceHostUpcomingActivities: (
+    token: string,
+    page = DEFAULT_PAGE,
+    perPage = DEFAULT_PAGE_SIZE
+  ): Promise<IHostUpcomingActivitiesResponse> => {
+    const { DEVICE_HOST_UPCOMING_ACTIVITIES } = endpoints;
+
+    const queryParams = {
+      page,
+      per_page: perPage,
+    };
+
+    const queryString = buildQueryStringFromParams(queryParams);
+    const path = `${DEVICE_HOST_UPCOMING_ACTIVITIES(token)}?${queryString}`;
+
+    return sendRequest("GET", path);
+  },
 };

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -9,6 +9,7 @@ import createMockLicense from "__mocks__/licenseMock";
 import createMockMacAdmins from "__mocks__/macAdminsMock";
 import { createMockHostCertificate } from "__mocks__/certificatesMock";
 import { createMockAppleMdmCommandResult } from "__mocks__/commandMock";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
 
 import { baseUrl } from "test/test-utils";
 import { IDUPDetails } from "interfaces/host";
@@ -17,6 +18,10 @@ import {
   IGetSetupExperienceStatusesResponse,
 } from "services/entities/device_user";
 import { IGetHostCertificatesResponse } from "services/entities/hosts";
+import {
+  IHostPastActivitiesResponse,
+  IHostUpcomingActivitiesResponse,
+} from "services/entities/activities";
 
 export const defaultDeviceHandler = http.get(baseUrl("/device/:token"), () => {
   return HttpResponse.json({
@@ -89,6 +94,50 @@ export const deviceSetupExperienceHandler = (
 export const emptySetupExperienceHandler = deviceSetupExperienceHandler({
   setup_experience_results: { software: [], scripts: [] },
 });
+
+export const defaultDevicePastActivitiesHandler = http.get(
+  baseUrl("/device/:token/activities"),
+  () => {
+    return HttpResponse.json<IHostPastActivitiesResponse>({
+      activities: [],
+      meta: { has_next_results: false, has_previous_results: false },
+    });
+  }
+);
+
+export const customDevicePastActivitiesHandler = (
+  overrides?: Partial<IHostPastActivitiesResponse>
+) =>
+  http.get(baseUrl("/device/:token/activities"), () => {
+    return HttpResponse.json<IHostPastActivitiesResponse>({
+      activities: [createMockHostPastActivity()],
+      meta: { has_next_results: false, has_previous_results: false },
+      ...overrides,
+    });
+  });
+
+export const defaultDeviceUpcomingActivitiesHandler = http.get(
+  baseUrl("/device/:token/activities/upcoming"),
+  () => {
+    return HttpResponse.json<IHostUpcomingActivitiesResponse>({
+      activities: [],
+      count: 0,
+      meta: { has_next_results: false, has_previous_results: false },
+    });
+  }
+);
+
+export const customDeviceUpcomingActivitiesHandler = (
+  overrides?: Partial<IHostUpcomingActivitiesResponse>
+) =>
+  http.get(baseUrl("/device/:token/activities/upcoming"), () => {
+    return HttpResponse.json<IHostUpcomingActivitiesResponse>({
+      activities: [],
+      count: 0,
+      meta: { has_next_results: false, has_previous_results: false },
+      ...overrides,
+    });
+  });
 
 export const getDeviceVppCommandResultHandler = http.get(
   `/device/:token/software/commands/:uuid/results`,

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -64,6 +64,12 @@ export default {
   DEVICE_CERTIFICATES: (token: string): string => {
     return `/${API_VERSION}/fleet/device/${token}/certificates`;
   },
+  DEVICE_HOST_PAST_ACTIVITIES: (token: string): string => {
+    return `/${API_VERSION}/fleet/device/${token}/activities`;
+  },
+  DEVICE_HOST_UPCOMING_ACTIVITIES: (token: string): string => {
+    return `/${API_VERSION}/fleet/device/${token}/activities/upcoming`;
+  },
   DEVICE_SETUP_EXPERIENCE_STATUSES: (token: string): string => {
     return `/${API_VERSION}/fleet/device/${token}/setup_experience/status`;
   },

--- a/server/activity/api/list_host_past_activities.go
+++ b/server/activity/api/list_host_past_activities.go
@@ -6,3 +6,11 @@ import "context"
 type ListHostPastActivitiesService interface {
 	ListHostPastActivities(ctx context.Context, hostID uint, opt ListOptions) ([]*Activity, *PaginationMetadata, error)
 }
+
+// ListHostPastActivitiesForDeviceService lists past activities for a host in a
+// context where access to the host has already been established by the caller
+// (e.g. via a device authentication token). Implementations skip user-mode
+// authorization checks.
+type ListHostPastActivitiesForDeviceService interface {
+	ListHostPastActivitiesForDevice(ctx context.Context, hostID uint, opt ListOptions) ([]*Activity, *PaginationMetadata, error)
+}

--- a/server/activity/api/service.go
+++ b/server/activity/api/service.go
@@ -7,6 +7,7 @@ package api
 type Service interface {
 	ListActivitiesService
 	ListHostPastActivitiesService
+	ListHostPastActivitiesForDeviceService
 	StreamActivitiesService
 	NewActivityService
 	CleanupExpiredActivitiesService

--- a/server/activity/internal/service/handler_test.go
+++ b/server/activity/internal/service/handler_test.go
@@ -134,6 +134,10 @@ func (m *mockService) ListHostPastActivities(_ context.Context, _ uint, _ api.Li
 	panic("mockService.ListHostPastActivities should not be called in validation tests")
 }
 
+func (m *mockService) ListHostPastActivitiesForDevice(_ context.Context, _ uint, _ api.ListOptions) ([]*api.Activity, *api.PaginationMetadata, error) {
+	panic("mockService.ListHostPastActivitiesForDevice should not be called in validation tests")
+}
+
 func (m *mockService) StreamActivities(_ context.Context, _ api.JSONLogger) error {
 	panic("mockService.StreamActivities should not be called in validation tests")
 }

--- a/server/activity/internal/service/service.go
+++ b/server/activity/internal/service/service.go
@@ -123,6 +123,24 @@ func (s *Service) ListHostPastActivities(ctx context.Context, hostID uint, opt a
 		return nil, nil, err
 	}
 
+	return s.listHostPastActivities(ctx, hostID, opt, true /* enrich */)
+}
+
+// ListHostPastActivitiesForDevice returns past activities for a specific host
+// in a context where the caller (e.g. a device-token-authenticated request)
+// has already established access to the host. This skips the user-mode
+// authorization checks performed by ListHostPastActivities.
+//
+// Enrichment via the user-lookup ACL is also skipped: enrichment goes through
+// the legacy Fleet user service, which requires a user subject in context and
+// would reject a device-authenticated request. The activity record already
+// stores the actor's email and name at write time, so the only field omitted
+// is the actor's gravatar URL.
+func (s *Service) ListHostPastActivitiesForDevice(ctx context.Context, hostID uint, opt api.ListOptions) ([]*api.Activity, *api.PaginationMetadata, error) {
+	return s.listHostPastActivities(ctx, hostID, opt, false /* enrich */)
+}
+
+func (s *Service) listHostPastActivities(ctx context.Context, hostID uint, opt api.ListOptions, enrich bool) ([]*api.Activity, *api.PaginationMetadata, error) {
 	applyListOptionsDefaults(&opt, "a.created_at")
 	// Convert public options to internal options
 	internalOpt := types.ListOptions{
@@ -135,9 +153,11 @@ func (s *Service) ListHostPastActivities(ctx context.Context, hostID uint, opt a
 		return nil, nil, ctxerr.Wrap(ctx, err, "list host past activities")
 	}
 
-	// Enrich activities with user data via ACL
-	if err := s.enrichWithUserData(ctx, activities); err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "enrich activities with user data")
+	if enrich {
+		// Enrich activities with user data via ACL
+		if err := s.enrichWithUserData(ctx, activities); err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "enrich activities with user data")
+		}
 	}
 
 	return activities, meta, nil

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -9,10 +9,13 @@ import (
 )
 
 // ActivityWriteService is the subset of the activity bounded context service
-// used by the legacy service layer for write operations.
+// used by the legacy service layer for write operations and for reads from
+// device-authenticated contexts where host access has already been verified by
+// the caller.
 type ActivityWriteService interface {
 	api.NewActivityService
 	api.CleanupHostActivitiesService
+	api.ListHostPastActivitiesForDeviceService
 }
 
 // NewActivityFunc is the function signature for creating a new activity.

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -684,6 +684,12 @@ type Service interface {
 	// (e.g. it did complete), it returns a not found error.
 	CancelHostUpcomingActivity(ctx context.Context, hostID uint, executionID string) error
 
+	// ListHostPastActivitiesForDevice lists past activities for the specified
+	// host in a device-token-authenticated context. It bypasses user-mode
+	// authorization since access to the host has already been verified by the
+	// device authentication middleware.
+	ListHostPastActivitiesForDevice(ctx context.Context, hostID uint, opt ListOptions) ([]*Activity, *PaginationMetadata, error)
+
 	// /////////////////////////////////////////////////////////////////////////////
 	// UserRolesService
 

--- a/server/mock/activity_mock.go
+++ b/server/mock/activity_mock.go
@@ -29,6 +29,9 @@ type MockActivityService struct {
 	CleanupHostActivitiesFunc        func(ctx context.Context, hostIDs []uint) error
 	CleanupHostActivitiesFuncInvoked bool
 
+	ListHostPastActivitiesForDeviceFunc        func(ctx context.Context, hostID uint, opt activity_api.ListOptions) ([]*activity_api.Activity, *activity_api.PaginationMetadata, error)
+	ListHostPastActivitiesForDeviceFuncInvoked bool
+
 	mu sync.Mutex
 }
 
@@ -59,4 +62,14 @@ func (m *MockActivityService) CleanupHostActivities(ctx context.Context, hostIDs
 		return m.CleanupHostActivitiesFunc(ctx, hostIDs)
 	}
 	return nil
+}
+
+func (m *MockActivityService) ListHostPastActivitiesForDevice(ctx context.Context, hostID uint, opt activity_api.ListOptions) ([]*activity_api.Activity, *activity_api.PaginationMetadata, error) {
+	m.mu.Lock()
+	m.ListHostPastActivitiesForDeviceFuncInvoked = true
+	m.mu.Unlock()
+	if m.ListHostPastActivitiesForDeviceFunc != nil {
+		return m.ListHostPastActivitiesForDeviceFunc(ctx, hostID, opt)
+	}
+	return nil, &activity_api.PaginationMetadata{}, nil
 }

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -412,6 +412,8 @@ type ListHostUpcomingActivitiesFunc func(ctx context.Context, hostID uint, opt f
 
 type CancelHostUpcomingActivityFunc func(ctx context.Context, hostID uint, executionID string) error
 
+type ListHostPastActivitiesForDeviceFunc func(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error)
+
 type ApplyUserRolesSpecsFunc func(ctx context.Context, specs fleet.UsersRoleSpec) error
 
 type CreateCertificateTemplateFunc func(ctx context.Context, name string, teamID uint, certificateAuthorityID uint, subjectName string, subjectAlternativeName string) (*fleet.CertificateTemplateResponse, error)
@@ -1514,6 +1516,9 @@ type Service struct {
 
 	CancelHostUpcomingActivityFunc        CancelHostUpcomingActivityFunc
 	CancelHostUpcomingActivityFuncInvoked bool
+
+	ListHostPastActivitiesForDeviceFunc        ListHostPastActivitiesForDeviceFunc
+	ListHostPastActivitiesForDeviceFuncInvoked bool
 
 	ApplyUserRolesSpecsFunc        ApplyUserRolesSpecsFunc
 	ApplyUserRolesSpecsFuncInvoked bool
@@ -3659,6 +3664,13 @@ func (s *Service) CancelHostUpcomingActivity(ctx context.Context, hostID uint, e
 	s.CancelHostUpcomingActivityFuncInvoked = true
 	s.mu.Unlock()
 	return s.CancelHostUpcomingActivityFunc(ctx, hostID, executionID)
+}
+
+func (s *Service) ListHostPastActivitiesForDevice(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
+	s.mu.Lock()
+	s.ListHostPastActivitiesForDeviceFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListHostPastActivitiesForDeviceFunc(ctx, hostID, opt)
 }
 
 func (s *Service) ApplyUserRolesSpecs(ctx context.Context, specs fleet.UsersRoleSpec) error {

--- a/server/service/activities.go
+++ b/server/service/activities.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
+	authzctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -66,18 +68,35 @@ func listHostUpcomingActivitiesEndpoint(ctx context.Context, request interface{}
 // ListHostUpcomingActivities returns a slice of upcoming activities for the
 // specified host.
 func (svc *Service) ListHostUpcomingActivities(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.UpcomingActivity, *fleet.PaginationMetadata, error) {
-	// First ensure the user has access to list hosts, then check the specific
-	// host once team_id is loaded.
-	if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
-		return nil, nil, err
-	}
-	host, err := svc.ds.HostLite(ctx, hostID)
-	if err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "get host")
-	}
-	// Authorize again with team loaded now that we have team_id
-	if err := svc.authz.Authorize(ctx, host, fleet.ActionRead); err != nil {
-		return nil, nil, err
+	// Device-authenticated callers (e.g. the My Device page) have already had
+	// host access verified by the device-token middleware. Skip user-mode authz
+	// in that case and use the host injected into context. Require the caller
+	// to pass the matching host ID so that no caller can ever read another
+	// host's queue under a device token.
+	if svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceToken) ||
+		svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceCertificate) ||
+		svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceURL) {
+		h, ok := hostctx.FromContext(ctx)
+		if !ok {
+			return nil, nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+		}
+		if h.ID != hostID {
+			return nil, nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("device authentication does not match requested host"))
+		}
+	} else {
+		// First ensure the user has access to list hosts, then check the specific
+		// host once team_id is loaded.
+		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
+			return nil, nil, err
+		}
+		host, err := svc.ds.HostLite(ctx, hostID)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "get host")
+		}
+		// Authorize again with team loaded now that we have team_id
+		if err := svc.authz.Authorize(ctx, host, fleet.ActionRead); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	// cursor-based pagination is not supported for upcoming activities
@@ -92,6 +111,53 @@ func (svc *Service) ListHostUpcomingActivities(ctx context.Context, hostID uint,
 	opt.IncludeMetadata = true
 
 	return svc.ds.ListHostUpcomingActivities(ctx, hostID, opt)
+}
+
+// ListHostPastActivitiesForDevice returns past activities for the specified
+// host in a device-token-authenticated context. The device-token middleware is
+// expected to have already established access to the host; no further
+// authorization is performed here beyond delegating to the activity bounded
+// context's device variant.
+func (svc *Service) ListHostPastActivitiesForDevice(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
+	if !svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceToken) &&
+		!svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceCertificate) &&
+		!svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceURL) {
+		return nil, nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("device authentication required"))
+	}
+	h, ok := hostctx.FromContext(ctx)
+	if !ok {
+		return nil, nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+	}
+	if h.ID != hostID {
+		return nil, nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("device token does not match requested host"))
+	}
+
+	apiDirection := activity_api.OrderAscending
+	if opt.OrderDirection == fleet.OrderDescending {
+		apiDirection = activity_api.OrderDescending
+	}
+	apiOpt := activity_api.ListOptions{
+		Page:           opt.Page,
+		PerPage:        opt.PerPage,
+		After:          opt.After,
+		OrderKey:       opt.OrderKey,
+		OrderDirection: apiDirection,
+		MatchQuery:     opt.MatchQuery,
+	}
+
+	acts, apiMeta, err := svc.activitySvc.ListHostPastActivitiesForDevice(ctx, hostID, apiOpt)
+	if err != nil {
+		return nil, nil, err
+	}
+	var meta *fleet.PaginationMetadata
+	if apiMeta != nil {
+		meta = &fleet.PaginationMetadata{
+			HasNextResults:     apiMeta.HasNextResults,
+			HasPreviousResults: apiMeta.HasPreviousResults,
+			TotalResults:       apiMeta.TotalResults,
+		}
+	}
+	return acts, meta, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -1096,3 +1096,86 @@ func (svc *Service) GetDeviceSetupExperienceStatus(ctx context.Context) (*fleet.
 
 	return nil, fleet.ErrMissingLicense
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// List Current Device's Past Activities
+////////////////////////////////////////////////////////////////////////////////
+
+type listDeviceHostPastActivitiesRequest struct {
+	Token       string            `url:"token"`
+	ListOptions fleet.ListOptions `url:"list_options"`
+}
+
+func (r *listDeviceHostPastActivitiesRequest) deviceAuthToken() string {
+	return r.Token
+}
+
+type listDeviceHostPastActivitiesResponse struct {
+	Meta       *fleet.PaginationMetadata `json:"meta"`
+	Activities []*fleet.Activity         `json:"activities"`
+	Err        error                     `json:"error,omitempty"`
+}
+
+func (r listDeviceHostPastActivitiesResponse) Error() error { return r.Err }
+
+func listDeviceHostPastActivitiesEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	host, ok := hostctx.FromContext(ctx)
+	if !ok {
+		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+		return listDeviceHostPastActivitiesResponse{Err: err}, nil
+	}
+
+	req := request.(*listDeviceHostPastActivitiesRequest)
+	acts, meta, err := svc.ListHostPastActivitiesForDevice(ctx, host.ID, req.ListOptions)
+	if err != nil {
+		return listDeviceHostPastActivitiesResponse{Err: err}, nil
+	}
+	if acts == nil {
+		acts = []*fleet.Activity{}
+	}
+	return listDeviceHostPastActivitiesResponse{Meta: meta, Activities: acts}, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// List Current Device's Upcoming Activities
+////////////////////////////////////////////////////////////////////////////////
+
+type listDeviceHostUpcomingActivitiesRequest struct {
+	Token       string            `url:"token"`
+	ListOptions fleet.ListOptions `url:"list_options"`
+}
+
+func (r *listDeviceHostUpcomingActivitiesRequest) deviceAuthToken() string {
+	return r.Token
+}
+
+type listDeviceHostUpcomingActivitiesResponse struct {
+	Meta       *fleet.PaginationMetadata `json:"meta"`
+	Activities []*fleet.UpcomingActivity `json:"activities"`
+	Count      uint                      `json:"count"`
+	Err        error                     `json:"error,omitempty"`
+}
+
+func (r listDeviceHostUpcomingActivitiesResponse) Error() error { return r.Err }
+
+func listDeviceHostUpcomingActivitiesEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	host, ok := hostctx.FromContext(ctx)
+	if !ok {
+		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+		return listDeviceHostUpcomingActivitiesResponse{Err: err}, nil
+	}
+
+	req := request.(*listDeviceHostUpcomingActivitiesRequest)
+	acts, meta, err := svc.ListHostUpcomingActivities(ctx, host.ID, req.ListOptions)
+	if err != nil {
+		return listDeviceHostUpcomingActivitiesResponse{Err: err}, nil
+	}
+	if acts == nil {
+		acts = []*fleet.UpcomingActivity{}
+	}
+	var count uint
+	if meta != nil {
+		count = meta.TotalResults
+	}
+	return listDeviceHostUpcomingActivitiesResponse{Meta: meta, Activities: acts, Count: count}, nil
+}

--- a/server/service/devices_test.go
+++ b/server/service/devices_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -1042,5 +1043,143 @@ func TestAuthenticateDeviceRejectsIOSIPadOS(t *testing.T) {
 		require.Equal(t, uint(5), host.ID)
 		require.Equal(t, "ubuntu", host.Platform)
 		require.False(t, debug)
+	})
+}
+
+func TestListHostUpcomingActivities_DeviceAuth(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{SkipCreateTestUsers: true})
+
+	const deviceHostID uint = 42
+	deviceHost := &fleet.Host{ID: deviceHostID, Platform: "darwin"}
+
+	wantActs := []*fleet.UpcomingActivity{{Activity: fleet.Activity{ID: 1, Type: "ran_script"}}}
+	wantMeta := &fleet.PaginationMetadata{HasNextResults: false, HasPreviousResults: false, TotalResults: 1}
+
+	var gotHostID uint
+	ds.ListHostUpcomingActivitiesFunc = func(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.UpcomingActivity, *fleet.PaginationMetadata, error) {
+		gotHostID = hostID
+		return wantActs, wantMeta, nil
+	}
+
+	// Without HostContext (no device authn), the call should fall through to the
+	// user-mode authz path and fail (no viewer in ctx).
+	_, _, err := svc.ListHostUpcomingActivities(ctx, deviceHostID, fleet.ListOptions{})
+	require.Error(t, err)
+	require.False(t, ds.ListHostUpcomingActivitiesFuncInvoked)
+
+	// Device-auth context but hostID arg does not match the host on the ctx:
+	// reject rather than silently swap.
+	deviceCtx := test.HostContext(ctx, deviceHost)
+	_, _, err = svc.ListHostUpcomingActivities(deviceCtx, deviceHostID+1, fleet.ListOptions{})
+	require.Error(t, err)
+	var authErr *fleet.AuthRequiredError
+	require.ErrorAs(t, err, &authErr)
+	require.False(t, ds.ListHostUpcomingActivitiesFuncInvoked)
+
+	// Device-auth context with the matching hostID: succeeds.
+	gotActs, gotMeta, err := svc.ListHostUpcomingActivities(deviceCtx, deviceHostID, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.True(t, ds.ListHostUpcomingActivitiesFuncInvoked)
+	require.Equal(t, deviceHostID, gotHostID)
+	require.Equal(t, wantActs, gotActs)
+	require.Equal(t, wantMeta, gotMeta)
+}
+
+func TestListHostPastActivitiesForDevice(t *testing.T) {
+	ds := new(mock.Store)
+	opts := &TestServerOpts{SkipCreateTestUsers: true}
+	svc, ctx := newTestService(t, ds, nil, nil, opts)
+
+	const deviceHostID uint = 99
+	deviceHost := &fleet.Host{ID: deviceHostID, Platform: "darwin"}
+
+	wantActs := []*fleet.Activity{{ID: 7, Type: "ran_script"}}
+	wantMeta := &activity_api.PaginationMetadata{HasNextResults: true, HasPreviousResults: false, TotalResults: 5}
+
+	var gotHostID uint
+	var gotOpt activity_api.ListOptions
+	opts.ActivityMock.ListHostPastActivitiesForDeviceFunc = func(ctx context.Context, hostID uint, opt activity_api.ListOptions) ([]*activity_api.Activity, *activity_api.PaginationMetadata, error) {
+		gotHostID = hostID
+		gotOpt = opt
+		return wantActs, wantMeta, nil
+	}
+
+	t.Run("rejects non-device context", func(t *testing.T) {
+		_, _, err := svc.ListHostPastActivitiesForDevice(ctx, deviceHostID, fleet.ListOptions{})
+		require.Error(t, err)
+		var authErr *fleet.AuthRequiredError
+		require.ErrorAs(t, err, &authErr)
+		require.False(t, opts.ActivityMock.ListHostPastActivitiesForDeviceFuncInvoked)
+	})
+
+	t.Run("rejects when context host id doesn't match arg", func(t *testing.T) {
+		deviceCtx := test.HostContext(ctx, deviceHost)
+		_, _, err := svc.ListHostPastActivitiesForDevice(deviceCtx, deviceHostID+1, fleet.ListOptions{})
+		require.Error(t, err)
+	})
+
+	t.Run("delegates to activity service for matching device host", func(t *testing.T) {
+		deviceCtx := test.HostContext(ctx, deviceHost)
+		acts, meta, err := svc.ListHostPastActivitiesForDevice(deviceCtx, deviceHostID, fleet.ListOptions{
+			Page: 2, PerPage: 8, OrderDirection: fleet.OrderDescending,
+		})
+		require.NoError(t, err)
+		require.True(t, opts.ActivityMock.ListHostPastActivitiesForDeviceFuncInvoked)
+		require.Equal(t, deviceHostID, gotHostID)
+		require.Equal(t, uint(2), gotOpt.Page)
+		require.Equal(t, uint(8), gotOpt.PerPage)
+		require.Equal(t, activity_api.OrderDescending, gotOpt.OrderDirection)
+		require.Equal(t, wantActs, acts)
+		require.NotNil(t, meta)
+		require.True(t, meta.HasNextResults)
+		require.Equal(t, uint(5), meta.TotalResults)
+	})
+}
+
+func TestListDeviceHostActivitiesEndpoints(t *testing.T) {
+	ds := new(mock.Store)
+	opts := &TestServerOpts{SkipCreateTestUsers: true}
+	svc, ctx := newTestService(t, ds, nil, nil, opts)
+
+	host := &fleet.Host{ID: 17, Platform: "darwin"}
+	deviceCtx := test.HostContext(ctx, host)
+
+	t.Run("past activities endpoint", func(t *testing.T) {
+		opts.ActivityMock.ListHostPastActivitiesForDeviceFunc = func(ctx context.Context, hostID uint, opt activity_api.ListOptions) ([]*activity_api.Activity, *activity_api.PaginationMetadata, error) {
+			require.Equal(t, host.ID, hostID)
+			return []*activity_api.Activity{{ID: 1, Type: "ran_script"}}, &activity_api.PaginationMetadata{}, nil
+		}
+
+		req := &listDeviceHostPastActivitiesRequest{Token: "tok"}
+		resp, err := listDeviceHostPastActivitiesEndpoint(deviceCtx, req, svc)
+		require.NoError(t, err)
+		require.NoError(t, resp.Error())
+		typed, ok := resp.(listDeviceHostPastActivitiesResponse)
+		require.True(t, ok)
+		require.Len(t, typed.Activities, 1)
+	})
+
+	t.Run("upcoming activities endpoint", func(t *testing.T) {
+		ds.ListHostUpcomingActivitiesFunc = func(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.UpcomingActivity, *fleet.PaginationMetadata, error) {
+			require.Equal(t, host.ID, hostID)
+			return []*fleet.UpcomingActivity{{Activity: fleet.Activity{ID: 2, Type: "lock_host"}}}, &fleet.PaginationMetadata{TotalResults: 3}, nil
+		}
+
+		req := &listDeviceHostUpcomingActivitiesRequest{Token: "tok"}
+		resp, err := listDeviceHostUpcomingActivitiesEndpoint(deviceCtx, req, svc)
+		require.NoError(t, err)
+		require.NoError(t, resp.Error())
+		typed, ok := resp.(listDeviceHostUpcomingActivitiesResponse)
+		require.True(t, ok)
+		require.Len(t, typed.Activities, 1)
+		require.Equal(t, uint(3), typed.Count)
+	})
+
+	t.Run("past activities endpoint without host context returns auth error", func(t *testing.T) {
+		req := &listDeviceHostPastActivitiesRequest{Token: "tok"}
+		resp, err := listDeviceHostPastActivitiesEndpoint(ctx, req, svc)
+		require.NoError(t, err)
+		require.Error(t, resp.Error())
 	})
 }

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -915,6 +915,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint, getDeviceSoftwareInstallResultsRequest{})
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/software/uninstall/{execution_id}/results", getDeviceSoftwareUninstallResultsEndpoint, getDeviceSoftwareUninstallResultsRequest{})
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/certificates", listDeviceCertificatesEndpoint, listDeviceCertificatesRequest{})
+	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/activities", listDeviceHostPastActivitiesEndpoint, listDeviceHostPastActivitiesRequest{})
+	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/activities/upcoming", listDeviceHostUpcomingActivitiesEndpoint, listDeviceHostUpcomingActivitiesRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/setup_experience/status", getDeviceSetupExperienceStatusEndpoint, getDeviceSetupExperienceStatusRequest{})
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/software/titles/{software_title_id}/icon", getDeviceSoftwareIconEndpoint, getDeviceSoftwareIconRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis"
@@ -549,4 +550,88 @@ func (s *integrationEnterpriseTestSuite) TestAlternativeBrowserHostSetting() {
 	require.NoError(t, json.NewDecoder(res.Body).Decode(&getDesktopResp))
 	require.NoError(t, res.Body.Close())
 	require.Equal(t, "althost", getDesktopResp.AlternativeBrowserHost)
+}
+
+func (s *integrationTestSuite) TestDeviceAuthenticatedActivities() {
+	t := s.T()
+
+	newHostWithToken := func(label string) (*fleet.Host, string) {
+		h, err := s.ds.NewHost(context.Background(), &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now().Add(-1 * time.Minute),
+			OsqueryHostID:   ptr.String(t.Name() + label),
+			NodeKey:         ptr.String(t.Name() + label),
+			UUID:            uuid.New().String(),
+			Hostname:        fmt.Sprintf("%s%s.local", t.Name(), label),
+			Platform:        "darwin",
+		})
+		require.NoError(t, err)
+
+		tok := fmt.Sprintf("token_test_device_activities_%s", label)
+		mysqltest.ExecAdhocSQL(t, s.ds, func(db sqlx.ExtContext) error {
+			_, err := db.ExecContext(context.Background(), `INSERT INTO host_device_auth (host_id, token) VALUES (?, ?)`, h.ID, tok)
+			return err
+		})
+		return h, tok
+	}
+
+	hostA, tokenA := newHostWithToken("a")
+	hostB, tokenB := newHostWithToken("b")
+
+	// Seed a distinct past activity for each host.
+	ctx := context.Background()
+	u := s.users["admin1@example.com"]
+	activitySvc := mysqltest.NewTestActivityService(t, s.ds)
+	apiUser := &activity_api.User{ID: u.ID, Name: u.Name, Email: u.Email}
+	require.NoError(t, activitySvc.NewActivity(ctx, apiUser, fleet.ActivityTypeRanScript{
+		HostID:            hostA.ID,
+		HostDisplayName:   hostA.Hostname,
+		ScriptExecutionID: "exec-a",
+		ScriptName:        "host-a.sh",
+	}))
+	require.NoError(t, activitySvc.NewActivity(ctx, apiUser, fleet.ActivityTypeRanScript{
+		HostID:            hostB.ID,
+		HostDisplayName:   hostB.Hostname,
+		ScriptExecutionID: "exec-b",
+		ScriptName:        "host-b.sh",
+	}))
+
+	// hostA's token sees only hostA's activity (previously 403'd because the
+	// device-authenticated context has no user subject for the enrichment path).
+	var pastRespA listDeviceHostPastActivitiesResponse
+	res := s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+tokenA+"/activities?page=0&per_page=8", nil, http.StatusOK)
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&pastRespA))
+	require.NoError(t, res.Body.Close())
+	require.Len(t, pastRespA.Activities, 1)
+	require.Equal(t, "ran_script", pastRespA.Activities[0].Type)
+	require.NotNil(t, pastRespA.Activities[0].ActorEmail)
+	require.Equal(t, u.Email, *pastRespA.Activities[0].ActorEmail)
+
+	// Host isolation: hostB's token must not surface hostA's activity. We assert
+	// the response contains only hostB's row, identified by its unique
+	// script_execution_id in the activity details payload.
+	var pastRespB listDeviceHostPastActivitiesResponse
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+tokenB+"/activities?page=0&per_page=8", nil, http.StatusOK)
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&pastRespB))
+	require.NoError(t, res.Body.Close())
+	require.Len(t, pastRespB.Activities, 1)
+	require.NotNil(t, pastRespB.Activities[0].Details)
+	require.Contains(t, string(*pastRespB.Activities[0].Details), "exec-b")
+	require.NotContains(t, string(*pastRespB.Activities[0].Details), "exec-a")
+
+	// Upcoming for hostA: empty list.
+	var upcomingResp listDeviceHostUpcomingActivitiesResponse
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+tokenA+"/activities/upcoming?page=0&per_page=8", nil, http.StatusOK)
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&upcomingResp))
+	require.NoError(t, res.Body.Close())
+	require.NotNil(t, upcomingResp.Activities)
+	require.Empty(t, upcomingResp.Activities)
+
+	// Invalid token: should be unauthorized.
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/no_such_token/activities", nil, http.StatusUnauthorized)
+	require.NoError(t, res.Body.Close())
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/no_such_token/activities/upcoming", nil, http.StatusUnauthorized)
+	require.NoError(t, res.Body.Close())
 }


### PR DESCRIPTION
The device user page now display an activity log of past and future events. It does not yet support displaying MDM commands.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Partially addresses #22491

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity panel on the My Device page with Past and Upcoming tabs, pagination, and Install Details modal for installed‑software entries.

* **Behavior Changes**
  * “Show info” controls hidden for admin‑only activity types on My Device.
  * Upcoming tab disabled for Android hosts.

* **Tests**
  * Added unit and integration tests covering device‑authenticated past/upcoming activity endpoints and UI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->