### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.10.6",
+      "version": "12.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac') AND version_compare(bundle_short_version, '12.10.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac') AND version_compare(bundle_short_version, '12.11.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.10.6/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.11.0/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "5b41187d",
-      "sha256": "c7d801c47bb0e91e9b9c41e04149ad598efd8cd67ea23e3756bc29cb9e49ca3f",
+      "sha256": "2f203f6dffb69d10a42b02f53d182b9e69d8e6d9326eeaf6c485c3c9e82a9813",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.10.6",
+      "version": "12.11.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.10.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.11.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.10.6/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.11.0/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "7f25f88d9775d6f40dd5246b9d855056ff3a0ad6cf38ec83fa5f232f92dfd489",
+      "sha256": "5bc0699508cde8e03d5046416978e3c26cefae4322c56cd056b9f134bfd4e22a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/splashtop-streamer/darwin.json
+++ b/ee/maintained-apps/outputs/splashtop-streamer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.8.2.0",
+      "version": "3.8.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer') AND version_compare(bundle_short_version, '3.8.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer') AND version_compare(bundle_short_version, '3.8.4.0') < 0);"
       },
-      "installer_url": "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v3.8.2.0.dmg",
+      "installer_url": "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v3.8.4.0.dmg",
       "install_script_ref": "f00dbb7b",
       "uninstall_script_ref": "1bf6ff1e",
-      "sha256": "3fec9ce3d376cf8e68ca67ebc971beec7eb7993f4fae48a299e8123885276355",
+      "sha256": "3d19bb58d48f2e1305cbf46fd09124d1004eb6b92c1e1d84a5e808fd7f326398",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tableplus/darwin.json
+++ b/ee/maintained-apps/outputs/tableplus/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.9.6",
+      "version": "7.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus') AND version_compare(bundle_short_version, '6.9.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus') AND version_compare(bundle_short_version, '7.0.0') < 0);"
       },
-      "installer_url": "https://files.tableplus.com/macos/676/TablePlus.dmg",
+      "installer_url": "https://files.tableplus.com/macos/700/TablePlus.dmg",
       "install_script_ref": "6ebc9cac",
       "uninstall_script_ref": "bc329865",
-      "sha256": "cf73bda94dccb38520ae566c5f961ecae8ac738d3b2c0bf3e7440db9021f1080",
+      "sha256": "b1234c6c8b8d29c031b1ce7f05473143c7cafdeae04ce7c20b27fc932d3886ae",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release metadata and checksums for multiple maintained applications: Postman (macOS and Windows to v12.11.0), Splashtop Streamer macOS (to v3.8.4.0), and TablePlus macOS (to v7.0.0).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->