### PR TITLE
Fleet UI: Fix extra margin causing scroll

### DIFF
--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -133,6 +133,7 @@ const InstallIconWithTooltip = ({
         underline={false}
         position="top"
         tipOffset={12}
+        fixedPositionStrategy
       >
         <Icon
           name={iconName}

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/_styles.scss
@@ -12,12 +12,6 @@
     height: 24px;
   }
 
-  &__install-icon {
-    // TODO: we do not want to use !important but have to for now. This is
-    // the same issue as the .software-name-cell class display value.
-    display: inline-flex !important;
-  }
-
   &__install-tooltip-text {
     font-weight: $regular;
     font-size: $xx-small;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -241,10 +241,6 @@ $shadow-transition-width: 16px;
     }
 
     tbody {
-      .component__tooltip-wrapper {
-        margin: 10px 0; // vertical padding multiline text with tooltip
-      }
-
       .component__tooltip-wrapper__element {
         white-space: initial; // wraps long text with tooltip
       }


### PR DESCRIPTION
## Issue
Closes #45197 

> Note: Will cherry-pick into 4.86.0

## Description
- Slight scroll still existed when a software install icon was present, fix that
- Fix long tooltip to overflow table container and not cause weird scroll either

## Screenshots


https://github.com/user-attachments/assets/5b323b77-683d-40d8-9e31-304b0095986e

Redundant code:
<img width="427" height="263" alt="Screenshot 2026-05-18 at 10 50 06 AM" src="https://github.com/user-attachments/assets/e635139b-2d04-4246-b8ed-8afadcf78e49" />

<img width="453" height="288" alt="Screenshot 2026-05-18 at 11 04 54 AM" src="https://github.com/user-attachments/assets/2ae5889b-fb34-48da-a1e2-2cb1b2781fc0" />

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip positioning for install icons in the data table software column.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->