### PR TITLE
Archive openspec change for auto-renew-non-proxied-certs

### DIFF
--- a/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/design.md
+++ b/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/design.md
@@ -1,0 +1,312 @@
+## Context
+
+Fleet's existing renewal pipeline assumes the server is in the cert-issuance path. For Fleet-issued MDM enrollment certs, `RenewSCEPCertificates` reads `nano_cert_auth_associations`. For profile-delivered certs from CAs that Fleet proxies (NDES, Custom SCEP Proxy, DigiCert, Smallstep), `RenewMDMManagedCertificates` reads `host_mdm_managed_certificates` rows that the proxy step populates at issuance.
+
+For non-proxied ACME (e.g. the customer-cisneros-a engagement, where the customer deploys an ACME profile against a private Hydrant fork) and non-proxied SCEP (Okta conditional access, Okta Verify), Fleet is not in the issuance path. The device performs the cert exchange directly with the CA. Fleet first sees the cert when it's reported via osquery (software certs) or the MDM `CertificateList` command (hardware-bound certs on Apple platforms). Today on macOS the `CertificateList` command is not used at all — only iOS/iPadOS use it via `IOSiPadOSRefetch`. So hardware-bound ACME certs on macOS are effectively invisible to Fleet, and even for software certs no `host_mdm_managed_certificates` row exists for the non-proxied flows so the renewal cron has nothing to act on.
+
+Importantly, this change does NOT add Hydrant ACME as a registerable CA type. Hydrant does not yet officially support ACME; the customer-cisneros-a use case relies on a private Hydrant fork. A `hydrant` CA type would not generalize to other customers, would bake a name into `host_mdm_managed_certificates.type` that may conflict with whatever the official Hydrant ACME integration looks like later, and is not necessary because the non-proxied mechanism described below works for any external ACME or SCEP server. When Hydrant ships official ACME support upstream, a first-class CA registration may be added separately.
+
+This change addresses both halves in two phases that ship as independent PR sequences:
+
+- **Phase 1 (#42827)** — extend MDM `CertificateList` ingestion to macOS. Self-contained, customer-visible (certs appear on host details page), independently shippable.
+- **Phase 2 (#40639)** — extend cert ingestion to also create `host_mdm_managed_certificates` rows so the existing renewal cron activates for non-proxied flows. Depends on Phase 1 for the macOS leg, otherwise independent (iOS/iPadOS already have `CertificateList` cadence; software-cert SCEP/ACME on macOS/Windows uses osquery ingestion).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make MDM-delivered certs visible on the host details page on macOS (Phase 1).
+- Auto-renew non-proxied ACME (including the customer-cisneros-a Hydrant deployment) and non-proxied SCEP profile-delivered certs on Apple platforms (macOS post-Phase 1, iOS, iPadOS today) and Windows (Phase 2) — **for profiles that opt in by including the marker variable**.
+- Reuse existing renewal cron unchanged. Reuse existing renewal threshold logic.
+- Use a single mechanism (extracting `fleet-<profile_uuid>` marker from cert Subject) for all platforms and all CA types in scope.
+- Make the marker opt-in: profiles that don't include it continue to work exactly as in 4.85 (manual redeployment for renewal). No upload-time enforcement, no GitOps breakage, no upgrade-day surprise.
+- Keep Phase 1 and Phase 2 independently mergeable so each is reviewable in isolation.
+
+**Non-Goals:**
+- Custom EST Proxy renewal (deliberately deferred; no customer driver).
+- New first-class CA type for Hydrant ACME (Hydrant does not officially support ACME yet; customer's private fork is the only deployment in scope; the non-proxied mechanism handles it without a CA registration).
+- New first-class CA type for Okta SCEP (renewal works without one).
+- **Forcing customers to add the marker.** Marker is opt-in; missing marker means no auto-renewal for that profile, not an error.
+- Renewal verification / silent-failure detection — orthogonal generic improvement that applies equally to existing proxied flows; out of scope here.
+- Generic operational alerting for unbounded renewal-loop scenarios — same reasoning, generic concern.
+- Recurring macOS `CertificateList` cadence (Phase 1 deliberately uses on-demand-only for load reasons).
+
+## Phase 1 Decisions (#42827 cert ingestion)
+
+### Decision 1.1: On-demand `CertificateList` per `InstallProfile` ack on macOS
+
+iOS/iPadOS use a recurring hourly cron (`IOSiPadOSRefetch`). macOS instead triggers `CertificateList` on demand when an ACME `InstallProfile` ack is received. Rationale: a recurring hourly `CertificateList` against every macOS host in a large fleet would be a significant MDM traffic increase. The on-demand model couples cert visibility to the events that actually change cert state (profile installs and renewals).
+
+**Alternatives considered:**
+- *Recurring daily/weekly cadence on macOS.* Rejected for v1 to keep ingestion traffic minimal. Could be revisited later as a backstop for external state drift.
+- *Use `IOSiPadOSRefetch` cron on macOS too.* Rejected — Apple's protocol semantics differ enough between the platforms that separate trigger paths are cleaner.
+
+**Implementation refinement (PR 1.2 final shape):** The InstallProfile-ack handler runs on every MDM command result, so the trigger gate lives in the hot path. A single indexed query (`ProfileHasACMEPayloadForCommand`) returns host platform, profile UUID, and ACME-payload presence (computed via `LOCATE` on the `mobileconfig` blob). The common case (non-darwin or non-ACME) early-returns without parsing the profile or transferring the blob to Go. Tracking row insertion happens AFTER `commander.CertificateList` succeeds — matching the iOS/iPadOS `IOSiPadOSRefetch` pattern — so a commander failure doesn't leave a stale tracking row that would suppress future triggers.
+
+**No pending-refetch deduplication.** The trigger deliberately does NOT skip enqueueing `CertificateList` when a previous refetch for the same host is still in flight. Reason: a refetch enqueued before the new `InstallProfile` ack can return BEFORE the device's ACME exchange has actually issued the new cert, capturing pre-renewal state. Skipping the new trigger because of that in-flight refetch would lose the renewed cert until something else surfaced it. Letting each ack queue its own refetch ensures the post-exchange state is always captured. Duplicate enqueues are tolerated because:
+- `host_mdm_commands` has a `(host_id, command_type)` primary key, so duplicate INSERTs collapse via `ON DUPLICATE KEY UPDATE` rather than erroring.
+- `handleRefetchCertsResults` is idempotent against an already-removed tracking row, so the second result lands safely after the first.
+
+This was a course-correction during PR 1.2 review — an earlier draft included `EXISTS` on `host_mdm_commands` for dedup; the race-window concern surfaced in review and the dedup was removed.
+
+### Decision 1.2: No deploy-time backfill — profile activity is the trigger
+
+We do NOT run a one-time `CertificateList` backfill across the macOS fleet at deploy. Rationale: ingestion is tied to profile activity. New ACME profile installs fire `CertificateList` via Decision 1.1. Customers who want auto-renewal opt in by redeploying a profile with `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in the cert Subject; that redeploy naturally fires the trigger and surfaces the marker-bearing cert. Customers who don't need auto-renewal can leave profiles untouched — those certs simply don't appear in `host_certificates` until something else surfaces them.
+
+**Implications:**
+- Customers who do not redeploy a particular ACME/SCEP profile see no certs from it in the host details page on macOS. Same outcome as today (unchanged behavior). No regression.
+- Visibility on macOS becomes conditional on profile activity. Customers who want immediate visibility for compliance/audit reasons must take an explicit action (redeploy).
+- Eliminates the rate-limiting / resumption / runbook complexity that a fleet-wide backfill would introduce.
+
+**Alternatives considered:**
+- *One-time `CertificateList` backfill across the fleet.* Rejected: the redeploy flow (when customers opt into auto-renewal) already surfaces the relevant certs. Customers who don't redeploy explicitly opted out of auto-renewal; backfilling their certs doesn't help them. Adds engineering and operational complexity (rate-limiting, completion tracking, resume-on-restart, monitoring) for a transparency benefit that is shorter-lived than the redeploy timeline.
+- *Synchronously backfill all hosts at first deploy.* Rejected for the same reason plus the thundering-herd problem on APNs / the MDM command queue.
+
+### Decision 1.3: Unified storage with `origin` column
+
+Store certs from both osquery and MDM `CertificateList` ingestion in `host_certificates`, deduplicated by `sha1_sum`. Add an `origin` column (`osquery` / `mdm`) so each ingestion source only soft-deletes rows it owns. The column is internal — not exposed in the public API.
+
+**Alternatives considered:**
+- *Separate `host_mdm_certificates` table.* Rejected: complicates the host details API by requiring a UNION across two tables. Single-table-with-origin is simpler.
+- *Expose `origin` in the API.* Rejected per discussion — clients only care about the unified deduped list.
+
+### Decision 1.4: Osquery sync downgrades existing `mdm` rows to `osquery`
+
+Refinement of Decision 1.3 surfaced during 2026-05-14 local validation. Today the `origin` column reflects "first ingestion source to see this cert." That's misleading: MDM `CertificateList` returns the entire device keychain on every InstallProfile ack, including Root CAs and other system certs the user installed manually. If MDM observes a non-MDM-delivered cert before the next osquery cert sync, the row gets `origin='mdm'` even though Fleet did not deliver it.
+
+**Decision:** when osquery sync UPSERTs a cert that already exists with `origin='mdm'`, downgrade `origin` to `'osquery'`. One-way only (mdm → osquery, never the reverse).
+
+**Why this is correct:**
+- Osquery sees a strict superset of what MDM `CertificateList` sees (the entire keychain, unfiltered). If osquery observes a cert, the device has it in the keychain by whatever path; the cert's presence is not evidence of MDM delivery.
+- MDM `CertificateList` observation is *not* sufficient evidence of MDM delivery, because the protocol returns every keychain entry, not just Fleet-delivered ones. The current MDM-only path remains the right one for first-seen MDM-delivered certs (ACME/SCEP) because they appear in the keychain only after the MDM-driven exchange.
+- The matcher path (PR 2.2) keys on the `fleet-<profile_uuid>` marker in the cert Subject, not on `origin`, so renewal correctness is unaffected. `origin` is purely for visibility / audit semantics.
+
+**Concretely:** the live row for a system cert observed by both sources lands as `origin='osquery'`. The live row for an ACME cert observed only by MDM (because hardware-bound certs are invisible to osquery on macOS) stays `origin='mdm'`. That matches intent: "did Fleet deliver this cert?"
+
+**Alternatives considered:**
+- *Filter what `CertificateList` ingests* — only persist certs that match an installed cert-issuing profile on the host. Rejected: requires inspecting profile contents during ingestion (currently we don't), creates a tight coupling between the ingestion path and the profile-matching logic, and loses visibility of MDM-delivered certs whose profile got removed but cert was retained. The downgrade approach keeps the ingestion path simple and lets matcher logic handle linkage separately.
+- *Three-valued `origin` column (`osquery` / `mdm` / `both`).* Rejected: doesn't add information — `both` would mean "observed by both," which is equivalent to "osquery saw it" since osquery is the superset. And it'd require enum migration plus a third soft-delete branch.
+- *Backfill existing rows on deploy.* Rejected: the next natural osquery sync downgrades affected rows. Adding a deploy-time scan is unnecessary churn for a slowly-self-correcting issue.
+
+### Decision 1.5: `RemoveProfile` ack also triggers on-demand `CertificateList` on macOS
+
+Symmetric companion to Decision 1.1. When a `RemoveProfile` is acked for a profile containing an ACME or SCEP payload on a macOS host, fire `CertificateList`. Per Apple's ACME-DA lifecycle (verified during 2026-05-14 local testing), the device drops the associated identity from its keychain when the delivering profile is removed; the refetch lets `UpdateHostCertificates`' source-scoped soft-delete clear the stale `host_certificates` row.
+
+Tracked as bug #45596 — surfaced during the Phase 2 demo-readiness review. The install side was closed by PR 1.2; the removal side was an oversight in the on-demand design.
+
+**Why this fits Phase 1 rather than a new feature:** the same architectural model as Decision 1.1 — refetch on the events that change cert state. Install and remove are symmetric events; closing only the install side leaves a visibility bug, not a missing feature.
+
+**iOS/iPadOS unaffected** — they continue to self-correct via the existing `IOSiPadOSRefetch` cron.
+
+**Out of scope:**
+- *Windows*: Windows uses osquery for cert visibility; `host_certificates` cleanup happens on the next osquery sync. No equivalent MDM-side trigger needed.
+- *Profile replacement (re-upload)*: already works via the install-side trigger. `RemoveProfile` for old + `InstallProfile` for new → install trigger fires `CertificateList` → soft-delete catches the old cert. Verified during 2026-05-14 local testing.
+
+## Phase 2 Decisions (#40639 renewal extension)
+
+### Decision 2.1: Extend `UpdateHostCertificates` to insert managed-cert rows
+
+`UpdateHostCertificates` (`server/datastore/mysql/host_certificates.go:30-200`) today only *updates* existing `host_mdm_managed_certificates` rows by matching ingested certs against `"fleet-" + row.profile_uuid`. We extend it: for each ingested cert, scan its Subject CN/OU for a `fleet-<uuid>` pattern; if found and no managed-cert row exists for that (host, profile), insert one populated from the cert.
+
+**Alternatives considered:**
+- *Create the row at profile install time* (a "pending" state). Rejected: produces orphan rows when a profile installs but the cert is never issued (CA failure, attestation rejected). The existing model — row exists iff a cert has been observed — has cleaner semantics.
+- *Add a separate "non-proxied managed cert" table*. Rejected: doubles the surface area of the renewal cron and the ingestion linkage logic. The existing table fits the new rows with one nullable column.
+
+### Decision 2.2: `host_mdm_managed_certificates.type` becomes nullable
+
+For ingestion-created rows we don't know the CA type — Fleet wasn't in the issuance path. The migration drops the `NOT NULL DEFAULT 'ndes'` and allows NULL. The renewal cron iterates `ListCATypesWithRenewalSupport()` plus a single NULL bucket, using null-safe equal (`hmmc.type <=> ?`) so the same parameterized query handles both registered types and NULL with no SQL branching.
+
+We do NOT add a `non_proxied` enum sentinel. NULL has the right semantics (unknown — Fleet wasn't in the issuance path), avoids a fake CA-type value that has to be excluded from every CA-type-aware query, and matches how the column is read by code that expects the registered CA type when one is present.
+
+**Knock-on requirement — matcher guard:** the existing `UpdateHostCertificates` matcher (#44691) skips rows where `!Type.SupportsRenewalID()`, which evaluates to `false` for the empty-string zero value that NULL scans into. Without an adjustment here, ingestion-created NULL-`type` rows would never have their `not_valid_after` advanced after a renewal completes, producing a non-terminating renewal loop. Phase 2 must treat empty/NULL `Type` as renewal-eligible in the matcher path.
+
+**Alternatives considered:**
+- *Add a `non_proxied` enum sentinel.* Rejected per above — extra value to maintain, no semantic gain.
+- *Synthesize a type at insert time by inspecting the profile content* (e.g., is it `com.apple.security.acme`? a SCEP payload pointing at a registered URL?). Rejected: brittle, leaks profile-content awareness into the datastore layer, and gains nothing — the renewal cron only cares about whether a row should be considered, not what produced it.
+
+### Decision 2.3: Marker extraction via regex on Subject CN/OU
+
+Inverted matching loop. Today: for each row, check ingested certs for `fleet-<row.profile_uuid>`. New: for each ingested cert, regex-extract `fleet-<uuid>` from Subject CN/OU and look up the profile by UUID.
+
+Constraints on the extracted UUID:
+- Must match Fleet's `profile_uuid` format (varchar(37), typically standard UUID with dashes — verify before regex finalization).
+- Looked-up profile must exist in `host_mdm_apple_profiles` or `host_mdm_windows_profiles` for this host. Otherwise the cert is from a stale or copied profile UUID and is ignored.
+
+**Alternatives considered:**
+- *Match by Issuer + Serial recorded at issuance.* Rejected: only works for proxied flows where Fleet saw the issuance. Useless here.
+- *Match by Subject == host identifier.* Rejected: breaks when one host has multiple profiles using the same CA.
+
+### Decision 2.4: Hydrant is not modeled as a CA type
+
+We do NOT add a `CAConfigHydrant` constant or include a `hydrant` value in `host_mdm_managed_certificates.type`. Reasoning:
+
+- Hydrant does not yet officially support ACME. The customer-cisneros-a deployment uses a private fork. A `hydrant` enum value or `CAConfigHydrant` constant would not generalize to other customers.
+- The non-proxied mechanism (Decision 2.2: NULL `type`, plus the renewal cron's NULL bucket) handles the customer's certs without any Hydrant-specific code path. The mechanism applies equally to any external ACME or SCEP server the customer's profile points at.
+- Once Hydrant ships official ACME support upstream, a first-class Hydrant ACME CA registration may be added separately. That work would include a CA configuration, an issuance proxy, and a real type value — the right model for it. Pre-baking the type now would force a name choice that may not match the eventual official integration.
+
+**Alternatives considered:**
+- *Add `CAConfigHydrant` now and use it for the customer.* Rejected: bakes a name into a shipped enum that may conflict with future official Hydrant ACME work; produces a CA type whose only meaning is "the customer-cisneros-a use case"; doesn't generalize to the next non-proxied customer.
+
+### Decision 2.5: No DB-side linkage backfill — opt-in redeploy provides the marker-bearing certs
+
+We do NOT run a DB-side linkage backfill at Phase 2 deploy. Rationale: marker-bearing certs do not exist on devices until a customer opts into auto-renewal by redeploying a profile with `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in the Subject. Before that opt-in, existing certs lack the marker — there is nothing to link.
+
+When the customer redeploys, the new ACME/SCEP exchange produces a cert with the marker in its Subject. Phase 1's on-demand `CertificateList` ingests it. Phase 2's `UpdateHostCertificates` insert path (Decision 2.1) creates the `host_mdm_managed_certificates` row. The renewal cron then picks it up at threshold.
+
+Customers who don't include the marker in their profiles simply don't get auto-renewal — same behavior as 4.85 and earlier. No linkage row gets created; the renewal cron has nothing to act on.
+
+**Alternatives considered:**
+- *Backfill scan over `host_certificates`.* Rejected: pre-opt-in certs don't carry the marker, so scanning them yields nothing useful. Post-opt-in certs are linked by the natural insert path. The backfill would be a no-op in both regimes.
+- *Re-run Phase 1's `CertificateList` backfill after Phase 2 ships.* Same problem — pre-opt-in certs lack the marker. Even if visible in `host_certificates`, they wouldn't link. And Phase 1's backfill itself was dropped (Decision 1.2).
+
+### Decision 2.6: The marker is optional — no profile-upload validation for missing marker
+
+`$FLEET_VAR_CERTIFICATE_RENEWAL_ID` is an **opt-in renewal activator**, not a required field. Profile uploads succeed regardless of whether the marker is present. Omitting it just means auto-renewal doesn't activate for that profile — Fleet falls back to today's manual-redeployment workflow for cert lifecycle, identical to 4.85 behavior.
+
+**Net-new validators (Apple ACME, Apple raw SCEP) are removed entirely.** PR 2.3 and PR 2.3b initially shipped validators that rejected profiles missing the marker; those validators are reverted under this scope. The marker is now purely advisory.
+
+**Pre-existing validators (proxy SCEP — NDES / Custom SCEP / Smallstep, Windows non-proxied SCEP) keep their existing renewal-ID enforcement.** Those validators predate this story (since 4.65) and customers have authored profiles against them for years. Loosening them would have no benefit and might silently flip working renewal off.
+
+The matcher (`host_certificates.go:195`) keeps its defensive CN-or-OU search for `fleet-<profile_uuid>`. If a customer puts the marker in CN instead of OU, the matcher may still find it depending on CA cooperation — no upload-time enforcement gets in the way.
+
+**Why this changed (scope reversal, 2026-05-15):**
+
+Validators initially rejected missing marker on the theory that "silent non-renewal is the failure mode this story exists to prevent." But that framing conflated two different customer scenarios:
+
+1. **Customer wants auto-renewal.** They add the marker. Today's behavior (with or without validators) gives them auto-renewal.
+2. **Customer doesn't want auto-renewal, or doesn't know it's a feature.** They don't add the marker. Today's behavior continues to work — they renew manually as they always have.
+
+Hard-rejecting case 2 breaks existing deployments. Specifically:
+
+- **GitOps trap:** A customer with existing Conditional Access / Okta Verify / ACME profiles in their GitOps spec runs `fleetctl gitops apply` after upgrading to 4.86. The profiles haven't changed. But upload now fails because the validators reject missing markers. Their next sync breaks.
+- **UI-edit trap:** A customer opens an existing profile in the UI, makes an unrelated edit (rename, label change), saves. The validator now rejects, breaking the edit.
+- **Conditional Access:** Fleet's own generated profile lacks the marker (#45580 surfaced this gap). Customers following the published guide can't deploy.
+
+The cost of hard rejection — broken upgrades for the customer base that doesn't even use auto-renewal — exceeded the benefit of catching the misconfiguration that's only relevant to customers who opted in. Marker stays as a documented variable; renewal activates when present; everything else continues unchanged.
+
+**Alternatives considered:**
+- *Reject missing marker (original design).* Rejected: GitOps continuity and upgrade-day breakage outweigh the silent-failure protection. Most customers don't even use auto-renewal; rejecting their existing profiles is a regression.
+- *Accept missing marker but reject misplaced marker (e.g., marker in CN instead of OU).* Considered. Modest benefit (catches typos for opted-in customers) at the cost of a partial validator that's harder to explain. Rejected for simplicity. The matcher's CN-or-OU search means misplaced markers may actually still work in practice; upload-time validation isn't necessary.
+- *Soft warning at upload time.* Considered. No UI surface to display a non-blocking warning today; activity log entries get lost. Discoverability worse than just documenting the requirement in the guide.
+
+### Decision 2.7: Variable rename — accept both `SCEP_RENEWAL_ID` and `CERTIFICATE_RENEWAL_ID`
+
+The customer-facing variable name was renamed from `$FLEET_VAR_SCEP_RENEWAL_ID` to `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` per PR #44069 (merged 2026-05-01 into `docs-v4.86.0`), referenced by #40639 as "[New variable name]". Reasoning: the variable is no longer SCEP-specific — it must apply to ACME profiles too for the customer-cisneros-a use case (and any future non-proxied flow), so the SCEP-prefixed name reads as a bug to anyone authoring an ACME profile.
+
+Today (4.85 and earlier) the only valid name is `SCEP_RENEWAL_ID`. The rename is half-shipped: docs use the new name, code still defines and substitutes only the old name. Phase 2 closes that gap.
+
+**Implementation approach:** add `FleetVarCertificateRenewalID = "CERTIFICATE_RENEWAL_ID"` alongside the existing `FleetVarSCEPRenewalID`. Both are recognized by `FindFleetVariables`. Both substitute to the same value (`"fleet-" + ProfileUUID`) via the same substitution helper — implemented as a single regex matching either name.
+
+**Substitution accepts both names everywhere.** The substitution code (`server/mdm/apple/profile_processor.go`, `server/mdm/microsoft/profile_variables.go`) uses the unified `FleetVarRenewalIDRegexp` so a profile authored with either name produces identical `fleet-<profile_uuid>` output at delivery time. New authoring should use the preferred name per documentation, but legacy name continues to work — no validation enforcement either way (see Decision 2.6).
+
+**Pre-existing proxy-SCEP validators retain their existing behavior** (NDES / Custom SCEP / Smallstep, Windows non-proxied SCEP). Those validators predate this story (since 4.65) and continue to require the renewal-ID variable in their authoring patterns. The variable rename adds preferred-name acceptance on those surfaces (PR 2.3 / PR 2.4 / PR 2.5) without dropping legacy-name back-compat. Customers running 4.85 SCEP profiles continue to work; new authoring can use either name.
+
+**Why accept both rather than hard-rename:**
+- Customers running 4.85 likely have `$FLEET_VAR_SCEP_RENEWAL_ID` in deployed SCEP profile Subjects. Hard-renaming the substitution constant would break those profiles on the next upload/edit cycle (substitution would leave the literal `$FLEET_VAR_SCEP_RENEWAL_ID` string in the profile, which the device CA rejects).
+- Backwards-compat cost is small: one extra regex alternation, one extra constant. No new datastore work, no migration.
+- We can deprecate `SCEP_RENEWAL_ID` in a later release once telemetry shows the long tail has migrated.
+
+**Alternatives considered:**
+- *Hard-rename — only `CERTIFICATE_RENEWAL_ID` works.* Rejected per the customer-impact reasoning above.
+- *Hard-rename with a deprecation warning on uploads using the old name.* Considered. Same back-compat issue for already-deployed profiles that don't get re-uploaded — they'd silently stop substituting. Reject for the same reason.
+- *Keep `SCEP_RENEWAL_ID` as the only name and revert the docs PR.* Rejected: docs decision is product-led and reflects the variable's actual scope (any cert, not just SCEP). The mismatch is a code-side gap to close, not a docs error to revert.
+
+**Historical note (2026-05-15 scope change):** earlier drafts of this Decision included a "net-new surfaces accept preferred-name-only and require OU placement" rule for the Apple ACME validator (PR 2.3) and Apple raw-SCEP validator (PR 2.3b). Those validators were removed entirely under Decision 2.6's scope reversal, so the net-new-vs-pre-existing distinction no longer has enforcement behavior to mediate. The matcher accepts the marker in CN or OU regardless. Customers who include the marker should use the preferred name in OU per documentation, but no validator enforces either choice.
+
+### Decision 2.8: INSERT path inherits the matcher's date-validity filter
+
+The INSERT path added in Decision 2.1 reuses the same per-cert validity filter as the existing matcher (#44691):
+
+```
+if cert.NotValidBefore.After(now) || cert.NotValidAfter.Before(now) {
+    continue
+}
+```
+
+For the **matcher's UPDATE path** this filter is clearly correct: it prevents the matcher from regressing an existing `hmmc.not_valid_after` backward when the device is reporting both a stale (just-expired) cert and a freshly-issued one alongside it. Without the filter, best-match-by-NotValidBefore could latch onto the older cert.
+
+For the **INSERT path** the filter is a deliberate design choice with a real trade-off:
+
+```
+   Cert in pool: marker matches profile, NotValidAfter < now (already expired)
+   No existing hmmc row.
+
+   With filter (chosen):
+     INSERT skipped → no hmmc row → renewal cron has nothing to act on
+     → cert stays unrenewed until device reports a fresh cert with the marker
+     (i.e., until the device successfully re-ACMEs on its own)
+
+   Without filter:
+     INSERT with expired dates → cron immediately triggers re-push
+     → device hopefully re-ACMEs → matcher updates row with fresh dates
+     If device DOESN'T re-ACME (attestation failure, CA rejection, etc.):
+        row sticks around with expired dates, cron loops forever
+```
+
+We keep the filter on the INSERT path for two reasons:
+
+- **Symmetry with the matcher.** Same shape of pool iteration on both paths makes the code easier to reason about and avoids two subtly different "how do we evaluate a pool cert" rules in the same function.
+- **Silent renewal-failure detection is a Non-Goal.** If a device's cert is already past expiry without a fresh one alongside it, that's a deeper failure mode (attestation rejection, CA outage, profile delivery problem) that re-pushing the profile won't necessarily fix. Inserting an expired-dates row would create a permanently-stuck row that the renewal cron loops on indefinitely — exactly the silent-failure pattern this story explicitly defers to a future change.
+
+The trade-off: customers whose certs have already expired BEFORE Phase 2 deploys (and whose devices haven't re-ACMEd to produce a fresh cert) won't get auto-recovered by Phase 2 alone. They need to either redeploy the profile manually or wait for the eventual silent-failure-detection follow-up.
+
+**Alternatives considered:**
+- *Drop the filter on INSERT only.* Rejected per the silent-failure-loop concern. Re-push without verification of the renewal outcome is the exact pattern that the deferred renewal-verification story is meant to address; building it into INSERT now would short-circuit that future design.
+- *Drop the filter on INSERT but require not-too-old (e.g., expired within last N days).* Considered. Adds a new tunable constant for one edge case; defers rather than resolves the silent-failure problem; rejected as over-engineering.
+
+## Phase Independence
+
+The expected ship cadence is "both phases together" — both deliver value to the same customer-cisneros-a use case and the redeploy step that activates Phase 2 is also what surfaces certs into Phase 1's ingestion. Each phase is still independently mergeable to keep PRs reviewable in isolation.
+
+Phase 1 alone (if Phase 2 is delayed): macOS ACME certs become visible after the customer reinstalls the delivering profile. No renewal yet.
+
+Phase 2 alone (if Phase 1 is delayed): iOS/iPadOS non-proxied ACME renewal works (existing `IOSiPadOSRefetch` cadence ingests the certs after redeploy), Windows Okta SCEP renewal works (osquery ingests), macOS Okta SCEP works (osquery ingests software certs after redeploy). Only macOS hardware-bound non-proxied ACME (the customer-cisneros-a target) requires Phase 1.
+
+## Risks / Trade-offs
+
+- **Risk**: Existing customer profiles in production may be missing the marker. Hard validation breaks them on next edit.
+  → Mitigation: validation only fires on new uploads/edits, not retroactively on existing profiles. Document the requirement in release notes. Existing-fleet behavior unchanged for profiles already in place — they simply won't auto-renew, which matches today's behavior.
+
+- **Risk**: Profile UUID format assumption — the regex relies on `varchar(37)` standard UUID shape. If Fleet ever changes profile UUID format, the regex misses certs.
+  → Mitigation: source-of-truth is `host_mdm_*_profiles.profile_uuid`. Sample existing rows to confirm format before finalizing regex. Make the regex permissive within reasonable bounds and reject captures that don't resolve to an existing profile.
+
+- **Risk**: Customer copies a profile from one Fleet instance to another. Old profile UUID is baked into the cert Subject. New Fleet instance can't resolve it.
+  → Mitigation: cert is simply not linked, no harm done. Renewal won't happen until a new cert with a current-instance profile UUID lands. Document this as a known constraint of cert portability.
+
+- **Risk**: Type B silent failure (profile installs, cert exchange silently fails) leads to unbounded retry loop.
+  → Accepted: identical to existing proxied-CA behavior in production. Out of scope per Non-Goals.
+
+- **Risk**: Customers fail to redeploy ACME/SCEP profiles after upgrade and assume renewal is working when it isn't.
+  → Mitigation: profile-upload validation (Decision 2.6) rejects new uploads missing the marker, surfacing the requirement actively. Release notes call out the redeploy step explicitly. Documentation includes a checklist customers can run to verify renewal is active for each profile.
+
+- **Trade-off**: Reusing `host_mdm_managed_certificates` for non-proxied rows pollutes its semantics (the column `type` no longer reliably identifies the CA). Cleaner alternative would be a separate table, but the duplication cost outweighs the conceptual purity.
+
+## Migration Plan
+
+**Phase 1 deploy:**
+1. Schema migration: add `host_certificates.origin` column with default `osquery` for existing rows.
+2. Code deploy: `CertificateList` ack-trigger handler for macOS, source-aware deletion logic, dedup by `sha1_sum`.
+3. No backfill job. Customer redeploys of ACME/SCEP profiles activate ingestion per-host.
+
+**Phase 2 deploy:**
+1. Schema migration: allow `host_mdm_managed_certificates.type` to be NULL.
+2. Code deploy: `UpdateHostCertificates` insert path, renewal-list update, profile validation.
+3. Customer action required: redeploy ACME/SCEP profiles with `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in cert Subject. Until they do, renewal does not activate for that profile.
+4. Verification: confirm renewal cron picks up rows created by post-redeploy ingestion as certs near threshold.
+
+**Rollback**: per phase. Phase 1 code rollback returns to existing iOS/iPadOS-only `CertificateList` behavior; the `origin` column persists harmlessly. Phase 2 code rollback restores update-only behavior on `UpdateHostCertificates`; the NULL `type` rows remain but won't be selected by the rolled-back renewal cron's strict `type` clause.
+
+## Open Questions
+
+- **Windows Subject substitution** (Phase 2): today's `$FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID` substitutes into the OMA-URI container path, not the cert Subject. For Windows renewal to use the same matching mechanism, either the customer profile must reuse `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in the cert Subject (CertificateRequestBody/SubjectName CSP node), or a Windows-specific Subject variable is introduced. Engineering to confirm Windows profile authoring conventions.
+
+- **Profile UUID format** (Phase 2): RESOLVED — empirically the marker is always literally `"fleet-" + profile_uuid` (substituted by `server/mdm/microsoft/profile_variables.go:125` and `server/mdm/apple/profile_processor.go:401-404`). No regex needed; substring search suffices.
+
+- **Validation surface** (Phase 2): GitOps profile uploads (`fleetctl gitops`) should also enforce the marker requirement. Confirm `fleetctl` profile validation shares the same code path as UI upload.
+
+- **Customer-facing redeploy guidance** (Phase 2): documentation must clearly explain that existing profiles need to be re-uploaded with the marker. Should the release-notes / guide include a `fleetctl` snippet customers can run to identify which existing profiles need updating?
+
+- **Observability** (deferred): activity log entry on successful renewal vs. log-only? Out of scope per Non-Goals but worth tracking as a follow-up improvement.
+
+- **Flow B — enrollment-time ACME cert detection** (gap in Phase 1 as currently implemented): PR 1.2 covers Flow A — profile-install ack triggers `CertificateList`. It does NOT cover Flow B — silicon Macs enrolling via DEP with `AppleRequireHardwareAttestation=true` get an ACME-issued enrollment cert that's invisible to osquery and never lands in `host_certificates` because no `InstallProfile` ack is involved in the enrollment ceremony (the cert is part of the enrollment profile itself). Closing this requires hooking `CertificateList` into either `mdmlifecycle.turnOnApple` (single-fire on first enrollment) or the `TokenUpdate` handler. Tracked as a follow-up sub-task; required to fully deliver #42827's customer promise for the cisneros-a use case.
+
+- **Coordination with #44691** (Phase 2): PR #44691 restructures the matcher in `UpdateHostCertificates` (`toInsertBySHA1` map, pool-selection per hmmc row, best-match-wins, monotonic-forward predicate, `hmmcBackfillGrace`). It targets `main` and is expected to merge before our Phase 2 work lands. Our INSERT path (Decision 2.1) is conceptually orthogonal — `#44691` updates existing rows that got stuck NULL; we insert rows that don't exist yet. Implementation plan: land #44691 first, rebase Phase 2 work on top, add the INSERT loop alongside the restructured matcher rather than weaving into it. Reuse `toInsertBySHA1` / `incomingBySHA1` maps it already builds.

--- a/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/proposal.md
+++ b/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Fleet's renewal cron (`RenewMDMManagedCertificates`) automatically re-pushes profiles to renew expiring certs for proxied CAs (NDES SCEP, Custom SCEP Proxy, DigiCert, Smallstep) but does not work for non-proxied flows where the device talks directly to an external CA — non-proxied ACME and non-proxied SCEP (including Okta conditional access and Okta Verify w/ static challenge). For these, Fleet has no view of issuance, so no `host_mdm_managed_certificates` row gets created, so the renewal cron has nothing to act on. This blocks the 4.86 customer promise (#40639, customer-cisneros-a) where the customer deploys an ACME profile against their own Hydrant deployment (a private fork that supports ACME — Hydrant does not officially support ACME at the time of this writing) and needs those device certs to auto-renew before expiry to prevent service disruption (Wi-Fi, MDM identity).
+
+For the customer-cisneros-a target on macOS, the ACME certs are hardware-bound and entirely invisible to osquery — they only appear via the MDM `CertificateList` command. Fleet uses this command on iOS/iPadOS today but not on macOS. So delivering the customer promise also requires extending MDM cert ingestion to macOS (#42827, also assigned to this work).
+
+Non-goal of this change: model "Hydrant ACME" as a registerable CA type. The customer's Hydrant fork is private and the upstream Hydrant product does not yet officially support ACME, so a `hydrant` CA registration would not generalize to other customers. The non-proxied mechanism described below works for any ACME or SCEP server the customer's profile points at, regardless of vendor — Hydrant in this engagement, something else for the next customer. Once Hydrant ships official ACME support, a first-class Hydrant ACME CA registration may be added separately and is out of scope here.
+
+This change covers both #42827 (cert ingestion) and #40639 (renewal). The two stories ship as independent phases because #42827 is independently valuable (admins can see ACME certs on the host details page even before renewal lands) and the dependency is one-directional: renewal of macOS hardware-bound certs cannot work until ingestion is in place.
+
+## What Changes
+
+### Phase 1 — #42827 cert ingestion (macOS)
+
+- Extend MDM `CertificateList` command usage to macOS hosts. iOS/iPadOS already use it via `IOSiPadOSRefetch`.
+- Trigger model: on-demand `CertificateList` when an ACME `InstallProfile` ack is received. NOT a recurring cadence — would generate too much MDM traffic across a full fleet.
+- Ingest *all* MDM-delivered certs returned (not only ACME), deduplicating against osquery-ingested certs by `host_certificates.sha1_sum`.
+- Add `host_certificates.origin` column (`osquery` / `mdm`) to scope deletion semantics so each ingestion source only soft-deletes rows it owns. Internal-only — not exposed in API.
+- No deploy-time backfill: customers must re-deploy ACME/SCEP profiles to enable renewal (Phase 2 requires the marker variable in profile Subject). Redeploy → InstallProfile ack → on-demand `CertificateList` → cert ingested. The natural flow covers existing fleet without a separate backfill mechanism.
+
+### Phase 2 — #40639 renewal extension
+
+- Extend `UpdateHostCertificates` to *insert* `host_mdm_managed_certificates` rows when an ingested cert's Subject contains a `fleet-<profile_uuid>` marker but no matching managed-cert row exists. Today this function only updates existing rows.
+- Extract the renewal ID marker from the cert Subject (CN or OU) and resolve it to a profile UUID. Verify the profile is installed on this host before inserting.
+- Allow `host_mdm_managed_certificates.type` to be NULL for rows created from ingestion (no proxy step → no known CA type). The renewal cron then iterates the union of registered CA types plus a NULL bucket, so non-proxied rows are processed alongside proxied rows.
+- Adjust the matcher in `UpdateHostCertificates` so the existing `SupportsRenewalID()` skip does not silently exclude NULL-`type` rows — without this, ingestion-created rows would never have their `not_valid_after` advanced after a renewal completes, producing a non-terminating renewal loop.
+- Profile-authoring validation: reject SCEP/ACME profile uploads that lack `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in the cert Subject. Without the marker, no renewal can ever fire. This validation also functions as the trigger for customers to redeploy existing profiles with the marker, which in turn surfaces certs into ingestion via the Phase 1 mechanism.
+- No DB-side linkage backfill: marker-bearing certs only exist on devices after the customer redeploys profiles with `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in the Subject. Redeploy triggers Phase 1 ingestion, which feeds Phase 2's natural insert path. No pre-existing marker-bearing certs to backfill.
+- TODO (engineering confirmation): Windows scope — the current `$FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID` substitutes into the OMA-URI container path, not the cert Subject. Either reuse `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in the Subject, or introduce a Windows-specific Subject variable.
+
+## Capabilities
+
+### New Capabilities
+
+- `cert-ingestion-mdm`: MDM `CertificateList`-based ingestion of certs from Apple devices. Covers the trigger model (on-demand per `InstallProfile` ack, plus one-time backfill at deploy), unified storage in `host_certificates` with origin tracking, and dedup with osquery-ingested rows. Phase 1 of this change.
+- `cert-renewal-non-proxied`: Auto-renewal of MDM-delivered SCEP and ACME certificates issued by external CAs that Fleet does not proxy (e.g. the customer's Hydrant deployment in customer-cisneros-a, Okta SCEP). Covers ingestion-driven managed-cert row creation, profile-authoring validation, platform coverage (macOS, iOS, iPadOS, Windows). Phase 2 of this change, depends on `cert-ingestion-mdm` being shipped for the macOS leg.
+
+### Modified Capabilities
+
+<!-- No existing specs in openspec/specs/ — all behavior is captured in the new capabilities above. -->
+
+## Impact
+
+### Phase 1 (#42827)
+
+- **Code**:
+  - `server/mdm/apple/apple_mdm.go` — extend on-demand `CertificateList` to macOS; today only iOS/iPadOS via `IOSiPadOSRefetch`.
+  - `server/service/apple_mdm.go` — hook into the `InstallProfile` ack handler to trigger `CertificateList` for macOS ACME profile installs.
+  - `server/datastore/mysql/host_certificates.go` — dedup by `sha1_sum`, source-aware soft-delete.
+- **Schema**: add `host_certificates.origin` enum column (`osquery` / `mdm`); migration includes default value for existing rows.
+- **API**: no surface changes — the API returns a single deduped cert list; `origin` is internal.
+- **Customer-facing**: macOS ACME certs become visible on the host details page after the customer redeploys the delivering profile. No automatic backfill — visibility is conditional on profile activity, consistent with the redeploy requirement Phase 2 introduces.
+
+### Phase 2 (#40639)
+
+- **Code**:
+  - `server/datastore/mysql/host_certificates.go` — `UpdateHostCertificates` extension (insert path); matcher adjustment for NULL-`type` rows.
+  - `server/datastore/mysql/mdm.go` — extend `RenewMDMManagedCertificates` to iterate a NULL bucket alongside the registered CA types (null-safe equal `<=>`).
+  - `server/service/apple_mdm.go` — profile fleet-variable validation (extends existing SCEP validation to ACME payloads).
+  - `server/service/windows_mdm_profiles.go` — profile fleet-variable validation.
+- **Schema**: `host_mdm_managed_certificates.type` becomes nullable (allow NULL, drop the `'ndes'` default).
+- **API**: no surface changes — renewal happens in cron, no new endpoints.
+- **Dependencies**: depends on Phase 1 for the macOS leg. iOS/iPadOS/Windows legs are independent.
+- **Customer-facing**: Premium-only (consistent with existing renewal). Customers must include `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in profile Subject for renewal to function — documentation update required. Profile uploads missing the variable will be rejected.

--- a/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/specs/cert-ingestion-mdm/spec.md
+++ b/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/specs/cert-ingestion-mdm/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: MDM CertificateList ingestion on macOS
+
+The system SHALL collect installed certificates from MDM-enrolled macOS hosts using the Apple `CertificateList` MDM command, in addition to the existing osquery-based ingestion, so that hardware-bound certificates invisible to osquery (notably hardware-bound ACME identities) are surfaced in Fleet.
+
+#### Scenario: macOS ACME profile install triggers cert ingestion
+
+- **WHEN** an MDM-enrolled macOS host installs a profile containing a `com.apple.security.acme` payload and acks the `InstallProfile` command
+- **THEN** the system SHALL queue a `CertificateList` MDM command for that host
+- **AND** the resulting cert list SHALL be ingested into `host_certificates`
+
+#### Scenario: macOS does NOT use a recurring CertificateList cadence
+
+- **WHEN** the system processes its scheduled MDM cron jobs on macOS hosts
+- **THEN** the system SHALL NOT enqueue `CertificateList` on a recurring cadence
+- **AND** SHALL rely on `InstallProfile`-ack triggers (per Decision 1.1) for macOS ingestion. There is no deploy-time backfill (per Decision 1.2 — the customer redeploy step that activates Phase 2 also produces the `InstallProfile` acks that drive Phase 1 ingestion).
+
+#### Scenario: Multiple ACME profile acks in flight do not dedupe the trigger
+
+- **WHEN** an `InstallProfile` ack arrives for an ACME profile on a macOS host while a previous `CertificateList` refetch for the same host is still pending
+- **THEN** the system SHALL still enqueue a new `CertificateList` for the new ack, not skip it because of the in-flight refetch
+- **AND** the duplicate enqueue SHALL collapse via the `host_mdm_commands` `(host_id, command_type)` primary key (`ON DUPLICATE KEY UPDATE`)
+- **AND** when both refetch results eventually arrive, the result handler SHALL process each idempotently (the second is safe to receive after the first removes the tracking row)
+- **AND** this guarantees the post-ACME-exchange cert state is captured even if the prior refetch returned before the device's ACME exchange completed
+
+#### Scenario: iOS and iPadOS continue using existing refetch cadence
+
+- **WHEN** the existing `IOSiPadOSRefetch` cron runs against iOS or iPadOS hosts
+- **THEN** the system SHALL continue to enqueue `CertificateList` on its established hourly cadence without change
+
+### Requirement: Unified cert storage with origin tracking
+
+The system SHALL store certs from both osquery and MDM `CertificateList` ingestion in a single `host_certificates` table, deduplicated by `sha1_sum`, with an `origin` column scoping deletion semantics per ingestion source.
+
+#### Scenario: Cert visible to both osquery and MDM appears once
+
+- **WHEN** the same cert is reported by both osquery's `certificates` table and MDM `CertificateList` for the same host
+- **THEN** the system SHALL store exactly one row keyed by `(host_id, sha1_sum)`
+
+#### Scenario: Hardware-bound cert visible only via MDM is stored as origin=mdm
+
+- **WHEN** an MDM `CertificateList` response includes a hardware-bound cert that osquery cannot see
+- **THEN** the system SHALL insert a row with `origin = 'mdm'`
+- **AND** subsequent osquery sync runs SHALL NOT delete that row
+
+#### Scenario: Origin is not exposed in the public API
+
+- **WHEN** a client requests the host certificates API
+- **THEN** the response SHALL be a single deduped list of certs without exposing the `origin` column
+- **AND** the column SHALL exist purely as an internal implementation concern
+
+### Requirement: Source-scoped deletion
+
+The system SHALL only soft-delete `host_certificates` rows whose `origin` matches the ingestion source that is reporting the latest cert state, so each source cannot remove rows owned by another source.
+
+#### Scenario: Osquery sync does not delete MDM-only certs
+
+- **WHEN** osquery reports a fresh cert list that omits a hardware-bound MDM-ingested cert
+- **THEN** the system SHALL NOT mark the MDM-origin cert as deleted
+
+#### Scenario: MDM CertificateList response does not delete osquery certs
+
+- **WHEN** an MDM `CertificateList` response omits a software cert that osquery is reporting
+- **THEN** the system SHALL NOT mark the osquery-origin cert as deleted

--- a/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/specs/cert-renewal-non-proxied/spec.md
+++ b/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/specs/cert-renewal-non-proxied/spec.md
@@ -1,0 +1,138 @@
+## ADDED Requirements
+
+### Requirement: Auto-renewal for non-proxied ACME certs on Apple platforms
+
+The system SHALL automatically renew non-proxied ACME certificates (issued by an external CA that Fleet does not proxy — e.g. the customer-cisneros-a Hydrant deployment) on macOS, iOS, and iPadOS hosts before expiration by re-pushing the delivering profile, when the cert was issued in response to a profile installed by Fleet and the cert's Subject contains a Fleet-generated renewal-ID marker.
+
+The mechanism SHALL NOT depend on Fleet having a registered CA for the issuing service. Eligibility is determined by the presence of a `host_mdm_managed_certificates` row (created from ingestion when the marker is present), regardless of whether the row's `type` is set or NULL.
+
+#### Scenario: Non-proxied ACME cert nears expiration on iOS
+
+- **WHEN** an iOS host has an ACME cert (issued by an external CA Fleet does not proxy) linked to a Fleet-installed profile, the cert's `not_valid_after` falls within the renewal threshold (validity_period > 30 days → 30 days; ≤ 30 days → validity_period/2)
+- **THEN** the system SHALL set the profile's status to NULL so the next profile-manager cron run triggers a re-push
+- **AND** SHALL select the row from the renewal cron's NULL-`type` bucket without requiring a registered CA for the issuing service
+
+#### Scenario: Non-proxied ACME cert nears expiration on macOS
+
+- **WHEN** a macOS host has a hardware-bound non-proxied ACME cert (visible only via MDM `CertificateList`) linked to a Fleet-installed profile and the cert nears expiration
+- **THEN** the system SHALL re-push the profile to trigger a new ACME exchange between the device and the external CA
+- **AND** the new cert SHALL be ingested via the on-demand `CertificateList` triggered by the resulting profile-install ack (provided by #42827)
+- **AND** the linked managed-cert row's `not_valid_after` SHALL be advanced when the new cert is ingested
+- **AND** the matcher SHALL update the row even when its `type` is NULL — the existing `SupportsRenewalID()` skip MUST NOT exclude NULL-`type` rows
+
+### Requirement: Auto-renewal for non-proxied SCEP certs (Okta)
+
+The system SHALL automatically renew non-proxied SCEP certificates (Okta conditional access, Okta Verify w/ static challenge) on macOS, iOS, iPadOS, and Windows hosts using the same profile re-push mechanism as non-proxied ACME, when the cert's Subject contains the renewal-ID marker.
+
+#### Scenario: Okta SCEP cert renewal on Windows
+
+- **WHEN** a Windows host has an Okta-issued SCEP cert linked to a Fleet-installed profile and the cert nears expiration
+- **THEN** the system SHALL set the profile's status to NULL to trigger a re-push
+- **AND** the device SHALL re-execute SCEP enrollment with Okta directly without any Fleet proxy step
+- **AND** the new cert SHALL be ingested via the next osquery `certificates` table report
+
+#### Scenario: Okta Verify SCEP cert with static challenge on macOS
+
+- **WHEN** a macOS host has an Okta-issued SCEP cert (using a static challenge embedded in the profile) linked to a Fleet-installed profile and the cert nears expiration
+- **THEN** the system SHALL re-push the profile so the device re-runs SCEP using the same static challenge
+- **AND** the new cert SHALL be ingested via osquery and the linked managed-cert row updated
+
+### Requirement: Managed-cert row creation from cert ingestion
+
+The system SHALL create `host_mdm_managed_certificates` rows when a cert is first ingested whose Subject contains a `fleet-<profile_uuid>` marker matching a profile installed on the same host, instead of requiring the row to be created at proxy issuance time.
+
+#### Scenario: First-time cert ingestion creates managed-cert row
+
+- **WHEN** the system ingests a cert via osquery or `CertificateList` whose Subject CN or OU contains the substring `fleet-<uuid>`, AND `<uuid>` resolves to a `profile_uuid` present in `host_mdm_apple_profiles` or `host_mdm_windows_profiles` for the same host, AND no `host_mdm_managed_certificates` row exists for that (host_uuid, profile_uuid) pair
+- **THEN** the system SHALL insert a new `host_mdm_managed_certificates` row populated with the cert's `serial`, `not_valid_before`, and `not_valid_after`
+- **AND** SHALL set `type` to NULL or to a non-proxied sentinel value
+- **AND** SHALL leave `challenge_retrieved_at` NULL since no proxy step occurred
+
+#### Scenario: Subsequent cert ingestion updates existing row
+
+- **WHEN** the system ingests a renewed cert whose Subject marker matches an existing `host_mdm_managed_certificates` row
+- **THEN** the system SHALL update that row's `serial` and `not_valid_after` from the new cert
+- **AND** SHALL NOT create a duplicate row
+
+#### Scenario: Cert with marker that does not resolve to a profile is ignored
+
+- **WHEN** the system ingests a cert whose Subject contains `fleet-<uuid>` but `<uuid>` does not match any profile installed on the host (stale, copied, or wrong tenant)
+- **THEN** the system SHALL NOT insert a `host_mdm_managed_certificates` row
+- **AND** SHALL log the mismatch at debug level for troubleshooting
+
+### Requirement: Profile-upload validation enforces renewal-ID marker
+
+The system SHALL reject profile uploads (via UI, API, or `fleetctl gitops`) when the profile contains a SCEP or ACME payload whose cert Subject does not include a renewal-ID marker variable in CN or OU. Both `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` (preferred, customer-facing name per PR #44069) and the legacy `$FLEET_VAR_SCEP_RENEWAL_ID` SHALL be accepted as valid markers. Validation error messages SHALL reference only `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` to steer new authoring toward the preferred name.
+
+#### Scenario: Apple ACME profile missing renewal-ID variable is rejected
+
+- **WHEN** a user uploads an Apple configuration profile containing a `com.apple.security.acme` payload whose `Subject` field does not contain `$FLEET_VAR_CERTIFICATE_RENEWAL_ID`
+- **THEN** the system SHALL respond with a 422 Invalid Argument error
+- **AND** the error message SHALL name `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` and explain that it is required in the cert Subject for the cert to auto-renew
+
+#### Scenario: Apple SCEP profile missing renewal-ID variable is rejected
+
+- **WHEN** a user uploads an Apple configuration profile containing a `com.apple.security.scep` payload whose `Subject` field does not contain `$FLEET_VAR_CERTIFICATE_RENEWAL_ID`
+- **THEN** the system SHALL respond with a 422 Invalid Argument error
+- **AND** the error message SHALL name `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` and explain the requirement
+
+#### Scenario: Profile without renewable payloads is unaffected
+
+- **WHEN** a user uploads a profile with no SCEP or ACME payloads (e.g., a Wi-Fi profile, a restrictions profile)
+- **THEN** the system SHALL NOT require `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` and SHALL accept the profile
+
+#### Scenario: Legacy `SCEP_RENEWAL_ID` variable is still accepted
+
+- **WHEN** a user uploads a profile whose cert Subject contains `$FLEET_VAR_SCEP_RENEWAL_ID` (the pre-rename variable name) in CN or OU
+- **THEN** the system SHALL accept the profile (the legacy name remains valid for back-compat with profiles authored against pre-4.86 docs)
+- **AND** SHALL substitute the same value (`fleet-<profile_uuid>`) as it would for `$FLEET_VAR_CERTIFICATE_RENEWAL_ID`
+
+### Requirement: Renewal-ID variable substitution recognizes both names
+
+The system SHALL recognize both `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` (preferred) and `$FLEET_VAR_SCEP_RENEWAL_ID` (legacy) when substituting renewal-ID markers into profile content. Both names SHALL substitute to the identical string `"fleet-" + profile_uuid`. The variable name has no semantic effect on the resulting cert Subject — only on what the profile author types.
+
+#### Scenario: New variable substitutes to fleet-<profile_uuid>
+
+- **WHEN** a profile contains `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in a cert Subject field
+- **THEN** the system SHALL replace it with `"fleet-" + profile_uuid` before delivering the profile to the device
+
+#### Scenario: Legacy variable substitutes identically
+
+- **WHEN** a profile contains `$FLEET_VAR_SCEP_RENEWAL_ID` in a cert Subject field
+- **THEN** the system SHALL replace it with `"fleet-" + profile_uuid` — the same value the new variable produces
+- **AND** the resulting cert Subject SHALL be indistinguishable on the wire from one authored with the new variable name
+
+### Requirement: Profile redeploy activates renewal for existing fleet
+
+The system SHALL rely on customer profile redeploy as the activation step that surfaces marker-bearing certs into ingestion, instead of running a deploy-time backfill. Profile redeploy is required because Phase 2 introduces the marker-in-Subject requirement that pre-existing profiles do not satisfy.
+
+#### Scenario: Customer redeploys ACME profile with marker
+
+- **WHEN** a customer adds `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` to an existing ACME profile's Subject and redeploys it via Fleet UI or `fleetctl gitops`
+- **THEN** the resulting `InstallProfile` ack on each affected host SHALL trigger a `CertificateList` (Phase 1 mechanism)
+- **AND** the new cert (issued with the marker in Subject) SHALL be ingested
+- **AND** the `UpdateHostCertificates` insert path SHALL create the corresponding `host_mdm_managed_certificates` row
+- **AND** the renewal cron SHALL pick up the row at the configured threshold
+
+#### Scenario: Customer does not redeploy a profile
+
+- **WHEN** a customer upgrades to the version with these changes but does not redeploy a particular ACME/SCEP profile
+- **THEN** the system SHALL NOT auto-renew certs from that profile
+- **AND** the system SHALL NOT silently degrade or alter behavior for that profile beyond the existing baseline
+
+### Requirement: Non-proxied managed-cert rows are eligible for renewal
+
+The system SHALL include `host_mdm_managed_certificates` rows with NULL `type` in the renewal cron's selection set, so they are processed alongside rows from proxied CAs. Hydrant ACME and other non-proxied flows SHALL NOT be modeled as registered CA types — the NULL bucket is the canonical mechanism for any external CA Fleet does not proxy.
+
+#### Scenario: Renewal cron selects non-proxied row near expiration
+
+- **WHEN** `RenewMDMManagedCertificates` runs and a row exists with `type` IS NULL, `not_valid_after` within the renewal threshold, and a non-NULL profile status
+- **THEN** the system SHALL include the row in the rows it processes
+- **AND** SHALL set the corresponding profile's status to NULL to trigger re-push
+- **AND** SHALL match the row using a null-safe equal predicate so the same SQL handles registered and NULL `type` values
+
+#### Scenario: Matcher advances NULL-`type` row after renewal
+
+- **WHEN** a renewal completes for a NULL-`type` row, a fresh cert is ingested, and `UpdateHostCertificates` runs the matcher
+- **THEN** the system SHALL advance the row's `not_valid_after` from the new cert
+- **AND** SHALL NOT skip the row solely because its `type` is NULL or empty

--- a/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/tasks.md
+++ b/openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/tasks.md
@@ -1,0 +1,220 @@
+> **Phase boundaries**: This change covers two stories. **Phase 1 (#42827)** is MDM cert ingestion for macOS — independently shippable. **Phase 2 (#40639)** is non-proxied cert renewal — depends on Phase 1 for the macOS hardware-bound leg. Expected to ship together.
+>
+> **No backfills**: Customers must redeploy ACME/SCEP profiles with `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in the cert Subject to enable renewal. Redeploy fires `InstallProfile` → on-demand `CertificateList` (Phase 1) → cert ingestion → managed-cert row insert (Phase 2). The natural redeploy flow replaces what would have been a deploy-time backfill in either phase.
+>
+> **Status at archive (2026-05-18):** all implementation PRs merged or in flight as drafts (PRs #45531, #45662, #45663, #45695). Remaining unchecked items are post-implementation work tracked outside this change:
+> - **§2b** RemoveProfile cleanup — tracked as bug #45596.
+> - **§4** Phase 1 QA verification — real silicon Mac, requires hardware.
+> - **§9.4** Internal field doc — intentionally skipped (not customer-facing).
+> - **§10.1–10.7** Phase 2 QA verification — Smallstep local validation complete; Hydrant verification still pending external dependency. Tracked in #40639 verification section.
+
+---
+
+# Phase 1 — #42827 cert ingestion for macOS
+
+> Customer outcome: ACME and other MDM-delivered certs become visible on macOS host details *after the customer redeploys the delivering profile*. No automatic backfill.
+
+## 1. PR 1.1 — Storage foundation (origin column, dedup)
+
+Goal: prepare `host_certificates` to store certs from a second ingestion source. No new behavior triggered yet.
+
+- [x] 1.1.1 Migration: add `host_certificates.origin` column (`enum('osquery','mdm')`, default `'osquery'` for existing rows) — `server/datastore/mysql/migrations/tables/20260505115111_AddOriginToHostCertificates.go` + test file (timestamp bumped from 20260428151210 to land after newer migrations on main; merged via PR #44339)
+- [x] 1.1.2 Update `UpdateHostCertificates` in `server/datastore/mysql/host_certificates.go` to set `origin` based on the ingestion source parameter; default to `osquery` when called from existing osquery paths
+- [x] 1.1.3 Update soft-delete logic so each ingestion source only deletes its own `origin`-matching rows (osquery sync doesn't delete `mdm` rows; MDM response doesn't delete `osquery` rows)
+- [x] 1.1.4 Datastore tests for source-scoped deletion: pre-populate rows with mixed origin, run osquery sync omitting an `mdm` row, verify it survives; mirror for MDM-side
+- [x] 1.1.5 Run `make generate-mock` if datastore interface signatures change
+
+## 2. PR 1.2 — On-demand CertificateList for macOS
+
+Goal: hook `CertificateList` into the ACME `InstallProfile` ack flow on macOS. Activates ingestion for new and renewed profile installs.
+
+- [x] 2.1 In `server/service/apple_mdm.go` `CommandAndReportResults` `case "InstallProfile"`, detect when an acked profile contained a `com.apple.security.acme` payload on a macOS host (PR #44372)
+- [x] 2.2 Enqueue `CertificateList` for the host using existing commander; reuse `RefetchCertsCommandUUIDPrefix` for tracking
+- [x] 2.3 Ensure `handleRefetchCertsResults` continues to process the response and call `UpdateHostCertificates` with `origin='mdm'`
+- [x] 2.4 Tests: simulate an ACME `InstallProfile` ack on a macOS host and verify `CertificateList` is queued; verify result handler ingests certs with `origin='mdm'`
+- [x] 2.5 Verify iOS/iPadOS path (`server/mdm/apple/apple_mdm.go:1585-1605`) still works unchanged — no regressions
+- [x] 2.6 Implementation note: gating happens server-side via a single indexed lookup (`ProfileHasACMEPayloadForCommand`) that bundles platform check and ACME-payload presence (`LOCATE` on `mobileconfig`). No plist parse on the hot path. Tracking row is added AFTER the commander succeeds (matching the iOS/iPadOS pattern) so a CertificateList enqueue failure doesn't leave a stale tracking row. Pending-refetch dedup was deliberately NOT included — see design.md Decision 1.1's "No pending-refetch deduplication" note. Duplicates collapse via the `host_mdm_commands` `(host_id, command_type)` PK and `handleRefetchCertsResults` is idempotent.
+
+> **Known gap — Flow B (enrollment-time)**: PR 1.2 covers Flow A (profile-install ack triggers refetch) but not Flow B (DEP enrollment with hardware attestation issues an ACME enrollment cert that's invisible to osquery). Hooking into `mdmlifecycle.turnOnApple` or `TokenUpdate` for newly-enrolled silicon Macs is required to fully close #42827 for the customer-cisneros-a use case. Tracked as a follow-up sub-task; not in PR 1.2's scope.
+
+## 2b. PR 1.2b — RemoveProfile cleanup (bug #45596)
+
+Goal: symmetric companion to PR 1.2. RemoveProfile ack on macOS should trigger CertificateList so stale `host_certificates` rows clean up via the existing source-scoped soft-delete. See design.md Decision 1.5.
+
+Tracked as bug rather than sub-task because the install-side trigger (PR 1.2) closed only half the lifecycle; the removal side is a visibility bug in the on-demand design.
+
+- [ ] 2b.1 In `server/service/apple_mdm.go` `CommandAndReportResults` `case "RemoveProfile"`, detect ACME or SCEP payload removals on macOS hosts. Extend `ProfileHasACMEPayloadForCommand` (and the `ProfileACMECommandResult` type) to also report `HasSCEPPayload` so the same query serves both triggers.
+- [ ] 2b.2 Enqueue `CertificateList` via the existing commander. Tracking row added AFTER commander success — same pattern as PR 1.2 (§2.6).
+- [ ] 2b.3 Tests in `apple_mdm_test.go`: macOS+ACME → triggers; macOS+SCEP → triggers; macOS+neither → no trigger; iOS → no trigger; command-not-found → no error, no trigger. Mirror the matrix from `TestMaybeQueueCertificateListForACMEProfile`.
+- [ ] 2b.4 No changes needed for `host_mdm_managed_certificates` cleanup: when `UpdateOrDeleteHostMDMAppleProfile` removes the profile row, the orphaned hmmc row is cleaned up by the existing `CleanUpMDMManagedCertificates` cron on the next tick.
+
+## 3. PR 1.3 — Phase 1 documentation
+
+- [x] 3.1 Update host details documentation to mention macOS ACME / MDM-delivered cert visibility — explicitly note that visibility activates per-host on profile install/redeploy. (Shipped via PR #44997.)
+- [x] 3.2 Release notes entry for Phase 1. (Shipped via PR #44997 — `changes/42827-macos-mdm-certificate-ingestion`.)
+
+## 4. Phase 1 verification (QA, not a PR)
+
+- [ ] 4.1 Real silicon Mac via ABM/DEP enrollment with hardware attestation enabled — install a fresh ACME profile, verify cert appears on host details after `InstallProfile` ack
+- [ ] 4.2 Hardware-bound ACME cert visible only via `CertificateList` — confirm it appears in API response with `origin=mdm` recorded internally
+- [ ] 4.3 Dedup verification: a cert visible to both osquery and `CertificateList` appears as exactly one row
+- [ ] 4.4 Existing-profile scenario: install an ACME profile, then verify that without re-pushing the profile no new ingestion occurs (validates the no-backfill design)
+
+---
+
+# Phase 2 — #40639 non-proxied cert renewal
+
+> Depends on Phase 1 for the macOS leg. iOS/iPadOS/Windows legs work independently. Customer outcome: non-proxied ACME (e.g. customer's Hydrant deployment) and Okta SCEP certs auto-renew before expiration *for profiles redeployed with the marker variable*.
+
+## 5. PR 2.1 — Schema and renewal-cron foundation
+
+Goal: prepare the data model for ingestion-created managed-cert rows. No behavior change yet. Independently mergeable.
+
+- [x] 5.1 Verify `profile_uuid` format across `host_mdm_apple_profiles` / `host_mdm_windows_profiles` — empirically resolved by reading the substitution code (`server/mdm/microsoft/profile_variables.go:125`, `server/mdm/apple/profile_processor.go:401-404`): the marker is always literally `"fleet-" + profile_uuid`. PR 2.2 marker extraction can rely on substring matching against CN/OU; no regex needed.
+- [x] 5.2 Migration: allow `host_mdm_managed_certificates.type` to be NULL — `server/datastore/mysql/migrations/tables/20260507160833_AllowNullTypeOnHostMDMManagedCertificates.go` + test file. NOTE: revise the stashed migration to drop the `'hydrant'` enum addition — Hydrant is not modeled as a CA type (see design.md Decision 2.4).
+- [ ] 5.3 (REMOVED — see design.md Decision 2.4) ~~Add `CAConfigHydrant` legacy constant; include in renewal lists~~. Hydrant is not modeled as a CA type. The NULL-`type` mechanism (5.4) is the entire renewal path for non-proxied flows.
+- [x] 5.4 Update `RenewMDMManagedCertificates` SELECT in `server/datastore/mysql/mdm.go` to iterate `ListCATypesWithRenewalSupport()` plus a single NULL bucket using null-safe equal (`hmmc.type <=> ?`).
+- [x] 5.5 Datastore tests: existing-type rows still selected, NULL-type rows now selected, non-renewable types still ignored. (Reduce the stashed test — drop the `hydrant` arm; keep the `ndes` and NULL arms.)
+
+## 6. PR 2.2 — Ingestion-driven managed-cert row creation
+
+Goal: extend `UpdateHostCertificates` to insert `host_mdm_managed_certificates` rows when ingested certs carry a renewal-ID marker. Core change.
+
+- [x] 6.1 Marker extraction strategy: use substring search for `"fleet-" + profile_uuid` against ingested certs' CN/OU, mirroring the existing matcher loop's approach (origin/main `host_certificates.go:188-189`). No new regex helper needed — the source-of-truth profile UUID list comes from the host's `host_mdm_apple_profiles` / `host_mdm_windows_profiles` rows and can be enumerated.
+- [x] 6.2 Extend `UpdateHostCertificates` in `server/datastore/mysql/host_certificates.go` to add an INSERT pass: for each profile installed on the host without a corresponding `host_mdm_managed_certificates` row, search the incoming/toInsert pool for a cert whose CN or OU contains `"fleet-" + profile_uuid`; if found, INSERT a row populated with the cert's `serial`, `not_valid_before`, `not_valid_after`, NULL `type`, NULL `ca_name`, NULL `challenge_retrieved_at`. Reuse `toInsertBySHA1` / `incomingBySHA1` already built by #44691.
+- [x] 6.3 **Matcher-guard fix (load-bearing for ingestion-created rows):** adjust the existing matcher's `if !hostMDMManagedCert.Type.SupportsRenewalID() { continue }` skip so empty/NULL `Type` rows are NOT excluded. Without this, ingestion-created NULL-`type` rows would never have their `not_valid_after` advanced after a renewal completes, producing a non-terminating renewal loop. See design.md Decision 2.2.
+- [x] 6.4 Datastore tests covering: first-time ingestion creates NULL-`type` row; subsequent ingestion updates existing NULL-`type` row's `not_valid_after` (validates 6.3); mismatched UUID ignored; marker present but profile not installed on this host; existing proxied-`type` rows continue to work as before (no regression)
+- [x] 6.5 Service-level integration test: simulate an osquery cert report with a marker-bearing cert and verify the managed-cert row materializes
+- [x] 6.6 Run `make generate-mock` if datastore interface signatures change
+
+> **Coordination with #44691**: That PR restructures the matcher in `UpdateHostCertificates` (introduces `toInsertBySHA1` map, pool-selection per hmmc row, best-match-wins, monotonic-forward predicate, `hmmcBackfillGrace`). It targets `main` and is expected to land before this PR. Our INSERT path lands as a separate loop alongside that restructured matcher, reusing `toInsertBySHA1`/`incomingBySHA1` it already builds. Plan to rebase against main once #44691 merges.
+
+## 7. PR 2.3 — Apple variable rename (validator removed per scope change 2026-05-15)
+
+Goal: add code support for the renamed customer-facing variable (`$FLEET_VAR_CERTIFICATE_RENEWAL_ID`, per design.md Decision 2.7).
+
+**Scope change 2026-05-15:** the ACME upload validator that initially shipped in this PR (rejected profiles missing the marker) is reverted. The marker is now opt-in per design.md Decision 2.6 — missing marker is accepted, no GitOps breakage. Tasks below reflect the original scope; revert work is tracked under §7d.
+
+- [x] 7.1 Add `FleetVarCertificateRenewalID = "CERTIFICATE_RENEWAL_ID"` constant in `server/fleet/mdm.go` alongside the existing `FleetVarSCEPRenewalID`. Both are recognized by `FindFleetVariables`.
+- [x] 7.2 Extend `FleetVarSCEPRenewalIDRegexp` (or add a sibling regex) to match either name, then expose a unified `FleetVarRenewalIDRegexp` used by all substitution sites. Both names substitute to identical output: `"fleet-" + profile_uuid`. Touch points: `server/mdm/apple/profile_processor.go:401-404`, `server/mdm/microsoft/profile_variables.go:124-125`.
+- [x] 7.3 ~~Detect ACME payload types in Apple profile content during validation in `server/service/apple_mdm.go` and reject when the renewal-ID marker is missing from the cert Subject.~~ **Reverted per §7d.** The per-CA SCEP validators (NDES/Custom SCEP/Smallstep) keep their existing renewal-ID enforcement (pre-existing surface).
+- [x] 7.4 ~~Require `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` in cert Subject OU only; reject otherwise.~~ **Reverted per §7d.**
+- [x] 7.5 ~~Confirm the same code path is hit by `fleetctl gitops` profile uploads; add an integration test if not already covered.~~ Verification moot once validator is removed; gitops continuity is the *reason* for the removal.
+- [x] 7.6 ~~Tests that exercise rejection behaviors.~~ **Reverted per §7d** — tests flip to accept missing marker.
+- [x] 7.7 Release-notes draft: variable-name rename note (legacy still accepted, new name preferred for new authoring) AND the validator-removal scope change. Frame the marker as opt-in for auto-renewal. (Shipped in PR 2.5 / #45695 — `changes/40639-non-proxied-cert-renewal`.)
+
+## 7b. PR 2.3b — Apple non-proxied SCEP validator (reverted per scope change 2026-05-15)
+
+**Scope change 2026-05-15:** PR 2.3b added `additionalNonProxiedSCEPValidation` to enforce the renewal-ID marker on raw-SCEP profiles. Per design.md Decision 2.6 scope reversal, the marker is opt-in and this validator is reverted entirely.
+
+The original implementation tasks below are kept for history; revert work is tracked under §7d.
+
+- [x] 7b.1 ~~In `server/service/apple_mdm.go`, add `additionalNonProxiedSCEPValidation`.~~ **Reverted per §7d.**
+- [x] 7b.2 ~~OU-only / preferred-name-only enforcement.~~ **Reverted per §7d.**
+- [x] 7b.3 ~~Wire into `validateConfigProfileFleetVariables`.~~ **Reverted per §7d.**
+- [x] 7b.4 ~~Tests covering OU-only / preferred-only acceptance and rejection cases.~~ **Reverted per §7d** — tests flip to accept all shapes.
+- [x] 7b.5 Release-notes alignment for raw-SCEP customers (Okta SCEP / Okta Verify) — now part of the broader "marker is opt-in" messaging. (Shipped in PR 2.5 / #45695.)
+
+## 7d. PR 2.3d — Revert Apple ACME and raw-SCEP validators (scope change 2026-05-15)
+
+Goal: implement the Decision 2.6 scope reversal. Remove the upload-time renewal-ID enforcement added in PR 2.3 (#45043) and PR 2.3b (#45364). Marker becomes opt-in.
+
+- [x] 7d.1 In `server/service/apple_mdm.go`, remove `additionalACMEValidation` and its call site in `validateConfigProfileFleetVariables`. Also remove the supporting `acmeProfileForValidation` / `acmePayloadForValidation` types. (PR #45643.)
+- [x] 7d.2 Remove `additionalNonProxiedSCEPValidation` and its call site. (PR #45643. The SCEP-or-ACME bypass in `mdm_profiles.go` was retained since it's still correct for non-validator reasons; comment updated.)
+- [x] 7d.3 Update `apple_mdm_test.go`: delete `TestAdditionalACMEValidation` and `TestAdditionalNonProxiedSCEPValidation`. Add a regression test that confirms ACME and raw-SCEP profiles without the marker upload successfully. (PR #45643 — `TestApplePayloadValidatorsAreOptional`.)
+- [x] 7d.4 Update integration tests: flip rejection assertions to acceptance; delete the obsolete Conditional Access failure-mode test. (Shipped in PR 2.5b / #45663.)
+- [x] 7d.5 Confirm pre-existing proxy SCEP validators (NDES / Custom SCEP / Smallstep) keep their existing renewal-ID enforcement unchanged — they predate this story since 4.65 and are not in scope for the reversal. (Verified in PR #45643.)
+- [x] 7d.6 Document the scope change in the PR description, referencing Decision 2.6 and the GitOps-continuity rationale. (PR #45643.)
+
+## 7c. PR 2.3c — Origin downgrade on osquery rediscovery
+
+Goal: fix the `origin` column semantics so it reflects "delivery channel" rather than "first ingestion source to see this cert." Today MDM `CertificateList` ingests every cert in the device keychain on InstallProfile ack — including Root CAs and other system certs the user installed manually. If MDM sees a system cert before the next osquery sync, the row gets `origin=mdm`, which is misleading (the cert was not MDM-delivered).
+
+Surfaced during 2026-05-14 local validation: user-installed `localdev-tim Root CA` ended up with `origin=mdm` because the ACME profile install fired `CertificateList` before the next osquery cert sync, and `CertificateList` returns the entire keychain.
+
+See design.md Decision 1.3.
+
+- [x] 7c.1 In `server/datastore/mysql/host_certificates.go`'s osquery-side ingestion path (`UpdateHostCertificates` when called with `origin='osquery'`), if an UPSERT matches an existing row with `origin='mdm'`, set `origin='osquery'`. The downgrade is one-way (mdm → osquery). MDM ingestion still creates rows with `origin='mdm'` for first-seen certs. (PR #45531, draft.)
+- [x] 7c.2 Rationale captured in design.md Decision 1.4.
+- [x] 7c.3 Datastore test for the downgrade. (PR #45531 — `testUpdateHostCertificatesOriginDowngrade`.)
+- [x] 7c.4 No backfill — natural osquery sync cycles correct affected rows over time. Reclassified as cleanup task #45528 (no longer a sub-task).
+
+## 8. PR 2.4 — Windows variable-rename back-compat (pre-existing surface, scope-change-unaffected)
+
+Goal: extend the pre-existing Windows proxy-SCEP validators (NDES, Custom SCEP) to accept the preferred variable name in addition to the legacy name, so customers can author either spelling.
+
+**Scope-change note (2026-05-15):** Decision 2.6's reversal does NOT affect this PR. The Windows validators touched here are pre-existing surfaces (since 4.85, originally from PR #37170) that have always enforced a renewal-ID variable in SubjectName for profiles using Fleet's NDES or Custom SCEP proxy variables. PR 2.4 just added preferred-name acceptance; it did not introduce new enforcement.
+
+- [x] 8.1 Resolve the Windows Subject substitution open question (see design.md): can `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` be reused in the Windows profile cert Subject, or does Windows need a new Subject-targeted variable? (Resolved: reuse `$FLEET_VAR_CERTIFICATE_RENEWAL_ID` via the unified regex; PR #45237.)
+- [x] 8.2 If a new variable is required, add it to `server/fleet/mdm.go` and substitution logic in `server/datastore/mysql/microsoft_mdm.go` and `server/mdm/microsoft/profile_variables.go`. Reuse the unified `FleetVarRenewalIDRegexp` from PR 2.3 task 7.2 so Windows accepts both legacy and new names without duplicating regex logic.
+- [x] 8.3 Extend the existing Windows NDES / Custom SCEP validators in `server/service/windows_mdm_profiles.go` to accept either renewal-ID variable name in the SubjectName OU (back-compat per Decision 2.7). Validation error messages reference only `$FLEET_VAR_CERTIFICATE_RENEWAL_ID`. **No new validation surface introduced** — the variable presence requirement on these proxy-SCEP paths predates this story.
+- [x] 8.4 Tests mirroring PR 2.3's coverage but for Windows profiles, including legacy-name back-compat.
+
+## 9. PR 2.5 — Phase 2 documentation
+
+Can ship in parallel with PR 2.3 / 2.4.
+
+**Framing under Decision 2.6 scope reversal (2026-05-15):** the marker is opt-in. Customers who add it get auto-renewal; customers who don't continue to manage cert lifecycle as in 4.85. Docs should present the marker as a *new capability* rather than a *required migration step*.
+
+- [x] 9.1 Update Fleet's certificate renewal guide to document non-proxied SCEP and ACME renewal as an opt-in feature. (PR #45695 — `articles/connect-end-user-to-wifi-with-certificate.md` migrated.)
+- [x] 9.2 Add example profile snippets showing correct marker placement in Subject OU; framed as opt-in. (PR #45695 — Okta Verify macOS and Windows guides updated.)
+- [x] 9.3 Optional opt-in guidance for existing customers. (PR #45695 — added to Okta Verify macOS, Windows, and Conditional Access guides.)
+- [ ] 9.4 Reference doc note that `host_mdm_managed_certificates.type` may be NULL for non-proxied rows. (Internal field — not customer-facing; intentionally not added to public docs.)
+- [x] 9.5 Variable rename note: legacy `$FLEET_VAR_SCEP_RENEWAL_ID` still works. (PR #45695 — back-compat callout in WiFi guide. rachaelshaw's #43293 already merged to `docs-v4.86.0`.)
+- [x] 9.6 Release-notes entry consolidating Phase 2 changes. (PR #45695 — `changes/40639-non-proxied-cert-renewal`.)
+
+## 10. Phase 2 verification (QA, not a PR)
+
+- [ ] 10.1 Non-proxied ACME (customer-cisneros-a's Hydrant deployment) on real silicon Mac (Phase 1 fully shipped): redeploy a profile with the marker, force a cert near expiration, verify renewal cron triggers, profile re-pushes, new cert ingested via on-demand `CertificateList`, managed-cert row updated; row remains NULL `type` throughout. (Local end-to-end validation completed 2026-05-14 against a Smallstep ACME-DA test CA: profile install → cert ingest → managed-cert row materialized → renewal cron picked up the row when `not_valid_after` was advanced into the threshold → InstallProfile re-push → new cert ingested → row's `not_valid_after` advanced. **Hydrant verification still required** — Smallstep needed CA-side template fix to preserve OU; whether Hydrant preserves OU by default is unverified and load-bearing for the customer promise.)
+- [ ] 10.2 Non-proxied ACME on iOS / iPadOS: redeploy profile with marker, verify existing `IOSiPadOSRefetch` cron path picks up the new flow without regression
+- [ ] 10.3 Okta conditional access SCEP on macOS via osquery ingestion path (after profile redeploy)
+- [ ] 10.4 Okta Verify SCEP (static challenge) on macOS (after profile redeploy)
+- [ ] 10.5 Okta SCEP on Windows (after profile redeploy)
+- [ ] 10.6 Opt-out path: deploy a profile WITHOUT the marker; confirm the profile uploads cleanly (no validator rejection per Decision 2.6), the cert lands in `host_certificates` for visibility, but NO `host_mdm_managed_certificates` row materializes and NO renewal happens. Validates the opt-in framing — customers who don't add the marker continue with 4.85-style manual renewal, unbroken.
+- [ ] 10.7 ~~Profile-validation rejection: attempt to upload an ACME/SCEP profile without the marker; confirm rejection with the expected error message.~~ **Removed per Decision 2.6 scope reversal — validators no longer reject missing marker.** Replaced by 10.6 (opt-out path) above.
+
+---
+
+## 11. Per-PR checklist (apply to each implementation PR)
+
+- [x] 11.1 `make lint-go` passes — verified on each merged PR via CI.
+- [x] 11.2 Datastore tests pass.
+- [x] 11.3 Service tests pass.
+- [x] 11.4 `make generate-mock` run where needed.
+- [x] 11.5 PR descriptions name the parent story and phase/PR position.
+
+---
+
+## PR sequencing summary
+
+```
+   PHASE 1 (#42827)
+   ──────────────────────────────────────────────────────
+   PR 1.1 (origin column, dedup)  ─── foundation
+       │
+       ▼
+   PR 1.2 (CertificateList trigger) ── activates ingestion
+       │
+       ▼
+   PR 1.3 (docs)                  ─── parallel-able
+
+   ──────────────── PHASE 1 SHIPS ────────────────
+
+   PHASE 2 (#40639)
+   ──────────────────────────────────────────────────────
+   PR 2.1 (schema + CA list)      ─── foundation
+       │
+       ▼
+   PR 2.2 (UpdateHostCertificates) ── core change
+       │
+       ├──────────────────┬───────────────────┐
+       ▼                  ▼                   ▼
+   PR 2.3 (Apple        PR 2.4 (Windows    PR 2.5 (docs,
+   validation)          validation,        parallel)
+                        blocked on
+                        Windows TODO)
+```
+
+Phase 1: 3 PRs (was 4 — backfill dropped).
+Phase 2: 5 PRs (was 6 — linkage backfill dropped).
+Total: 8 implementation/docs PRs (down from 10).


### PR DESCRIPTION
**Related issues:** Documentation follow-up to #45696 (Phase 1 #42827 + Phase 2 #40639)

## What this PR does

Archives the openspec change for the cert-renewal work that landed via #45696. Moves the 6 files (proposal, design, specs, tasks, `.openspec.yaml`) into `openspec/changes/archive/2026-05-18-auto-renew-non-proxied-certs/`.

## Why this is split from #45696

The `openspec/` directory has a single codeowner (@lukeheath). Splitting the archive into its own PR keeps the integration PR's review queue moving independently of the openspec sign-off.

## Reviewer notes (@lukeheath)

- All 6 files are net-new in this PR — no edits to existing openspec content.
- The content reflects the final state of the change after the 2026-05-15 scope reversal (Decision 2.6 — marker is opt-in) and the 2026-05-18 task audit.
- `tasks.md` reflects shipped state across §1-3, §5-8, §7c, §7d, §9 (most), §11. Remaining unchecked items have a status note at the top describing where they're tracked (bug #45596, Phase 1/2 QA, etc.).

## What's customer-visible

Nothing. This PR is internal spec archival only.