### PR TITLE
Add mostRecentCampaign to event records

### DIFF
--- a/website/api/controllers/create-or-update-one-newsletter-subscription.js
+++ b/website/api/controllers/create-or-update-one-newsletter-subscription.js
@@ -67,6 +67,7 @@ module.exports = {
         salesforceContactId: recordIds.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Subscribed to the Fleet newsletter',
+        relatedCampaign: recordIds.mostRecentCampaign,
       });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {

--- a/website/api/controllers/create-or-update-one-newsletter-subscription.js
+++ b/website/api/controllers/create-or-update-one-newsletter-subscription.js
@@ -53,7 +53,7 @@ module.exports = {
     let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;
 
     sails.helpers.flow.build(async()=>{
-      let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+      let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
         emailAddress: emailAddress,
         contactSource: 'Website - Newsletter',
         description: `Subscribed to the Fleet newsletter`,
@@ -63,11 +63,11 @@ module.exports = {
       });
 
       await sails.helpers.salesforce.createHistoricalEvent.with({
-        salesforceAccountId: recordIds.salesforceAccountId,
-        salesforceContactId: recordIds.salesforceContactId,
+        salesforceAccountId: recordDetails.salesforceAccountId,
+        salesforceContactId: recordDetails.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Subscribed to the Fleet newsletter',
-        relatedCampaign: recordIds.mostRecentCampaign,
+        relatedCampaign: recordDetails.mostRecentCampaign,
       });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {

--- a/website/api/controllers/customers/create-quote.js
+++ b/website/api/controllers/customers/create-quote.js
@@ -103,6 +103,7 @@ module.exports = {
         eventType: 'Intent signal',
         intentSignal: 'Created a quote for a self-service Fleet Premium license',
         eventContent: descriptionForContactUpdate,
+        relatedCampaign: recordIds.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/customers/create-quote.js
+++ b/website/api/controllers/customers/create-quote.js
@@ -80,7 +80,7 @@ module.exports = {
         - Other hosts: ${inputs.otherHosts}
       `;
 
-      let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+      let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
         emailAddress: this.req.me.emailAddress,
         firstName: this.req.me.firstName,
         lastName: this.req.me.lastName,
@@ -93,17 +93,17 @@ module.exports = {
       });
 
       // If the Contact record returned by the updateOrCreateContactAndAccount does not have a parent Account record, throw an error to stop the build helper.
-      if(!recordIds.salesforceAccountId) {
-        throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
+      if(!recordDetails.salesforceAccountId) {
+        throw new Error(`Could not create historical event. The contact record (ID: ${recordDetails.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
       }
       // Create the new Fleet website page view record.
       await sails.helpers.salesforce.createHistoricalEvent.with({
-        salesforceAccountId: recordIds.salesforceAccountId,
-        salesforceContactId: recordIds.salesforceContactId,
+        salesforceAccountId: recordDetails.salesforceAccountId,
+        salesforceContactId: recordDetails.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Created a quote for a self-service Fleet Premium license',
         eventContent: descriptionForContactUpdate,
-        relatedCampaign: recordIds.mostRecentCampaign,
+        relatedCampaign: recordDetails.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -98,7 +98,7 @@ Fleet Premium subscription details:
     sails.helpers.flow.build(async ()=>{
 
       await sails.helpers.flow.build(async ()=>{
-        let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+        let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
           emailAddress: emailAddress,
           firstName: firstName,
           lastName: lastName,
@@ -110,17 +110,17 @@ Fleet Premium subscription details:
         });
 
         // If the Contact record returned by the updateOrCreateContactAndAccount does not have a parent Account record, throw an error to stop the build helper.
-        if(!recordIds.salesforceAccountId) {
-          throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
+        if(!recordDetails.salesforceAccountId) {
+          throw new Error(`Could not create historical event. The contact record (ID: ${recordDetails.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
         }
         // Create the new Fleet website page view record.
         await sails.helpers.salesforce.createHistoricalEvent.with({
-          salesforceAccountId: recordIds.salesforceAccountId,
-          salesforceContactId: recordIds.salesforceContactId,
+          salesforceAccountId: recordDetails.salesforceAccountId,
+          salesforceContactId: recordDetails.salesforceContactId,
           eventType: 'Intent signal',
           intentSignal: 'Submitted the "Send a message" form',
           eventContent: message,
-          relatedCampaign: recordIds.mostRecentCampaign,
+          relatedCampaign: recordDetails.mostRecentCampaign,
         }).intercept((err)=>{
           return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
         });

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -120,6 +120,7 @@ Fleet Premium subscription details:
           eventType: 'Intent signal',
           intentSignal: 'Submitted the "Send a message" form',
           eventContent: message,
+          relatedCampaign: recordIds.mostRecentCampaign,
         }).intercept((err)=>{
           return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
         });

--- a/website/api/controllers/deliver-gitops-workshop-request.js
+++ b/website/api/controllers/deliver-gitops-workshop-request.js
@@ -70,7 +70,7 @@ module.exports = {
     let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;
 
     await sails.helpers.flow.build(async ()=>{
-      let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+      let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
         emailAddress: emailAddress,
         firstName: firstName,
         lastName: lastName,
@@ -83,21 +83,21 @@ module.exports = {
 
       // Add contact to campaign.
       await sails.helpers.salesforce.createCampaignMember.with({
-        salesforceContactId: recordIds.salesforceContactId,
+        salesforceContactId: recordDetails.salesforceContactId,
         salesforceCampaignId: '701UG00000bLCLpYAO',// 2026_01-FE-GitOps_Workshop_Interest Campaign
       });
 
-      if(!recordIds.salesforceAccountId) {
-        throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
+      if(!recordDetails.salesforceAccountId) {
+        throw new Error(`Could not create historical event. The contact record (ID: ${recordDetails.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
       }
       // Create the new historical event record.
       await sails.helpers.salesforce.createHistoricalEvent.with({
-        salesforceAccountId: recordIds.salesforceAccountId,
-        salesforceContactId: recordIds.salesforceContactId,
+        salesforceAccountId: recordDetails.salesforceAccountId,
+        salesforceContactId: recordDetails.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Submitted the "GitOps workshop request" form',
         eventContent: descriptionForCrmUpdate,
-        relatedCampaign: recordIds.mostRecentCampaign,
+        relatedCampaign: recordDetails.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/deliver-gitops-workshop-request.js
+++ b/website/api/controllers/deliver-gitops-workshop-request.js
@@ -97,6 +97,7 @@ module.exports = {
         eventType: 'Intent signal',
         intentSignal: 'Submitted the "GitOps workshop request" form',
         eventContent: descriptionForCrmUpdate,
+        relatedCampaign: recordIds.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/deliver-whitepaper-download-request.js
+++ b/website/api/controllers/deliver-whitepaper-download-request.js
@@ -58,6 +58,7 @@ module.exports = {
         eventType: 'Intent signal',
         intentSignal: 'Requested whitepaper download',
         eventContent: whitepaperName,
+        relatedCampaign: recordIds.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/deliver-whitepaper-download-request.js
+++ b/website/api/controllers/deliver-whitepaper-download-request.js
@@ -36,7 +36,7 @@ module.exports = {
     let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;
 
     sails.helpers.flow.build(async ()=>{
-      let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+      let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
         emailAddress: emailAddress,
         firstName: firstName,
         lastName: lastName,
@@ -48,17 +48,17 @@ module.exports = {
       });
 
       // If the Contact record returned by the updateOrCreateContactAndAccount does not have a parent Account record, throw an error to stop the build helper.
-      if(!recordIds.salesforceAccountId) {
-        throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
+      if(!recordDetails.salesforceAccountId) {
+        throw new Error(`Could not create historical event. The contact record (ID: ${recordDetails.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
       }
       // Create the new Fleet website page view record.
       await sails.helpers.salesforce.createHistoricalEvent.with({
-        salesforceAccountId: recordIds.salesforceAccountId,
-        salesforceContactId: recordIds.salesforceContactId,
+        salesforceAccountId: recordDetails.salesforceAccountId,
+        salesforceContactId: recordDetails.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Requested whitepaper download',
         eventContent: whitepaperName,
-        relatedCampaign: recordIds.mostRecentCampaign,
+        relatedCampaign: recordDetails.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -225,7 +225,7 @@ the account verification message.)`,
 
 
     sails.helpers.flow.build(async ()=>{
-      let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+      let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
         emailAddress: newEmailAddress,
         firstName: firstName,
         lastName: lastName,
@@ -236,16 +236,16 @@ the account verification message.)`,
       });
 
       // Throw an error to stop the build() helper if a contact is missing a parent account record.
-      if(!recordIds.salesforceAccountId) {
-        throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
+      if(!recordDetails.salesforceAccountId) {
+        throw new Error(`Could not create historical event. The contact record (ID: ${recordDetails.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
       }
 
       await sails.helpers.salesforce.createHistoricalEvent.with({
-        salesforceAccountId: recordIds.salesforceAccountId,
-        salesforceContactId: recordIds.salesforceContactId,
+        salesforceAccountId: recordDetails.salesforceAccountId,
+        salesforceContactId: recordDetails.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Signed up for a fleetdm.com account',
-        relatedCampaign: recordIds.mostRecentCampaign,
+        relatedCampaign: recordDetails.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -245,6 +245,7 @@ the account verification message.)`,
         salesforceContactId: recordIds.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Signed up for a fleetdm.com account',
+        relatedCampaign: recordIds.mostRecentCampaign,
       }).intercept((err)=>{
         return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });

--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -150,7 +150,7 @@ module.exports = {
       eventContent: historicalContent,
       eventContentUrl: historicalContentUrl,
       linkedinUrl: trimmedLinkedinUrl,
-      relatedCampaign,
+      relatedCampaign: relatedCampaign || recordIds.mostRecentCampaign,
     })
     .intercept((err)=>{
       sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a historical event record could not be created. Full error: ${require('util').inspect(err)}`);

--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -114,7 +114,7 @@ module.exports = {
     }
 
 
-    let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+    let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
       firstName,
       lastName,
       linkedinUrl,
@@ -131,8 +131,8 @@ module.exports = {
       }
     });
 
-    if(!recordIds.salesforceAccountId) {
-      sails.log.warn(`When the receive-from-clay received information about a user's activity (name: ${firstName} ${lastName}), activity: ${intentSignal}). A contact was successfully updated, but the webhook is unable to continue because this contact is not associated with any Salesforce account record. Contact ID: ${recordIds.salesforceContactId}`);
+    if(!recordDetails.salesforceAccountId) {
+      sails.log.warn(`When the receive-from-clay received information about a user's activity (name: ${firstName} ${lastName}), activity: ${intentSignal}). A contact was successfully updated, but the webhook is unable to continue because this contact is not associated with any Salesforce account record. Contact ID: ${recordDetails.salesforceContactId}`);
       throw 'couldNotCreateActivity';
     }
 
@@ -143,14 +143,14 @@ module.exports = {
 
     // Create the new Fleet website page view record.
     let newHistoricalRecordId = await sails.helpers.salesforce.createHistoricalEvent.with({
-      salesforceAccountId: recordIds.salesforceAccountId,
-      salesforceContactId: recordIds.salesforceContactId,
+      salesforceAccountId: recordDetails.salesforceAccountId,
+      salesforceContactId: recordDetails.salesforceContactId,
       eventType: 'Intent signal',
       intentSignal: intentSignal,
       eventContent: historicalContent,
       eventContentUrl: historicalContentUrl,
       linkedinUrl: trimmedLinkedinUrl,
-      relatedCampaign: relatedCampaign || recordIds.mostRecentCampaign,
+      relatedCampaign: relatedCampaign || recordDetails.mostRecentCampaign,
     })
     .intercept((err)=>{
       sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a historical event record could not be created. Full error: ${require('util').inspect(err)}`);
@@ -160,8 +160,8 @@ module.exports = {
     // All done.
     return {
       historicalRecordId: newHistoricalRecordId,
-      contactId: recordIds.salesforceContactId,
-      accountId: recordIds.salesforceAccountId
+      contactId: recordDetails.salesforceContactId,
+      accountId: recordDetails.salesforceAccountId
     };
 
   }

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -656,7 +656,8 @@ module.exports = {
 
     return {
       salesforceAccountId,
-      salesforceContactId
+      salesforceContactId,
+      mostRecentCampaign: attributionDetails ? attributionDetails.campaign : undefined
     };
 
   }

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -113,7 +113,8 @@ module.exports = {
     success: {
       outputType: {
         salesforceAccountId: 'string',
-        salesforceContactId: 'string'
+        salesforceContactId: 'string',
+        mostRecentCampaign: 'string'
       }
     },
 
@@ -130,7 +131,8 @@ module.exports = {
       sails.log.verbose('Skipping Salesforce integration...');
       return {
         salesforceAccountId: undefined,
-        salesforceContactId: undefined
+        salesforceContactId: undefined,
+        mostRecentCampaign: undefined
       };
     }
 

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -381,7 +381,8 @@ will be disabled and/or hidden in the UI.
                       salesforceAccountId: recordIds.salesforceAccountId,
                       fleetWebsitePageUrl: `https://fleetdm.com${req.url}`,
                       eventType: 'Website page view',
-                      websiteVisitReason: websiteVisitReason
+                      websiteVisitReason: websiteVisitReason,
+                      relatedCampaign: recordIds.mostRecentCampaign,
                     }).intercept((err)=>{
                       return new Error(`Could not create new Fleet website page view record. Error: ${err}`);
                     });

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -360,7 +360,7 @@ will be disabled and/or hidden in the UI.
                     }
                     let attributionCookieOrUndefined = req.cookies.marketingAttribution;// Will be undefined if this is not set.
 
-                    let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+                    let recordDetails = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
                       emailAddress: sanitizedUser.emailAddress,
                       firstName: sanitizedUser.firstName,
                       lastName: sanitizedUser.lastName,
@@ -377,12 +377,12 @@ will be disabled and/or hidden in the UI.
                     }
                     // Create the new Fleet website page view record.
                     await sails.helpers.salesforce.createHistoricalEvent.with({
-                      salesforceContactId: recordIds.salesforceContactId,
-                      salesforceAccountId: recordIds.salesforceAccountId,
+                      salesforceContactId: recordDetails.salesforceContactId,
+                      salesforceAccountId: recordDetails.salesforceAccountId,
                       fleetWebsitePageUrl: `https://fleetdm.com${req.url}`,
                       eventType: 'Website page view',
                       websiteVisitReason: websiteVisitReason,
-                      relatedCampaign: recordIds.mostRecentCampaign,
+                      relatedCampaign: recordDetails.mostRecentCampaign,
                     }).intercept((err)=>{
                       return new Error(`Could not create new Fleet website page view record. Error: ${err}`);
                     });


### PR DESCRIPTION
Following the pattern we have for Clay updating historical events with the campaign name, this updates the historical event to include the campaign name for website events.

After the contact is created/updated, we now include the campaign name as a parameter for the historical event to update/populate the existing field on the sfdc historical event object. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Historical events for signups, newsletter subscriptions, contact/quote requests, whitepaper downloads, workshop requests, and page views now include campaign association to improve marketing analytics.
* **Bug Fixes / Reliability**
  * Webhooks now fall back to the most recent campaign when none is provided.
* **Chores**
  * Backend responses now expose a mostRecentCampaign field to support campaign attribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->