### PR TITLE
Add temporary landing page process to the handbook

### DIFF
--- a/handbook/company/writing.md
+++ b/handbook/company/writing.md
@@ -325,6 +325,25 @@ We leave large gaps between values to make future changes easier. For example, t
 
 When adding or reordering a page, try to leave as much room between values as possible. If you were adding a new page that would go between the two pages from the example above, you would add `<meta name="pageOrderInSection" value="150">` to the page.
 
+## Temporary landing pages
+
+> To create page for the main website, use the standard [website request](https://fleetdm.com/handbook/company/communications#fleetdm-com) process.
+
+Temporary landing pages are intended for driving traffic from ads, events, and campaigns. They live in the [landing-pages](https://github.com/fleetdm/fleet/tree/main/website/views/pages/landing-pages) folder of the Fleet repo, and use the `/lp` URL path.
+ 
+These pages are:
+- **Not linked from the nav.** They do not appear in the site navigation or any other part of the main site.
+- **Excluded from the sitemap.** Search engines will not index them. They are not intended to build SEO/GEO value.
+- **Not subject to content or design review.** They can go up fast without going through the [standard drafting process](https://fleetdm.com/handbook/company/product-groups#making-changes).
+- **Created using Claude, Kilo, or manually.** If you're comfortable working in the repo, add a page to the [landing-pages](https://github.com/fleetdm/fleet/tree/main/website/views/pages/landing-pages) folder directly. Otherwise, use Claude or Kilo to generate one.
+
+Examples of pages that live behind `/lp`:
+- A landing page for a conference booth or meetup
+- A landing page for an ad campaign
+- A giveaway page for an event
+
+If an `/lp` page gets traction and the messaging resonates, it can be promoted to the main site. At which point, it goes through the [website request](https://fleetdm.com/handbook/company/communications#fleetdm-com) process.
+
 
 ## Writing style
 


### PR DESCRIPTION
This PR adds the company process for temporary landing pages to the handbook.

For now, I have included it in the writing handbook, since this is where we document processes for publishing content on the website. I plan to separate these topics at a later date.