### PR TITLE
Update link text from 'ABM' to 'Apple Business'

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -90,10 +90,10 @@ const NoVppAppsMessage = () => (
         You must purchase apps in{" "}
         <CustomLink
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/abm-apps`}
-          text="ABM"
+          text="Apple Business"
           newTab
         />
-        .<br />
+        <br />
         App Store apps that are already added to this fleet are not listed.
       </>
     }


### PR DESCRIPTION
For the following quick win:
- https://github.com/fleetdm/fleet/issues/44831


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated terminology in the no VPP apps message from "ABM" to "Apple Business" for clarity.
  * Adjusted line break formatting for improved message layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->