### PR TITLE
Ignore WiX CVEs

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -579,6 +579,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-20 11:41:33
 
+### [CVE-2026-4878](https://nvd.nist.gov/vuln/detail/CVE-2026-4878)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not call cap_set_file() when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libcap2`,`pkg:deb/debian/libcap2-bin`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
+
 ### [CVE-2026-4775](https://nvd.nist.gov/vuln/detail/CVE-2026-4775)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -586,6 +594,38 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libtiff6`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-20 11:42:37
+
+### [CVE-2026-41254](https://nvd.nist.gov/vuln/detail/CVE-2026-41254)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not perform color management via Little CMS when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/liblcms2-2`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
+
+### [CVE-2026-40962](https://nvd.nist.gov/vuln/detail/CVE-2026-40962)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process media files when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libavcodec61`,`pkg:deb/debian/libavformat61`,`pkg:deb/debian/libavutil59`,`pkg:deb/debian/libswresample5`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
+
+### [CVE-2026-40386](https://nvd.nist.gov/vuln/detail/CVE-2026-40386)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process EXIF metadata when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libexif12`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
+
+### [CVE-2026-40385](https://nvd.nist.gov/vuln/detail/CVE-2026-40385)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process EXIF metadata when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libexif12`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
 
 ### [CVE-2026-33636](https://nvd.nist.gov/vuln/detail/CVE-2026-33636)
 - **Author:** @lucasmrod
@@ -603,6 +643,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-08 11:01:10
 
+### [CVE-2026-32775](https://nvd.nist.gov/vuln/detail/CVE-2026-32775)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process EXIF metadata when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libexif12`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
+
 ### [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -618,6 +666,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libgstreamer-plugins-base1.0-0`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-03-24 12:23:52
+
+### [CVE-2026-29111](https://nvd.nist.gov/vuln/detail/CVE-2026-29111)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use systemd IPC APIs when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libsystemd0`,`pkg:deb/debian/libudev1`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
 
 ### [CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390)
 - **Author:** @lucasmrod
@@ -650,6 +706,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-27 14:23:45
+
+### [CVE-2026-27135](https://nvd.nist.gov/vuln/detail/CVE-2026-27135)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not serve or handle HTTP/2 traffic via libnghttp2 when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libnghttp2-14`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
+
+### [CVE-2026-1837](https://nvd.nist.gov/vuln/detail/CVE-2026-1837)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process JPEG XL images when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libjxl0.11`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:16:53
 
 ### [CVE-2026-0861](https://nvd.nist.gov/vuln/detail/CVE-2026-0861)
 - **Author:** @lucasmrod

--- a/security/vex/wix/CVE-2026-1837.vex.json
+++ b/security/vex/wix/CVE-2026-1837.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-0d4746549b20fce8c815f03c8270827c5d0d494fa2032b5d54fed8c7aca213f9",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-1837"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libjxl0.11"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process JPEG XL images when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-27135.vex.json
+++ b/security/vex/wix/CVE-2026-27135.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-73552b7c5ed212f189df87122be375c91581d5346f8522eeb2810ee0c87ca28e",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27135"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libnghttp2-14"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not serve or handle HTTP/2 traffic via libnghttp2 when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-29111.vex.json
+++ b/security/vex/wix/CVE-2026-29111.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-dd929dc1c8f90acbf70e94b7037e29ff4e67210f25c85263af7a6f44549cc651",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-29111"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libsystemd0"
+        },
+        {
+          "@id": "pkg:deb/debian/libudev1"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use systemd IPC APIs when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-32775.vex.json
+++ b/security/vex/wix/CVE-2026-32775.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-58ef2f6b79734e37fce118f193515a32cd2467b828b54e1fff06ee3b3f63ab48",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32775"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libexif12"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process EXIF metadata when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-40385.vex.json
+++ b/security/vex/wix/CVE-2026-40385.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-25670b68003f7cff6f8df287a864e2a41c39b5f4afc1f4d163c970ad17e6a3c5",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40385"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libexif12"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process EXIF metadata when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-40386.vex.json
+++ b/security/vex/wix/CVE-2026-40386.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-329aaa98edb6e3bda89cf9f700baf01cab7a2f745840bc7fbf9fb90f764186f9",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40386"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libexif12"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process EXIF metadata when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-40962.vex.json
+++ b/security/vex/wix/CVE-2026-40962.vex.json
@@ -1,0 +1,35 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b96df7a634a5aeb7fcc2b0ca6f5692de2847fdb9a4322d2b09c76c474bd36452",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40962"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libavcodec61"
+        },
+        {
+          "@id": "pkg:deb/debian/libavformat61"
+        },
+        {
+          "@id": "pkg:deb/debian/libavutil59"
+        },
+        {
+          "@id": "pkg:deb/debian/libswresample5"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process media files when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-41254.vex.json
+++ b/security/vex/wix/CVE-2026-41254.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-5e9d0ddb2d5ece43fe9012799368c32e4f42d884b7239df84ae876787a7be256",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41254"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/liblcms2-2"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not perform color management via Little CMS when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-4878.vex.json
+++ b/security/vex/wix/CVE-2026-4878.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-7cae4b68e088aef0ff07fc9ab5552e3b59f4cd9a31b5865afd4e712ffb8930ed",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:16:53.047579-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-4878"
+      },
+      "timestamp": "2026-05-19T10:16:53.047579-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libcap2"
+        },
+        {
+          "@id": "pkg:deb/debian/libcap2-bin"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not call cap_set_file() when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes the following warnings: https://github.com/fleetdm/fleet/actions/runs/26081772268.

Run using this branch: https://github.com/fleetdm/fleet/actions/runs/26100260311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security vulnerability assessments for nine CVEs, confirming they do not impact wix as the vulnerable code paths are not executed in the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->