### PR TITLE
Fix patched query parentheses in outputs

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -87,7 +87,7 @@ func TestIngestValidations(t *testing.T) {
 				Version: "1.0",
 			}
 
-		case "ok", "install_script_path", "uninstall_script_path", "uninstall_script_path_with_pre", "uninstall_script_path_with_post", "patch_policy_path":
+		case "ok", "docker-desktop", "install_script_path", "uninstall_script_path", "uninstall_script_path_with_pre", "uninstall_script_path_with_post", "patch_policy_path":
 			cask = brewCask{
 				Token:   appToken,
 				Name:    []string{appToken},
@@ -120,6 +120,7 @@ func TestIngestValidations(t *testing.T) {
 		{"missing URL for cask nourl", inputApp{Token: "nourl", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
 		{"parse URL for cask invalidurl", inputApp{Token: "invalidurl", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
 		{"", inputApp{Token: "ok", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
+		{"", inputApp{Token: "docker-desktop", UniqueIdentifier: "com.electron.dockerdesktop", InstallerFormat: "dmg", Name: "Docker Desktop", Slug: "docker-desktop/darwin"}},
 		{"", inputApp{Token: "install_script_path", UniqueIdentifier: "abc", InstallerFormat: "pkg", InstallScriptPath: path.Join(tempDir, "install_script.sh")}},
 		{"", inputApp{Token: "uninstall_script_path", UniqueIdentifier: "abc", InstallerFormat: "pkg", UninstallScriptPath: path.Join(tempDir, "uninstall_script.sh")}},
 		{"cannot provide pre-uninstall scripts if uninstall script is provided", inputApp{Token: "uninstall_script_path_with_pre", UniqueIdentifier: "abc", InstallerFormat: "pkg", UninstallScriptPath: path.Join(tempDir, "uninstall_script.sh"), PreUninstallScripts: []string{"foo", "bar"}}},
@@ -149,11 +150,122 @@ func TestIngestValidations(t *testing.T) {
 				require.Equal(t, testUninstallScriptContents, out.UninstallScript)
 			}
 
-			require.Equal(t,
-				fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
-				out.Queries.Patched,
-			)
+			if c.inputApp.Token == "docker-desktop" {
+				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';", out.Queries.Exists)
+				require.Equal(t,
+					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '1.0') < 0);",
+					out.Queries.Patched,
+				)
+			} else {
+				require.Equal(t,
+					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
+					out.Queries.Patched,
+				)
+			}
 
 		})
 	}
+}
+
+// TestIngestCaskPath verifies that when an input app sets cask_path, the
+// ingester reads cask JSON from that local file and makes no HTTP call.
+// This is the path used for casks committed into inputs/homebrew/custom-tap/.
+func TestIngestCaskPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	caskJSON, err := json.Marshal(brewCask{
+		Token:   "local-cask",
+		Name:    []string{"Local Cask"},
+		URL:     "https://example.com/local/installer.pkg",
+		Version: "9.9.9",
+		SHA256:  "deadbeef",
+	})
+	require.NoError(t, err)
+
+	caskPath := path.Join(tempDir, "local-cask.json")
+	require.NoError(t, os.WriteFile(caskPath, caskJSON, 0o644))
+
+	// Server that should never be called when cask_path is set; any hit is a
+	// bug because it means the ingester fell back to HTTP.
+	var httpHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		httpHits++
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+	i := &brewIngester{
+		logger:  slog.New(slog.DiscardHandler),
+		client:  fleethttp.NewClient(fleethttp.WithTimeout(10 * time.Second)),
+		baseURL: srv.URL + "/",
+	}
+
+	out, err := i.ingestOne(ctx, inputApp{
+		Token:            "local-cask",
+		UniqueIdentifier: "com.example.localcask",
+		InstallerFormat:  "pkg",
+		Name:             "Local Cask",
+		CaskPath:         caskPath,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/local/installer.pkg", out.InstallerURL)
+	require.Equal(t, "9.9.9", out.Version)
+	require.Equal(t, "deadbeef", out.SHA256)
+	require.Equal(t, 0, httpHits, "cask_path path must not make an HTTP call")
+
+	// Missing file yields an actionable error.
+	_, err = i.ingestOne(ctx, inputApp{
+		Token:            "missing",
+		UniqueIdentifier: "com.example.missing",
+		InstallerFormat:  "pkg",
+		Name:             "Missing",
+		CaskPath:         path.Join(tempDir, "does-not-exist.json"),
+	})
+	require.ErrorContains(t, err, "reading local cask JSON file")
+	require.Equal(t, 0, httpHits)
+
+	// Token mismatch between input and cask file is rejected so a misconfigured
+	// cask_path can't silently ingest the wrong app.
+	mismatchPath := path.Join(tempDir, "mismatch.json")
+	mismatchJSON, err := json.Marshal(brewCask{
+		Token:   "some-other-cask",
+		Name:    []string{"Some Other Cask"},
+		URL:     "https://example.com/other/installer.pkg",
+		Version: "1.0.0",
+		SHA256:  "cafebabe",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(mismatchPath, mismatchJSON, 0o644))
+
+	_, err = i.ingestOne(ctx, inputApp{
+		Token:            "local-cask",
+		UniqueIdentifier: "com.example.localcask",
+		InstallerFormat:  "pkg",
+		Name:             "Local Cask",
+		CaskPath:         mismatchPath,
+	})
+	require.ErrorContains(t, err, "does not match input token")
+	require.Equal(t, 0, httpHits)
+
+	// Cask file with an empty name is rejected.
+	emptyNamePath := path.Join(tempDir, "empty-name.json")
+	emptyNameJSON, err := json.Marshal(brewCask{
+		Token:   "local-cask",
+		Name:    []string{},
+		URL:     "https://example.com/local/installer.pkg",
+		Version: "9.9.9",
+		SHA256:  "deadbeef",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(emptyNamePath, emptyNameJSON, 0o644))
+
+	_, err = i.ingestOne(ctx, inputApp{
+		Token:            "local-cask",
+		UniqueIdentifier: "com.example.localcask",
+		InstallerFormat:  "pkg",
+		Name:             "Local Cask",
+		CaskPath:         emptyNamePath,
+	})
+	require.ErrorContains(t, err, "empty name")
+	require.Equal(t, 0, httpHits)
 }

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -87,7 +87,7 @@ func TestIngestValidations(t *testing.T) {
 				Version: "1.0",
 			}
 
-		case "ok", "docker-desktop", "install_script_path", "uninstall_script_path", "uninstall_script_path_with_pre", "uninstall_script_path_with_post", "patch_policy_path":
+		case "ok", "install_script_path", "uninstall_script_path", "uninstall_script_path_with_pre", "uninstall_script_path_with_post", "patch_policy_path":
 			cask = brewCask{
 				Token:   appToken,
 				Name:    []string{appToken},
@@ -120,7 +120,6 @@ func TestIngestValidations(t *testing.T) {
 		{"missing URL for cask nourl", inputApp{Token: "nourl", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
 		{"parse URL for cask invalidurl", inputApp{Token: "invalidurl", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
 		{"", inputApp{Token: "ok", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
-		{"", inputApp{Token: "docker-desktop", UniqueIdentifier: "com.electron.dockerdesktop", InstallerFormat: "dmg", Name: "Docker Desktop", Slug: "docker-desktop/darwin"}},
 		{"", inputApp{Token: "install_script_path", UniqueIdentifier: "abc", InstallerFormat: "pkg", InstallScriptPath: path.Join(tempDir, "install_script.sh")}},
 		{"", inputApp{Token: "uninstall_script_path", UniqueIdentifier: "abc", InstallerFormat: "pkg", UninstallScriptPath: path.Join(tempDir, "uninstall_script.sh")}},
 		{"cannot provide pre-uninstall scripts if uninstall script is provided", inputApp{Token: "uninstall_script_path_with_pre", UniqueIdentifier: "abc", InstallerFormat: "pkg", UninstallScriptPath: path.Join(tempDir, "uninstall_script.sh"), PreUninstallScripts: []string{"foo", "bar"}}},
@@ -150,122 +149,11 @@ func TestIngestValidations(t *testing.T) {
 				require.Equal(t, testUninstallScriptContents, out.UninstallScript)
 			}
 
-			if c.inputApp.Token == "docker-desktop" {
-				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';", out.Queries.Exists)
-				require.Equal(t,
-					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '1.0') < 0);",
-					out.Queries.Patched,
-				)
-			} else {
-				require.Equal(t,
-					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
-					out.Queries.Patched,
-				)
-			}
+			require.Equal(t,
+				fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
+				out.Queries.Patched,
+			)
 
 		})
 	}
-}
-
-// TestIngestCaskPath verifies that when an input app sets cask_path, the
-// ingester reads cask JSON from that local file and makes no HTTP call.
-// This is the path used for casks committed into inputs/homebrew/custom-tap/.
-func TestIngestCaskPath(t *testing.T) {
-	tempDir := t.TempDir()
-
-	caskJSON, err := json.Marshal(brewCask{
-		Token:   "local-cask",
-		Name:    []string{"Local Cask"},
-		URL:     "https://example.com/local/installer.pkg",
-		Version: "9.9.9",
-		SHA256:  "deadbeef",
-	})
-	require.NoError(t, err)
-
-	caskPath := path.Join(tempDir, "local-cask.json")
-	require.NoError(t, os.WriteFile(caskPath, caskJSON, 0o644))
-
-	// Server that should never be called when cask_path is set; any hit is a
-	// bug because it means the ingester fell back to HTTP.
-	var httpHits int
-	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		httpHits++
-	}))
-	t.Cleanup(srv.Close)
-
-	ctx := context.Background()
-	i := &brewIngester{
-		logger:  slog.New(slog.DiscardHandler),
-		client:  fleethttp.NewClient(fleethttp.WithTimeout(10 * time.Second)),
-		baseURL: srv.URL + "/",
-	}
-
-	out, err := i.ingestOne(ctx, inputApp{
-		Token:            "local-cask",
-		UniqueIdentifier: "com.example.localcask",
-		InstallerFormat:  "pkg",
-		Name:             "Local Cask",
-		CaskPath:         caskPath,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "https://example.com/local/installer.pkg", out.InstallerURL)
-	require.Equal(t, "9.9.9", out.Version)
-	require.Equal(t, "deadbeef", out.SHA256)
-	require.Equal(t, 0, httpHits, "cask_path path must not make an HTTP call")
-
-	// Missing file yields an actionable error.
-	_, err = i.ingestOne(ctx, inputApp{
-		Token:            "missing",
-		UniqueIdentifier: "com.example.missing",
-		InstallerFormat:  "pkg",
-		Name:             "Missing",
-		CaskPath:         path.Join(tempDir, "does-not-exist.json"),
-	})
-	require.ErrorContains(t, err, "reading local cask JSON file")
-	require.Equal(t, 0, httpHits)
-
-	// Token mismatch between input and cask file is rejected so a misconfigured
-	// cask_path can't silently ingest the wrong app.
-	mismatchPath := path.Join(tempDir, "mismatch.json")
-	mismatchJSON, err := json.Marshal(brewCask{
-		Token:   "some-other-cask",
-		Name:    []string{"Some Other Cask"},
-		URL:     "https://example.com/other/installer.pkg",
-		Version: "1.0.0",
-		SHA256:  "cafebabe",
-	})
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(mismatchPath, mismatchJSON, 0o644))
-
-	_, err = i.ingestOne(ctx, inputApp{
-		Token:            "local-cask",
-		UniqueIdentifier: "com.example.localcask",
-		InstallerFormat:  "pkg",
-		Name:             "Local Cask",
-		CaskPath:         mismatchPath,
-	})
-	require.ErrorContains(t, err, "does not match input token")
-	require.Equal(t, 0, httpHits)
-
-	// Cask file with an empty name is rejected.
-	emptyNamePath := path.Join(tempDir, "empty-name.json")
-	emptyNameJSON, err := json.Marshal(brewCask{
-		Token:   "local-cask",
-		Name:    []string{},
-		URL:     "https://example.com/local/installer.pkg",
-		Version: "9.9.9",
-		SHA256:  "deadbeef",
-	})
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(emptyNamePath, emptyNameJSON, 0o644))
-
-	_, err = i.ingestOne(ctx, inputApp{
-		Token:            "local-cask",
-		UniqueIdentifier: "com.example.localcask",
-		InstallerFormat:  "pkg",
-		Name:             "Local Cask",
-		CaskPath:         emptyNamePath,
-	})
-	require.ErrorContains(t, err, "empty name")
-	require.Equal(t, 0, httpHits)
 }

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -158,7 +158,7 @@ func TestIngestValidations(t *testing.T) {
 				)
 			} else {
 				require.Equal(t,
-					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
+					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
 					out.Queries.Patched,
 				)
 			}

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -158,7 +158,7 @@ func TestIngestValidations(t *testing.T) {
 				)
 			} else {
 				require.Equal(t,
-					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
+					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
 					out.Queries.Patched,
 				)
 			}

--- a/ee/maintained-apps/outputs/010-editor/darwin.json
+++ b/ee/maintained-apps/outputs/010-editor/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.0.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.SweetScape.010Editor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.SweetScape.010Editor') AND version_compare(bundle_short_version, '16.0.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.SweetScape.010Editor') AND version_compare(bundle_short_version, '16.0.4') < 0);"
       },
       "installer_url": "https://download.sweetscape.com/010EditorMacARM64Installer16.0.4.dmg",
       "install_script_ref": "2fdd9af7",

--- a/ee/maintained-apps/outputs/010-editor/windows.json
+++ b/ee/maintained-apps/outputs/010-editor/windows.json
@@ -4,7 +4,7 @@
       "version": "16.0.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE '010 Editor %' AND publisher = 'SweetScape Software';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE '010 Editor %' AND publisher = 'SweetScape Software') AND version_compare(version, '16.0.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE '010 Editor %' AND publisher = 'SweetScape Software') AND version_compare(version, '16.0.4') < 0);"
       },
       "installer_url": "https://download.sweetscape.com/010EditorWin64Installer16.0.4.exe",
       "install_script_ref": "5764f801",

--- a/ee/maintained-apps/outputs/1password/darwin.json
+++ b/ee/maintained-apps/outputs/1password/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.12.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password') AND version_compare(bundle_short_version, '8.12.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.1password.1password') AND version_compare(bundle_short_version, '8.12.12') < 0);"
       },
       "installer_url": "https://downloads.1password.com/mac/1Password.pkg",
       "install_script_ref": "ef2a17ff",

--- a/ee/maintained-apps/outputs/1password/windows.json
+++ b/ee/maintained-apps/outputs/1password/windows.json
@@ -4,7 +4,7 @@
       "version": "8.12.12",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.') AND version_compare(version, '8.12.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = '1Password' AND publisher = 'Agilebits Inc.') AND version_compare(version, '8.12.12') < 0);"
       },
       "installer_url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-8.12.12.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/7-zip/windows.json
+++ b/ee/maintained-apps/outputs/7-zip/windows.json
@@ -4,7 +4,7 @@
       "version": "26.01",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE '7-Zip %' AND publisher = 'Igor Pavlov';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE '7-Zip %' AND publisher = 'Igor Pavlov') AND version_compare(version, '26.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE '7-Zip %' AND publisher = 'Igor Pavlov') AND version_compare(version, '26.01') < 0);"
       },
       "installer_url": "https://7-zip.org/a/7z2601-x64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/8x8-work/darwin.json
+++ b/ee/maintained-apps/outputs/8x8-work/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.33.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.8x8---virtual-office';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.8x8---virtual-office') AND version_compare(bundle_short_version, '8.33.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.electron.8x8---virtual-office') AND version_compare(bundle_short_version, '8.33.2') < 0);"
       },
       "installer_url": "https://work-desktop-assets.8x8.com/prod-publish/ga/work-arm64-dmg-v8.33.2-2.dmg",
       "install_script_ref": "4fae7a5b",

--- a/ee/maintained-apps/outputs/8x8-work/windows.json
+++ b/ee/maintained-apps/outputs/8x8-work/windows.json
@@ -4,7 +4,7 @@
       "version": "8.33.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = '8x8 Work' AND publisher = '8x8 Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = '8x8 Work' AND publisher = '8x8 Inc.') AND version_compare(version, '8.33.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = '8x8 Work' AND publisher = '8x8 Inc.') AND version_compare(version, '8.33.2') < 0);"
       },
       "installer_url": "https://work-desktop-assets.8x8.com/prod-publish/ga/work-64-msi-v8.33.2-2.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/abstract/darwin.json
+++ b/ee/maintained-apps/outputs/abstract/darwin.json
@@ -4,7 +4,7 @@
       "version": "98.6.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.elasticprojects.abstract-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.elasticprojects.abstract-desktop') AND version_compare(bundle_short_version, '98.6.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.elasticprojects.abstract-desktop') AND version_compare(bundle_short_version, '98.6.3') < 0);"
       },
       "installer_url": "https://downloads.goabstract.com/mac/Abstract-98.6.3.zip",
       "install_script_ref": "ca022a22",

--- a/ee/maintained-apps/outputs/adobe-acrobat-reader/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-reader/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.001.21529",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader') AND version_compare(bundle_short_version, '26.001.21529') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.adobe.Reader') AND version_compare(bundle_short_version, '26.001.21529') < 0);"
       },
       "installer_url": "https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2600121529/AcroRdrDC_2600121529_MUI.dmg",
       "install_script_ref": "94edcf98",

--- a/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
@@ -4,7 +4,7 @@
       "version": "26.001.21529",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe') AND version_compare(version, '26.001.21529') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe') AND version_compare(version, '26.001.21529') < 0);"
       },
       "installer_url": "https://ardownload3.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2600121529/AcroRdrDCx642600121529_MUI.exe",
       "install_script_ref": "7dc0b065",

--- a/ee/maintained-apps/outputs/adobe-creative-cloud/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-creative-cloud/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.9.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.acc.AdobeCreativeCloud';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.acc.AdobeCreativeCloud') AND version_compare(bundle_short_version, '6.9.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.adobe.acc.AdobeCreativeCloud') AND version_compare(bundle_short_version, '6.9.1.1') < 0);"
       },
       "installer_url": "https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.9.1/1/macarm64/ACCCx6_9_1_1.dmg",
       "install_script_ref": "a331ea84",

--- a/ee/maintained-apps/outputs/adobe-digital-editions/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-digital-editions/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.5.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.adobedigitaleditions.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.adobedigitaleditions.app') AND version_compare(bundle_short_version, '4.5.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.adobe.adobedigitaleditions.app') AND version_compare(bundle_short_version, '4.5.12') < 0);"
       },
       "installer_url": "https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.dmg",
       "install_script_ref": "da201b49",

--- a/ee/maintained-apps/outputs/adobe-dng-converter/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-dng-converter/darwin.json
@@ -4,7 +4,7 @@
       "version": "18.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.DNGConverter';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.DNGConverter') AND version_compare(bundle_short_version, '18.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.adobe.DNGConverter') AND version_compare(bundle_short_version, '18.3') < 0);"
       },
       "installer_url": "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_18_3.dmg",
       "install_script_ref": "f3bdbd2a",

--- a/ee/maintained-apps/outputs/aircall/darwin.json
+++ b/ee/maintained-apps/outputs/aircall/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.1.66",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.aircall.phone';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'io.aircall.phone') AND version_compare(bundle_short_version, '3.1.66') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'io.aircall.phone') AND version_compare(bundle_short_version, '3.1.66') < 0);"
       },
       "installer_url": "https://download-electron.aircall.io/Aircall-3.1.66.dmg",
       "install_script_ref": "8fc42b5e",

--- a/ee/maintained-apps/outputs/aircall/windows.json
+++ b/ee/maintained-apps/outputs/aircall/windows.json
@@ -4,7 +4,7 @@
       "version": "3.1.66",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Aircall' AND publisher = 'Aircall';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Aircall' AND publisher = 'Aircall') AND version_compare(version, '3.1.66') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Aircall' AND publisher = 'Aircall') AND version_compare(version, '3.1.66') < 0);"
       },
       "installer_url": "https://download-electron.aircall.io/Aircall-3.1.66.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/airtame/darwin.json
+++ b/ee/maintained-apps/outputs/airtame/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.15.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application') AND version_compare(bundle_short_version, '4.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.airtame.airtame-application') AND version_compare(bundle_short_version, '4.15.0') < 0);"
       },
       "installer_url": "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-4.15.0.dmg",
       "install_script_ref": "f0367273",

--- a/ee/maintained-apps/outputs/airtame/windows.json
+++ b/ee/maintained-apps/outputs/airtame/windows.json
@@ -4,7 +4,7 @@
       "version": "4.15.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Airtame %' AND publisher = 'Airtame';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Airtame %' AND publisher = 'Airtame') AND version_compare(version, '4.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Airtame %' AND publisher = 'Airtame') AND version_compare(version, '4.15.0') < 0);"
       },
       "installer_url": "https://downloads.airtame.com/app/latest/win/Airtame-4.15.0-setup.exe",
       "install_script_ref": "8a919fae",

--- a/ee/maintained-apps/outputs/amazon-chime/darwin.json
+++ b/ee/maintained-apps/outputs/amazon-chime/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.23.22522",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazon.Amazon-Chime';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazon.Amazon-Chime') AND version_compare(bundle_short_version, '5.23.22522') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.amazon.Amazon-Chime') AND version_compare(bundle_short_version, '5.23.22522') < 0);"
       },
       "installer_url": "https://clients.chime.aws/mac-nme/AmazonChime-5.23.22522.dmg",
       "install_script_ref": "6ac4810f",

--- a/ee/maintained-apps/outputs/android-studio/darwin.json
+++ b/ee/maintained-apps/outputs/android-studio/darwin.json
@@ -4,7 +4,7 @@
       "version": "2025.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio') AND version_compare(bundle_short_version, '2025.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.google.android.studio') AND version_compare(bundle_short_version, '2025.3') < 0);"
       },
       "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2025.3.4.7/android-studio-panda4-patch1-mac_arm.dmg",
       "install_script_ref": "c737fe39",

--- a/ee/maintained-apps/outputs/anka-virtualization/darwin.json
+++ b/ee/maintained-apps/outputs/anka-virtualization/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.9.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.veertu.anka';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.veertu.anka') AND version_compare(bundle_short_version, '3.9.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.veertu.anka') AND version_compare(bundle_short_version, '3.9.0') < 0);"
       },
       "installer_url": "https://downloads.veertu.com/anka/Anka-3.9.0.215.pkg",
       "install_script_ref": "82c7a931",

--- a/ee/maintained-apps/outputs/anydesk/darwin.json
+++ b/ee/maintained-apps/outputs/anydesk/darwin.json
@@ -4,7 +4,7 @@
       "version": "9.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.philandro.anydesk';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.philandro.anydesk') AND version_compare(bundle_short_version, '9.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.philandro.anydesk') AND version_compare(bundle_short_version, '9.7.0') < 0);"
       },
       "installer_url": "https://download.anydesk.com/anydesk.dmg",
       "install_script_ref": "a3e522af",

--- a/ee/maintained-apps/outputs/apparency/darwin.json
+++ b/ee/maintained-apps/outputs/apparency/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.Apparency';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.Apparency') AND version_compare(bundle_short_version, '3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.mothersruin.Apparency') AND version_compare(bundle_short_version, '3.2') < 0);"
       },
       "installer_url": "https://www.mothersruin.com/software/archives/Apparency-3.2.dmg",
       "install_script_ref": "8b90bbdb",

--- a/ee/maintained-apps/outputs/appcleaner/darwin.json
+++ b/ee/maintained-apps/outputs/appcleaner/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.6.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.freemacsoft.AppCleaner';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'net.freemacsoft.AppCleaner') AND version_compare(bundle_short_version, '3.6.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'net.freemacsoft.AppCleaner') AND version_compare(bundle_short_version, '3.6.8') < 0);"
       },
       "installer_url": "https://www.freemacsoft.net/downloads/AppCleaner_3.6.8.zip",
       "install_script_ref": "1593491b",

--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.147.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser') AND version_compare(bundle_short_version, '1.147.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'company.thebrowser.Browser') AND version_compare(bundle_short_version, '1.147.0') < 0);"
       },
       "installer_url": "https://releases.arc.net/release/Arc-1.147.0-80797.zip",
       "install_script_ref": "bb0dd542",

--- a/ee/maintained-apps/outputs/archaeology/darwin.json
+++ b/ee/maintained-apps/outputs/archaeology/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.Archaeology';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.Archaeology') AND version_compare(bundle_short_version, '1.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.mothersruin.Archaeology') AND version_compare(bundle_short_version, '1.5') < 0);"
       },
       "installer_url": "https://www.mothersruin.com/software/downloads/Archaeology.dmg",
       "install_script_ref": "673cc2cb",

--- a/ee/maintained-apps/outputs/arduino-ide/darwin.json
+++ b/ee/maintained-apps/outputs/arduino-ide/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.3.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2') AND version_compare(bundle_short_version, '2.3.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'cc.arduino.IDE2') AND version_compare(bundle_short_version, '2.3.8') < 0);"
       },
       "installer_url": "https://github.com/arduino/arduino-ide/releases/download/2.3.8/arduino-ide_2.3.8_macOS_ARM64.dmg",
       "install_script_ref": "b8e694ce",

--- a/ee/maintained-apps/outputs/asana/darwin.json
+++ b/ee/maintained-apps/outputs/asana/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.7.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.asana';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.asana') AND version_compare(bundle_short_version, '2.7.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.electron.asana') AND version_compare(bundle_short_version, '2.7.1') < 0);"
       },
       "installer_url": "https://desktop-downloads.asana.com/darwin_arm64/prod/v2.7.1/Asana-darwin-arm64-2.7.1.zip",
       "install_script_ref": "d3c589b5",

--- a/ee/maintained-apps/outputs/asana/windows.json
+++ b/ee/maintained-apps/outputs/asana/windows.json
@@ -4,7 +4,7 @@
       "version": "2.7.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Asana' AND publisher = 'Asana, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Asana' AND publisher = 'Asana, Inc.') AND version_compare(version, '2.7.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Asana' AND publisher = 'Asana, Inc.') AND version_compare(version, '2.7.1') < 0);"
       },
       "installer_url": "https://desktop-downloads.asana.com/win32_x64/prod/v2.7.1/AsanaSetup.exe",
       "install_script_ref": "7d7fdd9d",

--- a/ee/maintained-apps/outputs/audacity/darwin.json
+++ b/ee/maintained-apps/outputs/audacity/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.7.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.audacityteam.audacity';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.audacityteam.audacity') AND version_compare(bundle_short_version, '3.7.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.audacityteam.audacity') AND version_compare(bundle_short_version, '3.7.7') < 0);"
       },
       "installer_url": "https://github.com/audacity/audacity/releases/download/Audacity-3.7.7/audacity-macOS-3.7.7-arm64.dmg",
       "install_script_ref": "ca3e7e55",

--- a/ee/maintained-apps/outputs/avast-secure-browser/darwin.json
+++ b/ee/maintained-apps/outputs/avast-secure-browser/darwin.json
@@ -4,7 +4,7 @@
       "version": "139.0.6697.68",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.avast.AvastSecureBrowser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.avast.AvastSecureBrowser') AND version_compare(bundle_short_version, '139.0.6697.68') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.avast.AvastSecureBrowser') AND version_compare(bundle_short_version, '139.0.6697.68') < 0);"
       },
       "installer_url": "https://cdn-update.avast.securebrowser.com/browser/mac/arm/139.0.6697.68/AvastSecureBrowser.dmg",
       "install_script_ref": "a5cd4886",

--- a/ee/maintained-apps/outputs/aws-vpn-client/darwin.json
+++ b/ee/maintained-apps/outputs/aws-vpn-client/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.3.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazonaws.acvc.osx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazonaws.acvc.osx') AND version_compare(bundle_short_version, '5.3.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.amazonaws.acvc.osx') AND version_compare(bundle_short_version, '5.3.5') < 0);"
       },
       "installer_url": "https://d20adtppz83p9s.cloudfront.net/OSX_ARM64/5.3.5/AWS_VPN_Client_ARM64.pkg",
       "install_script_ref": "53e8589e",

--- a/ee/maintained-apps/outputs/balenaetcher/darwin.json
+++ b/ee/maintained-apps/outputs/balenaetcher/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.1.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.balena.etcher';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'io.balena.etcher') AND version_compare(bundle_short_version, '2.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'io.balena.etcher') AND version_compare(bundle_short_version, '2.1.6') < 0);"
       },
       "installer_url": "https://github.com/balena-io/etcher/releases/download/v2.1.6/balenaEtcher-2.1.6-arm64.dmg",
       "install_script_ref": "2e2f21f8",

--- a/ee/maintained-apps/outputs/bbedit/darwin.json
+++ b/ee/maintained-apps/outputs/bbedit/darwin.json
@@ -4,7 +4,7 @@
       "version": "15.5.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.barebones.bbedit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.barebones.bbedit') AND version_compare(bundle_short_version, '15.5.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.barebones.bbedit') AND version_compare(bundle_short_version, '15.5.5') < 0);"
       },
       "installer_url": "https://s3.amazonaws.com/BBSW-download/BBEdit_15.5.5.dmg",
       "install_script_ref": "c4ab4266",

--- a/ee/maintained-apps/outputs/betterdisplay/darwin.json
+++ b/ee/maintained-apps/outputs/betterdisplay/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'pro.betterdisplay.BetterDisplay';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'pro.betterdisplay.BetterDisplay') AND version_compare(bundle_short_version, '4.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'pro.betterdisplay.BetterDisplay') AND version_compare(bundle_short_version, '4.3.3') < 0);"
       },
       "installer_url": "https://github.com/waydabber/BetterDisplay/releases/download/v4.3.3/BetterDisplay-v4.3.3.dmg",
       "install_script_ref": "d892af0a",

--- a/ee/maintained-apps/outputs/beyond-compare/darwin.json
+++ b/ee/maintained-apps/outputs/beyond-compare/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.2.1.32035",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ScooterSoftware.BeyondCompare';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.ScooterSoftware.BeyondCompare') AND version_compare(bundle_short_version, '5.2.1.32035') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.ScooterSoftware.BeyondCompare') AND version_compare(bundle_short_version, '5.2.1.32035') < 0);"
       },
       "installer_url": "https://www.scootersoftware.com/files/BCompareOSX-5.2.1.32035.zip",
       "install_script_ref": "5fca1cb5",

--- a/ee/maintained-apps/outputs/bitwarden/darwin.json
+++ b/ee/maintained-apps/outputs/bitwarden/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bitwarden.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.bitwarden.desktop') AND version_compare(bundle_short_version, '2026.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.bitwarden.desktop') AND version_compare(bundle_short_version, '2026.3.1') < 0);"
       },
       "installer_url": "https://github.com/bitwarden/clients/releases/download/desktop-v2026.3.1/Bitwarden-2026.3.1-universal.dmg",
       "install_script_ref": "1bffc483",

--- a/ee/maintained-apps/outputs/blender/darwin.json
+++ b/ee/maintained-apps/outputs/blender/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.blenderfoundation.blender';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.blenderfoundation.blender') AND version_compare(bundle_short_version, '5.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.blenderfoundation.blender') AND version_compare(bundle_short_version, '5.1.2') < 0);"
       },
       "installer_url": "https://download.blender.org/release/Blender5.1/blender-5.1.2-macos-arm64.dmg",
       "install_script_ref": "6c68d444",

--- a/ee/maintained-apps/outputs/blender/windows.json
+++ b/ee/maintained-apps/outputs/blender/windows.json
@@ -4,7 +4,7 @@
       "version": "5.1.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Blender' AND publisher = 'Blender Foundation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Blender' AND publisher = 'Blender Foundation') AND version_compare(version, '5.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Blender' AND publisher = 'Blender Foundation') AND version_compare(version, '5.1.2') < 0);"
       },
       "installer_url": "https://download.blender.org/release/Blender5.1/blender-5.1.2-windows-x64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/box-drive/darwin.json
+++ b/ee/maintained-apps/outputs/box-drive/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.51.233",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.box.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.box.desktop') AND version_compare(bundle_short_version, '2.51.233') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.box.desktop') AND version_compare(bundle_short_version, '2.51.233') < 0);"
       },
       "installer_url": "https://e3.boxcdn.net/desktop/releases/mac/BoxDrive-2.51.233.pkg",
       "install_script_ref": "5b80f593",

--- a/ee/maintained-apps/outputs/box-drive/windows.json
+++ b/ee/maintained-apps/outputs/box-drive/windows.json
@@ -4,7 +4,7 @@
       "version": "2.51.234",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Box' AND publisher = 'Box, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Box' AND publisher = 'Box, Inc.') AND version_compare(version, '2.51.234') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Box' AND publisher = 'Box, Inc.') AND version_compare(version, '2.51.234') < 0);"
       },
       "installer_url": "https://e3.boxcdn.net/desktop/releases/win/BoxDrive-2.51.234.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -4,7 +4,7 @@
       "version": "148.1.90.122",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser') AND version_compare(bundle_short_version, '148.1.90.122') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.brave.Browser') AND version_compare(bundle_short_version, '148.1.90.122') < 0);"
       },
       "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/190.122/Brave-Browser-arm64.dmg",
       "install_script_ref": "51f78f89",

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -4,7 +4,7 @@
       "version": "148.1.90.122",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc') AND version_compare(version, '148.1.90.122') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Brave' AND publisher = 'Brave Software Inc') AND version_compare(version, '148.1.90.122') < 0);"
       },
       "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.90.122/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",

--- a/ee/maintained-apps/outputs/bruno/darwin.json
+++ b/ee/maintained-apps/outputs/bruno/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app') AND version_compare(bundle_short_version, '3.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.usebruno.app') AND version_compare(bundle_short_version, '3.3.0') < 0);"
       },
       "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.3.0/bruno_3.3.0_arm64_mac.dmg",
       "install_script_ref": "162ba575",

--- a/ee/maintained-apps/outputs/calibre/darwin.json
+++ b/ee/maintained-apps/outputs/calibre/darwin.json
@@ -4,7 +4,7 @@
       "version": "9.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre') AND version_compare(bundle_short_version, '9.8.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'net.kovidgoyal.calibre') AND version_compare(bundle_short_version, '9.8.0') < 0);"
       },
       "installer_url": "https://download.calibre-ebook.com/9.8.0/calibre-9.8.0.dmg",
       "install_script_ref": "6ee1f446",

--- a/ee/maintained-apps/outputs/camtasia/darwin.json
+++ b/ee/maintained-apps/outputs/camtasia/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.techsmith.camtasia';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.techsmith.camtasia') AND version_compare(bundle_short_version, '2026.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.techsmith.camtasia') AND version_compare(bundle_short_version, '2026.1.0') < 0);"
       },
       "installer_url": "https://download.techsmith.com/camtasiamac/releases/2026.1.0/Camtasia.dmg",
       "install_script_ref": "2fda011f",

--- a/ee/maintained-apps/outputs/camtasia/windows.json
+++ b/ee/maintained-apps/outputs/camtasia/windows.json
@@ -4,7 +4,7 @@
       "version": "26.1.2.16723",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation') AND version_compare(version, '26.1.2.16723') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Camtasia' AND publisher = 'TechSmith Corporation') AND version_compare(version, '26.1.2.16723') < 0);"
       },
       "installer_url": "https://download.techsmith.com/camtasiastudio/releases/2612/camtasia.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/canva/darwin.json
+++ b/ee/maintained-apps/outputs/canva/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.122.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.canva.CanvaDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.canva.CanvaDesktop') AND version_compare(bundle_short_version, '1.122.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.canva.CanvaDesktop') AND version_compare(bundle_short_version, '1.122.0') < 0);"
       },
       "installer_url": "https://desktop-release.canva.com/Canva-1.122.0-universal.dmg",
       "install_script_ref": "a8898c91",

--- a/ee/maintained-apps/outputs/cavalry/darwin.json
+++ b/ee/maintained-apps/outputs/cavalry/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.7.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.scenegroup.cavalry';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.scenegroup.cavalry') AND version_compare(bundle_short_version, '2.7.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.scenegroup.cavalry') AND version_compare(bundle_short_version, '2.7.2') < 0);"
       },
       "installer_url": "https://cavalry.studio/downloads/latest/Cavalry.dmg",
       "install_script_ref": "ac471589",

--- a/ee/maintained-apps/outputs/charles/darwin.json
+++ b/ee/maintained-apps/outputs/charles/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.xk72.Charles';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.xk72.Charles') AND version_compare(bundle_short_version, '5.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.xk72.Charles') AND version_compare(bundle_short_version, '5.1') < 0);"
       },
       "installer_url": "https://www.charlesproxy.com/assets/release/5.1/charles-proxy-5.1.dmg",
       "install_script_ref": "51e3611c",

--- a/ee/maintained-apps/outputs/chatgpt-atlas/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt-atlas/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.2026.119.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.atlas';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.atlas') AND version_compare(bundle_short_version, '1.2026.119.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.openai.atlas') AND version_compare(bundle_short_version, '1.2026.119.1') < 0);"
       },
       "installer_url": "https://persistent.oaistatic.com/atlas/public/ChatGPT_Atlas_Desktop_public_1.2026.119.1_20260504231115000.dmg",
       "install_script_ref": "a5fd4e54",

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.2026.118",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat') AND version_compare(bundle_short_version, '1.2026.118') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.openai.chat') AND version_compare(bundle_short_version, '1.2026.118') < 0);"
       },
       "installer_url": "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2026.118_1777682760.dmg",
       "install_script_ref": "c2132138",

--- a/ee/maintained-apps/outputs/cisco-jabber/darwin.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/darwin.json
@@ -4,7 +4,7 @@
       "version": "15.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber') AND version_compare(bundle_short_version, '15.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.cisco.jabber') AND version_compare(bundle_short_version, '15.2.1') < 0);"
       },
       "installer_url": "https://binaries.webex.com/jabberclientmac/20260122074039/Install_Cisco-Jabber-Mac.pkg",
       "install_script_ref": "2756548e",

--- a/ee/maintained-apps/outputs/cisco-jabber/windows.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/windows.json
@@ -4,7 +4,7 @@
       "version": "15.2.2.60904",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cisco Jabber' AND publisher = 'Cisco Systems, Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Cisco Jabber' AND publisher = 'Cisco Systems, Inc') AND version_compare(version, '15.2.2.60904') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Cisco Jabber' AND publisher = 'Cisco Systems, Inc') AND version_compare(version, '15.2.2.60904') < 0);"
       },
       "installer_url": "https://binaries.webex.com/jabberclientwindows/20260429083041/CiscoJabberSetup.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/citrix-workspace/darwin.json
+++ b/ee/maintained-apps/outputs/citrix-workspace/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.03.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.citrix.receiver.nomas';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.citrix.receiver.nomas') AND version_compare(bundle_short_version, '26.03.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.citrix.receiver.nomas') AND version_compare(bundle_short_version, '26.03.0') < 0);"
       },
       "installer_url": "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Mac/CitrixWorkspaceAppUniversal26.03.0.49.pkg",
       "install_script_ref": "fe7ba180",

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.7196.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop') AND version_compare(bundle_short_version, '1.7196.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.anthropic.claudefordesktop') AND version_compare(bundle_short_version, '1.7196.3') < 0);"
       },
       "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.7196.3/Claude-ca0c62bc1d73c3f4d2f37816bd25565587fb4443.zip",
       "install_script_ref": "8b957973",

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -4,7 +4,7 @@
       "version": "1.7196.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC') AND version_compare(version, '1.7196.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Claude' AND publisher = 'Anthropic, PBC') AND version_compare(version, '1.7196.3') < 0);"
       },
       "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.7196.3/Claude-ca0c62bc1d73c3f4d2f37816bd25565587fb4443.msix",
       "install_script_ref": "31a0b698",

--- a/ee/maintained-apps/outputs/cleanmymac/darwin.json
+++ b/ee/maintained-apps/outputs/cleanmymac/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5') AND version_compare(bundle_short_version, '5.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.macpaw.CleanMyMac5') AND version_compare(bundle_short_version, '5.3.1') < 0);"
       },
       "installer_url": "https://dl.devmate.com/com.macpaw.CleanMyMac5/50301.0.2601271414/1769524551/CleanMyMac5-50301.0.2601271414.zip",
       "install_script_ref": "fff893a1",

--- a/ee/maintained-apps/outputs/cleanshot/darwin.json
+++ b/ee/maintained-apps/outputs/cleanshot/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.8.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.getcleanshot.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.getcleanshot.app') AND version_compare(bundle_short_version, '4.8.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.getcleanshot.app') AND version_compare(bundle_short_version, '4.8.8') < 0);"
       },
       "installer_url": "https://updates.getcleanshot.com/v3/CleanShot-X-4.8.8.dmg",
       "install_script_ref": "ad9395c4",

--- a/ee/maintained-apps/outputs/clickup/darwin.json
+++ b/ee/maintained-apps/outputs/clickup/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.5.208",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.clickup.desktop-app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.clickup.desktop-app') AND version_compare(bundle_short_version, '3.5.208') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.clickup.desktop-app') AND version_compare(bundle_short_version, '3.5.208') < 0);"
       },
       "installer_url": "https://download.todesktop.com/221003ra4tebclw/ClickUp%203.5.208%20-%20Build%20260505zrf6t7imk-arm64.dmg",
       "install_script_ref": "4b21205a",

--- a/ee/maintained-apps/outputs/clickup/windows.json
+++ b/ee/maintained-apps/outputs/clickup/windows.json
@@ -4,7 +4,7 @@
       "version": "3.5.208",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'ClickUp' AND publisher = 'ClickUp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'ClickUp' AND publisher = 'ClickUp') AND version_compare(version, '3.5.208') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'ClickUp' AND publisher = 'ClickUp') AND version_compare(version, '3.5.208') < 0);"
       },
       "installer_url": "https://download.todesktop.com/221003ra4tebclw/ClickUp-3.5.208-build-260505zrf6t7imk-x64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/clion/darwin.json
+++ b/ee/maintained-apps/outputs/clion/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.CLion') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.2-aarch64.dmg",
       "install_script_ref": "19fdf393",

--- a/ee/maintained-apps/outputs/clockify/darwin.json
+++ b/ee/maintained-apps/outputs/clockify/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.12.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'coing.ClockifyDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'coing.ClockifyDesktop') AND version_compare(bundle_short_version, '2.12.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'coing.ClockifyDesktop') AND version_compare(bundle_short_version, '2.12.4') < 0);"
       },
       "installer_url": "https://clockify.me/downloads/ClockifyDesktop.zip",
       "install_script_ref": "de01ae28",

--- a/ee/maintained-apps/outputs/cloudflare-warp/darwin.json
+++ b/ee/maintained-apps/outputs/cloudflare-warp/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.4.1350.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.cloudflare.1dot1dot1dot1.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.cloudflare.1dot1dot1dot1.macos') AND version_compare(bundle_short_version, '2026.4.1350.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.cloudflare.1dot1dot1dot1.macos') AND version_compare(bundle_short_version, '2026.4.1350.0') < 0);"
       },
       "installer_url": "https://downloads.cloudflareclient.com/v1/download/macos/version/2026.4.1350.0",
       "install_script_ref": "e97d4551",

--- a/ee/maintained-apps/outputs/codex-cli/windows.json
+++ b/ee/maintained-apps/outputs/codex-cli/windows.json
@@ -4,7 +4,7 @@
       "version": "0.130.0",
       "queries": {
         "exists": "SELECT 1 FROM file WHERE path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM file WHERE path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe') AND version_compare(version, '0.130.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\Program Files\\Codex CLI\\codex.exe' OR path LIKE '%\\AppData\\Local\\Programs\\Codex CLI\\codex.exe') AND version_compare(version, '0.130.0') < 0);"
       },
       "installer_url": "https://github.com/openai/codex/releases/download/rust-v0.130.0/codex-x86_64-pc-windows-msvc.exe.zip",
       "install_script_ref": "8bb4b68b",

--- a/ee/maintained-apps/outputs/connect-fonts/darwin.json
+++ b/ee/maintained-apps/outputs/connect-fonts/darwin.json
@@ -4,7 +4,7 @@
       "version": "28.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion') AND version_compare(bundle_short_version, '28.1.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.extensis.SuitcaseFusion') AND version_compare(bundle_short_version, '28.1.4') < 0);"
       },
       "installer_url": "https://bin.extensis.com/ConnectFonts-M-28-1-4.dmg",
       "install_script_ref": "b7069397",

--- a/ee/maintained-apps/outputs/coteditor/darwin.json
+++ b/ee/maintained-apps/outputs/coteditor/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor') AND version_compare(bundle_short_version, '7.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.coteditor.CotEditor') AND version_compare(bundle_short_version, '7.0.3') < 0);"
       },
       "installer_url": "https://github.com/coteditor/CotEditor/releases/download/7.0.3/CotEditor_7.0.3.dmg",
       "install_script_ref": "25436bc3",

--- a/ee/maintained-apps/outputs/crashplan/darwin.json
+++ b/ee/maintained-apps/outputs/crashplan/darwin.json
@@ -4,7 +4,7 @@
       "version": "11.9.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.crashplan.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.crashplan.desktop') AND version_compare(bundle_short_version, '11.9.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.crashplan.desktop') AND version_compare(bundle_short_version, '11.9.1') < 0);"
       },
       "installer_url": "https://download.crashplan.com/installs/agent/cloud/11.9.1/19/install/CrashPlan_11.9.1_19_Mac.dmg",
       "install_script_ref": "0a300cc3",

--- a/ee/maintained-apps/outputs/crashplan/windows.json
+++ b/ee/maintained-apps/outputs/crashplan/windows.json
@@ -4,7 +4,7 @@
       "version": "11.9.1.19",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'CrashPlan' AND publisher = 'CrashPlan Group LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'CrashPlan' AND publisher = 'CrashPlan Group LLC') AND version_compare(version, '11.9.1.19') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'CrashPlan' AND publisher = 'CrashPlan Group LLC') AND version_compare(version, '11.9.1.19') < 0);"
       },
       "installer_url": "https://download.crashplan.com/installs/agent/cloud/11.9.1/19/install/CrashPlan_11.9.1_19_Win64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.4.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92') AND version_compare(bundle_short_version, '3.4.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.todesktop.230313mzl4w4u92') AND version_compare(bundle_short_version, '3.4.20') < 0);"
       },
       "installer_url": "https://downloads.cursor.com/production/0cf8b06883f54e26bb4f0fb8647c9500ccb4331f/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -4,7 +4,7 @@
       "version": "3.4.20",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere') AND version_compare(version, '3.4.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Cursor' AND publisher = 'Anysphere') AND version_compare(version, '3.4.20') < 0);"
       },
       "installer_url": "https://downloads.cursor.com/production/0cf8b06883f54e26bb4f0fb8647c9500ccb4331f/win32/x64/system-setup/CursorSetup-x64-3.4.20.exe",
       "install_script_ref": "03589b5e",

--- a/ee/maintained-apps/outputs/cyberduck/darwin.json
+++ b/ee/maintained-apps/outputs/cyberduck/darwin.json
@@ -4,7 +4,7 @@
       "version": "9.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck') AND version_compare(bundle_short_version, '9.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'ch.sudo.cyberduck') AND version_compare(bundle_short_version, '9.4.1') < 0);"
       },
       "installer_url": "https://update.cyberduck.io/Cyberduck-9.4.1.44384.zip",
       "install_script_ref": "3390ca0f",

--- a/ee/maintained-apps/outputs/cyberduck/windows.json
+++ b/ee/maintained-apps/outputs/cyberduck/windows.json
@@ -4,7 +4,7 @@
       "version": "9.4.1.44384",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cyberduck' AND publisher = 'iterate GmbH';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Cyberduck' AND publisher = 'iterate GmbH') AND version_compare(version, '9.4.1.44384') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Cyberduck' AND publisher = 'iterate GmbH') AND version_compare(version, '9.4.1.44384') < 0);"
       },
       "installer_url": "https://update.cyberduck.io//Cyberduck-Installer-9.4.1.44384.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/dash/darwin.json
+++ b/ee/maintained-apps/outputs/dash/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.kapeli.dashdoc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.kapeli.dashdoc') AND version_compare(bundle_short_version, '8.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.kapeli.dashdoc') AND version_compare(bundle_short_version, '8.1.1') < 0);"
       },
       "installer_url": "https://kapeli.com/downloads/v8/Dash.zip",
       "install_script_ref": "a498324c",

--- a/ee/maintained-apps/outputs/datagrip/darwin.json
+++ b/ee/maintained-apps/outputs/datagrip/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.datagrip';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.datagrip') AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.datagrip') AND version_compare(bundle_short_version, '2026.1.3') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.1.3-aarch64.dmg",
       "install_script_ref": "f3cdf82b",

--- a/ee/maintained-apps/outputs/db-browser-for-sqlite/darwin.json
+++ b/ee/maintained-apps/outputs/db-browser-for-sqlite/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.13.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sqlitebrowser.sqlitebrowser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.sqlitebrowser.sqlitebrowser') AND version_compare(bundle_short_version, '3.13.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.sqlitebrowser.sqlitebrowser') AND version_compare(bundle_short_version, '3.13.1') < 0);"
       },
       "installer_url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.1/DB.Browser.for.SQLite-v3.13.1.dmg",
       "install_script_ref": "34ab4ccf",

--- a/ee/maintained-apps/outputs/dbeaver-community/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-community/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.0.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product') AND version_compare(bundle_short_version, '26.0.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.jkiss.dbeaver.core.product') AND version_compare(bundle_short_version, '26.0.5') < 0);"
       },
       "installer_url": "https://dbeaver.io/files/26.0.5/dbeaver-ce-26.0.5-macos-aarch64.dmg",
       "install_script_ref": "abe5b0d5",

--- a/ee/maintained-apps/outputs/dbeaver-enterprise/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-enterprise/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.enterprise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.enterprise') AND version_compare(bundle_short_version, '26.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.dbeaver.product.enterprise') AND version_compare(bundle_short_version, '26.0.0') < 0);"
       },
       "installer_url": "https://downloads.dbeaver.net/enterprise/26.0.0/dbeaver-ee-26.0.0-macos-aarch64.dmg",
       "install_script_ref": "a96abe07",

--- a/ee/maintained-apps/outputs/dbeaverlite/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverlite/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite') AND version_compare(bundle_short_version, '26.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.dbeaver.product.lite') AND version_compare(bundle_short_version, '26.0.0') < 0);"
       },
       "installer_url": "https://downloads.dbeaver.net/lite/26.0.0/dbeaver-le-26.0.0-macos-aarch64.dmg",
       "install_script_ref": "c1cba05a",

--- a/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate') AND version_compare(bundle_short_version, '26.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.dbeaver.product.ultimate') AND version_compare(bundle_short_version, '26.0.0') < 0);"
       },
       "installer_url": "https://downloads.dbeaver.net/ultimate/26.0.0/dbeaver-ue-26.0.0-macos-aarch64.dmg",
       "install_script_ref": "0a44a77f",

--- a/ee/maintained-apps/outputs/dcv-viewer/darwin.json
+++ b/ee/maintained-apps/outputs/dcv-viewer/darwin.json
@@ -4,7 +4,7 @@
       "version": "2025.0.8846",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nicesoftware.dcvviewer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.nicesoftware.dcvviewer') AND version_compare(bundle_short_version, '2025.0.8846') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.nicesoftware.dcvviewer') AND version_compare(bundle_short_version, '2025.0.8846') < 0);"
       },
       "installer_url": "https://d1uj6qtbmh3dt5.cloudfront.net/2025.0/Clients/nice-dcv-viewer-2025.0.8846.arm64.dmg",
       "install_script_ref": "6586b7bb",

--- a/ee/maintained-apps/outputs/deepl/darwin.json
+++ b/ee/maintained-apps/outputs/deepl/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.4.24484530",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.linguee.DeepLCopyTranslator';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.linguee.DeepLCopyTranslator') AND version_compare(bundle_short_version, '26.4.24484530') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.linguee.DeepLCopyTranslator') AND version_compare(bundle_short_version, '26.4.24484530') < 0);"
       },
       "installer_url": "https://www.deepl.com/macos/download/26.4/24484530/DeepL.dmg",
       "install_script_ref": "acdd1ea2",

--- a/ee/maintained-apps/outputs/dialpad/darwin.json
+++ b/ee/maintained-apps/outputs/dialpad/darwin.json
@@ -4,7 +4,7 @@
       "version": "2605.0.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad') AND version_compare(bundle_short_version, '2605.0.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.electron.dialpad') AND version_compare(bundle_short_version, '2605.0.4') < 0);"
       },
       "installer_url": "https://download.dialpad.com/osx/arm64/dialpad.pkg",
       "install_script_ref": "49548b01",

--- a/ee/maintained-apps/outputs/discord/darwin.json
+++ b/ee/maintained-apps/outputs/discord/darwin.json
@@ -4,7 +4,7 @@
       "version": "0.0.391",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord') AND version_compare(bundle_short_version, '0.0.391') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.hnc.Discord') AND version_compare(bundle_short_version, '0.0.391') < 0);"
       },
       "installer_url": "https://dl.discordapp.net/apps/osx/0.0.391/Discord.dmg",
       "install_script_ref": "57ec7b28",

--- a/ee/maintained-apps/outputs/discord/windows.json
+++ b/ee/maintained-apps/outputs/discord/windows.json
@@ -4,7 +4,7 @@
       "version": "1.0.9238",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.') AND version_compare(version, '1.0.9238') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Discord' AND publisher = 'Discord Inc.') AND version_compare(version, '1.0.9238') < 0);"
       },
       "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9238/DiscordSetup.exe",
       "install_script_ref": "fd04e860",

--- a/ee/maintained-apps/outputs/displaylink/darwin.json
+++ b/ee/maintained-apps/outputs/displaylink/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.displaylink.DisplayLinkUserAgent';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.displaylink.DisplayLinkUserAgent') AND version_compare(bundle_short_version, '16.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.displaylink.DisplayLinkUserAgent') AND version_compare(bundle_short_version, '16.0') < 0);"
       },
       "installer_url": "https://www.synaptics.com/sites/default/files/exe_files/2026-04/DisplayLink%20Manager%20Graphics%20Connectivity16.0-EXE.pkg",
       "install_script_ref": "a740a9c9",

--- a/ee/maintained-apps/outputs/docker/windows.json
+++ b/ee/maintained-apps/outputs/docker/windows.json
@@ -4,7 +4,7 @@
       "version": "4.73.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.') AND version_compare(version, '4.73.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Docker Desktop' AND publisher = 'Docker Inc.') AND version_compare(version, '4.73.0') < 0);"
       },
       "installer_url": "https://desktop.docker.com/win/main/amd64/226246/Docker%20Desktop%20Installer.exe",
       "install_script_ref": "b06042dd",

--- a/ee/maintained-apps/outputs/drawio/darwin.json
+++ b/ee/maintained-apps/outputs/drawio/darwin.json
@@ -4,7 +4,7 @@
       "version": "30.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop') AND version_compare(bundle_short_version, '30.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jgraph.drawio.desktop') AND version_compare(bundle_short_version, '30.0.2') < 0);"
       },
       "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.0.2/draw.io-arm64-30.0.2.dmg",
       "install_script_ref": "c5526876",

--- a/ee/maintained-apps/outputs/dropbox/darwin.json
+++ b/ee/maintained-apps/outputs/dropbox/darwin.json
@@ -4,7 +4,7 @@
       "version": "252.4.3485",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox') AND version_compare(bundle_short_version, '252.4.3485') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.getdropbox.dropbox') AND version_compare(bundle_short_version, '252.4.3485') < 0);"
       },
       "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20252.4.3485.arm64.dmg",
       "install_script_ref": "59c04bcb",

--- a/ee/maintained-apps/outputs/druva-insync/darwin.json
+++ b/ee/maintained-apps/outputs/druva-insync/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.6.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.druva.inSyncClient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.druva.inSyncClient') AND version_compare(bundle_short_version, '7.6.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.druva.inSyncClient') AND version_compare(bundle_short_version, '7.6.1') < 0);"
       },
       "installer_url": "https://downloads.druva.com/downloads/inSync/MAC/7.6.1/inSync-7.6.1-r110931.dmg",
       "install_script_ref": "72f0f8fe",

--- a/ee/maintained-apps/outputs/druva-insync/windows.json
+++ b/ee/maintained-apps/outputs/druva-insync/windows.json
@@ -4,7 +4,7 @@
       "version": "7.5.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Druva inSync %' AND publisher = 'Druva Technologies Pte. Ltd.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Druva inSync %' AND publisher = 'Druva Technologies Pte. Ltd.') AND version_compare(version, '7.5.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Druva inSync %' AND publisher = 'Druva Technologies Pte. Ltd.') AND version_compare(version, '7.5.7') < 0);"
       },
       "installer_url": "https://downloads.druva.com/downloads/inSync/Windows/7.5.7/inSync7.5.7r110923.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/eclipse-ide/darwin.json
+++ b/ee/maintained-apps/outputs/eclipse-ide/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.39",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers') AND version_compare(bundle_short_version, '4.39') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'epp.package.committers') AND version_compare(bundle_short_version, '4.39') < 0);"
       },
       "installer_url": "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2026-03/R/eclipse-committers-2026-03-R-macosx-cocoa-aarch64.dmg&r=1",
       "install_script_ref": "99517b0e",

--- a/ee/maintained-apps/outputs/egnyte/darwin.json
+++ b/ee/maintained-apps/outputs/egnyte/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.17.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.egnyte.DesktopApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.egnyte.DesktopApp') AND version_compare(bundle_short_version, '1.17.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.egnyte.DesktopApp') AND version_compare(bundle_short_version, '1.17.0') < 0);"
       },
       "installer_url": "https://egnyte-cdn.egnyte.com/desktopapp/mac/en-us/1.17.0/Egnyte_1.17.0_2340.dmg",
       "install_script_ref": "22bcf81a",

--- a/ee/maintained-apps/outputs/elgato-control-center/darwin.json
+++ b/ee/maintained-apps/outputs/elgato-control-center/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.8.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.corsair.ControlCenter';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.corsair.ControlCenter') AND version_compare(bundle_short_version, '1.8.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.corsair.ControlCenter') AND version_compare(bundle_short_version, '1.8.2') < 0);"
       },
       "installer_url": "https://edge.elgato.com/egc/macos/eccm/1.8.2/ElgatoControlCenter-1.8.2.20643.zip",
       "install_script_ref": "b4374aef",

--- a/ee/maintained-apps/outputs/elgato-stream-deck/darwin.json
+++ b/ee/maintained-apps/outputs/elgato-stream-deck/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.elgato.StreamDeck';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.elgato.StreamDeck') AND version_compare(bundle_short_version, '7.4.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.elgato.StreamDeck') AND version_compare(bundle_short_version, '7.4.2') < 0);"
       },
       "installer_url": "https://edge.elgato.com/egc/macos/sd/Stream_Deck_7.4.2.22730.pkg",
       "install_script_ref": "1dd644a7",

--- a/ee/maintained-apps/outputs/expressvpn/darwin.json
+++ b/ee/maintained-apps/outputs/expressvpn/darwin.json
@@ -4,7 +4,7 @@
       "version": "14.1.1.13156",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.expressvpn.ExpressVPN';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.expressvpn.ExpressVPN') AND version_compare(bundle_short_version, '14.1.1.13156') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.expressvpn.ExpressVPN') AND version_compare(bundle_short_version, '14.1.1.13156') < 0);"
       },
       "installer_url": "https://www.expressvpn.works/clients/mac/expressvpn-macos-universal-14.1.1.13156_release.zip",
       "install_script_ref": "c5afbbfa",

--- a/ee/maintained-apps/outputs/figma/darwin.json
+++ b/ee/maintained-apps/outputs/figma/darwin.json
@@ -4,7 +4,7 @@
       "version": "126.3.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop') AND version_compare(bundle_short_version, '126.3.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.figma.Desktop') AND version_compare(bundle_short_version, '126.3.12') < 0);"
       },
       "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.3.12.zip",
       "install_script_ref": "f0952230",

--- a/ee/maintained-apps/outputs/figma/windows.json
+++ b/ee/maintained-apps/outputs/figma/windows.json
@@ -4,7 +4,7 @@
       "version": "126.4.9",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.') AND version_compare(version, '126.4.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Figma' AND publisher = 'Figma, Inc.') AND version_compare(version, '126.4.9') < 0);"
       },
       "installer_url": "https://desktop.figma.com/win/build/Figma-126.4.9.exe",
       "install_script_ref": "442d71b3",

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -4,7 +4,7 @@
       "version": "150.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox') AND version_compare(bundle_short_version, '150.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.mozilla.firefox') AND version_compare(bundle_short_version, '150.0.3') < 0);"
       },
       "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/150.0.3/mac/en-US/Firefox%20150.0.3.dmg",
       "install_script_ref": "f659d0e6",

--- a/ee/maintained-apps/outputs/firefox/windows.json
+++ b/ee/maintained-apps/outputs/firefox/windows.json
@@ -4,7 +4,7 @@
       "version": "150.0.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla') AND version_compare(version, '150.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla') AND version_compare(version, '150.0.3') < 0);"
       },
       "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/150.0.3/win64/en-US/Firefox%20Setup%20150.0.3.exe",
       "install_script_ref": "80fb9175",

--- a/ee/maintained-apps/outputs/firefox@esr/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@esr/darwin.json
@@ -4,7 +4,7 @@
       "version": "140.10.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox') AND version_compare(bundle_short_version, '140.10.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.mozilla.firefox') AND version_compare(bundle_short_version, '140.10.2') < 0);"
       },
       "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.10.2esr/mac/en-US/Firefox%20140.10.2esr.dmg",
       "install_script_ref": "f659d0e6",

--- a/ee/maintained-apps/outputs/firefox@esr/windows.json
+++ b/ee/maintained-apps/outputs/firefox@esr/windows.json
@@ -4,7 +4,7 @@
       "version": "140.10.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '140.10.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '140.10.2') < 0);"
       },
       "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.10.2esr/win64/en-US/Firefox%20Setup%20140.10.2esr.exe",
       "install_script_ref": "36995f4f",

--- a/ee/maintained-apps/outputs/fleet-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/fleet-desktop/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.fleetdm.fleet-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.fleetdm.fleet-desktop') AND version_compare(bundle_short_version, '1.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.fleetdm.fleet-desktop') AND version_compare(bundle_short_version, '1.2.0') < 0);"
       },
       "installer_url": "https://github.com/allenhouchins/fleet-desktop/releases/download/v1.2.0/fleet_desktop-v1.2.0.pkg",
       "install_script_ref": "b6404dfa",

--- a/ee/maintained-apps/outputs/fork/darwin.json
+++ b/ee/maintained-apps/outputs/fork/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.66.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.DanPristupov.Fork';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.DanPristupov.Fork') AND version_compare(bundle_short_version, '2.66.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.DanPristupov.Fork') AND version_compare(bundle_short_version, '2.66.7') < 0);"
       },
       "installer_url": "https://cdn.fork.dev/mac/Fork-2.66.7.dmg",
       "install_script_ref": "c596b8e7",

--- a/ee/maintained-apps/outputs/front/darwin.json
+++ b/ee/maintained-apps/outputs/front/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.73.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.frontapp.Front';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.frontapp.Front') AND version_compare(bundle_short_version, '3.73.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.frontapp.Front') AND version_compare(bundle_short_version, '3.73.0') < 0);"
       },
       "installer_url": "https://dl.frontapp.com/desktop/builds/3.73.0/Front-3.73.0-arm64.zip",
       "install_script_ref": "42b34fcd",

--- a/ee/maintained-apps/outputs/ghostty/darwin.json
+++ b/ee/maintained-apps/outputs/ghostty/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mitchellh.ghostty';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.mitchellh.ghostty') AND version_compare(bundle_short_version, '1.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.mitchellh.ghostty') AND version_compare(bundle_short_version, '1.3.1') < 0);"
       },
       "installer_url": "https://release.files.ghostty.org/1.3.1/Ghostty.dmg",
       "install_script_ref": "a1155274",

--- a/ee/maintained-apps/outputs/gimp/darwin.json
+++ b/ee/maintained-apps/outputs/gimp/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.2.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.gimp.gimp-3.0';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.gimp.gimp-3.0') AND version_compare(bundle_short_version, '3.2.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.gimp.gimp-3.0') AND version_compare(bundle_short_version, '3.2.4') < 0);"
       },
       "installer_url": "https://download.gimp.org/gimp/v3.2/macos/gimp-3.2.4-arm64.dmg",
       "install_script_ref": "5b1978b6",

--- a/ee/maintained-apps/outputs/gimp/windows.json
+++ b/ee/maintained-apps/outputs/gimp/windows.json
@@ -4,7 +4,7 @@
       "version": "3.2.4.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team') AND version_compare(version, '3.2.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'GIMP %' AND publisher = 'The GIMP Team') AND version_compare(version, '3.2.4.0') < 0);"
       },
       "installer_url": "https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe",
       "install_script_ref": "7e5269bc",

--- a/ee/maintained-apps/outputs/github-desktop/windows.json
+++ b/ee/maintained-apps/outputs/github-desktop/windows.json
@@ -4,7 +4,7 @@
       "version": "3.5.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.') AND version_compare(version, '3.5.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.') AND version_compare(version, '3.5.8') < 0);"
       },
       "installer_url": "https://desktop.githubusercontent.com/releases/3.5.8-b1d863ab/GitHubDesktopSetup-x64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/github/darwin.json
+++ b/ee/maintained-apps/outputs/github/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.5.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient') AND version_compare(bundle_short_version, '3.5.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.github.GitHubClient') AND version_compare(bundle_short_version, '3.5.8') < 0);"
       },
       "installer_url": "https://desktop.githubusercontent.com/releases/3.5.8-b1d863ab/GitHubDesktop-arm64.zip",
       "install_script_ref": "98ab6ed8",

--- a/ee/maintained-apps/outputs/gitkraken/darwin.json
+++ b/ee/maintained-apps/outputs/gitkraken/darwin.json
@@ -4,7 +4,7 @@
       "version": "12.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken') AND version_compare(bundle_short_version, '12.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.axosoft.gitkraken') AND version_compare(bundle_short_version, '12.1.1') < 0);"
       },
       "installer_url": "https://api.gitkraken.dev/releases/production/darwin/arm64/12.1.1/GitKraken-v12.1.1.zip",
       "install_script_ref": "f20ab23e",

--- a/ee/maintained-apps/outputs/goland/darwin.json
+++ b/ee/maintained-apps/outputs/goland/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.goland') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/go/goland-2026.1.2-aarch64.dmg",
       "install_script_ref": "402340c3",

--- a/ee/maintained-apps/outputs/google-chrome/darwin.json
+++ b/ee/maintained-apps/outputs/google-chrome/darwin.json
@@ -4,7 +4,7 @@
       "version": "148.0.7778.168",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome') AND version_compare(bundle_short_version, '148.0.7778.168') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.google.Chrome') AND version_compare(bundle_short_version, '148.0.7778.168') < 0);"
       },
       "installer_url": "https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg",
       "install_script_ref": "6981ff84",

--- a/ee/maintained-apps/outputs/google-chrome/windows.json
+++ b/ee/maintained-apps/outputs/google-chrome/windows.json
@@ -4,7 +4,7 @@
       "version": "148.0.7778.168",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Google Chrome' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Google Chrome' AND publisher = 'Google LLC') AND version_compare(version, '148.0.7778.168') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Google Chrome' AND publisher = 'Google LLC') AND version_compare(version, '148.0.7778.168') < 0);"
       },
       "installer_url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/google-credential-provider-for-windows/windows.json
+++ b/ee/maintained-apps/outputs/google-credential-provider-for-windows/windows.json
@@ -4,7 +4,7 @@
       "version": "138.0.7204.26",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Google Credential Provider for Windows' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Google Credential Provider for Windows' AND publisher = 'Google LLC') AND version_compare(version, '138.0.7204.26') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Google Credential Provider for Windows' AND publisher = 'Google LLC') AND version_compare(version, '138.0.7204.26') < 0);"
       },
       "installer_url": "https://dl.google.com/credentialprovider/gcpwstandaloneenterprise64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/google-drive/darwin.json
+++ b/ee/maintained-apps/outputs/google-drive/darwin.json
@@ -4,7 +4,7 @@
       "version": "125.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs') AND version_compare(bundle_short_version, '125.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.google.drivefs') AND version_compare(bundle_short_version, '125.0') < 0);"
       },
       "installer_url": "https://dl.google.com/drive-file-stream/5-percent/GoogleDrive.dmg",
       "install_script_ref": "fe628b65",

--- a/ee/maintained-apps/outputs/google-drive/windows.json
+++ b/ee/maintained-apps/outputs/google-drive/windows.json
@@ -4,7 +4,7 @@
       "version": "125.0.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Google Drive' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Google Drive' AND publisher = 'Google LLC') AND version_compare(version, '125.0.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Google Drive' AND publisher = 'Google LLC') AND version_compare(version, '125.0.0.0') < 0);"
       },
       "installer_url": "https://dl.google.com/release2/drive-file-stream/jdnygtxjhspl3nvfi5zi6oumli_125.0.0.0/setup.exe",
       "install_script_ref": "fa36b892",

--- a/ee/maintained-apps/outputs/gpg-suite/darwin.json
+++ b/ee/maintained-apps/outputs/gpg-suite/darwin.json
@@ -4,7 +4,7 @@
       "version": "2023.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.gpgtools.updater';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.gpgtools.updater') AND version_compare(bundle_short_version, '2023.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.gpgtools.updater') AND version_compare(bundle_short_version, '2023.3') < 0);"
       },
       "installer_url": "https://releases.gpgtools.org/GPG_Suite-2023.3.dmg",
       "install_script_ref": "26a66c0c",

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.165.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama') AND version_compare(bundle_short_version, '1.165.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.grammarly.ProjectLlama') AND version_compare(bundle_short_version, '1.165.1') < 0);"
       },
       "installer_url": "https://download-mac.grammarly.com/versions/1.165.1.0/Grammarly.dmg",
       "install_script_ref": "20d5bd8f",

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.220.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app') AND version_compare(bundle_short_version, '7.220.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.granola.app') AND version_compare(bundle_short_version, '7.220.0') < 0);"
       },
       "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.220.0/Granola-7.220.0-mac-universal.dmg",
       "install_script_ref": "08986ac7",

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -4,7 +4,7 @@
       "version": "7.220.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola') AND version_compare(version, '7.220.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Granola %' AND publisher = 'Granola') AND version_compare(version, '7.220.0') < 0);"
       },
       "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.220.0-win-x64.exe",
       "install_script_ref": "3f66ac53",

--- a/ee/maintained-apps/outputs/hyper/darwin.json
+++ b/ee/maintained-apps/outputs/hyper/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'co.zeit.hyper';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'co.zeit.hyper') AND version_compare(bundle_short_version, '3.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'co.zeit.hyper') AND version_compare(bundle_short_version, '3.4.1') < 0);"
       },
       "installer_url": "https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-arm64.zip",
       "install_script_ref": "0d87a0d8",

--- a/ee/maintained-apps/outputs/iina/darwin.json
+++ b/ee/maintained-apps/outputs/iina/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.colliderli.iina';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.colliderli.iina') AND version_compare(bundle_short_version, '1.4.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.colliderli.iina') AND version_compare(bundle_short_version, '1.4.2') < 0);"
       },
       "installer_url": "https://dl-portal.iina.io/IINA.v1.4.2-build164.dmg",
       "install_script_ref": "ac168c5b",

--- a/ee/maintained-apps/outputs/imazing-profile-editor/darwin.json
+++ b/ee/maintained-apps/outputs/imazing-profile-editor/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.DigiDNA.iMazingProfileEditorMac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.DigiDNA.iMazingProfileEditorMac') AND version_compare(bundle_short_version, '2.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.DigiDNA.iMazingProfileEditorMac') AND version_compare(bundle_short_version, '2.2.0') < 0);"
       },
       "installer_url": "https://downloads.imazing.com/mac/iMazing-Profile-Editor/2.2.0.392103/iMazing_Profile_Editor_2.2.0.392103.dmg",
       "install_script_ref": "51ec6794",

--- a/ee/maintained-apps/outputs/imazing/darwin.json
+++ b/ee/maintained-apps/outputs/imazing/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.5.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.DigiDNA.iMazing3Mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.DigiDNA.iMazing3Mac') AND version_compare(bundle_short_version, '3.5.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.DigiDNA.iMazing3Mac') AND version_compare(bundle_short_version, '3.5.2') < 0);"
       },
       "installer_url": "https://downloads.imazing.com/mac/iMazing/3.5.2.24017/iMazing_3.5.2.24017.dmg",
       "install_script_ref": "0525fbb7",

--- a/ee/maintained-apps/outputs/inkscape/darwin.json
+++ b/ee/maintained-apps/outputs/inkscape/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.4.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.inkscape.Inkscape';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.inkscape.Inkscape') AND version_compare(bundle_short_version, '1.4.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.inkscape.Inkscape') AND version_compare(bundle_short_version, '1.4.4') < 0);"
       },
       "installer_url": "https://media.inkscape.org/dl/resources/file/Inkscape-1.4.4_arm64.dmg",
       "install_script_ref": "ab3c3b86",

--- a/ee/maintained-apps/outputs/inkscape/windows.json
+++ b/ee/maintained-apps/outputs/inkscape/windows.json
@@ -4,7 +4,7 @@
       "version": "1.4.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Inkscape' AND publisher = 'Inkscape';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Inkscape' AND publisher = 'Inkscape') AND version_compare(version, '1.4.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Inkscape' AND publisher = 'Inkscape') AND version_compare(version, '1.4.4') < 0);"
       },
       "installer_url": "https://media.inkscape.org/dl/resources/file/inkscape-1.4.4_2026-05-05_dcaf3e7-x64.signed_xMx7DJV.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/insomnia/darwin.json
+++ b/ee/maintained-apps/outputs/insomnia/darwin.json
@@ -4,7 +4,7 @@
       "version": "12.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app') AND version_compare(bundle_short_version, '12.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.insomnia.app') AND version_compare(bundle_short_version, '12.5.0') < 0);"
       },
       "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4012.5.0/Insomnia.Core-12.5.0.dmg",
       "install_script_ref": "5fd2f033",

--- a/ee/maintained-apps/outputs/intellij-idea-ce/darwin.json
+++ b/ee/maintained-apps/outputs/intellij-idea-ce/darwin.json
@@ -4,7 +4,7 @@
       "version": "2025.2.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij.ce';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij.ce') AND version_compare(bundle_short_version, '2025.2.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.intellij.ce') AND version_compare(bundle_short_version, '2025.2.5') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/idea/ideaIC-2025.2.5-aarch64.dmg",
       "install_script_ref": "37b1e122",

--- a/ee/maintained-apps/outputs/intellij-idea/darwin.json
+++ b/ee/maintained-apps/outputs/intellij-idea/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.intellij') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/idea/ideaIU-2026.1.2-aarch64.dmg",
       "install_script_ref": "d4229fa3",

--- a/ee/maintained-apps/outputs/intune-company-portal/darwin.json
+++ b/ee/maintained-apps/outputs/intune-company-portal/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.2604.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.CompanyPortalMac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.CompanyPortalMac') AND version_compare(bundle_short_version, '5.2604.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.CompanyPortalMac') AND version_compare(bundle_short_version, '5.2604.0') < 0);"
       },
       "installer_url": "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_5.2604.0-Upgrade.pkg",
       "install_script_ref": "f176f95a",

--- a/ee/maintained-apps/outputs/iterm2/darwin.json
+++ b/ee/maintained-apps/outputs/iterm2/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.6.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.googlecode.iterm2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.googlecode.iterm2') AND version_compare(bundle_short_version, '3.6.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.googlecode.iterm2') AND version_compare(bundle_short_version, '3.6.10') < 0);"
       },
       "installer_url": "https://iterm2.com/downloads/stable/iTerm2-3_6_10.zip",
       "install_script_ref": "49f7590e",

--- a/ee/maintained-apps/outputs/jabra-direct/darwin.json
+++ b/ee/maintained-apps/outputs/jabra-direct/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.27.03702",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jabra.directonline';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jabra.directonline') AND version_compare(bundle_short_version, '6.27.03702') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jabra.directonline') AND version_compare(bundle_short_version, '6.27.03702') < 0);"
       },
       "installer_url": "https://jabraxpressonlineprdstor.blob.core.windows.net/jdo/JabraDirectSetup.dmg",
       "install_script_ref": "7bbfe6e4",

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.4.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox') AND version_compare(bundle_short_version, '3.4.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.toolbox') AND version_compare(bundle_short_version, '3.4.3') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.4.3.81140-arm64.dmg",
       "install_script_ref": "947b5689",

--- a/ee/maintained-apps/outputs/keepassxc/darwin.json
+++ b/ee/maintained-apps/outputs/keepassxc/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.7.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.keepassx.keepassxc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.keepassx.keepassxc') AND version_compare(bundle_short_version, '2.7.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.keepassx.keepassxc') AND version_compare(bundle_short_version, '2.7.12') < 0);"
       },
       "installer_url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.7.12/KeePassXC-2.7.12-arm64.dmg",
       "install_script_ref": "ea2ab047",

--- a/ee/maintained-apps/outputs/keepassxc/windows.json
+++ b/ee/maintained-apps/outputs/keepassxc/windows.json
@@ -4,7 +4,7 @@
       "version": "2.7.12",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'KeePassXC' AND publisher = 'KeePassXC Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'KeePassXC' AND publisher = 'KeePassXC Team') AND version_compare(version, '2.7.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'KeePassXC' AND publisher = 'KeePassXC Team') AND version_compare(version, '2.7.12') < 0);"
       },
       "installer_url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.7.12/KeePassXC-2.7.12-Win64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/keka/darwin.json
+++ b/ee/maintained-apps/outputs/keka/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.6.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.aone.keka';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.aone.keka') AND version_compare(bundle_short_version, '1.6.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.aone.keka') AND version_compare(bundle_short_version, '1.6.4') < 0);"
       },
       "installer_url": "https://github.com/aonez/Keka/releases/download/v1.6.4/Keka-1.6.4.dmg",
       "install_script_ref": "c516b96f",

--- a/ee/maintained-apps/outputs/kitty/darwin.json
+++ b/ee/maintained-apps/outputs/kitty/darwin.json
@@ -4,7 +4,7 @@
       "version": "0.46.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty') AND version_compare(bundle_short_version, '0.46.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'net.kovidgoyal.kitty') AND version_compare(bundle_short_version, '0.46.2') < 0);"
       },
       "installer_url": "https://github.com/kovidgoyal/kitty/releases/download/v0.46.2/kitty-0.46.2.dmg",
       "install_script_ref": "ed099ff0",

--- a/ee/maintained-apps/outputs/krita/darwin.json
+++ b/ee/maintained-apps/outputs/krita/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.3.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.krita';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.krita') AND version_compare(bundle_short_version, '5.3.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.kde.krita') AND version_compare(bundle_short_version, '5.3.1.1') < 0);"
       },
       "installer_url": "https://download.kde.org/stable/krita/5.3.1/krita-5.3.1.1-signed.dmg",
       "install_script_ref": "dc30a86d",

--- a/ee/maintained-apps/outputs/krita/windows.json
+++ b/ee/maintained-apps/outputs/krita/windows.json
@@ -4,7 +4,7 @@
       "version": "5.3.1.100",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation') AND version_compare(version, '5.3.1.100') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Krita_x64' AND publisher = 'Krita Foundation') AND version_compare(version, '5.3.1.100') < 0);"
       },
       "installer_url": "https://download.kde.org/stable/krita/5.3.1/krita-x64-5.3.1-setup.exe",
       "install_script_ref": "4899cb9d",

--- a/ee/maintained-apps/outputs/lastpass/windows.json
+++ b/ee/maintained-apps/outputs/lastpass/windows.json
@@ -4,7 +4,7 @@
       "version": "5.4.2.1452",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'LastPass' AND publisher = 'LastPass US LP.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'LastPass' AND publisher = 'LastPass US LP.') AND version_compare(version, '5.4.2.1452') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'LastPass' AND publisher = 'LastPass US LP.') AND version_compare(version, '5.4.2.1452') < 0);"
       },
       "installer_url": "https://download.cloud.lastpass.com/windows_installer/LastPassInstaller.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/lens/darwin.json
+++ b/ee/maintained-apps/outputs/lens/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.4.151333-latest",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens') AND version_compare(bundle_short_version, '2026.4.151333-latest') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.electron.kontena-lens') AND version_compare(bundle_short_version, '2026.4.151333-latest') < 0);"
       },
       "installer_url": "https://api.k8slens.dev/binaries/Lens-2026.4.151333-latest-arm64.dmg",
       "install_script_ref": "89ac64d8",

--- a/ee/maintained-apps/outputs/libreoffice/darwin.json
+++ b/ee/maintained-apps/outputs/libreoffice/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.2.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.libreoffice.script';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.libreoffice.script') AND version_compare(bundle_short_version, '26.2.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.libreoffice.script') AND version_compare(bundle_short_version, '26.2.3') < 0);"
       },
       "installer_url": "https://download.documentfoundation.org/libreoffice/stable/26.2.3/mac/aarch64/LibreOffice_26.2.3_MacOS_aarch64.dmg",
       "install_script_ref": "4ee74664",

--- a/ee/maintained-apps/outputs/linear/darwin.json
+++ b/ee/maintained-apps/outputs/linear/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.30.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear') AND version_compare(bundle_short_version, '1.30.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.linear') AND version_compare(bundle_short_version, '1.30.2') < 0);"
       },
       "installer_url": "https://releases.linear.app/Linear-1.30.2-universal.dmg",
       "install_script_ref": "a8868f79",

--- a/ee/maintained-apps/outputs/linear/windows.json
+++ b/ee/maintained-apps/outputs/linear/windows.json
@@ -4,7 +4,7 @@
       "version": "1.28.13",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Linear %' AND publisher = 'Linear Orbit, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Linear %' AND publisher = 'Linear Orbit, Inc.') AND version_compare(version, '1.28.13') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Linear %' AND publisher = 'Linear Orbit, Inc.') AND version_compare(version, '1.28.13') < 0);"
       },
       "installer_url": "https://download.todesktop.com/200315glz2793v6/Linear%20Setup%201.28.13%20-%20Build%20260318pho1bttxr-x64.exe",
       "install_script_ref": "166c7345",

--- a/ee/maintained-apps/outputs/little-snitch/darwin.json
+++ b/ee/maintained-apps/outputs/little-snitch/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'at.obdev.LittleSnitch';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'at.obdev.LittleSnitch') AND version_compare(bundle_short_version, '6.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'at.obdev.LittleSnitch') AND version_compare(bundle_short_version, '6.3.3') < 0);"
       },
       "installer_url": "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-6.3.3.dmg",
       "install_script_ref": "9465ca89",

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -4,7 +4,7 @@
       "version": "0.347.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop') AND version_compare(bundle_short_version, '0.347.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.loom.desktop') AND version_compare(bundle_short_version, '0.347.8') < 0);"
       },
       "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.347.8-arm64.dmg",
       "install_script_ref": "3b74ae49",

--- a/ee/maintained-apps/outputs/lulu/darwin.json
+++ b/ee/maintained-apps/outputs/lulu/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.3.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app') AND version_compare(bundle_short_version, '4.3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.objective-see.lulu.app') AND version_compare(bundle_short_version, '4.3.2') < 0);"
       },
       "installer_url": "https://github.com/objective-see/LuLu/releases/download/v4.3.2/LuLu_4.3.2.dmg",
       "install_script_ref": "f9bcc791",

--- a/ee/maintained-apps/outputs/maccy/darwin.json
+++ b/ee/maintained-apps/outputs/maccy/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.6.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.p0deje.Maccy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.p0deje.Maccy') AND version_compare(bundle_short_version, '2.6.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.p0deje.Maccy') AND version_compare(bundle_short_version, '2.6.1') < 0);"
       },
       "installer_url": "https://github.com/p0deje/Maccy/releases/download/2.6.1/Maccy.app.zip",
       "install_script_ref": "e52430d0",

--- a/ee/maintained-apps/outputs/marvel/darwin.json
+++ b/ee/maintained-apps/outputs/marvel/darwin.json
@@ -4,7 +4,7 @@
       "version": "11.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.marvelprototyping.marvelmacos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.marvelprototyping.marvelmacos') AND version_compare(bundle_short_version, '11.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.marvelprototyping.marvelmacos') AND version_compare(bundle_short_version, '11.5') < 0);"
       },
       "installer_url": "https://storage.googleapis.com/sketch-plugin/11.5/Marvel.zip",
       "install_script_ref": "1dce8e44",

--- a/ee/maintained-apps/outputs/mattermost/darwin.json
+++ b/ee/maintained-apps/outputs/mattermost/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop') AND version_compare(bundle_short_version, '6.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'Mattermost.Desktop') AND version_compare(bundle_short_version, '6.2.0') < 0);"
       },
       "installer_url": "https://releases.mattermost.com/desktop/6.2.0/mattermost-desktop-6.2.0-mac-arm64.zip",
       "install_script_ref": "b8367a3b",

--- a/ee/maintained-apps/outputs/messenger/darwin.json
+++ b/ee/maintained-apps/outputs/messenger/darwin.json
@@ -4,7 +4,7 @@
       "version": "525.0.0.34.106",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.facebook.archon.developerID';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.facebook.archon.developerID') AND version_compare(bundle_short_version, '525.0.0.34.106') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.facebook.archon.developerID') AND version_compare(bundle_short_version, '525.0.0.34.106') < 0);"
       },
       "installer_url": "https://www.messenger.com/messenger/desktop/downloadV2/?platform=mac&variant=catalyst",
       "install_script_ref": "dcf96cd1",

--- a/ee/maintained-apps/outputs/microsoft-auto-update/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-auto-update/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.83",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.autoupdate2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.autoupdate2') AND version_compare(bundle_short_version, '4.83') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.autoupdate2') AND version_compare(bundle_short_version, '4.83') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_AutoUpdate_4.83.26040910_Updater.pkg",
       "install_script_ref": "64b51d51",

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -4,7 +4,7 @@
       "version": "148.0.3967.70",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac') AND version_compare(bundle_short_version, '148.0.3967.70') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.edgemac') AND version_compare(bundle_short_version, '148.0.3967.70') < 0);"
       },
       "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/5678e805-962c-4a19-a14c-85a9417ce604/MicrosoftEdge-148.0.3967.70.dmg",
       "install_script_ref": "caf6f785",

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -4,7 +4,7 @@
       "version": "148.0.3967.54",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation') AND version_compare(version, '148.0.3967.54') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation') AND version_compare(version, '148.0.3967.54') < 0);"
       },
       "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/1c94fae2-b0f4-4415-bb95-dae4c4c7189d/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/microsoft-excel/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-excel/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.109",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel') AND version_compare(bundle_short_version, '16.109') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.Excel') AND version_compare(bundle_short_version, '16.109') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Excel_16.109.26051019_Installer.pkg",
       "install_script_ref": "eddda183",

--- a/ee/maintained-apps/outputs/microsoft-onenote/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-onenote/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.109",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac') AND version_compare(bundle_short_version, '16.109') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.onenote.mac') AND version_compare(bundle_short_version, '16.109') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_16.109.26051019_Updater.pkg",
       "install_script_ref": "70d803a9",

--- a/ee/maintained-apps/outputs/microsoft-outlook/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-outlook/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.109",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Outlook';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Outlook') AND version_compare(bundle_short_version, '16.109') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.Outlook') AND version_compare(bundle_short_version, '16.109') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_16.109.26051019_Installer.pkg",
       "install_script_ref": "c97bbff2",

--- a/ee/maintained-apps/outputs/microsoft-powerpoint/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-powerpoint/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.109",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint') AND version_compare(bundle_short_version, '16.109') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.Powerpoint') AND version_compare(bundle_short_version, '16.109') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_PowerPoint_16.109.26051019_Installer.pkg",
       "install_script_ref": "849b2d93",

--- a/ee/maintained-apps/outputs/microsoft-teams/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-teams/darwin.json
@@ -4,7 +4,7 @@
       "version": "26106.2113.4690.1073",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2') AND version_compare(bundle_short_version, '26106.2113.4690.1073') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.teams2') AND version_compare(bundle_short_version, '26106.2113.4690.1073') < 0);"
       },
       "installer_url": "https://statics.teams.cdn.office.net/production-osx/26106.2113.4690.1073/MicrosoftTeams.pkg",
       "install_script_ref": "9842434b",

--- a/ee/maintained-apps/outputs/microsoft-word/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-word/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.109",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word') AND version_compare(bundle_short_version, '16.109') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.Word') AND version_compare(bundle_short_version, '16.109') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Word_16.109.26051019_Installer.pkg",
       "install_script_ref": "1324a1ed",

--- a/ee/maintained-apps/outputs/miro/darwin.json
+++ b/ee/maintained-apps/outputs/miro/darwin.json
@@ -4,7 +4,7 @@
       "version": "0.11.140",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard') AND version_compare(bundle_short_version, '0.11.140') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.electron.realtimeboard') AND version_compare(bundle_short_version, '0.11.140') < 0);"
       },
       "installer_url": "https://desktop.miro.com/platforms/darwin-arm64/Install-Miro.dmg",
       "install_script_ref": "6933c518",

--- a/ee/maintained-apps/outputs/mongodb-compass/darwin.json
+++ b/ee/maintained-apps/outputs/mongodb-compass/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.49.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mongodb.compass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.mongodb.compass') AND version_compare(bundle_short_version, '1.49.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.mongodb.compass') AND version_compare(bundle_short_version, '1.49.7') < 0);"
       },
       "installer_url": "https://downloads.mongodb.com/compass/mongodb-compass-1.49.7-darwin-arm64.dmg",
       "install_script_ref": "14733ba0",

--- a/ee/maintained-apps/outputs/mysqlworkbench/darwin.json
+++ b/ee/maintained-apps/outputs/mysqlworkbench/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.0.47.CE",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.oracle.workbench.MySQLWorkbench';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.oracle.workbench.MySQLWorkbench') AND version_compare(bundle_short_version, '8.0.47.CE') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.oracle.workbench.MySQLWorkbench') AND version_compare(bundle_short_version, '8.0.47.CE') < 0);"
       },
       "installer_url": "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-8.0.47-macos-arm64.dmg",
       "install_script_ref": "00e190a3",

--- a/ee/maintained-apps/outputs/nextcloud/darwin.json
+++ b/ee/maintained-apps/outputs/nextcloud/darwin.json
@@ -4,7 +4,7 @@
       "version": "33.0.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.desktopclient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.desktopclient') AND version_compare(bundle_short_version, '33.0.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.nextcloud.desktopclient') AND version_compare(bundle_short_version, '33.0.4') < 0);"
       },
       "installer_url": "https://github.com/nextcloud-releases/desktop/releases/download/v33.0.4/Nextcloud-33.0.4.pkg",
       "install_script_ref": "1072c9cc",

--- a/ee/maintained-apps/outputs/nordpass/darwin.json
+++ b/ee/maintained-apps/outputs/nordpass/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.6.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass') AND version_compare(bundle_short_version, '7.6.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.nordsec.nordpass') AND version_compare(bundle_short_version, '7.6.20') < 0);"
       },
       "installer_url": "https://downloads.npass.app/mac/arm/NordPass.dmg",
       "install_script_ref": "4a839c31",

--- a/ee/maintained-apps/outputs/nordvpn/darwin.json
+++ b/ee/maintained-apps/outputs/nordvpn/darwin.json
@@ -4,7 +4,7 @@
       "version": "10.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos') AND version_compare(bundle_short_version, '10.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.nordvpn.macos') AND version_compare(bundle_short_version, '10.2.0') < 0);"
       },
       "installer_url": "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/10.2.0/NordVPN.pkg",
       "install_script_ref": "60b24e24",

--- a/ee/maintained-apps/outputs/notepad++/windows.json
+++ b/ee/maintained-apps/outputs/notepad++/windows.json
@@ -4,7 +4,7 @@
       "version": "8.9.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Notepad++' AND publisher = 'Notepad++ Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Notepad++' AND publisher = 'Notepad++ Team') AND version_compare(version, '8.9.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Notepad++' AND publisher = 'Notepad++ Team') AND version_compare(version, '8.9.5') < 0);"
       },
       "installer_url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.5/npp.8.9.5.Installer.x64.exe",
       "install_script_ref": "46c6fee6",

--- a/ee/maintained-apps/outputs/notion-calendar/darwin.json
+++ b/ee/maintained-apps/outputs/notion-calendar/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.133.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.cron.electron';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.cron.electron') AND version_compare(bundle_short_version, '1.133.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.cron.electron') AND version_compare(bundle_short_version, '1.133.0') < 0);"
       },
       "installer_url": "https://calendar-desktop-release.notion-static.com/Notion%20Calendar-darwin-arm64-1.133.0.zip",
       "install_script_ref": "d0f24b42",

--- a/ee/maintained-apps/outputs/notion/darwin.json
+++ b/ee/maintained-apps/outputs/notion/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.17.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'notion.id';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'notion.id') AND version_compare(bundle_short_version, '7.17.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'notion.id') AND version_compare(bundle_short_version, '7.17.0') < 0);"
       },
       "installer_url": "https://desktop-release.notion-static.com/Notion-7.17.0-arm64.dmg",
       "install_script_ref": "d8e3e0c4",

--- a/ee/maintained-apps/outputs/notion/windows.json
+++ b/ee/maintained-apps/outputs/notion/windows.json
@@ -4,7 +4,7 @@
       "version": "7.14.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc') AND version_compare(version, '7.14.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc') AND version_compare(version, '7.14.0') < 0);"
       },
       "installer_url": "https://desktop-release.notion-static.com/Notion%20Setup%207.14.0.exe",
       "install_script_ref": "0803ad8c",

--- a/ee/maintained-apps/outputs/nova/darwin.json
+++ b/ee/maintained-apps/outputs/nova/darwin.json
@@ -4,7 +4,7 @@
       "version": "13.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Nova';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Nova') AND version_compare(bundle_short_version, '13.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.panic.Nova') AND version_compare(bundle_short_version, '13.4') < 0);"
       },
       "installer_url": "https://panic.com/download/nova/Nova%2013.4.zip",
       "install_script_ref": "ce3cd317",

--- a/ee/maintained-apps/outputs/nudge/darwin.json
+++ b/ee/maintained-apps/outputs/nudge/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.1.2.81856",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.macadmins.Nudge';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.macadmins.Nudge') AND version_compare(bundle_short_version, '2.1.2.81856') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.github.macadmins.Nudge') AND version_compare(bundle_short_version, '2.1.2.81856') < 0);"
       },
       "installer_url": "https://github.com/macadmins/nudge/releases/download/v2.1.2.81856/Nudge-2.1.2.81856.pkg",
       "install_script_ref": "ff530f11",

--- a/ee/maintained-apps/outputs/obs/darwin.json
+++ b/ee/maintained-apps/outputs/obs/darwin.json
@@ -4,7 +4,7 @@
       "version": "32.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.obsproject.obs-studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.obsproject.obs-studio') AND version_compare(bundle_short_version, '32.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.obsproject.obs-studio') AND version_compare(bundle_short_version, '32.1.2') < 0);"
       },
       "installer_url": "https://cdn-fastly.obsproject.com/downloads/obs-studio-32.1.2-macos-apple.dmg",
       "install_script_ref": "8309d0cb",

--- a/ee/maintained-apps/outputs/obs/windows.json
+++ b/ee/maintained-apps/outputs/obs/windows.json
@@ -4,7 +4,7 @@
       "version": "32.1.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project') AND version_compare(version, '32.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'OBS Studio' AND publisher = 'OBS Project') AND version_compare(version, '32.1.2') < 0);"
       },
       "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.1.2/OBS-Studio-32.1.2-Windows-x64-Installer.exe",
       "install_script_ref": "8a919fae",

--- a/ee/maintained-apps/outputs/obsidian/darwin.json
+++ b/ee/maintained-apps/outputs/obsidian/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.12.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'md.obsidian';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'md.obsidian') AND version_compare(bundle_short_version, '1.12.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'md.obsidian') AND version_compare(bundle_short_version, '1.12.7') < 0);"
       },
       "installer_url": "https://github.com/obsidianmd/obsidian-releases/releases/download/v1.12.7/Obsidian-1.12.7.dmg",
       "install_script_ref": "8f4703ba",

--- a/ee/maintained-apps/outputs/okta-verify/darwin.json
+++ b/ee/maintained-apps/outputs/okta-verify/darwin.json
@@ -4,7 +4,7 @@
       "version": "9.63.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.okta.mobile';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.okta.mobile') AND version_compare(bundle_short_version, '9.63.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.okta.mobile') AND version_compare(bundle_short_version, '9.63.0') < 0);"
       },
       "installer_url": "https://okta.okta.com/artifacts/OKTA_VERIFY_MACOS/9.63.0/OktaVerify-9.63.0-6186-0c33212.pkg",
       "install_script_ref": "9061389b",

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -4,7 +4,7 @@
       "version": "0.24.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama') AND version_compare(bundle_short_version, '0.24.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.electron.ollama') AND version_compare(bundle_short_version, '0.24.0') < 0);"
       },
       "installer_url": "https://github.com/ollama/ollama/releases/download/v0.24.0/Ollama-darwin.zip",
       "install_script_ref": "9f174559",

--- a/ee/maintained-apps/outputs/ollama/windows.json
+++ b/ee/maintained-apps/outputs/ollama/windows.json
@@ -4,7 +4,7 @@
       "version": "0.24.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama') AND version_compare(version, '0.24.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Ollama' AND publisher = 'Ollama') AND version_compare(version, '0.24.0') < 0);"
       },
       "installer_url": "https://github.com/ollama/ollama/releases/download/v0.24.0/OllamaSetup.exe",
       "install_script_ref": "e14c71ee",

--- a/ee/maintained-apps/outputs/omnigraffle/darwin.json
+++ b/ee/maintained-apps/outputs/omnigraffle/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.25.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.omnigroup.OmniGraffle7';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.omnigroup.OmniGraffle7') AND version_compare(bundle_short_version, '7.25.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.omnigroup.OmniGraffle7') AND version_compare(bundle_short_version, '7.25.2') < 0);"
       },
       "installer_url": "https://downloads.omnigroup.com/software/macOS/12/OmniGraffle-7.25.2.dmg",
       "install_script_ref": "d2d63787",

--- a/ee/maintained-apps/outputs/omnissa-horizon-client/darwin.json
+++ b/ee/maintained-apps/outputs/omnissa-horizon-client/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.omnissa.horizon.client.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.omnissa.horizon.client.mac') AND version_compare(bundle_short_version, '8.16.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.omnissa.horizon.client.mac') AND version_compare(bundle_short_version, '8.16.0') < 0);"
       },
       "installer_url": "https://download3.omnissa.com/software/CART26FQ2_MAC_2506/Omnissa-Horizon-Client-2506-8.16.0-16536825094.dmg",
       "install_script_ref": "b3b16504",

--- a/ee/maintained-apps/outputs/onedrive/darwin.json
+++ b/ee/maintained-apps/outputs/onedrive/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.063.0405.0002",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive') AND version_compare(bundle_short_version, '26.063.0405.0002') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.OneDrive') AND version_compare(bundle_short_version, '26.063.0405.0002') < 0);"
       },
       "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.063.0405.0002/universal/OneDrive.pkg",
       "install_script_ref": "1e78de1c",

--- a/ee/maintained-apps/outputs/openvpn-connect/darwin.json
+++ b/ee/maintained-apps/outputs/openvpn-connect/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.8.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.openvpn.client.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.openvpn.client.app') AND version_compare(bundle_short_version, '3.8.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.openvpn.client.app') AND version_compare(bundle_short_version, '3.8.1') < 0);"
       },
       "installer_url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-3.8.1.5790_signed.dmg",
       "install_script_ref": "2ebecc60",

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -4,7 +4,7 @@
       "version": "131.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera') AND version_compare(bundle_short_version, '131.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.operasoftware.Opera') AND version_compare(bundle_short_version, '131.0') < 0);"
       },
       "installer_url": "https://get.geo.opera.com/pub/opera/desktop/131.0.5877.55/mac/Opera_131.0.5877.55_Setup.dmg",
       "install_script_ref": "3b931dc9",

--- a/ee/maintained-apps/outputs/orbstack/darwin.json
+++ b/ee/maintained-apps/outputs/orbstack/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt') AND version_compare(bundle_short_version, '2.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'dev.kdrag0n.MacVirt') AND version_compare(bundle_short_version, '2.1.3') < 0);"
       },
       "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.1.3_20115_arm64.dmg",
       "install_script_ref": "1ca1398e",

--- a/ee/maintained-apps/outputs/p4v/darwin.json
+++ b/ee/maintained-apps/outputs/p4v/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.perforce.p4v';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.perforce.p4v') AND version_compare(bundle_short_version, '2026.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.perforce.p4v') AND version_compare(bundle_short_version, '2026.1') < 0);"
       },
       "installer_url": "https://filehost.perforce.com/perforce/r26.1/bin.macosx12u/P4V.dmg",
       "install_script_ref": "bbe80cf5",

--- a/ee/maintained-apps/outputs/parallels/darwin.json
+++ b/ee/maintained-apps/outputs/parallels/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.3.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.parallels.desktop.console';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.parallels.desktop.console') AND version_compare(bundle_short_version, '26.3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.parallels.desktop.console') AND version_compare(bundle_short_version, '26.3.2') < 0);"
       },
       "installer_url": "https://download.parallels.com/desktop/v26/26.3.2-57398/ParallelsDesktop-26.3.2-57398.dmg",
       "install_script_ref": "1142d1f5",

--- a/ee/maintained-apps/outputs/pgadmin4/darwin.json
+++ b/ee/maintained-apps/outputs/pgadmin4/darwin.json
@@ -4,7 +4,7 @@
       "version": "9.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4') AND version_compare(bundle_short_version, '9.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.pgadmin.pgadmin4') AND version_compare(bundle_short_version, '9.15') < 0);"
       },
       "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.15/macos/pgadmin4-9.15-arm64.dmg",
       "install_script_ref": "f011b895",

--- a/ee/maintained-apps/outputs/phpstorm/darwin.json
+++ b/ee/maintained-apps/outputs/phpstorm/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm') AND version_compare(bundle_short_version, '2026.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.PhpStorm') AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1.1-aarch64.dmg",
       "install_script_ref": "902fe9f9",

--- a/ee/maintained-apps/outputs/podman-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/podman-desktop/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.27.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop') AND version_compare(bundle_short_version, '1.27.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'io.podmandesktop.PodmanDesktop') AND version_compare(bundle_short_version, '1.27.1') < 0);"
       },
       "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.27.1/podman-desktop-1.27.1-arm64.dmg",
       "install_script_ref": "203496d5",

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -4,7 +4,7 @@
       "version": "12.11.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac') AND version_compare(bundle_short_version, '12.11.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.postmanlabs.mac') AND version_compare(bundle_short_version, '12.11.2') < 0);"
       },
       "installer_url": "https://dl.pstmn.io/download/version/12.11.2/osx_arm64",
       "install_script_ref": "96d73870",

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -4,7 +4,7 @@
       "version": "12.11.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.11.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.11.0') < 0);"
       },
       "installer_url": "https://dl.pstmn.io/download/version/12.11.0/windows_64",
       "install_script_ref": "538f63bf",

--- a/ee/maintained-apps/outputs/pritunl/darwin.json
+++ b/ee/maintained-apps/outputs/pritunl/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.3.4566.62",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl') AND version_compare(bundle_short_version, '1.3.4566.62') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.electron.pritunl') AND version_compare(bundle_short_version, '1.3.4566.62') < 0);"
       },
       "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4566.62/Pritunl.pkg.zip",
       "install_script_ref": "50fa15ff",

--- a/ee/maintained-apps/outputs/privileges/darwin.json
+++ b/ee/maintained-apps/outputs/privileges/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.5.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'corp.sap.privileges';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'corp.sap.privileges') AND version_compare(bundle_short_version, '2.5.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'corp.sap.privileges') AND version_compare(bundle_short_version, '2.5.3') < 0);"
       },
       "installer_url": "https://github.com/SAP/macOS-enterprise-privileges/releases/download/2.5.3/Privileges_2.5.3.pkg",
       "install_script_ref": "5bb63e36",

--- a/ee/maintained-apps/outputs/proton-mail/darwin.json
+++ b/ee/maintained-apps/outputs/proton-mail/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.12.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop') AND version_compare(bundle_short_version, '1.12.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'ch.protonmail.desktop') AND version_compare(bundle_short_version, '1.12.1') < 0);"
       },
       "installer_url": "https://proton.me/download/mail/macos/1.12.1/ProtonMail-desktop.dmg",
       "install_script_ref": "b4912f29",

--- a/ee/maintained-apps/outputs/protonvpn/darwin.json
+++ b/ee/maintained-apps/outputs/protonvpn/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.5.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonvpn.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonvpn.mac') AND version_compare(bundle_short_version, '6.5.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'ch.protonvpn.mac') AND version_compare(bundle_short_version, '6.5.1') < 0);"
       },
       "installer_url": "https://vpn.protondownload.com/download/macos/6.5.1/ProtonVPN_mac_v6.5.1.dmg",
       "install_script_ref": "74000e5c",

--- a/ee/maintained-apps/outputs/proxifier/darwin.json
+++ b/ee/maintained-apps/outputs/proxifier/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.initex.proxifier.v3.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.initex.proxifier.v3.macos') AND version_compare(bundle_short_version, '3.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.initex.proxifier.v3.macos') AND version_compare(bundle_short_version, '3.15') < 0);"
       },
       "installer_url": "https://www.proxifier.com/download/ProxifierMac.dmg",
       "install_script_ref": "29aa068c",

--- a/ee/maintained-apps/outputs/proxyman/darwin.json
+++ b/ee/maintained-apps/outputs/proxyman/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.10.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.proxyman.NSProxy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.proxyman.NSProxy') AND version_compare(bundle_short_version, '6.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.proxyman.NSProxy') AND version_compare(bundle_short_version, '6.10.0') < 0);"
       },
       "installer_url": "https://download.proxyman.com/61000/Proxyman_6.10.0.dmg",
       "install_script_ref": "0152bcaa",

--- a/ee/maintained-apps/outputs/putty/windows.json
+++ b/ee/maintained-apps/outputs/putty/windows.json
@@ -4,7 +4,7 @@
       "version": "0.83.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'PuTTY release %' AND publisher = 'Simon Tatham';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'PuTTY release %' AND publisher = 'Simon Tatham') AND version_compare(version, '0.83.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'PuTTY release %' AND publisher = 'Simon Tatham') AND version_compare(version, '0.83.0.0') < 0);"
       },
       "installer_url": "https://the.earth.li/~sgtatham/putty/0.83/w64/putty-64bit-0.83-installer.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/pycharm-ce/darwin.json
+++ b/ee/maintained-apps/outputs/pycharm-ce/darwin.json
@@ -4,7 +4,7 @@
       "version": "2025.2.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.pycharm.ce';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.pycharm.ce') AND version_compare(bundle_short_version, '2025.2.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.pycharm.ce') AND version_compare(bundle_short_version, '2025.2.5') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/python/pycharm-community-2025.2.5-aarch64.dmg",
       "install_script_ref": "a31eab0c",

--- a/ee/maintained-apps/outputs/pycharm/darwin.json
+++ b/ee/maintained-apps/outputs/pycharm/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.pycharm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.pycharm') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.pycharm') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/python/pycharm-professional-2026.1.2-aarch64.dmg",
       "install_script_ref": "965320c8",

--- a/ee/maintained-apps/outputs/rancher/darwin.json
+++ b/ee/maintained-apps/outputs/rancher/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.22.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.rancherdesktop.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'io.rancherdesktop.app') AND version_compare(bundle_short_version, '1.22.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'io.rancherdesktop.app') AND version_compare(bundle_short_version, '1.22.3') < 0);"
       },
       "installer_url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.22.3/Rancher.Desktop-1.22.3.aarch64.dmg",
       "install_script_ref": "b85fd429",

--- a/ee/maintained-apps/outputs/rapidapi/darwin.json
+++ b/ee/maintained-apps/outputs/rapidapi/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.5.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.luckymarmot.Paw';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.luckymarmot.Paw') AND version_compare(bundle_short_version, '4.5.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.luckymarmot.Paw') AND version_compare(bundle_short_version, '4.5.5') < 0);"
       },
       "installer_url": "https://cdn-builds.paw.cloud/paw/RapidAPI-4.5.5.zip",
       "install_script_ref": "0df9725c",

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.104.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos') AND version_compare(bundle_short_version, '1.104.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.raycast.macos') AND version_compare(bundle_short_version, '1.104.17') < 0);"
       },
       "installer_url": "https://releases.raycast.com/releases/1.104.17/download?build=arm",
       "install_script_ref": "8461608e",

--- a/ee/maintained-apps/outputs/rectangle/darwin.json
+++ b/ee/maintained-apps/outputs/rectangle/darwin.json
@@ -4,7 +4,7 @@
       "version": "0.95",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.knollsoft.Rectangle';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.knollsoft.Rectangle') AND version_compare(bundle_short_version, '0.95') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.knollsoft.Rectangle') AND version_compare(bundle_short_version, '0.95') < 0);"
       },
       "installer_url": "https://github.com/rxhanson/Rectangle/releases/download/v0.95/Rectangle0.95.dmg",
       "install_script_ref": "371087aa",

--- a/ee/maintained-apps/outputs/rider/darwin.json
+++ b/ee/maintained-apps/outputs/rider/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider') AND version_compare(bundle_short_version, '2026.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.rider') AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.1-aarch64.dmg",
       "install_script_ref": "84469f70",

--- a/ee/maintained-apps/outputs/royal-tsx/darwin.json
+++ b/ee/maintained-apps/outputs/royal-tsx/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.4.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lemonmojo.RoyalTSX.App';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.lemonmojo.RoyalTSX.App') AND version_compare(bundle_short_version, '6.4.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.lemonmojo.RoyalTSX.App') AND version_compare(bundle_short_version, '6.4.3') < 0);"
       },
       "installer_url": "https://royaltsx-v6.royalapps.com/updates/royaltsx_6.4.3.1000.dmg",
       "install_script_ref": "8a40c4cb",

--- a/ee/maintained-apps/outputs/rubymine/darwin.json
+++ b/ee/maintained-apps/outputs/rubymine/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.rubymine') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1.2-aarch64.dmg",
       "install_script_ref": "8f81415c",

--- a/ee/maintained-apps/outputs/rustrover/darwin.json
+++ b/ee/maintained-apps/outputs/rustrover/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.rustrover') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/rustrover/RustRover-2026.1.2-aarch64.dmg",
       "install_script_ref": "028dc763",

--- a/ee/maintained-apps/outputs/santa/darwin.json
+++ b/ee/maintained-apps/outputs/santa/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.northpolesec.santa';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.northpolesec.santa') AND version_compare(bundle_short_version, '2026.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.northpolesec.santa') AND version_compare(bundle_short_version, '2026.3') < 0);"
       },
       "installer_url": "https://github.com/northpolesec/santa/releases/download/2026.3/santa-2026.3.dmg",
       "install_script_ref": "7d1fb427",

--- a/ee/maintained-apps/outputs/sequel-ace/darwin.json
+++ b/ee/maintained-apps/outputs/sequel-ace/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sequelace.SequelAce';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.sequelace.SequelAce') AND version_compare(bundle_short_version, '5.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.sequelace.SequelAce') AND version_compare(bundle_short_version, '5.2.1') < 0);"
       },
       "installer_url": "https://github.com/Sequel-Ace/Sequel-Ace/releases/download/production/5.2.1-20100/Sequel-Ace-5.2.1.zip",
       "install_script_ref": "fd823f80",

--- a/ee/maintained-apps/outputs/shottr/darwin.json
+++ b/ee/maintained-apps/outputs/shottr/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.9.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cc.ffitch.shottr';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'cc.ffitch.shottr') AND version_compare(bundle_short_version, '1.9.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'cc.ffitch.shottr') AND version_compare(bundle_short_version, '1.9.1') < 0);"
       },
       "installer_url": "https://shottr.cc/dl/Shottr-1.9.1.dmg",
       "install_script_ref": "71416b4f",

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.10.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop') AND version_compare(bundle_short_version, '8.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.whispersystems.signal-desktop') AND version_compare(bundle_short_version, '8.10.0') < 0);"
       },
       "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.10.0.zip",
       "install_script_ref": "fac7f399",

--- a/ee/maintained-apps/outputs/sketch/darwin.json
+++ b/ee/maintained-apps/outputs/sketch/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bohemiancoding.sketch3';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.bohemiancoding.sketch3') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.bohemiancoding.sketch3') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.sketch.com/sketch-2026.1.2-228390.zip",
       "install_script_ref": "af1163b0",

--- a/ee/maintained-apps/outputs/slack/darwin.json
+++ b/ee/maintained-apps/outputs/slack/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.50.121",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap') AND version_compare(bundle_short_version, '4.50.121') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.tinyspeck.slackmacgap') AND version_compare(bundle_short_version, '4.50.121') < 0);"
       },
       "installer_url": "https://slack.com/api/desktop.latestRelease?redirect=1&variant=pkg&arch=universal",
       "install_script_ref": "6025885d",

--- a/ee/maintained-apps/outputs/slack/windows.json
+++ b/ee/maintained-apps/outputs/slack/windows.json
@@ -4,7 +4,7 @@
       "version": "4.50.121",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.') AND version_compare(version, '4.50.121') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Slack' AND publisher = 'Slack Technologies Inc.') AND version_compare(version, '4.50.121') < 0);"
       },
       "installer_url": "https://downloads.slack-edge.com/desktop-releases/windows/x64/4.50.121/Slack.msix",
       "install_script_ref": "1d82bbc6",

--- a/ee/maintained-apps/outputs/snagit/darwin.json
+++ b/ee/maintained-apps/outputs/snagit/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.TechSmith.Snagit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.TechSmith.Snagit') AND version_compare(bundle_short_version, '2026.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.TechSmith.Snagit') AND version_compare(bundle_short_version, '2026.1.0') < 0);"
       },
       "installer_url": "https://download.techsmith.com/snagitmac/releases/2026.1.0/snagit.dmg",
       "install_script_ref": "38b5a841",

--- a/ee/maintained-apps/outputs/sourcetree/darwin.json
+++ b/ee/maintained-apps/outputs/sourcetree/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.2.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.torusknot.SourceTreeNotMAS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.torusknot.SourceTreeNotMAS') AND version_compare(bundle_short_version, '4.2.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.torusknot.SourceTreeNotMAS') AND version_compare(bundle_short_version, '4.2.17') < 0);"
       },
       "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_4.2.17_311.zip",
       "install_script_ref": "524920c6",

--- a/ee/maintained-apps/outputs/sourcetree/windows.json
+++ b/ee/maintained-apps/outputs/sourcetree/windows.json
@@ -4,7 +4,7 @@
       "version": "3.4.30",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Sourcetree Enterprise' AND publisher = 'Atlassian';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Sourcetree Enterprise' AND publisher = 'Atlassian') AND version_compare(version, '3.4.30') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Sourcetree Enterprise' AND publisher = 'Atlassian') AND version_compare(version, '3.4.30') < 0);"
       },
       "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourcetreeEnterpriseSetup_3.4.30.msi",
       "install_script_ref": "17f62246",

--- a/ee/maintained-apps/outputs/splashtop-business/darwin.json
+++ b/ee/maintained-apps/outputs/splashtop-business/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.8.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.stb.macosx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.stb.macosx') AND version_compare(bundle_short_version, '3.8.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.splashtop.stb.macosx') AND version_compare(bundle_short_version, '3.8.4.0') < 0);"
       },
       "installer_url": "https://d17kmd0va0f0mp.cloudfront.net/macclient/STB/Splashtop_Business_Mac_INSTALLER_v3.8.4.0.dmg",
       "install_script_ref": "4013dae8",

--- a/ee/maintained-apps/outputs/splashtop-streamer/darwin.json
+++ b/ee/maintained-apps/outputs/splashtop-streamer/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.8.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer') AND version_compare(bundle_short_version, '3.8.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.splashtop.Splashtop-Streamer') AND version_compare(bundle_short_version, '3.8.4.0') < 0);"
       },
       "installer_url": "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v3.8.4.0.dmg",
       "install_script_ref": "f00dbb7b",

--- a/ee/maintained-apps/outputs/spotify/darwin.json
+++ b/ee/maintained-apps/outputs/spotify/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.2.89.539",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client') AND version_compare(bundle_short_version, '1.2.89.539') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.spotify.client') AND version_compare(bundle_short_version, '1.2.89.539') < 0);"
       },
       "installer_url": "https://download.scdn.co/SpotifyARM64.dmg",
       "install_script_ref": "fc3fdef8",

--- a/ee/maintained-apps/outputs/spotify/windows.json
+++ b/ee/maintained-apps/outputs/spotify/windows.json
@@ -4,7 +4,7 @@
       "version": "1.2.89.539.gfb3c63a3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB') AND version_compare(version, '1.2.89.539.gfb3c63a3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Spotify' AND publisher = 'Spotify AB') AND version_compare(version, '1.2.89.539.gfb3c63a3') < 0);"
       },
       "installer_url": "https://download.scdn.co/SpotifyFullSetupX64.exe",
       "install_script_ref": "7e4727ac",

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.12.14",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats') AND version_compare(bundle_short_version, '2.12.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'eu.exelban.Stats') AND version_compare(bundle_short_version, '2.12.14') < 0);"
       },
       "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.14/Stats.dmg",
       "install_script_ref": "f88ba8e0",

--- a/ee/maintained-apps/outputs/steam/darwin.json
+++ b/ee/maintained-apps/outputs/steam/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.valvesoftware.steam';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.valvesoftware.steam') AND version_compare(bundle_short_version, '6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.valvesoftware.steam') AND version_compare(bundle_short_version, '6.0') < 0);"
       },
       "installer_url": "https://cdn.cloudflare.steamstatic.com/client/installer/steam.dmg",
       "install_script_ref": "11351382",

--- a/ee/maintained-apps/outputs/steam/windows.json
+++ b/ee/maintained-apps/outputs/steam/windows.json
@@ -4,7 +4,7 @@
       "version": "2.10.91.91",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Steam' AND publisher = 'Valve Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Steam' AND publisher = 'Valve Corporation') AND version_compare(version, '2.10.91.91') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Steam' AND publisher = 'Valve Corporation') AND version_compare(version, '2.10.91.91') < 0);"
       },
       "installer_url": "https://cdn.akamai.steamstatic.com/client/installer/SteamSetup.exe",
       "install_script_ref": "abd50ee4",

--- a/ee/maintained-apps/outputs/sublime-merge/darwin.json
+++ b/ee/maintained-apps/outputs/sublime-merge/darwin.json
@@ -4,7 +4,7 @@
       "version": "Build 2125",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sublimemerge';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.sublimemerge') AND version_compare(bundle_short_version, 'Build 2125') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.sublimemerge') AND version_compare(bundle_short_version, 'Build 2125') < 0);"
       },
       "installer_url": "https://download.sublimetext.com/sublime_merge_build_2125_mac.zip",
       "install_script_ref": "72f00fad",

--- a/ee/maintained-apps/outputs/sublime-text/darwin.json
+++ b/ee/maintained-apps/outputs/sublime-text/darwin.json
@@ -4,7 +4,7 @@
       "version": "Build 4200",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sublimetext.4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.sublimetext.4') AND version_compare(bundle_short_version, 'Build 4200') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.sublimetext.4') AND version_compare(bundle_short_version, 'Build 4200') < 0);"
       },
       "installer_url": "https://download.sublimetext.com/sublime_text_build_4200_mac.zip",
       "install_script_ref": "109c9962",

--- a/ee/maintained-apps/outputs/sublime-text/windows.json
+++ b/ee/maintained-apps/outputs/sublime-text/windows.json
@@ -4,7 +4,7 @@
       "version": "4.0.0.420000",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Sublime Text' AND publisher = 'Sublime HQ Pty Ltd';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Sublime Text' AND publisher = 'Sublime HQ Pty Ltd') AND version_compare(version, '4.0.0.420000') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Sublime Text' AND publisher = 'Sublime HQ Pty Ltd') AND version_compare(version, '4.0.0.420000') < 0);"
       },
       "installer_url": "https://download.sublimetext.com/sublime_text_build_4200_x64_setup.exe",
       "install_script_ref": "ab680647",

--- a/ee/maintained-apps/outputs/surfshark/darwin.json
+++ b/ee/maintained-apps/outputs/surfshark/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.27.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct') AND version_compare(bundle_short_version, '4.27.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.surfshark.vpnclient.macos.direct') AND version_compare(bundle_short_version, '4.27.0') < 0);"
       },
       "installer_url": "https://downloads.surfshark.com/macOS/stable/4.27.0/4324/Surfshark.dmg",
       "install_script_ref": "f1af60b5",

--- a/ee/maintained-apps/outputs/suspicious-package/darwin.json
+++ b/ee/maintained-apps/outputs/suspicious-package/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.6.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.SuspiciousPackage';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.SuspiciousPackage') AND version_compare(bundle_short_version, '4.6.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.mothersruin.SuspiciousPackage') AND version_compare(bundle_short_version, '4.6.1') < 0);"
       },
       "installer_url": "https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg",
       "install_script_ref": "4b49b778",

--- a/ee/maintained-apps/outputs/swiftdialog/darwin.json
+++ b/ee/maintained-apps/outputs/swiftdialog/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog') AND version_compare(bundle_short_version, '3.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'au.csiro.dialog') AND version_compare(bundle_short_version, '3.0.1') < 0);"
       },
       "installer_url": "https://github.com/swiftDialog/swiftDialog/releases/download/v3.0.1/dialog-3.0.1-4955.pkg",
       "install_script_ref": "a2e5b6be",

--- a/ee/maintained-apps/outputs/tableau/darwin.json
+++ b/ee/maintained-apps/outputs/tableau/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tableausoftware.Desktop.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.tableausoftware.Desktop.app') AND version_compare(bundle_short_version, '2026.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.tableausoftware.Desktop.app') AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
       "installer_url": "https://downloads.tableau.com/esdalt/2026.1.1/TableauDesktop-2026-1-1-arm64.dmg",
       "install_script_ref": "3d60fdfd",

--- a/ee/maintained-apps/outputs/tableplus/darwin.json
+++ b/ee/maintained-apps/outputs/tableplus/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus') AND version_compare(bundle_short_version, '7.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.tinyapp.TablePlus') AND version_compare(bundle_short_version, '7.0.0') < 0);"
       },
       "installer_url": "https://files.tableplus.com/macos/700/TablePlus.dmg",
       "install_script_ref": "6ebc9cac",

--- a/ee/maintained-apps/outputs/tailscale-app/darwin.json
+++ b/ee/maintained-apps/outputs/tailscale-app/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.98.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.tailscale.ipn.macsys';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'io.tailscale.ipn.macsys') AND version_compare(bundle_short_version, '1.98.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'io.tailscale.ipn.macsys') AND version_compare(bundle_short_version, '1.98.2') < 0);"
       },
       "installer_url": "https://pkgs.tailscale.com/stable/Tailscale-1.98.2-macos.pkg",
       "install_script_ref": "efaa1aa0",

--- a/ee/maintained-apps/outputs/tailscale/windows.json
+++ b/ee/maintained-apps/outputs/tailscale/windows.json
@@ -4,7 +4,7 @@
       "version": "1.98.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Tailscale' AND publisher = 'Tailscale Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Tailscale' AND publisher = 'Tailscale Inc.') AND version_compare(version, '1.98.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Tailscale' AND publisher = 'Tailscale Inc.') AND version_compare(version, '1.98.2') < 0);"
       },
       "installer_url": "https://pkgs.tailscale.com/stable/tailscale-setup-1.98.2-amd64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/teamviewer/darwin.json
+++ b/ee/maintained-apps/outputs/teamviewer/darwin.json
@@ -4,7 +4,7 @@
       "version": "15.76.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.teamviewer.TeamViewer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.teamviewer.TeamViewer') AND version_compare(bundle_short_version, '15.76.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.teamviewer.TeamViewer') AND version_compare(bundle_short_version, '15.76.6') < 0);"
       },
       "installer_url": "https://dl.teamviewer.com/download/version_15x/update/15.76.6/TeamViewer.pkg",
       "install_script_ref": "71f9d405",

--- a/ee/maintained-apps/outputs/teamviewer/windows.json
+++ b/ee/maintained-apps/outputs/teamviewer/windows.json
@@ -4,7 +4,7 @@
       "version": "15.76.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'TeamViewer' AND publisher = 'TeamViewer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'TeamViewer' AND publisher = 'TeamViewer') AND version_compare(version, '15.76.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'TeamViewer' AND publisher = 'TeamViewer') AND version_compare(version, '15.76.6') < 0);"
       },
       "installer_url": "https://download.teamviewer.com/download/version_15x/TeamViewer_Setup_x64_15.76.6.exe",
       "install_script_ref": "45f422bf",

--- a/ee/maintained-apps/outputs/telegram/windows.json
+++ b/ee/maintained-apps/outputs/telegram/windows.json
@@ -4,7 +4,7 @@
       "version": "6.8.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC') AND version_compare(version, '6.8.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC') AND version_compare(version, '6.8.2') < 0);"
       },
       "installer_url": "https://td.telegram.org/tx64/tsetup-x64.6.8.2.exe",
       "install_script_ref": "0b88a95e",

--- a/ee/maintained-apps/outputs/teleport-connect/darwin.json
+++ b/ee/maintained-apps/outputs/teleport-connect/darwin.json
@@ -4,7 +4,7 @@
       "version": "18.8.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect') AND version_compare(bundle_short_version, '18.8.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'gravitational.teleport.connect') AND version_compare(bundle_short_version, '18.8.1') < 0);"
       },
       "installer_url": "https://cdn.teleport.dev/Teleport%20Connect-18.8.1.dmg",
       "install_script_ref": "2d18e0ca",

--- a/ee/maintained-apps/outputs/teleport-suite/darwin.json
+++ b/ee/maintained-apps/outputs/teleport-suite/darwin.json
@@ -4,7 +4,7 @@
       "version": "18.8.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.gravitational.teleport.tsh';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.gravitational.teleport.tsh') AND version_compare(bundle_short_version, '18.8.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.gravitational.teleport.tsh') AND version_compare(bundle_short_version, '18.8.1') < 0);"
       },
       "installer_url": "https://cdn.teleport.dev/teleport-18.8.1.pkg",
       "install_script_ref": "7a279a2a",

--- a/ee/maintained-apps/outputs/textexpander/darwin.json
+++ b/ee/maintained-apps/outputs/textexpander/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.4.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.smileonmymac.textexpander';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.smileonmymac.textexpander') AND version_compare(bundle_short_version, '8.4.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.smileonmymac.textexpander') AND version_compare(bundle_short_version, '8.4.3') < 0);"
       },
       "installer_url": "https://cdn.textexpander.com/mac/843.7/TextExpander_8.4.3.dmg",
       "install_script_ref": "f5683078",

--- a/ee/maintained-apps/outputs/the-unarchiver/darwin.json
+++ b/ee/maintained-apps/outputs/the-unarchiver/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.3.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cx.c3.theunarchiver';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'cx.c3.theunarchiver') AND version_compare(bundle_short_version, '4.3.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'cx.c3.theunarchiver') AND version_compare(bundle_short_version, '4.3.9') < 0);"
       },
       "installer_url": "https://dl.devmate.com/com.macpaw.site.theunarchiver/147/1742287964/TheUnarchiver-147.zip",
       "install_script_ref": "9b767367",

--- a/ee/maintained-apps/outputs/thunderbird/darwin.json
+++ b/ee/maintained-apps/outputs/thunderbird/darwin.json
@@ -4,7 +4,7 @@
       "version": "150.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird') AND version_compare(bundle_short_version, '150.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.mozilla.thunderbird') AND version_compare(bundle_short_version, '150.0.2') < 0);"
       },
       "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/150.0.2/mac/en-US/Thunderbird%20150.0.2.dmg",
       "install_script_ref": "158d6bf3",

--- a/ee/maintained-apps/outputs/thunderbird/windows.json
+++ b/ee/maintained-apps/outputs/thunderbird/windows.json
@@ -4,7 +4,7 @@
       "version": "150.0.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla') AND version_compare(version, '150.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla') AND version_compare(version, '150.0.2') < 0);"
       },
       "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/150.0.2/win64/en-US/Thunderbird%20Setup%20150.0.2.exe",
       "install_script_ref": "26f2daf8",

--- a/ee/maintained-apps/outputs/todoist-app/darwin.json
+++ b/ee/maintained-apps/outputs/todoist-app/darwin.json
@@ -4,7 +4,7 @@
       "version": "9.27.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todoist.mac.Todoist';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.todoist.mac.Todoist') AND version_compare(bundle_short_version, '9.27.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.todoist.mac.Todoist') AND version_compare(bundle_short_version, '9.27.1') < 0);"
       },
       "installer_url": "https://electron-dl.todoist.com/mac/Todoist-darwin-9.27.1-arm64-latest.dmg",
       "install_script_ref": "ace689e3",

--- a/ee/maintained-apps/outputs/tor-browser/darwin.json
+++ b/ee/maintained-apps/outputs/tor-browser/darwin.json
@@ -4,7 +4,7 @@
       "version": "15.0.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser') AND version_compare(bundle_short_version, '15.0.13') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.torproject.torbrowser') AND version_compare(bundle_short_version, '15.0.13') < 0);"
       },
       "installer_url": "https://www.torproject.org/dist/torbrowser/15.0.13/tor-browser-macos-15.0.13.dmg",
       "install_script_ref": "c62f94f8",

--- a/ee/maintained-apps/outputs/tower/darwin.json
+++ b/ee/maintained-apps/outputs/tower/darwin.json
@@ -4,7 +4,7 @@
       "version": "16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.fournova.Tower';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.fournova.Tower') AND version_compare(bundle_short_version, '16.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.fournova.Tower') AND version_compare(bundle_short_version, '16.0') < 0);"
       },
       "installer_url": "https://www.git-tower.com/apps/tower3-mac/534-1e48e030/Tower-16.0-534.zip",
       "install_script_ref": "59069b9f",

--- a/ee/maintained-apps/outputs/transmit/darwin.json
+++ b/ee/maintained-apps/outputs/transmit/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.11.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Transmit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Transmit') AND version_compare(bundle_short_version, '5.11.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.panic.Transmit') AND version_compare(bundle_short_version, '5.11.6') < 0);"
       },
       "installer_url": "https://download-cdn.panic.com/transmit/Transmit%205.11.6.zip",
       "install_script_ref": "55acb255",

--- a/ee/maintained-apps/outputs/tunnelblick/darwin.json
+++ b/ee/maintained-apps/outputs/tunnelblick/darwin.json
@@ -4,7 +4,7 @@
       "version": "8.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.tunnelblick.tunnelblick';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'net.tunnelblick.tunnelblick') AND version_compare(bundle_short_version, '8.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'net.tunnelblick.tunnelblick') AND version_compare(bundle_short_version, '8.0.1') < 0);"
       },
       "installer_url": "https://tunnelblick.net/iprelease/Tunnelblick_8.0.1_build_6301.dmg",
       "install_script_ref": "114a42cd",

--- a/ee/maintained-apps/outputs/twingate/darwin.json
+++ b/ee/maintained-apps/outputs/twingate/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.120",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.twingate.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.twingate.macos') AND version_compare(bundle_short_version, '2026.120') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.twingate.macos') AND version_compare(bundle_short_version, '2026.120') < 0);"
       },
       "installer_url": "https://binaries.twingate.com/client/macos/2026.120.24748/Twingate.pkg",
       "install_script_ref": "bc774d90",

--- a/ee/maintained-apps/outputs/twingate/windows.json
+++ b/ee/maintained-apps/outputs/twingate/windows.json
@@ -4,7 +4,7 @@
       "version": "20.26.120.9484",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.') AND version_compare(version, '20.26.120.9484') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Twingate' AND publisher = 'Twingate Inc.') AND version_compare(version, '20.26.120.9484') < 0);"
       },
       "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.120.9484/TwingateWindowsInstaller.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/utm/darwin.json
+++ b/ee/maintained-apps/outputs/utm/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.7.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.utmapp.UTM';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.utmapp.UTM') AND version_compare(bundle_short_version, '4.7.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.utmapp.UTM') AND version_compare(bundle_short_version, '4.7.5') < 0);"
       },
       "installer_url": "https://github.com/utmapp/UTM/releases/download/v4.7.5/UTM.dmg",
       "install_script_ref": "7687f17e",

--- a/ee/maintained-apps/outputs/virtualbox/darwin.json
+++ b/ee/maintained-apps/outputs/virtualbox/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.2.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox') AND version_compare(bundle_short_version, '7.2.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.virtualbox.app.VirtualBox') AND version_compare(bundle_short_version, '7.2.8') < 0);"
       },
       "installer_url": "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-macOSArm64.dmg",
       "install_script_ref": "aa84721d",

--- a/ee/maintained-apps/outputs/viscosity/darwin.json
+++ b/ee/maintained-apps/outputs/viscosity/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.12.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.viscosityvpn.Viscosity';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.viscosityvpn.Viscosity') AND version_compare(bundle_short_version, '1.12.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.viscosityvpn.Viscosity') AND version_compare(bundle_short_version, '1.12.1') < 0);"
       },
       "installer_url": "https://swupdate.sparklabs.com/download/mac/release/viscosity/Viscosity%201.12.1.dmg",
       "install_script_ref": "54b2d2f1",

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.120.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode') AND version_compare(bundle_short_version, '1.120.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.VSCode') AND version_compare(bundle_short_version, '1.120.0') < 0);"
       },
       "installer_url": "https://update.code.visualstudio.com/1.120.0/darwin-arm64/stable",
       "install_script_ref": "e6d54100",

--- a/ee/maintained-apps/outputs/visual-studio-code/windows.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/windows.json
@@ -4,7 +4,7 @@
       "version": "1.119.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation') AND version_compare(version, '1.119.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation') AND version_compare(version, '1.119.0') < 0);"
       },
       "installer_url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/8b640eef5a6c6089c029249d48efa5c99adf7d51/VSCodeSetup-x64-1.119.0.exe",
       "install_script_ref": "49122823",

--- a/ee/maintained-apps/outputs/vlc/darwin.json
+++ b/ee/maintained-apps/outputs/vlc/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.0.23",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.videolan.vlc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.videolan.vlc') AND version_compare(bundle_short_version, '3.0.23') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.videolan.vlc') AND version_compare(bundle_short_version, '3.0.23') < 0);"
       },
       "installer_url": "https://get.videolan.org/vlc/3.0.23/macosx/vlc-3.0.23-arm64.dmg",
       "install_script_ref": "ef2741e8",

--- a/ee/maintained-apps/outputs/vlc/windows.json
+++ b/ee/maintained-apps/outputs/vlc/windows.json
@@ -4,7 +4,7 @@
       "version": "3.0.23",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'VLC media player' AND publisher = 'VideoLAN';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'VLC media player' AND publisher = 'VideoLAN') AND version_compare(version, '3.0.23') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'VLC media player' AND publisher = 'VideoLAN') AND version_compare(version, '3.0.23') < 0);"
       },
       "installer_url": "https://download.videolan.org/pub/videolan/vlc/3.0.23/win64/vlc-3.0.23-win64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/vnc-viewer/darwin.json
+++ b/ee/maintained-apps/outputs/vnc-viewer/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.15.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.realvnc.vncviewer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.realvnc.vncviewer') AND version_compare(bundle_short_version, '7.15.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.realvnc.vncviewer') AND version_compare(bundle_short_version, '7.15.1') < 0);"
       },
       "installer_url": "https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-7.15.1-MacOSX-universal.dmg",
       "install_script_ref": "6478a2e4",

--- a/ee/maintained-apps/outputs/wacom-tablet/darwin.json
+++ b/ee/maintained-apps/outputs/wacom-tablet/darwin.json
@@ -4,7 +4,7 @@
       "version": "6.4.13-4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.wacom.WacomCenter';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.wacom.WacomCenter') AND version_compare(bundle_short_version, '6.4.13-4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.wacom.WacomCenter') AND version_compare(bundle_short_version, '6.4.13-4') < 0);"
       },
       "installer_url": "https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_6.4.13-4.dmg",
       "install_script_ref": "b3be5def",

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -4,7 +4,7 @@
       "version": "0.2026.05.18.05.32.02",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable') AND version_compare(bundle_short_version, '0.2026.05.18.05.32.02') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'dev.warp.Warp-Stable') AND version_compare(bundle_short_version, '0.2026.05.18.05.32.02') < 0);"
       },
       "installer_url": "https://releases.warp.dev/stable/v0.2026.05.18.05.32.stable_02/Warp.dmg",
       "install_script_ref": "4b1c0c37",

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -4,7 +4,7 @@
       "version": "46.5.0.34931",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark') AND version_compare(bundle_short_version, '46.5.0.34931') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'Cisco-Systems.Spark') AND version_compare(bundle_short_version, '46.5.0.34931') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "1fe5b1af",

--- a/ee/maintained-apps/outputs/webex/windows.json
+++ b/ee/maintained-apps/outputs/webex/windows.json
@@ -4,7 +4,7 @@
       "version": "46.5.0.34931",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cisco Webex' AND publisher = 'Cisco Systems, Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Cisco Webex' AND publisher = 'Cisco Systems, Inc') AND version_compare(version, '46.5.0.34931') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Cisco Webex' AND publisher = 'Cisco Systems, Inc') AND version_compare(version, '46.5.0.34931') < 0);"
       },
       "installer_url": "https://binaries.webex.com/WebexDesktop-Win-64-Gold/20260513172520/Webex.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/webstorm/darwin.json
+++ b/ee/maintained-apps/outputs/webstorm/darwin.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.jetbrains.WebStorm') AND version_compare(bundle_short_version, '2026.1.2') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.2-aarch64.dmg",
       "install_script_ref": "a0f305dd",

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -4,7 +4,7 @@
       "version": "26.19.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp') AND version_compare(bundle_short_version, '26.19.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'net.whatsapp.WhatsApp') AND version_compare(bundle_short_version, '26.19.17') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "a776e715",

--- a/ee/maintained-apps/outputs/windows-app/darwin.json
+++ b/ee/maintained-apps/outputs/windows-app/darwin.json
@@ -4,7 +4,7 @@
       "version": "11.3.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.rdc.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.rdc.macos') AND version_compare(bundle_short_version, '11.3.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.microsoft.rdc.macos') AND version_compare(bundle_short_version, '11.3.5') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_11.3.5_installer.pkg",
       "install_script_ref": "efbdee96",

--- a/ee/maintained-apps/outputs/windsurf/darwin.json
+++ b/ee/maintained-apps/outputs/windsurf/darwin.json
@@ -4,7 +4,7 @@
       "version": "2.3.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf') AND version_compare(bundle_short_version, '2.3.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.exafunction.windsurf') AND version_compare(bundle_short_version, '2.3.9') < 0);"
       },
       "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/a5d3f1ff990cabc0e8001cce6642bdb7ad429e73/Windsurf-darwin-arm64-2.3.9.dmg",
       "install_script_ref": "c8128892",

--- a/ee/maintained-apps/outputs/wireshark-app/darwin.json
+++ b/ee/maintained-apps/outputs/wireshark-app/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.6.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.wireshark.Wireshark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.wireshark.Wireshark') AND version_compare(bundle_short_version, '4.6.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.wireshark.Wireshark') AND version_compare(bundle_short_version, '4.6.5') < 0);"
       },
       "installer_url": "https://www.wireshark.org/download/osx/all-versions/Wireshark%204.6.5.dmg",
       "install_script_ref": "3ddd9799",

--- a/ee/maintained-apps/outputs/wireshark/windows.json
+++ b/ee/maintained-apps/outputs/wireshark/windows.json
@@ -4,7 +4,7 @@
       "version": "4.6.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org') AND version_compare(version, '4.6.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org') AND version_compare(version, '4.6.5') < 0);"
       },
       "installer_url": "https://2.na.dl.wireshark.org/win64/all-versions/Wireshark-4.6.5-x64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/wrike/darwin.json
+++ b/ee/maintained-apps/outputs/wrike/darwin.json
@@ -4,7 +4,7 @@
       "version": "4.6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.wrike.Wrike';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.wrike.Wrike') AND version_compare(bundle_short_version, '4.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.wrike.Wrike') AND version_compare(bundle_short_version, '4.6.0') < 0);"
       },
       "installer_url": "https://dl.wrike.com/download/WrikeDesktopApp_ARM.v4.6.0.dmg",
       "install_script_ref": "21525012",

--- a/ee/maintained-apps/outputs/xcreds/darwin.json
+++ b/ee/maintained-apps/outputs/xcreds/darwin.json
@@ -4,7 +4,7 @@
       "version": "5.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.twocanoes.xcreds';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.twocanoes.xcreds') AND version_compare(bundle_short_version, '5.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.twocanoes.xcreds') AND version_compare(bundle_short_version, '5.9') < 0);"
       },
       "installer_url": "https://github.com/twocanoes/xcreds/releases/download/tag-5.9(9148)/XCreds_Build-9148_Version-5.9.pkg",
       "install_script_ref": "319ed828",

--- a/ee/maintained-apps/outputs/yubico-authenticator/darwin.json
+++ b/ee/maintained-apps/outputs/yubico-authenticator/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.yubioath';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.yubioath') AND version_compare(bundle_short_version, '7.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.yubico.yubioath') AND version_compare(bundle_short_version, '7.3.3') < 0);"
       },
       "installer_url": "https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-7.3.3-mac.dmg",
       "install_script_ref": "c6cba690",

--- a/ee/maintained-apps/outputs/yubico-authenticator/windows.json
+++ b/ee/maintained-apps/outputs/yubico-authenticator/windows.json
@@ -4,7 +4,7 @@
       "version": "7.3.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Yubico Authenticator' AND publisher = 'Yubico AB';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Yubico Authenticator' AND publisher = 'Yubico AB') AND version_compare(version, '7.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Yubico Authenticator' AND publisher = 'Yubico AB') AND version_compare(version, '7.3.3') < 0);"
       },
       "installer_url": "https://github.com/Yubico/yubioath-flutter/releases/download/7.3.3/yubico-authenticator-7.3.3-win64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/yubico-yubikey-manager/darwin.json
+++ b/ee/maintained-apps/outputs/yubico-yubikey-manager/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.2.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.ykman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.ykman') AND version_compare(bundle_short_version, '1.2.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.yubico.ykman') AND version_compare(bundle_short_version, '1.2.5') < 0);"
       },
       "installer_url": "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.5-mac.pkg",
       "install_script_ref": "11ef47ae",

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.2.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed') AND version_compare(bundle_short_version, '1.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'dev.zed.Zed') AND version_compare(bundle_short_version, '1.2.6') < 0);"
       },
       "installer_url": "https://zed.dev/api/releases/stable/1.2.6/Zed-aarch64.dmg",
       "install_script_ref": "7a64bca0",

--- a/ee/maintained-apps/outputs/zen/darwin.json
+++ b/ee/maintained-apps/outputs/zen/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.19.13b",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen') AND version_compare(bundle_short_version, '1.19.13b') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'app.zen-browser.zen') AND version_compare(bundle_short_version, '1.19.13b') < 0);"
       },
       "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.19.13b/zen.macos-universal.dmg",
       "install_script_ref": "6dc5817a",

--- a/ee/maintained-apps/outputs/zeplin/darwin.json
+++ b/ee/maintained-apps/outputs/zeplin/darwin.json
@@ -4,7 +4,7 @@
       "version": "10.32.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx') AND version_compare(bundle_short_version, '10.32.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'io.zeplin.osx') AND version_compare(bundle_short_version, '10.32.0') < 0);"
       },
       "installer_url": "https://pkg.zeplin.io/macos/latest/zeplin-darwin-universal.zip",
       "install_script_ref": "afce9a92",

--- a/ee/maintained-apps/outputs/zoom-rooms/darwin.json
+++ b/ee/maintained-apps/outputs/zoom-rooms/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.0.0.12322",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.ZoomPresence';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.ZoomPresence') AND version_compare(bundle_short_version, '7.0.0.12322') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'us.zoom.ZoomPresence') AND version_compare(bundle_short_version, '7.0.0.12322') < 0);"
       },
       "installer_url": "https://cdn.zoom.us/prod/7.0.0.12322/ZoomRooms.pkg",
       "install_script_ref": "6eed23df",

--- a/ee/maintained-apps/outputs/zoom/darwin.json
+++ b/ee/maintained-apps/outputs/zoom/darwin.json
@@ -4,7 +4,7 @@
       "version": "7.0.5.81138",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.xos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.xos') AND version_compare(bundle_short_version, '7.0.5.81138') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'us.zoom.xos') AND version_compare(bundle_short_version, '7.0.5.81138') < 0);"
       },
       "installer_url": "https://zoom.us/client/latest/ZoomInstallerIT.pkg",
       "install_script_ref": "05e6a85c",

--- a/ee/maintained-apps/outputs/zoom/windows.json
+++ b/ee/maintained-apps/outputs/zoom/windows.json
@@ -4,7 +4,7 @@
       "version": "7.0.38856",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND publisher = 'Zoom';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND publisher = 'Zoom') AND version_compare(version, '7.0.38856') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Zoom Workplace (X64)' AND publisher = 'Zoom') AND version_compare(version, '7.0.38856') < 0);"
       },
       "installer_url": "https://zoom.us/client/7.0.5.38856/ZoomInstallerFull.msi?archType=x64",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/zotero/darwin.json
+++ b/ee/maintained-apps/outputs/zotero/darwin.json
@@ -4,7 +4,7 @@
       "version": "9.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero') AND version_compare(bundle_short_version, '9.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'org.zotero.zotero') AND version_compare(bundle_short_version, '9.0.3') < 0);"
       },
       "installer_url": "https://download.zotero.org/client/release/9.0.3/Zotero-9.0.3.dmg",
       "install_script_ref": "c792140b",

--- a/ee/maintained-apps/outputs/zotero/windows.json
+++ b/ee/maintained-apps/outputs/zotero/windows.json
@@ -4,7 +4,7 @@
       "version": "9.0.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship';",
-        "patched": "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship') AND version_compare(version, '9.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship') AND version_compare(version, '9.0.3') < 0);"
       },
       "installer_url": "https://download.zotero.org/client/release/9.0.3/Zotero-9.0.3_x64_setup.exe",
       "install_script_ref": "d29b62d2",

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -19,21 +19,20 @@ type PolicyData struct {
 }
 
 const (
-	templateStart      = "SELECT 1 WHERE NOT EXISTS ("
-	templateEndDarwin  = " AND version_compare(bundle_short_version, '%s') < 0);"
-	templateEndWindows = " AND version_compare(version, '%s') < 0);"
+	// templateStart and templateEnd* wrap the caller-supplied exists query in an
+	// inner set of parentheses so that any OR in the WHERE body binds before the
+	// appended AND version_compare(...) clause.
+	templateStart      = "SELECT 1 WHERE NOT EXISTS (("
+	templateEndDarwin  = ") AND version_compare(bundle_short_version, '%s') < 0);"
+	templateEndWindows = ") AND version_compare(version, '%s') < 0);"
 )
 
 var (
-	ErrWrongPlatform   = errors.New("platform should be darwin or windows")
-	ErrNoExistsQuery   = errors.New("exists query was not provided")
-	ErrNoWhereInExists = errors.New("exists query is missing a WHERE clause")
+	ErrWrongPlatform = errors.New("platform should be darwin or windows")
+	ErrNoExistsQuery = errors.New("exists query was not provided")
 )
 
-// GenerateQueryForManifest wraps the "exists" query to create a patch policy query.
-// The WHERE body of the exists query is wrapped in parentheses so that any OR in
-// the body binds before the appended AND version_compare(...) clause (SQL operator
-// precedence: AND > OR).
+// GenerateQueryForManifest wraps the "exists" query to create a patch policy query
 func GenerateQueryForManifest(p PolicyData) (string, error) {
 	if p.ExistsQuery == "" {
 		return "", ErrNoExistsQuery
@@ -43,18 +42,11 @@ func GenerateQueryForManifest(p PolicyData) (string, error) {
 	// so fmt.Sprintf doesn't interpret them as format verbs.
 	before = strings.ReplaceAll(before, "%", "%%")
 
-	const whereKeyword = " WHERE "
-	idx := strings.Index(before, whereKeyword)
-	if idx < 0 {
-		return "", ErrNoWhereInExists
-	}
-	wrapped := before[:idx+len(whereKeyword)] + "(" + before[idx+len(whereKeyword):] + ")"
-
 	switch p.Platform {
 	case "darwin":
-		return fmt.Sprintf(templateStart+wrapped+templateEndDarwin, p.Version), nil
+		return fmt.Sprintf(templateStart+before+templateEndDarwin, p.Version), nil
 	case "windows":
-		return fmt.Sprintf(templateStart+wrapped+templateEndWindows, p.Version), nil
+		return fmt.Sprintf(templateStart+before+templateEndWindows, p.Version), nil
 	}
 	return "", ErrWrongPlatform
 }

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -25,11 +25,15 @@ const (
 )
 
 var (
-	ErrWrongPlatform = errors.New("platform should be darwin or windows")
-	ErrNoExistsQuery = errors.New("exists query was not provided")
+	ErrWrongPlatform   = errors.New("platform should be darwin or windows")
+	ErrNoExistsQuery   = errors.New("exists query was not provided")
+	ErrNoWhereInExists = errors.New("exists query is missing a WHERE clause")
 )
 
-// GenerateQueryForManifest wraps the "exists" query to create a patch policy query
+// GenerateQueryForManifest wraps the "exists" query to create a patch policy query.
+// The WHERE body of the exists query is wrapped in parentheses so that any OR in
+// the body binds before the appended AND version_compare(...) clause (SQL operator
+// precedence: AND > OR).
 func GenerateQueryForManifest(p PolicyData) (string, error) {
 	if p.ExistsQuery == "" {
 		return "", ErrNoExistsQuery
@@ -39,11 +43,18 @@ func GenerateQueryForManifest(p PolicyData) (string, error) {
 	// so fmt.Sprintf doesn't interpret them as format verbs.
 	before = strings.ReplaceAll(before, "%", "%%")
 
+	const whereKeyword = " WHERE "
+	idx := strings.Index(before, whereKeyword)
+	if idx < 0 {
+		return "", ErrNoWhereInExists
+	}
+	wrapped := before[:idx+len(whereKeyword)] + "(" + before[idx+len(whereKeyword):] + ")"
+
 	switch p.Platform {
 	case "darwin":
-		return fmt.Sprintf(templateStart+before+templateEndDarwin, p.Version), nil
+		return fmt.Sprintf(templateStart+wrapped+templateEndDarwin, p.Version), nil
 	case "windows":
-		return fmt.Sprintf(templateStart+before+templateEndWindows, p.Version), nil
+		return fmt.Sprintf(templateStart+wrapped+templateEndWindows, p.Version), nil
 	}
 	return "", ErrWrongPlatform
 }

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -25,15 +25,11 @@ const (
 )
 
 var (
-	ErrWrongPlatform   = errors.New("platform should be darwin or windows")
-	ErrNoExistsQuery   = errors.New("exists query was not provided")
-	ErrNoWhereInExists = errors.New("exists query is missing a WHERE clause")
+	ErrWrongPlatform = errors.New("platform should be darwin or windows")
+	ErrNoExistsQuery = errors.New("exists query was not provided")
 )
 
-// GenerateQueryForManifest wraps the "exists" query to create a patch policy query.
-// The WHERE body of the exists query is wrapped in parentheses so that any OR in
-// the body binds before the appended AND version_compare(...) clause (SQL operator
-// precedence: AND > OR).
+// GenerateQueryForManifest wraps the "exists" query to create a patch policy query
 func GenerateQueryForManifest(p PolicyData) (string, error) {
 	if p.ExistsQuery == "" {
 		return "", ErrNoExistsQuery
@@ -43,18 +39,11 @@ func GenerateQueryForManifest(p PolicyData) (string, error) {
 	// so fmt.Sprintf doesn't interpret them as format verbs.
 	before = strings.ReplaceAll(before, "%", "%%")
 
-	const whereKeyword = " WHERE "
-	idx := strings.Index(before, whereKeyword)
-	if idx < 0 {
-		return "", ErrNoWhereInExists
-	}
-	wrapped := before[:idx+len(whereKeyword)] + "(" + before[idx+len(whereKeyword):] + ")"
-
 	switch p.Platform {
 	case "darwin":
-		return fmt.Sprintf(templateStart+wrapped+templateEndDarwin, p.Version), nil
+		return fmt.Sprintf(templateStart+before+templateEndDarwin, p.Version), nil
 	case "windows":
-		return fmt.Sprintf(templateStart+wrapped+templateEndWindows, p.Version), nil
+		return fmt.Sprintf(templateStart+before+templateEndWindows, p.Version), nil
 	}
 	return "", ErrWrongPlatform
 }

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -19,20 +19,21 @@ type PolicyData struct {
 }
 
 const (
-	// templateStart and templateEnd* wrap the caller-supplied exists query in an
-	// inner set of parentheses so that any OR in the WHERE body binds before the
-	// appended AND version_compare(...) clause.
-	templateStart      = "SELECT 1 WHERE NOT EXISTS (("
-	templateEndDarwin  = ") AND version_compare(bundle_short_version, '%s') < 0);"
-	templateEndWindows = ") AND version_compare(version, '%s') < 0);"
+	templateStart      = "SELECT 1 WHERE NOT EXISTS ("
+	templateEndDarwin  = " AND version_compare(bundle_short_version, '%s') < 0);"
+	templateEndWindows = " AND version_compare(version, '%s') < 0);"
 )
 
 var (
-	ErrWrongPlatform = errors.New("platform should be darwin or windows")
-	ErrNoExistsQuery = errors.New("exists query was not provided")
+	ErrWrongPlatform   = errors.New("platform should be darwin or windows")
+	ErrNoExistsQuery   = errors.New("exists query was not provided")
+	ErrNoWhereInExists = errors.New("exists query is missing a WHERE clause")
 )
 
-// GenerateQueryForManifest wraps the "exists" query to create a patch policy query
+// GenerateQueryForManifest wraps the "exists" query to create a patch policy query.
+// The WHERE body of the exists query is wrapped in parentheses so that any OR in
+// the body binds before the appended AND version_compare(...) clause (SQL operator
+// precedence: AND > OR).
 func GenerateQueryForManifest(p PolicyData) (string, error) {
 	if p.ExistsQuery == "" {
 		return "", ErrNoExistsQuery
@@ -42,11 +43,18 @@ func GenerateQueryForManifest(p PolicyData) (string, error) {
 	// so fmt.Sprintf doesn't interpret them as format verbs.
 	before = strings.ReplaceAll(before, "%", "%%")
 
+	const whereKeyword = " WHERE "
+	idx := strings.Index(before, whereKeyword)
+	if idx < 0 {
+		return "", ErrNoWhereInExists
+	}
+	wrapped := before[:idx+len(whereKeyword)] + "(" + before[idx+len(whereKeyword):] + ")"
+
 	switch p.Platform {
 	case "darwin":
-		return fmt.Sprintf(templateStart+before+templateEndDarwin, p.Version), nil
+		return fmt.Sprintf(templateStart+wrapped+templateEndDarwin, p.Version), nil
 	case "windows":
-		return fmt.Sprintf(templateStart+before+templateEndWindows, p.Version), nil
+		return fmt.Sprintf(templateStart+wrapped+templateEndWindows, p.Version), nil
 	}
 	return "", ErrWrongPlatform
 }

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -20,7 +20,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo' AND version_compare(bundle_short_version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query",
@@ -29,7 +29,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.' AND version_compare(version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query with LIKE percent wildcard",
@@ -38,7 +38,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "12.5.6",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.5.6') < 0);",
 		},
 		{
 			name: "windows from exists query with multiple LIKE percent wildcards",
@@ -47,16 +47,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "139.0.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
-		},
-		{
-			name: "windows from exists query containing OR (precedence fix)",
-			p: patch_policy.PolicyData{
-				Platform:    "windows",
-				Version:     "0.130.0",
-				ExistsQuery: "SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b';",
-			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla' AND version_compare(version, '139.0.0') < 0);",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -20,7 +20,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query",
@@ -29,7 +29,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query with LIKE percent wildcard",
@@ -38,7 +38,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "12.5.6",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
 		},
 		{
 			name: "windows from exists query with multiple LIKE percent wildcards",
@@ -47,7 +47,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "139.0.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
 		},
 		{
 			name: "windows from exists query containing OR (precedence fix)",
@@ -56,7 +56,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "0.130.0",
 				ExistsQuery: "SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -20,7 +20,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo' AND version_compare(bundle_short_version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query",
@@ -29,7 +29,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.' AND version_compare(version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query with LIKE percent wildcard",
@@ -38,7 +38,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "12.5.6",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.5.6') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
 		},
 		{
 			name: "windows from exists query with multiple LIKE percent wildcards",
@@ -47,7 +47,16 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "139.0.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla' AND version_compare(version, '139.0.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
+		},
+		{
+			name: "windows from exists query containing OR (precedence fix)",
+			p: patch_policy.PolicyData{
+				Platform:    "windows",
+				Version:     "0.130.0",
+				ExistsQuery: "SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b';",
+			},
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -20,7 +20,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE (bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query",
@@ -29,7 +29,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query with LIKE percent wildcard",
@@ -38,7 +38,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "12.5.6",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
 		},
 		{
 			name: "windows from exists query with multiple LIKE percent wildcards",
@@ -47,7 +47,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "139.0.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE (name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
 		},
 		{
 			name: "windows from exists query containing OR (precedence fix)",
@@ -56,7 +56,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "0.130.0",
 				ExistsQuery: "SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Normalize the SQL used for "patched" checks by removing an extra set of outer parentheses and placing parentheses around the inner WHERE conditions. This updates the generated/expected patched queries across many ee/maintained-apps JSON outputs, the Homebrew ingester test, and pkg/patch_policy (and its tests) so the version_compare and existence checks are formatted consistently and parse as intended.
