### PR TITLE
Refactor GenerateQueryForManifest query building

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -158,7 +158,7 @@ func TestIngestValidations(t *testing.T) {
 				)
 			} else {
 				require.Equal(t,
-					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = '%s') AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
+					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
 					out.Queries.Patched,
 				)
 			}

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -18,37 +18,54 @@ type PolicyData struct {
 	Version     string
 }
 
-const (
-	// templateStart and templateEnd* wrap the caller-supplied exists query in an
-	// inner set of parentheses so that any OR in the WHERE body binds before the
-	// appended AND version_compare(...) clause.
-	templateStart      = "SELECT 1 WHERE NOT EXISTS (("
-	templateEndDarwin  = ") AND version_compare(bundle_short_version, '%s') < 0);"
-	templateEndWindows = ") AND version_compare(version, '%s') < 0);"
-)
+const existsQueryPrefix = "SELECT 1 FROM "
 
 var (
 	ErrWrongPlatform = errors.New("platform should be darwin or windows")
 	ErrNoExistsQuery = errors.New("exists query was not provided")
 )
 
-// GenerateQueryForManifest wraps the "exists" query to create a patch policy query
+// GenerateQueryForManifest wraps the "exists" query to create a patch policy query.
+// The exists query must be of the form: SELECT 1 FROM <table> WHERE <conditions>;
+// The patched query moves version_compare into the NOT EXISTS subquery WHERE clause.
 func GenerateQueryForManifest(p PolicyData) (string, error) {
 	if p.ExistsQuery == "" {
 		return "", ErrNoExistsQuery
 	}
-	before, _ := strings.CutSuffix(p.ExistsQuery, ";")
-	// Escape any literal '%' in the exists query (e.g. SQL LIKE patterns)
-	// so fmt.Sprintf doesn't interpret them as format verbs.
-	before = strings.ReplaceAll(before, "%", "%%")
 
+	var versionCompare string
 	switch p.Platform {
 	case "darwin":
-		return fmt.Sprintf(templateStart+before+templateEndDarwin, p.Version), nil
+		versionCompare = fmt.Sprintf("version_compare(bundle_short_version, '%s') < 0", p.Version)
 	case "windows":
-		return fmt.Sprintf(templateStart+before+templateEndWindows, p.Version), nil
+		versionCompare = fmt.Sprintf("version_compare(version, '%s') < 0", p.Version)
+	default:
+		return "", ErrWrongPlatform
 	}
-	return "", ErrWrongPlatform
+
+	before, _ := strings.CutSuffix(p.ExistsQuery, ";")
+	before = strings.TrimSpace(before)
+	if !strings.HasPrefix(before, existsQueryPrefix) {
+		return "", fmt.Errorf("exists query must start with %q", existsQueryPrefix)
+	}
+
+	rest := strings.TrimPrefix(before, existsQueryPrefix)
+	whereIdx := strings.Index(rest, " WHERE ")
+	if whereIdx < 0 {
+		return "", errors.New("exists query must contain a WHERE clause")
+	}
+
+	table := rest[:whereIdx]
+	conditions := rest[whereIdx+len(" WHERE "):]
+	// Parenthesize OR conditions so AND binds to version_compare before OR.
+	if strings.Contains(conditions, " OR ") {
+		conditions = "(" + conditions + ")"
+	}
+
+	return fmt.Sprintf(
+		"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM %s WHERE %s AND %s);",
+		table, conditions, versionCompare,
+	), nil
 }
 
 // GenerateFromInstaller creates a patch policy with all fields from an installer

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -20,7 +20,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo') AND version_compare(bundle_short_version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.foo' AND version_compare(bundle_short_version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query",
@@ -29,7 +29,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "1.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.') AND version_compare(version, '1.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Foo x64' AND publisher = 'Bar, Inc.' AND version_compare(version, '1.0') < 0);",
 		},
 		{
 			name: "windows from exists query with LIKE percent wildcard",
@@ -38,7 +38,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "12.5.6",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman') AND version_compare(version, '12.5.6') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.5.6') < 0);",
 		},
 		{
 			name: "windows from exists query with multiple LIKE percent wildcards",
@@ -47,7 +47,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "139.0.0",
 				ExistsQuery: "SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla') AND version_compare(version, '139.0.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox % ESR %' AND publisher = 'Mozilla' AND version_compare(version, '139.0.0') < 0);",
 		},
 		{
 			name: "windows from exists query containing OR (precedence fix)",
@@ -56,7 +56,7 @@ func TestGenerateQueryForManifest(t *testing.T) {
 				Version:     "0.130.0",
 				ExistsQuery: "SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b';",
 			},
-			want: "SELECT 1 WHERE NOT EXISTS ((SELECT 1 FROM file WHERE path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
+			want: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path = 'C:\\a' OR path LIKE '%\\b') AND version_compare(version, '0.130.0') < 0);",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Replace ad-hoc template concatenation with parsing and validation of the caller-provided EXISTS query in GenerateQueryForManifest. The function now enforces the "SELECT 1 FROM " prefix, extracts the table and WHERE conditions, parenthesizes OR conditions so AND binds correctly to version_compare, and returns clear errors for missing WHERE or wrong platform. Corresponding expected SQL strings in tests were updated (including a homebrew ingester test) to match the new query format.
