### PR TITLE
Use stored platform for installers so zip-based Windows FMAs can install

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1589,8 +1589,7 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 }
 
 func (svc *Service) installSoftwareTitleUsingInstaller(ctx context.Context, host *fleet.Host, installer *fleet.SoftwareInstaller) error {
-	ext := filepath.Ext(installer.Name)
-	requiredPlatform := packageExtensionToPlatform(ext)
+	ext, requiredPlatform := installerRequiredPlatform(installer)
 	if requiredPlatform == "" {
 		// this should never happen
 		return ctxerr.Errorf(ctx, "software installer has unsupported type %s", ext)
@@ -1699,8 +1698,7 @@ func (svc *Service) UninstallSoftwareTitle(ctx context.Context, hostID uint, sof
 	}
 
 	// Validate platform
-	ext := filepath.Ext(installer.Name)
-	requiredPlatform := packageExtensionToPlatform(ext)
+	ext, requiredPlatform := installerRequiredPlatform(installer)
 	if requiredPlatform == "" {
 		// this should never happen
 		return ctxerr.Errorf(ctx, "software installer has unsupported type %s", ext)
@@ -3223,8 +3221,7 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 			}
 		}
 
-		ext := filepath.Ext(installer.Name)
-		requiredPlatform := packageExtensionToPlatform(ext)
+		ext, requiredPlatform := installerRequiredPlatform(installer)
 		if requiredPlatform == "" {
 			// this should never happen
 			return ctxerr.Errorf(ctx, "software installer has unsupported type %s", ext)
@@ -3335,6 +3332,17 @@ func (svc *Service) selfServiceInstallInHouseApp(ctx context.Context, host *flee
 
 	err = svc.ds.InsertHostInHouseAppInstall(ctx, host.ID, iha.InstallerID, softwareTitleID, uuid.NewString(), fleet.HostSoftwareInstallOptions{SelfService: true})
 	return ctxerr.Wrap(ctx, err, "insert in house app install")
+}
+
+// installerRequiredPlatform returns the file extension and the platform required
+// to install the package. The installer's stored Platform is authoritative when
+// set (e.g. .zip is used on both darwin and windows).
+func installerRequiredPlatform(installer *fleet.SoftwareInstaller) (ext, requiredPlatform string) {
+	ext = filepath.Ext(installer.Name)
+	if installer.Platform != "" {
+		return ext, installer.Platform
+	}
+	return ext, packageExtensionToPlatform(ext)
 }
 
 // packageExtensionToPlatform returns the platform name based on the

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3355,8 +3355,9 @@ func installerRequiredPlatform(installer *fleet.SoftwareInstaller) (ext, require
 // SoftwareInstallerPlatformFromExtension).
 //
 // .zip is intentionally omitted: it is ambiguous across platforms (a Windows
-// installer or a macOS app bundle), so the stored Platform must be used. Only FMAs allow 
-// for .zip uploads which require a Platform, so this fallback is never hit for zip.
+// installer or a macOS app bundle), so the stored Platform must be used. Both
+// FMAs and uploads always set Platform for .zip, so this fallback is never hit
+// for zip.
 func packageExtensionToPlatform(ext string) string {
 	var requiredPlatform string
 	switch ext {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3334,9 +3334,10 @@ func (svc *Service) selfServiceInstallInHouseApp(ctx context.Context, host *flee
 	return ctxerr.Wrap(ctx, err, "insert in house app install")
 }
 
-// installerRequiredPlatform returns the file extension and the platform required
-// to install the package. The installer's stored Platform is authoritative when
-// set (e.g. .zip is used on both darwin and windows).
+// installerRequiredPlatform returns the file extension and the platform used for
+// platform validation. The installer's stored Platform is used when set (e.g.
+// .zip installers may target windows or darwin). Note that `.sh` installers are
+// stored as platform=linux but are allowed on any unix-like host by callers.
 func installerRequiredPlatform(installer *fleet.SoftwareInstaller) (ext, requiredPlatform string) {
 	ext = filepath.Ext(installer.Name)
 	if installer.Platform != "" {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3346,17 +3346,23 @@ func installerRequiredPlatform(installer *fleet.SoftwareInstaller) (ext, require
 }
 
 // packageExtensionToPlatform returns the platform name based on the
-// package extension. Returns an empty string if there is no match.
+// package extension. Returns an empty string if there is no match. This is only
+// used as a fallback by installerRequiredPlatform when an installer has no
+// stored Platform; prefer the stored Platform, which is authoritative.
 //
 // .msix is included for Fleet-maintained Windows apps only; custom package
 // upload still rejects .msix (see addMetadataToSoftwarePayload and
 // SoftwareInstallerPlatformFromExtension).
+//
+// .zip is intentionally omitted: it is ambiguous across platforms (a Windows
+// installer or a macOS app bundle), so the stored Platform must be used. Only FMAs allow 
+// for .zip uploads which require a Platform, so this fallback is never hit for zip.
 func packageExtensionToPlatform(ext string) string {
 	var requiredPlatform string
 	switch ext {
 	case ".msi", ".exe", ".ps1", ".msix":
 		requiredPlatform = "windows"
-	case ".pkg", ".dmg", ".zip":
+	case ".pkg", ".dmg":
 		requiredPlatform = "darwin"
 	case ".deb", ".rpm", ".gz", ".tgz", ".sh":
 		requiredPlatform = "linux"

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -954,6 +954,63 @@ func TestInstallShScriptOnDarwin(t *testing.T) {
 	require.True(t, ds.InsertSoftwareInstallRequestFuncInvoked, "install request should be created")
 }
 
+// TestInstallZipInstallerUsesStoredPlatform tests that .zip installers use the
+// stored platform (windows or darwin) rather than inferring darwin from the extension.
+func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc := newTestService(t, ds)
+
+	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return &fleet.Host{
+			ID:           1,
+			OrbitNodeKey: ptr.String("orbit_key"),
+			Platform:     "windows",
+			TeamID:       ptr.Uint(1),
+		}, nil
+	}
+
+	ds.GetInHouseAppMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) (*fleet.SoftwareInstaller, error) {
+		return nil, nil
+	}
+
+	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{
+			InstallerID: 10,
+			Name:        "codex-x86_64-pc-windows-msvc.exe.zip",
+			Extension:   "zip",
+			Platform:    "windows",
+			TeamID:      ptr.Uint(1),
+			TitleID:     ptr.Uint(100),
+			SelfService: false,
+		}, nil
+	}
+
+	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
+		return true, nil
+	}
+
+	ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
+		return nil, nil
+	}
+
+	ds.ResetNonPolicyInstallAttemptsFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint) error {
+		return nil
+	}
+
+	ds.InsertSoftwareInstallRequestFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
+		return "install-uuid", nil
+	}
+
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{
+		User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+	})
+
+	err := svc.InstallSoftwareTitle(ctx, 1, 100)
+	require.NoError(t, err, ".zip windows installer on windows host should succeed")
+	require.True(t, ds.InsertSoftwareInstallRequestFuncInvoked, "install request should be created")
+}
+
 // TestInstallShScriptOnWindowsFails tests that .sh scripts can't be installed on Windows hosts.
 func TestInstallShScriptOnWindowsFails(t *testing.T) {
 	t.Parallel()

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -963,7 +963,6 @@ func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {
 
 	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
 		return &fleet.Host{
-		return &fleet.Host{
 			ID:           1,
 			OrbitNodeKey: new("orbit_key"),
 			Platform:     "windows",
@@ -1009,6 +1008,101 @@ func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {
 
 	err := svc.InstallSoftwareTitle(ctx, 1, 100)
 	require.NoError(t, err, ".zip windows installer on windows host should succeed")
+	require.True(t, ds.InsertSoftwareInstallRequestFuncInvoked, "install request should be created")
+}
+
+// TestUninstallZipInstallerUsesStoredPlatform tests that .zip installers use the
+// stored platform during uninstall, so a Windows host can uninstall a Windows
+// .zip package without the helper inferring darwin from the extension.
+func TestUninstallZipInstallerUsesStoredPlatform(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc := newTestService(t, ds)
+
+	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return &fleet.Host{
+			ID:           1,
+			OrbitNodeKey: new("orbit_key"),
+			Platform:     "windows",
+			TeamID:       new(uint(1)),
+		}, nil
+	}
+
+	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{
+			InstallerID:              10,
+			Name:                     "codex-x86_64-pc-windows-msvc.exe.zip",
+			Extension:                "zip",
+			Platform:                 "windows",
+			TeamID:                   new(uint(1)),
+			TitleID:                  new(uint(100)),
+			UninstallScriptContentID: 20,
+		}, nil
+	}
+
+	ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
+		return nil, nil
+	}
+
+	ds.GetAnyScriptContentsFunc = func(ctx context.Context, id uint) ([]byte, error) {
+		return []byte("uninstall script"), nil
+	}
+
+	ds.InsertSoftwareUninstallRequestFunc = func(ctx context.Context, executionID string, hostID uint, softwareInstallerID uint, selfService bool) error {
+		return nil
+	}
+
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{
+		User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)},
+	})
+
+	err := svc.UninstallSoftwareTitle(ctx, 1, 100)
+	require.NoError(t, err, ".zip windows installer on windows host should uninstall")
+	require.True(t, ds.InsertSoftwareUninstallRequestFuncInvoked, "uninstall request should be created")
+}
+
+// TestSelfServiceInstallZipInstallerUsesStoredPlatform tests that .zip
+// installers use the stored platform during self-service install, so a Windows
+// host can self-service install a Windows .zip package without the helper
+// inferring darwin from the extension.
+func TestSelfServiceInstallZipInstallerUsesStoredPlatform(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc := newTestService(t, ds)
+
+	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{
+			InstallerID: 10,
+			Name:        "codex-x86_64-pc-windows-msvc.exe.zip",
+			Extension:   "zip",
+			Platform:    "windows",
+			TeamID:      new(uint(1)),
+			TitleID:     new(uint(100)),
+			SelfService: true,
+		}, nil
+	}
+
+	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
+		return true, nil
+	}
+
+	ds.ResetNonPolicyInstallAttemptsFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint) error {
+		return nil
+	}
+
+	ds.InsertSoftwareInstallRequestFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
+		return "install-uuid", nil
+	}
+
+	host := &fleet.Host{
+		ID:           1,
+		OrbitNodeKey: new("orbit_key"),
+		Platform:     "windows",
+		TeamID:       new(uint(1)),
+	}
+
+	err := svc.SelfServiceInstallSoftwareTitle(context.Background(), host, 100)
+	require.NoError(t, err, ".zip windows installer on windows host should self-service install")
 	require.True(t, ds.InsertSoftwareInstallRequestFuncInvoked, "install request should be created")
 }
 

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -963,10 +963,11 @@ func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {
 
 	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
 		return &fleet.Host{
+		return &fleet.Host{
 			ID:           1,
-			OrbitNodeKey: ptr.String("orbit_key"),
+			OrbitNodeKey: new("orbit_key"),
 			Platform:     "windows",
-			TeamID:       ptr.Uint(1),
+			TeamID:       new(uint(1)),
 		}, nil
 	}
 
@@ -980,8 +981,8 @@ func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {
 			Name:        "codex-x86_64-pc-windows-msvc.exe.zip",
 			Extension:   "zip",
 			Platform:    "windows",
-			TeamID:      ptr.Uint(1),
-			TitleID:     ptr.Uint(100),
+			TeamID:      new(uint(1)),
+			TitleID:     new(uint(100)),
 			SelfService: false,
 		}, nil
 	}
@@ -1003,7 +1004,7 @@ func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {
 	}
 
 	ctx := viewer.NewContext(context.Background(), viewer.Viewer{
-		User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+		User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)},
 	})
 
 	err := svc.InstallSoftwareTitle(ctx, 1, 100)


### PR DESCRIPTION
This pull request improves how the platform is determined for software installers, ensuring that the installer's stored platform is used when available, rather than inferring it from the file extension. This is especially important for `.zip` installers, which may be used on multiple platforms. The changes also add a new test to verify this behavior.

Trying to install a zip-based FMA on Windows:
<img width="1485" height="499" alt="Screenshot 2026-06-04 at 12 39 50 PM" src="https://github.com/user-attachments/assets/cbeecefd-6376-44d9-8e93-dd93f0c714f9" />



**Platform detection improvements:**

* Added the `installerRequiredPlatform` helper function, which returns the file extension and uses the installer's stored `Platform` field if set; otherwise, it falls back to inferring the platform from the extension. This ensures correct handling for installers like `.zip` files used on both Windows and macOS.
* Updated all relevant service methods (`installSoftwareTitleUsingInstaller`, `UninstallSoftwareTitle`, and `SelfServiceInstallSoftwareTitle`) to use `installerRequiredPlatform` for platform validation instead of inferring from the file extension alone. [[1]](diffhunk://#diff-b3883848dac3454f4ed4968a94f9ca335241f9f99bfad92f95a6bfb7157523ebL1592-R1592) [[2]](diffhunk://#diff-b3883848dac3454f4ed4968a94f9ca335241f9f99bfad92f95a6bfb7157523ebL1702-R1701) [[3]](diffhunk://#diff-b3883848dac3454f4ed4968a94f9ca335241f9f99bfad92f95a6bfb7157523ebL3226-R3224)

**Testing improvements:**

* Added a new test, `TestInstallZipInstallerUsesStoredPlatform`, to verify that `.zip` installers use the stored platform (e.g., "windows") rather than inferring "darwin" from the extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Platform enforcement now prefers stored installer platform metadata (zip treated as ambiguous), preventing incorrect platform selection for install, uninstall, and self-service install flows.

* **Tests**
  * Added tests verifying `.zip` installers use stored platform metadata for install, uninstall, and self-service install scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->