### PR TITLE
Improve referrer matching and add domains

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -320,11 +320,15 @@ module.exports = {
             'https://www.quora.com/',
           ];
 
-          if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.some((domain) => marketingAttributionCookie.referrer.startsWith(domain))) {
+          let referrer = typeof marketingAttributionCookie.referrer === 'string'
+            ? marketingAttributionCookie.referrer
+            : '';
+
+          if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.some((domain) => referrer.startsWith(domain))) {
             // If search engine » Organic search
             attributionDetails.sourceChannelDetails = 'Organic search (OS)';
             attributionDetails.campaign = 'Default-OS-Organic';
-          } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.some((domain) => marketingAttributionCookie.referrer.startsWith(domain))) {
+          } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.some((domain) => referrer.startsWith(domain))) {
             // If social media » Organic social
             attributionDetails.sourceChannelDetails = 'Organic social (SOC)';
             attributionDetails.campaign = 'Default-SOC-Social';

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -281,35 +281,50 @@ module.exports = {
         } else {
           // Otherwise, we'll check the referer value and attempt to categorize the referer.
           let REFERRER_DOMAINS_FOR_ORGANIC_SEARCH = [
-            'https://www.google.com/',
+            'https://www.google.',      // covers all ~190 country variants (google.com, google.co.uk, google.de, etc.)
             'https://www.bing.com/',
             'https://search.yahoo.com/',
             'https://duckduckgo.com/',
             'https://www.baidu.com/',
             'https://www.ecosia.org/',
+            'https://www.startpage.com/',
+            'https://search.brave.com/',
+            'https://kagi.com/',
             'https://www.ask.com/',
             'https://www.aol.com/',
-            'https://www.startpage.com/',
+            'https://yandex.com/',
+            'https://yandex.ru/',
           ];
 
           let REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL = [
-            'https://www.facebook.com/',
-            'https://l.facebook.com/',
-            'https://www.instagram.com/',
-            'https://t.co/',
-            'https://x.com/',
             'https://www.linkedin.com/',
+            'https://linkedin.com/',
+            'https://lnkd.in/',
             'https://www.reddit.com/',
             'https://old.reddit.com/',
+            'https://news.ycombinator.com/',
+            'https://x.com/',
+            'https://twitter.com/',
+            'https://www.twitter.com/',
+            'https://t.co/',
+            'https://www.facebook.com/',
+            'https://l.facebook.com/',
+            'https://m.facebook.com/',
+            'https://www.instagram.com/',
+            'https://www.threads.net/',
+            'https://bsky.app/',
+            'https://mastodon.social/',
+            'https://fosstodon.org/',
+            'https://www.youtube.com/',
             'https://www.pinterest.com/',
             'https://www.quora.com/',
           ];
 
-          if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.includes(marketingAttributionCookie.referrer)) {
+          if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.some((domain) => marketingAttributionCookie.referrer.startsWith(domain))) {
             // If search engine » Organic search
             attributionDetails.sourceChannelDetails = 'Organic search (OS)';
             attributionDetails.campaign = 'Default-OS-Organic';
-          } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.includes(marketingAttributionCookie.referrer)) {
+          } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.some((domain) => marketingAttributionCookie.referrer.startsWith(domain))) {
             // If social media » Organic social
             attributionDetails.sourceChannelDetails = 'Organic social (SOC)';
             attributionDetails.campaign = 'Default-SOC-Social';


### PR DESCRIPTION
A small bug in our attribution logic. R

Replace exact equality checks with startsWith() (via Array.some). 

The classification uses Array.includes(), which requires an **exact string match**. 
The lists contain bare root domains:  for example

> 'https://www.linkedin.com/'
> 'https://www.reddit.com/'
> 'https://x.com/'

The stored referrer is always the full URL of the specific page the visitor came from, including path. 

So - if an Organic Social URL was https://www.linkedin.com/feed/ 
It does not equal https://www.linkedin.com/ 
and 
The match fails, and the visit falls through to Web Referral.  (this would be incorrect)


Also - Expand search engine list (generalized Google domain, added Startpage, Brave, Kagi, Yandex entries) and significantly extend social referrer list (LinkedIn variants, lnkd.in, Hacker News, X/Twitter variants, Facebook mobile/l.facebook, Instagram, Threads, Bsky, Mastodon instances, YouTube, Reddit variants, Pinterest, Quora, etc.). 

These changes make Organic search/social detection more accurate across country TLDs, subdomains and shortened links.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Salesforce traffic attribution by expanding organic referrer allowlists and enhancing matching to better detect organic search and social sources.
  * Normalized referrer values when absent or malformed to prevent misclassification, yielding more accurate traffic categorization and attribution reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->