### PR TITLE
Populate referrer fields from marketing cookie

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -483,6 +483,8 @@ module.exports = {
         contactValuesToSet.Most_recent_campaign__c = attributionDetails.campaign;// eslint-disable-line camelcase
         contactValuesToSet.Most_recent_campaign_initial_url__c = attributionDetails.initialUrl;// eslint-disable-line camelcase
         contactValuesToSet.GCLID__c = attributionDetails.gclid;// eslint-disable-line camelcase
+        contactValuesToSet.Source_referrer_url__c = marketingAttributionCookie.referrer;// eslint-disable-line camelcase
+        contactValuesToSet.Most_recent_referrer_url__c = marketingAttributionCookie.referrer;// eslint-disable-line camelcase
       }
 
 
@@ -612,6 +614,7 @@ module.exports = {
           contactValuesToSet.Most_recent_campaign__c = attributionDetails.campaign;// eslint-disable-line camelcase
           contactValuesToSet.Most_recent_campaign_initial_url__c = attributionDetails.initialUrl;// eslint-disable-line camelcase
         }
+        contactValuesToSet.Most_recent_referrer_url__c = marketingAttributionCookie.referrer;// eslint-disable-line camelcase
       }
 
 


### PR DESCRIPTION
Set Salesforce contact referrer fields from marketingAttributionCookie.referrer. Adds Source_referrer_url__c and Most_recent_referrer_url__c assignments in the initial attribution block and an additional Most_recent_referrer_url__c assignment in the later block so referrer data is persisted when creating/updating contacts.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Salesforce integration with improved contact attribution tracking. Referrer information is now automatically captured and stored in designated attribution fields for both newly created and updated contact records, enabling more comprehensive tracking of customer acquisition sources and marketing engagement paths throughout the user journey.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->