### PR TITLE
Fleet UI: Add add variable button, update no results live empty state

### DIFF
--- a/changes/44326-empty-states
+++ b/changes/44326-empty-states
@@ -1,0 +1,3 @@
+- UI table controls stay visible when empty. On Hosts, Reports, Policies, and Software pages, search bars, filters, dropdowns, remain visible but disabled when empty — avoids layout shift when the first item is added. Item count remains visible.
+- UI has action-oriented empty state copy. Headers describe current state ("No hosts", "No policies for this fleet") instead of prompting action. Body text explains what to expect. CTA buttons are explicit ("Add policy", "Schedule a report") and permission gated.
+- UI shows consistent page descriptions and learn more links (added to Settings. Fleets, Ticket destinations, Certificates, and Identity provider pages).

--- a/frontend/pages/ManageControlsPage/Variables/Variables.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tests.tsx
@@ -64,9 +64,11 @@ describe("Custom variables", () => {
             "Add a custom variable to make it available in scripts and profiles."
           )
         ).toBeInTheDocument();
-        expect(
-          screen.getByRole("button", { name: "Add custom variable" })
-        ).toBeInTheDocument();
+        // Header button and EmptyState CTA button both render
+        const addButtons = screen.getAllByRole("button", {
+          name: /Add custom variable/,
+        });
+        expect(addButtons).toHaveLength(2);
       });
     });
 

--- a/frontend/pages/ManageControlsPage/Variables/Variables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tsx
@@ -167,43 +167,19 @@ const Variables = () => {
     </>
   );
 
-  const renderPageDescription = () => (
-    <PageDescription
-      variant="tab-panel"
-      content={
-        <>
-          {isPremiumTier
-            ? "Manage custom variables that will be available in scripts and profiles across all fleets."
-            : "Manage custom variables that will be available in scripts and profiles."}{" "}
-          <CustomLink
-            text="Learn more"
-            url={`${FLEET_WEBSITE_URL}/guides/secrets-in-scripts-and-configuration-profiles`}
-            newTab
-          />
-        </>
-      }
-    />
-  );
+  const isEmpty = !isLoading && data?.count === 0;
 
-  if (isLoading) {
-    return (
-      <div className={baseClass}>
-        <div className={`${baseClass}__page-header`}>
-          {renderPageDescription()}
-        </div>
+  const renderContent = () => {
+    if (isLoading) {
+      return (
         <div className={`${baseClass}__loading`}>
           <Spinner />
         </div>
-      </div>
-    );
-  }
+      );
+    }
 
-  if (data?.count === 0) {
-    return (
-      <div className={baseClass}>
-        <div className={`${baseClass}__page-header`}>
-          {renderPageDescription()}
-        </div>
+    if (isEmpty) {
+      return (
         <EmptyState
           variant="header-list"
           header="No custom variables"
@@ -227,36 +203,10 @@ const Variables = () => {
             ) : undefined
           }
         />
-        {showAddModal && (
-          <AddCustomVariableModal
-            onCancel={() => setShowAddModal(false)}
-            onSave={onSaveVariable}
-          />
-        )}
-      </div>
-    );
-  }
+      );
+    }
 
-  return (
-    <div className={baseClass}>
-      <div className={`${baseClass}__page-header`}>
-        {renderPageDescription()}
-        {canEdit && (
-          <GitOpsModeTooltipWrapper
-            renderChildren={(disableChildren) => (
-              <Button
-                variant="inverse"
-                size="small"
-                onClick={onClickAddVariable}
-                disabled={disableChildren}
-              >
-                <Icon name="plus" />
-                <span>Add custom variable</span>
-              </Button>
-            )}
-          />
-        )}
-      </div>
+    return (
       <PaginatedList<IVariable>
         ref={paginatedListRef}
         pageSize={VARIABLES_PAGE_SIZE}
@@ -281,6 +231,44 @@ const Variables = () => {
           </span>
         }
       />
+    );
+  };
+
+  return (
+    <div className={baseClass}>
+      <div className={`${baseClass}__page-header`}>
+        <PageDescription
+          variant="tab-panel"
+          content={
+            <>
+              {isPremiumTier
+                ? "Manage custom variables that will be available in scripts and profiles across all fleets."
+                : "Manage custom variables that will be available in scripts and profiles."}{" "}
+              <CustomLink
+                text="Learn more"
+                url={`${FLEET_WEBSITE_URL}/guides/secrets-in-scripts-and-configuration-profiles`}
+                newTab
+              />
+            </>
+          }
+        />
+        {canEdit && (
+          <GitOpsModeTooltipWrapper
+            renderChildren={(disableChildren) => (
+              <Button
+                variant="inverse"
+                size="small"
+                onClick={onClickAddVariable}
+                disabled={disableChildren}
+              >
+                <Icon name="plus" />
+                <span>Add custom variable</span>
+              </Button>
+            )}
+          />
+        )}
+      </div>
+      {renderContent()}
       {showAddModal && (
         <AddCustomVariableModal
           onCancel={() => setShowAddModal(false)}

--- a/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
@@ -167,10 +167,13 @@ const PolicyResults = ({
     if (finishedWithNoResults) {
       return (
         <EmptyState
-          header="Your live report returned no results"
-          info={`Expecting to see results? Check to see if the host${
-            targetsTotalCount > 1 ? "s" : ""
-          } you targeted reported "Online" or check out the "Errors" table.`}
+          header="No results returned"
+          info={
+            <>
+              Check whether the host{targetsTotalCount > 1 ? "s" : ""} are
+              online or review the <strong>Errors</strong> tab for details.
+            </>
+          }
         />
       );
     }

--- a/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
@@ -165,13 +165,19 @@ const PolicyResults = ({
     }
 
     if (finishedWithNoResults) {
+      const hostVerb = targetsTotalCount === 1 ? "host is" : "hosts are";
+      const errorsMessage = errors?.length ? (
+        <>
+          {" "}
+          or review the <strong>Errors</strong> tab for details
+        </>
+      ) : null;
       return (
         <EmptyState
           header="No results returned"
           info={
             <>
-              Check whether the host{targetsTotalCount > 1 ? "s" : ""} are
-              online or review the <strong>Errors</strong> tab for details.
+              Check whether the {hostVerb} online{errorsMessage}.
             </>
           }
         />

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -158,10 +158,13 @@ const QueryResults = ({
   const renderNoResults = () => {
     return (
       <EmptyState
-        header="Your live report returned no results"
-        info={`Expecting to see results? Check to see if the host${
-          targetsTotalCount > 1 ? "s" : ""
-        } you targeted reported "Online" or check out the "Errors" table.`}
+        header="No results returned"
+        info={
+          <>
+            Check whether the host{targetsTotalCount > 1 ? "s" : ""} are online
+            or review the <strong>Errors</strong> tab for details.
+          </>
+        }
       />
     );
   };

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -156,13 +156,19 @@ const QueryResults = ({
   };
 
   const renderNoResults = () => {
+    const hostVerb = targetsTotalCount === 1 ? "host is" : "hosts are";
+    const errorsMessage = errors?.length ? (
+      <>
+        {" "}
+        or review the <strong>Errors</strong> tab for details
+      </>
+    ) : null;
     return (
       <EmptyState
         header="No results returned"
         info={
           <>
-            Check whether the host{targetsTotalCount > 1 ? "s" : ""} are online
-            or review the <strong>Errors</strong> tab for details.
+            Check whether the {hostVerb} online{errorsMessage}.
           </>
         }
       />


### PR DESCRIPTION
## Issue
Closes #44326 
Part of #35483

> Note: This is a part of 4.86.0 found while self-QAing Empty states

## Description

<img width="1349" height="721" alt="Screenshot 2026-05-19 at 10 51 03 AM" src="https://github.com/user-attachments/assets/3105eceb-44f8-40a9-8599-e546041d13a7" />

<img width="1350" height="682" alt="Screenshot 2026-05-19 at 11 04 10 AM" src="https://github.com/user-attachments/assets/3c2065d9-ce0c-4c57-9a98-08c125bc31e8" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- [x] Add changelog for #44326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated empty-state test to verify two "Add custom variable" buttons render.

* **Refactor**
  * Streamlined Variables page rendering by centralizing loading and empty-state logic.

* **Bug Fixes**
  * Improved empty-state copy in policy and query result views with clearer, conditional troubleshooting guidance.

* **Documentation**
  * Standardized empty-state behavior and messaging across several pages; table controls remain visible but disabled when lists are empty.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->