### PR TITLE
Update commit SHA in snapshot docker images

### DIFF
--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0


### PR DESCRIPTION
## What's the issue I'm trying to solve here?

1. So I have a PR (say branch name `pr-foobar`).
2. The PR will do a docker publish (say docker image with tag `fleetdm/fleet:pr-foobar`).
3. Load test environment deployed with such docker image tag (`fleetdm/fleet:pr-foobar`).
4. I go to My account > and see Fleet has version `0.0.0-SNAPSHOT-<SOME-SHA>` (0.0.0-SNAPSHOT is expected because it's a branch). Example in screenshot below.
5. I do `git fetch origin && git show <SOME-SHA>` to know exactly what's deployed.
6. Turns out `<SOME-SHA>` is some SHA known to Github, but not in the fleet's git repository.

Problem: I really want to tie what's running with an actual commit SHA. And this PR solves that for these load tests that use branches.

<img width="298" height="809" alt="Screenshot 2026-05-19 at 12 57 05 PM" src="https://github.com/user-attachments/assets/d46fa037-1de5-4cf0-b768-6ec9dbe33620" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow checkout behavior so pull-request-triggered runs use the PR head commit, ensuring the correct code is checked out and improving build/test reliability and snapshot accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->