### PR TITLE
Use ubuntu-latest runner for docs CI check

### DIFF
--- a/.github/workflows/check-automated-doc.yml
+++ b/.github/workflows/check-automated-doc.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   check-doc-gen:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0

--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -336,8 +336,11 @@ type OsqueryCommandLineFlagsMacOS struct {
 	DisableEndpointsecurityFim bool   `json:"disable_endpointsecurity_fim"`
 	EnableKeyboardEvents       bool   `json:"enable_keyboard_events"`
 	EnableMouseEvents          bool   `json:"enable_mouse_events"`
+	EsFimEnableOpenEvents      bool   `json:"es_fim_enable_open_events"`
 	EsFimMutePathLiteral       string `json:"es_fim_mute_path_literal"`
 	EsFimMutePathPrefix        string `json:"es_fim_mute_path_prefix"`
+	KeychainAccessCache        bool   `json:"keychain_access_cache"`
+	KeychainAccessInterval     uint32 `json:"keychain_access_interval"`
 }
 
 // those osquery flags are not OS-specific, but are also not visible using

--- a/server/fleet/agent_options_generated.go
+++ b/server/fleet/agent_options_generated.go
@@ -62,7 +62,6 @@ type osqueryOptions struct {
 	EnableForeign bool `json:"enable_foreign"`
 	EnableNumericMonitoring bool `json:"enable_numeric_monitoring"`
 	Ephemeral bool `json:"ephemeral"`
-	EsFimEnableOpenEvents bool `json:"es_fim_enable_open_events"`
 	EventsExpiry uint64 `json:"events_expiry"`
 	EventsMax uint64 `json:"events_max"`
 	EventsOptimize bool `json:"events_optimize"`
@@ -71,8 +70,6 @@ type osqueryOptions struct {
 	HashCacheMax uint32 `json:"hash_cache_max"`
 	HostIdentifier string `json:"host_identifier"`
 	IgnoreTableExceptions bool `json:"ignore_table_exceptions"`
-	KeychainAccessCache bool `json:"keychain_access_cache"`
-	KeychainAccessInterval uint32 `json:"keychain_access_interval"`
 	LoggerEventType bool `json:"logger_event_type"`
 	LoggerKafkaAcks string `json:"logger_kafka_acks"`
 	LoggerKafkaBrokers string `json:"logger_kafka_brokers"`
@@ -217,7 +214,6 @@ type osqueryCommandLineFlags struct {
 	EnrollSecretPath string `json:"enroll_secret_path"`
 	EnrollTlsEndpoint string `json:"enroll_tls_endpoint"`
 	Ephemeral bool `json:"ephemeral"`
-	EsFimEnableOpenEvents bool `json:"es_fim_enable_open_events"`
 	EventsExpiry uint64 `json:"events_expiry"`
 	EventsMax uint64 `json:"events_max"`
 	EventsOptimize bool `json:"events_optimize"`
@@ -233,8 +229,6 @@ type osqueryCommandLineFlags struct {
 	HostIdentifier string `json:"host_identifier"`
 	IgnoreTableExceptions bool `json:"ignore_table_exceptions"`
 	Install bool `json:"install"`
-	KeychainAccessCache bool `json:"keychain_access_cache"`
-	KeychainAccessInterval uint32 `json:"keychain_access_interval"`
 	LoggerEventType bool `json:"logger_event_type"`
 	LoggerKafkaAcks string `json:"logger_kafka_acks"`
 	LoggerKafkaBrokers string `json:"logger_kafka_brokers"`

--- a/tools/osquery-agent-options/README.md
+++ b/tools/osquery-agent-options/README.md
@@ -4,7 +4,7 @@ This directory contains a script (a Go command) that generates the struct needed
 
 It writes the resulting Go code to stdout (the `osqueryOptions` and the `osqueryCommandLineFlags` structs) to a file provided as argument.
 
-This command only supports macOS.
+This command supports macOS and Linux.
 
 Whenever there's a new version of osquery, just update the variable `osqueryVersion`.
 

--- a/tools/osquery-agent-options/main.go
+++ b/tools/osquery-agent-options/main.go
@@ -66,27 +66,17 @@ type templateData struct {
 
 func main() {
 	fmt.Printf("Generating osquery flags for version: %s\n", osqueryVersion)
-	if runtime.GOOS != "darwin" {
-		log.Fatal("Currently only supported on macOS")
-	}
-	urlStr := fmt.Sprintf("https://updates.fleetdm.com/targets/osqueryd/macos-app/%s/osqueryd.app.tar.gz", osqueryVersion)
-	osqueryTUFURL, err := url.Parse(urlStr)
-	if err != nil {
-		log.Fatalf("parse osquery TUF URL: %q: %s", urlStr, err)
-	}
+
 	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatalf("create temp dir: %s", err)
 	}
 	defer os.RemoveAll(tmpDir)
-	osquerydAppTarGzPath := filepath.Join(tmpDir, "osqueryd.app.tar.gz")
-	if err := download.Download(http.DefaultClient, osqueryTUFURL, osquerydAppTarGzPath); err != nil {
-		log.Fatalf("download osqueryd.app.tar.gz to %s: %s", osquerydAppTarGzPath, err) //nolint:gocritic // ignore exitAfterDefer
+
+	osquerydPath, err := downloadOsqueryd(tmpDir)
+	if err != nil {
+		log.Fatalf("download osqueryd: %s", err) //nolint:gocritic // ignore exitAfterDefer
 	}
-	if err := extractTarGz(osquerydAppTarGzPath); err != nil {
-		log.Fatalf("extract tar.gz %q: %s", osquerydAppTarGzPath, err)
-	}
-	osquerydPath := filepath.Join(filepath.Dir(osquerydAppTarGzPath), "osquery.app", "Contents", "MacOS", "osqueryd")
 
 	// marshal/unmarshal the OS-specific structs into a map so we have all their
 	// keys and we can ignore them in the auto-generated structs (because we
@@ -214,6 +204,44 @@ func main() {
 
 	if err := outputFile.Close(); err != nil {
 		log.Fatalf("close file %q: %s", outputFilePath, err)
+	}
+}
+
+// downloadOsqueryd fetches osqueryd for the current OS into tmpDir and returns
+// the path to the executable. macOS ships as a tar.gz app bundle; Linux ships
+// as a single binary.
+func downloadOsqueryd(tmpDir string) (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		urlStr := fmt.Sprintf("https://updates.fleetdm.com/targets/osqueryd/macos-app/%s/osqueryd.app.tar.gz", osqueryVersion)
+		osqueryTUFURL, err := url.Parse(urlStr)
+		if err != nil {
+			return "", fmt.Errorf("parse osquery TUF URL %q: %w", urlStr, err)
+		}
+		osquerydAppTarGzPath := filepath.Join(tmpDir, "osqueryd.app.tar.gz")
+		if err := download.Download(http.DefaultClient, osqueryTUFURL, osquerydAppTarGzPath); err != nil {
+			return "", fmt.Errorf("download osqueryd.app.tar.gz to %s: %w", osquerydAppTarGzPath, err)
+		}
+		if err := extractTarGz(osquerydAppTarGzPath); err != nil {
+			return "", fmt.Errorf("extract tar.gz %q: %w", osquerydAppTarGzPath, err)
+		}
+		return filepath.Join(tmpDir, "osquery.app", "Contents", "MacOS", "osqueryd"), nil
+	case "linux":
+		urlStr := fmt.Sprintf("https://updates.fleetdm.com/targets/osqueryd/linux/%s/osqueryd", osqueryVersion)
+		osqueryTUFURL, err := url.Parse(urlStr)
+		if err != nil {
+			return "", fmt.Errorf("parse osquery TUF URL %q: %w", urlStr, err)
+		}
+		osquerydPath := filepath.Join(tmpDir, "osqueryd")
+		if err := download.Download(http.DefaultClient, osqueryTUFURL, osquerydPath); err != nil {
+			return "", fmt.Errorf("download osqueryd to %s: %w", osquerydPath, err)
+		}
+		if err := os.Chmod(osquerydPath, 0o755); err != nil { // nolint:gosec // G302
+			return "", fmt.Errorf("chmod osqueryd: %w", err)
+		}
+		return osquerydPath, nil
+	default:
+		return "", fmt.Errorf("unsupported OS: %s (only macOS and Linux are supported)", runtime.GOOS)
 	}
 }
 


### PR DESCRIPTION
I see no reason to use macOS for this job (given how unreliable and slow macOS runners are).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow runner switched to ubuntu-latest.
  * Internal tooling updated to download and prepare the osqueryd binary for macOS and Linux.
  * macOS agent configuration expanded with additional options for keychain access and file-monitoring behavior.

---

Note: No end-user visible features or breaking changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->