### PR TITLE
fix: correct typo 'explicity' to 'explicitly' in comment

### DIFF
--- a/frontend/utilities/osquery_tables.ts
+++ b/frontend/utilities/osquery_tables.ts
@@ -4,7 +4,7 @@ import { IOsQueryTable } from "interfaces/osquery_table";
 
 import osqueryFleetTablesJSON from "../../schema/osquery_fleet_schema.json";
 
-// Typecasting explicity here as we are adding more rigid types such as
+// Typecasting explicitly here as we are adding more rigid types such as
 // OsqueryPlatform for platform names, instead of just any strings.
 const queryTable = osqueryFleetTablesJSON as IOsQueryTable[];
 


### PR DESCRIPTION
This is an independent contribution.

## Summary

Corrects a spelling error in a code comment in `frontend/utilities/osquery_tables.ts`.

## Changes

- `frontend/utilities/osquery_tables.ts`: 1 character changed (`+1 -1`)

## Root Cause

The comment reads "Typecasting explicity here" — a misspelling of "explicitly".

## Testing

- Comment-only change — no functional impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in code comments for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->