### PR TITLE
Fix SCEP proxy corrupting GET PKIOperation messages containing '+'

### DIFF
--- a/changes/45291-fix-scep-proxy-plus
+++ b/changes/45291-fix-scep-proxy-plus
@@ -1,0 +1,1 @@
+- Fixed SCEP proxy corrupting GET PKIOperation messages containing literal `+` in the base64 query parameter.

--- a/server/mdm/scep/server/repro_e2e_test.go
+++ b/server/mdm/scep/server/repro_e2e_test.go
@@ -1,0 +1,72 @@
+package scepserver_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestPKIOperationGET_LiteralPlus verifies that GET PKIOperation works
+// with literal '+' in the base64 message query parameter (not percent-encoded).
+// Regression test for https://github.com/fleetdm/fleet/issues/45291.
+func TestPKIOperationGET_LiteralPlus(t *testing.T) {
+	server, _, teardown := newServer(t)
+	defer teardown()
+
+	pkcsreq := loadTestFile(t, "../testdata/PKCSReq.der")
+	message := base64.StdEncoding.EncodeToString(pkcsreq)
+
+	if !strings.Contains(message, "+") {
+		t.Fatal("test payload must contain '+' to be a valid regression test")
+	}
+
+	// Build request with literal '+' in the query string (NOT percent-encoded).
+	// This is what jScep and other SCEP clients that don't percent-escape send.
+	rawURL := fmt.Sprintf("%s/scep?operation=PKIOperation&message=%s", server.URL, message)
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Override RawQuery to ensure '+' stays literal and is not percent-encoded.
+	req.URL.RawQuery = "operation=PKIOperation&message=" + message
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET PKIOperation with literal '+' returned %d (want 200): %s", resp.StatusCode, string(body))
+	}
+}
+
+// TestPKIOperationGET_PercentEncodedPlus verifies that GET PKIOperation
+// continues to work when '+' is percent-encoded as %%2B.
+func TestPKIOperationGET_PercentEncodedPlus(t *testing.T) {
+	server, _, teardown := newServer(t)
+	defer teardown()
+
+	pkcsreq := loadTestFile(t, "../testdata/PKCSReq.der")
+	message := base64.StdEncoding.EncodeToString(pkcsreq)
+
+	// Percent-encode '+' and '/' as a well-behaved client would.
+	escaped := strings.ReplaceAll(message, "+", "%2B")
+	escaped = strings.ReplaceAll(escaped, "/", "%2F")
+	rawURL := fmt.Sprintf("%s/scep?operation=PKIOperation&message=%s", server.URL, escaped)
+
+	resp, err := http.Get(rawURL) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET PKIOperation with percent-encoded '+' returned %d (want 200): %s", resp.StatusCode, string(body))
+	}
+}

--- a/server/mdm/scep/server/transport.go
+++ b/server/mdm/scep/server/transport.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/mdm/scep/kitlogadapter"
 	"github.com/go-kit/kit/transport"
@@ -164,24 +165,47 @@ func decodeSCEPRequestWithIdentifier(_ context.Context, r *http.Request) (interf
 	return request, nil
 }
 
+// rawQueryParam extracts a query parameter value from the raw query string
+// without decoding '+' as space. This is necessary because url.Values.Get()
+// performs HTML-form decoding ('+' → space), which is wrong for RFC 3986 query
+// strings where '+' is a literal character. See #45291.
+func rawQueryParam(rawQuery, key string) (value string, ok bool) {
+	for rawQuery != "" {
+		var part string
+		if i := strings.IndexByte(rawQuery, '&'); i >= 0 {
+			part, rawQuery = rawQuery[:i], rawQuery[i+1:]
+		} else {
+			part, rawQuery = rawQuery, ""
+		}
+		if k, v, found := strings.Cut(part, "="); found && k == key {
+			return v, true
+		} else if !found && k == key {
+			return "", true
+		}
+	}
+	return "", false
+}
+
 // extract message from request
 func message(r *http.Request) ([]byte, error) {
 	switch r.Method {
 	case "GET":
 		var msg string
 		q := r.URL.Query()
-		if _, ok := q["message"]; ok {
-			msg = q.Get("message")
-		}
 		op := q.Get("operation")
 		if op == "PKIOperation" {
-			if len(msg) == 0 {
+			// For PKIOperation, read the message from the raw query string
+			// to preserve literal '+' characters in the base64 payload.
+			// url.Values.Get() decodes '+' as space (correct for form-encoded
+			// POST bodies, wrong for query strings per RFC 3986). See #45291.
+			rawMsg, hasMsg := rawQueryParam(r.URL.RawQuery, "message")
+			if !hasMsg || len(rawMsg) == 0 {
 				return nil, &BadRequestError{Message: "missing PKIOperation message"}
 			}
 
-			msg2, err := url.PathUnescape(msg)
+			msg2, err := url.PathUnescape(rawMsg)
 			if err != nil {
-				return nil, &BadRequestError{Message: fmt.Sprintf("invalid PKIOperation message: %s", msg)}
+				return nil, &BadRequestError{Message: fmt.Sprintf("invalid PKIOperation message: %s", rawMsg)}
 			}
 
 			decoded, err := base64.StdEncoding.DecodeString(msg2)
@@ -190,6 +214,9 @@ func message(r *http.Request) ([]byte, error) {
 			}
 
 			return decoded, nil
+		}
+		if _, ok := q["message"]; ok {
+			msg = q.Get("message")
 		}
 		return []byte(msg), nil
 	case "POST":

--- a/server/mdm/scep/server/transport.go
+++ b/server/mdm/scep/server/transport.go
@@ -172,8 +172,8 @@ func decodeSCEPRequestWithIdentifier(_ context.Context, r *http.Request) (interf
 func rawQueryParam(rawQuery, key string) (value string, ok bool) {
 	for rawQuery != "" {
 		var part string
-		if i := strings.IndexByte(rawQuery, '&'); i >= 0 {
-			part, rawQuery = rawQuery[:i], rawQuery[i+1:]
+		if before, after, found := strings.Cut(rawQuery, "&"); found {
+			part, rawQuery = before, after
 		} else {
 			part, rawQuery = rawQuery, ""
 		}


### PR DESCRIPTION
Closes #45291

## Summary

- Fix `message()` in `server/mdm/scep/server/transport.go` to parse the `message` query parameter from `r.URL.RawQuery` instead of `r.URL.Query().Get()`, preserving literal `+` in base64 payloads
- Add regression tests for both literal `+` and percent-encoded `%2B` GET PKIOperation requests

## Problem

`r.URL.Query().Get("message")` performs HTML-form decoding, which converts literal `+` to space. This is correct for `application/x-www-form-urlencoded` POST bodies but wrong for RFC 3986 query strings where `+` is a literal character. Since base64 standard encoding produces `+` for roughly 1-in-16 input bytes, virtually every real PKCS#7 envelope triggers HTTP 400 when sent via GET PKIOperation without percent-encoding.

Affected clients: Fleet Android agent (jScep), some Microsoft NDES configurations, any embedded SCEP client using GET.

## Manual test: BEFORE the fix

Built the standalone SCEP server from `main` (before the fix), started it on `localhost:9091`, and sent a GET PKIOperation with a real PKCS#7 payload (3284 bytes base64, 24 literal `+` characters):

```
$ MSG=$(base64 < server/mdm/scep/testdata/PKCSReq.der | tr -d '\n')

$ curl -s -o /dev/null -w "%{http_code}" "http://localhost:9091/scep?operation=PKIOperation&message=${MSG}"
400

$ cat response.txt
failed to base64 decode message: illegal base64 data at input byte 255: MIIJmQ...
```

The server returned **HTTP 400** because `url.Values.Get()` decoded `+` as space, corrupting the base64 at byte 255 (the position of the first `+`).

With percent-encoded `+` (`%2B`), the same server returned **HTTP 200**, confirming the bug is server-side decoding of literal `+`.

## Manual test: AFTER the fix

Built the standalone SCEP server from this branch, started it on `localhost:9090`, and repeated the same tests:

```
$ MSG=$(base64 < server/mdm/scep/testdata/PKCSReq.der | tr -d '\n')

=== Literal '+' in query ===
$ curl -s -o /dev/null -w "%{http_code}" "http://localhost:9090/scep?operation=PKIOperation&message=${MSG}"
200

=== Percent-encoded %2B ===
$ ESCAPED_MSG=$(echo "$MSG" | sed 's/+/%2B/g; s/\//%2F/g')
$ curl -s -o /dev/null -w "%{http_code}" "http://localhost:9090/scep?operation=PKIOperation&message=${ESCAPED_MSG}"
200
```

Both literal `+` and percent-encoded `%2B` now return **HTTP 200**.

## Automated tests

All 11 SCEP server tests pass, including two new regression tests:

```
=== RUN   TestPKIOperationGET_LiteralPlus
--- PASS: TestPKIOperationGET_LiteralPlus (0.03s)
=== RUN   TestPKIOperationGET_PercentEncodedPlus
--- PASS: TestPKIOperationGET_PercentEncodedPlus (0.02s)
...
ok  github.com/fleetdm/fleet/v4/server/mdm/scep/server  0.654s
```

## Code walkthrough

### `rawQueryParam()` (new helper, `transport.go:168-187`)

Extracts a query parameter value from `r.URL.RawQuery` by splitting on `&` and `=` without any decoding. This preserves literal `+` and `/` characters in the value. It only handles the simple case needed here (first match, no multi-value support) since SCEP messages have exactly one `message` parameter.

### `message()` changes (`transport.go:189-220`)

For `PKIOperation` only:
1. Reads `message` via `rawQueryParam(r.URL.RawQuery, "message")` instead of `q.Get("message")` -- literal `+` is preserved
2. Applies `url.PathUnescape()` -- decodes `%2B` back to `+`, `%2F` back to `/`, etc. (so clients that percent-encode still work)
3. `base64.StdEncoding.DecodeString()` proceeds as before

For non-PKIOperation GET requests (e.g., `GetCACert`, `GetCACaps`), the existing `q.Get()` path is preserved unchanged since those messages are plain text, not base64.

## Test plan

- [x] Manual curl: literal `+` returns 200 (was 400 before fix)
- [x] Manual curl: percent-encoded `%2B` returns 200 (unchanged)
- [x] `TestPKIOperationGET_LiteralPlus` -- GET PKIOperation with literal `+` in query returns 200
- [x] `TestPKIOperationGET_PercentEncodedPlus` -- GET PKIOperation with `%2B` in query returns 200
- [x] `TestPKIOperationGET` (existing) -- GET PKIOperation via `params.Encode()` still works
- [x] `TestPKIOperation` (existing) -- POST PKIOperation unaffected
- [x] `TestCACaps`, `TestGetCACertMessage`, `TestInvalidReqs` (existing) -- non-PKIOperation paths unaffected
- [x] Full SCEP package test suite passes