### PR TITLE
Fleet UI: post-QA empty state gap fixes

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
@@ -115,20 +115,23 @@ const OSUpdates = ({ router, teamIdForApi, queryParams }: IOSUpdates) => {
 
   // FIXME: Handle error states for app config and team config (need specifications for this).
   // mdm is not enabled for mac or windows.
+  // TODO: Consistency with PageDescription component and empty state messaging for when mdm is not enabled.
   if (
     !config?.mdm.enabled_and_configured &&
     !config?.mdm.windows_enabled_and_configured
   ) {
     return (
-      <EmptyState
-        header="Additional configuration required"
-        info="MDM must be turned on to change settings on your hosts."
-        primaryButton={
-          <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
-            Turn on
-          </Button>
-        }
-      />
+      <div className={baseClass}>
+        <EmptyState
+          header="Additional configuration required"
+          info="MDM must be turned on to change settings on your hosts."
+          primaryButton={
+            <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
+              Turn on
+            </Button>
+          }
+        />
+      </div>
     );
   }
 

--- a/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssues.tsx
+++ b/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssues.tsx
@@ -22,38 +22,28 @@ const MunkiIssuesTable = ({
   munkiIssues,
   deviceType,
 }: IMunkiIssuesTableProps): JSX.Element => {
-  const tableMunkiIssues = munkiIssues;
-  const tableHeaders = munkiIssuesTableHeaders;
-
   return (
     <Card className={baseClass} borderRadiusSize="xxlarge" paddingSize="xlarge">
       <CardHeader header="Munki issues" />
-      {munkiIssues?.length ? (
-        <div className={deviceType || ""}>
-          <TableContainer
-            columnConfigs={tableHeaders}
-            data={tableMunkiIssues || []}
-            isLoading={isLoading}
-            defaultSortHeader="name"
-            defaultSortDirection="asc"
-            resultsTitle="issue"
-            emptyComponent={() => (
-              <EmptyState
-                header="No Munki issues detected"
-                info="The last time Munki ran on this host, no issues were reported."
-              />
-            )}
-            showMarkAllPages={false}
-            isAllPagesSelected={false}
-            isClientSidePagination
-          />
-        </div>
-      ) : (
-        <EmptyState
-          header="No Munki issues detected"
-          info="The last time Munki ran on this host, no issues were reported."
+      <div className={deviceType || ""}>
+        <TableContainer
+          columnConfigs={munkiIssuesTableHeaders}
+          data={munkiIssues || []}
+          isLoading={isLoading}
+          defaultSortHeader="name"
+          defaultSortDirection="asc"
+          resultsTitle="issue"
+          emptyComponent={() => (
+            <EmptyState
+              header="No Munki issues detected"
+              info="The last time Munki ran on this host, no issues were reported."
+            />
+          )}
+          showMarkAllPages={false}
+          isAllPagesSelected={false}
+          isClientSidePagination
         />
-      )}
+      </div>
     </Card>
   );
 };


### PR DESCRIPTION
## Issue 
Closes #44923 

## Description
- Add gap above empty state for OS Settings
- Add gap above empty state for Host details > Softwarev> Munki issues

## Screenshots of fixes

<img width="1353" height="530" alt="Screenshot 2026-05-19 at 1 16 05 PM" src="https://github.com/user-attachments/assets/baa1c7be-824f-4b2d-a3c5-5292ea8b79d5" />

<img width="1544" height="521" alt="Screenshot 2026-05-19 at 1 19 49 PM" src="https://github.com/user-attachments/assets/60b7734a-6abf-4797-8713-c15a9518fddf" />


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved empty state handling for disabled MDM configurations
  * Simplified display logic for Munki issues table when no issues are detected
  * Enhanced consistency in component messaging and styling across pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->