### PR TITLE
Ignore fleet CVEs in fleetctl

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -346,6 +346,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-03-13 12:33:34
 
+### [CVE-2026-26062](https://nvd.nist.gov/vuln/detail/CVE-2026-26062)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** This is a vulnerability in Fleet, not fleetctl.
+- **Products:** `fleetctl`,`pkg:golang/github.com/fleetdm/fleet/v4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:30:00
+
 ### [CVE-2026-26061](https://nvd.nist.gov/vuln/detail/CVE-2026-26061)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -362,6 +370,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-03-23 19:12:15
 
+### [CVE-2026-24899](https://nvd.nist.gov/vuln/detail/CVE-2026-24899)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** This is a vulnerability in Fleet, not fleetctl.
+- **Products:** `fleetctl`,`pkg:golang/github.com/fleetdm/fleet/v4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:30:00
+
 ### [CVE-2026-24515](https://nvd.nist.gov/vuln/detail/CVE-2026-24515)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -369,6 +385,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `fleetctl`,`pkg:deb/debian/libexpat1`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-01-03 15:15:53
+
+### [CVE-2026-23998](https://nvd.nist.gov/vuln/detail/CVE-2026-23998)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** This is a vulnerability in Fleet, not fleetctl.
+- **Products:** `fleetctl`,`pkg:golang/github.com/fleetdm/fleet/v4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:30:00
 
 ### [CVE-2026-23517](https://nvd.nist.gov/vuln/detail/CVE-2026-23517)
 - **Author:** @lucasmrod

--- a/security/vex/fleetctl/CVE-2026-23998.vex.json
+++ b/security/vex/fleetctl/CVE-2026-23998.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-31459f5066351a95855b9511bc53b345630d5fee548a1ae5fc2e06435c94dfec",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-23998"
+      },
+      "timestamp": "2026-05-19T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/github.com/fleetdm/fleet/v4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "This is a vulnerability in Fleet, not fleetctl",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2026-24899.vex.json
+++ b/security/vex/fleetctl/CVE-2026-24899.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-847b5d5b11f66dff858f24e978347ea6749db735b5c40cc042d820b13a2fd89f",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-24899"
+      },
+      "timestamp": "2026-05-19T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/github.com/fleetdm/fleet/v4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "This is a vulnerability in Fleet, not fleetctl",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2026-26062.vex.json
+++ b/security/vex/fleetctl/CVE-2026-26062.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-48176c66cb004765d92721009d839a7512f978fadeea6a74783f9dbe5e55854d",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-26062"
+      },
+      "timestamp": "2026-05-19T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/github.com/fleetdm/fleet/v4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "This is a vulnerability in Fleet, not fleetctl",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/26082254809/job/76686528770.

Run: https://github.com/fleetdm/fleet/actions/runs/26114400277.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added formal security assessment documents for three CVEs (CVE-2026-23998, CVE-2026-24899, CVE-2026-26062), declaring that fleetctl and related packages remain unaffected. Each document provides detailed technical justification explaining why vulnerabilities are not present in the execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->