### PR TITLE
Fix CVEs reported on latest released fleetctl version

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -268,6 +268,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-03-23 16:44:57
 
+### [CVE-2026-7598](https://nvd.nist.gov/vuln/detail/CVE-2026-7598)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** libssh2 is not used in fleetdm/fleetctl; go binary runs as entrypoint and does not use libssh2.
+- **Products:** `fleetctl`,`pkg:deb/debian/libssh2-1t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:35:00
+
+### [CVE-2026-42010](https://nvd.nist.gov/vuln/detail/CVE-2026-42010)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** gnutls is not used in fleetdm/fleetctl (go binary uses Go's TLS).
+- **Products:** `fleetctl`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-19 10:35:00
+
 ### [CVE-2026-40962](https://nvd.nist.gov/vuln/detail/CVE-2026-40962)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2026-42010.vex.json
+++ b/security/vex/fleetctl/CVE-2026-42010.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-19ddb3f633ee2eecb23a1c73d16c8c9f78d7fe2882d72f22e00f72b6593381cf",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:35:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42010"
+      },
+      "timestamp": "2026-05-19T10:35:00.000000-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "gnutls is not used in fleetdm/fleetctl (go binary uses Go's TLS)",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2026-7598.vex.json
+++ b/security/vex/fleetctl/CVE-2026-7598.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-556ebabeebd3eb772c85c379e4f350bb9cef05cee714d7725062bf6774ddf28a",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-19T10:35:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-7598"
+      },
+      "timestamp": "2026-05-19T10:35:00.000000-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh2-1t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "libssh2 is not used in fleetdm/fleetctl; go binary runs as entrypoint and does not use libssh2",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/26082083437/job/76685948651

Run: https://github.com/fleetdm/fleet/actions/runs/26115317286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added formal vulnerability assessments for CVE-2026-42010 and CVE-2026-7598, confirming both vulnerabilities do not affect fleetctl. Each assessment includes detailed documentation explaining why the vulnerable code is not present in fleetctl's execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->