### PR TITLE
Fix iOS and iPadOS logos in dark theme

### DIFF
--- a/changes/fix-iOS-iPadOS-logo-in-dark-theme
+++ b/changes/fix-iOS-iPadOS-logo-in-dark-theme
@@ -1,1 +1,1 @@
-* Fixed iOS and iPadOS logo in the OS list in dark theme.
+* Fixed iOS and iPadOS logos on the OS list in dark theme.

--- a/changes/fix-iOS-iPadOS-logo-in-dark-theme
+++ b/changes/fix-iOS-iPadOS-logo-in-dark-theme
@@ -1,0 +1,1 @@
+* Fixed iOS and iPadOS logo in the OS list in dark theme.

--- a/frontend/pages/SoftwarePage/components/icons/iOS.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/iOS.tsx
@@ -7,6 +7,7 @@ const iOS = (props: SVGProps<SVGSVGElement>) => {
   if (props.width === "24") {
     return (
       <svg fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <path fill="#F9FAFC" d="M0 0h32v32H0z" />
         <g transform="translate(4, 4) scale(1.5)">
           <rect
             x="5"
@@ -33,6 +34,7 @@ const iOS = (props: SVGProps<SVGSVGElement>) => {
   }
   return (
     <svg fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path fill="#F9FAFC" d="M0 0h32v32H0z" />
       <g transform="translate(7, 7) scale(0.75)">
         <rect
           x="5.25"

--- a/frontend/pages/SoftwarePage/components/icons/iPadOS.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/iPadOS.tsx
@@ -7,6 +7,7 @@ const iPadOS = (props: SVGProps<SVGSVGElement>) => {
   if (props.width === "24") {
     return (
       <svg fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <path fill="#F9FAFC" d="M0 0h32v32H0z" />
         <g transform="translate(4, 4) scale(1.5)">
           <rect
             x="3.875"
@@ -29,6 +30,7 @@ const iPadOS = (props: SVGProps<SVGSVGElement>) => {
   }
   return (
     <svg fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path fill="#F9FAFC" d="M0 0h32v32H0z" />
       <g transform="translate(6, 7) scale(0.75)">
         <rect
           x="3.666"


### PR DESCRIPTION
Resolves: https://github.com/fleetdm/fleet/issues/45839.

Dogfood:
<img width="778" height="314" alt="Screenshot 2026-05-19 at 5 44 52 PM" src="https://github.com/user-attachments/assets/4a6433bf-612d-42bb-b3ea-961c19f54e90" />

With changes in this PR:
<img width="1811" height="373" alt="Screenshot 2026-05-20 at 9 22 58 AM" src="https://github.com/user-attachments/assets/ebf0f432-6592-40a2-bacb-72f6e63f7827" />
<img width="1811" height="373" alt="Screenshot 2026-05-20 at 9 22 44 AM" src="https://github.com/user-attachments/assets/f8bac481-4263-4d95-932d-f8599ed87055" />

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS and iPadOS icons so they render correctly in dark theme across the operating-system list.
  * Improved icon visibility and contrast in dark mode to ensure consistent appearance with other platform icons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->