### PR TITLE
Handbook: update temporary landing page section in handbook

### DIFF
--- a/handbook/company/writing.md
+++ b/handbook/company/writing.md
@@ -333,7 +333,6 @@ Temporary landing pages are intended for driving traffic from ads, events, and c
  
 These pages are:
 - **Not linked from the nav.** They do not appear in the site navigation or any other part of the main site.
-- **Excluded from the sitemap.** Search engines will not index them. They are not intended to build SEO/GEO value.
 - **Not subject to content or design review.** They can go up fast without going through the [standard drafting process](https://fleetdm.com/handbook/company/product-groups#making-changes).
 - **Created using Claude, Kilo, or manually.** If you're comfortable working in the repo, add a page to the [landing-pages](https://github.com/fleetdm/fleet/tree/main/website/views/pages/landing-pages) folder directly. Otherwise, use Claude or Kilo to generate one.
 


### PR DESCRIPTION

Removed a line about landing pages being excluded from the website's sitemap
