### PR TITLE
Refetch certs on macOS RemoveProfile ack for ACME/SCEP profiles

### DIFF
--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1682,13 +1682,14 @@ WHERE
 	return dest, nil
 }
 
-func (ds *Datastore) ProfileHasACMEPayloadForCommand(ctx context.Context, hostUUID, commandUUID string) (fleet.ProfileACMECommandResult, error) {
+func (ds *Datastore) ProfileCertPayloadsForCommand(ctx context.Context, hostUUID, commandUUID string) (fleet.ProfileCertPayloadProbe, error) {
 	const stmt = `
 SELECT
 	h.id              AS host_id,
 	h.platform        AS platform,
 	hmap.profile_uuid AS profile_uuid,
-	LOCATE('com.apple.security.acme', mac.mobileconfig) > 0 AS has_acme_payload
+	LOCATE('com.apple.security.acme', mac.mobileconfig) > 0 AS has_acme_payload,
+	LOCATE('com.apple.security.scep', mac.mobileconfig) > 0 AS has_scep_payload
 FROM host_mdm_apple_profiles hmap
 	JOIN hosts h
 		ON h.uuid = hmap.host_uuid
@@ -1697,7 +1698,7 @@ FROM host_mdm_apple_profiles hmap
 WHERE hmap.command_uuid = ?
 	AND hmap.host_uuid    = ?`
 
-	var dest fleet.ProfileACMECommandResult
+	var dest fleet.ProfileCertPayloadProbe
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, stmt, commandUUID, hostUUID)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -10664,7 +10664,7 @@ func testProfileCertPayloadsForCommand(t *testing.T, ds *Datastore) {
 		require.True(t, got.HasACMEPayload)
 	})
 
-	t.Run("darwin host with non-ACME profile reports has_acme_payload=false", func(t *testing.T) {
+	t.Run("darwin host with SCEP profile reports has_scep_payload=true and has_acme_payload=false", func(t *testing.T) {
 		profUUID := mkProfile(t, "scep-darwin", scepXML)
 		cmdUUID := uuid.NewString()
 		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
@@ -10673,6 +10673,7 @@ func testProfileCertPayloadsForCommand(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Equal(t, "darwin", got.Platform)
 		require.False(t, got.HasACMEPayload)
+		require.True(t, got.HasSCEPPayload)
 	})
 
 	t.Run("unknown command returns not found", func(t *testing.T) {

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -65,7 +65,7 @@ func TestMDMShared(t *testing.T) {
 		{"TestListNextPendingMDMWindowsHostUUIDsCursor", testListNextPendingMDMWindowsHostUUIDsCursor},
 		{"TestCleanUpMDMManagedCertificates", testCleanUpMDMManagedCertificates},
 		{"TestEnqueueCommandWithName", testEnqueueCommandWithName},
-		{"TestProfileHasACMEPayloadForCommand", testProfileHasACMEPayloadForCommand},
+		{"TestProfileCertPayloadsForCommand", testProfileCertPayloadsForCommand},
 		{"TestRenewMDMManagedCertificatesNullType", testRenewMDMManagedCertificatesNullType},
 	}
 
@@ -10604,7 +10604,7 @@ func testCleanUpMDMManagedCertificates(t *testing.T, ds *Datastore) {
 	})
 }
 
-func testProfileHasACMEPayloadForCommand(t *testing.T, ds *Datastore) {
+func testProfileCertPayloadsForCommand(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
 	host, err := ds.NewHost(ctx, &fleet.Host{
@@ -10656,7 +10656,7 @@ func testProfileHasACMEPayloadForCommand(t *testing.T, ds *Datastore) {
 		cmdUUID := uuid.NewString()
 		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
 
-		got, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, cmdUUID)
+		got, err := ds.ProfileCertPayloadsForCommand(ctx, host.UUID, cmdUUID)
 		require.NoError(t, err)
 		require.Equal(t, host.ID, got.HostID)
 		require.Equal(t, "darwin", got.Platform)
@@ -10669,14 +10669,14 @@ func testProfileHasACMEPayloadForCommand(t *testing.T, ds *Datastore) {
 		cmdUUID := uuid.NewString()
 		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
 
-		got, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, cmdUUID)
+		got, err := ds.ProfileCertPayloadsForCommand(ctx, host.UUID, cmdUUID)
 		require.NoError(t, err)
 		require.Equal(t, "darwin", got.Platform)
 		require.False(t, got.HasACMEPayload)
 	})
 
 	t.Run("unknown command returns not found", func(t *testing.T) {
-		_, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, "no-such-command")
+		_, err := ds.ProfileCertPayloadsForCommand(ctx, host.UUID, "no-such-command")
 		require.Error(t, err)
 		require.True(t, fleet.IsNotFound(err))
 	})
@@ -10686,7 +10686,7 @@ func testProfileHasACMEPayloadForCommand(t *testing.T, ds *Datastore) {
 		cmdUUID := uuid.NewString()
 		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
 
-		_, err := ds.ProfileHasACMEPayloadForCommand(ctx, "no-such-host", cmdUUID)
+		_, err := ds.ProfileCertPayloadsForCommand(ctx, "no-such-host", cmdUUID)
 		require.Error(t, err)
 		require.True(t, fleet.IsNotFound(err))
 	})

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -470,15 +470,12 @@ type Datastore interface {
 	// ingestion don't clobber each other's view.
 	UpdateHostCertificates(ctx context.Context, hostID uint, hostUUID string, certs []*HostCertificateRecord, origin HostCertificateOrigin) error
 
-	// ProfileHasACMEPayloadForCommand returns the host/profile gating data
-	// needed to decide whether an InstallProfile ack should trigger a
-	// CertificateList refetch: host platform, profile UUID, whether the
-	// delivered profile contains a com.apple.security.acme payload, and
-	// whether a refetch is already pending. All gates are computed
-	// server-side in a single indexed lookup so the per-ack hot path stays
-	// cheap. Substring-matched on the mobileconfig blob; bounded false-
-	// positive risk (one redundant CertificateList per false match).
-	ProfileHasACMEPayloadForCommand(ctx context.Context, hostUUID, commandUUID string) (ProfileACMECommandResult, error)
+	// ProfileCertPayloadsForCommand returns gating data for the
+	// InstallProfile / RemoveProfile CertificateList triggers: host
+	// platform, profile UUID, and ACME / SCEP payload presence.
+	// Substring-matched on the mobileconfig blob; one redundant
+	// CertificateList per false match is the only failure mode.
+	ProfileCertPayloadsForCommand(ctx context.Context, hostUUID, commandUUID string) (ProfileCertPayloadProbe, error)
 
 	// AreHostsConnectedToFleetMDM checks each host MDM enrollment with
 	// this server and returns a map indexed by the host uuid and a boolean

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -319,16 +319,16 @@ type HostMDMProfileRetryCount struct {
 	Retries     uint   `db:"retries"`
 }
 
-// ProfileACMECommandResult bundles the gates needed to decide whether an
-// InstallProfile ack should trigger a CertificateList refetch on macOS:
-// host platform, profile UUID, and whether the delivered profile contains a
-// com.apple.security.acme payload. Computed in a single query keyed on
-// (host_uuid, command_uuid).
-type ProfileACMECommandResult struct {
+// ProfileCertPayloadProbe gates the InstallProfile / RemoveProfile
+// CertificateList triggers on macOS. Install acts on HasACMEPayload only
+// (hardware-bound certs are invisible to osquery); remove acts on either
+// to clear stale rows after the device drops the cert from its keychain.
+type ProfileCertPayloadProbe struct {
 	HostID         uint   `db:"host_id"`
 	Platform       string `db:"platform"`
 	ProfileUUID    string `db:"profile_uuid"`
 	HasACMEPayload bool   `db:"has_acme_payload"`
+	HasSCEPPayload bool   `db:"has_scep_payload"`
 }
 
 // TeamIDSetter defines the method to set a TeamID value on a struct,

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -351,7 +351,7 @@ type ListHostCertificatesFunc func(ctx context.Context, hostID uint, opts fleet.
 
 type UpdateHostCertificatesFunc func(ctx context.Context, hostID uint, hostUUID string, certs []*fleet.HostCertificateRecord, origin fleet.HostCertificateOrigin) error
 
-type ProfileHasACMEPayloadForCommandFunc func(ctx context.Context, hostUUID string, commandUUID string) (fleet.ProfileACMECommandResult, error)
+type ProfileCertPayloadsForCommandFunc func(ctx context.Context, hostUUID string, commandUUID string) (fleet.ProfileCertPayloadProbe, error)
 
 type AreHostsConnectedToFleetMDMFunc func(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error)
 
@@ -2482,8 +2482,8 @@ type DataStore struct {
 	UpdateHostCertificatesFunc        UpdateHostCertificatesFunc
 	UpdateHostCertificatesFuncInvoked bool
 
-	ProfileHasACMEPayloadForCommandFunc        ProfileHasACMEPayloadForCommandFunc
-	ProfileHasACMEPayloadForCommandFuncInvoked bool
+	ProfileCertPayloadsForCommandFunc        ProfileCertPayloadsForCommandFunc
+	ProfileCertPayloadsForCommandFuncInvoked bool
 
 	AreHostsConnectedToFleetMDMFunc        AreHostsConnectedToFleetMDMFunc
 	AreHostsConnectedToFleetMDMFuncInvoked bool
@@ -6090,11 +6090,11 @@ func (s *DataStore) UpdateHostCertificates(ctx context.Context, hostID uint, hos
 	return s.UpdateHostCertificatesFunc(ctx, hostID, hostUUID, certs, origin)
 }
 
-func (s *DataStore) ProfileHasACMEPayloadForCommand(ctx context.Context, hostUUID string, commandUUID string) (fleet.ProfileACMECommandResult, error) {
+func (s *DataStore) ProfileCertPayloadsForCommand(ctx context.Context, hostUUID string, commandUUID string) (fleet.ProfileCertPayloadProbe, error) {
 	s.mu.Lock()
-	s.ProfileHasACMEPayloadForCommandFuncInvoked = true
+	s.ProfileCertPayloadsForCommandFuncInvoked = true
 	s.mu.Unlock()
-	return s.ProfileHasACMEPayloadForCommandFunc(ctx, hostUUID, commandUUID)
+	return s.ProfileCertPayloadsForCommandFunc(ctx, hostUUID, commandUUID)
 }
 
 func (s *DataStore) AreHostsConnectedToFleetMDM(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4152,6 +4152,14 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 			status = &fleet.MDMDeliveryVerifying
 			detail = ""
 		}
+		// Refetch certs when an ACME or SCEP profile is removed so the
+		// stale row clears.
+		if status != nil && *status == fleet.MDMDeliveryVerifying {
+			if err := svc.maybeQueueCertificateListForRemovedCertProfile(r.Context, cmdResult.Identifier(), cmdResult.CommandUUID); err != nil {
+				svc.logger.WarnContext(r.Context, "queue CertificateList after cert-profile removal",
+					"err", err, "host_uuid", cmdResult.Identifier(), "command_uuid", cmdResult.CommandUUID)
+			}
+		}
 		return nil, svc.ds.UpdateOrDeleteHostMDMAppleProfile(r.Context, &fleet.HostMDMAppleProfile{
 			CommandUUID:   cmdResult.CommandUUID,
 			HostUUID:      cmdResult.Identifier(),
@@ -5128,7 +5136,7 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchCertsResults(ctx conte
 // this hook because IOSiPadOSRefetch already runs CertificateList on a cron.
 //
 // Gating happens server-side in a single indexed query
-// (ProfileHasACMEPayloadForCommand): host platform and ACME payload presence.
+// (ProfileCertPayloadsForCommand): host platform and ACME payload presence.
 // The hot path early-returns for the common non-ACME / non-darwin cases
 // without parsing the profile or making additional roundtrips.
 //
@@ -5141,7 +5149,7 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchCertsResults(ctx conte
 // collapse via ON DUPLICATE KEY UPDATE, and handleRefetchCertsResults is
 // safe to call on an already-removed row.
 func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEProfile(ctx context.Context, hostUUID, commandUUID string) error {
-	res, err := svc.ds.ProfileHasACMEPayloadForCommand(ctx, hostUUID, commandUUID)
+	res, err := svc.ds.ProfileCertPayloadsForCommand(ctx, hostUUID, commandUUID)
 	if err != nil {
 		if fleet.IsNotFound(err) {
 			return nil
@@ -5160,6 +5168,35 @@ func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEPro
 	// Track after the commander call so a CertificateList enqueue failure
 	// doesn't leave a stale tracking row that would suppress future
 	// triggers. Matches the iOS/iPadOS pattern in IOSiPadOSRefetch.
+	if err := svc.ds.AddHostMDMCommands(ctx, []fleet.HostMDMCommand{{
+		HostID:      res.HostID,
+		CommandType: fleet.RefetchCertsCommandUUIDPrefix,
+	}}); err != nil {
+		return ctxerr.Wrap(ctx, err, "track refetch certs command")
+	}
+	return nil
+}
+
+// maybeQueueCertificateListForRemovedCertProfile fires CertificateList
+// after a RemoveProfile ack on a macOS host whose removed profile
+// contained an ACME or SCEP payload, so the stale cert row clears.
+// iOS/iPadOS self-correct via IOSiPadOSRefetch.
+func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForRemovedCertProfile(ctx context.Context, hostUUID, commandUUID string) error {
+	res, err := svc.ds.ProfileCertPayloadsForCommand(ctx, hostUUID, commandUUID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			return nil
+		}
+		return ctxerr.Wrap(ctx, err, "probe profile for cert payload")
+	}
+	if res.Platform != "darwin" || (!res.HasACMEPayload && !res.HasSCEPPayload) {
+		return nil
+	}
+
+	cmdUUID := uuid.NewString()
+	if err := svc.commander.CertificateList(ctx, []string{hostUUID}, fleet.RefetchCertsCommandUUIDPrefix+cmdUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "enqueue CertificateList")
+	}
 	if err := svc.ds.AddHostMDMCommands(ctx, []fleet.HostMDMCommand{{
 		HostID:      res.HostID,
 		CommandType: fleet.RefetchCertsCommandUUIDPrefix,

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2645,8 +2645,8 @@ func TestMDMCommandAndReportResultsProfileHandling(t *testing.T) {
 				require.ElementsMatch(t, toRetry, []string{profileIdentifier})
 				return nil
 			}
-			ds.ProfileHasACMEPayloadForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileACMECommandResult, error) {
-				return fleet.ProfileACMECommandResult{Platform: "ios"}, nil
+			ds.ProfileCertPayloadsForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileCertPayloadProbe, error) {
+				return fleet.ProfileCertPayloadProbe{Platform: "ios"}, nil
 			}
 
 			_, err := svc.CommandAndReportResults(
@@ -2691,14 +2691,14 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 
 	cases := []struct {
 		name             string
-		probeResult      fleet.ProfileACMECommandResult
+		probeResult      fleet.ProfileCertPayloadProbe
 		probeErr         error
 		expectAddCommand bool
 		expectEnqueue    bool
 	}{
 		{
 			name: "macOS + ACME profile: enqueues CertificateList",
-			probeResult: fleet.ProfileACMECommandResult{
+			probeResult: fleet.ProfileCertPayloadProbe{
 				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
 				HasACMEPayload: true,
 			},
@@ -2707,7 +2707,7 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 		},
 		{
 			name: "iOS host: skipped (existing refetch cron handles it)",
-			probeResult: fleet.ProfileACMECommandResult{
+			probeResult: fleet.ProfileCertPayloadProbe{
 				HostID: hostID, Platform: "ios", ProfileUUID: profileUUID,
 				HasACMEPayload: true,
 			},
@@ -2716,7 +2716,7 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 		},
 		{
 			name: "macOS + non-ACME profile: no trigger",
-			probeResult: fleet.ProfileACMECommandResult{
+			probeResult: fleet.ProfileCertPayloadProbe{
 				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
 				HasACMEPayload: false,
 			},
@@ -2734,7 +2734,7 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ds := new(mock.Store)
-			ds.ProfileHasACMEPayloadForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileACMECommandResult, error) {
+			ds.ProfileCertPayloadsForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileCertPayloadProbe, error) {
 				require.Equal(t, hostUUID, hUUID)
 				require.Equal(t, commandUUID, cmdUUID)
 				return c.probeResult, c.probeErr
@@ -2777,6 +2777,128 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 				commander: cmdr,
 			}
 			err := svc.maybeQueueCertificateListForACMEProfile(ctx, hostUUID, commandUUID)
+			require.NoError(t, err)
+
+			if c.expectAddCommand {
+				require.Len(t, addedCommands, 1)
+				require.Equal(t, fleet.RefetchCertsCommandUUIDPrefix, addedCommands[0].CommandType)
+				require.Equal(t, hostID, addedCommands[0].HostID)
+			} else {
+				require.Empty(t, addedCommands)
+			}
+			require.Equal(t, c.expectEnqueue, enqueued)
+		})
+	}
+}
+
+// TestMaybeQueueCertificateListForRemovedCertProfile verifies the
+// RemoveProfile-triggered CertificateList fires on macOS for ACME and SCEP
+// payloads (broader than the install-side trigger, which is ACME-only).
+func TestMaybeQueueCertificateListForRemovedCertProfile(t *testing.T) {
+	ctx := context.Background()
+	const (
+		hostUUID    = "host-uuid"
+		commandUUID = "cmd-uuid"
+		profileUUID = "profile-uuid"
+		hostID      = uint(42)
+	)
+
+	cases := []struct {
+		name             string
+		probeResult      fleet.ProfileCertPayloadProbe
+		probeErr         error
+		expectAddCommand bool
+		expectEnqueue    bool
+	}{
+		{
+			name: "macOS + ACME profile: enqueues CertificateList",
+			probeResult: fleet.ProfileCertPayloadProbe{
+				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
+				HasACMEPayload: true,
+			},
+			expectAddCommand: true,
+			expectEnqueue:    true,
+		},
+		{
+			name: "macOS + SCEP profile: enqueues CertificateList",
+			probeResult: fleet.ProfileCertPayloadProbe{
+				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
+				HasSCEPPayload: true,
+			},
+			expectAddCommand: true,
+			expectEnqueue:    true,
+		},
+		{
+			name: "macOS + neither ACME nor SCEP: no trigger",
+			probeResult: fleet.ProfileCertPayloadProbe{
+				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
+			},
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+		{
+			name: "iOS host: skipped (IOSiPadOSRefetch cron handles it)",
+			probeResult: fleet.ProfileCertPayloadProbe{
+				HostID: hostID, Platform: "ios", ProfileUUID: profileUUID,
+				HasACMEPayload: true,
+			},
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+		{
+			name:             "command not found: no error, no trigger",
+			probeErr:         &notFoundError{},
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			ds.ProfileCertPayloadsForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileCertPayloadProbe, error) {
+				require.Equal(t, hostUUID, hUUID)
+				require.Equal(t, commandUUID, cmdUUID)
+				return c.probeResult, c.probeErr
+			}
+			var addedCommands []fleet.HostMDMCommand
+			ds.AddHostMDMCommandsFunc = func(ctx context.Context, cmds []fleet.HostMDMCommand) error {
+				addedCommands = append(addedCommands, cmds...)
+				return nil
+			}
+
+			mdmStorage := &mdmmock.MDMAppleStore{}
+			pushFactory, _ := newMockAPNSPushProviderFactory()
+			pusher := nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushFactory, NewNanoMDMLogger(slog.New(slog.DiscardHandler)))
+			cmdr := apple_mdm.NewMDMAppleCommander(mdmStorage, pusher)
+			var enqueued bool
+			mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+				enqueued = true
+				require.Equal(t, []string{hostUUID}, id)
+				require.Equal(t, "CertificateList", cmd.Command.Command.RequestType)
+				return nil, nil
+			}
+			mdmStorage.RetrievePushInfoFunc = func(ctx context.Context, ids []string) (map[string]*mdm.Push, error) {
+				res := make(map[string]*mdm.Push, len(ids))
+				for _, id := range ids {
+					res[id] = &mdm.Push{Token: []byte(id), Topic: "topic", PushMagic: "magic"}
+				}
+				return res, nil
+			}
+			mdmStorage.RetrievePushCertFunc = func(ctx context.Context, topic string) (*tls.Certificate, string, error) {
+				cert, err := tls.LoadX509KeyPair("testdata/server.pem", "testdata/server.key")
+				return &cert, "", err
+			}
+			mdmStorage.IsPushCertStaleFunc = func(ctx context.Context, topic string, staleToken string) (bool, error) {
+				return false, nil
+			}
+
+			svc := &MDMAppleCheckinAndCommandService{
+				ds:        ds,
+				logger:    slog.New(slog.DiscardHandler),
+				commander: cmdr,
+			}
+			err := svc.maybeQueueCertificateListForRemovedCertProfile(ctx, hostUUID, commandUUID)
 			require.NoError(t, err)
 
 			if c.expectAddCommand {


### PR DESCRIPTION
**Related issue:** Resolves #45596

## What this PR does

Fires a `CertificateList` MDM refetch when a macOS host acknowledges a `RemoveProfile` for a profile containing an ACME or non-proxied SCEP payload. The existing source-scoped soft-delete in `UpdateHostCertificates` then clears the now-removed cert row, and the host details page / API stop showing a stale entry.


## Renames

The shared probe was named for the install-side trigger, which was ACME-only. Now that the removal-side trigger reports SCEP too:

- `ProfileACMECommandResult` → `ProfileCertPayloadProbe`
- `ProfileHasACMEPayloadForCommand` → `ProfileCertPayloadsForCommand`


# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect SCEP certificate payloads in addition to ACME in MDM profiles.
  * Queue an automatic CertificateList refresh when certificate-based profiles are removed.

* **Bug Fixes**
  * Improved handling of profile removals to ensure stale certificate entries are cleared reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->