### PR TITLE
fix: correct typo "occured" to "occurred" in ErrorChain comment

### DIFF
--- a/server/mdm/nanomdm/mdm/command.go
+++ b/server/mdm/nanomdm/mdm/command.go
@@ -11,7 +11,7 @@ var (
 	ErrInvalidCommand       = errors.New("invalid command")
 )
 
-// ErrorChain represents errors that occured on the client executing an MDM command.
+// ErrorChain represents errors that occurred on the client executing an MDM command.
 type ErrorChain struct {
 	ErrorCode            int
 	ErrorDomain          string


### PR DESCRIPTION
This is an independent contribution made by an individual developer. This work is not associated with any hackathon, competition, or coordinated PR campaign.

## Summary

Fixes a typo in a comment in `server/mdm/nanomdm/mdm/command.go` where "occured" should be "occurred" in the `ErrorChain` type documentation.

## Root Cause

The comment on line 14 of `command.go` describing the `ErrorChain` type uses the misspelling "occured" instead of the correct spelling "occurred".

## Fix

Changed "occured" to "occurred" in the type documentation comment.

## Changes

- `server/mdm/nanomdm/mdm/command.go`: 1 line changed (`+1 -1`)

## Testing

- The change modifies only a comment string; no functional behavior is affected.
- `go build ./...` passes with no regressions.
- The `ErrorChain` type documentation now uses the correct spelling. ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed spelling in internal comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->