### PR TITLE
Fleet UI: Center align premium message, remove left align prop, dead CSS

### DIFF
--- a/frontend/components/PremiumFeatureMessage/PremiumFeatureMessage.tsx
+++ b/frontend/components/PremiumFeatureMessage/PremiumFeatureMessage.tsx
@@ -6,36 +6,23 @@ import Icon from "components/Icon";
 
 interface IPremiumFeatureMessage {
   className?: string;
-  /** Aligns premium message, default: centered */
-  alignment?: "left";
 }
 
 const baseClass = "premium-feature-message-container";
 
-const PremiumFeatureMessage = ({
-  className,
-  alignment,
-}: IPremiumFeatureMessage) => {
-  const classes = classnames(
-    baseClass,
-    {
-      [`${baseClass}__align-${alignment}`]: alignment !== undefined,
-    },
-    className
-  );
+const PremiumFeatureMessage = ({ className }: IPremiumFeatureMessage) => {
+  const classes = classnames(baseClass, className);
 
   return (
     <div className={classes}>
       <div className="premium-feature-message">
         <Icon name="premium-feature" />
         <p>This feature is included in Fleet Premium.</p>
-        <div className="external-link-and-icon">
-          <CustomLink
-            url="https://fleetdm.com/upgrade"
-            text="Learn more"
-            newTab
-          />
-        </div>
+        <CustomLink
+          url="https://fleetdm.com/upgrade"
+          text="Learn more"
+          newTab
+        />
       </div>
     </div>
   );

--- a/frontend/components/PremiumFeatureMessage/_styles.scss
+++ b/frontend/components/PremiumFeatureMessage/_styles.scss
@@ -4,11 +4,6 @@
   align-items: center;
   font-size: $x-small;
 
-  &__align-left {
-    justify-content: left;
-    align-items: left;
-  }
-
   .premium-feature-message {
     display: flex;
     gap: 4px;
@@ -18,12 +13,6 @@
       // need to set line-height to normal for the icons and text to be aligned
       line-height: normal;
       margin: 0;
-    }
-
-    .external-link-and-icon {
-      display: flex;
-      gap: 4px;
-      align-items: center;
     }
   }
 }

--- a/frontend/pages/SoftwarePage/components/modals/AddSoftwareModal/AddSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/AddSoftwareModal/AddSoftwareModal.tsx
@@ -34,7 +34,7 @@ const AddSoftwareModal = ({ onExit, isFreeTier }: IAddSoftwareModalProps) => {
     if (isFreeTier) {
       return (
         <>
-          <PremiumFeatureMessage alignment="left" />{" "}
+          <PremiumFeatureMessage />
           <div className="modal-cta-wrap">
             <Button onClick={onExit}>Close</Button>
           </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/AppleBusinessManagerSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/AppleBusinessManagerSection.tsx
@@ -36,7 +36,7 @@ const AppleBusinessManagerSection = ({
   return (
     <SettingsSection title="Apple Business (AB)" className={baseClass}>
       {!isPremiumTier ? (
-        <PremiumFeatureMessage alignment="left" />
+        <PremiumFeatureMessage />
       ) : (
         <div className={`${baseClass}__content`}>
           <AppleAutomaticEnrollmentCard

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MicrosoftEntraSection/MicrosoftEntraSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MicrosoftEntraSection/MicrosoftEntraSection.tsx
@@ -30,7 +30,7 @@ const MicrosoftEntraSection = ({
   return (
     <SettingsSection title="Microsoft Entra" className={baseClass}>
       {!isPremiumTier ? (
-        <PremiumFeatureMessage alignment="left" />
+        <PremiumFeatureMessage />
       ) : (
         <div className={`${baseClass}__content`}>
           <WindowsAutomaticEnrollmentCard


### PR DESCRIPTION
## Issue
Closees #43646 

## Description
- Found during QA
- The premium message on Apple Business and Microsoft Entra was left-aligned instead of centered, and fixing it was two prop removals — less effort than writing a new ticket

## Screenshot of fix

<img width="1246" height="706" alt="Screenshot 2026-05-20 at 9 17 24 AM" src="https://github.com/user-attachments/assets/29f5c002-7fbf-4b62-9023-3ba3e10e5eab" />


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the premium feature message component by removing unnecessary configuration options and streamlining the presentation of links, improving code maintainability while ensuring consistent display across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->