### PR TITLE
Ignore WiX CVEs

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -635,6 +635,30 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-20 11:42:37
 
+### [CVE-2026-42011](https://nvd.nist.gov/vuln/detail/CVE-2026-42011)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS).
+- **Products:** `wix`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-20 10:30:00
+
+### [CVE-2026-42010](https://nvd.nist.gov/vuln/detail/CVE-2026-42010)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS).
+- **Products:** `wix`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-20 10:30:00
+
+### [CVE-2026-42009](https://nvd.nist.gov/vuln/detail/CVE-2026-42009)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS).
+- **Products:** `wix`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-20 10:30:00
+
 ### [CVE-2026-41254](https://nvd.nist.gov/vuln/detail/CVE-2026-41254)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -666,6 +690,30 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libexif12`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:16:53
+
+### [CVE-2026-3833](https://nvd.nist.gov/vuln/detail/CVE-2026-3833)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS).
+- **Products:** `wix`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-20 10:30:00
+
+### [CVE-2026-33846](https://nvd.nist.gov/vuln/detail/CVE-2026-33846)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS).
+- **Products:** `wix`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-20 10:30:00
+
+### [CVE-2026-33845](https://nvd.nist.gov/vuln/detail/CVE-2026-33845)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS).
+- **Products:** `wix`,`pkg:deb/debian/libgnutls30t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-20 10:30:00
 
 ### [CVE-2026-33636](https://nvd.nist.gov/vuln/detail/CVE-2026-33636)
 - **Author:** @lucasmrod

--- a/security/vex/wix/CVE-2026-33845.vex.json
+++ b/security/vex/wix/CVE-2026-33845.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-affb81a8a1ab7be95c179a6cb73329650a5ed68e80ded735148ed5e19225c3af",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-20T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33845"
+      },
+      "timestamp": "2026-05-20T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS)",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-33846.vex.json
+++ b/security/vex/wix/CVE-2026-33846.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-44553ed02bc93457340c30b49065197101534c81fa2d83d01884f9ccde945c16",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-20T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33846"
+      },
+      "timestamp": "2026-05-20T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS)",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-3833.vex.json
+++ b/security/vex/wix/CVE-2026-3833.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-3ff83cdedfd4136acefd46e797b47536c35c125e3d1b84859475595fd45f7983",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-20T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-3833"
+      },
+      "timestamp": "2026-05-20T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS)",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-42009.vex.json
+++ b/security/vex/wix/CVE-2026-42009.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-17e56b0d3b5b125ffcdd412a53fa7fa16fb96321d267849d54826b4a3884ca07",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-20T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42009"
+      },
+      "timestamp": "2026-05-20T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS)",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-42010.vex.json
+++ b/security/vex/wix/CVE-2026-42010.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-ebfde94389d825f76671da61a7d42b3fd43134c84f3b575448931b3ded2b3ba9",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-20T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42010"
+      },
+      "timestamp": "2026-05-20T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS)",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-42011.vex.json
+++ b/security/vex/wix/CVE-2026-42011.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-200f4a112213c87d87e95b87906b8a276c7e94768140ff9bc69e9ed64726df73",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-20T10:30:00.000000-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42011"
+      },
+      "timestamp": "2026-05-20T10:30:00.000000-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgnutls30t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use gnutls when using fleetdm/wix (go binary uses Go's TLS)",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/26146951814/job/76904628046.

Run: https://github.com/fleetdm/fleet/actions/runs/26166642789.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenVEX documents confirming the wix product is not affected by six GnuTLS vulnerabilities (CVE-2026-33845, CVE-2026-33846, CVE-2026-3833, CVE-2026-42009, CVE-2026-42010, CVE-2026-42011), as the vulnerable code is not in the execution path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->