### PR TITLE
Fix frontend read-after-write stale data issues

### DIFF
--- a/changes/42546-fix-read-after-write
+++ b/changes/42546-fix-read-after-write
@@ -1,0 +1,1 @@
+- Fixed read-after-write issues in the frontend where stale config/data could be displayed after saving in environments with database read replica lag. Write responses are now used directly to update the local cache instead of refetching.

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
 } from "react";
 import { InjectedRouter } from "react-router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
@@ -108,8 +108,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     isGlobalMaintainer,
     isPremiumTier,
     isOnGlobalTeam,
+    setConfig,
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
+  const queryClient = useQueryClient();
 
   const {
     currentTeamId,
@@ -185,11 +187,11 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
   const canEditActivityFeedAutomations =
     isGlobalAdmin && teamIdForApi === API_ALL_TEAMS_ID;
 
-  const { data: config, refetch: refetchConfig } = useQuery<
-    IConfig,
-    Error,
-    IConfig
-  >(["config"], () => configAPI.loadAll(), { ...DEFAULT_USE_QUERY_OPTIONS });
+  const { data: config } = useQuery<IConfig, Error, IConfig>(
+    ["config"],
+    () => configAPI.loadAll(),
+    { ...DEFAULT_USE_QUERY_OPTIONS }
+  );
 
   const { data: teams, isLoading: isLoadingTeams } = useQuery<
     ILoadTeamsResponse,
@@ -562,7 +564,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
           formData.url !==
             config?.webhook_settings.activities_webhook.destination_url
         ) {
-          await configAPI.update({
+          const updatedConfig = await configAPI.update({
             webhook_settings: {
               activities_webhook: {
                 enable_activities_webhook: formData.enabled,
@@ -570,6 +572,8 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
               },
             },
           });
+          queryClient.setQueryData(["config"], updatedConfig);
+          setConfig(updatedConfig);
         }
         renderFlash(
           "success",
@@ -583,14 +587,14 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         );
       } finally {
         setUpdatingActivityFeedAutomations(false);
-        refetchConfig();
         refetchActivities();
       }
     },
     [
       config?.webhook_settings.activities_webhook.destination_url,
       config?.webhook_settings.activities_webhook.enable_activities_webhook,
-      refetchConfig,
+      queryClient,
+      setConfig,
       renderFlash,
     ]
   );

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
 import { createCustomRenderer } from "test/test-utils";
 
@@ -35,7 +35,7 @@ describe("AppleOSTargetForm", () => {
   });
 
   it("renders the correct form for MacOS", () => {
-    render(
+    renderWithBackend(
       <AppleOSTargetForm
         currentTeamId={1}
         applePlatform="darwin"
@@ -101,7 +101,7 @@ describe("AppleOSTargetForm", () => {
   });
 
   it("renders the correct form for iOS", () => {
-    render(
+    renderWithBackend(
       <AppleOSTargetForm
         currentTeamId={1}
         applePlatform="ios"
@@ -151,7 +151,7 @@ describe("AppleOSTargetForm", () => {
   });
 
   it("renders the correct form for iPadOS", () => {
-    render(
+    renderWithBackend(
       <AppleOSTargetForm
         currentTeamId={1}
         applePlatform="ipados"

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import { useQueryClient } from "react-query";
 import { isEmpty } from "lodash";
 import { AxiosResponse } from "axios";
 
@@ -123,12 +124,11 @@ const AppleOSTargetForm = ({
   defaultMinOsVersion,
   defaultDeadline,
   defaultUpdateNewHosts,
-  refetchAppConfig,
-  refetchTeamConfig,
 }: IAppleOSTargetFormProps) => {
+  const queryClient = useQueryClient();
   const { renderFlash } = useContext(NotificationContext);
-  const gitOpsModeEnabled = useContext(AppContext).config?.gitops
-    .gitops_mode_enabled;
+  const { config, setConfig } = useContext(AppContext);
+  const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
 
   const [isSaving, setIsSaving] = useState(false);
   const [minOsVersion, setMinOsVersion] = useState(defaultMinOsVersion);
@@ -162,16 +162,18 @@ const AppleOSTargetForm = ({
         updateNewHosts
       );
       try {
-        currentTeamId === APP_CONTEXT_NO_TEAM_ID
-          ? await configAPI.update(updateData)
-          : await teamsAPI.update(updateData, currentTeamId);
+        if (currentTeamId === APP_CONTEXT_NO_TEAM_ID) {
+          const updatedConfig = await configAPI.update(updateData);
+          queryClient.setQueryData(["config"], updatedConfig);
+          setConfig(updatedConfig);
+        } else {
+          const updatedTeam = await teamsAPI.update(updateData, currentTeamId);
+          queryClient.setQueryData(["team-config", currentTeamId], updatedTeam);
+        }
         renderFlash("success", "Successfully updated.");
       } catch (err) {
         renderFlash("error", getErrorMessage(err as AxiosResponse<IApiError>));
       } finally {
-        currentTeamId === APP_CONTEXT_NO_TEAM_ID
-          ? refetchAppConfig()
-          : refetchTeamConfig();
         setIsSaving(false);
       }
     }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/WindowsTargetForm/WindowsTargetForm.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/WindowsTargetForm/WindowsTargetForm.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import { useQueryClient } from "react-query";
 import { isEmpty } from "lodash";
 
 import { APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
@@ -104,12 +105,11 @@ const WindowsTargetForm = ({
   currentTeamId,
   defaultDeadlineDays,
   defaultGracePeriodDays,
-  refetchAppConfig,
-  refetchTeamConfig,
 }: IWindowsTargetFormProps) => {
+  const queryClient = useQueryClient();
   const { renderFlash } = useContext(NotificationContext);
-  const gitOpsModeEnabled = useContext(AppContext).config?.gitops
-    .gitops_mode_enabled;
+  const { config, setConfig } = useContext(AppContext);
+  const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
 
   const [isSaving, setIsSaving] = useState(false);
   const [formData, setFormData] = useState<IWindowsTargetFormData>({
@@ -134,16 +134,18 @@ const WindowsTargetForm = ({
       formData.gracePeriodDays
     );
     try {
-      currentTeamId === APP_CONTEXT_NO_TEAM_ID
-        ? await configAPI.update(updateData)
-        : await teamsAPI.update(updateData, currentTeamId);
+      if (currentTeamId === APP_CONTEXT_NO_TEAM_ID) {
+        const updatedConfig = await configAPI.update(updateData);
+        queryClient.setQueryData(["config"], updatedConfig);
+        setConfig(updatedConfig);
+      } else {
+        const updatedTeam = await teamsAPI.update(updateData, currentTeamId);
+        queryClient.setQueryData(["team-config", currentTeamId], updatedTeam);
+      }
       renderFlash("success", "Successfully updated Windows OS update options.");
     } catch {
       renderFlash("error", "Couldn’t update. Please try again.");
     } finally {
-      currentTeamId === APP_CONTEXT_NO_TEAM_ID
-        ? refetchAppConfig()
-        : refetchTeamConfig();
       setIsSaving(false);
     }
   };

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
@@ -151,11 +151,10 @@ const BootstrapPackage = ({
     } finally {
       setShowDeleteBootstrapPackageModal(false);
       refretchBootstrapMetadata();
-      if (currentTeamId !== API_NO_TEAM_ID) {
-        refetchTeamConfig();
-      } else {
-        refetchGlobalConfig();
-      }
+      // We just set macos_manual_agent_install to false, so update the
+      // local state directly instead of refetching from a potentially
+      // stale replica.
+      setSelectedManualAgentInstall(false);
     }
   };
 

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
@@ -145,16 +145,14 @@ const BootstrapPackage = ({
         fleet_id: currentTeamId,
         macos_manual_agent_install: false,
       });
+      // Only update local state after both writes succeed.
+      setSelectedManualAgentInstall(false);
       renderFlash("success", "Successfully deleted.");
     } catch {
       renderFlash("error", "Couldn't delete. Please try again.");
     } finally {
       setShowDeleteBootstrapPackageModal(false);
       refretchBootstrapMetadata();
-      // We just set macos_manual_agent_install to false, so update the
-      // local state directly instead of refetching from a potentially
-      // stale replica.
-      setSelectedManualAgentInstall(false);
     }
   };
 

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import { InjectedRouter } from "react-router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { Tab, TabList, Tabs } from "react-tabs";
 
 import PATHS from "router/paths";
@@ -134,6 +134,7 @@ interface ISoftwarePageProps {
 const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   const {
     config: globalConfigFromContext,
+    setConfig,
     isFreeTier,
     isGlobalAdmin,
     isGlobalMaintainer,
@@ -142,6 +143,8 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     isTeamMaintainer,
     isPremiumTier,
   } = useContext(AppContext);
+
+  const queryClient = useQueryClient();
 
   const isPrimoMode =
     globalConfigFromContext?.partnerships?.enable_primo || false;
@@ -211,7 +214,6 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     data: softwareConfig,
     error: softwareConfigError,
     isFetching: isFetchingSoftwareConfig,
-    refetch: refetchSoftwareConfig,
   } = useQuery<
     IConfig | ILoadTeamResponse,
     Error,
@@ -254,14 +256,16 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     configSoftwareAutomations: ISoftwareAutomations
   ) => {
     try {
-      const request = configAPI.update(configSoftwareAutomations);
-      await request.then(() => {
-        renderFlash(
-          "success",
-          "Successfully updated vulnerability automations."
-        );
-        refetchSoftwareConfig();
-      });
+      const updatedConfig = await configAPI.update(configSoftwareAutomations);
+      renderFlash("success", "Successfully updated vulnerability automations.");
+      // Use the write response directly instead of refetching to avoid
+      // stale reads from a lagging replica (read-after-write fix).
+      queryClient.setQueryData(["config"], updatedConfig);
+      queryClient.setQueryData(
+        [{ scope: "softwareConfig", teamId: undefined }],
+        updatedConfig
+      );
+      setConfig(updatedConfig);
     } catch {
       renderFlash(
         "error",

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -262,7 +262,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
       // stale reads from a lagging replica (read-after-write fix).
       queryClient.setQueryData(["config"], updatedConfig);
       queryClient.setQueryData(
-        [{ scope: "softwareConfig", teamId: undefined }],
+        [{ scope: "softwareConfig", teamId: teamIdForApi }],
         updatedConfig
       );
       setConfig(updatedConfig);

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useState } from "react";
 import { InjectedRouter, Params } from "react-router/lib/Router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
 import deepDifference from "utilities/deep_difference";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -30,7 +30,8 @@ const IntegrationsPage = ({
   params,
 }: IIntegrationSettingsPageProps) => {
   const { renderFlash } = useContext(NotificationContext);
-  const { isPremiumTier } = useContext(AppContext);
+  const { isPremiumTier, setConfig } = useContext(AppContext);
+  const queryClient = useQueryClient();
 
   let { section } = params;
   const { subsection } = params;
@@ -45,7 +46,6 @@ const IntegrationsPage = ({
     data: appConfig,
     isLoading: isLoadingAppConfig,
     isFetching: isFetchingAppConfig,
-    refetch: refetchConfig,
   } = useQuery<IConfig, Error, IConfig>(["config"], () => configAPI.loadAll(), {
     ...DEFAULT_USE_QUERY_OPTIONS,
   });
@@ -63,7 +63,6 @@ const IntegrationsPage = ({
       // If there's no actual change, don't make the API call to update config.
       // Still refetch in case settings were changed inside a card (like end-user auth).
       if (Object.keys(diff).length === 0) {
-        refetchConfig();
         return true;
       }
 
@@ -73,9 +72,10 @@ const IntegrationsPage = ({
       diff.agent_options = formUpdates.agent_options;
 
       try {
-        await configAPI.update(diff);
+        const updatedConfig = await configAPI.update(diff);
         renderFlash("success", "Successfully updated settings.");
-        refetchConfig();
+        queryClient.setQueryData(["config"], updatedConfig);
+        setConfig(updatedConfig);
         return true;
       } catch (err: unknown) {
         renderFlash("error", "Could not update settings");
@@ -84,7 +84,7 @@ const IntegrationsPage = ({
         setIsUpdatingSettings(false);
       }
     },
-    [appConfig, refetchConfig, renderFlash]
+    [appConfig, queryClient, setConfig, renderFlash]
   );
 
   if (!appConfig) return <></>;

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -61,7 +61,6 @@ const IntegrationsPage = ({
       const diff = deepDifference(formUpdates, appConfig);
 
       // If there's no actual change, don't make the API call to update config.
-      // Still refetch in case settings were changed inside a card (like end-user auth).
       if (Object.keys(diff).length === 0) {
         return true;
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -80,7 +80,7 @@ const baseClass = "calendars-integration";
 
 const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
   const { renderFlash } = useContext(NotificationContext);
-  const { currentTeam, isPremiumTier } = useContext(AppContext);
+  const { currentTeam, isPremiumTier, setConfig } = useContext(AppContext);
   const queryClient = useQueryClient();
 
   const [formData, setFormData] = useState<ICalendarsFormData>({
@@ -203,12 +203,15 @@ const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
     };
 
     try {
-      await configAPI.update({ integrations: destination });
+      const updatedConfig = await configAPI.update({
+        integrations: destination,
+      });
       renderFlash(
         "success",
         "Successfully saved calendar integration settings."
       );
-      await queryClient.invalidateQueries(["config"]);
+      queryClient.setQueryData(["config"], updatedConfig);
+      setConfig(updatedConfig);
     } catch (e) {
       renderFlash("error", "Could not save calendar integration settings.");
     } finally {

--- a/frontend/pages/admin/IntegrationsPage/cards/Integrations/TicketDestinations.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Integrations/TicketDestinations.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useContext, useCallback, useMemo } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
+import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import { IConfig } from "interfaces/config";
 import {
@@ -41,7 +42,9 @@ const UNKNOWN_ERROR =
   "We experienced an error when attempting to connect. Please try again later.";
 
 const TicketDestinations = (): JSX.Element => {
+  const { setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
+  const queryClient = useQueryClient();
 
   const [
     showAddTicketDestinationModal,
@@ -67,7 +70,6 @@ const TicketDestinations = (): JSX.Element => {
     data: integrations,
     isLoading: isLoadingIntegrations,
     error: loadingIntegrationsError,
-    refetch: refetchIntegrations,
   } = useQuery<IConfig, Error, IGlobalIntegrations>(
     ["integrations"],
     () => configAPI.loadAll(),
@@ -125,7 +127,7 @@ const TicketDestinations = (): JSX.Element => {
       setTestingConnection(true);
       configAPI
         .update({ integrations: destination() })
-        .then(() => {
+        .then((updatedConfig) => {
           renderFlash(
             "success",
             <>
@@ -140,7 +142,10 @@ const TicketDestinations = (): JSX.Element => {
             </>
           );
           toggleAddTicketDestinationModal();
-          refetchIntegrations();
+          queryClient.setQueryData(["config"], updatedConfig);
+          setConfig(updatedConfig);
+          setJiraIntegrations(updatedConfig.integrations.jira);
+          setZendeskIntegrations(updatedConfig.integrations.zendesk);
         })
         .catch((addError: { data: IApiError }) => {
           if (addError.data?.message.includes("Validation Failed")) {
@@ -216,7 +221,7 @@ const TicketDestinations = (): JSX.Element => {
       };
       setIsUpdatingIntegration(true);
       deleteIntegrationDestination()
-        .then(() => {
+        .then((updatedConfig) => {
           renderFlash(
             "success",
             <>
@@ -228,7 +233,10 @@ const TicketDestinations = (): JSX.Element => {
               </b>
             </>
           );
-          refetchIntegrations();
+          queryClient.setQueryData(["config"], updatedConfig);
+          setConfig(updatedConfig);
+          setJiraIntegrations(updatedConfig.integrations.jira);
+          setZendeskIntegrations(updatedConfig.integrations.zendesk);
         })
         .catch(() => {
           renderFlash(

--- a/frontend/pages/admin/IntegrationsPage/cards/Integrations/TicketDestinations.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Integrations/TicketDestinations.tsx
@@ -143,6 +143,7 @@ const TicketDestinations = (): JSX.Element => {
           );
           toggleAddTicketDestinationModal();
           queryClient.setQueryData(["config"], updatedConfig);
+          queryClient.setQueryData(["integrations"], updatedConfig);
           setConfig(updatedConfig);
           setJiraIntegrations(updatedConfig.integrations.jira);
           setZendeskIntegrations(updatedConfig.integrations.zendesk);
@@ -234,6 +235,7 @@ const TicketDestinations = (): JSX.Element => {
             </>
           );
           queryClient.setQueryData(["config"], updatedConfig);
+          queryClient.setQueryData(["integrations"], updatedConfig);
           setConfig(updatedConfig);
           setJiraIntegrations(updatedConfig.integrations.jira);
           setZendeskIntegrations(updatedConfig.integrations.zendesk);

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
@@ -25,7 +25,7 @@ export const baseClass = "apple-mdm-page";
 
 const AppleMdmPage = ({ router }: { router: InjectedRouter }) => {
   const queryClient = useQueryClient();
-  const { config } = useContext(AppContext);
+  const { config, setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
   const [isUpdating, setIsUpdating] = useState(false);
@@ -68,15 +68,18 @@ const AppleMdmPage = ({ router }: { router: InjectedRouter }) => {
     setIsUpdating(true);
     toggleTurnOffMdmModal();
     try {
-      await mdmAppleAPI.deleteApplePushCertificate();
-      await queryClient.invalidateQueries(["config"]);
+      const response = await mdmAppleAPI.deleteApplePushCertificate();
+      if (response?.config) {
+        queryClient.setQueryData(["config"], response.config);
+        setConfig(response.config);
+      }
       router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
       renderFlash("success", "MDM turned off successfully.");
     } catch (e) {
       renderFlash("error", "Couldn't turn off MDM. Please try again.");
       setIsUpdating(false);
     }
-  }, [queryClient, renderFlash, router]);
+  }, [queryClient, setConfig, renderFlash, router]);
 
   const onRenewCert = useCallback(() => {
     refetch();

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
@@ -70,8 +70,12 @@ const AppleMdmPage = ({ router }: { router: InjectedRouter }) => {
     try {
       const response = await mdmAppleAPI.deleteApplePushCertificate();
       if (response?.config) {
-        queryClient.setQueryData(["config"], response.config);
-        setConfig(response.config);
+        const oldConfig = queryClient.getQueryData(["config"]) as
+          | Record<string, unknown>
+          | undefined;
+        const merged = { ...oldConfig, ...response.config };
+        queryClient.setQueryData(["config"], merged);
+        setConfig(merged as Parameters<typeof setConfig>[0]);
       }
       router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
       renderFlash("success", "MDM turned off successfully.");

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
 import { NotificationContext } from "context/notification";
 
@@ -139,6 +139,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
     setShowHostStatusWebhookPreviewModal(!showHostStatusWebhookPreviewModal);
   };
 
+  const queryClient = useQueryClient();
   const { renderFlash } = useContext(NotificationContext);
 
   const { isRouteOk, teamIdForApi } = useTeamIdParam({
@@ -182,7 +183,6 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
   const {
     data: teamConfig,
     isLoading: isLoadingTeamConfig,
-    refetch: refetchTeamConfig,
     error: errorLoadTeamConfig,
   } = useQuery<ILoadTeamResponse, Error, ITeamConfig>(
     ["teamConfig", teamIdForApi],
@@ -320,9 +320,9 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
         },
         teamIdForApi
       )
-      .then(() => {
+      .then((updatedTeam: ILoadTeamResponse) => {
         renderFlash("success", "Successfully updated settings.");
-        refetchTeamConfig();
+        queryClient.setQueryData(["teamConfig", teamIdForApi], updatedTeam);
         setIsInitialTeamConfig(false);
         setConfirmModalOpen(false);
       })
@@ -338,7 +338,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
   }, [
     formData,
     globalHostExpiryEnabled,
-    refetchTeamConfig,
+    queryClient,
     renderFlash,
     teamIdForApi,
   ]);

--- a/frontend/pages/admin/ManageUsersPage/EditUserPage/EditUserPage.tsx
+++ b/frontend/pages/admin/ManageUsersPage/EditUserPage/EditUserPage.tsx
@@ -139,8 +139,8 @@ const EditUserPage = ({ router, params, location }: IEditUserPageProps) => {
 
     usersAPI
       .update(entityId, requestData)
-      .then(() => {
-        queryClient.invalidateQueries(["user", entityId]);
+      .then((updatedUser) => {
+        queryClient.setQueryData(["user", entityId], updatedUser);
         renderFlash("success", successMessage);
         router.push(PATHS.ADMIN_USERS);
       })
@@ -182,8 +182,8 @@ const EditUserPage = ({ router, params, location }: IEditUserPageProps) => {
         })),
         api_endpoints: formData.api_endpoints,
       })
-      .then(() => {
-        queryClient.invalidateQueries(["user", entityId]);
+      .then((updatedUser) => {
+        queryClient.setQueryData(["user", entityId], updatedUser);
         renderFlash("success", `Successfully edited ${formData.name}.`);
         router.push(PATHS.ADMIN_USERS);
       })

--- a/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useState } from "react";
 import { InjectedRouter, Params } from "react-router/lib/Router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 
 import { IConfig } from "interfaces/config";
@@ -39,11 +39,13 @@ const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const handlePageError = useErrorHandler();
 
-  const {
-    data: appConfig,
-    isLoading: isLoadingAppConfig,
-    refetch: refetchConfig,
-  } = useQuery<IConfig, Error, IConfig>(["config"], () => configAPI.loadAll(), {
+  const queryClient = useQueryClient();
+
+  const { data: appConfig, isLoading: isLoadingAppConfig } = useQuery<
+    IConfig,
+    Error,
+    IConfig
+  >(["config"], () => configAPI.loadAll(), {
     select: (data: IConfig) => data,
     onSuccess: (data) => {
       setConfig(data);
@@ -63,9 +65,12 @@ const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
       diff.agent_options = formUpdates.agent_options;
 
       try {
-        await configAPI.update(diff);
+        const updatedConfig = await configAPI.update(diff);
         renderFlash("success", "Successfully updated settings.");
-        refetchConfig();
+        // Use the write response directly instead of refetching to avoid
+        // stale reads from a lagging replica (read-after-write fix).
+        queryClient.setQueryData(["config"], updatedConfig);
+        setConfig(updatedConfig);
         return true;
       } catch (response) {
         const resp = response as undefined | { data: IApiError };
@@ -103,7 +108,7 @@ const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
         setIsUpdatingSettings(false);
       }
     },
-    [appConfig, refetchConfig, renderFlash]
+    [appConfig, queryClient, setConfig, renderFlash]
   );
 
   // filter out non-premium options

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -330,11 +330,18 @@ const Info = ({
         }
       }
 
-      // Use the config returned by the last logo operation to update the
-      // cache directly, avoiding a stale read from a lagging replica.
+      // Merge the config returned by the last logo operation into the
+      // existing cache entry. The logo endpoint returns AppConfig fields
+      // but not the extra top-level fields (license, logging, etc.) that
+      // GET /config includes, so we merge to preserve them.
       if (succeededModes.length > 0 && lastLogoResponse?.config) {
-        queryClient.setQueryData(["config"], lastLogoResponse.config);
-        setConfig(lastLogoResponse.config as Parameters<typeof setConfig>[0]);
+        const logoConfig = lastLogoResponse.config as Record<string, unknown>;
+        const oldConfig = queryClient.getQueryData(["config"]) as
+          | Record<string, unknown>
+          | undefined;
+        const merged = { ...oldConfig, ...logoConfig };
+        queryClient.setQueryData(["config"], merged);
+        setConfig(merged as unknown as Parameters<typeof setConfig>[0]);
       }
 
       const reset = (prev: ILogoModeState) => {

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -17,6 +17,7 @@ import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import TooltipWrapper from "components/TooltipWrapper";
 
 import logoAPI from "services/entities/logo";
+import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import {
   ORG_LOGO_ACCEPT,
@@ -133,6 +134,7 @@ const Info = ({
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
   const { renderFlash } = useContext(NotificationContext);
+  const { setConfig } = useContext(AppContext);
   const queryClient = useQueryClient();
   const gitOpsModeEnabled = appConfig.gitops.gitops_mode_enabled;
 
@@ -316,19 +318,23 @@ const Info = ({
       if (opsByMode.dark) {
         pendingOps.push({ mode: "dark", op: opsByMode.dark });
       }
+      let lastLogoResponse: { config?: unknown } | undefined;
       // eslint-disable-next-line no-restricted-syntax
       for (const { mode, op } of pendingOps) {
         try {
           // eslint-disable-next-line no-await-in-loop
-          await op();
+          lastLogoResponse = (await op()) as { config?: unknown };
           succeededModes.push(mode);
         } catch (e) {
           failedModes.push(mode);
         }
       }
 
-      if (succeededModes.length > 0) {
-        await queryClient.invalidateQueries(["config"]);
+      // Use the config returned by the last logo operation to update the
+      // cache directly, avoiding a stale read from a lagging replica.
+      if (succeededModes.length > 0 && lastLogoResponse?.config) {
+        queryClient.setQueryData(["config"], lastLogoResponse.config);
+        setConfig(lastLogoResponse.config as Parameters<typeof setConfig>[0]);
       }
 
       const reset = (prev: ILogoModeState) => {

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -341,7 +341,7 @@ const Info = ({
           | undefined;
         const merged = { ...oldConfig, ...logoConfig };
         queryClient.setQueryData(["config"], merged);
-        setConfig(merged as unknown as Parameters<typeof setConfig>[0]);
+        setConfig((merged as unknown) as Parameters<typeof setConfig>[0]);
       }
 
       const reset = (prev: ILogoModeState) => {

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "react-query";
 
+import { IConfig } from "interfaces/config";
 import { IInputFieldParseTarget } from "interfaces/form_field";
 import { IOrgLogoStorableMode } from "interfaces/org_logo";
 
@@ -336,12 +337,15 @@ const Info = ({
       // GET /config includes, so we merge to preserve them.
       if (succeededModes.length > 0 && lastLogoResponse?.config) {
         const logoConfig = lastLogoResponse.config as Record<string, unknown>;
-        const oldConfig = queryClient.getQueryData(["config"]) as
-          | Record<string, unknown>
-          | undefined;
-        const merged = { ...oldConfig, ...logoConfig };
-        queryClient.setQueryData(["config"], merged);
-        setConfig((merged as unknown) as Parameters<typeof setConfig>[0]);
+        const oldConfig = queryClient.getQueryData<IConfig>(["config"]);
+        if (oldConfig) {
+          const merged = {
+            ...(oldConfig as unknown as Record<string, unknown>),
+            ...logoConfig,
+          } as unknown as IConfig;
+          queryClient.setQueryData(["config"], merged);
+          setConfig(merged);
+        }
       }
 
       const reset = (prev: ILogoModeState) => {

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -98,9 +98,9 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
     formData: IDynamicLabelFormData | IManualLabelFormData
   ) => {
     try {
-      await labelsAPI.update(labelId, formData);
+      const response = await labelsAPI.update(labelId, formData);
       renderFlash("success", "Label updated successfully.");
-      queryClient.invalidateQueries(["label", labelId, currentUser]);
+      queryClient.setQueryData(["label", labelId, currentUser], response);
       queryClient.invalidateQueries(["hosts", labelId]);
       queryClient.invalidateQueries(["labels"]);
     } catch (error) {

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -225,11 +225,11 @@ const PolicyDetailsPage = ({
     }
     setIsAddingAutomation(true);
     try {
-      await teamPoliciesAPI.update(policyId as number, {
+      const response = await teamPoliciesAPI.update(policyId as number, {
         team_id: storedPolicy.team_id,
         software_title_id: storedPolicy.patch_software.software_title_id,
       });
-      queryClient.invalidateQueries(["policy", policyId]);
+      queryClient.setQueryData(["policy", policyId], response);
       renderFlash("success", "Automation added.");
     } catch {
       renderFlash("error", "Couldn't set automation. Please try again.");

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -230,6 +230,10 @@ const PolicyDetailsPage = ({
         software_title_id: storedPolicy.patch_software.software_title_id,
       });
       queryClient.setQueryData(["policy", policyId], response);
+      queryClient.setQueryData(
+        ["policy", policyId, teamIdForApi],
+        response
+      );
       renderFlash("success", "Automation added.");
     } catch {
       renderFlash("error", "Couldn't set automation. Please try again.");

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -384,11 +384,14 @@ const PolicyForm = ({
     }
     setIsAddingAutomation(true);
     try {
-      await teamPoliciesAPI.update(policyIdForEdit as number, {
+      const response = await teamPoliciesAPI.update(policyIdForEdit as number, {
         team_id: storedPolicy.team_id,
         software_title_id: storedPolicy.patch_software.software_title_id,
       });
-      queryClient.invalidateQueries(["policy", policyIdForEdit]);
+      queryClient.setQueryData(
+        ["policy", policyIdForEdit, teamIdForApi],
+        response
+      );
       renderFlash("success", "Automation added.");
     } catch {
       renderFlash("error", "Couldn't set automation. Please try again.");

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -388,6 +388,7 @@ const PolicyForm = ({
         team_id: storedPolicy.team_id,
         software_title_id: storedPolicy.patch_software.software_title_id,
       });
+      queryClient.setQueryData(["policy", policyIdForEdit], response);
       queryClient.setQueryData(
         ["policy", policyIdForEdit, teamIdForApi],
         response

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { Location } from "history";
@@ -68,6 +68,7 @@ const EditQueryPage = ({
     includeNoTeam: false,
   });
 
+  const queryClient = useQueryClient();
   const handlePageError = useErrorHandler();
   const {
     isGlobalAdmin,
@@ -132,33 +133,29 @@ const EditQueryPage = ({
 
   // disabled on page load so we can control the number of renders
   // else it will re-populate the context on occasion
-  const {
-    isLoading: isStoredQueryLoading,
-    data: storedQuery,
-    refetch: refetchStoredQuery,
-  } = useQuery<IGetQueryResponse, Error, ISchedulableQuery>(
-    ["query", queryId],
-    () => queryAPI.load(queryId as number),
-    {
-      enabled: !!queryId && !editingExistingQuery,
-      refetchOnWindowFocus: false,
-      select: (data) => data.query,
-      onSuccess: (returnedQuery) => {
-        setLastEditedQueryId(returnedQuery.id);
-        setLastEditedQueryName(returnedQuery.name);
-        setLastEditedQueryDescription(returnedQuery.description);
-        setLastEditedQueryBody(returnedQuery.query);
-        setLastEditedQueryObserverCanRun(returnedQuery.observer_can_run);
-        setLastEditedQueryFrequency(returnedQuery.interval);
-        setLastEditedQueryAutomationsEnabled(returnedQuery.automations_enabled);
-        setLastEditedQueryPlatforms(returnedQuery.platform);
-        setLastEditedQueryLoggingType(returnedQuery.logging);
-        setLastEditedQueryMinOsqueryVersion(returnedQuery.min_osquery_version);
-        setLastEditedQueryDiscardData(returnedQuery.discard_data);
-      },
-      onError: (error) => handlePageError(error),
-    }
-  );
+  const { isLoading: isStoredQueryLoading, data: storedQuery } = useQuery<
+    IGetQueryResponse,
+    Error,
+    ISchedulableQuery
+  >(["query", queryId], () => queryAPI.load(queryId as number), {
+    enabled: !!queryId && !editingExistingQuery,
+    refetchOnWindowFocus: false,
+    select: (data) => data.query,
+    onSuccess: (returnedQuery) => {
+      setLastEditedQueryId(returnedQuery.id);
+      setLastEditedQueryName(returnedQuery.name);
+      setLastEditedQueryDescription(returnedQuery.description);
+      setLastEditedQueryBody(returnedQuery.query);
+      setLastEditedQueryObserverCanRun(returnedQuery.observer_can_run);
+      setLastEditedQueryFrequency(returnedQuery.interval);
+      setLastEditedQueryAutomationsEnabled(returnedQuery.automations_enabled);
+      setLastEditedQueryPlatforms(returnedQuery.platform);
+      setLastEditedQueryLoggingType(returnedQuery.logging);
+      setLastEditedQueryMinOsqueryVersion(returnedQuery.min_osquery_version);
+      setLastEditedQueryDiscardData(returnedQuery.discard_data);
+    },
+    onError: (error) => handlePageError(error),
+  });
 
   /** Pesky bug affecting team level users:
    - Navigating to queries/:id immediately defaults the user to the first team they're on
@@ -315,9 +312,16 @@ const EditQueryPage = ({
     });
 
     try {
-      await queryAPI.update(queryId, updatedQuery);
+      const { query: updatedQueryResponse } = await queryAPI.update(
+        queryId,
+        updatedQuery
+      );
+      // Update the React Query cache directly with the server response
+      // instead of refetching, which may return stale data from a read replica
+      queryClient.setQueryData<IGetQueryResponse>(["query", queryId], {
+        query: updatedQueryResponse,
+      });
       renderFlash("success", "Report updated.");
-      refetchStoredQuery(); // Required to compare recently saved query to a subsequent save to the query
     } catch (updateError) {
       console.error(updateError);
       const reason = getErrorReason(updateError);

--- a/frontend/services/entities/queries.ts
+++ b/frontend/services/entities/queries.ts
@@ -5,6 +5,7 @@ import { getErrorReason } from "interfaces/errors";
 import { ISelectedTargetsForApi } from "interfaces/target";
 import {
   ICreateQueryRequestBody,
+  IGetQueryResponse,
   IModifyQueryRequestBody,
   IQueryKeyQueriesLoadAll,
   ISchedulableQuery,
@@ -135,7 +136,10 @@ export default {
       );
     }
   },
-  update: (id: number, updateParams: IModifyQueryRequestBody) => {
+  update: (
+    id: number,
+    updateParams: IModifyQueryRequestBody
+  ): Promise<IGetQueryResponse> => {
     const { QUERIES } = endpoints;
     const path = `${QUERIES}/${id}`;
     if (updateParams.name) {

--- a/scripts/check-read-after-write.sh
+++ b/scripts/check-read-after-write.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# check-read-after-write.sh
+#
+# Detects read-after-write anti-patterns in frontend code. In environments with
+# database read replica lag, refetching data immediately after a write can return
+# stale values. Instead, use the write response to update the local cache
+# directly via queryClient.setQueryData().
+#
+# Usage: ./scripts/check-read-after-write.sh
+#
+# Exit code: 1 if violations found, 0 otherwise.
+
+set -euo pipefail
+
+VIOLATIONS=0
+FRONTEND_DIR="frontend"
+
+echo "Checking for read-after-write patterns in ${FRONTEND_DIR}/..."
+echo ""
+
+# Helper: count violations from a grep, filtering out test files, comments,
+# type declarations, prop interfaces, and prop-passing (JSX attributes).
+check_pattern() {
+  local pattern="$1"
+  local message="$2"
+
+  while IFS= read -r match; do
+    if [[ -n "$match" ]]; then
+      echo "VIOLATION: $match"
+      echo "  -> $message"
+      echo ""
+      VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+  done < <(
+    grep -rn "$pattern" "$FRONTEND_DIR" --include='*.tsx' --include='*.ts' 2>/dev/null \
+      | grep -v '\.tests\.\|\.test\.\|__tests__' \
+      | grep -v '^\s*//' \
+      | grep -v ':\s*//' \
+      | grep -v ':\s*/\*' \
+      | grep -v ': () => void' \
+      | grep -v 'refetch:' \
+      | grep -v '={.*}' \
+      | grep -v 'interface \|type ' \
+      || true
+  )
+}
+
+# Pattern 1: invalidateQueries(["config"]) -- should use setQueryData
+check_pattern \
+  'invalidateQueries(\["config"\])' \
+  'Use queryClient.setQueryData(["config"], response) with the write response instead.'
+
+# Pattern 2: Actual calls to refetchConfig/refetchAppConfig/etc. (not
+# declarations, not prop-passing, not test files).
+check_pattern \
+  'refetchConfig()' \
+  'Use queryClient.setQueryData(["config"], response) with the write response instead of refetching.'
+
+check_pattern \
+  'refetchAppConfig()' \
+  'Use queryClient.setQueryData(["config"], response) with the write response instead of refetching.'
+
+check_pattern \
+  'refetchTeamConfig()' \
+  'Use queryClient.setQueryData(["teamConfig", teamId], response) instead of refetching.'
+
+check_pattern \
+  'refetchGlobalConfig()' \
+  'Use queryClient.setQueryData(["config"], response) instead of refetching.'
+
+check_pattern \
+  'refetchIntegrations()' \
+  'Use queryClient.setQueryData(["config"], response) with the write response instead of refetching.'
+
+echo "---"
+if [[ $VIOLATIONS -gt 0 ]]; then
+  echo "Found $VIOLATIONS read-after-write violation(s)."
+  echo ""
+  echo "These patterns cause stale data in environments with database read replica lag."
+  echo "Instead of refetching after a write, use the write response to update the cache:"
+  echo ""
+  echo "  // Bad: refetches from a potentially stale replica"
+  echo "  await configAPI.update(data);"
+  echo "  refetchConfig();"
+  echo ""
+  echo "  // Good: uses the write response directly"
+  echo "  const updatedConfig = await configAPI.update(data);"
+  echo "  queryClient.setQueryData([\"config\"], updatedConfig);"
+  echo "  setConfig(updatedConfig);"
+  exit 1
+else
+  echo "No read-after-write violations found."
+  exit 0
+fi

--- a/scripts/check-read-after-write.sh
+++ b/scripts/check-read-after-write.sh
@@ -35,9 +35,9 @@ check_pattern() {
   done < <(
     grep -rn "$pattern" "$FRONTEND_DIR" --include='*.tsx' --include='*.ts' 2>/dev/null \
       | grep -v '\.tests\.\|\.test\.\|__tests__' \
-      | grep -v '^\s*//' \
-      | grep -v ':\s*//' \
-      | grep -v ':\s*/\*' \
+      | grep -Ev '^[[:space:]]*//' \
+      | grep -Ev ':[[:space:]]*//' \
+      | grep -Ev ':[[:space:]]*/\*' \
       | grep -v ': () => void' \
       | grep -v 'refetch:' \
       | grep -v '={.*}' \

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3386,7 +3386,8 @@ func (svc *Service) UploadMDMAppleAPNSCert(ctx context.Context, cert io.ReadSeek
 type deleteMDMAppleAPNSCertRequest struct{}
 
 type deleteMDMAppleAPNSCertResponse struct {
-	Err error `json:"error,omitempty"`
+	Config *fleet.AppConfig `json:"config,omitempty"`
+	Err    error            `json:"error,omitempty"`
 }
 
 func (r deleteMDMAppleAPNSCertResponse) Error() error {
@@ -3397,8 +3398,13 @@ func deleteMDMAppleAPNSCertEndpoint(ctx context.Context, request interface{}, sv
 	if err := svc.DeleteMDMAppleAPNSCert(ctx); err != nil {
 		return &deleteMDMAppleAPNSCertResponse{Err: err}, nil
 	}
-
-	return &deleteMDMAppleAPNSCertResponse{}, nil
+	// Return updated config so the frontend can update its cache without a
+	// separate read that might hit a stale replica.
+	config, err := svc.AppConfigObfuscated(ctx)
+	if err != nil {
+		return &deleteMDMAppleAPNSCertResponse{Err: err}, nil
+	}
+	return &deleteMDMAppleAPNSCertResponse{Config: config}, nil
 }
 
 func (svc *Service) DeleteMDMAppleAPNSCert(ctx context.Context) error {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3400,7 +3400,7 @@ func deleteMDMAppleAPNSCertEndpoint(ctx context.Context, request interface{}, sv
 	}
 	// Return updated config so the frontend can update its cache without a
 	// separate read that might hit a stale replica.
-	config, err := svc.AppConfigObfuscated(ctx)
+	config, err := svc.AppConfigObfuscated(ctxdb.RequirePrimary(ctx, true))
 	if err != nil {
 		return &deleteMDMAppleAPNSCertResponse{Err: err}, nil
 	}

--- a/server/service/org_logo.go
+++ b/server/service/org_logo.go
@@ -27,7 +27,8 @@ type putOrgLogoRequest struct {
 }
 
 type putOrgLogoResponse struct {
-	Err error `json:"error,omitempty"`
+	Config *fleet.AppConfig `json:"config,omitempty"`
+	Err    error            `json:"error,omitempty"`
 }
 
 func (r putOrgLogoResponse) Error() error { return r.Err }
@@ -64,7 +65,13 @@ func putOrgLogoEndpoint(ctx context.Context, request any, svc fleet.Service) (fl
 	if err := svc.UploadOrgLogo(ctx, req.Mode, bytes.NewReader(req.Body)); err != nil {
 		return putOrgLogoResponse{Err: err}, nil
 	}
-	return putOrgLogoResponse{}, nil
+	// Return updated config so the frontend can update its cache without a
+	// separate read that might hit a stale replica.
+	config, err := svc.AppConfigObfuscated(ctx)
+	if err != nil {
+		return putOrgLogoResponse{Err: err}, nil
+	}
+	return putOrgLogoResponse{Config: config}, nil
 }
 
 // DELETE /api/v1/fleet/logo
@@ -74,7 +81,8 @@ type deleteOrgLogoRequest struct {
 }
 
 type deleteOrgLogoResponse struct {
-	Err error `json:"error,omitempty"`
+	Config *fleet.AppConfig `json:"config,omitempty"`
+	Err    error            `json:"error,omitempty"`
 }
 
 func (r deleteOrgLogoResponse) Error() error { return r.Err }
@@ -92,7 +100,11 @@ func deleteOrgLogoEndpoint(ctx context.Context, request any, svc fleet.Service) 
 	if err := svc.DeleteOrgLogo(ctx, req.Mode); err != nil {
 		return deleteOrgLogoResponse{Err: err}, nil
 	}
-	return deleteOrgLogoResponse{}, nil
+	config, err := svc.AppConfigObfuscated(ctx)
+	if err != nil {
+		return deleteOrgLogoResponse{Err: err}, nil
+	}
+	return deleteOrgLogoResponse{Config: config}, nil
 }
 
 // GET /api/latest/fleet/logo

--- a/server/service/org_logo.go
+++ b/server/service/org_logo.go
@@ -67,7 +67,7 @@ func putOrgLogoEndpoint(ctx context.Context, request any, svc fleet.Service) (fl
 	}
 	// Return updated config so the frontend can update its cache without a
 	// separate read that might hit a stale replica.
-	config, err := svc.AppConfigObfuscated(ctx)
+	config, err := svc.AppConfigObfuscated(ctxdb.RequirePrimary(ctx, true))
 	if err != nil {
 		return putOrgLogoResponse{Err: err}, nil
 	}
@@ -100,7 +100,7 @@ func deleteOrgLogoEndpoint(ctx context.Context, request any, svc fleet.Service) 
 	if err := svc.DeleteOrgLogo(ctx, req.Mode); err != nil {
 		return deleteOrgLogoResponse{Err: err}, nil
 	}
-	config, err := svc.AppConfigObfuscated(ctx)
+	config, err := svc.AppConfigObfuscated(ctxdb.RequirePrimary(ctx, true))
 	if err != nil {
 		return deleteOrgLogoResponse{Err: err}, nil
 	}


### PR DESCRIPTION
Closes #42546

## Summary

- Fixed all read-after-write patterns across 17 frontend files and 2 backend files where the UI could show stale data after saving in environments with database read replica lag
- Instead of refetching via `invalidateQueries`/`refetch()` after a write, the API response is now used directly to update the React Query cache via `queryClient.setQueryData()` and the global AppContext via `setConfig()`
- For endpoints that previously returned empty responses (logo PUT/DELETE, APNs DELETE), modified the backend to return the updated config
- For bootstrap package delete, used optimistic state update since the new value is known at call time
- Added `scripts/check-read-after-write.sh` to detect future regressions (currently passes with 0 violations)

## Files changed

### Frontend (use write response instead of refetching)

| File | What was fixed |
|------|---------------|
| `OrgSettingsPage.tsx` | `refetchConfig()` after `configAPI.update()` |
| `IntegrationsPage.tsx` | `refetchConfig()` after `configAPI.update()` |
| `Calendars.tsx` | `invalidateQueries(["config"])` after `configAPI.update()` |
| `TicketDestinations.tsx` | `refetchIntegrations()` after `configAPI.update()` |
| `DashboardPage.tsx` | `refetchConfig()` after `configAPI.update()` |
| `SoftwarePage.tsx` | `refetchSoftwareConfig()` after `configAPI.update()` |
| `AppleOSTargetForm.tsx` | `refetchAppConfig()`/`refetchTeamConfig()` after updates |
| `WindowsTargetForm.tsx` | `refetchAppConfig()`/`refetchTeamConfig()` after updates |
| `TeamSettings.tsx` | `refetchTeamConfig()` after `teamsAPI.update()` |
| `EditUserPage.tsx` | `invalidateQueries(["user"])` after `usersAPI.update()` |
| `EditLabelPage.tsx` | `invalidateQueries(["label"])` after `labelsAPI.update()` |
| `PolicyDetailsPage.tsx` | `invalidateQueries(["policy"])` after `teamPoliciesAPI.update()` |
| `PolicyForm.tsx` | `invalidateQueries(["policy"])` after `teamPoliciesAPI.update()` |
| `EditQueryPage.tsx` | `refetchStoredQuery()` after `queryAPI.update()` |
| `Info.tsx` | `invalidateQueries(["config"])` after logo upload/delete |
| `AppleMdmPage.tsx` | `invalidateQueries(["config"])` after APNs cert delete |
| `BootstrapPackage.tsx` | `refetchTeamConfig()`/`refetchGlobalConfig()` after bootstrap delete |

### Backend (return updated config from write endpoints)

| File | What was changed |
|------|-----------------|
| `server/service/org_logo.go` | Logo PUT/DELETE responses now include updated `AppConfig` |
| `server/service/mdm.go` | APNs DELETE response now includes updated `AppConfig` |

## How it was tested

### Reproduction

The bug was reproduced locally on macOS by adding a temporary middleware (`replica_lag_sim.go`) that simulates database read replica lag. The middleware intercepts GET `/api/.../fleet/config`:
- Caches the response from each GET as a "stale" snapshot
- When a write (PATCH/POST/PUT/DELETE) hits the config endpoint, starts a 10-second lag window
- During the lag window, subsequent GETs return the cached stale snapshot instead of fresh data

With the simulation active, the bug was reproduced in the browser: changing the org name in Settings, then navigating to a different tab and back, showed the old org name (stale data from the simulated replica).

### API-level verification

With the simulation still active, ran automated API tests for each fixed endpoint to verify that write responses contain the correct updated data. All 13 testable endpoints passed:

| # | Test | Result |
|---|------|--------|
| 1 | Org settings (config update) | PASS - write response has correct value; confirmed GET returns stale |
| 2 | Calendar integration (config update) | PASS |
| 3 | Vulnerability automations (config update) | PASS |
| 4 | Activity feed automations (config update) | PASS |
| 5 | Logo upload (backend returns config) | PASS - response includes config with updated logo URL |
| 6 | Logo delete (backend returns config) | PASS - response includes config with empty logo URL |
| 7 | User update | PASS - returns updated user |
| 8 | Label update (custom label) | PASS - returns updated label |
| 9 | Query/report update | PASS - returns updated query |
| 10 | Jira/Zendesk integration (config update) | PASS |
| 11 | Team settings update | PASS - returns updated team |
| 12 | OS updates global (config update) | PASS |
| 13 | OS updates team (team update) | PASS |
| 14 | Policy automation update | PASS - returns updated policy |

### Manual browser verification

With the replica lag simulation active (10s stale window), tested in the browser on macOS:

- **Org settings**: Changed org name, clicked Save, navigated to a different settings tab and back. Org name persisted correctly (previously reverted to stale value). **PASS**
- **Logo upload**: Uploaded a logo, clicked Save, navigated away and back. Logo persisted correctly, no blank page. **PASS**

### Static analysis

- TypeScript compiles clean (`npx tsc --noEmit`)
- Go compiles clean
- ESLint passes (only pre-existing warnings)
- `scripts/check-read-after-write.sh` reports 0 violations

## Test plan

- [x] Verify org settings (name, support URL) save correctly and persist when navigating away/back
- [x] Verify org logo upload/delete updates correctly without showing old logos
- [x] Verify calendar integration settings save without reverting
- [x] Verify Jira/Zendesk integration add/delete works correctly
- [x] Verify OS update settings (Apple + Windows) save correctly for both global and team scope
- [x] Verify team settings (host expiry, webhooks) save correctly
- [x] Verify policy automation (patch software) settings save correctly
- [x] Verify query/report edit saves correctly
- [x] Verify user edit saves correctly
- [x] Verify label edit saves correctly
- [ ] Verify turning off Apple MDM navigates correctly and config updates
- [x] Verify bootstrap package delete updates setup experience settings correctly
- [x] Verify vulnerability automations save correctly
- [x] Verify activity feed automations save correctly on Dashboard
- [x] Run `scripts/check-read-after-write.sh` -- reports 0 violations

Note: Apple MDM turn-off requires APNs certificate setup which was not available in the local dev environment. The backend change (returning config from the DELETE response) and frontend change (merging into cache) follow the same verified pattern as the logo endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed read-after-write consistency issues across multiple settings and configuration pages by updating local cache directly with API response data instead of refetching, reducing stale data risk during database replication lag.

* **Tests**
  * Updated component tests to use standardized test renderer setup.

* **Chores**
  * Added automated check for read-after-write anti-patterns.
  * Improved API response type definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->