### PR TITLE
Update fleet-desktop and zoom-rooms casks

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
@@ -1,6 +1,6 @@
 cask "fleet-desktop" do
-  version "1.2.0"
-  sha256 "d58a07e71d350b6c7fc39319080c28ad56d298f41ef45c67e0114940dce41420"
+  version "1.2.1"
+  sha256 "a6c29ee908baa46a6eae76b38141435043135919d958b2d2cf546ba72d2a8911"
 
   url "https://github.com/allenhouchins/fleet-desktop/releases/download/v#{version}/fleet_desktop-v#{version}.pkg"
   name "Fleet Desktop"

--- a/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/zoom-rooms.rb
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/zoom-rooms.rb
@@ -1,6 +1,6 @@
 cask "zoom-rooms" do
-  version "7.0.0.12322"
-  sha256 "c35229e6066732aec7f26b762d0f2d43ab7b8270e512fbabe5bbb77a9c714bbc"
+  version "7.0.5.12655"
+  sha256 "8fb2ab355a5bdd0acdae3c6e0f10d8d41556a3011478f4faf6198dcad96dd0d1"
 
   url "https://cdn.zoom.us/prod/#{version}/ZoomRooms.pkg"
   name "Zoom Rooms"

--- a/ee/maintained-apps/inputs/homebrew/custom-tap/api/fleet-desktop.json
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/api/fleet-desktop.json
@@ -6,15 +6,17 @@
   ],
   "desc": "End-user client for Fleet device management",
   "homepage": "https://github.com/allenhouchins/fleet-desktop",
-  "url": "https://github.com/allenhouchins/fleet-desktop/releases/download/v1.2.0/fleet_desktop-v1.2.0.pkg",
+  "url": "https://github.com/allenhouchins/fleet-desktop/releases/download/v1.2.1/fleet_desktop-v1.2.1.pkg",
   "url_specs": {},
-  "version": "1.2.0",
+  "version": "1.2.1",
   "autobump": true,
   "no_autobump_message": null,
   "skip_livecheck": false,
   "bundle_version": null,
   "bundle_short_version": null,
-  "sha256": "d58a07e71d350b6c7fc39319080c28ad56d298f41ef45c67e0114940dce41420",
+  "pinned": false,
+  "pinned_version": null,
+  "sha256": "a6c29ee908baa46a6eae76b38141435043135919d958b2d2cf546ba72d2a8911",
   "artifacts": [
     {
       "uninstall": [
@@ -26,7 +28,7 @@
     },
     {
       "pkg": [
-        "fleet_desktop-v1.2.0.pkg"
+        "fleet_desktop-v1.2.1.pkg"
       ]
     },
     {
@@ -72,6 +74,6 @@
   "languages": [],
   "ruby_source_path": "Casks/fleet-desktop.rb",
   "ruby_source_checksum": {
-    "sha256": "22014d0a5d40491927793478b16940b9c38306b8a7c44058e0b356bb17a35493"
+    "sha256": "dcc8f6940f331ff7a2182b7479f3ccb3f7f12672294122ba337f777431caf63e"
   }
 }

--- a/ee/maintained-apps/inputs/homebrew/custom-tap/api/zoom-rooms.json
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/api/zoom-rooms.json
@@ -6,15 +6,17 @@
   ],
   "desc": "Conference room software for Zoom meetings",
   "homepage": "https://www.zoom.com/en/products/zoom-rooms/",
-  "url": "https://cdn.zoom.us/prod/7.0.0.12322/ZoomRooms.pkg",
+  "url": "https://cdn.zoom.us/prod/7.0.5.12655/ZoomRooms.pkg",
   "url_specs": {},
-  "version": "7.0.0.12322",
+  "version": "7.0.5.12655",
   "autobump": true,
   "no_autobump_message": null,
   "skip_livecheck": true,
   "bundle_version": null,
   "bundle_short_version": null,
-  "sha256": "c35229e6066732aec7f26b762d0f2d43ab7b8270e512fbabe5bbb77a9c714bbc",
+  "pinned": false,
+  "pinned_version": null,
+  "sha256": "8fb2ab355a5bdd0acdae3c6e0f10d8d41556a3011478f4faf6198dcad96dd0d1",
   "artifacts": [
     {
       "uninstall": [
@@ -85,6 +87,6 @@
   "languages": [],
   "ruby_source_path": "Casks/zoom-rooms.rb",
   "ruby_source_checksum": {
-    "sha256": "5a428ab919a9c0da0d54f4868ef4ce49693f83a778de7cdd508f063ef770514f"
+    "sha256": "98706d4c8a4f74ed1141121ece328aa42902c0b9366d4e6b374ede6174968f8f"
   }
 }


### PR DESCRIPTION
Bump fleet-desktop to 1.2.1 and zoom-rooms to 7.0.5.12655. Update cask files and matching API JSONs: package URLs, filenames, version strings, SHA256 checksums, and ruby_source_checksum values to match the new upstream releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Fleet Desktop to version 1.2.1
  * Updated Zoom Rooms to version 7.0.5.12655

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->