### PR TITLE
Manage Automations: Policy details page changes

### DIFF
--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -20,6 +20,8 @@ export default PropTypes.shape({
   updated_at: PropTypes.string.isRequired,
 });
 
+export type OtherAutomationType = "webhook" | "ticket";
+
 export interface IStoredPolicyResponse {
   policy: IPolicy;
 }
@@ -50,6 +52,7 @@ export interface IPolicy {
   install_software?: IPolicySoftwareToInstall;
   run_script?: Pick<IScript, "id" | "name">;
   patch_software?: IPolicySoftwareToInstall;
+  continuous_automations_enabled?: boolean;
   labels_include_any?: ILabelPolicy[];
   labels_include_all?: ILabelPolicy[];
   labels_exclude_any?: ILabelPolicy[];

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -6,7 +6,11 @@ import PATHS from "router/paths";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import { PolicyContext } from "context/policy";
-import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";
+import {
+  IPolicy,
+  IStoredPolicyResponse,
+  OtherAutomationType,
+} from "interfaces/policy";
 import { ILabelPolicy } from "interfaces/label";
 import {
   API_ALL_TEAMS_ID,
@@ -177,6 +181,7 @@ const PolicyDetailsPage = ({
   const policyFleetName = getPolicyFleetName(storedPolicy, teamData);
 
   let currentAutomatedPolicies: number[] = [];
+  let otherAutomationType: OtherAutomationType | undefined;
   if (teamData?.team) {
     const {
       webhook_settings: { failing_policies_webhook: webhook },
@@ -188,6 +193,11 @@ const PolicyDetailsPage = ({
       false;
     if (isIntegrationEnabled || webhook?.enable_failing_policies_webhook) {
       currentAutomatedPolicies = webhook?.policy_ids || [];
+    }
+    if (isIntegrationEnabled) {
+      otherAutomationType = "ticket";
+    } else if (webhook?.enable_failing_policies_webhook) {
+      otherAutomationType = "webhook";
     }
   }
 
@@ -442,6 +452,7 @@ const PolicyDetailsPage = ({
                 canEditPolicy={canEditPolicy}
                 onAddAutomation={onAddPatchAutomation}
                 isAddingAutomation={isAddingAutomation}
+                otherAutomationType={otherAutomationType}
               />
             )}
           </>

--- a/frontend/pages/policies/edit/EditPolicyPage.tsx
+++ b/frontend/pages/policies/edit/EditPolicyPage.tsx
@@ -10,6 +10,7 @@ import {
   IPolicyFormData,
   IPolicy,
   IStoredPolicyResponse,
+  OtherAutomationType,
 } from "interfaces/policy";
 import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import globalPoliciesAPI from "services/entities/global_policies";
@@ -221,6 +222,7 @@ const PolicyPage = ({
   );
 
   let currentAutomatedPolicies: number[] = [];
+  let otherAutomationType: OtherAutomationType | undefined;
   if (teamData?.team) {
     const {
       webhook_settings: { failing_policies_webhook: webhook },
@@ -232,6 +234,11 @@ const PolicyPage = ({
       false;
     if (isIntegrationEnabled || webhook?.enable_failing_policies_webhook) {
       currentAutomatedPolicies = webhook?.policy_ids || [];
+    }
+    if (isIntegrationEnabled) {
+      otherAutomationType = "ticket";
+    } else if (webhook?.enable_failing_policies_webhook) {
+      otherAutomationType = "webhook";
     }
   }
 
@@ -327,6 +334,7 @@ const PolicyPage = ({
       renderLiveQueryWarning,
       teamIdForApi,
       currentAutomatedPolicies,
+      otherAutomationType,
     };
 
     return <QueryEditor {...queryEditorOpts} />;

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
@@ -351,9 +351,11 @@ describe("PolicyAutomations", () => {
       );
 
       expect(
-        screen.getByText(
-          "Software and script automations run every time Fleet receives a failing response. All other automations run on a host's first failure, or when a host's response changes from pass to fail."
-        )
+        screen.getByText(/Software and script automations run/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("every time")).toBeInTheDocument();
+      expect(
+        screen.getByText(/All other automations run on a host's first failure/)
       ).toBeInTheDocument();
     });
 

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
@@ -48,6 +48,26 @@ const renderWithAppContext = (ui: React.ReactElement) => {
   );
 };
 
+const createMockPolicy = (overrides?: Partial<IPolicy>): IPolicy => ({
+  id: 1,
+  name: "Test policy",
+  query: "SELECT 1;",
+  description: "",
+  author_id: 1,
+  author_name: "Admin",
+  author_email: "admin@example.com",
+  resolution: "",
+  platform: "darwin",
+  team_id: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  critical: false,
+  calendar_events_enabled: false,
+  conditional_access_enabled: false,
+  type: "dynamic",
+  ...overrides,
+});
+
 const defaultProps = {
   onAddAutomation: jest.fn(),
   currentAutomatedPolicies: [] as number[],
@@ -175,6 +195,183 @@ describe("PolicyAutomations", () => {
       );
 
       expect(screen.queryByText(/Automatically patch/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("automations list", () => {
+    it("shows empty state when no automations are configured", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy()}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.getByText("No automations")).toBeInTheDocument();
+    });
+
+    it("shows software automation row", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({
+            install_software: { name: "Zoom", software_title_id: 42 },
+          })}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.getByText("Zoom")).toBeInTheDocument();
+      expect(screen.queryByText("No automations")).not.toBeInTheDocument();
+    });
+
+    it("shows script automation row", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({
+            run_script: { id: 1, name: "fix.sh" },
+          })}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.getByText("fix.sh")).toBeInTheDocument();
+    });
+
+    it("shows calendar automation row", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({ calendar_events_enabled: true })}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.getByText("Maintenance window")).toBeInTheDocument();
+    });
+
+    it("shows conditional access automation row", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({
+            conditional_access_enabled: true,
+          })}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.getByText("Block single sign-on")).toBeInTheDocument();
+    });
+
+    it("shows 'Webhook' for other automation when otherAutomationType is webhook", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({ id: 1 })}
+          currentAutomatedPolicies={[1]}
+          canEditPolicy={false}
+          onAddAutomation={jest.fn()}
+          otherAutomationType="webhook"
+        />
+      );
+
+      expect(screen.getByText("Webhook")).toBeInTheDocument();
+      expect(screen.queryByText("Ticket")).not.toBeInTheDocument();
+    });
+
+    it("shows 'Ticket' for other automation when otherAutomationType is ticket", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({ id: 1 })}
+          currentAutomatedPolicies={[1]}
+          canEditPolicy={false}
+          onAddAutomation={jest.fn()}
+          otherAutomationType="ticket"
+        />
+      );
+
+      expect(screen.getByText("Ticket")).toBeInTheDocument();
+      expect(screen.queryByText("Webhook")).not.toBeInTheDocument();
+    });
+
+    it("shows 'Webhook or ticket' for other automation when otherAutomationType is not set", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({ id: 1 })}
+          currentAutomatedPolicies={[1]}
+          canEditPolicy={false}
+          onAddAutomation={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText("Webhook or ticket")).toBeInTheDocument();
+    });
+
+    it("does not show row type labels", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({ calendar_events_enabled: true })}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.queryByText("Calendar")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("footer text", () => {
+    it("shows default footer text when continuous_automations_enabled is not set", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy()}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          "Automations run on a host's first failure, or when a host's response changes from pass to fail."
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("shows continuous footer text when continuous_automations_enabled is true", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy({
+            continuous_automations_enabled: true,
+          })}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          "Software and script automations run every time Fleet receives a failing response. All other automations run on a host's first failure, or when a host's response changes from pass to fail."
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("shows footer text even in the empty state", () => {
+      renderWithAppContext(
+        <PolicyAutomations
+          storedPolicy={createMockPolicy()}
+          canEditPolicy={false}
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.getByText("No automations")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Automations run on a host's first failure, or when a host's response changes from pass to fail."
+        )
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tests.tsx
@@ -308,18 +308,6 @@ describe("PolicyAutomations", () => {
 
       expect(screen.getByText("Webhook or ticket")).toBeInTheDocument();
     });
-
-    it("does not show row type labels", () => {
-      renderWithAppContext(
-        <PolicyAutomations
-          storedPolicy={createMockPolicy({ calendar_events_enabled: true })}
-          canEditPolicy={false}
-          {...defaultProps}
-        />
-      );
-
-      expect(screen.queryByText("Calendar")).not.toBeInTheDocument();
-    });
   });
 
   describe("footer text", () => {

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router";
 
-import { IPolicy } from "interfaces/policy";
+import { IPolicy, OtherAutomationType } from "interfaces/policy";
 import PATHS from "router/paths";
 import { getPathWithQueryParams } from "utilities/url";
 
@@ -21,7 +21,13 @@ interface IPolicyAutomationsProps {
   canEditPolicy: boolean;
   onAddAutomation: () => void;
   isAddingAutomation?: boolean;
+  otherAutomationType?: OtherAutomationType;
 }
+
+const OTHER_AUTOMATION_NAMES: Record<OtherAutomationType, string> = {
+  webhook: "Webhook",
+  ticket: "Ticket",
+};
 
 interface IAutomationRow {
   name: string;
@@ -39,6 +45,7 @@ const PolicyAutomations = ({
   canEditPolicy,
   onAddAutomation,
   isAddingAutomation,
+  otherAutomationType,
 }: IPolicyAutomationsProps): JSX.Element => {
   const isPatchPolicy = storedPolicy.type === "patch";
   const hasPatchSoftware = !!storedPolicy.patch_software;
@@ -100,8 +107,11 @@ const PolicyAutomations = ({
   }
 
   if (currentAutomatedPolicies.includes(storedPolicy.id)) {
+    const otherName = otherAutomationType
+      ? OTHER_AUTOMATION_NAMES[otherAutomationType]
+      : "Webhook or ticket";
     automationRows.push({
-      name: "Create ticket or send webhook",
+      name: otherName,
       type: "Other",
       graphicName: "settings",
       sortOrder: 4,
@@ -146,40 +156,44 @@ const PolicyAutomations = ({
           />
         </div>
       )}
-      {automationRows.length > 0 && (
-        <>
-          <div className={`${baseClass}__list-label`}>Automations</div>
-          <div className={`${baseClass}__list`}>
-            {automationRows.map((row) => (
-              <div
-                key={`${row.type}-${row.name}`}
-                className={`${baseClass}__row`}
-              >
-                <div className={`${baseClass}__row-name`}>
-                  {row.isSoftware ? (
-                    <SoftwareIcon name={row.name} size="small" />
-                  ) : (
-                    row.graphicName && (
-                      <Graphic
-                        name={row.graphicName}
-                        key={`${row.graphicName}-graphic`}
-                        className={`${baseClass}__row-graphic ${
-                          row.graphicName === "file-sh" ||
-                          row.graphicName === "file-ps1"
-                            ? "scale-40-24"
-                            : ""
-                        }`}
-                      />
-                    )
-                  )}
-                  {row.link ? <Link to={row.link}>{row.name}</Link> : row.name}
-                </div>
-                <span className={`${baseClass}__row-type`}>{row.type}</span>
+      <div className={`${baseClass}__list-label`}>Automations</div>
+      {automationRows.length > 0 ? (
+        <div className={`${baseClass}__list`}>
+          {automationRows.map((row) => (
+            <div
+              key={`${row.type}-${row.name}`}
+              className={`${baseClass}__row`}
+            >
+              <div className={`${baseClass}__row-name`}>
+                {row.isSoftware ? (
+                  <SoftwareIcon name={row.name} size="small" />
+                ) : (
+                  row.graphicName && (
+                    <Graphic
+                      name={row.graphicName}
+                      key={`${row.graphicName}-graphic`}
+                      className={`${baseClass}__row-graphic ${
+                        row.graphicName === "file-sh" ||
+                        row.graphicName === "file-ps1"
+                          ? "scale-40-24"
+                          : ""
+                      }`}
+                    />
+                  )
+                )}
+                {row.link ? <Link to={row.link}>{row.name}</Link> : row.name}
               </div>
-            ))}
-          </div>
-        </>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className={`${baseClass}__empty-state`}>No automations</div>
       )}
+      <p className={`${baseClass}__footer-text`}>
+        {storedPolicy.continuous_automations_enabled
+          ? "Software and script automations run every time Fleet receives a failing response. All other automations run on a host's first failure, or when a host's response changes from pass to fail."
+          : "Automations run on a host's first failure, or when a host's response changes from pass to fail."}
+      </p>
     </div>
   );
 };

--- a/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/PolicyAutomations.tsx
@@ -130,7 +130,7 @@ const PolicyAutomations = ({
     "";
 
   return (
-    <div className={`${baseClass} form-field`}>
+    <div className={baseClass}>
       {showCtaCard && (
         <div className={`${baseClass}__cta-card`}>
           <span className={`${baseClass}__cta-label`}>
@@ -190,9 +190,17 @@ const PolicyAutomations = ({
         <div className={`${baseClass}__empty-state`}>No automations</div>
       )}
       <p className={`${baseClass}__footer-text`}>
-        {storedPolicy.continuous_automations_enabled
-          ? "Software and script automations run every time Fleet receives a failing response. All other automations run on a host's first failure, or when a host's response changes from pass to fail."
-          : "Automations run on a host's first failure, or when a host's response changes from pass to fail."}
+        {storedPolicy.continuous_automations_enabled ? (
+          <>
+            Software and script automations run <b>every time</b> Fleet receives
+            a failing response.
+            <br />
+            All other automations run on a host&apos;s first failure, or when a
+            host&apos;s response changes from pass to fail.
+          </>
+        ) : (
+          "Automations run on a host's first failure, or when a host's response changes from pass to fail."
+        )}
       </p>
     </div>
   );

--- a/frontend/pages/policies/edit/components/PolicyAutomations/_styles.scss
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/_styles.scss
@@ -31,7 +31,6 @@
   &__row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     padding: 0 $pad-large;
     height: 40px;
     border-top: 1px solid $ui-fleet-black-10;
@@ -59,7 +58,18 @@
     }
   }
 
-  &__row-type {
-    color: $ui-fleet-black-75;
+  &__empty-state {
+    display: flex;
+    align-items: center;
+    padding: $pad-medium $pad-large;
+    border: 1px solid $ui-fleet-black-10;
+    border-radius: 8px;
+    color: $ui-fleet-black-50;
+  }
+
+  &__footer-text {
+    margin-top: $pad-small;
+    margin-bottom: 0;
+    color: $ui-fleet-black-50;
   }
 }

--- a/frontend/pages/policies/edit/components/PolicyAutomations/_styles.scss
+++ b/frontend/pages/policies/edit/components/PolicyAutomations/_styles.scss
@@ -1,5 +1,7 @@
 .policy-automations {
-  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
   font-size: $x-small;
 
   &__cta-card {
@@ -19,6 +21,7 @@
   }
 
   &__list {
+    max-width: 600px;
     border: 1px solid $ui-fleet-black-10;
     border-radius: 8px;
   }
@@ -61,15 +64,15 @@
   &__empty-state {
     display: flex;
     align-items: center;
-    padding: $pad-medium $pad-large;
+    max-width: 600px;
+    height: 40px;
+    padding: 0 $pad-large;
     border: 1px solid $ui-fleet-black-10;
     border-radius: 8px;
     color: $ui-fleet-black-50;
   }
 
   &__footer-text {
-    margin-top: $pad-small;
-    margin-bottom: 0;
-    color: $ui-fleet-black-50;
+    color: $ui-fleet-black-75;
   }
 }

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -20,7 +20,11 @@ import {
 } from "components/TargetLabelSelector/labelScopes";
 import { getPathWithQueryParams } from "utilities/url";
 
-import { IPolicy, IPolicyFormData } from "interfaces/policy";
+import {
+  IPolicy,
+  IPolicyFormData,
+  OtherAutomationType,
+} from "interfaces/policy";
 import {
   APP_CONTEXT_ALL_TEAMS_SUMMARY,
   APP_CONTEXT_NO_TEAM_SUMMARY,
@@ -83,6 +87,7 @@ interface IPolicyFormProps {
   onClickAutofillResolution: () => Promise<void>;
   resetAiAutofillData: () => void;
   currentAutomatedPolicies: number[];
+  otherAutomationType?: OtherAutomationType;
   onCancel?: () => void;
 }
 
@@ -120,6 +125,7 @@ const PolicyForm = ({
   onClickAutofillResolution,
   resetAiAutofillData,
   currentAutomatedPolicies,
+  otherAutomationType,
   onCancel,
 }: IPolicyFormProps): JSX.Element => {
   const [errors, setErrors] = useState<{ [key: string]: any }>({}); // string | null | undefined or boolean | undefined
@@ -696,6 +702,7 @@ const PolicyForm = ({
               canEditPolicy={isEditMode}
               onAddAutomation={onAddPatchAutomation}
               isAddingAutomation={isAddingAutomation}
+              otherAutomationType={otherAutomationType}
             />
           )}
           {isEditMode &&

--- a/frontend/pages/policies/edit/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/edit/screens/QueryEditor.tsx
@@ -12,7 +12,11 @@ import debounce from "utilities/debounce";
 import deepDifference from "utilities/deep_difference";
 import { getPathWithQueryParams } from "utilities/url";
 import { getErrorReason } from "interfaces/errors";
-import { IPolicyFormData, IPolicy } from "interfaces/policy";
+import {
+  IPolicyFormData,
+  IPolicy,
+  OtherAutomationType,
+} from "interfaces/policy";
 
 import BackButton from "components/BackButton";
 import PolicyForm from "pages/policies/edit/components/PolicyForm";
@@ -34,6 +38,7 @@ interface IQueryEditorProps {
   renderLiveQueryWarning: () => JSX.Element | null;
   teamIdForApi?: number;
   currentAutomatedPolicies?: number[];
+  otherAutomationType?: OtherAutomationType;
 }
 
 const QueryEditor = ({
@@ -52,6 +57,7 @@ const QueryEditor = ({
   renderLiveQueryWarning,
   teamIdForApi,
   currentAutomatedPolicies,
+  otherAutomationType,
 }: IQueryEditorProps): JSX.Element | null => {
   const { currentUser, isPremiumTier, filteredPoliciesPath } = useContext(
     AppContext
@@ -296,6 +302,7 @@ const QueryEditor = ({
         onClickAutofillResolution={onClickAutofillResolution}
         resetAiAutofillData={() => setPolicyAutofillData(null)}
         currentAutomatedPolicies={currentAutomatedPolicies || []}
+        otherAutomationType={otherAutomationType}
         onCancel={
           policyIdForEdit
             ? () =>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45145 

Implemented changes for the details page. Figma: https://www.figma.com/design/QeOcex5LtuDYG9XrGnMFLZ/-42651-Easier-to-manage-policy-automations-with-continuous-retry-option-for-software-scripts?node-id=5324-2588&t=vaLDU8QQXQ7vUq1k-0

NOTE: decided to show the Automations section with an empty state (was a TODO in Figma):

<img width="262" height="158" alt="Screenshot 2026-05-20 at 4 53 24 PM" src="https://github.com/user-attachments/assets/137e992c-ca6e-41e0-8fe4-8948e232561f" />


# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/17d6e3f4-8cf2-443f-b895-cb5e3e13e985


