### PR TITLE
Fix for Potentially uninitialized local variable

### DIFF
--- a/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
@@ -158,7 +158,7 @@ module Puppet::Util
       when :post
         request = Net::HTTP::Post.new(uri.request_uri)
       else
-        throw "HTTP method #{method} not implemented"
+        raise ArgumentError, "HTTP method #{method} not implemented"
       end
 
       headers['Authorization'] = "Bearer #{token}"


### PR DESCRIPTION
Address [code quality report](https://github.com/fleetdm/fleet/security/quality/rules/rb%2Funinitialized-local-variable),

Use explicit argument validation / exception flow in the `case method` block so invalid methods cannot continue to the later `request[...]` lines.

Best fix (without changing intended functionality): in `ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb`, replace the `throw "HTTP method #{method} not implemented"` in the `else` branch with `raise ArgumentError, "HTTP method #{method} not implemented"`. This makes invalid methods fail fast with a standard Ruby exception, and ensures code after the `case` only runs when `request` has been assigned.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling in the Puppet Fleet client utility for better exception management when processing HTTP requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->