### PR TITLE
Cherry-pick #45752: Fix Android/Windows profile edits via GitOps rejected when AppConfig is stale

### DIFF
--- a/changes/45705-android-gitops-fix
+++ b/changes/45705-android-gitops-fix
@@ -1,0 +1,1 @@
+- Fixed `fleetctl gitops` rejecting Android or Windows configuration profiles when editing an existing team, even when the corresponding MDM platform was configured.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1741,29 +1741,14 @@ func (svc *Service) editTeamFromSpec(
 	}
 	team.Config.MDM.MacOSSetup.RequireAllSoftwareWindows = spec.MDM.MacOSSetup.RequireAllSoftwareWindows
 
+	// Whether Windows/Android MDM is configured is gated at the global level
+	// in ModifyAppConfig; createTeamFromSpec doesn't gate custom_settings on
+	// the configured flag, and gating it here can spuriously reject team
+	// edits when the cached AppConfig lags behind a recent enable.
 	if spec.MDM.WindowsSettings.CustomSettings.Set {
-		if !windowsEnabledAndConfigured &&
-			len(spec.MDM.WindowsSettings.CustomSettings.Value) > 0 &&
-			!fleet.MDMProfileSpecsMatch(team.Config.MDM.WindowsSettings.CustomSettings.Value, spec.MDM.WindowsSettings.CustomSettings.Value) {
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("windows_settings.configuration_profiles",
-				`Couldn’t edit windows_settings.configuration_profiles. `+fleet.ErrWindowsMDMNotConfigured.Error()))
-		}
-
 		team.Config.MDM.WindowsSettings.CustomSettings = spec.MDM.WindowsSettings.CustomSettings
 	}
-
-	androidEnabledAndConfigured := appCfg.MDM.AndroidEnabledAndConfigured
-	if opts.DryRunAssumptions != nil && opts.DryRunAssumptions.AndroidEnabledAndConfigured.Valid {
-		androidEnabledAndConfigured = opts.DryRunAssumptions.AndroidEnabledAndConfigured.Value
-	}
 	if spec.MDM.AndroidSettings.CustomSettings.Set {
-		if !androidEnabledAndConfigured &&
-			len(spec.MDM.AndroidSettings.CustomSettings.Value) > 0 &&
-			!fleet.MDMProfileSpecsMatch(team.Config.MDM.AndroidSettings.CustomSettings.Value, spec.MDM.AndroidSettings.CustomSettings.Value) {
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("android_settings.configuration_profiles",
-				`Couldn’t edit android_settings.configuration_profiles. `+fleet.ErrAndroidMDMNotConfigured.Error()))
-		}
-
 		team.Config.MDM.AndroidSettings.CustomSettings = spec.MDM.AndroidSettings.CustomSettings
 	}
 

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -1113,3 +1113,125 @@ func TestUpdateTeamMDMAppleSetupManualAgent(t *testing.T) {
 
 	}
 }
+
+// TestApplyTeamSpecsCustomSettingsWithoutMDMConfigured verifies that GitOps
+// team edits can add Windows or Android configuration profiles without being
+// rejected by an MDM-configured check on the team-edit path. The previous
+// check fired when the AppConfig's *EnabledAndConfigured flag was false, which
+// surfaced as a customer bug when the cached AppConfig lagged behind a recent
+// platform-enable. createTeamFromSpec has never gated this, so we mirror it.
+func TestApplyTeamSpecsCustomSettingsWithoutMDMConfigured(t *testing.T) {
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+	adminUser := &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}
+	ctx := test.UserContext(context.Background(), adminUser)
+
+	const teamName = "Mobile"
+
+	newSvc := func(t *testing.T, mdmConfigured bool) (*Service, *mock.Store, **fleet.Team) {
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			ac := &fleet.AppConfig{}
+			// mdmConfigured=false simulates the bug condition: the cached
+			// AppConfig still reports MDM as off even though it has actually
+			// been enabled. The fix must let the edit proceed regardless.
+			ac.MDM.AndroidEnabledAndConfigured = mdmConfigured
+			ac.MDM.WindowsEnabledAndConfigured = mdmConfigured
+			return ac, nil
+		}
+		ds.TeamByFilenameFunc = func(ctx context.Context, _ string) (*fleet.Team, error) {
+			return nil, &notFoundError{}
+		}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			// Existing team has no Android/Windows custom settings — the spec
+			// is adding the first profile.
+			return &fleet.Team{ID: 42, Name: name}, nil
+		}
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			return nil, nil
+		}
+		var saved *fleet.Team
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			saved = team
+			return team, nil
+		}
+
+		mockSvc := &svcmock.Service{}
+		mockSvc.NewActivityFunc = func(ctx context.Context, _ *fleet.User, _ fleet.ActivityDetails) error {
+			return nil
+		}
+
+		svc := &Service{
+			Service: mockSvc,
+			ds:      ds,
+			config: config.FleetConfig{
+				Server: config.ServerConfig{PrivateKey: "something"},
+			},
+			authz:  authorizer,
+			logger: slog.New(slog.DiscardHandler),
+		}
+		return svc, ds, &saved
+	}
+
+	t.Run("adds android profile when AppConfig reports Android MDM off", func(t *testing.T) {
+		svc, ds, saved := newSvc(t, false)
+		spec := &fleet.TeamSpec{
+			Name: teamName,
+			MDM: fleet.TeamSpecMDM{
+				AndroidSettings: fleet.AndroidSettings{
+					CustomSettings: optjson.SetSlice([]fleet.MDMProfileSpec{
+						{Path: "profiles/android.json"},
+					}),
+				},
+			},
+		}
+
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.NotNil(t, *saved)
+		require.Len(t, (*saved).Config.MDM.AndroidSettings.CustomSettings.Value, 1)
+		require.Equal(t, "profiles/android.json", (*saved).Config.MDM.AndroidSettings.CustomSettings.Value[0].Path)
+	})
+
+	t.Run("adds windows profile when AppConfig reports Windows MDM off", func(t *testing.T) {
+		svc, ds, saved := newSvc(t, false)
+		spec := &fleet.TeamSpec{
+			Name: teamName,
+			MDM: fleet.TeamSpecMDM{
+				WindowsSettings: fleet.WindowsSettings{
+					CustomSettings: optjson.SetSlice([]fleet.MDMProfileSpec{
+						{Path: "profiles/windows.xml"},
+					}),
+				},
+			},
+		}
+
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.NotNil(t, *saved)
+		require.Len(t, (*saved).Config.MDM.WindowsSettings.CustomSettings.Value, 1)
+		require.Equal(t, "profiles/windows.xml", (*saved).Config.MDM.WindowsSettings.CustomSettings.Value[0].Path)
+	})
+
+	t.Run("adds android profile when AppConfig reports Android MDM on (happy path)", func(t *testing.T) {
+		svc, ds, saved := newSvc(t, true)
+		spec := &fleet.TeamSpec{
+			Name: teamName,
+			MDM: fleet.TeamSpecMDM{
+				AndroidSettings: fleet.AndroidSettings{
+					CustomSettings: optjson.SetSlice([]fleet.MDMProfileSpec{
+						{Path: "profiles/android.json"},
+					}),
+				},
+			},
+		}
+
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.NotNil(t, *saved)
+		require.Len(t, (*saved).Config.MDM.AndroidSettings.CustomSettings.Value, 1)
+	})
+}


### PR DESCRIPTION
Cherry-pick of #45752 into the RC branch.