### PR TITLE
Fleet UI: Empty state for single run script modal similar to empty state batch script modal, etc

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tests.tsx
@@ -1,0 +1,187 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { createCustomRenderer } from "test/test-utils";
+import createMockUser from "__mocks__/userMock";
+import createMockConfig from "__mocks__/configMock";
+import { createMockHostScript } from "__mocks__/scriptMock";
+
+import RunScriptModal from "./RunScriptModal";
+
+const baseProps = {
+  hostTeamId: 7,
+  onClose: jest.fn(),
+  page: 0,
+  setPage: jest.fn(),
+  hostScriptResponse: { scripts: [], meta: { has_next_results: false } },
+  isFetchingHostScripts: false,
+  isLoadingHostScripts: false,
+  isError: false,
+  onClickViewScript: jest.fn(),
+  onClickRunDetails: jest.fn(),
+  onClickRun: jest.fn(),
+  isRunningScript: false,
+  isHidden: false,
+};
+
+describe("RunScriptModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("empty state", () => {
+    it("shows the 'Add a script' link with fleet_id for a premium admin", () => {
+      const adminUser = createMockUser({ global_role: "admin" });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: true,
+            currentUser: adminUser,
+          },
+        },
+      });
+
+      render(<RunScriptModal {...baseProps} currentUser={adminUser} />);
+
+      expect(screen.getByText("No scripts available")).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: /Add a script/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute(
+        "href",
+        expect.stringContaining("fleet_id=7")
+      );
+      expect(screen.getByText(/available to this host/i)).toBeInTheDocument();
+    });
+
+    it("omits fleet_id from the link on free tier", () => {
+      const adminUser = createMockUser({ global_role: "admin" });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: false,
+            currentUser: adminUser,
+          },
+        },
+      });
+
+      render(<RunScriptModal {...baseProps} currentUser={adminUser} />);
+
+      const link = screen.getByRole("link", { name: /Add a script/i });
+      expect(link).toBeInTheDocument();
+      expect(link.getAttribute("href")).not.toContain("fleet_id");
+    });
+
+    it("hides the link and shows guidance text for a global technician", () => {
+      const technicianUser = createMockUser({ global_role: "technician" });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: true,
+            currentUser: technicianUser,
+          },
+        },
+      });
+
+      render(<RunScriptModal {...baseProps} currentUser={technicianUser} />);
+
+      expect(screen.getByText("No scripts available")).toBeInTheDocument();
+      expect(
+        screen.getByText("Ask your admin to add a script for this host.")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /Add a script/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides the link for a team technician on the host's team", () => {
+      const technicianUser = createMockUser({
+        global_role: null,
+        teams: [{ id: 7, name: "Some team", role: "technician" }],
+      });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: true,
+            currentUser: technicianUser,
+          },
+        },
+      });
+
+      render(<RunScriptModal {...baseProps} currentUser={technicianUser} />);
+
+      expect(
+        screen.getByText("Ask your admin to add a script for this host.")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /Add a script/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("table state", () => {
+    it("renders the script table instead of the empty state when scripts exist", () => {
+      const adminUser = createMockUser({ global_role: "admin" });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: true,
+            currentUser: adminUser,
+          },
+        },
+      });
+
+      render(
+        <RunScriptModal
+          {...baseProps}
+          currentUser={adminUser}
+          hostScriptResponse={{
+            scripts: [createMockHostScript({ name: "cleanup.sh" })],
+            meta: { has_next_results: false },
+          }}
+        />
+      );
+
+      expect(screen.queryByText("No scripts available")).not.toBeInTheDocument();
+      // TooltipTruncatedTextCell renders the script name in both the cell and tooltip
+      expect(screen.getAllByText("cleanup.sh").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("error and loading states", () => {
+    it("renders DataError when isError is true", () => {
+      const adminUser = createMockUser({ global_role: "admin" });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: true,
+            currentUser: adminUser,
+          },
+        },
+      });
+
+      render(
+        <RunScriptModal
+          {...baseProps}
+          currentUser={adminUser}
+          isError
+          hostScriptResponse={undefined}
+        />
+      );
+
+      expect(screen.queryByText("No scripts available")).not.toBeInTheDocument();
+      expect(screen.getByText(/something's gone wrong/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tests.tsx
@@ -151,7 +151,9 @@ describe("RunScriptModal", () => {
         />
       );
 
-      expect(screen.queryByText("No scripts available")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("No scripts available")
+      ).not.toBeInTheDocument();
       // TooltipTruncatedTextCell renders the script name in both the cell and tooltip
       expect(screen.getAllByText("cleanup.sh").length).toBeGreaterThan(0);
     });
@@ -180,7 +182,9 @@ describe("RunScriptModal", () => {
         />
       );
 
-      expect(screen.queryByText("No scripts available")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("No scripts available")
+      ).not.toBeInTheDocument();
       expect(screen.getByText(/something's gone wrong/i)).toBeInTheDocument();
     });
   });

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tests.tsx
@@ -13,7 +13,10 @@ const baseProps = {
   onClose: jest.fn(),
   page: 0,
   setPage: jest.fn(),
-  hostScriptResponse: { scripts: [], meta: { has_next_results: false } },
+  hostScriptResponse: {
+    scripts: [],
+    meta: { has_next_results: false, has_previous_results: false },
+  },
   isFetchingHostScripts: false,
   isLoadingHostScripts: false,
   isError: false,
@@ -53,6 +56,34 @@ describe("RunScriptModal", () => {
         expect.stringContaining("fleet_id=7")
       );
       expect(screen.getByText(/available to this host/i)).toBeInTheDocument();
+    });
+
+    it("falls back to fleet_id=0 (No team) when the host is unassigned", () => {
+      const adminUser = createMockUser({ global_role: "admin" });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: true,
+            currentUser: adminUser,
+          },
+        },
+      });
+
+      render(
+        <RunScriptModal
+          {...baseProps}
+          currentUser={adminUser}
+          hostTeamId={null}
+        />
+      );
+
+      const link = screen.getByRole("link", { name: /Add a script/i });
+      expect(link).toHaveAttribute(
+        "href",
+        expect.stringContaining("fleet_id=0")
+      );
     });
 
     it("omits fleet_id from the link on free tier", () => {
@@ -97,6 +128,29 @@ describe("RunScriptModal", () => {
       expect(
         screen.queryByRole("link", { name: /Add a script/i })
       ).not.toBeInTheDocument();
+    });
+
+    it("shows the link for a team maintainer on the host's team", () => {
+      const maintainerUser = createMockUser({
+        global_role: null,
+        teams: [{ id: 7, name: "Some team", role: "maintainer" }],
+      });
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            config: createMockConfig(),
+            isPremiumTier: true,
+            currentUser: maintainerUser,
+          },
+        },
+      });
+
+      render(<RunScriptModal {...baseProps} currentUser={maintainerUser} />);
+
+      expect(
+        screen.getByRole("link", { name: /Add a script/i })
+      ).toBeInTheDocument();
     });
 
     it("hides the link for a team technician on the host's team", () => {
@@ -146,7 +200,7 @@ describe("RunScriptModal", () => {
           currentUser={adminUser}
           hostScriptResponse={{
             scripts: [createMockHostScript({ name: "cleanup.sh" })],
-            meta: { has_next_results: false },
+            meta: { has_next_results: false, has_previous_results: false },
           }}
         />
       );

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
@@ -5,6 +5,7 @@ import PATHS from "router/paths";
 import { AppContext } from "context/app";
 
 import { IHostScript } from "interfaces/script";
+import { APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
 import { IUser } from "interfaces/user";
 import { IHostScriptsResponse } from "services/entities/scripts";
 
@@ -109,12 +110,14 @@ const RunScriptModal = ({
 
   const tableData = hostScriptResponse?.scripts;
 
-  // Technicians can run scripts but can't upload them — hide the "Add a script"
-  // link for them since it would lead to a page they can't act on.
-  const isTechnician =
+  // Only admins and maintainers (global or on the host's team) can upload scripts,
+  // so the "Add a script" link is hidden for everyone else (e.g. technicians).
+  const canAddScript =
     !!currentUser &&
-    (permissions.isGlobalTechnician(currentUser) ||
-      permissions.isTeamTechnician(currentUser, hostTeamId));
+    (permissions.isGlobalAdmin(currentUser) ||
+      permissions.isGlobalMaintainer(currentUser) ||
+      permissions.isTeamAdmin(currentUser, hostTeamId) ||
+      permissions.isTeamMaintainer(currentUser, hostTeamId));
 
   return (
     <Modal
@@ -135,19 +138,21 @@ const RunScriptModal = ({
               variant="header-list"
               header="No scripts available"
               info={
-                isTechnician ? (
-                  "Ask your admin to add a script for this host."
-                ) : (
+                canAddScript ? (
                   <>
                     <CustomLink
                       url={getPathWithQueryParams(
                         PATHS.CONTROLS_SCRIPTS,
-                        isPremiumTier ? { fleet_id: hostTeamId } : undefined
+                        isPremiumTier
+                          ? { fleet_id: hostTeamId ?? APP_CONTEXT_NO_TEAM_ID }
+                          : undefined
                       )}
                       text="Add a script"
                     />{" "}
                     available to this host.
                   </>
+                ) : (
+                  "Ask your admin to add a script for this host."
                 )
               }
             />

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
@@ -1,12 +1,18 @@
 import React, { useCallback, useContext, useMemo } from "react";
 
+import PATHS from "router/paths";
+
 import { AppContext } from "context/app";
 
 import { IHostScript } from "interfaces/script";
 import { IUser } from "interfaces/user";
 import { IHostScriptsResponse } from "services/entities/scripts";
 
+import permissions from "utilities/permissions";
+import { getPathWithQueryParams } from "utilities/url";
+
 import Button from "components/buttons/Button";
+import CustomLink from "components/CustomLink";
 import DataError from "components/DataError/DataError";
 import EmptyState from "components/EmptyState";
 import Modal from "components/Modal";
@@ -55,7 +61,7 @@ const RunScriptModal = ({
   isRunningScript,
   isHidden = false,
 }: IRunScriptModalProps) => {
-  const { config } = useContext(AppContext);
+  const { config, isPremiumTier } = useContext(AppContext);
 
   const onSelectAction = useCallback(
     async (action: string, script: IHostScript) => {
@@ -103,6 +109,13 @@ const RunScriptModal = ({
 
   const tableData = hostScriptResponse?.scripts;
 
+  // Technicians can run scripts but can't upload them — hide the "Add a script"
+  // link for them since it would lead to a page they can't act on.
+  const isTechnician =
+    !!currentUser &&
+    (permissions.isGlobalTechnician(currentUser) ||
+      permissions.isTeamTechnician(currentUser, hostTeamId));
+
   return (
     <Modal
       title="Run script"
@@ -119,8 +132,24 @@ const RunScriptModal = ({
           !isError &&
           (!tableData || tableData.length === 0) && (
             <EmptyState
-              header="No scripts available for this host"
-              info="Expecting to see scripts? Close this modal and try again."
+              variant="header-list"
+              header="No scripts available"
+              info={
+                isTechnician ? (
+                  "Ask your admin to add a script for this host."
+                ) : (
+                  <>
+                    <CustomLink
+                      url={getPathWithQueryParams(
+                        PATHS.CONTROLS_SCRIPTS,
+                        isPremiumTier ? { fleet_id: hostTeamId } : undefined
+                      )}
+                      text="Add a script"
+                    />{" "}
+                    available to this host.
+                  </>
+                )
+              }
             />
           )}
         {!isLoadingHostScripts &&

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tsx
@@ -255,9 +255,7 @@ const SelectReportModal = ({
       {renderDescription()}
       {renderReports()}
       <div className="modal-cta-wrap">
-        <Button onClick={onCancel} variant="inverse">
-          Close
-        </Button>
+        <Button onClick={onCancel}>Close</Button>
       </div>
     </Modal>
   );


### PR DESCRIPTION
## Issue
Closes #44326 

## Description
- Originally only did Run script modal from the manage host page which is the RunBatchScriptModal...
- Apparently there's a second modal for running script on a singular host on the host details page that should be updated similar to the other modal
- Caught by QA @Brajim20 
- Wrong color for the close button

## Screenshot

- New empty state for selecting a report from host details page
<img width="1158" height="496" alt="Screenshot 2026-05-20 at 5 12 29 PM" src="https://github.com/user-attachments/assets/2adedff8-7a4f-4290-9449-8ade32d0c501" />

- Close button is the correct variant (green)
<img width="1166" height="448" alt="Screenshot 2026-05-21 at 9 27 05 AM" src="https://github.com/user-attachments/assets/ad7d492f-1804-4cd6-96fc-d32bc49e0d6e" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

TODO
- [ ] Add to Figma
- [ ] Add to QA specs
- [ ] Add team technician nuance (they don't see a CTA to add a script, only team admin and team maintainers can do so)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Empty-state messaging and “Add a script” link now vary by user role and account tier—technicians see guidance to contact an admin; admins get an actionable “Add a script” link (premium accounts include fleet scoping).

* **Tests**
  * New test suite covering empty, populated, and error states across roles and tiers, including link visibility and tooltip behavior.

* **Style**
  * Modal footer button variant adjusted for consistent appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->