### PR TITLE
Website: update earliest supported Safari version

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -986,7 +986,7 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '14',//« earliest version that suppports the embedded podcast player.
+          iOS: '15',//« earliest version that suppports the embedded podcast player.
           Android: '6' // « Note: the earliest version we can test for compatibility issues with on browserstack is Android 7, but Google's search crawler uses an Android 6 user agent.
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -991,7 +991,7 @@
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
           msedge: '84',//« earliest version to support the gap css property.
-          safari: '15',//« earliest version that fully suppports the gap css property.
+          safari: '15',//« earliest version that fully supports the gap css property.
           firefox: '103',//« earliest version to support the backdrop filter css property.
           chrome: '84',//« earliest version to support the gap css property.
           opera: '70',//« earliest version to support the gap css property.

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -986,12 +986,12 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '15',//« earliest version that suppports the embedded podcast player.
+          iOS: '14',//« earliest version that suppports the embedded podcast player.
           Android: '6' // « Note: the earliest version we can test for compatibility issues with on browserstack is Android 7, but Google's search crawler uses an Android 6 user agent.
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
           msedge: '84',//« earliest version to support the gap css property.
-          safari: '14',//« earliest version that suppports the gap css property.
+          safari: '15',//« earliest version that fully suppports the gap css property.
           firefox: '103',//« earliest version to support the backdrop filter css property.
           chrome: '84',//« earliest version to support the gap css property.
           opera: '70',//« earliest version to support the gap css property.


### PR DESCRIPTION
Changes:
- Updated the earliest version of Safari the website supports (14 » 15).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported Safari version for browser compatibility — more Safari users will now see the “unsupported browser” overlay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->