### PR TITLE
Fix to populate host_emails during Linux/Windows SSO enrollment

### DIFF
--- a/changes/45066-windows-idp-device-mapping
+++ b/changes/45066-windows-idp-device-mapping
@@ -1,0 +1,1 @@
+* Fixed "User email" being unset in GET /api/v1/fleet/hosts for Windows and Linux hosts enrolling with end-user authentication.

--- a/changes/45066-windows-idp-device-mapping
+++ b/changes/45066-windows-idp-device-mapping
@@ -1,1 +1,1 @@
-* Fixed "User email" being unset in GET /api/v1/fleet/hosts for Windows and Linux hosts enrolling with end-user authentication.
+* Fixed "User email" in device_mapping being unset in GET /api/v1/fleet/hosts for Windows and Linux hosts enrolling with end-user authentication.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2336,6 +2336,17 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 		HardwareSerial: hostInfo.HardwareSerial,
 		Platform:       hostInfo.Platform,
 		PlatformLike:   hostInfo.PlatformLike,
+		// Mirror the hardware UUID onto the returned struct so callers that
+		// rely on host.UUID after this function returns (e.g. linking the
+		// Windows MDM enrollment, host_emails reconciliation in
+		// server/service/orbit.go) see a non-empty value. The hosts row's
+		// uuid column ends up set to this value in both branches below:
+		// the INSERT path stores it directly, and the UPDATE path uses
+		// COALESCE(NULLIF(uuid, ''), ?) — i.e. it fills in this UUID when
+		// the existing row had no uuid and otherwise keeps the existing
+		// value, which by construction matches hostInfo.HardwareUUID
+		// (matchHostDuringEnrollment matched on this UUID).
+		UUID: hostInfo.HardwareUUID,
 	}
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		serialToMatch := hostInfo.HardwareSerial

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2336,17 +2336,6 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 		HardwareSerial: hostInfo.HardwareSerial,
 		Platform:       hostInfo.Platform,
 		PlatformLike:   hostInfo.PlatformLike,
-		// Mirror the hardware UUID onto the returned struct so callers that
-		// rely on host.UUID after this function returns (e.g. linking the
-		// Windows MDM enrollment, host_emails reconciliation in
-		// server/service/orbit.go) see a non-empty value. The hosts row's
-		// uuid column ends up set to this value in both branches below:
-		// the INSERT path stores it directly, and the UPDATE path uses
-		// COALESCE(NULLIF(uuid, ''), ?) — i.e. it fills in this UUID when
-		// the existing row had no uuid and otherwise keeps the existing
-		// value, which by construction matches hostInfo.HardwareUUID
-		// (matchHostDuringEnrollment matched on this UUID).
-		UUID: hostInfo.HardwareUUID,
 	}
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		serialToMatch := hostInfo.HardwareSerial
@@ -2500,6 +2489,17 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "update host identity cert host id")
 			}
+		}
+
+		// Read back the persisted uuid so the returned struct matches the
+		// hosts row. Callers (e.g. orbit Windows MDM linking, host_emails
+		// reconciliation in server/service/orbit.go) rely on host.UUID after
+		// this returns; the value can diverge from hostInfo.HardwareUUID in
+		// the UPDATE branch because matchHostDuringEnrollment can match by
+		// osquery_host_id or hardware_serial and the UPDATE preserves the
+		// existing uuid via COALESCE(NULLIF(uuid, ''), ?).
+		if err := sqlx.GetContext(ctx, tx, &host.UUID, `SELECT uuid FROM hosts WHERE id = ?`, host.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "load persisted host uuid after orbit enroll")
 		}
 
 		return nil

--- a/server/datastore/mysql/mdm_idp_accounts_test.go
+++ b/server/datastore/mysql/mdm_idp_accounts_test.go
@@ -34,7 +34,13 @@ func TestMDMIdPAccountsReconciliation(t *testing.T) {
 func testAssociateHostMDMIdPAccountTriggersReconciliation(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
-	// Android and one Apple platform to verify cross-platform behavior
+	// Android, macOS, Windows, and Linux to verify cross-platform
+	// behavior. Windows and Linux pin down issue #45066: the Orbit Setup
+	// Experience SSO callback (shared by Windows MSI / Linux Orbit enrollment
+	// with End User Authentication).
+	//
+	// This test ensures the full AssociateHostMDMIdPAccount
+	// populates host_emails on every supported platform.
 	platforms := []struct {
 		name     string
 		platform string
@@ -42,6 +48,8 @@ func testAssociateHostMDMIdPAccountTriggersReconciliation(t *testing.T, ds *Data
 	}{
 		{"Android", "android", "android-host-uuid"},
 		{"macOS", "darwin", "macos-host-uuid"}, // Apple platforms
+		{"Windows", "windows", "windows-host-uuid"},
+		{"Linux", "ubuntu", "linux-host-uuid"},
 	}
 
 	// create IdP account

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	maintained_apps "github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
 	"github.com/fleetdm/fleet/v4/server/mdm/maintainedapps/maintainedappstest"
+	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	mdmtest "github.com/fleetdm/fleet/v4/server/mdm/testing_utils"
 	"github.com/fleetdm/fleet/v4/server/policies"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -115,6 +116,13 @@ func (s *integrationEnterpriseTestSuite) SetupSuite() {
 	require.NoError(s.T(), err)
 	s.softwareTitleIconStore = softwareTitleIconStore
 
+	// Configure Windows WSTEP cert/key paths so the server initializes a
+	// wstepCertManager and can validate Windows MSI EUA tokens sent via
+	// /api/fleet/orbit/enroll. Required by TestOrbitEnrollWithEUAToken.
+	fleetCfg := config.TestConfig()
+	fleetCfg.MDM.WindowsWSTEPIdentityCert = "testdata/server.pem"
+	fleetCfg.MDM.WindowsWSTEPIdentityKey = "testdata/server.key"
+
 	config := TestServerOpts{
 		License: &fleet.LicenseInfo{
 			Tier: fleet.TierPremium,
@@ -145,6 +153,7 @@ func (s *integrationEnterpriseTestSuite) SetupSuite() {
 		SoftwareTitleIconStore:          softwareTitleIconStore,
 		ConditionalAccessMicrosoftProxy: mockedConditionalAccessMicrosoftProxyInstance,
 		DBConns:                         s.dbConns,
+		FleetConfig:                     &fleetCfg,
 	}
 	if os.Getenv("FLEET_INTEGRATION_TESTS_DISABLE_LOG") != "" {
 		config.Logger = slog.New(slog.DiscardHandler)
@@ -30612,4 +30621,281 @@ func (s *integrationEnterpriseTestSuite) TestOrbitOsqueryReEnrollDoesNotChangeTe
 		require.NotNil(t, hostLite.TeamID)
 		require.Equal(t, teamA.ID, *hostLite.TeamID)
 	})
+}
+
+// TestOrbitEnrollWithIdPPopulatesDeviceMapping covers issue #45066: orbit
+// enrolling a Linux or Windows host through the End User Authentication flow
+// must populate host_emails so the hosts list endpoint returns
+// device_mapping. The flow being exercised is:
+//
+//  1. Orbit calls /api/fleet/orbit/enroll. End User Auth is required, there
+//     is no IdP association for this host UUID yet, so the server returns
+//     END_USER_AUTH_REQUIRED.
+//  2. Orbit opens a browser, the user authenticates, and the SSO callback
+//     in ee/server/service/mdm.go writes the mdm_idp_accounts +
+//     host_mdm_idp_accounts rows via the bare AssociateHostMDMIdPAccountDB
+//     (the hosts row does not exist yet at this point — only the IdP-side
+//     tables are populated). We simulate that callback by inserting the
+//     same rows directly.
+//  3. Orbit retries /api/fleet/orbit/enroll. EnrollOrbit creates the hosts
+//     row, and the post-EnrollOrbit reconcile in server/service/orbit.go
+//     calls AssociateHostMDMIdPAccount to populate host_emails.
+//
+// Pre-fix behavior: host_emails stayed empty, so ListHostDeviceMapping
+// returned nothing and the hosts list endpoint returned device_mapping=null
+// even though the single-host endpoint showed the IdP user via SCIM.
+func (s *integrationEnterpriseTestSuite) TestOrbitEnrollWithIdPPopulatesDeviceMapping() {
+	t := s.T()
+	ctx := t.Context()
+
+	// Create a team with End User Authentication enabled, then use that
+	// team's enroll secret. We use a team-level flag rather than the
+	// app-config level because the enterprise suite enables EnableCachedDS,
+	// and writes via s.ds bypass the running server's cached AppConfig
+	// wrapper. Team config is read via TeamLite (not in the cached layer),
+	// so a direct s.ds write is visible to the server immediately.
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{
+		Name:        t.Name(),
+		Description: t.Name(),
+		Config: fleet.TeamConfig{
+			MDM: fleet.TeamMDM{
+				MacOSSetup: fleet.MacOSSetup{
+					EnableEndUserAuthentication: true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Use a fresh background context — t.Context() has already been
+		// cancelled by the time cleanup runs, and DeleteTeam opens its own
+		// transaction.
+		require.NoError(t, s.ds.DeleteTeam(context.Background(), team.ID))
+	})
+
+	enrollSecret := t.Name() + "-secret"
+	require.NoError(t, s.ds.ApplyEnrollSecrets(ctx, &team.ID, []*fleet.EnrollSecret{{Secret: enrollSecret}}))
+
+	// Orbit client capabilities — Linux and Windows orbit builds advertise
+	// CapabilityEndUserAuth. Without this header the EnrollOrbit handler
+	// short-circuits past the EUA gating (with a logged warning) and the bug
+	// would not be exercised.
+	var caps fleet.CapabilityMap
+	caps.PopulateFromString(string(fleet.CapabilityEndUserAuth))
+	capsHeaders := map[string]string{fleet.CapabilitiesHeader: caps.String()}
+
+	runFlow := func(t *testing.T, platform, platformLike string) {
+		hostUUID := uuid.New().String()
+		hostSerial := uuid.New().String()
+		hostName := strings.ReplaceAll(t.Name(), "/", "-") + ".local"
+		idpEmail := strings.ReplaceAll(uuid.NewString(), "-", "") + "@example.com"
+
+		enrollBody, err := json.Marshal(fleet.EnrollOrbitRequest{
+			EnrollSecret:   enrollSecret,
+			HardwareUUID:   hostUUID,
+			HardwareSerial: hostSerial,
+			Hostname:       hostName,
+			Platform:       platform,
+			PlatformLike:   platformLike,
+			HardwareModel:  "TestModel",
+		})
+		require.NoError(t, err)
+
+		// Step 1: First orbit enrollment attempt — no IdP linked yet, so the
+		// server returns END_USER_AUTH_REQUIRED (HTTP 401).
+		res := s.DoRawWithHeaders("POST", "/api/fleet/orbit/enroll", enrollBody, http.StatusUnauthorized, capsHeaders)
+		respBody, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		require.NoError(t, err)
+		require.Contains(t, string(respBody), "END_USER_AUTH_REQUIRED",
+			"expected EUA gating to block enrollment when no IdP is linked")
+
+		// The hosts row must not exist yet — the orbit enroll path returned
+		// before reaching EnrollOrbit.
+		_, err = s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err))
+
+		// Step 2: Simulate the Orbit Setup Experience SSO callback writing the
+		// IdP account and linking it to the host UUID. This matches what
+		// ee/server/service/mdm.go's mdmSSOHandleCallbackAuth does after the
+		// browser-based SSO completes (the user authenticates against the IdP,
+		// the SAML response lands at /api/v1/fleet/mdm/sso/callback, and the
+		// initiator is SSOInitiatorOrbitSetupExperience).
+		require.NoError(t, s.ds.InsertMDMIdPAccount(ctx, &fleet.MDMIdPAccount{
+			Username: idpEmail,
+			Fullname: "Test User",
+			Email:    idpEmail,
+		}))
+		idpAcct, err := s.ds.GetMDMIdPAccountByEmail(ctx, idpEmail)
+		require.NoError(t, err)
+		require.NotNil(t, idpAcct)
+		// Use the bare DB variant — this is the function the SSO callback
+		// uses, and the hosts row does not exist yet so the reconciling
+		// variant would error on the host-id lookup.
+		require.NoError(t, s.ds.AssociateHostMDMIdPAccountDB(ctx, hostUUID, idpAcct.UUID))
+
+		// host_mdm_idp_accounts is now populated, but host_emails is not.
+		var preCount int
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &preCount,
+				`SELECT COUNT(*) FROM host_mdm_idp_accounts WHERE host_uuid = ?`, hostUUID)
+		})
+		require.Equal(t, 1, preCount)
+
+		// Step 3: Orbit retries the enrollment — EnrollOrbit creates the hosts
+		// row and the post-EnrollOrbit reconcile in orbit.go calls
+		// AssociateHostMDMIdPAccount, which populates host_emails.
+		res = s.DoRawWithHeaders("POST", "/api/fleet/orbit/enroll", enrollBody, http.StatusOK, capsHeaders)
+		var orbitResp enrollOrbitResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&orbitResp))
+		res.Body.Close()
+		require.NotEmpty(t, orbitResp.OrbitNodeKey)
+
+		// Step 4: Verify host_emails got populated — this is what fixes the
+		// hosts list endpoint returning device_mapping=null (issue #45066).
+		hostLite, err := s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.NoError(t, err)
+		require.NotZero(t, hostLite.ID)
+
+		dms, err := s.ds.ListHostDeviceMapping(ctx, hostLite.ID)
+		require.NoError(t, err)
+		require.Len(t, dms, 1,
+			"host_emails must be populated after the post-EnrollOrbit reconcile (issue #45066)")
+		require.Equal(t, idpEmail, dms[0].Email)
+		require.Equal(t, fleet.DeviceMappingMDMIdpAccounts, dms[0].Source)
+	}
+
+	t.Run("linux", func(t *testing.T) {
+		runFlow(t, "ubuntu", "debian")
+	})
+
+	t.Run("windows", func(t *testing.T) {
+		runFlow(t, "windows", "")
+	})
+}
+
+// TestOrbitEnrollWithEUAToken covers the Windows MSI EUA-token branch in
+// EnrollOrbit (the `case platform == "windows" && euaToken != ""` arm of the
+// End User Auth switch in server/service/orbit.go). This is the flow Fleet
+// uses when it enqueues a fleetd MSI install command on a Windows host that
+// already enrolled in Windows MDM with an Azure UPN: the MSI carries a
+// Fleet-signed EUA JWT so orbit can finish enrollment without prompting the
+// user for SSO again.
+//
+// The test exercises the full server-side flow:
+//
+//  1. An mdm_windows_enrollments row exists for some MDM device, with a
+//     valid Azure UPN captured during MDM enrollment.
+//  2. The orbit request to /api/fleet/orbit/enroll carries a Fleet-signed
+//     EUA token (issued in production by svc.generateWindowsEUAToken).
+//  3. processWindowsEUAToken validates the JWT and resolves the mdm IdP
+//     account for the UPN (creating one if needed).
+//  4. EnrollOrbit creates the hosts row, then the post-EnrollOrbit reconcile
+//     in orbit.go calls AssociateHostMDMIdPAccount with that IdP account
+//     UUID, populating host_emails so the hosts list endpoint returns
+//     device_mapping (issue #45066).
+func (s *integrationEnterpriseTestSuite) TestOrbitEnrollWithEUAToken() {
+	t := s.T()
+	ctx := t.Context()
+
+	// Build our own wstepCertManager using the same cert/key the test server
+	// was configured with (SetupSuite points WindowsWSTEPIdentityCert/Key at
+	// testdata/server.pem and server.key). The server's wstepCertManager
+	// validates the token; ours signs it.
+	certPEM, err := os.ReadFile("testdata/server.pem")
+	require.NoError(t, err)
+	keyPEM, err := os.ReadFile("testdata/server.key")
+	require.NoError(t, err)
+	certManager, err := microsoft_mdm.NewCertManager(nil, certPEM, keyPEM)
+	require.NoError(t, err)
+
+	// Team with End User Authentication enabled so the orbit handler reaches
+	// the EUA switch. Team config is read via TeamLite which is not in the
+	// caching layer, so direct s.ds writes are visible to the server.
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{
+		Name:        t.Name(),
+		Description: t.Name(),
+		Config: fleet.TeamConfig{
+			MDM: fleet.TeamMDM{
+				MacOSSetup: fleet.MacOSSetup{
+					EnableEndUserAuthentication: true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, s.ds.DeleteTeam(context.Background(), team.ID))
+	})
+
+	enrollSecret := t.Name() + "-secret"
+	require.NoError(t, s.ds.ApplyEnrollSecrets(ctx, &team.ID, []*fleet.EnrollSecret{{Secret: enrollSecret}}))
+
+	// Pre-create the Windows MDM enrollment that the EUA token will reference.
+	// In production this row is written when the device enrolls in Windows
+	// MDM (Autopilot/Azure-joined). processWindowsEUAToken looks it up by
+	// mdm_device_id to verify the token came from a real enrolled device.
+	hostUUID := uuid.New().String()
+	hostSerial := uuid.New().String()
+	mdmDeviceID := uuid.New().String()
+	idpEmail := strings.ReplaceAll(uuid.NewString(), "-", "") + "@example.com"
+	require.NoError(t, s.ds.MDMWindowsInsertEnrolledDevice(ctx, &fleet.MDMWindowsEnrolledDevice{
+		MDMDeviceID:            mdmDeviceID,
+		MDMHardwareID:          uuid.New().String(),
+		MDMDeviceState:         "enrolled",
+		MDMDeviceType:          "Windows",
+		MDMDeviceName:          "win-eua-test",
+		MDMEnrollType:          "DeviceEnrollmentManager",
+		MDMEnrollUserID:        idpEmail,
+		MDMEnrollProtoVersion:  "5.0",
+		MDMEnrollClientVersion: "10.0.19045",
+		MDMNotInOOBE:           true,
+		HostUUID:               "",
+	}))
+
+	// Sign an EUA token the same way svc.generateWindowsEUAToken would.
+	euaToken, err := certManager.NewEUAToken(idpEmail, mdmDeviceID)
+	require.NoError(t, err)
+	require.NotEmpty(t, euaToken)
+
+	// Capabilities header — the EUA branch requires the orbit client to
+	// advertise CapabilityEndUserAuth, otherwise the switch falls through
+	// with a logged warning and enrollment is allowed without EUA.
+	var caps fleet.CapabilityMap
+	caps.PopulateFromString(string(fleet.CapabilityEndUserAuth))
+	capsHeaders := map[string]string{fleet.CapabilitiesHeader: caps.String()}
+
+	enrollBody, err := json.Marshal(fleet.EnrollOrbitRequest{
+		EnrollSecret:   enrollSecret,
+		HardwareUUID:   hostUUID,
+		HardwareSerial: hostSerial,
+		Hostname:       strings.ReplaceAll(t.Name(), "/", "-") + ".win.local",
+		Platform:       "windows",
+		HardwareModel:  "TestModel",
+		EUAToken:       euaToken,
+	})
+	require.NoError(t, err)
+
+	// Single orbit enroll call — the EUA token authenticates the user, so
+	// no second retry is required (unlike the browser-SSO flow).
+	res := s.DoRawWithHeaders("POST", "/api/fleet/orbit/enroll", enrollBody, http.StatusOK, capsHeaders)
+	var orbitResp enrollOrbitResponse
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&orbitResp))
+	res.Body.Close()
+	require.NotEmpty(t, orbitResp.OrbitNodeKey)
+
+	// host_emails must be populated — issue #45066. Without the
+	// post-EnrollOrbit reconcile, processWindowsEUAToken's write would have
+	// landed in host_mdm_idp_accounts but never made it into host_emails,
+	// so the hosts list endpoint would still return device_mapping=null.
+	hostLite, err := s.ds.HostLiteByIdentifier(ctx, hostUUID)
+	require.NoError(t, err)
+	require.NotZero(t, hostLite.ID)
+
+	dms, err := s.ds.ListHostDeviceMapping(ctx, hostLite.ID)
+	require.NoError(t, err)
+	require.Len(t, dms, 1, "host_emails must be populated after EUA-token orbit enrollment (issue #45066)")
+	require.Equal(t, idpEmail, dms[0].Email)
+	require.Equal(t, fleet.DeviceMappingMDMIdpAccounts, dms[0].Source)
 }

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -91,20 +91,23 @@ func (svc *Service) AuthenticateOrbitHost(ctx context.Context, orbitNodeKey stri
 }
 
 // processWindowsEUAToken validates a Fleet-signed EUA token from the Windows MSI
-// installer, links the user's IdP account to the host, and returns the UPN and
-// device ID for use in post-enrollment steps.
-func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string, euaToken string) (upn string, deviceID string, err error) {
+// installer, ensures the IdP account exists, and returns the UPN, device ID,
+// and IdP account UUID. The actual host_mdm_idp_accounts row is written by
+// the caller after the host row has been created by EnrollOrbit, so that the
+// reconcileHostEmailsFromMdmIdpAccounts step inside AssociateHostMDMIdPAccount
+// can populate host_emails for the hosts list device_mapping (issue #45066).
+func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string, euaToken string) (upn string, deviceID string, idpAcctUUID string, err error) {
 	if svc.wstepCertManager == nil {
 		// Windows MDM is not configured on this server so the token cannot be validated.
 		// Fall back to prompting the user for authentication.
-		return "", "", fleet.NewOrbitIDPAuthRequiredError()
+		return "", "", "", fleet.NewOrbitIDPAuthRequiredError()
 	}
 
 	claims, tokenErr := svc.wstepCertManager.GetEUATokenClaims(euaToken)
 	if tokenErr != nil {
 		svc.logger.WarnContext(ctx, "EUA token validation failed, falling back to end user auth prompt",
 			"err", tokenErr, "host_uuid", hostUUID)
-		return "", "", fleet.NewOrbitIDPAuthRequiredError()
+		return "", "", "", fleet.NewOrbitIDPAuthRequiredError()
 	}
 	upn = claims.UPN
 	deviceID = claims.DeviceID
@@ -114,9 +117,9 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 		if fleet.IsNotFound(err) {
 			svc.logger.WarnContext(ctx, "EUA token device_id not found in windows mdm enrollments, falling back to end user auth prompt",
 				"device_id", deviceID, "host_uuid", hostUUID)
-			return "", "", fleet.NewOrbitIDPAuthRequiredError()
+			return "", "", "", fleet.NewOrbitIDPAuthRequiredError()
 		}
-		return "", "", ctxerr.Wrap(ctx, err, "getting windows mdm enrollment for EUA token")
+		return "", "", "", ctxerr.Wrap(ctx, err, "getting windows mdm enrollment for EUA token")
 	}
 
 	// Fetch or create the mdm_idp_accounts row for this email.
@@ -124,28 +127,23 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 	// that may have been populated by SCIM provisioning.
 	acct, err := svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 	if err != nil && !fleet.IsNotFound(err) {
-		return "", "", ctxerr.Wrap(ctx, err, "getting mdm idp account by email for EUA token")
+		return "", "", "", ctxerr.Wrap(ctx, err, "getting mdm idp account by email for EUA token")
 	}
 	if fleet.IsNotFound(err) {
 		if err := svc.ds.InsertMDMIdPAccount(ctx, &fleet.MDMIdPAccount{Email: upn, Username: upn}); err != nil {
-			return "", "", ctxerr.Wrap(ctx, err, "inserting mdm idp account for EUA token")
+			return "", "", "", ctxerr.Wrap(ctx, err, "inserting mdm idp account for EUA token")
 		}
 		// Re-fetch to get the UUID assigned by the DB.
 		acct, err = svc.ds.GetMDMIdPAccountByEmail(ctxdb.RequirePrimary(ctx, true), upn)
 		if err != nil {
-			return "", "", ctxerr.Wrap(ctx, err, "re-fetching mdm idp account after insert for EUA token")
+			return "", "", "", ctxerr.Wrap(ctx, err, "re-fetching mdm idp account after insert for EUA token")
 		}
 	}
 	if acct == nil {
-		return "", "", ctxerr.New(ctx, "mdm idp account not found for EUA token")
+		return "", "", "", ctxerr.New(ctx, "mdm idp account not found for EUA token")
 	}
 
-	// Link the IdP account to this host UUID in host_mdm_idp_accounts.
-	if err := svc.ds.AssociateHostMDMIdPAccountDB(ctx, hostUUID, acct.UUID); err != nil {
-		return "", "", ctxerr.Wrap(ctx, err, "associating host with mdm idp account for EUA token")
-	}
-
-	return upn, deviceID, nil
+	return upn, deviceID, acct.UUID, nil
 }
 
 // EnrollOrbit enrolls an Orbit instance to Fleet and returns the orbit node key.
@@ -221,7 +219,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 		isEndUserAuthRequired = team.Config.MDM.MacOSSetup.EnableEndUserAuthentication
 	}
 
-	var euaDeviceID, euaUPN string
+	var euaDeviceID, euaUPN, euaIdpAcctUUID string
 
 	if isEndUserAuthRequired {
 		if hostInfo.HardwareUUID == "" {
@@ -252,12 +250,13 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 				case platform == "windows" && euaToken != "":
 					// A Windows host already authenticated during MDM enrollment and the
 					// EUA token was passed by the MSI installer.
-					upn, deviceID, err := svc.processWindowsEUAToken(ctx, hostInfo.HardwareUUID, euaToken)
+					upn, deviceID, idpAcctUUID, err := svc.processWindowsEUAToken(ctx, hostInfo.HardwareUUID, euaToken)
 					if err != nil {
 						return "", err
 					}
 					euaUPN = upn
 					euaDeviceID = deviceID
+					euaIdpAcctUUID = idpAcctUUID
 					// Continue enrollment — do not return END_USER_AUTH_REQUIRED.
 				default:
 					// Otherwise report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
@@ -276,6 +275,40 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 	)
 	if err != nil {
 		return "", fleet.OrbitError{Message: "failed to enroll " + err.Error()}
+	}
+
+	platform := host.FleetPlatform()
+
+	// Now that EnrollOrbit has created the hosts row, reconcile host_emails with
+	// any IdP association that was written before this point — either by
+	// processWindowsEUAToken above (Windows MSI) or by the Orbit Setup
+	// Experience SSO callback (Linux/Windows, ee/server/service/mdm.go). Without
+	// this, the hosts list endpoint returns device_mapping: null even though
+	// the single-host endpoint shows IdP info via SCIM (issue #45066).
+	//
+	// Scoped to Linux and Windows only: macOS hosts reconcile host_emails via
+	// ReconcileMDMAppleEnrollRef during MDM enrollment.
+	//
+	// Use hostInfo.HardwareUUID — the host pointer returned by EnrollOrbit
+	// only has its ID assigned, not its UUID.
+	if isEndUserAuthRequired && (platform == "linux" || platform == "windows") {
+		idpAcctUUID := euaIdpAcctUUID
+		if idpAcctUUID == "" {
+			// No EUA token in this request — see if the SSO callback already
+			// wrote a host_mdm_idp_accounts row for this host UUID.
+			if idp, err := svc.ds.GetMDMIdPAccountByHostUUID(ctx, hostInfo.HardwareUUID); err != nil {
+				svc.logger.ErrorContext(ctx, "failed to look up mdm idp account for reconciliation",
+					"err", err, "host_uuid", hostInfo.HardwareUUID)
+			} else if idp != nil {
+				idpAcctUUID = idp.UUID
+			}
+		}
+		if idpAcctUUID != "" {
+			if err := svc.ds.AssociateHostMDMIdPAccount(ctx, hostInfo.HardwareUUID, idpAcctUUID); err != nil {
+				svc.logger.ErrorContext(ctx, "failed to associate host with mdm idp account post-enrollment",
+					"err", err, "host_uuid", hostInfo.HardwareUUID, "idp_acct_uuid", idpAcctUUID)
+			}
+		}
 	}
 
 	if euaDeviceID != "" {
@@ -308,7 +341,6 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 	// Associate the newly-enrolled host with a SCIM user if applicable.
 	// Do this only for linux and windows devices, as macOS devices
 	// are associated during MDM enrollment.
-	platform := host.FleetPlatform()
 	if platform == "linux" || platform == "windows" {
 		svc.logger.DebugContext(ctx, "attempting to associate enrolled host with SCIM user", "host_id", host.ID, "platform", platform)
 		if err := svc.ds.MaybeAssociateHostWithScimUser(ctx, host.ID); err != nil {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -134,7 +134,7 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 			return "", "", "", ctxerr.Wrap(ctx, err, "inserting mdm idp account for EUA token")
 		}
 		// Re-fetch to get the UUID assigned by the DB.
-		acct, err = svc.ds.GetMDMIdPAccountByEmail(ctxdb.RequirePrimary(ctx, true), upn)
+		acct, err = svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 		if err != nil {
 			return "", "", "", ctxerr.Wrap(ctx, err, "re-fetching mdm idp account after insert for EUA token")
 		}
@@ -150,6 +150,17 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInfo, enrollSecret string, euaToken string) (string, error) {
 	// this is not a user-authenticated endpoint
 	svc.authz.SkipAuthorization(ctx)
+
+	// Force primary reads for the whole handler. EnrollOrbit is a
+	// read-after-write flow: the Setup Experience SSO callback and the MSI
+	// EUA token path both write to host_mdm_idp_accounts immediately before
+	// orbit retries enrollment, and a stale replica read here would silently
+	// reintroduce the IdP-association bugs we fixed in #45066 (and could
+	// also re-trigger END_USER_AUTH_REQUIRED on the first read of
+	// GetMDMIdPAccountByHostUUID). The enrollment endpoint is low-traffic
+	// (runs once per device, not on every check-in), so the load impact on
+	// the primary is negligible.
+	ctx = ctxdb.RequirePrimary(ctx, true)
 
 	logging.WithLevel(
 		logging.WithExtras(ctx,
@@ -288,9 +299,6 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 	//
 	// Scoped to Linux and Windows only: macOS hosts reconcile host_emails via
 	// ReconcileMDMAppleEnrollRef during MDM enrollment.
-	//
-	// Use hostInfo.HardwareUUID — the host pointer returned by EnrollOrbit
-	// only has its ID assigned, not its UUID.
 	if isEndUserAuthRequired && (platform == "linux" || platform == "windows") {
 		idpAcctUUID := euaIdpAcctUUID
 		if idpAcctUUID == "" {

--- a/server/service/orbit_eua_test.go
+++ b/server/service/orbit_eua_test.go
@@ -128,17 +128,13 @@ func TestProcessWindowsEUAToken(t *testing.T) {
 			require.Equal(t, testUPN, account.Email)
 			return nil
 		}
-		ds.AssociateHostMDMIdPAccountDBFunc = func(ctx context.Context, hostUUID, acctUUID string) error {
-			require.Equal(t, testHostUUID, hostUUID)
-			require.Equal(t, testAcctUUID, acctUUID)
-			return nil
-		}
 
-		upn, deviceID, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
+		upn, deviceID, idpAcctUUID, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
 		require.NoError(t, err)
 		require.Equal(t, testUPN, upn)
 		require.Equal(t, testDeviceID, deviceID)
-		require.True(t, ds.AssociateHostMDMIdPAccountDBFuncInvoked)
+		require.Equal(t, testAcctUUID, idpAcctUUID, "must return idp account uuid so caller can associate after EnrollOrbit creates the host row")
+		require.False(t, ds.AssociateHostMDMIdPAccountFuncInvoked, "association is deferred until after EnrollOrbit (issue #45066)")
 	})
 
 	t.Run("valid token, account already exists in db", func(t *testing.T) {
@@ -153,17 +149,14 @@ func TestProcessWindowsEUAToken(t *testing.T) {
 		ds.GetMDMIdPAccountByEmailFunc = func(ctx context.Context, email string) (*fleet.MDMIdPAccount, error) {
 			return &fleet.MDMIdPAccount{UUID: testAcctUUID, Email: testUPN, Username: "existing-username", Fullname: "Existing Name"}, nil
 		}
-		ds.AssociateHostMDMIdPAccountDBFunc = func(ctx context.Context, hostUUID, acctUUID string) error {
-			return nil
-		}
 
-		_, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
+		_, _, idpAcctUUID, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
 		require.NoError(t, err)
 		require.False(t, ds.InsertMDMIdPAccountFuncInvoked, "should not insert when account already exists")
-		require.True(t, ds.AssociateHostMDMIdPAccountDBFuncInvoked)
+		require.Equal(t, testAcctUUID, idpAcctUUID)
 	})
 
-	t.Run("valid token, enrollment already has host_uuid — still links idp account", func(t *testing.T) {
+	t.Run("valid token, enrollment already has host_uuid — still returns idp account uuid", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := newTestServiceWithWSTEP(t, ds)
 		token := makeToken(t, svc, testUPN, testDeviceID)
@@ -177,25 +170,20 @@ func TestProcessWindowsEUAToken(t *testing.T) {
 		ds.GetMDMIdPAccountByEmailFunc = func(ctx context.Context, email string) (*fleet.MDMIdPAccount, error) {
 			return &fleet.MDMIdPAccount{UUID: testAcctUUID, Email: testUPN, Username: testUPN}, nil
 		}
-		ds.AssociateHostMDMIdPAccountDBFunc = func(ctx context.Context, hostUUID, acctUUID string) error {
-			require.Equal(t, testHostUUID, hostUUID)
-			require.Equal(t, testAcctUUID, acctUUID)
-			return nil
-		}
 
-		upn, deviceID, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
+		upn, deviceID, idpAcctUUID, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
 		require.NoError(t, err)
 		require.Equal(t, testUPN, upn)
 		require.Equal(t, testDeviceID, deviceID)
+		require.Equal(t, testAcctUUID, idpAcctUUID)
 		require.True(t, ds.GetMDMIdPAccountByEmailFuncInvoked, "should still fetch idp account even when enrollment has host_uuid")
-		require.True(t, ds.AssociateHostMDMIdPAccountDBFuncInvoked, "should still link idp account even when enrollment has host_uuid")
 	})
 
 	t.Run("invalid token falls back to END_USER_AUTH_REQUIRED", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := newTestServiceWithWSTEP(t, ds)
 
-		_, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, "this.is.not.a.valid.token")
+		_, _, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, "this.is.not.a.valid.token")
 		require.Error(t, err)
 		var orbitErr *fleet.OrbitError
 		require.ErrorAs(t, err, &orbitErr)
@@ -207,7 +195,7 @@ func TestProcessWindowsEUAToken(t *testing.T) {
 		ds := new(mock.Store)
 		svc := &Service{ds: ds, logger: slog.New(slog.DiscardHandler)}
 
-		_, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, "any.token.value")
+		_, _, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, "any.token.value")
 		require.Error(t, err)
 		var orbitErr *fleet.OrbitError
 		require.ErrorAs(t, err, &orbitErr)
@@ -224,7 +212,7 @@ func TestProcessWindowsEUAToken(t *testing.T) {
 			return nil, mysql_errors.NotFound("MDMWindowsEnrolledDevice")
 		}
 
-		_, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
+		_, _, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
 		require.Error(t, err)
 		var orbitErr *fleet.OrbitError
 		require.ErrorAs(t, err, &orbitErr)


### PR DESCRIPTION
Resolves #45066.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user email/device mapping for Windows and Linux hosts enrolling via end-user authentication (browser-based and EUA-token flows). Host listings and device mapping now reliably show the IdP email after enrollment, improving device identification and inventory accuracy.

* **Tests**
  * Expanded integration tests to validate end-to-end enrollment and device mapping across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->