### PR TITLE
gkarr 23242 byod manual profile updates

### DIFF
--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1537,11 +1537,19 @@ func (svc *Service) GetMDMManualEnrollmentProfile(ctx context.Context) ([]byte, 
 		return nil, fmt.Errorf("loading SCEP challenge from the database: %w", err)
 	}
 
+	// This endpoint serves an unsigned profile for an IT admin to download and
+	// distribute (e.g. by email). The target device is unknown at this point,
+	// so we default to the macOS AccessRights value — preserving legacy
+	// behavior and the "don't change the macOS enrollment profile" constraint
+	// from #23242. iOS/iPadOS BYOD devices that enroll via the
+	// device-initiated download flow (mdmAppleEnrollEndpoint) get the
+	// restricted AccessRights via that path.
 	mobileConfig, err := apple_mdm.GenerateEnrollmentProfileMobileconfig(
 		appConfig.OrgInfo.OrgName,
 		appConfig.MDMUrl(),
 		string(assets[fleet.MDMAssetSCEPChallenge].Value),
 		topic,
+		"darwin",
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err)

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1112,6 +1112,25 @@ var OTASCEPTemplate = template.Must(template.New("").Funcs(funcMap).Parse(`<?xml
 //
 // During a profile replacement, the system updates payloads with the same PayloadIdentifier and
 // PayloadUUID in the old and new profiles.
+//
+// AccessRights bitmask (per Apple's com.apple.mdm reference at
+// https://developer.apple.com/documentation/devicemanagement/mdm):
+//
+//	1    Inspect installed config profiles
+//	2    Install/remove config profiles (mandatory)
+//	4    Device lock and passcode removal   (candidate to drop for BYOD in a future change)
+//	8    Device erase                       (dropped for iOS/iPadOS BYOD via #23242)
+//	16   Query device info
+//	32   Query network info
+//	64   Inspect installed provisioning profiles
+//	128  Install/remove provisioning profiles
+//	256  Inspect installed applications
+//	512  Restriction queries
+//	1024 Security queries
+//	2048 Manipulate settings
+//	4096 App management
+//
+// 8191 = all bits set (default for macOS). 8183 = 8191 - 8 (no device erase, for iOS/iPadOS BYOD).
 var enrollmentProfileMobileconfigTemplate = template.Must(template.New("").Funcs(funcMap).Parse(`
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1149,7 +1168,7 @@ var enrollmentProfileMobileconfigTemplate = template.Must(template.New("").Funcs
 		</dict>
 		<dict>
 			<key>AccessRights</key>
-			<integer>8191</integer>
+			<integer>{{ .AccessRights }}</integer>
 			<key>CheckOutWhenRemoved</key>
 			<true/>
 			<key>IdentityCertificateUUID</key>
@@ -1315,7 +1334,7 @@ var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").F
 		</dict>
 		<dict>
 			<key>AccessRights</key>
-			<integer>8191</integer>
+			<integer>{{ .AccessRights }}</integer>
 			<key>CheckOutWhenRemoved</key>
 			<true/>
 			<key>IdentityCertificateUUID</key>
@@ -1356,7 +1375,32 @@ var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").F
 </dict>
 </plist>`))
 
-func GenerateEnrollmentProfileMobileconfig(orgName, fleetURL, scepChallenge, topic string) ([]byte, error) {
+// AccessRights values selected per platform. See the comment on
+// enrollmentProfileMobileconfigTemplate above for the bit definitions.
+const (
+	// EnrollmentAccessRightsDefault is the legacy "all rights" value used for
+	// macOS enrollments. iOS/iPadOS used to receive this same value as well.
+	EnrollmentAccessRightsDefault = 8191
+	// EnrollmentAccessRightsBYODiOS is used for iOS/iPadOS BYOD (manual
+	// profile) enrollments. It is EnrollmentAccessRightsDefault with the
+	// "Device erase" bit (8) cleared. See #23242.
+	EnrollmentAccessRightsBYODiOS = 8183
+)
+
+// accessRightsForPlatform returns the AccessRights value to embed in the MDM
+// enrollment payload for the given Fleet host platform string (matches the
+// values stored in hosts.platform).
+func accessRightsForPlatform(platform string) int {
+	switch platform {
+	case "ios", "ipados":
+		return EnrollmentAccessRightsBYODiOS
+	default:
+		// macOS ("darwin"), unknown/empty platforms keep the legacy default.
+		return EnrollmentAccessRightsDefault
+	}
+}
+
+func GenerateEnrollmentProfileMobileconfig(orgName, fleetURL, scepChallenge, topic, platform string) ([]byte, error) {
 	scepURL, err := ResolveAppleSCEPURL(fleetURL)
 	if err != nil {
 		return nil, fmt.Errorf("resolve Apple SCEP url: %w", err)
@@ -1373,12 +1417,14 @@ func GenerateEnrollmentProfileMobileconfig(orgName, fleetURL, scepChallenge, top
 		SCEPChallenge string
 		Topic         string
 		ServerURL     string
+		AccessRights  int
 	}{
 		Organization:  orgName,
 		SCEPURL:       scepURL,
 		SCEPChallenge: scepChallenge,
 		Topic:         topic,
 		ServerURL:     serverURL,
+		AccessRights:  accessRightsForPlatform(platform),
 	}); err != nil {
 		return nil, fmt.Errorf("execute template: %w", err)
 	}
@@ -1431,7 +1477,7 @@ func AddEnrollmentRefToFleetURL(fleetURL, reference string) (string, error) {
 	return u.String(), nil
 }
 
-func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, deviceSerial, topic string) ([]byte, error) {
+func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, deviceSerial, topic, platform string) ([]byte, error) {
 	serverURL, err := ResolveAppleMDMURL(mdmURL)
 	if err != nil {
 		return nil, fmt.Errorf("resolve Apple MDM url: %w", err)
@@ -1450,6 +1496,7 @@ func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, devic
 		ServerURL        string
 		ClientIdentifier string
 		SerialTemplate   string
+		AccessRights     int
 	}{
 		Organization:     orgName,
 		DirectoryURL:     acmeURL,
@@ -1457,6 +1504,7 @@ func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, devic
 		ServerURL:        serverURL,
 		ClientIdentifier: deviceSerial,
 		SerialTemplate:   `%SerialNumber%`, // Apple replaces this placeholder with the device's serial number during enrollment
+		AccessRights:     accessRightsForPlatform(platform),
 	}); err != nil {
 		return nil, fmt.Errorf("execute template: %w", err)
 	}

--- a/server/mdm/apple/apple_mdm_test.go
+++ b/server/mdm/apple/apple_mdm_test.go
@@ -210,6 +210,7 @@ func TestGenerateEnrollmentProfileMobileconfig(t *testing.T) {
 		PayloadType    string
 		ServerURL      string      // used by the enrollment payload
 		PayloadContent scepPayload // scep contains a nested payload content dict
+		AccessRights   int         // only present on the com.apple.mdm payload
 	}
 
 	type enrollmentProfile struct {
@@ -218,57 +219,89 @@ func TestGenerateEnrollmentProfileMobileconfig(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		orgName       string
-		fleetURL      string
-		scepChallenge string
-		expectError   bool
+		name                 string
+		orgName              string
+		fleetURL             string
+		scepChallenge        string
+		platform             string
+		expectedAccessRights int
+		expectError          bool
 	}{
 		{
-			name:          "valid input with simple values",
-			orgName:       "Fleet",
-			fleetURL:      "https://example.com",
-			scepChallenge: "testChallenge",
-			expectError:   false,
+			name:                 "macOS keeps legacy AccessRights",
+			orgName:              "Fleet",
+			fleetURL:             "https://example.com",
+			scepChallenge:        "testChallenge",
+			platform:             "darwin",
+			expectedAccessRights: EnrollmentAccessRightsDefault,
 		},
 		{
-			name:          "organization name and enroll secret with special characters",
-			orgName:       `Fleet & Co. "Special" <Org>`,
-			fleetURL:      "https://example.com",
-			scepChallenge: "test/&Challenge",
-			expectError:   false,
+			name:                 "iOS BYOD gets restricted AccessRights (no device erase)",
+			orgName:              "Fleet",
+			fleetURL:             "https://example.com",
+			scepChallenge:        "testChallenge",
+			platform:             "ios",
+			expectedAccessRights: EnrollmentAccessRightsBYODiOS,
+		},
+		{
+			name:                 "iPadOS BYOD gets restricted AccessRights (no device erase)",
+			orgName:              "Fleet",
+			fleetURL:             "https://example.com",
+			scepChallenge:        "testChallenge",
+			platform:             "ipados",
+			expectedAccessRights: EnrollmentAccessRightsBYODiOS,
+		},
+		{
+			name:                 "empty platform falls back to legacy AccessRights",
+			orgName:              "Fleet",
+			fleetURL:             "https://example.com",
+			scepChallenge:        "testChallenge",
+			platform:             "",
+			expectedAccessRights: EnrollmentAccessRightsDefault,
+		},
+		{
+			name:                 "organization name and enroll secret with special characters",
+			orgName:              `Fleet & Co. "Special" <Org>`,
+			fleetURL:             "https://example.com",
+			scepChallenge:        "test/&Challenge",
+			platform:             "darwin",
+			expectedAccessRights: EnrollmentAccessRightsDefault,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := GenerateEnrollmentProfileMobileconfig(tt.orgName, tt.fleetURL, tt.scepChallenge, "com.foo.bar")
+			result, err := GenerateEnrollmentProfileMobileconfig(tt.orgName, tt.fleetURL, tt.scepChallenge, "com.foo.bar", tt.platform)
 			if tt.expectError {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, result)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
 
-				var profile enrollmentProfile
+			var profile enrollmentProfile
 
-				require.NoError(t, plist.Unmarshal(result, &profile))
+			require.NoError(t, plist.Unmarshal(result, &profile))
 
-				for _, p := range profile.PayloadContent {
-					switch p.PayloadType {
-					case "com.apple.security.scep":
-						scepURL, err := ResolveAppleSCEPURL(tt.fleetURL)
-						require.NoError(t, err)
-						require.Equal(t, scepURL, p.PayloadContent.URL)
-						require.Equal(t, tt.scepChallenge, p.PayloadContent.Challenge)
-					case "com.apple.mdm":
-						mdmURL, err := ResolveAppleMDMURL(tt.fleetURL)
-						require.NoError(t, err)
-						require.Contains(t, mdmURL, p.ServerURL)
-					default:
-						require.Failf(t, "unrecognized payload type in enrollment profile: %s", p.PayloadType)
-					}
+			foundMDM := false
+			for _, p := range profile.PayloadContent {
+				switch p.PayloadType {
+				case "com.apple.security.scep":
+					scepURL, err := ResolveAppleSCEPURL(tt.fleetURL)
+					require.NoError(t, err)
+					require.Equal(t, scepURL, p.PayloadContent.URL)
+					require.Equal(t, tt.scepChallenge, p.PayloadContent.Challenge)
+				case "com.apple.mdm":
+					foundMDM = true
+					mdmURL, err := ResolveAppleMDMURL(tt.fleetURL)
+					require.NoError(t, err)
+					require.Contains(t, mdmURL, p.ServerURL)
+					require.Equal(t, tt.expectedAccessRights, p.AccessRights, "AccessRights for platform %q", tt.platform)
+				default:
+					require.Failf(t, "unrecognized payload type in enrollment profile: %s", p.PayloadType)
 				}
 			}
+			require.True(t, foundMDM, "enrollment profile must contain a com.apple.mdm payload")
 		})
 	}
 }

--- a/server/mdm/apple/util.go
+++ b/server/mdm/apple/util.go
@@ -22,6 +22,24 @@ import (
 // Note Apple rejects CSRs if the key size is not 2048.
 const rsaKeySize = 2048
 
+// ProductToPlatform maps an Apple device product string (e.g. "iPhone14,5",
+// "iPad13,1", "MacBookPro18,3") to a Fleet host platform string matching the
+// values stored in hosts.platform ("ios", "ipados", "darwin").
+//
+// Used to pick platform-appropriate enrollment payload values such as
+// AccessRights — see GenerateEnrollmentProfileMobileconfig.
+func ProductToPlatform(product string) string {
+	p := strings.ToLower(product)
+	switch {
+	case strings.HasPrefix(p, "iphone"), strings.HasPrefix(p, "ipod"):
+		return "ios"
+	case strings.HasPrefix(p, "ipad"):
+		return "ipados"
+	default:
+		return "darwin"
+	}
+}
+
 // newPrivateKey creates an RSA private key
 func newPrivateKey() (*rsa.PrivateKey, error) {
 	return rsa.GenerateKey(rand.Reader, rsaKeySize)

--- a/server/mdm/apple/util_test.go
+++ b/server/mdm/apple/util_test.go
@@ -41,6 +41,26 @@ func TestMDMAppleEnrollURL(t *testing.T) {
 	}
 }
 
+func TestProductToPlatform(t *testing.T) {
+	cases := []struct {
+		product  string
+		expected string
+	}{
+		{"iPhone14,5", "ios"},
+		{"iphone7,2", "ios"},
+		{"iPod9,1", "ios"},
+		{"iPad13,1", "ipados"},
+		{"IPAD8,11", "ipados"},
+		{"MacBookPro18,3", "darwin"},
+		{"Macmini9,1", "darwin"},
+		{"", "darwin"},
+		{"something-unexpected", "darwin"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.expected, ProductToPlatform(c.product), "product=%q", c.product)
+	}
+}
+
 func TestGenerateRandomPin(t *testing.T) {
 	for i := 1; i <= 100; i++ {
 		pin, err := GenerateRandomPin(i)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7393,15 +7393,15 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 	}
 
 	// NOTE: we don't offer ACME enrollment via OTA.
-	// OTA can target macOS (as well as iOS/iPadOS), and we don't have device
-	// info at this point in the flow to distinguish them, so we use the
-	// macOS default ("darwin") AccessRights — keeping the legacy behavior.
+	// Derive the platform from the device's PRODUCT (e.g. "iPhone14,5",
+	// "MacBookPro18,3") so iOS/iPadOS BYOD enrollments get the
+	// restricted AccessRights (no device erase). See #23242.
 	enrollmentProf, err := apple_mdm.GenerateEnrollmentProfileMobileconfig(
 		appCfg.OrgInfo.OrgName,
 		mdmURL,
 		string(assets[fleet.MDMAssetSCEPChallenge].Value),
 		topic,
-		"darwin",
+		apple_mdm.ProductToPlatform(deviceInfo.Product),
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generating manual enrollment profile")

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2244,11 +2244,13 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 
 	}
 
+	platform := apple_mdm.ProductToPlatform(machineInfo.Product)
+
 	var enrollProf []byte
 	if requireACME {
-		enrollProf, err = svc.generateMDMAppleACMEEnrollProfile(ctx, machineInfo.Serial, appConfig.OrgInfo.OrgName, mdmURL, topic)
+		enrollProf, err = svc.generateMDMAppleACMEEnrollProfile(ctx, machineInfo.Serial, appConfig.OrgInfo.OrgName, mdmURL, topic, platform)
 	} else {
-		enrollProf, err = svc.generateMDMAppleSCEPEnrollProfile(ctx, appConfig.OrgInfo.OrgName, mdmURL, topic)
+		enrollProf, err = svc.generateMDMAppleSCEPEnrollProfile(ctx, appConfig.OrgInfo.OrgName, mdmURL, topic, platform)
 	}
 
 	if err != nil {
@@ -2321,7 +2323,7 @@ func isMacACMESupported(modelIdentifier string, osVersion string) (bool, error) 
 	return true, nil
 }
 
-func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardwareSerial string, orgName string, mdmURL string, topic string) ([]byte, error) {
+func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardwareSerial string, orgName string, mdmURL string, topic string, platform string) ([]byte, error) {
 	acmeIdent, err := svc.acmeSvc.NewACMEEnrollment(ctx, hardwareSerial)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "creating ACME enrollment")
@@ -2333,6 +2335,7 @@ func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardw
 		acmeIdent,
 		hardwareSerial,
 		topic,
+		platform,
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generateMDMAppleACMEEnrollProfile: generating ACME enrollment profile")
@@ -2341,7 +2344,7 @@ func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardw
 	return b, nil
 }
 
-func (svc *Service) generateMDMAppleSCEPEnrollProfile(ctx context.Context, orgName string, mdmURL string, topic string) ([]byte, error) {
+func (svc *Service) generateMDMAppleSCEPEnrollProfile(ctx context.Context, orgName string, mdmURL string, topic string, platform string) ([]byte, error) {
 	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
 		fleet.MDMAssetSCEPChallenge,
 	}, nil)
@@ -2354,6 +2357,7 @@ func (svc *Service) generateMDMAppleSCEPEnrollProfile(ctx context.Context, orgNa
 		mdmURL,
 		string(assets[fleet.MDMAssetSCEPChallenge].Value),
 		topic,
+		platform,
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generateMDMAppleSCEPEnrollProfile: generating enrollment profile")
@@ -6098,6 +6102,40 @@ const scepCertRenewalThresholdDays = 180
 // ~4 million devices expiring at the same time.
 const maxCertsRenewalPerRun = 100
 
+// getPlatformsForSCEPRenewal returns a map of host UUID → platform string
+// (matching the values in hosts.platform) for the union of the given
+// associations. Used during SCEP renewal so the generated enrollment profile
+// can carry the right AccessRights value per host platform (see #23242).
+//
+// Runs as part of a cron with no user context, so it uses an admin team
+// filter to bypass team scoping.
+func getPlatformsForSCEPRenewal(ctx context.Context, ds fleet.Datastore, groups ...[]fleet.SCEPIdentityAssociation) (map[string]string, error) {
+	seen := map[string]struct{}{}
+	uuids := make([]string, 0)
+	for _, g := range groups {
+		for _, a := range g {
+			if _, ok := seen[a.HostUUID]; ok {
+				continue
+			}
+			seen[a.HostUUID] = struct{}{}
+			uuids = append(uuids, a.HostUUID)
+		}
+	}
+	if len(uuids) == 0 {
+		return map[string]string{}, nil
+	}
+	adminFilter := fleet.TeamFilter{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}}
+	hosts, err := ds.ListHostsLiteByUUIDs(ctx, adminFilter, uuids)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list hosts by uuid for SCEP renewal")
+	}
+	out := make(map[string]string, len(hosts))
+	for _, h := range hosts {
+		out[h.UUID] = h.Platform
+	}
+	return out, nil
+}
+
 func RenewSCEPCertificates(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -6210,32 +6248,44 @@ func RenewSCEPCertificates(
 	}
 	scepChallenge := string(assets[fleet.MDMAssetSCEPChallenge].Value)
 
+	// Look up host platforms once so we can pick the right AccessRights value
+	// per host (iOS/iPadOS BYOD get a restricted profile; macOS keeps the
+	// legacy one). See #23242.
+	platformByHostUUID, err := getPlatformsForSCEPRenewal(ctx, ds, assocsWithoutRefs, assocsWithRefs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "looking up host platforms for SCEP renewal")
+	}
+
 	// acmeAssocsByHostUUID will store the associations for hosts that require ACME renewal, which
 	// will be handled separately since they require a different enrollment profile.
 	acmeAssocsByHostUUID := make(map[string]fleet.SCEPIdentityAssociation)
 
-	// Filter for ACME requirements then send a single command for all the hosts without references.
+	// Filter for ACME requirements then send commands for hosts without references.
+	// Group by platform so iOS/iPadOS BYOD hosts get the restricted-AccessRights
+	// profile while macOS hosts continue to get the legacy profile.
 	if len(assocsWithoutRefs) > 0 {
-		var filteredAssocs []fleet.SCEPIdentityAssociation
+		assocsByPlatform := map[string][]fleet.SCEPIdentityAssociation{}
 		for _, assoc := range assocsWithoutRefs {
 			if _, ok := acmeRequiredByHostUUID[assoc.HostUUID]; ok {
 				acmeAssocsByHostUUID[assoc.HostUUID] = assoc
 				continue
 			}
-			filteredAssocs = append(filteredAssocs, assoc)
+			platform := platformByHostUUID[assoc.HostUUID]
+			assocsByPlatform[platform] = append(assocsByPlatform[platform], assoc)
 		}
 
-		if len(filteredAssocs) > 0 {
+		for platform, group := range assocsByPlatform {
 			profile, err := apple_mdm.GenerateEnrollmentProfileMobileconfig(
 				appConfig.OrgInfo.OrgName,
 				appConfig.MDMUrl(),
 				scepChallenge,
 				mdmPushCertTopic,
+				platform,
 			)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "generating enrollment profile for hosts without enroll reference")
 			}
-			if err := renewMDMAppleEnrollmentProfile(ctx, ds, commander, logger, filteredAssocs, profile, appConfig.OrgInfo.OrgName+" enrollment"); err != nil {
+			if err := renewMDMAppleEnrollmentProfile(ctx, ds, commander, logger, group, profile, appConfig.OrgInfo.OrgName+" enrollment"); err != nil {
 				return ctxerr.Wrap(ctx, err, "sending profile to hosts without associations")
 			}
 		}
@@ -6299,6 +6349,7 @@ func RenewSCEPCertificates(
 			enrollURL,
 			scepChallenge,
 			mdmPushCertTopic,
+			platformByHostUUID[assoc.HostUUID],
 		)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "generating enrollment profile for hosts with enroll reference")
@@ -6332,12 +6383,15 @@ func RenewSCEPCertificates(
 			return ctxerr.Wrap(ctx, err, "creating new ACME enrollment")
 		}
 
+		// ACME renewal targets only Apple Silicon Macs (see isMacACMESupported),
+		// so we always pass the macOS platform.
 		profile, err := apple_mdm.GenerateACMEEnrollmentProfileMobileconfig(
 			appConfig.OrgInfo.OrgName,
 			enrollURL,
 			acmeIdent,
 			di.HardwareSerial,
 			mdmPushCertTopic,
+			"darwin",
 		)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "generating enrollment profile for hosts requiring ACME renewal")
@@ -7338,12 +7392,16 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 		return nil, ctxerr.Wrap(ctx, err, "extracting topic from APNs cert")
 	}
 
-	// NOTE: we don't offer ACME enrollment via OTA
+	// NOTE: we don't offer ACME enrollment via OTA.
+	// OTA can target macOS (as well as iOS/iPadOS), and we don't have device
+	// info at this point in the flow to distinguish them, so we use the
+	// macOS default ("darwin") AccessRights — keeping the legacy behavior.
 	enrollmentProf, err := apple_mdm.GenerateEnrollmentProfileMobileconfig(
 		appCfg.OrgInfo.OrgName,
 		mdmURL,
 		string(assets[fleet.MDMAssetSCEPChallenge].Value),
 		topic,
+		"darwin",
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generating manual enrollment profile")

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -4800,7 +4800,7 @@ func TestAppleMDMFileVaultEscrowFunctions(t *testing.T) {
 
 func TestGenerateEnrollmentProfileMobileConfig(t *testing.T) {
 	// SCEP challenge should be escaped for XML
-	b, err := apple_mdm.GenerateEnrollmentProfileMobileconfig("foo", "https://example.com", "foo&bar", "topic")
+	b, err := apple_mdm.GenerateEnrollmentProfileMobileconfig("foo", "https://example.com", "foo&bar", "topic", "darwin")
 	require.NoError(t, err)
 	require.Contains(t, string(b), "foo&amp;bar")
 }
@@ -5624,6 +5624,57 @@ func TestRenewSCEPCertificatesBranches(t *testing.T) {
 			},
 			expectedError: true,
 		},
+		{
+			// #23242: iOS/iPadOS BYOD hosts get a profile with the restricted
+			// AccessRights (no device erase); macOS hosts keep the legacy
+			// AccessRights. The cron must split the no-refs batch by platform
+			// and send a separate InstallProfile command per group.
+			name: "InstallProfile splits hostsWithoutRefs by platform",
+			customExpectations: func(t *testing.T, ds *mock.Store, cfg *config.FleetConfig, appleStore *mdmmock.MDMAppleStore, commander *apple_mdm.MDMAppleCommander) {
+				ds.GetHostCertAssociationsToExpireFunc = func(ctx context.Context, expiryDays int, limit int) ([]fleet.SCEPIdentityAssociation, error) {
+					return []fleet.SCEPIdentityAssociation{
+						{HostUUID: "macUUID", EnrollReference: ""},
+						{HostUUID: "ipadUUID", EnrollReference: ""},
+					}, nil
+				}
+				ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+					hosts := make([]*fleet.Host, 0, len(uuids))
+					for _, u := range uuids {
+						platform := "darwin"
+						if u == "ipadUUID" {
+							platform = "ipados"
+						}
+						hosts = append(hosts, &fleet.Host{UUID: u, Platform: platform})
+					}
+					return hosts, nil
+				}
+
+				var sawHostBatches [][]string
+				appleStore.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+					require.Equal(t, "InstallProfile", cmd.Command.Command.RequestType)
+					sawHostBatches = append(sawHostBatches, append([]string{}, id...))
+					return map[string]error{}, nil
+				}
+				ds.SetCommandForPendingSCEPRenewalFunc = func(ctx context.Context, assocs []fleet.SCEPIdentityAssociation, cmdUUID string) error {
+					require.Len(t, assocs, 1, "each platform group should contain its single host")
+					return nil
+				}
+
+				t.Cleanup(func() {
+					require.Len(t, sawHostBatches, 2, "expected one InstallProfile per platform group")
+					seen := map[string]struct{}{}
+					for _, batch := range sawHostBatches {
+						require.Len(t, batch, 1)
+						seen[batch[0]] = struct{}{}
+					}
+					_, sawMac := seen["macUUID"]
+					_, sawIPad := seen["ipadUUID"]
+					require.True(t, sawMac, "macOS host should receive its own InstallProfile")
+					require.True(t, sawIPad, "iPadOS host should receive its own InstallProfile")
+				})
+			},
+			expectedError: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -5649,6 +5700,17 @@ func TestRenewSCEPCertificatesBranches(t *testing.T) {
 
 			ds.SetCommandForPendingSCEPRenewalFunc = func(ctx context.Context, assocs []fleet.SCEPIdentityAssociation, cmdUUID string) error {
 				return nil
+			}
+
+			// Default platform lookup for SCEP renewal — empty platform means
+			// the generator falls back to the legacy AccessRights value (macOS
+			// default). Individual cases can override.
+			ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+				hosts := make([]*fleet.Host, 0, len(uuids))
+				for _, u := range uuids {
+					hosts = append(hosts, &fleet.Host{UUID: u, Platform: "darwin"})
+				}
+				return hosts, nil
 			}
 
 			appleStorage.RetrievePushInfoFunc = func(ctx context.Context, targets []string) (map[string]*mdm.Push, error) {
@@ -5956,6 +6018,16 @@ func TestRenewACMECertificatesBranches(t *testing.T) {
 
 			ds.SetCommandForPendingSCEPRenewalFunc = func(ctx context.Context, assocs []fleet.SCEPIdentityAssociation, cmdUUID string) error {
 				return nil
+			}
+
+			// Default platform lookup for SCEP renewal (see #23242). All
+			// hosts in these ACME tests are Macs.
+			ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+				hosts := make([]*fleet.Host, 0, len(uuids))
+				for _, u := range uuids {
+					hosts = append(hosts, &fleet.Host{UUID: u, Platform: "darwin"})
+				}
+				return hosts, nil
 			}
 
 			appleStorage.RetrievePushInfoFunc = func(ctx context.Context, targets []string) (map[string]*mdm.Push, error) {


### PR DESCRIPTION
Resolves: #23242 
- **Initial plan to remove erase from byod manual enrollments**
- **Actual fix that made iphone enroll w/o erase**
