### PR TITLE
Add OCI version labels to Fleet container images

### DIFF
--- a/.goreleaser-snapshot.yml
+++ b/.goreleaser-snapshot.yml
@@ -71,5 +71,7 @@ dockers:
       - fleet
       - fleetctl
     dockerfile: tools/fleet-docker/Dockerfile
+    build_flag_templates:
+      - "--build-arg=FLEET_VERSION={{.Version}}"
     image_templates:
       - 'fleetdm/fleet:{{ envOrDefault "DOCKER_IMAGE_TAG" .Branch }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -127,6 +127,8 @@ dockers:
       - fleet
       - fleetctl
     dockerfile: tools/fleet-docker/Dockerfile
+    build_flag_templates:
+      - "--build-arg=FLEET_VERSION={{.Version}}"
     image_templates:
       - "fleetdm/fleet:{{ .Tag }}"
       - "fleetdm/fleet:v{{ .Major }}"

--- a/tools/fleet-docker/Dockerfile
+++ b/tools/fleet-docker/Dockerfile
@@ -1,5 +1,10 @@
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+ARG FLEET_VERSION=unknown
 LABEL maintainer="Fleet Developers"
+LABEL org.opencontainers.image.version="${FLEET_VERSION}"
+LABEL org.opencontainers.image.vendor="Fleet Device Management Inc."
+LABEL org.opencontainers.image.title="fleet"
+LABEL org.opencontainers.image.source="https://github.com/fleetdm/fleet"
 
 RUN apk --update add ca-certificates
 RUN apk --no-cache add jq


### PR DESCRIPTION
Adding this to reduce Vanta false positives. 

I verified the --build-arg FLEET_VERSION=4.85.0 flows through correctly and produces the expected labels:                                                                   

```json                                                                                                                                                                             
  {                                                                                                                                                                          
    "org.opencontainers.image.version": "4.85.0",                                                                                                                            
    "org.opencontainers.image.vendor": "Fleet Device Management Inc.",                                                                                                       
    "org.opencontainers.image.title": "fleet",                                                                                                                               
    "org.opencontainers.image.source": "https://github.com/fleetdm/fleet"                                                                                                    
  } 
```    

## Summary

- Adds `org.opencontainers.image.version` (plus vendor, title, source) labels to the Fleet Docker image
- Passes the build version from goreleaser to the Dockerfile via `build_flag_templates` in both release and snapshot configs
- Fixes recurring false positive CVEs in AWS ECR Inspector caused by the scanner misreading Go pseudo-versions as `v4.0.0`

## Root cause

AWS ECR Inspector scans container images for known vulnerabilities. Without OCI metadata labels, it falls back to parsing Go module paths inside the binary and extracts pseudo-versions like `v4.0.0-20260520161837-b15a13199713` as base version `v4.0.0`. Since `v4.0.0` predates every Fleet CVE fix, the scanner flags already-patched vulnerabilities as open.

## Changes

| File | Change |
|------|--------|
| `tools/fleet-docker/Dockerfile` | Added `ARG FLEET_VERSION` and OCI labels |
| `.goreleaser.yml` | Added `build_flag_templates` for release builds |
| `.goreleaser-snapshot.yml` | Added `build_flag_templates` for snapshot builds |

## Test plan

- [ ] Build a snapshot image locally with `goreleaser build --snapshot` and verify `docker inspect` shows the `org.opencontainers.image.version` label
- [ ] Confirm release goreleaser config passes the tag version correctly
- [ ] After merge and next release, verify ECR Inspector no longer flags false positive CVEs for the new image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include release version information in container images.
  * Added OCI-compliant metadata labels (vendor, title, source) to Docker images for improved identification and traceability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->