### PR TITLE
Updating SSE to be spec compliant, which now appears to work with ngrok

### DIFF
--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -1491,8 +1491,21 @@ This endpoint is used to get server-sent events (SSE) messages, so that UI know 
 
 `Status: 200`
 
+The response is a stream of [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events). The connection is held open while signup is in progress; the server emits SSE comment heartbeats (e.g. `:heartbeat`) periodically and a single terminating event when the outcome is known.
+
+On success:
+
 ```
-Android Enterprise successfully connected
+data: Android Enterprise successfully connected
+
+```
+
+If signup fails on the server side (e.g. an internal error retrieving app config) the server emits an error event instead:
+
+```
+event: error
+data: Error getting app config: <message>
+
 ```
 
 ### Android Enterprise PubSub push endpoint

--- a/frontend/services/entities/mdm_android.ts
+++ b/frontend/services/entities/mdm_android.ts
@@ -51,10 +51,12 @@ export default {
         }
         const decoder = new TextDecoder();
         const successSignal = "data: Android Enterprise successfully connected";
-        // Buffer accumulates decoded text so a success message split across
-        // multiple chunks (valid with chunked transfer encoding) is still
-        // detected.
+        const errorMarker = "event: error";
+        // Buffer accumulates decoded text so a frame split across multiple
+        // chunks (valid with chunked transfer encoding) is still detected.
+        const tailLen = Math.max(successSignal.length, errorMarker.length);
         let buffer = "";
+        let loggedError = false;
 
         while (true) {
           // eslint-disable-next-line no-await-in-loop
@@ -65,20 +67,20 @@ export default {
             reject(new Error("Android MDM SSE ended before success signal"));
             return;
           }
-          const chunk = decoder.decode(value, { stream: true });
+          buffer += decoder.decode(value, { stream: true });
           // Surface backend-emitted error events. Chrome's EventStream tab
           // doesn't attach to fetch-based SSE reliably, so without this log
           // the only signal of a server-side failure is the generic UI
           // toast.
-          if (chunk.includes("event: error")) {
-            console.error("[android-sse]:", chunk);
+          if (!loggedError && buffer.includes(errorMarker)) {
+            console.error("[android-sse]:", buffer);
+            loggedError = true;
           }
-          buffer += chunk;
           if (buffer.includes(successSignal)) {
             resolve();
             return;
           }
-          buffer = buffer.slice(-successSignal.length);
+          buffer = buffer.slice(-tailLen);
         }
       } catch (error) {
         if ((error as Error).name === "AbortError") {

--- a/frontend/services/entities/mdm_android.ts
+++ b/frontend/services/entities/mdm_android.ts
@@ -39,6 +39,7 @@ export default {
           method: "GET",
           headers: {
             Authorization: `Bearer ${authToken.get()}`,
+            Accept: "text/event-stream",
           },
           signal: abortSignal,
         });
@@ -49,7 +50,7 @@ export default {
           return;
         }
         const decoder = new TextDecoder();
-        const successSignal = "Android Enterprise successfully connected";
+        const successSignal = "data: Android Enterprise successfully connected";
         // Buffer accumulates decoded text so a success message split across
         // multiple chunks (valid with chunked transfer encoding) is still
         // detected.
@@ -64,7 +65,15 @@ export default {
             reject(new Error("Android MDM SSE ended before success signal"));
             return;
           }
-          buffer += decoder.decode(value, { stream: true });
+          const chunk = decoder.decode(value, { stream: true });
+          // Surface backend-emitted error events. Chrome's EventStream tab
+          // doesn't attach to fetch-based SSE reliably, so without this log
+          // the only signal of a server-side failure is the generic UI
+          // toast.
+          if (chunk.includes("event: error")) {
+            console.error("[android-sse]:", chunk);
+          }
+          buffer += chunk;
           if (buffer.includes(successSignal)) {
             resolve();
             return;

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -639,7 +639,7 @@ type enterpriseSSEResponse struct {
 	done chan string
 }
 
-func (r enterpriseSSEResponse) HijackRender(_ context.Context, w http.ResponseWriter) {
+func (r enterpriseSSEResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -655,6 +655,9 @@ func (r enterpriseSSEResponse) HijackRender(_ context.Context, w http.ResponseWr
 
 	for {
 		select {
+		case <-ctx.Done():
+			// Client disconnected; stop holding the response open.
+			return
 		case data, ok := <-r.done:
 			if ok {
 				_, _ = fmt.Fprint(w, data)
@@ -662,9 +665,9 @@ func (r enterpriseSSEResponse) HijackRender(_ context.Context, w http.ResponseWr
 			}
 			return
 		case <-time.After(5 * time.Second):
-			// We send a heartbeat to prevent the load balancer from closing the (otherwise idle) connection.
-			// The leading colon indicates this is a comment, and is ignored by SSE consumers. A blank
-			// line (\n\n) terminates the event per spec.
+			// Heartbeat as an SSE comment (line starting with ":"). Comments are
+			// ignored by SSE consumers but keep the connection alive for proxies.
+			// Blank line (\n\n) terminates the event per spec.
 			// https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
 			_, _ = fmt.Fprint(w, ":heartbeat\n\n")
 			w.(http.Flusher).Flush()
@@ -685,7 +688,10 @@ func (svc *Service) EnterpriseSignupSSE(ctx context.Context) (chan string, error
 		return nil, err
 	}
 
-	done := make(chan string)
+	// Buffered so the poller's single send can always complete, even if the
+	// HTTP handler (HijackRender) has already exited due to client disconnect.
+	// Without this, the producer goroutine would leak on an unbuffered channel.
+	done := make(chan string, 1)
 	go func() {
 		if svc.signupSSECheck(ctx, done) {
 			return
@@ -710,7 +716,9 @@ func (svc *Service) signupSSECheck(ctx context.Context, done chan string) bool {
 	appConfig, err := svc.ds.AppConfig(ctx)
 	if err != nil {
 		// SSE error event: distinct event type so a client can branch on it.
-		done <- fmt.Sprintf("event: error\ndata: Error getting app config: %v\n\n", err)
+		// Strip newlines from err so embedded line breaks don't break SSE framing.
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		done <- fmt.Sprintf("event: error\ndata: Error getting app config: %s\n\n", msg)
 		return true
 	}
 	if appConfig.MDM.AndroidEnabledAndConfigured {

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -32,7 +32,9 @@ var testSetEmptyPrivateKey bool
 
 const (
 	DefaultSignupSSEInterval = 3 * time.Second
-	SignupSSESuccess         = "Android Enterprise successfully connected"
+	// SignupSSESuccess is the SSE event sent on the wire when the Android
+	// enterprise signup completes. Spec-compliant SSE framing ("data: " field + blank-line terminator).
+	SignupSSESuccess = "data: Android Enterprise successfully connected\n\n"
 )
 
 type Service struct {
@@ -661,9 +663,10 @@ func (r enterpriseSSEResponse) HijackRender(_ context.Context, w http.ResponseWr
 			return
 		case <-time.After(5 * time.Second):
 			// We send a heartbeat to prevent the load balancer from closing the (otherwise idle) connection.
-			// The leading colon indicates this is a comment, and is ignored.
+			// The leading colon indicates this is a comment, and is ignored by SSE consumers. A blank
+			// line (\n\n) terminates the event per spec.
 			// https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
-			_, _ = fmt.Fprint(w, ":heartbeat\n")
+			_, _ = fmt.Fprint(w, ":heartbeat\n\n")
 			w.(http.Flusher).Flush()
 		}
 	}
@@ -706,7 +709,8 @@ func (svc *Service) EnterpriseSignupSSE(ctx context.Context) (chan string, error
 func (svc *Service) signupSSECheck(ctx context.Context, done chan string) bool {
 	appConfig, err := svc.ds.AppConfig(ctx)
 	if err != nil {
-		done <- fmt.Sprintf("Error getting app config: %v", err)
+		// SSE error event: distinct event type so a client can branch on it.
+		done <- fmt.Sprintf("event: error\ndata: Error getting app config: %v\n\n", err)
 		return true
 	}
 	if appConfig.MDM.AndroidEnabledAndConfigured {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45862 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  - Already added in the previous PR.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of enrollment errors sent by the server, ensuring error messages surface reliably.
  * Prevented streaming leaks by stopping background work when a client disconnects.

* **Documentation / Protocol**
  * Made server-to-client streaming more spec-compliant (framing, heartbeats) for more robust Android Enterprise enrollment communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->