### PR TITLE
Refactor HostTableConfig to gate selection by capability, not role

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tests.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tests.tsx
@@ -1,0 +1,122 @@
+import {
+  generateAvailableTableHeaders,
+  generateVisibleTableColumns,
+} from "./HostTableConfig";
+
+const getIds = (columns: { id?: string }[]) => columns.map((c) => c.id ?? "");
+
+describe("generateAvailableTableHeaders", () => {
+  describe("free tier", () => {
+    it("hides selection, team_name, and mdm columns when the user cannot select hosts", () => {
+      const ids = getIds(
+        generateAvailableTableHeaders({
+          isFreeTier: true,
+          canSelectHosts: false,
+        })
+      );
+
+      expect(ids).not.toContain("selection");
+      expect(ids).not.toContain("team_name");
+      expect(ids).not.toContain("mdm.server_url");
+      expect(ids).not.toContain("mdm.enrollment_status");
+    });
+
+    it("shows selection but still hides team_name and mdm columns when the user can select hosts", () => {
+      const ids = getIds(
+        generateAvailableTableHeaders({
+          isFreeTier: true,
+          canSelectHosts: true,
+        })
+      );
+
+      expect(ids).toContain("selection");
+      expect(ids).not.toContain("team_name");
+      expect(ids).not.toContain("mdm.server_url");
+      expect(ids).not.toContain("mdm.enrollment_status");
+    });
+  });
+
+  describe("premium tier", () => {
+    it("hides only the selection column when the user cannot select hosts", () => {
+      const ids = getIds(
+        generateAvailableTableHeaders({
+          isFreeTier: false,
+          canSelectHosts: false,
+        })
+      );
+
+      expect(ids).not.toContain("selection");
+      expect(ids).toContain("team_name");
+      expect(ids).toContain("mdm.server_url");
+      expect(ids).toContain("mdm.enrollment_status");
+    });
+
+    it("shows selection, team_name, and mdm columns when the user can select hosts", () => {
+      const ids = getIds(
+        generateAvailableTableHeaders({
+          isFreeTier: false,
+          canSelectHosts: true,
+        })
+      );
+
+      expect(ids).toContain("selection");
+      expect(ids).toContain("team_name");
+      expect(ids).toContain("mdm.server_url");
+      expect(ids).toContain("mdm.enrollment_status");
+    });
+  });
+
+  it("places selection as the leading column when shown", () => {
+    const ids = getIds(
+      generateAvailableTableHeaders({
+        isFreeTier: false,
+        canSelectHosts: true,
+      })
+    );
+
+    expect(ids[0]).toBe("selection");
+  });
+});
+
+describe("generateVisibleTableColumns", () => {
+  it("removes columns listed in hiddenColumns", () => {
+    const ids = getIds(
+      generateVisibleTableColumns({
+        hiddenColumns: ["hostname", "computer_name", "uuid"],
+        isFreeTier: false,
+        canSelectHosts: true,
+      })
+    );
+
+    expect(ids).not.toContain("hostname");
+    expect(ids).not.toContain("computer_name");
+    expect(ids).not.toContain("uuid");
+    // Unrelated columns are unaffected.
+    expect(ids).toContain("display_name");
+    expect(ids).toContain("selection");
+  });
+
+  it("still hides the selection column when canSelectHosts is false, regardless of hiddenColumns", () => {
+    const ids = getIds(
+      generateVisibleTableColumns({
+        hiddenColumns: [],
+        isFreeTier: false,
+        canSelectHosts: false,
+      })
+    );
+
+    expect(ids).not.toContain("selection");
+  });
+
+  it("can hide the selection column via hiddenColumns even when canSelectHosts is true", () => {
+    const ids = getIds(
+      generateVisibleTableColumns({
+        hiddenColumns: ["selection"],
+        isFreeTier: false,
+        canSelectHosts: true,
+      })
+    );
+
+    expect(ids).not.toContain("selection");
+  });
+});

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -684,47 +684,39 @@ const defaultHiddenColumns = [
   "hardware_serial",
 ];
 
+const FREE_TIER_HIDDEN_COLUMN_IDS = [
+  "team_name",
+  "mdm.server_url",
+  "mdm.enrollment_status",
+];
+
 /**
- * Will generate a host table column configuration based off of the current user
- * permissions and license tier of fleet they are on.
+ * Will generate a host table column configuration based off of the current
+ * license tier and whether the current user can select hosts for bulk actions.
+ *
+ * `canSelectHosts` controls the leading checkbox column. It's a capability,
+ * not a role check — callers compute it from whichever roles/conditions apply
+ * to the bulk action(s) the page exposes.
  */
 const generateAvailableTableHeaders = ({
   isFreeTier = true,
-  isOnlyObserver = true,
+  canSelectHosts = false,
   teamId,
 }: {
   isFreeTier: boolean | undefined;
-  isOnlyObserver: boolean | undefined;
+  canSelectHosts: boolean | undefined;
   teamId?: number;
 }): IHostTableColumnConfig[] => {
-  return allHostTableHeaders(teamId).reduce(
-    (columns: Column<IHost>[], currentColumn: Column<IHost>) => {
-      // skip over column headers that are not shown in free observer tier
-      if (isFreeTier) {
-        if (
-          isOnlyObserver &&
-          ["selection", "team_name"].includes(currentColumn.id || "")
-        ) {
-          return columns;
-          // skip over column headers that are not shown in free admin/maintainer
-        }
-        if (
-          currentColumn.id === "team_name" ||
-          currentColumn.id === "mdm.server_url" ||
-          currentColumn.id === "mdm.enrollment_status"
-        ) {
-          return columns;
-        }
-      } else if (isOnlyObserver && currentColumn.id === "selection") {
-        // In premium tier, we want to check user role to enable/disable select column
-        return columns;
-      }
-
-      columns.push(currentColumn);
-      return columns;
-    },
-    []
-  );
+  return allHostTableHeaders(teamId).filter((column) => {
+    const id = column.id ?? "";
+    if (id === "selection" && !canSelectHosts) {
+      return false;
+    }
+    if (isFreeTier && FREE_TIER_HIDDEN_COLUMN_IDS.includes(id)) {
+      return false;
+    }
+    return true;
+  });
 };
 
 /**
@@ -733,18 +725,18 @@ const generateAvailableTableHeaders = ({
 const generateVisibleTableColumns = ({
   hiddenColumns,
   isFreeTier = true,
-  isOnlyObserver = true,
+  canSelectHosts = false,
   teamId,
 }: {
   hiddenColumns: string[];
   isFreeTier: boolean | undefined;
-  isOnlyObserver: boolean | undefined;
+  canSelectHosts: boolean | undefined;
   teamId?: number;
 }): IHostTableColumnConfig[] => {
   // remove columns set as hidden by the user.
   return generateAvailableTableHeaders({
     isFreeTier,
-    isOnlyObserver,
+    canSelectHosts,
     teamId,
   }).filter((column) => {
     return !hiddenColumns.includes(column.id as string);

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1442,7 +1442,10 @@ const ManageHostsPage = ({
 
     return (
       <EditColumnsModal
-        columns={generateAvailableTableHeaders({ isFreeTier, isOnlyObserver })}
+        columns={generateAvailableTableHeaders({
+          isFreeTier,
+          canSelectHosts: !isOnlyObserver,
+        })}
         hiddenColumns={hiddenColumns}
         onSaveColumns={onSaveColumns}
         onCancelColumns={toggleEditColumnsModal}
@@ -1573,7 +1576,7 @@ const ManageHostsPage = ({
         const tableColumns = generateVisibleTableColumns({
           hiddenColumns,
           isFreeTier,
-          isOnlyObserver,
+          canSelectHosts: !isOnlyObserver,
           teamId: teamIdForApi,
         });
 
@@ -1822,10 +1825,10 @@ const ManageHostsPage = ({
     const tableColumns = generateVisibleTableColumns({
       hiddenColumns,
       isFreeTier,
-      isOnlyObserver:
-        isOnlyObserver ||
-        isGlobalTechnician ||
-        (!isOnGlobalTeam && !isTeamMaintainerOrTeamAdmin),
+      canSelectHosts:
+        !isOnlyObserver &&
+        !isGlobalTechnician &&
+        (isOnGlobalTeam || isTeamMaintainerOrTeamAdmin),
       teamId: teamIdForApi,
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for host table column configuration across subscription tiers and user permissions.

* **Refactor**
  * Updated host table column visibility logic to enforce tier-specific restrictions. Free tier users now have limited access to certain columns, while host selection capability is properly controlled based on user roles and permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/45990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->