### PR TITLE
Adding basic GA4 tags for webinars and whitepapers

### DIFF
--- a/website/assets/js/pages/articles/basic-webinar.page.js
+++ b/website/assets/js/pages/articles/basic-webinar.page.js
@@ -52,6 +52,9 @@ parasails.registerPage('basic-webinar', {
         });
         qualified('showFormExperience', 'experience-1772126772950');
       }
+      if (typeof gtag !== 'undefined') {
+        gtag('event', 'fleet_website__webinar_registration');
+      }
       this.syncing = true;
       this.goto(this.thisPage.url+'/watch');
     },

--- a/website/assets/js/pages/articles/basic-whitepaper.page.js
+++ b/website/assets/js/pages/articles/basic-whitepaper.page.js
@@ -52,6 +52,9 @@ parasails.registerPage('basic-whitepaper', {
         });
         qualified('showFormExperience', 'experience-1772126772950');
       }
+      if (typeof gtag !== 'undefined') {
+        gtag('event', 'fleet_website__whitepaper_download');
+      }
       let pdfDownloadLink = document.createElement('a');
       pdfDownloadLink.href = `/pdfs/${this.thisPage.meta.whitepaperFilename}`;
       pdfDownloadLink.download = this.thisPage.meta.whitepaperFilename;


### PR DESCRIPTION
Adds code to fire GA4 events for whitepapers and webinars

closes fleetdm/confidential#16033
