### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/1password/darwin.json
+++ b/ee/maintained-apps/outputs/1password/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "8.12.12",
+      "version": "8.12.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.21') < 0);"
       },
       "installer_url": "https://downloads.1password.com/mac/1Password.pkg",
       "install_script_ref": "ef2a17ff",

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8089.1",
+      "version": "1.8555.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.8089.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.8555.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.8089.1/Claude-b98a06c70e376344e3b6938d6980242e8cc20547.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.8555.0/Claude-8245b7a72393fec67fa946b26a825bfbd3f947b3.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "e555285c",
-      "sha256": "228d2afe22f4d5978398c64650bb88b63768f4d1bc0ed9658c674553dce1afd5",
+      "sha256": "3841b6e5c04f36a029d88c080b1e7f3c972fa60c890dd2f31323dd74503076d7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8089.1",
+      "version": "1.8555.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.8089.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.8555.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.8089.1/Claude-b98a06c70e376344e3b6938d6980242e8cc20547.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.8555.0/Claude-8245b7a72393fec67fa946b26a825bfbd3f947b3.msix",
       "install_script_ref": "31a0b698",
       "uninstall_script_ref": "03f72055",
-      "sha256": "1005f8846fb167c345671bac4be402a168f9122156c4831daca8b71014d2f357",
+      "sha256": "33de95a44e5e9e1fa8c9ba1eefe576fa88887d8fa4e865574e044194e2a8e2b6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0",
+      "version": "151.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0.1') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0/mac/en-US/Firefox%20151.0.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.1/mac/en-US/Firefox%20151.0.1.dmg",
       "install_script_ref": "f659d0e6",
       "uninstall_script_ref": "e8f976a6",
-      "sha256": "5a56ebd8f0f8cec94a86e04c6793e1d1502b40206f5d4c86fff5b7a270e84f6b",
+      "sha256": "6e3714ef92305e1164fcb7188e47cc1f076f7836c631a428470b154a188fb3e9",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox/windows.json
+++ b/ee/maintained-apps/outputs/firefox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0",
+      "version": "151.0.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '151.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '151.0.1') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0/win64/en-US/Firefox%20Setup%20151.0.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.1/win64/en-US/Firefox%20Setup%20151.0.1.exe",
       "install_script_ref": "80fb9175",
       "uninstall_script_ref": "8b5e20e4",
-      "sha256": "358381238a840831da8a6cda16721692df91a74bc44847ff0285da12de788a8d",
+      "sha256": "1275fd22df71bab098c19671d6c5037c424a1594359a721be20a642c827f6e71",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/github-desktop/windows.json
+++ b/ee/maintained-apps/outputs/github-desktop/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.8",
+      "version": "3.5.9",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.' AND version_compare(version, '3.5.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.' AND version_compare(version, '3.5.9') < 0);"
       },
-      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.8-b1d863ab/GitHubDesktopSetup-x64.msi",
+      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.9-370cc108/GitHubDesktopSetup-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "f0fcaa82",
-      "sha256": "90fc7236f06e1888c378acd9b92fb411732508632306627aedc59559d5255027",
+      "sha256": "b3d10ef725512fbc03a2e153001ade85034607e9f9a181e2cd0027cc01ab8480",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/github/darwin.json
+++ b/ee/maintained-apps/outputs/github/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.8",
+      "version": "3.5.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.5.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.5.9') < 0);"
       },
-      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.8-b1d863ab/GitHubDesktop-arm64.zip",
+      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.9-370cc108/GitHubDesktop-arm64.zip",
       "install_script_ref": "98ab6ed8",
       "uninstall_script_ref": "ab6a6ca8",
-      "sha256": "7b1278f06231ea4a429da5055ccef44347b4c06f6b5bde35d97bba898911fbda",
+      "sha256": "0dc488a3039f7602ac7df93f16986f1dcbfcea38a135686e79df3533346e598a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.255.4",
+      "version": "7.255.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.255.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.255.6') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.4/Granola-7.255.4-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.6/Granola-7.255.6-mac-universal.dmg",
       "install_script_ref": "08986ac7",
       "uninstall_script_ref": "67249f33",
-      "sha256": "0ae929fc2201ca9fcc92057c2a93bdbd8b990fa5d0dc90f899ca2ca4caad02d5",
+      "sha256": "4b83958195692e068378b1962d5c0ccd707650567acda4926d5b92d3283cb83e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.220.0",
+      "version": "7.255.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.220.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.255.6') < 0);"
       },
-      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.220.0-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.6/Granola-7.255.6-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "9d2c2e59379be7dc1351965b9e33a24adba4b0dbf46146bdafb0e2edc76f5a8a",
+      "sha256": "d5d47b969639bba37af72b9d826dc6f65fa4084945d8eb568f3e88abed56a698",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.348.4",
+      "version": "0.349.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.348.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.349.0') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.348.4-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.349.0-arm64.dmg",
       "install_script_ref": "3b74ae49",
       "uninstall_script_ref": "8f032bbc",
-      "sha256": "8370273e552345ca1855c99ec94f92ad54b0dcb8b5d09d5025fa041c644daec0",
+      "sha256": "039f1aec076189f23acf58ad6638107fe001182502bfdbf59327cec024db4d35",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/twingate/windows.json
+++ b/ee/maintained-apps/outputs/twingate/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "20.26.120.9484",
+      "version": "20.26.140.168",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.120.9484') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.140.168') < 0);"
       },
-      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.120.9484/TwingateWindowsInstaller.msi",
+      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.140.168/TwingateWindowsInstaller.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "72d99820",
-      "sha256": "910be7968824db00f772a433ec6b4f56d839e840127cbd6a2b191917b3f343e5",
+      "sha256": "a823aab7137f1889343ed1dfe2fe958cc993151fde8bd3862bc8f8eaf6b16aad",
       "default_categories": [
         "Productivity"
       ],


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata for multiple applications: 1Password (8.12.21), Claude, Firefox (151.0.1), GitHub Desktop (3.5.9), Granola (7.255.6), Loom (0.349.0), and Twingate (20.26.140.168). Updated corresponding installer URLs and checksums to reflect new releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->