### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/1password/darwin.json
+++ b/ee/maintained-apps/outputs/1password/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "8.12.21",
+      "version": "8.12.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.21') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.12') < 0);"
       },
       "installer_url": "https://downloads.1password.com/mac/1Password.pkg",
       "install_script_ref": "ef2a17ff",

--- a/ee/maintained-apps/outputs/1password/darwin.json
+++ b/ee/maintained-apps/outputs/1password/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "8.12.12",
+      "version": "8.12.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.21') < 0);"
       },
       "installer_url": "https://downloads.1password.com/mac/1Password.pkg",
       "install_script_ref": "ef2a17ff",

--- a/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.001.21529",
+      "version": "26.001.21563",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND version_compare(version, '26.001.21529') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND version_compare(version, '26.001.21563') < 0);"
       },
-      "installer_url": "https://ardownload3.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2600121529/AcroRdrDCx642600121529_MUI.exe",
+      "installer_url": "https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2600121563/AcroRdrDCx642600121563_MUI.exe",
       "install_script_ref": "7dc0b065",
       "uninstall_script_ref": "3bb10c80",
-      "sha256": "5b830c22c81899c8af581af2f6dc041ff28dd64dd897fa5fab1d9c012cead3ef",
+      "sha256": "b6688fca29dac5b7c7a2b9d540d481eba573781dba6da2a6cfdddb4f02dcaf91",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.147.1",
+      "version": "1.148.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.147.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.148.0') < 0);"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.147.1-81091.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.148.0-81146.zip",
       "install_script_ref": "bb0dd542",
       "uninstall_script_ref": "d70061d5",
-      "sha256": "56751c26ab40ea203194e5c2d709207e4fdfec7a829d0ab1781de076e72f92e1",
+      "sha256": "c54b5ade71b6b7f0ddbddd4e0e54795b1f90bc4f77dda2db96f6aa7b6378f119",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8089.1",
+      "version": "1.8555.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.8089.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.8555.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.8089.1/Claude-b98a06c70e376344e3b6938d6980242e8cc20547.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.8555.0/Claude-8245b7a72393fec67fa946b26a825bfbd3f947b3.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "e555285c",
-      "sha256": "228d2afe22f4d5978398c64650bb88b63768f4d1bc0ed9658c674553dce1afd5",
+      "sha256": "3841b6e5c04f36a029d88c080b1e7f3c972fa60c890dd2f31323dd74503076d7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0",
+      "version": "151.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0.1') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0/mac/en-US/Firefox%20151.0.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.1/mac/en-US/Firefox%20151.0.1.dmg",
       "install_script_ref": "f659d0e6",
       "uninstall_script_ref": "e8f976a6",
-      "sha256": "5a56ebd8f0f8cec94a86e04c6793e1d1502b40206f5d4c86fff5b7a270e84f6b",
+      "sha256": "6e3714ef92305e1164fcb7188e47cc1f076f7836c631a428470b154a188fb3e9",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox/windows.json
+++ b/ee/maintained-apps/outputs/firefox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0",
+      "version": "151.0.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '151.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '151.0.1') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0/win64/en-US/Firefox%20Setup%20151.0.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.1/win64/en-US/Firefox%20Setup%20151.0.1.exe",
       "install_script_ref": "80fb9175",
       "uninstall_script_ref": "8b5e20e4",
-      "sha256": "358381238a840831da8a6cda16721692df91a74bc44847ff0285da12de788a8d",
+      "sha256": "1275fd22df71bab098c19671d6c5037c424a1594359a721be20a642c827f6e71",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/github-desktop/windows.json
+++ b/ee/maintained-apps/outputs/github-desktop/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.8",
+      "version": "3.5.9",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.' AND version_compare(version, '3.5.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.' AND version_compare(version, '3.5.9') < 0);"
       },
-      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.8-b1d863ab/GitHubDesktopSetup-x64.msi",
+      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.9-370cc108/GitHubDesktopSetup-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "f0fcaa82",
-      "sha256": "90fc7236f06e1888c378acd9b92fb411732508632306627aedc59559d5255027",
+      "sha256": "b3d10ef725512fbc03a2e153001ade85034607e9f9a181e2cd0027cc01ab8480",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/github/darwin.json
+++ b/ee/maintained-apps/outputs/github/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.8",
+      "version": "3.5.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.5.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.5.9') < 0);"
       },
-      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.8-b1d863ab/GitHubDesktop-arm64.zip",
+      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.9-370cc108/GitHubDesktop-arm64.zip",
       "install_script_ref": "98ab6ed8",
       "uninstall_script_ref": "ab6a6ca8",
-      "sha256": "7b1278f06231ea4a429da5055ccef44347b4c06f6b5bde35d97bba898911fbda",
+      "sha256": "0dc488a3039f7602ac7df93f16986f1dcbfcea38a135686e79df3533346e598a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.255.4",
+      "version": "7.255.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.255.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.255.6') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.4/Granola-7.255.4-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.6/Granola-7.255.6-mac-universal.dmg",
       "install_script_ref": "08986ac7",
       "uninstall_script_ref": "67249f33",
-      "sha256": "0ae929fc2201ca9fcc92057c2a93bdbd8b990fa5d0dc90f899ca2ca4caad02d5",
+      "sha256": "4b83958195692e068378b1962d5c0ccd707650567acda4926d5b92d3283cb83e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.220.0",
+      "version": "7.255.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.220.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.255.6') < 0);"
       },
-      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.220.0-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.6/Granola-7.255.6-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "9d2c2e59379be7dc1351965b9e33a24adba4b0dbf46146bdafb0e2edc76f5a8a",
+      "sha256": "d5d47b969639bba37af72b9d826dc6f65fa4084945d8eb568f3e88abed56a698",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.348.4",
+      "version": "0.349.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.348.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.349.0') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.348.4-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.349.0-arm64.dmg",
       "install_script_ref": "3b74ae49",
       "uninstall_script_ref": "8f032bbc",
-      "sha256": "8370273e552345ca1855c99ec94f92ad54b0dcb8b5d09d5025fa041c644daec0",
+      "sha256": "039f1aec076189f23acf58ad6638107fe001182502bfdbf59327cec024db4d35",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "148.0.3967.70",
+      "version": "148.0.3967.83",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '148.0.3967.70') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '148.0.3967.83') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/5678e805-962c-4a19-a14c-85a9417ce604/MicrosoftEdge-148.0.3967.70.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/cbe3f056-80b0-4d3c-aa6c-d308911e50c2/MicrosoftEdge-148.0.3967.83.dmg",
       "install_script_ref": "caf6f785",
       "uninstall_script_ref": "81159c4c",
-      "sha256": "41694e7dacbb1d653b67a9fb9eb712a804bbfb3a5ccc2068f35bcd585fc091b2",
+      "sha256": "d11600fb6a355677ddaef27c6d0c5826674ab886ff226736b9456b484189754b",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/omnigraffle/darwin.json
+++ b/ee/maintained-apps/outputs/omnigraffle/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.25.2",
+      "version": "7.25.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.omnigroup.OmniGraffle7';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.omnigroup.OmniGraffle7' AND version_compare(bundle_short_version, '7.25.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.omnigroup.OmniGraffle7' AND version_compare(bundle_short_version, '7.25.3') < 0);"
       },
-      "installer_url": "https://downloads.omnigroup.com/software/macOS/12/OmniGraffle-7.25.2.dmg",
+      "installer_url": "https://downloads.omnigroup.com/software/macOS/12/OmniGraffle-7.25.3.dmg",
       "install_script_ref": "d2d63787",
       "uninstall_script_ref": "81081b86",
-      "sha256": "9dc0895b1c3b7abf51c25c2ac8ad1aff0ab8c8a036d979ad23d9b8a21a97eb97",
+      "sha256": "97c9b8a264ec380a4955c1c8a3cf583010003881dd1b0cf46f712d73ef33480b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/podman-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/podman-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.27.1",
+      "version": "1.27.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop' AND version_compare(bundle_short_version, '1.27.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop' AND version_compare(bundle_short_version, '1.27.2') < 0);"
       },
-      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.27.1/podman-desktop-1.27.1-arm64.dmg",
+      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.27.2/podman-desktop-1.27.2-arm64.dmg",
       "install_script_ref": "203496d5",
       "uninstall_script_ref": "f9369f45",
-      "sha256": "07a5b26c5d8bd93f76d853e6ded976ec759c0281141cab1898ed2f5948eb4213",
+      "sha256": "bbacf1a268c8f7ac8a67c6e24ea500c96dfb0e2b825ae2a187a60434a37cb045",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/twingate/windows.json
+++ b/ee/maintained-apps/outputs/twingate/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "20.26.120.9484",
+      "version": "20.26.140.168",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.120.9484') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.140.168') < 0);"
       },
-      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.120.9484/TwingateWindowsInstaller.msi",
+      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.140.168/TwingateWindowsInstaller.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "72d99820",
-      "sha256": "910be7968824db00f772a433ec6b4f56d839e840127cbd6a2b191917b3f343e5",
+      "sha256": "a823aab7137f1889343ed1dfe2fe958cc993151fde8bd3862bc8f8eaf6b16aad",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.05.18.05.32.02",
+      "version": "0.2026.05.20.09.21.02",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.05.18.05.32.02') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.05.20.09.21.02') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.05.18.05.32.stable_02/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.05.20.09.21.stable_02/Warp.dmg",
       "install_script_ref": "4b1c0c37",
       "uninstall_script_ref": "bd923c6f",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.20.20",
+      "version": "26.20.23",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.20.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.20.23') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "a776e715",

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.3.5",
+      "version": "1.3.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.3.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.3.6') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.3.5/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.3.6/Zed-aarch64.dmg",
       "install_script_ref": "7a64bca0",
       "uninstall_script_ref": "315158ff",
-      "sha256": "79789809a98327b23d40600be258745d3dbfc66680b4c7ae7fe5c948b733185b",
+      "sha256": "5cdfa2857ad24147ca92714e7197b4b3f0f5090fc93993419c2e0f4f651ee4de",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata for 13 macOS applications: 1Password, Arc, Claude, Firefox, GitHub Desktop, Granola, Loom, Microsoft Edge, OmniGraffle, Podman Desktop, Warp, WhatsApp, and Zed
  * Updated version metadata for 5 Windows applications: Adobe Acrobat Reader, Firefox, GitHub Desktop, Granola, and Twingate

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->