### PR TITLE
Fix: My Device page not showing correct light/dark mode logo

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -196,6 +196,8 @@ func (svc *Service) GetFleetDesktopSummary(ctx context.Context) (fleet.DesktopSu
 	sum.Config.OrgInfo.OrgName = appCfg.OrgInfo.OrgName
 	sum.Config.OrgInfo.OrgLogoURL = appCfg.OrgInfo.OrgLogoURL
 	sum.Config.OrgInfo.OrgLogoURLLightBackground = appCfg.OrgInfo.OrgLogoURLLightBackground
+	sum.Config.OrgInfo.OrgLogoURLDarkMode = appCfg.OrgInfo.OrgLogoURLDarkMode
+	sum.Config.OrgInfo.OrgLogoURLLightMode = appCfg.OrgInfo.OrgLogoURLLightMode
 	sum.Config.OrgInfo.ContactURL = appCfg.OrgInfo.ContactURL
 
 	// mdm information

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -238,8 +238,12 @@ export interface IHostResponse {
 export interface IDUPDetails {
   host: IHostDevice;
   license: ILicense;
+  /** @deprecated use `org_logo_url_dark_mode` */
   org_logo_url: string;
+  /** @deprecated use `org_logo_url_light_mode` */
   org_logo_url_light_background: string;
+  org_logo_url_dark_mode?: string;
+  org_logo_url_light_mode?: string;
   org_contact_url: string;
   disk_encryption_enabled?: boolean;
   platform?: HostPlatform;

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -178,6 +178,17 @@ const DeviceUserPage = ({
   const [refetchStartTime, setRefetchStartTime] = useState<number | null>(null);
   const [showRefetchSpinner, setShowRefetchSpinner] = useState(false);
 
+  const [darkMode, setDarkMode] = useState(() => isDarkMode());
+
+  useEffect(() => {
+    const onThemeChange = (e: Event) => {
+      setDarkMode((e as CustomEvent).detail.dark);
+    };
+    window.addEventListener("fleet-theme-change", onThemeChange);
+    return () =>
+      window.removeEventListener("fleet-theme-change", onThemeChange);
+  }, []);
+
   const { data: deviceMacAdminsData } = useQuery(
     ["macadmins", deviceAuthToken],
     () => deviceUserAPI.loadHostDetailsExtension(deviceAuthToken, "macadmins"),
@@ -356,7 +367,7 @@ const DeviceUserPage = ({
   } = dupDetails || {};
   const darkLogoURL = orgLogoUrlDarkMode || orgLogoUrl;
   const lightLogoURL = orgLogoUrlLightMode || orgLogoUrlLightBackground;
-  const orgLogoURL = isDarkMode() ? darkLogoURL : lightLogoURL;
+  const orgLogoURL = darkMode ? darkLogoURL : lightLogoURL;
   const isPremiumTier = license?.tier === "premium";
   const isAppleHost = isAppleDevice(host?.platform);
   const isIOSIPadOS = host?.platform === "ios" || host?.platform === "ipados";

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -45,6 +45,7 @@ import FlashMessage from "components/FlashMessage";
 import CustomLink from "components/CustomLink";
 
 import { normalizeEmptyValues } from "utilities/helpers";
+import { isDarkMode } from "utilities/theme";
 import PATHS from "router/paths";
 import {
   DEFAULT_USE_QUERY_OPTIONS,
@@ -345,11 +346,17 @@ const DeviceUserPage = ({
   const {
     host,
     license,
-    org_logo_url_light_background: orgLogoURL = "",
+    org_logo_url: orgLogoUrl = "",
+    org_logo_url_light_background: orgLogoUrlLightBackground = "",
+    org_logo_url_dark_mode: orgLogoUrlDarkMode = "",
+    org_logo_url_light_mode: orgLogoUrlLightMode = "",
     org_contact_url: orgContactURL = "",
     global_config: globalConfig = null as IDeviceGlobalConfig | null,
     self_service: hasSelfService = false,
   } = dupDetails || {};
+  const darkLogoURL = orgLogoUrlDarkMode || orgLogoUrl;
+  const lightLogoURL = orgLogoUrlLightMode || orgLogoUrlLightBackground;
+  const orgLogoURL = isDarkMode() ? darkLogoURL : lightLogoURL;
   const isPremiumTier = license?.tier === "premium";
   const isAppleHost = isAppleDevice(host?.platform);
   const isIOSIPadOS = host?.platform === "ios" || host?.platform === "ipados";

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -24,6 +24,8 @@ export const defaultDeviceHandler = http.get(baseUrl("/device/:token"), () => {
     license: createMockLicense(),
     org_logo_url: "",
     org_logo_url_light_background: "",
+    org_logo_url_dark_mode: "",
+    org_logo_url_light_mode: "",
     global_config: {
       mdm: { enabled_and_configured: false },
     },
@@ -38,6 +40,8 @@ export const customDeviceHandler = (overrides?: Partial<IDUPDetails>) =>
         license: createMockLicense(),
         org_logo_url: "",
         org_logo_url_light_background: "",
+        org_logo_url_dark_mode: "",
+        org_logo_url_light_mode: "",
         global_config: {
           mdm: { enabled_and_configured: false },
         },

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -18,38 +18,36 @@ import {
 } from "services/entities/device_user";
 import { IGetHostCertificatesResponse } from "services/entities/hosts";
 
-export const defaultDeviceHandler = http.get(baseUrl("/device/:token"), () => {
-  return HttpResponse.json({
-    host: createMockHost(),
-    license: createMockLicense(),
-    org_logo_url: "",
-    org_logo_url_light_background: "",
-    org_logo_url_dark_mode: "",
-    org_logo_url_light_mode: "",
-    global_config: {
-      mdm: { enabled_and_configured: false },
+const createDefaultDeviceResponse = (): IDUPDetails => ({
+  host: { ...createMockHost(), dep_assigned_to_fleet: false },
+  license: createMockLicense(),
+  org_logo_url: "",
+  org_logo_url_light_background: "",
+  org_logo_url_dark_mode: "",
+  org_logo_url_light_mode: "",
+  org_contact_url: "",
+  self_service: false,
+  global_config: {
+    mdm: {
+      enabled_and_configured: false,
+      require_all_software_macos: false,
     },
-  });
+    features: {
+      enable_software_inventory: false,
+      enable_conditional_access: false,
+      enable_conditional_access_bypass: false,
+    },
+  },
 });
 
+export const defaultDeviceHandler = http.get(baseUrl("/device/:token"), () =>
+  HttpResponse.json(createDefaultDeviceResponse())
+);
+
 export const customDeviceHandler = (overrides?: Partial<IDUPDetails>) =>
-  http.get(baseUrl("/device/:token"), () => {
-    const response = Object.assign(
-      {
-        host: createMockHost(),
-        license: createMockLicense(),
-        org_logo_url: "",
-        org_logo_url_light_background: "",
-        org_logo_url_dark_mode: "",
-        org_logo_url_light_mode: "",
-        global_config: {
-          mdm: { enabled_and_configured: false },
-        },
-      },
-      overrides
-    );
-    return HttpResponse.json(response);
-  });
+  http.get(baseUrl("/device/:token"), () =>
+    HttpResponse.json({ ...createDefaultDeviceResponse(), ...overrides })
+  );
 
 export const defaultMacAdminsHandler = http.get(
   baseUrl("/device/:token/macadmins"),

--- a/orbit/pkg/useraction/mdm_migration_darwin.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin.go
@@ -271,11 +271,17 @@ func isDarkMode() bool {
 }
 
 func (m *swiftDialogMDMMigrator) render(message string, flags ...string) (chan swiftDialogExitCode, chan error) {
-	icon := m.props.OrgInfo.OrgLogoURL
-
-	// If the user is using light mode we will set the icon to use the light background logo
-	if !isDarkMode() {
-		icon = m.props.OrgInfo.OrgLogoURLLightBackground
+	var icon string
+	if isDarkMode() {
+		icon = m.props.OrgInfo.OrgLogoURLDarkMode
+		if icon == "" {
+			icon = m.props.OrgInfo.OrgLogoURL
+		}
+	} else {
+		icon = m.props.OrgInfo.OrgLogoURLLightMode
+		if icon == "" {
+			icon = m.props.OrgInfo.OrgLogoURLLightBackground
+		}
 	}
 
 	// If the user has not set an org logo url, we will use the default fleet logo.

--- a/server/fleet/device.go
+++ b/server/fleet/device.go
@@ -38,9 +38,13 @@ type DesktopMDMConfig struct {
 // DesktopMDMConfig is a subset of fleet.OrgInfo with configuration that's relevant
 // to Fleet Desktop to operate.
 type DesktopOrgInfo struct {
-	OrgName                   string `json:"org_name"`
-	OrgLogoURL                string `json:"org_logo_url"`
+	OrgName string `json:"org_name"`
+	// Deprecated: use OrgLogoURLDarkMode.
+	OrgLogoURL string `json:"org_logo_url"`
+	// Deprecated: use OrgLogoURLLightMode.
 	OrgLogoURLLightBackground string `json:"org_logo_url_light_background"`
+	OrgLogoURLDarkMode        string `json:"org_logo_url_dark_mode"`
+	OrgLogoURLLightMode       string `json:"org_logo_url_light_mode"`
 	ContactURL                string `json:"contact_url"`
 }
 

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -108,14 +108,18 @@ func (r *getDeviceHostRequest) deviceAuthToken() string {
 }
 
 type getDeviceHostResponse struct {
-	Host                      *fleet.HostDetailResponse `json:"host"`
-	SelfService               bool                      `json:"self_service"`
-	OrgLogoURL                string                    `json:"org_logo_url"`
-	OrgLogoURLLightBackground string                    `json:"org_logo_url_light_background"`
-	OrgContactURL             string                    `json:"org_contact_url"`
-	Err                       error                     `json:"error,omitempty"`
-	License                   fleet.LicenseInfo         `json:"license"`
-	GlobalConfig              fleet.DeviceGlobalConfig  `json:"global_config"`
+	Host *fleet.HostDetailResponse `json:"host"`
+	// Deprecated: use OrgLogoURLDarkMode.
+	OrgLogoURL string `json:"org_logo_url"`
+	// Deprecated: use OrgLogoURLLightMode.
+	OrgLogoURLLightBackground string                   `json:"org_logo_url_light_background"`
+	OrgLogoURLDarkMode        string                   `json:"org_logo_url_dark_mode"`
+	OrgLogoURLLightMode       string                   `json:"org_logo_url_light_mode"`
+	SelfService               bool                     `json:"self_service"`
+	OrgContactURL             string                   `json:"org_contact_url"`
+	Err                       error                    `json:"error,omitempty"`
+	License                   fleet.LicenseInfo        `json:"license"`
+	GlobalConfig              fleet.DeviceGlobalConfig `json:"global_config"`
 }
 
 func (r getDeviceHostResponse) Error() error { return r.Err }
@@ -237,6 +241,8 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 		Host:                      resp,
 		OrgLogoURL:                ac.OrgInfo.OrgLogoURL,
 		OrgLogoURLLightBackground: ac.OrgInfo.OrgLogoURLLightBackground,
+		OrgLogoURLDarkMode:        ac.OrgInfo.OrgLogoURLDarkMode,
+		OrgLogoURLLightMode:       ac.OrgInfo.OrgLogoURLLightMode,
 		OrgContactURL:             ac.OrgInfo.ContactURL,
 		License:                   *license,
 		GlobalConfig:              deviceGlobalConfig,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46034

## Testing

- [x] QA'd all new/changed functionality manually

### Before

My Device page was showing the light mode logo even when in dark mode.

<img width="1412" height="756" alt="Screenshot 2026-05-22 at 11 51 57 AM" src="https://github.com/user-attachments/assets/9f098d96-b9d1-4618-b6f4-e7ee49629506" />

<img width="1340" height="708" alt="Screenshot 2026-05-22 at 11 35 59 AM" src="https://github.com/user-attachments/assets/dfff3a53-e08b-4b7a-a3fc-97f33e0d691d" />

### After

My Device page correctly shows the logo for both modes

Light:
<img width="1434" height="725" alt="Screenshot 2026-05-22 at 11 48 51 AM" src="https://github.com/user-attachments/assets/4d5913c5-5264-40ac-bbdf-21c271637898" />
<img width="1337" height="451" alt="Screenshot 2026-05-22 at 11 48 55 AM" src="https://github.com/user-attachments/assets/1cd6193e-b910-46ea-8f89-0cd88ad07382" />

Dark (Fleet's default logo):
<img width="1127" height="644" alt="Screenshot 2026-05-22 at 11 48 08 AM" src="https://github.com/user-attachments/assets/a55a0026-f301-4281-8419-83cc9a707bb7" />
<img width="1357" height="528" alt="Screenshot 2026-05-22 at 11 48 15 AM" src="https://github.com/user-attachments/assets/471a604a-9524-4d5a-8af4-cfe09d2430fc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization logos now adapt to dark or light mode, showing the appropriate themed variant across the app.
* **Bug Fixes / Improvements**
  * Device and host pages now pick the correct logo variant with sensible fallbacks so logos display consistently when theme-specific images are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->