### PR TITLE
Fix Trivy SARIF upload attributing RC findings to main

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -150,3 +150,5 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
           category: trivy-${{ matrix.branch }}
+          ref: refs/heads/${{ matrix.branch }}
+          checkout_path: ${{ github.workspace }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -104,6 +104,10 @@ jobs:
         with:
           ref: ${{ matrix.branch || github.ref }}
 
+      - name: Capture checked-out commit SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{env.AWS_IAM_ROLE}}
@@ -151,4 +155,5 @@ jobs:
           sarif_file: "trivy-results.sarif"
           category: trivy-${{ matrix.branch }}
           ref: refs/heads/${{ matrix.branch }}
+          sha: ${{ steps.sha.outputs.sha }}
           checkout_path: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

The Trivy scan workflow runs a matrix of branches (main + active RC branches). The `upload-sarif` step doesn't set an explicit `ref`, so it defaults to `github.ref`. For `workflow_dispatch` and `schedule` events, `github.ref` is `refs/heads/main` regardless of which branch the matrix job checked out. This causes RC branch vulnerabilities to appear as main branch alerts in the Security tab, and those alerts can't be closed by fixing main alone.

Adds explicit `ref` and `checkout_path` parameters to `upload-sarif` so each matrix branch's findings are scoped to that branch only.

## Test plan

- [ ] Trigger the Trivy workflow manually after merge
- [ ] Verify RC branch alerts no longer appear under the main branch filter at /security/code-scanning?query=branch:main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to capture the checked-out commit SHA and include branch/ref and workspace info when uploading security scan results, improving traceability of scans and scan-to-commit mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->