### PR TITLE
Update LibreOffice token and mac version to 25.8.7

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/libreoffice.json
+++ b/ee/maintained-apps/inputs/homebrew/libreoffice.json
@@ -1,7 +1,7 @@
 {
   "name": "LibreOffice",
   "unique_identifier": "org.libreoffice.script",
-  "token": "libreoffice",
+  "token": "libreoffice-still",
   "installer_format": "dmg",
   "slug": "libreoffice/darwin",
   "default_categories": ["Productivity"]

--- a/ee/maintained-apps/outputs/libreoffice/darwin.json
+++ b/ee/maintained-apps/outputs/libreoffice/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.2.3",
+      "version": "25.8.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.libreoffice.script';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.libreoffice.script' AND version_compare(bundle_short_version, '26.2.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.libreoffice.script' AND version_compare(bundle_short_version, '25.8.7') < 0);"
       },
-      "installer_url": "https://download.documentfoundation.org/libreoffice/stable/26.2.3/mac/aarch64/LibreOffice_26.2.3_MacOS_aarch64.dmg",
+      "installer_url": "https://download.documentfoundation.org/libreoffice/stable/25.8.7/mac/aarch64/LibreOffice_25.8.7_MacOS_aarch64.dmg",
       "install_script_ref": "4ee74664",
       "uninstall_script_ref": "bc0ac5ef",
-      "sha256": "8ea6bdf67dbffc9c47104f73a3c98ed145ff26c00dde44c43633f5b3d741479f",
+      "sha256": "e7556aa61e282f89578ebaf35afdb09c94dcf9d6ee7c137004377bee81a6e900",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Switch the Homebrew input token from "libreoffice" to "libreoffice-still" and update the darwin output to version 25.8.7. Adjust the existence/patch queries, installer URL, and SHA256 to match 25.8.7; install/uninstall script refs and categories remain unchanged.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #https://github.com/fleetdm/fleet/issues/45781


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Homebrew LibreOffice package configuration
  * Pinned LibreOffice macOS version to 25.8.7 with updated installer verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->