### PR TITLE
Fixed the "host is offline" banner on the My device page incorrectly appearing

### DIFF
--- a/changes/45091-suppress-offline-banner-recent-enrollment
+++ b/changes/45091-suppress-offline-banner-recent-enrollment
@@ -1,0 +1,1 @@
+* Fixed the "host is offline" banner on the My device page incorrectly appearing during the first few minutes after an enrollment.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -301,10 +301,11 @@ const DeviceUserPage = ({
             const isIOSOrIPadOS =
               responseHost.platform === "ios" ||
               responseHost.platform === "ipados";
-            const skipOfflineBanner =
+            if (
+              responseHost.status === "online" ||
               isIOSOrIPadOS ||
-              isRecentlyEnrolled(responseHost.last_enrolled_at);
-            if (responseHost.status === "online" || skipOfflineBanner) {
+              isRecentlyEnrolled(responseHost.last_enrolled_at)
+            ) {
               setRefetchStartTime(Date.now());
               setTimeout(() => {
                 refetchDupDetails();
@@ -323,10 +324,11 @@ const DeviceUserPage = ({
               const isIOSOrIPadOS =
                 responseHost.platform === "ios" ||
                 responseHost.platform === "ipados";
-              const skipOfflineBanner =
+              if (
+                responseHost.status === "online" ||
                 isIOSOrIPadOS ||
-                isRecentlyEnrolled(responseHost.last_enrolled_at);
-              if (responseHost.status === "online" || skipOfflineBanner) {
+                isRecentlyEnrolled(responseHost.last_enrolled_at)
+              ) {
                 setTimeout(() => {
                   refetchDupDetails();
                   refetchExtensions();

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -67,6 +67,7 @@ import {
   isSoftwareScriptSetup,
   isIPhone,
   isIPad,
+  isRecentlyEnrolled,
 } from "./helpers";
 
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
@@ -295,10 +296,15 @@ const DeviceUserPage = ({
           if (!refetchStartTime) {
             // Here and below: iOS/iPadOS refetches use MDM commands which can be slower/less predictable
             // than osquery. Don't show an error, just reset and let the user try again.
+            // Recently enrolled hosts are also exempted: orbit endpoints don't update host_seen_times,
+            // so a fresh host can read as offline until its first osquery distributed-read.
             const isIOSOrIPadOS =
               responseHost.platform === "ios" ||
               responseHost.platform === "ipados";
-            if (responseHost.status === "online" || isIOSOrIPadOS) {
+            const skipOfflineBanner =
+              isIOSOrIPadOS ||
+              isRecentlyEnrolled(responseHost.last_enrolled_at);
+            if (responseHost.status === "online" || skipOfflineBanner) {
               setRefetchStartTime(Date.now());
               setTimeout(() => {
                 refetchDupDetails();
@@ -317,7 +323,10 @@ const DeviceUserPage = ({
               const isIOSOrIPadOS =
                 responseHost.platform === "ios" ||
                 responseHost.platform === "ipados";
-              if (responseHost.status === "online" || isIOSOrIPadOS) {
+              const skipOfflineBanner =
+                isIOSOrIPadOS ||
+                isRecentlyEnrolled(responseHost.last_enrolled_at);
+              if (responseHost.status === "online" || skipOfflineBanner) {
                 setTimeout(() => {
                   refetchDupDetails();
                   refetchExtensions();

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -58,7 +58,10 @@ export const isRecentlyEnrolled = (
   if (!lastEnrolledAt) return false;
   const enrolledAt = new Date(lastEnrolledAt).getTime();
   if (isNaN(enrolledAt)) return false;
-  return Date.now() - enrolledAt < RECENTLY_ENROLLED_THRESHOLD_MS;
+  // Require a non-negative delta so a future timestamp (e.g. from client/server clock skew) is not
+  // treated as "recent" and does not hide a real offline state indefinitely.
+  const delta = Date.now() - enrolledAt;
+  return delta >= 0 && delta < RECENTLY_ENROLLED_THRESHOLD_MS;
 };
 
 // Same solution as defined in /templates/enroll-ota.html (https://github.com/fleetdm/fleet/pull/26592)

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -47,6 +47,20 @@ export const isSoftwareScriptSetup = (s: ISetupStep) => {
   return s.source === "sh_packages" || s.source === "ps1_packages";
 };
 
+// Hosts after enrollment during which we suppress the "host is offline" banner.
+// Orbit endpoints do not update host_seen_times, so a freshly enrolled host can appear offline
+// until its first osquery distributed-read check-in (typically within 5-10 minutes).
+const RECENTLY_ENROLLED_THRESHOLD_MS = 10 * 60 * 1000;
+
+export const isRecentlyEnrolled = (
+  lastEnrolledAt: string | undefined
+): boolean => {
+  if (!lastEnrolledAt) return false;
+  const enrolledAt = new Date(lastEnrolledAt).getTime();
+  if (isNaN(enrolledAt)) return false;
+  return Date.now() - enrolledAt < RECENTLY_ENROLLED_THRESHOLD_MS;
+};
+
 // Same solution as defined in /templates/enroll-ota.html (https://github.com/fleetdm/fleet/pull/26592)
 export const isIPhone = (navigator: Navigator) =>
   /iPhone/i.test(navigator.userAgent);


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45091 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the "host is offline" banner briefly appeared on the My device page for newly enrolled devices. Recently enrolled hosts no longer show the offline banner during the first few minutes after enrollment, preventing confusing error flashes and improving device status accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46091?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->