### PR TITLE
Update enable-scripts-macos.sh to conditionally set ORBIT_ENABLE_SCRIPTS variable

### DIFF
--- a/assets/scripts/enable-scripts-macos.sh
+++ b/assets/scripts/enable-scripts-macos.sh
@@ -7,7 +7,7 @@ if [ "$EUID" -ne 0 ]; then
 fi
 # Check if variable currently exists
 /usr/libexec/PlistBuddy -c "Print EnvironmentVariables:ORBIT_ENABLE_SCRIPTS" "/Library/LaunchDaemons/com.fleetdm.orbit.plist" 2>/dev/null
-# Set or add plist environment variable to enable scrippts in Orbit
+# Set or add plist environment variable to enable scripts in Orbit
 if [ $? -eq 0 ]; then
   /usr/libexec/PlistBuddy -c "set EnvironmentVariables:ORBIT_ENABLE_SCRIPTS true" "/Library/LaunchDaemons/com.fleetdm.orbit.plist"
 else

--- a/assets/scripts/enable-scripts-macos.sh
+++ b/assets/scripts/enable-scripts-macos.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 # Please don't delete. This script is used in the guide here: https://fleetdm.com/guides/scripts
-
+plist_path="/Library/LaunchDaemons/com.fleetdm.orbit.plist"
 if [ "$EUID" -ne 0 ]; then
   echo "This script requires administrator privileges. Please run with sudo."
   exit 1
 fi
-# Enable scrippts in Orbit environment variables (plist)
-/usr/libexec/PlistBuddy -c "set EnvironmentVariables:ORBIT_ENABLE_SCRIPTS true" "/Library/LaunchDaemons/com.fleetdm.orbit.plist"
+# Check if variable currently exists
+/usr/libexec/PlistBuddy -c "Print EnvironmentVariables:ORBIT_ENABLE_SCRIPTS" "/Library/LaunchDaemons/com.fleetdm.orbit.plist" 2>/dev/null
+# Set or add plist environment variable to enable scrippts in Orbit
+if [ $? -eq 0 ]; then
+  /usr/libexec/PlistBuddy -c "set EnvironmentVariables:ORBIT_ENABLE_SCRIPTS true" "/Library/LaunchDaemons/com.fleetdm.orbit.plist"
+else
+  /usr/libexec/PlistBuddy -c "add EnvironmentVariables:ORBIT_ENABLE_SCRIPTS string true" "/Library/LaunchDaemons/com.fleetdm.orbit.plist"
+fi
 # Stop Orbit, wait for stop to complete, and then restart.
 launchctl bootout system/com.fleetdm.orbit
 while pgrep orbit > /dev/null; do sleep 1 ; done


### PR DESCRIPTION
Check if the `ORBIT_ENABLE_SCRIPTS` plist variable exists and set or add it accordingly in the plist.

Prior to this change, if the variable was not already present on the host, the script would fail to set the variable.

This change also sets the `plist_path` variable, which was missing in the original script.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS setup script to more reliably configure the launchd environment variable: it now detects whether the variable exists before updating or adding it, handles errors silently during probes, uses a single plist path variable instead of a hardcoded path, and ensures the service is restarted with the updated configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->