### PR TITLE
Fixed Windows MDM profiles being delivered to hosts in a non-deterministic order

### DIFF
--- a/changes/42225-windows-mdm-profile-delivery-order
+++ b/changes/42225-windows-mdm-profile-delivery-order
@@ -1,0 +1,1 @@
+- Fixed Windows MDM profiles being delivered to hosts in a non-deterministic order, which could cause CSP nodes using `LastWrite` conflict resolution to produce unpredictable effective values across reconciler runs.

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -3423,10 +3423,15 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 	// SyncML, which is gone — and the host would be stuck with an
 	// un-removable install. Re-query existence right before the upsert
 	// loops to shrink the race window to just the loop body.
+	// Sort the install profile UUIDs lexicographically so subsequent loops iterate in a deterministic order.
+	// Without this, Go's randomized map iteration delivers commands to the device in non-deterministic
+	// order; for Windows CSP nodes that use LastWrite conflict resolution, the effective setting on the
+	// device can change unpredictably between reconciler runs.
 	installProfileUUIDs := make([]string, 0, len(installTargets))
 	for profUUID := range installTargets {
 		installProfileUUIDs = append(installProfileUUIDs, profUUID)
 	}
+	slices.Sort(installProfileUUIDs)
 	stillExistingInstallProfiles, err := ds.GetExistingMDMWindowsProfileUUIDs(ctx, installProfileUUIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "checking Windows profile existence before install upsert")
@@ -3436,7 +3441,8 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 	// Variable profiles and remove commands are not pre-inserted because
 	// they require per-host or per-profile processing.
 	var bulkCommands []*fleet.MDMWindowsCommand
-	for profUUID, target := range installTargets {
+	for _, profUUID := range installProfileUUIDs {
+		target := installTargets[profUUID]
 		if _, stillExists := stillExistingInstallProfiles[profUUID]; !stillExists {
 			continue
 		}
@@ -3456,7 +3462,8 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 		}
 	}
 
-	for profUUID, target := range installTargets {
+	for _, profUUID := range installProfileUUIDs {
+		target := installTargets[profUUID]
 		if _, stillExists := stillExistingInstallProfiles[profUUID]; !stillExists {
 			logger.InfoContext(ctx, "skipping Windows profile install; profile was deleted after list",
 				"profile_uuid", profUUID, "host_count", len(target.hostUUIDs))
@@ -3568,7 +3575,14 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 	}
 
 	// Generate and enqueue <Delete> commands for profiles being removed from hosts.
-	for profUUID, target := range removeTargets {
+	// Sort for deterministic delivery order (see installProfileUUIDs comment above).
+	removeProfileUUIDs := make([]string, 0, len(removeTargets))
+	for profUUID := range removeTargets {
+		removeProfileUUIDs = append(removeProfileUUIDs, profUUID)
+	}
+	slices.Sort(removeProfileUUIDs)
+	for _, profUUID := range removeProfileUUIDs {
+		target := removeTargets[profUUID]
 		p, ok := profileContents[profUUID]
 		if !ok {
 			// Profile was deleted between list and fetch. (The deletion path already called cancelWindowsHostInstallsForDeletedMDMProfiles)

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5" //nolint:gosec // Windows MDM Auth uses MD5
 	"crypto/x509"
@@ -813,6 +814,122 @@ func TestReconcileWindowsProfilesWithFleetVariableError(t *testing.T) {
 		}
 	}
 	require.True(t, foundError, "Should have found a failed status update")
+}
+
+// TestReconcileWindowsProfilesDeliversInDeterministicOrder
+// When multiple Windows MDM profiles target the same host, the reconciler must deliver them in a stable, deterministic order so
+// that CSP nodes using LastWrite conflict resolution produce a predictable effective value on the device.
+func TestReconcileWindowsProfilesDeliversInDeterministicOrder(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	const hostUUID = "host-uuid-1"
+	// Profile UUIDs intentionally inserted out of sorted order; the reconciler must
+	// still deliver them in sorted order on every run.
+	insertOrder := []string{"prof-e", "prof-b", "prof-d", "prof-a", "prof-c"}
+	expectedSortedOrder := []string{"prof-a", "prof-b", "prof-c", "prof-d", "prof-e"}
+
+	syncMLByUUID := make(map[string][]byte, len(insertOrder))
+	for _, profUUID := range insertOrder {
+		syncMLByUUID[profUUID] = syncMLForTest("./" + profUUID)
+	}
+
+	// Run the reconciler many times. With Go's randomized map iteration and 5 profiles (120 permutations),
+	// an unsorted implementation fails within the first few runs.
+	const runs = 10
+	var firstOrder []string
+
+	for run := 0; run < runs; run++ {
+		ds := new(mock.Store)
+		ds.GetMDMWindowsReconcileCursorFunc = func(ctx context.Context) (string, error) {
+			return "", nil
+		}
+		ds.SetMDMWindowsReconcileCursorFunc = func(ctx context.Context, cursor string) error {
+			return nil
+		}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{WindowsEnabledAndConfigured: true}}, nil
+		}
+		ds.ListNextPendingMDMWindowsHostUUIDsFunc = func(ctx context.Context, after string, batchSize int) ([]string, error) {
+			return []string{hostUUID}, nil
+		}
+		ds.ListMDMWindowsProfilesToInstallForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMWindowsProfilePayload, error) {
+			payloads := make([]*fleet.MDMWindowsProfilePayload, 0, len(insertOrder))
+			for _, profUUID := range insertOrder {
+				payloads = append(payloads, &fleet.MDMWindowsProfilePayload{
+					ProfileUUID:   profUUID,
+					ProfileName:   profUUID,
+					HostUUID:      hostUUID,
+					Status:        &fleet.MDMDeliveryPending,
+					OperationType: fleet.MDMOperationTypeInstall,
+				})
+			}
+			return payloads, nil
+		}
+		ds.ListMDMWindowsProfilesToRemoveForHostsFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.MDMWindowsProfilePayload, error) {
+			return nil, nil
+		}
+		ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
+			out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
+			for _, u := range profileUUIDs {
+				out[u] = fleet.MDMWindowsProfileContents{SyncML: syncMLByUUID[u], Checksum: []byte("test-checksum")}
+			}
+			return out, nil
+		}
+		ds.GetExistingMDMWindowsProfileUUIDsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]struct{}, error) {
+			out := make(map[string]struct{}, len(profileUUIDs))
+			for _, u := range profileUUIDs {
+				out[u] = struct{}{}
+			}
+			return out, nil
+		}
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
+		ds.BulkUpsertMDMWindowsHostProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+			return nil
+		}
+		ds.BulkUpsertMDMManagedCertificatesFunc = func(ctx context.Context, payload []*fleet.MDMManagedCertificate) error {
+			return nil
+		}
+
+		// Capture the bulk-insert order: this is the order commands land in windows_mdm_commands, which determines per-host delivery
+		// order.
+		var bulkOrder []string
+		ds.MDMWindowsBulkInsertCommandsFunc = func(ctx context.Context, cmds []*fleet.MDMWindowsCommand) error {
+			for _, c := range cmds {
+				for _, profUUID := range insertOrder {
+					if bytes.Contains(c.RawCommand, []byte("./"+profUUID)) {
+						bulkOrder = append(bulkOrder, profUUID)
+						break
+					}
+				}
+			}
+			return nil
+		}
+
+		// Capture the per-profile enqueue order.
+		var enqueueOrder []string
+		ds.MDMWindowsEnqueueCommandAndUpsertHostProfilesFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand,
+			payload []*fleet.MDMWindowsBulkUpsertHostProfilePayload,
+		) error {
+			require.NotEmpty(t, payload)
+			enqueueOrder = append(enqueueOrder, payload[0].ProfileUUID)
+			return nil
+		}
+
+		require.NoError(t, ReconcileWindowsProfiles(ctx, ds, logger))
+		require.Len(t, bulkOrder, len(insertOrder), "all profiles should be bulk-inserted")
+		require.Len(t, enqueueOrder, len(insertOrder), "all profiles should be enqueued")
+		require.Equal(t, bulkOrder, enqueueOrder, "bulk insert and enqueue must use the same order")
+
+		if run == 0 {
+			firstOrder = append([]string(nil), enqueueOrder...)
+			require.Equal(t, expectedSortedOrder, firstOrder, "delivery order must be sorted by profile UUID")
+		} else {
+			require.Equal(t, firstOrder, enqueueOrder, "delivery order must be deterministic across runs (run %d)", run)
+		}
+	}
 }
 
 func TestReconcileWindowsProfileWithCertificateFailureDoesNotAddManagedCertificate(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42225

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows MDM profiles are now delivered to hosts in a deterministic order, ensuring consistent behavior across system reconciliation cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->