### PR TITLE
Fixing unreleased issue with vpp installs on byod

### DIFF
--- a/ee/server/service/install_vpp_associate_test.go
+++ b/ee/server/service/install_vpp_associate_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,29 +37,37 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 		body []byte
 	}
 
+	// handleRegisterUserV1 emulates Apple's synchronous v1 registerVPPUserSrv
+	// endpoint — the token is in the request body, not the Authorization header.
+	handleRegisterUserV1 := func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+		var body struct {
+			SToken            string `json:"sToken"`
+			ClientUserIDStr   string `json:"clientUserIdStr"`
+			ManagedAppleIDStr string `json:"managedAppleIDStr"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, bearerToken, body.SToken)
+		_, _ = fmt.Fprintf(w, `{"status":0,"user":{"userId":12345,"status":"Registered","clientUserIdStr":%q,"managedAppleIDStr":%q}}`,
+			body.ClientUserIDStr, body.ManagedAppleIDStr)
+	}
+
 	// Common mock-server setup. Captures the AssociateAssets body so the test
 	// can assert on the wire payload.
 	setupServer := func(t *testing.T, capt *captured) {
 		t.Helper()
 		setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "Bearer "+bearerToken, r.Header.Get("Authorization"))
 			switch {
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
+				assert.Equal(t, "Bearer "+bearerToken, r.Header.Get("Authorization"))
 				_, _ = w.Write([]byte(`{"assignments": []}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
+				assert.Equal(t, "Bearer "+bearerToken, r.Header.Get("Authorization"))
 				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
-			case r.Method == http.MethodPost && r.URL.Path == "/users/create":
-				body := struct {
-					Users []struct {
-						ClientUserId   string `json:"clientUserId"`
-						ManagedAppleId string `json:"managedAppleId"`
-					} `json:"users"`
-				}{}
-				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-				assert.Len(t, body.Users, 1)
-				_, _ = fmt.Fprintf(w, `{"eventId":"evt","users":[{"userId":"apple-1","clientUserId":%q,"managedAppleId":%q,"status":"Registered"}]}`,
-					body.Users[0].ClientUserId, body.Users[0].ManagedAppleId)
+			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+				handleRegisterUserV1(t, w, r)
 			case r.Method == http.MethodPost && r.URL.Path == "/assets/associate":
+				assert.Equal(t, "Bearer "+bearerToken, r.Header.Get("Authorization"))
 				b, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
 				capt.body = b
@@ -157,16 +166,8 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 				_, _ = w.Write([]byte(`{"assignments": []}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
-			case r.Method == http.MethodPost && r.URL.Path == "/users/create":
-				body := struct {
-					Users []struct {
-						ClientUserId   string `json:"clientUserId"`
-						ManagedAppleId string `json:"managedAppleId"`
-					} `json:"users"`
-				}{}
-				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-				_, _ = fmt.Fprintf(w, `{"eventId":"evt","users":[{"userId":"apple-1","clientUserId":%q,"managedAppleId":%q,"status":"Registered"}]}`,
-					body.Users[0].ClientUserId, body.Users[0].ManagedAppleId)
+			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+				handleRegisterUserV1(t, w, r)
 			case r.Method == http.MethodPost && r.URL.Path == "/assets/associate":
 				_, _ = w.Write([]byte(`{"eventId":"associate-evt"}`))
 			default:
@@ -193,16 +194,8 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 				_, _ = fmt.Fprintf(w, `{"assignments":[{"adamId":%q,"pricingParam":"STDQ"}]}`, adamID)
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				t.Errorf("/assets must not be queried when assignments already exist")
-			case r.Method == http.MethodPost && r.URL.Path == "/users/create":
-				body := struct {
-					Users []struct {
-						ClientUserId   string `json:"clientUserId"`
-						ManagedAppleId string `json:"managedAppleId"`
-					} `json:"users"`
-				}{}
-				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-				_, _ = fmt.Fprintf(w, `{"eventId":"evt","users":[{"userId":"apple-1","clientUserId":%q,"managedAppleId":%q,"status":"Registered"}]}`,
-					body.Users[0].ClientUserId, body.Users[0].ManagedAppleId)
+			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+				handleRegisterUserV1(t, w, r)
 			case r.Method == http.MethodPost && r.URL.Path == "/assets/associate":
 				associateCalls++
 				_, _ = w.Write([]byte(`{"eventId":"associate-evt"}`))
@@ -228,16 +221,8 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 				_, _ = w.Write([]byte(`{"assignments": []}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
-			case r.Method == http.MethodPost && r.URL.Path == "/users/create":
-				body := struct {
-					Users []struct {
-						ClientUserId   string `json:"clientUserId"`
-						ManagedAppleId string `json:"managedAppleId"`
-					} `json:"users"`
-				}{}
-				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-				_, _ = fmt.Fprintf(w, `{"eventId":"evt","users":[{"userId":"apple-1","clientUserId":%q,"managedAppleId":%q,"status":"Registered"}]}`,
-					body.Users[0].ClientUserId, body.Users[0].ManagedAppleId)
+			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+				handleRegisterUserV1(t, w, r)
 			case r.Method == http.MethodPost && r.URL.Path == "/assets/associate":
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte(`{"errorInfo":{},"errorMessage":"User has reached the maximum number of devices for this license.","errorNumber":9622}`))
@@ -258,6 +243,167 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 		// Internal error preserves Apple's raw response for debugging.
 		require.Error(t, bre.InternalErr)
 		require.Contains(t, bre.InternalErr.Error(), "9622")
+	})
+
+	t.Run("personal enrollment self-heals by recovering Apple-side user", func(t *testing.T) {
+		// First /assets/associate call returns Apple's 9609 "unable to find
+		// the registered user" error. Fleet should:
+		//   - call GET /users?managedAppleId=... and find the existing
+		//     (drifted) user,
+		//   - upsert that clientUserId back into vpp_client_users,
+		//   - retry /assets/associate with the recovered UUID and succeed.
+		//
+		// Critically, /registerVPPUserSrv should NOT be called a second time
+		// — Apple already has a user, re-registering would hit 9635.
+		const recoveredUUID = "recovered-uuid-from-apple"
+		var (
+			associateCalls            int
+			registerCalls             int
+			getUsersCalls             int
+			capturedFirstClientUserID string
+			capturedSecondClientUser  string
+		)
+		setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
+				_, _ = w.Write([]byte(`{"assignments": []}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/users":
+				getUsersCalls++
+				assert.Equal(t, "user@example.com", r.URL.Query().Get("managedAppleId"))
+				_, _ = fmt.Fprintf(w, `{"users":[{"clientUserId":%q,"idHash":"hash","status":"Associated"}]}`, recoveredUUID)
+			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
+				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
+			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+				registerCalls++
+				handleRegisterUserV1(t, w, r)
+			case r.Method == http.MethodPost && r.URL.Path == "/assets/associate":
+				associateCalls++
+				var got vpp.AssociateAssetsRequest
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+				assert.Len(t, got.ClientUserIds, 1)
+				if len(got.ClientUserIds) == 0 {
+					t.Errorf("associate request missing ClientUserIds")
+					return
+				}
+				if associateCalls == 1 {
+					capturedFirstClientUserID = got.ClientUserIds[0]
+					// Real-world Apple 9609 signature observed in #31138.
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(`{"errorInfo":{},"errorMessage":"Unable to find the registered user.","errorNumber":9609}`))
+					return
+				}
+				capturedSecondClientUser = got.ClientUserIds[0]
+				_, _ = w.Write([]byte(`{"eventId":"associate-evt-2"}`))
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		})
+
+		// Override managed-apple-id so the GET /users assertion above can pin it.
+		ds := setupDS(t, true)
+		ds.GetHostManagedAppleIDFunc = func(_ context.Context, _ uint) (string, error) {
+			return "user@example.com", nil
+		}
+		var upserts []*fleet.VPPClientUser
+		ds.InsertVPPClientUserFunc = func(_ context.Context, row *fleet.VPPClientUser) error {
+			upserts = append(upserts, row)
+			return nil
+		}
+
+		svc := &Service{ds: ds, logger: slog.New(slog.DiscardHandler)}
+		cmdUUID, err := svc.InstallVPPAppPostValidation(context.Background(), host, vppApp, bearerToken, fleet.HostSoftwareInstallOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, cmdUUID)
+
+		require.Equal(t, 2, associateCalls, "associate must be retried exactly once")
+		require.Equal(t, 1, getUsersCalls, "must look up the user by managed apple id before deciding to re-register")
+		require.Equal(t, 1, registerCalls, "only the initial ensureVPPClientUser register; no second register since Apple still has the user")
+
+		require.NotEqual(t, capturedFirstClientUserID, capturedSecondClientUser, "second associate must use the recovered clientUserId")
+		require.Equal(t, recoveredUUID, capturedSecondClientUser, "second associate must use the clientUserId returned by Apple's GET /users")
+
+		require.Len(t, upserts, 2, "initial register + cache resync from Apple")
+		require.Equal(t, recoveredUUID, upserts[1].ClientUserID)
+		require.Equal(t, fleet.VPPClientUserStatusRegistered, upserts[1].Status)
+		require.True(t, ds.InsertHostVPPSoftwareInstallFuncInvoked)
+	})
+
+	t.Run("personal enrollment falls back to re-register when Apple has no user", func(t *testing.T) {
+		// Same trigger (9609) but Apple's GET /users returns no active user
+		// — the prior one was retired or the Apple ID was somehow purged.
+		// Fleet should fall through to /registerVPPUserSrv, get a fresh UUID,
+		// upsert it, and retry the associate.
+		var (
+			associateCalls int
+			registerCalls  int
+			getUsersCalls  int
+		)
+		setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
+				_, _ = w.Write([]byte(`{"assignments": []}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/users":
+				getUsersCalls++
+				// Empty (or Retired-only) response — caller must re-register.
+				_, _ = w.Write([]byte(`{"users":[{"clientUserId":"retired-ghost","status":"Retired"}]}`))
+			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
+				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
+			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+				registerCalls++
+				handleRegisterUserV1(t, w, r)
+			case r.Method == http.MethodPost && r.URL.Path == "/assets/associate":
+				associateCalls++
+				if associateCalls == 1 {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(`{"errorInfo":{},"errorMessage":"Unable to find the registered user.","errorNumber":9609}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"eventId":"associate-evt-fallback"}`))
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		})
+
+		ds := setupDS(t, true)
+		svc := &Service{ds: ds, logger: slog.New(slog.DiscardHandler)}
+
+		_, err := svc.InstallVPPAppPostValidation(context.Background(), host, vppApp, bearerToken, fleet.HostSoftwareInstallOptions{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, getUsersCalls)
+		require.Equal(t, 2, registerCalls, "initial ensure + fallback re-register")
+		require.Equal(t, 2, associateCalls, "associate retried after re-register")
+	})
+
+	t.Run("personal enrollment does not self-heal on unrelated associate error", func(t *testing.T) {
+		// Make sure a non-9612 associate error still bubbles up — we don't
+		// want to mask the real error or churn through pointless re-registers.
+		var registerCalls int
+		setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
+				_, _ = w.Write([]byte(`{"assignments": []}`))
+			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
+				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
+			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+				registerCalls++
+				handleRegisterUserV1(t, w, r)
+			case r.Method == http.MethodPost && r.URL.Path == "/assets/associate":
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"errorInfo":{},"errorMessage":"Cannot establish a connection.","errorNumber":9610}`))
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		})
+
+		ds := setupDS(t, true)
+		svc := &Service{ds: ds, logger: slog.New(slog.DiscardHandler)}
+
+		_, err := svc.InstallVPPAppPostValidation(context.Background(), host, vppApp, bearerToken, fleet.HostSoftwareInstallOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "9610")
+		// Only the initial ensureVPPClientUser register — no self-heal retry.
+		require.Equal(t, 1, registerCalls)
 	})
 
 	// Pin the dev_mode override in scope until t.Cleanup runs — referenced by the

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1474,16 +1474,21 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 	isPersonal := hostMDM != nil && hostMDM.IsPersonalEnrollment
 
 	var clientUserID string
+	// personalTokenDB stays in scope past the BYOD branch so the self-heal
+	// path below (on an "unknown clientUserId" associate error) can
+	// re-register via Apple's v1 endpoint without re-doing the team-token
+	// lookup.
+	var personalTokenDB *fleet.VPPTokenDB
 	if isPersonal {
 		// Token-selection policy (per #44009): use the team's default token —
 		// `GetVPPTokenByTeamID` already returns the first token for the team
 		// (existing behavior). Multi-location support is deferred unless a
 		// customer hits the edge case.
-		tokenDB, err := svc.ds.GetVPPTokenByTeamID(ctx, host.TeamID)
+		personalTokenDB, err = svc.ds.GetVPPTokenByTeamID(ctx, host.TeamID)
 		if err != nil {
 			return "", ctxerr.Wrap(ctx, err, "fetching VPP token DB row for user-enrolled install")
 		}
-		clientUserID, err = svc.ensureVPPClientUser(ctx, host, tokenDB)
+		clientUserID, err = svc.ensureVPPClientUser(ctx, host, personalTokenDB)
 		if err != nil {
 			return "", ctxerr.Wrap(ctx, err, "ensure VPP client user")
 		}
@@ -1558,7 +1563,67 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 					InternalErr: ctxerr.WrapWithData(ctx, err, "associate asset rejected by Apple per-user device cap", map[string]any{"host_id": host.ID, "team_id": host.TeamID, "adam_id": vppApp.AdamID}),
 				}
 			}
-			return "", ctxerr.Wrapf(ctx, err, "associating asset with adamID %s to host %s", vppApp.AdamID, host.HardwareSerial)
+
+			// Self-heal a stale local cache: Apple says it doesn't recognize
+			// the clientUserId we sent. Recovery is two-step because Apple
+			// enforces one VPP user per (location, managedAppleId):
+			//
+			//   1. Ask Apple for its current user record for this Managed
+			//      Apple ID. If one exists, the local cache simply drifted
+			//      (DB restore, manual edit, prior bug); re-sync to Apple's
+			//      clientUserId and retry the associate.
+			//   2. If Apple has no user (or only Retired entries),
+			//      register a fresh one via the v1 endpoint.
+			//
+			// One retry only either way — if the follow-up associate fails,
+			// surface that error rather than looping.
+			if isPersonal && personalTokenDB != nil && vpp.IsUnknownClientUserError(err) {
+				managedAppleID, idErr := svc.ds.GetHostManagedAppleID(ctx, host.ID)
+				if idErr != nil {
+					return "", ctxerr.Wrap(ctx, idErr, "looking up managed apple id for vpp recovery")
+				}
+
+				existing, lookupErr := vpp.GetUserByManagedAppleID(ctx, personalTokenDB.Token, managedAppleID)
+				if lookupErr != nil {
+					return "", ctxerr.Wrap(ctx, lookupErr, "looking up vpp user by managed apple id for recovery")
+				}
+
+				var recoveredClientUserID string
+				if existing != nil {
+					// Apple still has the user — local cache drift only. Re-sync.
+					recoveredClientUserID = existing.ClientUserID
+					if upsertErr := svc.ds.InsertVPPClientUser(ctx, &fleet.VPPClientUser{
+						VPPTokenID:     personalTokenDB.ID,
+						ManagedAppleID: managedAppleID,
+						ClientUserID:   recoveredClientUserID,
+						Status:         fleet.VPPClientUserStatusRegistered,
+					}); upsertErr != nil {
+						return "", ctxerr.Wrap(ctx, upsertErr, "resyncing vpp client user cache from Apple")
+					}
+					svc.logger.WarnContext(ctx, "recovered vpp client user from Apple; resynced local cache",
+						"host_id", host.ID, "vpp_token_id", personalTokenDB.ID, "adam_id", vppApp.AdamID,
+						"recovered_status", string(existing.Status), "original_err", err.Error())
+				} else {
+					// Apple has no user (likely retired) — safe to mint a new one.
+					newID, regErr := svc.registerVPPClientUser(ctx, personalTokenDB.ID, managedAppleID, personalTokenDB.Token)
+					if regErr != nil {
+						return "", ctxerr.Wrap(ctx, regErr, "re-registering vpp client user after lookup returned no active user")
+					}
+					recoveredClientUserID = newID
+					svc.logger.WarnContext(ctx, "no active vpp user at Apple; registered a new one",
+						"host_id", host.ID, "vpp_token_id", personalTokenDB.ID, "adam_id", vppApp.AdamID,
+						"original_err", err.Error())
+				}
+
+				clientUserID = recoveredClientUserID
+				req.ClientUserIds = []string{recoveredClientUserID}
+				eventID, err = vpp.AssociateAssets(token, req)
+				if err != nil {
+					return "", ctxerr.Wrapf(ctx, err, "associating asset with adamID %s after vpp client user recovery", vppApp.AdamID)
+				}
+			} else {
+				return "", ctxerr.Wrapf(ctx, err, "associating asset with adamID %s to host %s", vppApp.AdamID, host.HardwareSerial)
+			}
 		}
 	}
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1615,7 +1615,6 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 						"original_err", err.Error())
 				}
 
-				clientUserID = recoveredClientUserID
 				req.ClientUserIds = []string{recoveredClientUserID}
 				eventID, err = vpp.AssociateAssets(token, req)
 				if err != nil {

--- a/ee/server/service/vpp_users.go
+++ b/ee/server/service/vpp_users.go
@@ -22,11 +22,12 @@ var errMissingManagedAppleID = fleet.NewUserMessageError(
 
 // ensureVPPClientUser returns the Fleet-generated clientUserId for the host's
 // Managed Apple ID at the given VPP token (location), creating the Apple-side
-// VPP user via POST /mdm/v2/users/create on first call. Idempotent: subsequent
-// calls return the cached clientUserId from vpp_client_users.
+// VPP user via Apple's synchronous v1 registerVPPUserSrv endpoint on first
+// call. Idempotent: subsequent calls return the cached clientUserId from
+// vpp_client_users.
 //
-// Used by the user-scoped Associate Assets path (subtask 06) for hosts enrolled
-// via Account-Driven User Enrollment (BYOD).
+// Used by the user-scoped Associate Assets path for hosts enrolled via
+// Account-Driven User Enrollment (BYOD).
 func (svc *Service) ensureVPPClientUser(ctx context.Context, host *fleet.Host, token *fleet.VPPTokenDB) (string, error) {
 	if host == nil {
 		return "", ctxerr.New(ctx, "ensureVPPClientUser: nil host")
@@ -53,74 +54,37 @@ func (svc *Service) ensureVPPClientUser(ctx context.Context, host *fleet.Host, t
 		return existing.ClientUserID, nil
 	}
 
-	// Either no row, or a prior attempt left it 'pending'. Reuse the
-	// previously-generated UUID on retry so Apple correlates the request with
-	// the same user record.
+	return svc.registerVPPClientUser(ctx, token.ID, managedAppleID, token.Token)
+}
+
+// registerVPPClientUser unconditionally registers a new VPP user via Apple's
+// synchronous v1 endpoint and upserts the (vpp_token_id, managed_apple_id)
+// row with the freshly-generated clientUserId, overwriting any prior cache
+// entry. Used by:
+//
+//   - ensureVPPClientUser on its first-call / cache-miss branch.
+//   - The install-flow self-heal path, when Apple rejects the cached
+//     clientUserId as unknown — bypassing the cache is the whole point of the
+//     retry, so this entry point exists to avoid a confusing 'force' flag on
+//     ensureVPPClientUser.
+func (svc *Service) registerVPPClientUser(ctx context.Context, tokenID uint, managedAppleID, token string) (string, error) {
 	clientUserID := uuid.NewString()
-	if existing != nil && existing.ClientUserID != "" {
-		clientUserID = existing.ClientUserID
-	}
 
-	resp, err := vpp.CreateUsers(token.Token, &vpp.CreateUsersRequest{
-		Users: []vpp.CreateUsersUser{{ClientUserId: clientUserID, ManagedAppleId: managedAppleID}},
-	})
+	// v1 registerVPPUserSrv is synchronous — a successful response means the
+	// user is registered and ready to receive license associations.
+	appleUserID, err := vpp.RegisterUser(token, clientUserID, managedAppleID)
 	if err != nil {
-		// Persist 'pending' so a future retry can reuse the same clientUserID
-		// rather than minting a fresh one (which would leave us with multiple
-		// Apple-side users for the same Managed Apple ID). Log if the persist
-		// itself fails — we still want to surface the original CreateUsers
-		// error to the caller.
-		if insertErr := svc.ds.InsertVPPClientUser(ctx, &fleet.VPPClientUser{
-			VPPTokenID:     token.ID,
-			ManagedAppleID: managedAppleID,
-			ClientUserID:   clientUserID,
-			Status:         fleet.VPPClientUserStatusPending,
-		}); insertErr != nil {
-			svc.logger.ErrorContext(ctx, "persisting pending vpp client user after CreateUsers failure",
-				"host_id", host.ID, "vpp_token_id", token.ID, "err", insertErr)
-		}
-		return "", ctxerr.Wrap(ctx, err, "calling Apple VPP create-users")
-	}
-
-	// Apple's /users/create is asynchronous in the v2 API: a 200 with eventId
-	// means user registration has been queued, and the per-user payload is
-	// returned later (separate /users/get poll, deferred to a follow-up
-	// subtask). If Apple did echo a per-user entry in the synchronous response,
-	// surface any per-user error; otherwise treat the eventId as success since
-	// downstream associate-assets uses our clientUserId, which Apple resolves
-	// once registration completes.
-	for i := range resp.Users {
-		u := &resp.Users[i]
-		if u.ClientUserId != clientUserID {
-			continue
-		}
-		if u.HasError() {
-			if insertErr := svc.ds.InsertVPPClientUser(ctx, &fleet.VPPClientUser{
-				VPPTokenID:     token.ID,
-				ManagedAppleID: managedAppleID,
-				ClientUserID:   clientUserID,
-				Status:         fleet.VPPClientUserStatusPending,
-			}); insertErr != nil {
-				svc.logger.ErrorContext(ctx, "persisting pending vpp client user after Apple per-user error",
-					"host_id", host.ID, "vpp_token_id", token.ID, "err", insertErr)
-			}
-			return "", ctxerr.Errorf(ctx, "Apple VPP create-users returned error for managed apple id %q: %s (code %d)",
-				managedAppleID, u.ErrorMessage, u.ErrorNumber)
-		}
+		return "", ctxerr.Wrapf(ctx, err, "registering vpp user for managed apple id %q", managedAppleID)
 	}
 
 	row := &fleet.VPPClientUser{
-		VPPTokenID:     token.ID,
+		VPPTokenID:     tokenID,
 		ManagedAppleID: managedAppleID,
 		ClientUserID:   clientUserID,
 		Status:         fleet.VPPClientUserStatusRegistered,
 	}
-	for i := range resp.Users {
-		if resp.Users[i].ClientUserId == clientUserID && resp.Users[i].UserId != "" {
-			appleUserID := resp.Users[i].UserId
-			row.AppleUserID = &appleUserID
-			break
-		}
+	if appleUserID != "" {
+		row.AppleUserID = &appleUserID
 	}
 	if err := svc.ds.InsertVPPClientUser(ctx, row); err != nil {
 		return "", ctxerr.Wrap(ctx, err, "persisting registered vpp client user")

--- a/ee/server/service/vpp_users.go
+++ b/ee/server/service/vpp_users.go
@@ -54,6 +54,31 @@ func (svc *Service) ensureVPPClientUser(ctx context.Context, host *fleet.Host, t
 		return existing.ClientUserID, nil
 	}
 
+	// Non-registered row (typically a legacy 'pending' entry from the prior
+	// v2 async flow, or a row left over from a failed registration). Apple
+	// enforces uniqueness on (location, managedAppleId), so blindly calling
+	// registerVPPClientUser with a fresh UUID will collide with any existing
+	// Apple-side user. Ask Apple first; if a user already exists, resync the
+	// local cache to its clientUserId rather than minting a new one.
+	if existing != nil {
+		appleUser, lookupErr := vpp.GetUserByManagedAppleID(ctx, token.Token, managedAppleID)
+		if lookupErr != nil {
+			return "", ctxerr.Wrapf(ctx, lookupErr, "looking up vpp user by managed apple id for token %d", token.ID)
+		}
+		if appleUser != nil {
+			row := &fleet.VPPClientUser{
+				VPPTokenID:     token.ID,
+				ManagedAppleID: managedAppleID,
+				ClientUserID:   appleUser.ClientUserID,
+				Status:         fleet.VPPClientUserStatusRegistered,
+			}
+			if err := svc.ds.InsertVPPClientUser(ctx, row); err != nil {
+				return "", ctxerr.Wrap(ctx, err, "resyncing vpp client user cache from Apple")
+			}
+			return appleUser.ClientUserID, nil
+		}
+	}
+
 	return svc.registerVPPClientUser(ctx, token.ID, managedAppleID, token.Token)
 }
 

--- a/ee/server/service/vpp_users.go
+++ b/ee/server/service/vpp_users.go
@@ -54,9 +54,8 @@ func (svc *Service) ensureVPPClientUser(ctx context.Context, host *fleet.Host, t
 		return existing.ClientUserID, nil
 	}
 
-	// Non-registered row (typically a legacy 'pending' entry from the prior
-	// v2 async flow, or a row left over from a failed registration). Apple
-	// enforces uniqueness on (location, managedAppleId), so blindly calling
+	// Non-registered row. Apple enforces uniqueness on
+	// (location, managedAppleId), so blindly calling
 	// registerVPPClientUser with a fresh UUID will collide with any existing
 	// Apple-side user. Ask Apple first; if a user already exists, resync the
 	// local cache to its clientUserId rather than minting a new one.

--- a/ee/server/service/vpp_users_test.go
+++ b/ee/server/service/vpp_users_test.go
@@ -34,28 +34,33 @@ func TestEnsureVPPClientUser_NewUser(t *testing.T) {
 	tokenDB := &fleet.VPPTokenDB{ID: 42, Token: "valid-token"}
 	host := &fleet.Host{ID: hostID}
 
-	var createCalls int
+	var registerCalls int
 	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
-		createCalls++
+		registerCalls++
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/users/create", r.URL.Path)
-		assert.Equal(t, "Bearer valid-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "/registerVPPUserSrv", r.URL.Path)
+		// v1 puts the token in the body, not the Authorization header.
+		assert.Empty(t, r.Header.Get("Authorization"))
 
 		var got struct {
-			Users []struct {
-				ClientUserId   string `json:"clientUserId"`
-				ManagedAppleId string `json:"managedAppleId"`
-			} `json:"users"`
+			SToken            string `json:"sToken"`
+			ClientUserIDStr   string `json:"clientUserIdStr"`
+			ManagedAppleIDStr string `json:"managedAppleIDStr"`
 		}
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
-		assert.Len(t, got.Users, 1)
-		assert.NotEmpty(t, got.Users[0].ClientUserId)
-		assert.Equal(t, managedAppleID, got.Users[0].ManagedAppleId)
+		assert.Equal(t, "valid-token", got.SToken)
+		assert.NotEmpty(t, got.ClientUserIDStr)
+		assert.Equal(t, managedAppleID, got.ManagedAppleIDStr)
 
 		_, _ = fmt.Fprintf(w, `{
-			"eventId": "evt-1",
-			"users": [{"userId":"apple-user-1","clientUserId":%q,"managedAppleId":%q,"status":"Registered"}]
-		}`, got.Users[0].ClientUserId, managedAppleID)
+			"status": 0,
+			"user": {
+				"userId": 98765,
+				"status": "Registered",
+				"clientUserIdStr": %q,
+				"managedAppleIDStr": %q
+			}
+		}`, got.ClientUserIDStr, managedAppleID)
 	})
 
 	ds := new(mock.Store)
@@ -78,7 +83,7 @@ func TestEnsureVPPClientUser_NewUser(t *testing.T) {
 	clientUserID, err := svc.ensureVPPClientUser(context.Background(), host, tokenDB)
 	require.NoError(t, err)
 	require.NotEmpty(t, clientUserID)
-	require.Equal(t, 1, createCalls)
+	require.Equal(t, 1, registerCalls)
 
 	require.NotNil(t, insertedRow)
 	require.Equal(t, tokenDB.ID, insertedRow.VPPTokenID)
@@ -86,7 +91,7 @@ func TestEnsureVPPClientUser_NewUser(t *testing.T) {
 	require.Equal(t, clientUserID, insertedRow.ClientUserID)
 	require.Equal(t, fleet.VPPClientUserStatusRegistered, insertedRow.Status)
 	require.NotNil(t, insertedRow.AppleUserID)
-	require.Equal(t, "apple-user-1", *insertedRow.AppleUserID)
+	require.Equal(t, "98765", *insertedRow.AppleUserID)
 }
 
 func TestEnsureVPPClientUser_ExistingRegisteredUser(t *testing.T) {
@@ -96,7 +101,7 @@ func TestEnsureVPPClientUser_ExistingRegisteredUser(t *testing.T) {
 
 	// Apple must NOT be called on cache hit.
 	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("Apple VPP create-users must not be called when a registered row exists; got %s %s", r.Method, r.URL.Path)
+		t.Fatalf("Apple VPP register-user must not be called when a registered row exists; got %s %s", r.Method, r.URL.Path)
 	})
 
 	ds := new(mock.Store)
@@ -119,72 +124,19 @@ func TestEnsureVPPClientUser_ExistingRegisteredUser(t *testing.T) {
 	require.False(t, ds.InsertVPPClientUserFuncInvoked)
 }
 
-func TestEnsureVPPClientUser_PendingRetryReusesUUID(t *testing.T) {
-	const (
-		managedAppleID = "user@example.com"
-		priorUUID      = "prior-uuid-1234"
-	)
+func TestEnsureVPPClientUser_AppleErrorSurfacesAndSkipsInsert(t *testing.T) {
+	const managedAppleID = "missing@example.com"
 	tokenDB := &fleet.VPPTokenDB{ID: 1, Token: "tok"}
 	host := &fleet.Host{ID: 1}
 
+	// v1 reports application-level errors synchronously — no Apple-side user
+	// exists, so we should surface the error and skip the DB write entirely.
 	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
-		var got struct {
-			Users []struct {
-				ClientUserId   string `json:"clientUserId"`
-				ManagedAppleId string `json:"managedAppleId"`
-			} `json:"users"`
-		}
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
-		assert.Equal(t, priorUUID, got.Users[0].ClientUserId, "retry must reuse the prior clientUserId")
-
-		_, _ = fmt.Fprintf(w, `{
-			"eventId": "evt",
-			"users": [{"userId":"apple-2","clientUserId":%q,"managedAppleId":%q,"status":"Registered"}]
-		}`, priorUUID, managedAppleID)
-	})
-
-	ds := new(mock.Store)
-	ds.GetHostManagedAppleIDFunc = func(_ context.Context, _ uint) (string, error) {
-		return managedAppleID, nil
-	}
-	ds.GetVPPClientUserFunc = func(_ context.Context, _ uint, _ string) (*fleet.VPPClientUser, error) {
-		return &fleet.VPPClientUser{
-			VPPTokenID:     tokenDB.ID,
-			ManagedAppleID: managedAppleID,
-			ClientUserID:   priorUUID,
-			Status:         fleet.VPPClientUserStatusPending,
-		}, nil
-	}
-	var lastInserted *fleet.VPPClientUser
-	ds.InsertVPPClientUserFunc = func(_ context.Context, row *fleet.VPPClientUser) error {
-		lastInserted = row
-		return nil
-	}
-
-	svc := newTestServiceWithDS(ds)
-	got, err := svc.ensureVPPClientUser(context.Background(), host, tokenDB)
-	require.NoError(t, err)
-	require.Equal(t, priorUUID, got)
-	require.NotNil(t, lastInserted)
-	require.Equal(t, fleet.VPPClientUserStatusRegistered, lastInserted.Status)
-}
-
-func TestEnsureVPPClientUser_PartialFailureKeepsPending(t *testing.T) {
-	const managedAppleID = "user@example.com"
-	tokenDB := &fleet.VPPTokenDB{ID: 1, Token: "tok"}
-	host := &fleet.Host{ID: 1}
-
-	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
-		var got struct {
-			Users []struct {
-				ClientUserId string `json:"clientUserId"`
-			} `json:"users"`
-		}
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
-		_, _ = fmt.Fprintf(w, `{
-			"eventId": "evt",
-			"users": [{"clientUserId":%q,"managedAppleId":%q,"errorMessage":"Managed Apple ID not found","errorNumber":9637}]
-		}`, got.Users[0].ClientUserId, managedAppleID)
+		_, _ = fmt.Fprint(w, `{
+			"status": -1,
+			"errorNumber": 9637,
+			"errorMessage": "Managed Apple ID not found"
+		}`)
 	})
 
 	ds := new(mock.Store)
@@ -194,9 +146,8 @@ func TestEnsureVPPClientUser_PartialFailureKeepsPending(t *testing.T) {
 	ds.GetVPPClientUserFunc = func(_ context.Context, _ uint, _ string) (*fleet.VPPClientUser, error) {
 		return nil, &notFoundError{}
 	}
-	var inserted *fleet.VPPClientUser
-	ds.InsertVPPClientUserFunc = func(_ context.Context, row *fleet.VPPClientUser) error {
-		inserted = row
+	ds.InsertVPPClientUserFunc = func(_ context.Context, _ *fleet.VPPClientUser) error {
+		t.Fatal("InsertVPPClientUser must not be called when v1 register-user returns an error")
 		return nil
 	}
 
@@ -204,8 +155,7 @@ func TestEnsureVPPClientUser_PartialFailureKeepsPending(t *testing.T) {
 	_, err := svc.ensureVPPClientUser(context.Background(), host, tokenDB)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "9637")
-	require.NotNil(t, inserted)
-	require.Equal(t, fleet.VPPClientUserStatusPending, inserted.Status, "partial failure must persist row as pending so retries can reuse the UUID")
+	require.False(t, ds.InsertVPPClientUserFuncInvoked)
 }
 
 func TestEnsureVPPClientUser_MissingManagedAppleID(t *testing.T) {

--- a/ee/server/service/vpp_users_test.go
+++ b/ee/server/service/vpp_users_test.go
@@ -124,6 +124,104 @@ func TestEnsureVPPClientUser_ExistingRegisteredUser(t *testing.T) {
 	require.False(t, ds.InsertVPPClientUserFuncInvoked)
 }
 
+// A non-registered cache row (typically 'pending' from the legacy v2 async
+// flow) must NOT be treated as a fresh registration target: Apple enforces
+// uniqueness on (location, managedAppleId), so registering with a new UUID
+// would collide. Instead, look the user up on Apple's side and resync.
+func TestEnsureVPPClientUser_PendingRowAppleHasUser(t *testing.T) {
+	const (
+		managedAppleID = "user@example.com"
+		appleClientID  = "apple-side-uuid"
+	)
+	tokenDB := &fleet.VPPTokenDB{ID: 1, Token: "tok"}
+	host := &fleet.Host{ID: 1}
+
+	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/users" {
+			assert.Equal(t, managedAppleID, r.URL.Query().Get("managedAppleId"))
+			_, _ = fmt.Fprintf(w, `{"users":[{"clientUserId":%q,"status":"Registered"}]}`, appleClientID)
+			return
+		}
+		t.Fatalf("unexpected Apple call %s %s — pending row + Apple-side user should resync without re-registering", r.Method, r.URL.Path)
+	})
+
+	ds := new(mock.Store)
+	ds.GetHostManagedAppleIDFunc = func(_ context.Context, _ uint) (string, error) {
+		return managedAppleID, nil
+	}
+	ds.GetVPPClientUserFunc = func(_ context.Context, _ uint, _ string) (*fleet.VPPClientUser, error) {
+		return &fleet.VPPClientUser{
+			VPPTokenID:     tokenDB.ID,
+			ManagedAppleID: managedAppleID,
+			ClientUserID:   "stale-pending-uuid",
+			Status:         fleet.VPPClientUserStatusPending,
+		}, nil
+	}
+	var insertedRow *fleet.VPPClientUser
+	ds.InsertVPPClientUserFunc = func(_ context.Context, row *fleet.VPPClientUser) error {
+		insertedRow = row
+		return nil
+	}
+
+	svc := newTestServiceWithDS(ds)
+	clientUserID, err := svc.ensureVPPClientUser(context.Background(), host, tokenDB)
+	require.NoError(t, err)
+	require.Equal(t, appleClientID, clientUserID)
+	require.NotNil(t, insertedRow)
+	require.Equal(t, appleClientID, insertedRow.ClientUserID)
+	require.Equal(t, fleet.VPPClientUserStatusRegistered, insertedRow.Status)
+}
+
+// Pending row + Apple has no user (only retired entries, or fully cleared) —
+// safe to mint a fresh registration via the v1 endpoint.
+func TestEnsureVPPClientUser_PendingRowAppleHasNoUser(t *testing.T) {
+	const managedAppleID = "user@example.com"
+	tokenDB := &fleet.VPPTokenDB{ID: 1, Token: "tok"}
+	host := &fleet.Host{ID: 1}
+
+	var registerCalls int
+	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/users":
+			_, _ = fmt.Fprint(w, `{"users":[]}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+			registerCalls++
+			var got struct {
+				ClientUserIDStr   string `json:"clientUserIdStr"`
+				ManagedAppleIDStr string `json:"managedAppleIDStr"`
+			}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+			_, _ = fmt.Fprintf(w, `{"status":0,"user":{"userId":1234,"status":"Registered","clientUserIdStr":%q,"managedAppleIDStr":%q}}`,
+				got.ClientUserIDStr, managedAppleID)
+		default:
+			t.Fatalf("unexpected Apple call %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	ds := new(mock.Store)
+	ds.GetHostManagedAppleIDFunc = func(_ context.Context, _ uint) (string, error) {
+		return managedAppleID, nil
+	}
+	ds.GetVPPClientUserFunc = func(_ context.Context, _ uint, _ string) (*fleet.VPPClientUser, error) {
+		return &fleet.VPPClientUser{
+			VPPTokenID:     tokenDB.ID,
+			ManagedAppleID: managedAppleID,
+			ClientUserID:   "stale-pending-uuid",
+			Status:         fleet.VPPClientUserStatusPending,
+		}, nil
+	}
+	ds.InsertVPPClientUserFunc = func(_ context.Context, _ *fleet.VPPClientUser) error {
+		return nil
+	}
+
+	svc := newTestServiceWithDS(ds)
+	clientUserID, err := svc.ensureVPPClientUser(context.Background(), host, tokenDB)
+	require.NoError(t, err)
+	require.NotEmpty(t, clientUserID)
+	require.NotEqual(t, "stale-pending-uuid", clientUserID)
+	require.Equal(t, 1, registerCalls)
+}
+
 func TestEnsureVPPClientUser_AppleErrorSurfacesAndSkipsInsert(t *testing.T) {
 	const managedAppleID = "missing@example.com"
 	tokenDB := &fleet.VPPTokenDB{ID: 1, Token: "tok"}

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/helpers.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/helpers.tests.tsx
@@ -35,6 +35,17 @@ describe("getInstallErrorMessage", () => {
     expect(result).toBe("No available licenses");
   });
 
+  it("surfaces the missing Managed Apple ID message as-is", () => {
+    const result = getInstallErrorMessage(
+      makeErr(
+        "Couldn't install. Fleet hasn't received a Managed Apple ID for this host yet. Please wait a few minutes after enrollment and try again."
+      )
+    );
+    expect(result).toBe(
+      "Couldn't install. Fleet hasn't received a Managed Apple ID for this host yet. Please wait a few minutes after enrollment and try again"
+    );
+  });
+
   it("returns unresolvable Fleet variable message", () => {
     const result = getInstallErrorMessage(
       makeErr(

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/helpers.tsx
@@ -49,7 +49,9 @@ const showAPIMessage = (message: string) => {
   return (
     message.includes("MDM is turned off") ||
     message.includes("No available licenses") ||
-    message.includes("Software title is not available for install")
+    message.includes("Software title is not available for install") ||
+    // BYOD VPP install before nanomdm has surfaced the host's Managed Apple ID.
+    message.includes("hasn't received a Managed Apple ID")
   );
 };
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -44,7 +44,10 @@ import UninstallSoftwareModal from "./components/UninstallSoftwareModal";
 import SoftwareInstructionsModal from "./components/OpenSoftwareModal";
 
 import { generateSoftwareTableHeaders } from "./components/SelfServiceTable/SelfServiceTableConfig";
-import { getLastInstall } from "../../HostSoftwareLibrary/helpers";
+import {
+  getInstallErrorMessage,
+  getLastInstall,
+} from "../../HostSoftwareLibrary/helpers";
 
 import { getUiStatus } from "../helpers";
 
@@ -446,7 +449,9 @@ const SoftwareSelfService = ({
         // We only show toast message if API returns an error
         renderFlash(
           "error",
-          `Couldn't ${isScriptPackage ? "run" : "install"}. Please try again.`
+          isScriptPackage
+            ? "Couldn't run. Please try again."
+            : getInstallErrorMessage(error)
         );
       }
     },

--- a/server/mdm/apple/util.go
+++ b/server/mdm/apple/util.go
@@ -120,7 +120,7 @@ func IsProfileNotFoundError(chain []mdm.ErrorChain) bool {
 // personally. Apple's raw "The app with iTunes Store ID <id> is already
 // installed." message leaks the App Store ID and gives the end user no
 // actionable next step — this copy (from #31138 Figma) is shown instead.
-const AppAlreadyInstalledBYODUserMessage = "Failed. This app is already installed. Please delete app first, an install via self-service."
+const AppAlreadyInstalledBYODUserMessage = "Failed. This app is already installed. Please delete the app first, then reinstall via Self Service."
 
 // IsAppAlreadyInstalledError reports whether the error chain from a failed
 // InstallApplication command indicates the app is already installed on the

--- a/server/mdm/apple/util.go
+++ b/server/mdm/apple/util.go
@@ -114,6 +114,14 @@ func IsProfileNotFoundError(chain []mdm.ErrorChain) bool {
 	return false
 }
 
+// AppAlreadyInstalledBYODUserMessage is the user-facing error message shown
+// when an InstallApplication command fails on an Account-Driven User
+// Enrollment (BYOD) host because the end user already has the app installed
+// personally. Apple's raw "The app with iTunes Store ID <id> is already
+// installed." message leaks the App Store ID and gives the end user no
+// actionable next step — this copy (from #31138 Figma) is shown instead.
+const AppAlreadyInstalledBYODUserMessage = "Failed. This app is already installed. Please delete app first, an install via self-service."
+
 // IsAppAlreadyInstalledError reports whether the error chain from a failed
 // InstallApplication command indicates the app is already installed on the
 // device — a common case on Account-Driven User Enrollment (BYOD) hosts where

--- a/server/mdm/apple/vpp/api.go
+++ b/server/mdm/apple/vpp/api.go
@@ -75,6 +75,49 @@ func IsMaxDevicesPerUserError(err error) bool {
 	return false
 }
 
+// IsUnknownClientUserError reports whether err indicates that Apple does not
+// recognize the clientUserId(s) Fleet sent on an associate-assets or
+// assignment query — typically because the user record was retired or never
+// completed registration on Apple's side, while Fleet still has it cached as
+// 'registered'.
+//
+// Used by the install flow to self-heal: on this error the caller should
+// re-register the VPP user via the v1 endpoint, replace the stale row, and
+// retry the original associate-assets call once.
+//
+// Confirmed code from production traffic:
+//   - 9609 / "Unable to find the registered user."
+//
+// Other codes (9605, 9612, 9627) are listed defensively against Apple's
+// docs; same substring backstop as IsMaxDevicesPerUserError catches future
+// drift.
+func IsUnknownClientUserError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var resp *ErrorResponse
+	if !errors.As(err, &resp) || resp == nil {
+		return false
+	}
+	switch resp.ErrorNumber {
+	case 9605, 9609, 9612, 9627:
+		return true
+	}
+	msg := strings.ToLower(resp.ErrorMessage)
+	if strings.Contains(msg, "unable to find") &&
+		(strings.Contains(msg, "registered user") || strings.Contains(msg, "client user") || strings.Contains(msg, "user")) {
+		return true
+	}
+	if strings.Contains(msg, "client user") &&
+		(strings.Contains(msg, "not found") || strings.Contains(msg, "unknown")) {
+		return true
+	}
+	if strings.Contains(msg, "user not found") {
+		return true
+	}
+	return false
+}
+
 // ResponseErrorInfo represents the request-specific information regarding the
 // failure.
 //
@@ -220,85 +263,154 @@ func AssociateAssets(token string, params *AssociateAssetsRequest) (string, erro
 	return respBody.EventID, nil
 }
 
-// CreateUsersRequest is the body for Apple's create-users endpoint.
+// RegisterUserResponse mirrors Apple's synchronous v1 register-user response.
 //
-// https://developer.apple.com/documentation/devicemanagement/create-users
-type CreateUsersRequest struct {
-	Users []CreateUsersUser `json:"users"`
-}
-
-// CreateUsersUser identifies a single VPP user to register against an Apple VPP
-// location. ClientUserId is a stable, Fleet-generated UUID; ManagedAppleId is
-// the user's Managed Apple ID surfaced from the host's TokenUpdate.
-type CreateUsersUser struct {
-	ClientUserId   string `json:"clientUserId"`
-	ManagedAppleId string `json:"managedAppleId"`
-}
-
-// CreateUsersResponse is the body returned by Apple's create-users endpoint.
+// Apple's v1 API responds synchronously with the full user record on success.
+// Status is 0 on success and -1 on error; the optional Error* fields carry
+// the application-level failure reason. UserID is Apple's assigned identifier.
 //
-// On success, EventID is populated and Users echoes back the registrations,
-// each carrying Apple's assigned UserId. Apple may return per-user errors
-// (e.g., for one of several requested users); callers must inspect each
-// CreateUsersResult.ErrorMessage / ErrorNumber to distinguish partial
-// failures from a fully successful batch.
-type CreateUsersResponse struct {
-	EventID string              `json:"eventId"`
-	Users   []CreateUsersResult `json:"users"`
-}
-
-// CreateUsersResult mirrors the per-user fields Apple may return.
-//
-// Modeled defensively: only ClientUserId is guaranteed in the response. UserId
-// is Apple's assigned identifier on success; the optional Error* fields carry
-// per-user partial-failure information.
-type CreateUsersResult struct {
-	UserId         string `json:"userId,omitempty"`
-	ClientUserId   string `json:"clientUserId"`
-	ManagedAppleId string `json:"managedAppleId,omitempty"`
-	Status         string `json:"status,omitempty"`
-	InviteCode     string `json:"inviteCode,omitempty"`
-	InviteURL      string `json:"inviteUrl,omitempty"`
-	// ErrorMessage and ErrorNumber are populated when Apple rejects this
-	// individual user even though the overall request succeeded with 200.
-	ErrorMessage string `json:"errorMessage,omitempty"`
+// https://developer.apple.com/documentation/devicemanagement/registervppuserresponse
+type RegisterUserResponse struct {
+	Status       int    `json:"status"`
 	ErrorNumber  int32  `json:"errorNumber,omitempty"`
+	ErrorMessage string `json:"errorMessage,omitempty"`
+	User         *struct {
+		UserID            json.Number `json:"userId"`
+		Status            string      `json:"status"`
+		ClientUserIDStr   string      `json:"clientUserIdStr"`
+		ManagedAppleIDStr string      `json:"managedAppleIDStr"`
+		Email             string      `json:"email,omitempty"`
+		InviteURL         string      `json:"inviteUrl,omitempty"`
+		InviteCode        string      `json:"inviteCode,omitempty"`
+	} `json:"user,omitempty"`
 }
 
-// HasError returns true if Apple flagged this individual user as failed.
-func (r *CreateUsersResult) HasError() bool {
-	return r.ErrorNumber != 0 || r.ErrorMessage != ""
-}
-
-// CreateUsers registers VPP users at Apple's create-users endpoint and returns
-// Apple's response. A nil error indicates the request itself succeeded; per-user
-// partial failures are surfaced on each CreateUsersResult — callers must check
-// HasError() on each entry rather than relying solely on the function's error.
+// RegisterUser registers a single VPP user via Apple's legacy synchronous v1
+// register-user endpoint. Use this rather than the v2 /users/create flow when
+// the caller needs definitive confirmation that registration succeeded before
+// proceeding — v1 returns the full user record (with Apple's assigned userId)
+// in the same response, whereas v2 only returns an eventId that must be
+// polled separately.
 //
-// https://developer.apple.com/documentation/devicemanagement/create-users
-func CreateUsers(token string, params *CreateUsersRequest) (*CreateUsersResponse, error) {
-	if params == nil || len(params.Users) == 0 {
-		return nil, errors.New("CreateUsersRequest: at least one user is required")
+// On any Apple-level failure (status != 0 or non-2xx with error payload),
+// returns an *ErrorResponse so callers can distinguish known error codes
+// (e.g. invalid Managed Apple ID).
+//
+// https://developer.apple.com/documentation/devicemanagement/registervppuserrequest
+func RegisterUser(token, clientUserID, managedAppleID string) (string, error) {
+	if clientUserID == "" || managedAppleID == "" {
+		return "", errors.New("RegisterUser: clientUserId and managedAppleId are required")
+	}
+
+	// v1 takes the VPP server token in the body rather than the
+	// Authorization header.
+	reqParams := struct {
+		SToken            string `json:"sToken"`
+		ClientUserIDStr   string `json:"clientUserIdStr"`
+		ManagedAppleIDStr string `json:"managedAppleIDStr"`
+	}{
+		SToken:            token,
+		ClientUserIDStr:   clientUserID,
+		ManagedAppleIDStr: managedAppleID,
 	}
 
 	var reqBody bytes.Buffer
-	if err := json.NewEncoder(&reqBody).Encode(params); err != nil {
-		return nil, fmt.Errorf("encoding params as JSON: %w", err)
+	if err := json.NewEncoder(&reqBody).Encode(reqParams); err != nil {
+		return "", fmt.Errorf("encoding params as JSON: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, getBaseURL()+"/users/create", &reqBody)
+	req, err := http.NewRequest(http.MethodPost, getV1BaseURL()+"/registerVPPUserSrv", &reqBody)
+	if err != nil {
+		return "", fmt.Errorf("creating request to Apple VPP endpoint: %w", err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	var resp RegisterUserResponse
+	if err := do(req, "", &resp); err != nil {
+		return "", fmt.Errorf("making request to Apple VPP endpoint: %w", err)
+	}
+
+	// v1 reports application-level failures via status == -1 with an
+	// errorMessage/errorNumber but a 200 transport. Surface those through the
+	// same *ErrorResponse callers already handle for v2.
+	if resp.Status != 0 || resp.ErrorNumber != 0 || resp.ErrorMessage != "" {
+		return "", &ErrorResponse{
+			ErrorMessage: resp.ErrorMessage,
+			ErrorNumber:  resp.ErrorNumber,
+		}
+	}
+	if resp.User == nil || resp.User.UserID == "" {
+		return "", errors.New("Apple VPP register-user returned no user record on success")
+	}
+
+	return resp.User.UserID.String(), nil
+}
+
+// VPPUserStatus mirrors the lifecycle states Apple reports in v2 /users
+// responses for a VPP user.
+type VPPUserStatus string
+
+const (
+	// VPPUserStatusRegistered: Apple has accepted the registration and
+	// issued an invite, but the end user has not yet linked their Apple
+	// Account.
+	VPPUserStatusRegistered VPPUserStatus = "Registered"
+	// VPPUserStatusAssociated: end user has accepted the invite and the
+	// Apple Account is bound to the VPP user record.
+	VPPUserStatusAssociated VPPUserStatus = "Associated"
+	// VPPUserStatusRetired: the user has been retired; a new registration
+	// for the same Managed Apple ID is permitted at this location.
+	VPPUserStatusRetired VPPUserStatus = "Retired"
+)
+
+// User is a single entry from Apple's v2 /users list response.
+type User struct {
+	ClientUserID string        `json:"clientUserId"`
+	IDHash       string        `json:"idHash"`
+	Status       VPPUserStatus `json:"status"`
+}
+
+// GetUserByManagedAppleID looks up the active VPP user for the given Managed
+// Apple ID at the location identified by the bearer token. Apple enforces
+// uniqueness on (location, managedAppleId), so a successful response carries
+// at most one non-retired user.
+//
+// Returns (nil, nil) when Apple has no user (or only retired users) for the
+// Apple ID — callers should fall through to RegisterUser in that case.
+// Returns a non-nil error only for transport / Apple-application errors.
+//
+// Used by the install self-heal path to recover a stale clientUserId after
+// Fleet's local cache drifts from Apple's record (e.g. a stale DB restore).
+//
+// https://developer.apple.com/documentation/devicemanagement/get-users
+func GetUserByManagedAppleID(ctx context.Context, token, managedAppleID string) (*User, error) {
+	if managedAppleID == "" {
+		return nil, errors.New("GetUserByManagedAppleID: managedAppleID is required")
+	}
+
+	q := url.Values{}
+	q.Set("managedAppleId", managedAppleID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, getBaseURL()+"/users?"+q.Encode(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request to Apple VPP endpoint: %w", err)
 	}
 
-	req.Header.Add("Content-Type", "application/json")
-
-	var respBody CreateUsersResponse
-	if err := do(req, token, &respBody); err != nil {
+	var resp struct {
+		Users []User `json:"users"`
+	}
+	if err := do(req, token, &resp); err != nil {
 		return nil, fmt.Errorf("making request to Apple VPP endpoint: %w", err)
 	}
 
-	return &respBody, nil
+	// Apple's contract is at-most-one non-retired user per (location, Apple ID),
+	// but we scan the full slice defensively in case a Retired ghost is
+	// returned alongside an active record on some iOS revision.
+	for i := range resp.Users {
+		if resp.Users[i].Status != VPPUserStatusRetired {
+			return &resp.Users[i], nil
+		}
+	}
+	return nil, nil
 }
 
 // AssetFilter represents the filters for querying assets.
@@ -472,7 +584,11 @@ func GetAssignments(token string, filter *AssignmentFilter) ([]Assignment, error
 }
 
 func do[T any](req *http.Request, token string, dest *T) error {
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	// v1 endpoints carry the token in the request body, so callers pass an
+	// empty string to skip the Authorization header.
+	if token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
 
 	// Reset the request body for retries. After client.Do reads the body,
 	// it's consumed. GetBody (set by http.NewRequest for *bytes.Buffer)
@@ -560,6 +676,17 @@ func getBaseURL() string {
 		return devURL
 	}
 	return "https://vpp.itunes.apple.com/mdm/v2"
+}
+
+// getV1BaseURL returns the base URL for Apple's legacy v1 VPP endpoints. The
+// dev override (FLEET_DEV_VPP_URL) is returned as-is so tests can mock both
+// v1 and v2 against the same httptest server using path-based routing.
+func getV1BaseURL() string {
+	devURL := dev_mode.Env("FLEET_DEV_VPP_URL")
+	if devURL != "" {
+		return devURL
+	}
+	return "https://vpp.itunes.apple.com/mdm"
 }
 
 // addFilter adds a filter to the query values if it is not the zero value.

--- a/server/mdm/apple/vpp/api_test.go
+++ b/server/mdm/apple/vpp/api_test.go
@@ -594,100 +594,158 @@ func TestDoRetry(t *testing.T) {
 	})
 }
 
-func TestCreateUsers(t *testing.T) {
-	t.Run("rejects empty request", func(t *testing.T) {
-		_, err := CreateUsers("token", nil)
+func TestRegisterUser(t *testing.T) {
+	t.Run("rejects empty client user id or managed apple id", func(t *testing.T) {
+		_, err := RegisterUser("tok", "", "user@example.com")
 		require.Error(t, err)
 
-		_, err = CreateUsers("token", &CreateUsersRequest{})
+		_, err = RegisterUser("tok", "uuid-1", "")
 		require.Error(t, err)
 	})
 
-	t.Run("success path returns event id and users", func(t *testing.T) {
+	t.Run("success returns apple userId synchronously", func(t *testing.T) {
 		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, "/users/create", r.URL.Path)
-			assert.Equal(t, "Bearer valid_token", r.Header.Get("Authorization"))
+			assert.Equal(t, "/registerVPPUserSrv", r.URL.Path)
+			// v1 carries the token in the body, not the Authorization header.
+			assert.Empty(t, r.Header.Get("Authorization"))
 			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 			body, err := io.ReadAll(r.Body)
 			assert.NoError(t, err)
 
-			var got CreateUsersRequest
+			var got struct {
+				SToken            string `json:"sToken"`
+				ClientUserIDStr   string `json:"clientUserIdStr"`
+				ManagedAppleIDStr string `json:"managedAppleIDStr"`
+			}
 			assert.NoError(t, json.Unmarshal(body, &got))
-			assert.Equal(t, []CreateUsersUser{
-				{ClientUserId: "uuid-1", ManagedAppleId: "user1@example.com"},
-				{ClientUserId: "uuid-2", ManagedAppleId: "user2@example.com"},
-			}, got.Users)
+			assert.Equal(t, "valid_token", got.SToken)
+			assert.Equal(t, "uuid-1", got.ClientUserIDStr)
+			assert.Equal(t, "user1@example.com", got.ManagedAppleIDStr)
 
 			_, _ = w.Write([]byte(`{
-				"eventId": "evt-123",
-				"users": [
-					{"userId":"apple-1","clientUserId":"uuid-1","managedAppleId":"user1@example.com","status":"Registered"},
-					{"userId":"apple-2","clientUserId":"uuid-2","managedAppleId":"user2@example.com","status":"Registered"}
-				]
+				"status": 0,
+				"user": {
+					"userId": 12345,
+					"status": "Registered",
+					"clientUserIdStr": "uuid-1",
+					"managedAppleIDStr": "user1@example.com"
+				}
 			}`))
 		})
 
-		resp, err := CreateUsers("valid_token", &CreateUsersRequest{
-			Users: []CreateUsersUser{
-				{ClientUserId: "uuid-1", ManagedAppleId: "user1@example.com"},
-				{ClientUserId: "uuid-2", ManagedAppleId: "user2@example.com"},
-			},
-		})
+		appleUserID, err := RegisterUser("valid_token", "uuid-1", "user1@example.com")
 		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, "evt-123", resp.EventID)
-		require.Len(t, resp.Users, 2)
-		require.Equal(t, "apple-1", resp.Users[0].UserId)
-		require.Equal(t, "Registered", resp.Users[0].Status)
-		require.False(t, resp.Users[0].HasError())
-		require.False(t, resp.Users[1].HasError())
+		require.Equal(t, "12345", appleUserID)
 	})
 
-	t.Run("partial failure surfaces per-user error info", func(t *testing.T) {
+	t.Run("apple application error surfaces as ErrorResponse", func(t *testing.T) {
 		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			// v1 application errors come back as HTTP 200 with status=-1.
 			_, _ = w.Write([]byte(`{
-				"eventId": "evt-456",
-				"users": [
-					{"userId":"apple-1","clientUserId":"uuid-1","managedAppleId":"user1@example.com","status":"Registered"},
-					{"clientUserId":"uuid-2","managedAppleId":"user2@example.com","errorMessage":"Managed Apple ID not found","errorNumber":9637}
-				]
+				"status": -1,
+				"errorNumber": 9637,
+				"errorMessage": "Managed Apple ID not found"
 			}`))
 		})
 
-		resp, err := CreateUsers("valid_token", &CreateUsersRequest{
-			Users: []CreateUsersUser{
-				{ClientUserId: "uuid-1", ManagedAppleId: "user1@example.com"},
-				{ClientUserId: "uuid-2", ManagedAppleId: "user2@example.com"},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, "evt-456", resp.EventID)
-		require.Len(t, resp.Users, 2)
+		_, err := RegisterUser("valid_token", "uuid-1", "missing@example.com")
+		require.Error(t, err)
 
-		require.False(t, resp.Users[0].HasError())
-		require.Equal(t, "apple-1", resp.Users[0].UserId)
-
-		require.True(t, resp.Users[1].HasError())
-		require.Equal(t, "uuid-2", resp.Users[1].ClientUserId)
-		require.Equal(t, "Managed Apple ID not found", resp.Users[1].ErrorMessage)
-		require.EqualValues(t, 9637, resp.Users[1].ErrorNumber)
-		require.Empty(t, resp.Users[1].UserId)
+		var appleErr *ErrorResponse
+		require.ErrorAs(t, err, &appleErr)
+		require.EqualValues(t, 9637, appleErr.ErrorNumber)
+		require.Equal(t, "Managed Apple ID not found", appleErr.ErrorMessage)
 	})
 
-	t.Run("apple-level error from /users/create", func(t *testing.T) {
+	t.Run("apple transport-level error surfaces as ErrorResponse", func(t *testing.T) {
 		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"errorInfo":{},"errorMessage":"Bad Request","errorNumber":400}`))
+			_, _ = w.Write([]byte(`{"errorMessage":"Bad Request","errorNumber":400}`))
 		})
 
-		resp, err := CreateUsers("valid_token", &CreateUsersRequest{
-			Users: []CreateUsersUser{{ClientUserId: "uuid-1", ManagedAppleId: "user1@example.com"}},
-		})
+		_, err := RegisterUser("valid_token", "uuid-1", "user1@example.com")
 		require.Error(t, err)
-		require.Nil(t, resp)
+		require.Contains(t, err.Error(), "error number: 400")
+	})
+
+	t.Run("success without user object is treated as error", func(t *testing.T) {
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status": 0}`))
+		})
+
+		_, err := RegisterUser("valid_token", "uuid-1", "user1@example.com")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no user record")
+	})
+}
+
+func TestGetUserByManagedAppleID(t *testing.T) {
+	t.Run("rejects empty managed apple id", func(t *testing.T) {
+		_, err := GetUserByManagedAppleID(t.Context(), "tok", "")
+		require.Error(t, err)
+	})
+
+	t.Run("returns the single non-retired user", func(t *testing.T) {
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/users", r.URL.Path)
+			assert.Equal(t, "user@example.com", r.URL.Query().Get("managedAppleId"))
+			assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"users":[{"clientUserId":"uuid-1","idHash":"hash-1","status":"Associated"}]}`))
+		})
+
+		got, err := GetUserByManagedAppleID(t.Context(), "tok", "user@example.com")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, "uuid-1", got.ClientUserID)
+		require.Equal(t, VPPUserStatusAssociated, got.Status)
+	})
+
+	t.Run("returns nil when Apple has no users", func(t *testing.T) {
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"users":[]}`))
+		})
+
+		got, err := GetUserByManagedAppleID(t.Context(), "tok", "missing@example.com")
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("skips Retired entries", func(t *testing.T) {
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"users":[{"clientUserId":"old","status":"Retired"}]}`))
+		})
+
+		got, err := GetUserByManagedAppleID(t.Context(), "tok", "user@example.com")
+		require.NoError(t, err)
+		require.Nil(t, got, "Retired-only response must be treated as 'no user' so caller re-registers")
+	})
+
+	t.Run("Registered user is recoverable too", func(t *testing.T) {
+		// A user who's been invited but hasn't accepted yet (status=Registered)
+		// is still a valid record — Fleet should sync to that clientUserId
+		// rather than try to mint a duplicate.
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"users":[{"clientUserId":"pending-uuid","status":"Registered"}]}`))
+		})
+
+		got, err := GetUserByManagedAppleID(t.Context(), "tok", "user@example.com")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, "pending-uuid", got.ClientUserID)
+		require.Equal(t, VPPUserStatusRegistered, got.Status)
+	})
+
+	t.Run("surfaces Apple application error", func(t *testing.T) {
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errorMessage":"Bad Request","errorNumber":400}`))
+		})
+
+		_, err := GetUserByManagedAppleID(t.Context(), "tok", "user@example.com")
+		require.Error(t, err)
 		require.Contains(t, err.Error(), "error number: 400")
 	})
 }
@@ -737,6 +795,88 @@ func TestIsMaxDevicesPerUserError(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expected, IsMaxDevicesPerUserError(tt.err))
+		})
+	}
+}
+
+func TestIsUnknownClientUserError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-VPP error",
+			err:      errors.New("network down"),
+			expected: false,
+		},
+		{
+			name:     "candidate code 9605",
+			err:      &ErrorResponse{ErrorMessage: "User not found", ErrorNumber: 9605},
+			expected: true,
+		},
+		{
+			// Production-observed signature from #31138 retry test on
+			// 2026-05-22 — pinning the exact code/message so a regression
+			// here flips the self-heal off and we'd notice in CI.
+			name:     "confirmed production signature 9609 / Unable to find the registered user.",
+			err:      &ErrorResponse{ErrorMessage: "Unable to find the registered user.", ErrorNumber: 9609},
+			expected: true,
+		},
+		{
+			name:     "9609 substring fallback when code drifts",
+			err:      &ErrorResponse{ErrorMessage: "Unable to find the registered user for this license.", ErrorNumber: 0},
+			expected: true,
+		},
+		{
+			name:     "candidate code 9612",
+			err:      &ErrorResponse{ErrorMessage: "Client user not found", ErrorNumber: 9612},
+			expected: true,
+		},
+		{
+			name:     "candidate code 9627",
+			err:      &ErrorResponse{ErrorMessage: "Unknown user id", ErrorNumber: 9627},
+			expected: true,
+		},
+		{
+			name:     "matched by case-insensitive 'client user not found' message",
+			err:      &ErrorResponse{ErrorMessage: "Client User Not Found in organization.", ErrorNumber: 99999},
+			expected: true,
+		},
+		{
+			name:     "matched by 'client user' + 'unknown' phrasing",
+			err:      &ErrorResponse{ErrorMessage: "Unknown client user supplied.", ErrorNumber: 0},
+			expected: true,
+		},
+		{
+			name:     "matched by 'user not found' phrasing",
+			err:      &ErrorResponse{ErrorMessage: "User not found.", ErrorNumber: 0},
+			expected: true,
+		},
+		{
+			name:     "unrelated VPP error 9610",
+			err:      &ErrorResponse{ErrorMessage: "Cannot establish a connection.", ErrorNumber: 9610},
+			expected: false,
+		},
+		{
+			name:     "max-devices error must NOT match unknown-user",
+			err:      &ErrorResponse{ErrorMessage: "User has reached the maximum number of devices.", ErrorNumber: 9622},
+			expected: false,
+		},
+		{
+			name:     "wrapped via fmt.Errorf %w still detected",
+			err:      fmt.Errorf("calling vpp: %w", &ErrorResponse{ErrorMessage: "Client user not found", ErrorNumber: 9612}),
+			expected: true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsUnknownClientUserError(tt.err))
 		})
 	}
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4022,12 +4022,15 @@ func (svc *MDMAppleCheckinAndCommandService) GetToken(_ *mdm.Request, _ *mdm.Get
 	return nil, nil
 }
 
-// hostIsPersonalEnrollment reports whether the host identified by the MDM
-// enrollment UUID is enrolled via Account-Driven User Enrollment (BYOD).
-// Returns false when the host or its MDM record can't be found — callers
-// fall through to the default (managed) path in that case.
-func (svc *MDMAppleCheckinAndCommandService) hostIsPersonalEnrollment(ctx context.Context, hostUUID string) (bool, error) {
-	host, err := svc.ds.HostLiteByIdentifier(ctx, hostUUID)
+// hostIsPersonalEnrollment reports whether the host identified by the given
+// MDM enrollment identifier is enrolled via Account-Driven User Enrollment
+// (BYOD). The identifier is whatever the MDM command result reports — a UDID
+// for device enrollments, or a User Enrollment EnrollmentID for BYOD —
+// resolved via HostLiteByIdentifier. Returns false when the host or its MDM
+// record can't be found — callers fall through to the default (managed) path
+// in that case.
+func (svc *MDMAppleCheckinAndCommandService) hostIsPersonalEnrollment(ctx context.Context, enrollmentIdentifier string) (bool, error) {
+	host, err := svc.ds.HostLiteByIdentifier(ctx, enrollmentIdentifier)
 	if err != nil {
 		if fleet.IsNotFound(err) {
 			return false, nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4260,7 +4260,7 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 		alreadyInstalledBYOD := false
 		if (cmdResult.Status == fleet.MDMAppleStatusError || cmdResult.Status == fleet.MDMAppleStatusCommandFormatError) &&
 			apple_mdm.IsAppAlreadyInstalledError(cmdResult.ErrorChain) {
-			isPersonal, err := svc.hostIsPersonalEnrollment(r.Context, cmdResult.Identifier())
+			isPersonal := r.Type == mdm.UserEnrollmentDevice
 			if err != nil {
 				return nil, ctxerr.Wrap(r.Context, err, "looking up enrollment type for InstallApplication already-installed result")
 			}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4022,6 +4022,28 @@ func (svc *MDMAppleCheckinAndCommandService) GetToken(_ *mdm.Request, _ *mdm.Get
 	return nil, nil
 }
 
+// hostIsPersonalEnrollment reports whether the host identified by the MDM
+// enrollment UUID is enrolled via Account-Driven User Enrollment (BYOD).
+// Returns false when the host or its MDM record can't be found — callers
+// fall through to the default (managed) path in that case.
+func (svc *MDMAppleCheckinAndCommandService) hostIsPersonalEnrollment(ctx context.Context, hostUUID string) (bool, error) {
+	host, err := svc.ds.HostLiteByIdentifier(ctx, hostUUID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			return false, nil
+		}
+		return false, ctxerr.Wrap(ctx, err, "host lite by identifier")
+	}
+	hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			return false, nil
+		}
+		return false, ctxerr.Wrap(ctx, err, "get host mdm")
+	}
+	return hostMDM.IsPersonalEnrollment, nil
+}
+
 func (svc *MDMAppleCheckinAndCommandService) runCommandHandlers(ctx context.Context, cmdName string, result fleet.MDMCommandResults) error {
 	handlers, ok := svc.commandHandlers[cmdName]
 	if ok {
@@ -4223,16 +4245,40 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 		err := svc.ds.MDMAppleSetPendingDeclarationsAs(r.Context, cmdResult.Identifier(), status, detail)
 		return nil, ctxerr.Wrap(r.Context, err, "update declaration status on DeclarativeManagement ack")
 	case "InstallApplication":
-		// "Already installed" is not a real failure: the end user grabbed the
-		// app from the App Store before Fleet's command landed. Treat it as a
-		// successful install and let the verification flow confirm presence —
-		// no retry, no failure activity. Applies to all enrollment types since
-		// Apple's behavior here is the same regardless of enrollment style.
+		// "Already installed" handling depends on enrollment type:
+		//   - Fully managed hosts: treat as a successful install — MDM can take
+		//     over the App Store copy, and verification will confirm presence.
+		//   - BYOD / Account-Driven User Enrollment: Apple won't let MDM claim
+		//     a personally-installed app, and InstalledApplicationList with
+		//     managedAppsOnly=true never reports it. Verification would loop
+		//     forever, so we fail the install with the user-facing message
+		//     from #31138 Figma and skip retries (replays produce the same
+		//     answer from Apple).
+		alreadyInstalledBYOD := false
 		if (cmdResult.Status == fleet.MDMAppleStatusError || cmdResult.Status == fleet.MDMAppleStatusCommandFormatError) &&
 			apple_mdm.IsAppAlreadyInstalledError(cmdResult.ErrorChain) {
-			svc.logger.InfoContext(r.Context, "InstallApplication reported app already installed; treating as success",
-				"host_uuid", cmdResult.Identifier(), "command_uuid", cmdResult.CommandUUID)
-			cmdResult.Status = fleet.MDMAppleStatusAcknowledged
+			isPersonal, err := svc.hostIsPersonalEnrollment(r.Context, cmdResult.Identifier())
+			if err != nil {
+				return nil, ctxerr.Wrap(r.Context, err, "looking up enrollment type for InstallApplication already-installed result")
+			}
+			if !isPersonal {
+				svc.logger.InfoContext(r.Context, "InstallApplication reported app already installed; treating as success",
+					"host_uuid", cmdResult.Identifier(), "command_uuid", cmdResult.CommandUUID)
+				cmdResult.Status = fleet.MDMAppleStatusAcknowledged
+			} else {
+				alreadyInstalledBYOD = true
+				// Replace Apple's raw "The app with iTunes Store ID <id> is
+				// already installed." with the user-facing copy. Downstream
+				// failure-display callers (FmtErrorChain etc.) will surface
+				// the substituted message.
+				cmdResult.ErrorChain = []mdm.ErrorChain{{
+					ErrorDomain:          "FleetInstallError",
+					ErrorCode:            12042,
+					USEnglishDescription: apple_mdm.AppAlreadyInstalledBYODUserMessage,
+				}}
+				svc.logger.InfoContext(r.Context, "InstallApplication failed on BYOD host: app already installed personally",
+					"host_uuid", cmdResult.Identifier(), "command_uuid", cmdResult.CommandUUID)
+			}
 		}
 
 		// create an activity for installing only if we're in a terminal error state
@@ -4243,11 +4289,13 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 			// N.b., VPP uses 0-based retry_count, so this comparison gives
 			// MaxSoftwareInstallAttempts retries (not attempts). This pre-dates
 			// the non-policy retry feature and is intentionally left as-is.
+			// Exception: the BYOD already-installed case is terminal — retrying
+			// would just hit the same wall.
 			vppInstall, err := svc.ds.GetHostVPPInstallByCommandUUID(r.Context, cmdResult.CommandUUID)
 			if err != nil {
 				return nil, ctxerr.Wrap(r.Context, err, "fetching host vpp install by command uuid")
 			}
-			if vppInstall != nil && vppInstall.RetryCount < fleet.MaxSoftwareInstallAttempts {
+			if !alreadyInstalledBYOD && vppInstall != nil && vppInstall.RetryCount < fleet.MaxSoftwareInstallAttempts {
 				if err := svc.ds.RetryVPPInstall(r.Context, vppInstall); err != nil {
 					return nil, ctxerr.Wrap(r.Context, err, "retrying VPP install for host")
 				}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4022,31 +4022,6 @@ func (svc *MDMAppleCheckinAndCommandService) GetToken(_ *mdm.Request, _ *mdm.Get
 	return nil, nil
 }
 
-// hostIsPersonalEnrollment reports whether the host identified by the given
-// MDM enrollment identifier is enrolled via Account-Driven User Enrollment
-// (BYOD). The identifier is whatever the MDM command result reports — a UDID
-// for device enrollments, or a User Enrollment EnrollmentID for BYOD —
-// resolved via HostLiteByIdentifier. Returns false when the host or its MDM
-// record can't be found — callers fall through to the default (managed) path
-// in that case.
-func (svc *MDMAppleCheckinAndCommandService) hostIsPersonalEnrollment(ctx context.Context, enrollmentIdentifier string) (bool, error) {
-	host, err := svc.ds.HostLiteByIdentifier(ctx, enrollmentIdentifier)
-	if err != nil {
-		if fleet.IsNotFound(err) {
-			return false, nil
-		}
-		return false, ctxerr.Wrap(ctx, err, "host lite by identifier")
-	}
-	hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
-	if err != nil {
-		if fleet.IsNotFound(err) {
-			return false, nil
-		}
-		return false, ctxerr.Wrap(ctx, err, "get host mdm")
-	}
-	return hostMDM.IsPersonalEnrollment, nil
-}
-
 func (svc *MDMAppleCheckinAndCommandService) runCommandHandlers(ctx context.Context, cmdName string, result fleet.MDMCommandResults) error {
 	handlers, ok := svc.commandHandlers[cmdName]
 	if ok {
@@ -4261,9 +4236,6 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 		if (cmdResult.Status == fleet.MDMAppleStatusError || cmdResult.Status == fleet.MDMAppleStatusCommandFormatError) &&
 			apple_mdm.IsAppAlreadyInstalledError(cmdResult.ErrorChain) {
 			isPersonal := r.Type == mdm.UserEnrollmentDevice
-			if err != nil {
-				return nil, ctxerr.Wrap(r.Context, err, "looking up enrollment type for InstallApplication already-installed result")
-			}
 			if !isPersonal {
 				svc.logger.InfoContext(r.Context, "InstallApplication reported app already installed; treating as success",
 					"host_uuid", cmdResult.Identifier(), "command_uuid", cmdResult.CommandUUID)

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2807,22 +2807,21 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 		}
 	}
 
-	// withEnrollmentType wires the host-lookup mocks so hostIsPersonalEnrollment
-	// resolves to the requested value without each subtest re-declaring the
-	// boilerplate.
-	withEnrollmentType := func(ds *mock.Store, personal bool) {
-		ds.HostLiteByIdentifierFunc = func(_ context.Context, _ string) (*fleet.HostLite, error) {
-			return &fleet.HostLite{ID: 1}, nil
+	// enrollReq builds an MDM request carrying the enrollment type the way
+	// nanomdm populates it in production. The InstallApplication handler reads
+	// r.Type directly (no DB lookup) to tell BYOD/Account-Driven User
+	// Enrollment apart from fully managed hosts.
+	enrollReq := func(personal bool) *mdm.Request {
+		var enrollType mdm.EnrollType = mdm.Device
+		if personal {
+			enrollType = mdm.UserEnrollmentDevice
 		}
-		ds.GetHostMDMFunc = func(_ context.Context, _ uint) (*fleet.HostMDM, error) {
-			return &fleet.HostMDM{HostID: 1, Enrolled: true, IsPersonalEnrollment: personal}, nil
-		}
+		return &mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{Type: enrollType, ID: hostUUID}}
 	}
 
 	t.Run("managed host: already installed bypasses retry and routes to verification", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := newSvc(ds)
-		withEnrollmentType(ds, false)
 
 		ds.GetMDMAppleCommandRequestTypeFunc = func(_ context.Context, cmd string) (string, error) {
 			require.Equal(t, commandUUID, cmd)
@@ -2836,7 +2835,7 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 		}
 
 		_, err := svc.CommandAndReportResults(
-			&mdm.Request{Context: ctx},
+			enrollReq(false),
 			&mdm.CommandResults{
 				Enrollment:  mdm.Enrollment{UDID: hostUUID},
 				CommandUUID: commandUUID,
@@ -2859,7 +2858,6 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 	t.Run("managed host: already installed via message fallback when code is unknown", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := newSvc(ds)
-		withEnrollmentType(ds, false)
 
 		ds.GetMDMAppleCommandRequestTypeFunc = func(_ context.Context, _ string) (string, error) {
 			return "InstallApplication", nil
@@ -2869,7 +2867,7 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 		}
 
 		_, err := svc.CommandAndReportResults(
-			&mdm.Request{Context: ctx},
+			enrollReq(false),
 			&mdm.CommandResults{
 				Enrollment:  mdm.Enrollment{UDID: hostUUID},
 				CommandUUID: commandUUID,
@@ -2889,7 +2887,6 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 	t.Run("BYOD host: already installed surfaces custom error and skips retry+verification", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := newSvc(ds)
-		withEnrollmentType(ds, true)
 
 		ds.GetMDMAppleCommandRequestTypeFunc = func(_ context.Context, _ string) (string, error) {
 			return "InstallApplication", nil
@@ -2919,7 +2916,7 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 			},
 		}
 
-		_, err := svc.CommandAndReportResults(&mdm.Request{Context: ctx}, cr)
+		_, err := svc.CommandAndReportResults(enrollReq(true), cr)
 		require.NoError(t, err)
 
 		// Status stays Error — we did NOT promote to success.

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2798,13 +2798,31 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 	)
 	ctx := context.Background()
 
+	noopActivityFn := func(_ context.Context, _ *fleet.User, _ fleet.ActivityDetails) error { return nil }
 	newSvc := func(ds *mock.Store) MDMAppleCheckinAndCommandService {
-		return MDMAppleCheckinAndCommandService{ds: ds, logger: slog.New(slog.DiscardHandler)}
+		return MDMAppleCheckinAndCommandService{
+			ds:            ds,
+			logger:        slog.New(slog.DiscardHandler),
+			newActivityFn: noopActivityFn,
+		}
 	}
 
-	t.Run("already installed bypasses retry and routes to verification", func(t *testing.T) {
+	// withEnrollmentType wires the host-lookup mocks so hostIsPersonalEnrollment
+	// resolves to the requested value without each subtest re-declaring the
+	// boilerplate.
+	withEnrollmentType := func(ds *mock.Store, personal bool) {
+		ds.HostLiteByIdentifierFunc = func(_ context.Context, _ string) (*fleet.HostLite, error) {
+			return &fleet.HostLite{ID: 1}, nil
+		}
+		ds.GetHostMDMFunc = func(_ context.Context, _ uint) (*fleet.HostMDM, error) {
+			return &fleet.HostMDM{HostID: 1, Enrolled: true, IsPersonalEnrollment: personal}, nil
+		}
+	}
+
+	t.Run("managed host: already installed bypasses retry and routes to verification", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := newSvc(ds)
+		withEnrollmentType(ds, false)
 
 		ds.GetMDMAppleCommandRequestTypeFunc = func(_ context.Context, cmd string) (string, error) {
 			require.Equal(t, commandUUID, cmd)
@@ -2838,9 +2856,10 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 		require.True(t, ds.IsHostPendingMDMInstallVerificationFuncInvoked)
 	})
 
-	t.Run("already installed via message fallback when code is unknown", func(t *testing.T) {
+	t.Run("managed host: already installed via message fallback when code is unknown", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := newSvc(ds)
+		withEnrollmentType(ds, false)
 
 		ds.GetMDMAppleCommandRequestTypeFunc = func(_ context.Context, _ string) (string, error) {
 			return "InstallApplication", nil
@@ -2865,6 +2884,56 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 		require.False(t, ds.GetHostVPPInstallByCommandUUIDFuncInvoked)
 		require.False(t, ds.RetryVPPInstallFuncInvoked)
 		require.True(t, ds.IsHostPendingMDMInstallVerificationFuncInvoked)
+	})
+
+	t.Run("BYOD host: already installed surfaces custom error and skips retry+verification", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc := newSvc(ds)
+		withEnrollmentType(ds, true)
+
+		ds.GetMDMAppleCommandRequestTypeFunc = func(_ context.Context, _ string) (string, error) {
+			return "InstallApplication", nil
+		}
+		// VPP install record returned with low retry count — should still NOT
+		// retry because the BYOD already-installed case is terminal.
+		ds.GetHostVPPInstallByCommandUUIDFunc = func(_ context.Context, _ string) (*fleet.HostVPPSoftwareInstallLite, error) {
+			return &fleet.HostVPPSoftwareInstallLite{HostID: 1, RetryCount: 0}, nil
+		}
+		// Setup-experience update is best-effort; return no-op so the test
+		// stays focused on the install-result path.
+		ds.MaybeUpdateSetupExperienceVPPStatusFunc = func(_ context.Context, _ string, _ string, _ fleet.SetupExperienceStatusResultStatus) (bool, error) {
+			return false, nil
+		}
+		var activityCmdResult *mdm.CommandResults
+		ds.GetPastActivityDataForVPPAppInstallFunc = func(_ context.Context, c *mdm.CommandResults) (*fleet.User, *fleet.ActivityInstalledAppStoreApp, error) {
+			activityCmdResult = c
+			return nil, &fleet.ActivityInstalledAppStoreApp{HostID: 1, Status: string(fleet.SoftwareInstallFailed)}, nil
+		}
+
+		cr := &mdm.CommandResults{
+			Enrollment:  mdm.Enrollment{UDID: hostUUID},
+			CommandUUID: commandUUID,
+			Status:      fleet.MDMAppleStatusError,
+			ErrorChain: []mdm.ErrorChain{
+				{ErrorCode: 12042, ErrorDomain: "MCMDMErrorDomain", USEnglishDescription: "The app with iTunes Store ID 546505307 is already installed."},
+			},
+		}
+
+		_, err := svc.CommandAndReportResults(&mdm.Request{Context: ctx}, cr)
+		require.NoError(t, err)
+
+		// Status stays Error — we did NOT promote to success.
+		require.Equal(t, fleet.MDMAppleStatusError, cr.Status)
+		// ErrorChain swapped to the user-facing copy.
+		require.Len(t, cr.ErrorChain, 1)
+		require.Equal(t, apple_mdm.AppAlreadyInstalledBYODUserMessage, cr.ErrorChain[0].USEnglishDescription)
+		// No retry, no verification — failure activity recorded with the swapped chain.
+		require.True(t, ds.GetHostVPPInstallByCommandUUIDFuncInvoked)
+		require.False(t, ds.RetryVPPInstallFuncInvoked)
+		require.False(t, ds.IsHostPendingMDMInstallVerificationFuncInvoked)
+		require.True(t, ds.GetPastActivityDataForVPPAppInstallFuncInvoked)
+		require.NotNil(t, activityCmdResult)
+		require.Equal(t, apple_mdm.AppAlreadyInstalledBYODUserMessage, activityCmdResult.ErrorChain[0].USEnglishDescription)
 	})
 
 	t.Run("unrelated install error still goes through retry path", func(t *testing.T) {

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -5144,8 +5144,9 @@ func (s *integrationMDMTestSuite) TestLinuxSetupExperienceEnqueueSoftwareInstall
 //
 // The setup-experience VPP install half of the BYOD flow is exercised by
 // unit-level tests (see TestInstallVPPAppPostValidation_AssociateAssetsRouting);
-// reproducing the full Apple /users/create + /assets/associate clientUserId
-// dance in this integration test would need a more complete VPP mock backend.
+// reproducing the full Apple /registerVPPUserSrv + /assets/associate
+// clientUserId dance in this integration test would need a more complete VPP
+// mock backend.
 func (s *integrationMDMTestSuite) TestSetupExperienceBYODiOS() {
 	t := s.T()
 	s.setSkipWorkerJobs(t)


### PR DESCRIPTION
## Summary

Three fixes for the BYOD/User-Enrollment VPP install flow shipped under #31138, all caught during QA on `gkarr-fix-byod-vpp`:

### 1. Switch VPP user registration from v2 (async) to v1 (sync)
The original implementation called Apple's `/mdm/v2/users/create`, which is asynchronous: a 200 response only confirms the registration was queued, with no `userId` returned. Fleet was storing the row as `registered` based on the `eventId` alone, which masked failures and left `apple_user_id` permanently `NULL`. Switched to Apple's legacy v1 `registerVPPUserSrv` endpoint, which returns the full user record (including Apple's `userId`) in the same response, so we know definitively whether registration succeeded.

- New `vpp.RegisterUser(token, clientUserID, managedAppleID)` posts to `https://vpp.itunes.apple.com/mdm/registerVPPUserSrv` with the token in the request body (v1 doesn't use the `Authorization` header).
- `ensureVPPClientUser` no longer writes "pending" rows on failure — v1's sync contract means we either succeed or surface the error.
- Removed the now-unused v2 `CreateUsers` types and tests.

### 2. Show a clear error when an end user already has the app installed personally
On BYOD/User-Enrolled hosts, when an end user has already installed an app from the App Store outside of Fleet, Apple's `InstallApplication` command fails with `"The app with iTunes Store ID <id> is already installed."` (code 12042). Previously Fleet treated this as success and entered the `InstalledApplicationList` verification loop — which never resolves on User Enrollment, since Apple's `managedAppsOnly: true` filter doesn't return personally-installed apps. The install appeared stuck.

- BYOD hosts now mark the install as failed instead of routing to verification, skip the retry path (the same install would just fail again), and surface the Figma-specified copy: `"Failed. This app is already installed. Please delete app first, an install via self-service."`
- Fully-managed hosts retain the existing behavior — MDM can take ownership of personally-installed apps on those devices, so the success-treatment is correct there.

### 3. Self-heal a stale `vpp_client_users` cache against Apple
If Fleet's cached `client_user_id` ever drifts from Apple's record (DB restore from a stale backup, manual tampering, future bug), Apple rejects `AssociateAssets` with code 9609 `"Unable to find the registered user."` and the install fails terminally. Apple enforces one VPP user per `(location, managed_apple_id)`, so blindly re-registering hits a different error (9635). The recovery is two-step:

1. On 9609, look up the existing user via `GET /mdm/v2/users?managedAppleId=…`. If Apple has an active record, upsert that `clientUserId` back into `vpp_client_users` and retry the associate.
2. If Apple genuinely has no active user (only Retired entries), register a fresh one via the v1 endpoint and retry.

Each branch logs a distinct `WARN` so the self-heal is visible in operator dashboards. Only one retry — if the follow-up associate fails, the second error is surfaced.

## Test plan

- [x] `make lint-go-incremental` — clean
- [x] `go test ./server/mdm/apple/vpp/... ./ee/server/service/... ./server/service/ -run '<targeted>'` — all green
- [x] Manual repro against a local k8s Fleet against Apple's production VPP endpoint:
  - Confirmed the original v2 install left `apple_user_id` NULL.
  - Confirmed the 9609 path triggers the lookup-then-recover branch after corrupting `vpp_client_users.client_user_id` and observing the WARN line + restored UUID.
- [ ] Manual install of a personally-installed App Store app on a BYOD-enrolled iPhone, verify the new error message is shown in self-service.
- [ ] Manual install of a VPP app on a managed iOS host — verify "already installed" still routes to verification (no regression in the managed path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * One-time self-heal for a specific Apple associate failure: recovers or re-registers the Apple-side user and retries association once; unrelated associate errors still surface.
  * BYOD “app already installed” errors now show a friendlier, actionable message and skip unnecessary retries.
  * Installer UI now surfaces precise install error messages from the API for non-script installs.

* **New Features**
  * Added synchronous VPP register-user and user-lookup support plus unknown-client-user error classification.

* **Tests**
  * Expanded tests for registration, lookup, recovery flows, and error matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->