### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8555.1",
+      "version": "1.8555.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.8555.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.8555.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.8555.1/Claude-cfe7d45eddd3d919d9d47913fd7b4f5f685d3044.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.8555.2/Claude-a476c316c741715263e34f9c9d2bc45b6d0f21c7.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "e555285c",
-      "sha256": "1b71221a4ae8121787b426057a1ccb6f7705634315a47d7b14388915de3b0c20",
+      "sha256": "0036e1dc8182aedca17975ae5038217a1b8bf137c8f9a435c3af843eaea9050d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8555.1",
+      "version": "1.8555.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.8555.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.8555.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.8555.1/Claude-cfe7d45eddd3d919d9d47913fd7b4f5f685d3044.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.8555.2/Claude-a476c316c741715263e34f9c9d2bc45b6d0f21c7.msix",
       "install_script_ref": "218aa85b",
       "uninstall_script_ref": "03f72055",
-      "sha256": "bc4aa26204753ee012c0d9d0282b99415769ae05bcd0afe01e0f70e1cf9087c2",
+      "sha256": "1c1c645f170314588e9249307a251ab77cdd007f5d5bc85ddf645cd7009c10b8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/coteditor/darwin.json
+++ b/ee/maintained-apps/outputs/coteditor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.0.3",
+      "version": "7.0.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor' AND version_compare(bundle_short_version, '7.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor' AND version_compare(bundle_short_version, '7.0.4') < 0);"
       },
-      "installer_url": "https://github.com/coteditor/CotEditor/releases/download/7.0.3/CotEditor_7.0.3.dmg",
+      "installer_url": "https://github.com/coteditor/CotEditor/releases/download/7.0.4/CotEditor_7.0.4.dmg",
       "install_script_ref": "25436bc3",
       "uninstall_script_ref": "51c19b9f",
-      "sha256": "e90f3414324ad163403b20965d454697f90fbd580559c3c89c443579cd720d57",
+      "sha256": "333939c23e217ec2f8e7ca778c1061df099d6bd0267c9157ced8032901a09c26",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.17",
+      "version": "3.5.33",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.5.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.5.33') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/d5b2fc092e16007956c9e5047f76097b9e626cab/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/aac81804b986d739acab348ed96b8bea6e83cc57/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "a4458d81",
-      "sha256": "3b8f87537bac46e8d7a7b99fc7fe3762e4446644dcc473257bdd78c42d764489",
+      "sha256": "31f404086bb01f643500c620a93decb8b4d9640164c36acae43758f542515b69",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.17",
+      "version": "3.5.33",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.5.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.5.33') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/d5b2fc092e16007956c9e5047f76097b9e626cab/win32/x64/system-setup/CursorSetup-x64-3.5.17.exe",
+      "installer_url": "https://downloads.cursor.com/production/aac81804b986d739acab348ed96b8bea6e83cc57/win32/x64/system-setup/CursorSetup-x64-3.5.33.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "69544572efa261a35e04732fc88a246b8116fd1a0e0e438cb1849df909320a2b",
+      "sha256": "e9b2399e783dc846142eeaa0b7292da1e9abd33cd7fbd48d9af6c7f02ae9c006",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/iina/darwin.json
+++ b/ee/maintained-apps/outputs/iina/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.2",
+      "version": "1.4.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.colliderli.iina';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.colliderli.iina' AND version_compare(bundle_short_version, '1.4.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.colliderli.iina' AND version_compare(bundle_short_version, '1.4.3') < 0);"
       },
-      "installer_url": "https://dl-portal.iina.io/IINA.v1.4.2-build164.dmg",
+      "installer_url": "https://dl.iina.io/IINA.v1.4.3.dmg",
       "install_script_ref": "ac168c5b",
       "uninstall_script_ref": "02a16561",
-      "sha256": "804e3368518f19039ebfbc3d698e1fabc9cd20f15fc4e42de635456cdf6a7f58",
+      "sha256": "899a15c3cee499d6e5d1a47bce02194a5a2709b3aa1c7ba82fb16a002fa81e02",
       "default_categories": [
         "Utilities"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer and version tracking metadata for Claude Desktop (1.8555.1→1.8555.2), CotEditor (7.0.3→7.0.4), Cursor (3.5.17→3.5.33), and IINA (1.4.2→1.4.3) across macOS and Windows platforms. Refreshed download links and verification checksums for current releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->