### PR TITLE
Better android host names

### DIFF
--- a/changes/41053-android-host-names
+++ b/changes/41053-android-host-names
@@ -1,0 +1,1 @@
+* Android host display name now uses "{IdP first name}'s {hardware model}" when an IdP account is associated.

--- a/server/mdm/android/service/enterprises_test.go
+++ b/server/mdm/android/service/enterprises_test.go
@@ -222,6 +222,12 @@ func InitCommonDSMocks() *AndroidMockDS {
 	ds.Store.UpdateHostOperatingSystemFunc = func(ctx context.Context, hostID uint, hostOS fleet.OperatingSystem) error {
 		return nil
 	}
+	ds.Store.GetMDMIdPAccountByUUIDFunc = func(ctx context.Context, uuid string) (*fleet.MDMIdPAccount, error) {
+		return nil, &notFoundError{}
+	}
+	ds.Store.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, &notFoundError{}
+	}
 	return &ds
 }
 

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -714,10 +714,10 @@ func (svc *Service) getHardwareModel(device *androidmanagement.Device) string {
 
 func (svc *Service) getComputerName(device *androidmanagement.Device, idpFullname string) string {
 	hardwareModel := svc.getHardwareModel(device)
-	if idpFullname == "" {
+	firstName := strings.SplitN(strings.TrimSpace(idpFullname), " ", 2)[0]
+	if firstName == "" {
 		return hardwareModel
 	}
-	firstName := strings.SplitN(idpFullname, " ", 2)[0]
 	return firstName + "'s " + hardwareModel
 }
 

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -192,7 +192,7 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 
 			// Emit system activity: mdm_unenrolled. For Android BYOD, InstalledFromDEP is always false.
 			// Use the computed display name from the device payload as lite host may not include it.
-			displayName := svc.getComputerName(&device)
+			displayName := svc.getHardwareModel(&device)
 			_ = svc.newActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
 				HostSerial:       "",
 				HostDisplayName:  displayName,
@@ -336,7 +336,7 @@ func (svc *Service) handlePubSubEnrollment(ctx context.Context, token string, ra
 				}
 			}
 
-			displayName := svc.getComputerName(&device)
+			displayName := svc.getHardwareModel(&device)
 			_ = svc.newActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
 				HostSerial:       "",
 				HostDisplayName:  displayName,
@@ -465,8 +465,17 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 	}
 	host.Device.DeviceID = deviceID
 
-	host.Host.ComputerName = svc.getComputerName(device)
-	host.Host.Hostname = svc.getComputerName(device)
+	var idpFullname string
+	idpAcct, err := svc.fleetDS.GetMDMIdPAccountByHostUUID(ctx, host.Host.UUID)
+	if err != nil && !fleet.IsNotFound(err) {
+		return ctxerr.Wrap(ctx, err, "getting IdP account for host")
+	}
+	if idpAcct != nil {
+		idpFullname = idpAcct.Fullname
+	}
+
+	host.Host.ComputerName = svc.getComputerName(device, idpFullname)
+	host.Host.Hostname = svc.getComputerName(device, idpFullname)
 	host.Host.Platform = "android"
 	host.Host.OSVersion = "Android " + device.SoftwareInfo.AndroidVersion
 	host.Host.Build = device.SoftwareInfo.AndroidBuildNumber
@@ -476,7 +485,7 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 
 	host.Host.HardwareSerial = device.HardwareInfo.SerialNumber
 	host.Host.CPUType = device.HardwareInfo.Hardware
-	host.Host.HardwareModel = svc.getComputerName(device)
+	host.Host.HardwareModel = svc.getHardwareModel(device)
 	host.Host.HardwareVendor = device.HardwareInfo.Brand
 	// Android hosts do not support dynamic labels so we should keep their labelUpdatedAt updated at every
 	// checkin to match platforms that do and make label logic simpler
@@ -599,11 +608,22 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 
 	gigsTotalDiskSpace, gigsDiskSpaceAvailable, percentDiskSpaceAvailable := svc.calculateAndroidStorageMetrics(ctx, device, false)
 
+	var idpFullname string
+	if enrollmentTokenRequest.IdpUUID != "" {
+		idpAcct, err := svc.ds.GetMDMIdPAccountByUUID(ctx, enrollmentTokenRequest.IdpUUID)
+		if err != nil && !fleet.IsNotFound(err) {
+			return ctxerr.Wrap(ctx, err, "getting IdP account for new host")
+		}
+		if idpAcct != nil {
+			idpFullname = idpAcct.Fullname
+		}
+	}
+
 	host := &fleet.AndroidHost{
 		Host: &fleet.Host{
 			TeamID:                    enrollSecret.GetTeamID(),
-			ComputerName:              svc.getComputerName(device),
-			Hostname:                  svc.getComputerName(device),
+			ComputerName:              svc.getComputerName(device, idpFullname),
+			Hostname:                  svc.getComputerName(device, idpFullname),
 			Platform:                  "android",
 			OSVersion:                 "Android " + device.SoftwareInfo.AndroidVersion,
 			Build:                     device.SoftwareInfo.AndroidBuildNumber,
@@ -613,7 +633,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 			PercentDiskSpaceAvailable: percentDiskSpaceAvailable,
 			HardwareSerial:            device.HardwareInfo.SerialNumber,
 			CPUType:                   device.HardwareInfo.Hardware,
-			HardwareModel:             svc.getComputerName(device),
+			HardwareModel:             svc.getHardwareModel(device),
 			HardwareVendor:            device.HardwareInfo.Brand,
 			LabelUpdatedAt:            time.Now(),
 			DetailUpdatedAt:           time.Time{},
@@ -688,9 +708,17 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 	return nil
 }
 
-func (svc *Service) getComputerName(device *androidmanagement.Device) string {
-	computerName := cases.Title(language.English, cases.Compact).String(device.HardwareInfo.Brand) + " " + device.HardwareInfo.Model
-	return computerName
+func (svc *Service) getHardwareModel(device *androidmanagement.Device) string {
+	return cases.Title(language.English, cases.Compact).String(device.HardwareInfo.Brand) + " " + device.HardwareInfo.Model
+}
+
+func (svc *Service) getComputerName(device *androidmanagement.Device, idpFullname string) string {
+	hardwareModel := device.HardwareInfo.Model
+	if idpFullname == "" {
+		return svc.getHardwareModel(device)
+	}
+	firstName := strings.SplitN(idpFullname, " ", 2)[0]
+	return firstName + "'s " + hardwareModel
 }
 
 func (svc *Service) getHostIfPresent(ctx context.Context, enterpriseSpecificID string) (*fleet.AndroidHost, error) {

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -727,13 +727,11 @@ func getHardwareModel(device *androidmanagement.Device) string {
 
 func getComputerName(device *androidmanagement.Device, idpFullname string) string {
 	hardwareModel := getHardwareModel(device)
-	parts := strings.Fields(idpFullname)
-	if len(parts) == 0 {
+	name := strings.TrimSpace(idpFullname)
+	if name == "" {
 		return hardwareModel
 	}
-	// Drop the last name; for single names, use as-is.
-	firstName := strings.Join(parts[:max(1, len(parts)-1)], " ")
-	return firstName + "'s " + hardwareModel
+	return name + "'s " + hardwareModel
 }
 
 func (svc *Service) getHostIfPresent(ctx context.Context, enterpriseSpecificID string) (*fleet.AndroidHost, error) {

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -191,10 +191,13 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 			}
 
 			// Emit system activity: mdm_unenrolled. For Android BYOD, InstalledFromDEP is always false.
-			// Use the computed display name from the device payload as lite host may not include it.
-			displayName := svc.getHardwareModel(&device)
+			var displayName, serial string
+			if hosts, herr := svc.fleetDS.ListHostsLiteByIDs(ctx, []uint{host.Host.ID}); herr == nil && len(hosts) == 1 && hosts[0] != nil {
+				displayName = hosts[0].DisplayName()
+				serial = hosts[0].HardwareSerial
+			}
 			_ = svc.newActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
-				HostSerial:       "",
+				HostSerial:       serial,
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,
 				Platform:         "android",
@@ -336,9 +339,13 @@ func (svc *Service) handlePubSubEnrollment(ctx context.Context, token string, ra
 				}
 			}
 
-			displayName := svc.getHardwareModel(&device)
+			var displayName, serial string
+			if hosts, herr := svc.fleetDS.ListHostsLiteByIDs(ctx, []uint{host.Host.ID}); herr == nil && len(hosts) == 1 && hosts[0] != nil {
+				displayName = hosts[0].DisplayName()
+				serial = hosts[0].HardwareSerial
+			}
 			_ = svc.newActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
-				HostSerial:       "",
+				HostSerial:       serial,
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,
 				Platform:         "android",
@@ -474,8 +481,8 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 		idpFullname = idpAcct.Fullname
 	}
 
-	host.Host.ComputerName = svc.getComputerName(device, idpFullname)
-	host.Host.Hostname = svc.getComputerName(device, idpFullname)
+	host.Host.ComputerName = getComputerName(device, idpFullname)
+	host.Host.Hostname = getComputerName(device, idpFullname)
 	host.Host.Platform = "android"
 	host.Host.OSVersion = "Android " + device.SoftwareInfo.AndroidVersion
 	host.Host.Build = device.SoftwareInfo.AndroidBuildNumber
@@ -485,7 +492,7 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 
 	host.Host.HardwareSerial = device.HardwareInfo.SerialNumber
 	host.Host.CPUType = device.HardwareInfo.Hardware
-	host.Host.HardwareModel = svc.getHardwareModel(device)
+	host.Host.HardwareModel = getHardwareModel(device)
 	host.Host.HardwareVendor = device.HardwareInfo.Brand
 	// Android hosts do not support dynamic labels so we should keep their labelUpdatedAt updated at every
 	// checkin to match platforms that do and make label logic simpler
@@ -622,8 +629,8 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 	host := &fleet.AndroidHost{
 		Host: &fleet.Host{
 			TeamID:                    enrollSecret.GetTeamID(),
-			ComputerName:              svc.getComputerName(device, idpFullname),
-			Hostname:                  svc.getComputerName(device, idpFullname),
+			ComputerName:              getComputerName(device, idpFullname),
+			Hostname:                  getComputerName(device, idpFullname),
 			Platform:                  "android",
 			OSVersion:                 "Android " + device.SoftwareInfo.AndroidVersion,
 			Build:                     device.SoftwareInfo.AndroidBuildNumber,
@@ -633,7 +640,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 			PercentDiskSpaceAvailable: percentDiskSpaceAvailable,
 			HardwareSerial:            device.HardwareInfo.SerialNumber,
 			CPUType:                   device.HardwareInfo.Hardware,
-			HardwareModel:             svc.getHardwareModel(device),
+			HardwareModel:             getHardwareModel(device),
 			HardwareVendor:            device.HardwareInfo.Brand,
 			LabelUpdatedAt:            time.Now(),
 			DetailUpdatedAt:           time.Time{},
@@ -708,16 +715,18 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 	return nil
 }
 
-func (svc *Service) getHardwareModel(device *androidmanagement.Device) string {
+func getHardwareModel(device *androidmanagement.Device) string {
 	return cases.Title(language.English, cases.Compact).String(device.HardwareInfo.Brand) + " " + device.HardwareInfo.Model
 }
 
-func (svc *Service) getComputerName(device *androidmanagement.Device, idpFullname string) string {
-	hardwareModel := svc.getHardwareModel(device)
-	firstName := strings.SplitN(strings.TrimSpace(idpFullname), " ", 2)[0]
-	if firstName == "" {
+func getComputerName(device *androidmanagement.Device, idpFullname string) string {
+	hardwareModel := getHardwareModel(device)
+	parts := strings.Fields(idpFullname)
+	if len(parts) == 0 {
 		return hardwareModel
 	}
+	// Drop the last name; for single names, use as-is.
+	firstName := strings.Join(parts[:max(1, len(parts)-1)], " ")
 	return firstName + "'s " + hardwareModel
 }
 

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -397,6 +397,12 @@ func (svc *Service) enrollHost(ctx context.Context, device *androidmanagement.De
 		}
 		host.TeamID = enrollSecret.GetTeamID()
 
+		if enrollmentTokenRequest.IdpUUID != "" {
+			if err := svc.ds.AssociateHostMDMIdPAccount(ctx, host.Host.UUID, enrollmentTokenRequest.IdpUUID); err != nil {
+				return ctxerr.Wrap(ctx, err, "updating IdP account on re-enrollment")
+			}
+		}
+
 		return svc.updateHost(ctx, device, host, true)
 	}
 

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -713,9 +713,9 @@ func (svc *Service) getHardwareModel(device *androidmanagement.Device) string {
 }
 
 func (svc *Service) getComputerName(device *androidmanagement.Device, idpFullname string) string {
-	hardwareModel := device.HardwareInfo.Model
+	hardwareModel := svc.getHardwareModel(device)
 	if idpFullname == "" {
-		return svc.getHardwareModel(device)
+		return hardwareModel
 	}
 	firstName := strings.SplitN(idpFullname, " ", 2)[0]
 	return firstName + "'s " + hardwareModel

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -346,6 +346,7 @@ func TestPubSubEnrollment(t *testing.T) {
 	})
 
 	t.Run("re-enrollment updates IdP association", func(t *testing.T) {
+		mockDS.NewAndroidHostFuncInvoked = false
 		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 			return &fleet.AppConfig{
 				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
@@ -400,8 +401,8 @@ func TestPubSubEnrollment(t *testing.T) {
 		require.True(t, mockDS.AssociateHostMDMIdPAccountFuncInvoked)
 		require.Equal(t, existingHostUUID, capturedHostUUID)
 		require.Equal(t, "new-user-idp-uuid", capturedIdpUUID)
-		// Should NOT have called NewAndroidHost (re-enrollment updates, not creates)
-		mockDS.NewAndroidHostFuncInvoked = false
+		// Re-enrollment should update, not create a new host
+		require.False(t, mockDS.NewAndroidHostFuncInvoked)
 	})
 }
 

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -986,9 +986,10 @@ func TestUpdateHost(t *testing.T) {
 		// UUID is properly set from device data
 		require.Equal(t, enterpriseSpecificID, capturedHost.Host.UUID, "UUID is properly set from EnterpriseSpecificId")
 
-		// Other fields were updated
+		// Other fields were updated (no IdP account, so falls back to hardware model)
 		require.Equal(t, "Updatedbrand UpdatedModel", capturedHost.Host.ComputerName)
 		require.Equal(t, "Updatedbrand UpdatedModel", capturedHost.Host.Hostname)
+		require.Equal(t, "Updatedbrand UpdatedModel", capturedHost.Host.HardwareModel)
 		require.Equal(t, "Android 15", capturedHost.Host.OSVersion)
 	})
 
@@ -1088,6 +1089,253 @@ func TestUpdateHost(t *testing.T) {
 		require.NotNil(t, capturedHost)
 
 		require.Equal(t, testBrandTestSerialHashed, capturedHost.Host.UUID)
+	})
+}
+
+func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
+	t.Run("updateHost uses IdP first name in computer name", func(t *testing.T) {
+		svc, mockDS := createAndroidService(t)
+
+		const enterpriseSpecificID = "IDP-TEST-UUID"
+
+		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
+			}, nil
+		}
+
+		mockDS.AndroidHostLiteFunc = func(ctx context.Context, esID string) (*fleet.AndroidHost, error) {
+			return &fleet.AndroidHost{
+				Host: &fleet.Host{
+					ID:   1,
+					UUID: enterpriseSpecificID,
+				},
+				Device: &android.Device{
+					HostID:               1,
+					DeviceID:             "device-1",
+					EnterpriseSpecificID: new(enterpriseSpecificID),
+				},
+			}, nil
+		}
+
+		// Mock IdP account lookup to return a user with a full name
+		mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+			return &fleet.MDMIdPAccount{
+				UUID:     "idp-acct-uuid",
+				Fullname: "Konstantin Sykulev",
+				Email:    "ksykulev@test.com",
+			}, nil
+		}
+
+		var capturedHost *fleet.AndroidHost
+		mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
+			capturedHost = host
+			return nil
+		}
+
+		device := androidmanagement.Device{
+			Name: createAndroidDeviceId("test-idp-display"),
+			HardwareInfo: &androidmanagement.HardwareInfo{
+				EnterpriseSpecificId: enterpriseSpecificID,
+				Brand:                "samsung",
+				Model:                "SM-A176U1",
+			},
+			SoftwareInfo: &androidmanagement.SoftwareInfo{AndroidVersion: "15"},
+			MemoryInfo:   &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
+			LastStatusReportTime: "2024-01-01T12:00:00Z",
+		}
+
+		deviceBytes, err := json.Marshal(device)
+		require.NoError(t, err)
+		message := &android.PubSubMessage{
+			Attributes: map[string]string{"notificationType": string(android.PubSubStatusReport)},
+			Data:       base64.StdEncoding.EncodeToString(deviceBytes),
+		}
+
+		err = svc.ProcessPubSubPush(t.Context(), "value", message)
+		require.NoError(t, err)
+		require.NotNil(t, capturedHost)
+
+		require.Equal(t, "Konstantin's SM-A176U1", capturedHost.Host.ComputerName)
+		require.Equal(t, "Konstantin's SM-A176U1", capturedHost.Host.Hostname)
+		require.Equal(t, "Samsung SM-A176U1", capturedHost.Host.HardwareModel)
+	})
+
+	t.Run("updateHost falls back to hardware model when no IdP account", func(t *testing.T) {
+		svc, mockDS := createAndroidService(t)
+
+		const enterpriseSpecificID = "NO-IDP-UUID"
+
+		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
+			}, nil
+		}
+
+		mockDS.AndroidHostLiteFunc = func(ctx context.Context, esID string) (*fleet.AndroidHost, error) {
+			return &fleet.AndroidHost{
+				Host: &fleet.Host{
+					ID:   2,
+					UUID: enterpriseSpecificID,
+				},
+				Device: &android.Device{
+					HostID:               2,
+					DeviceID:             "device-2",
+					EnterpriseSpecificID: new(enterpriseSpecificID),
+				},
+			}, nil
+		}
+
+		var capturedHost *fleet.AndroidHost
+		mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
+			capturedHost = host
+			return nil
+		}
+
+		device := androidmanagement.Device{
+			Name: createAndroidDeviceId("test-no-idp"),
+			HardwareInfo: &androidmanagement.HardwareInfo{
+				EnterpriseSpecificId: enterpriseSpecificID,
+				Brand:                "google",
+				Model:                "Pixel 7",
+			},
+			SoftwareInfo: &androidmanagement.SoftwareInfo{AndroidVersion: "14"},
+			MemoryInfo:   &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
+			LastStatusReportTime: "2024-01-01T12:00:00Z",
+		}
+
+		deviceBytes, err := json.Marshal(device)
+		require.NoError(t, err)
+		message := &android.PubSubMessage{
+			Attributes: map[string]string{"notificationType": string(android.PubSubStatusReport)},
+			Data:       base64.StdEncoding.EncodeToString(deviceBytes),
+		}
+
+		err = svc.ProcessPubSubPush(t.Context(), "value", message)
+		require.NoError(t, err)
+		require.NotNil(t, capturedHost)
+
+		require.Equal(t, "Google Pixel 7", capturedHost.Host.ComputerName)
+		require.Equal(t, "Google Pixel 7", capturedHost.Host.Hostname)
+		require.Equal(t, "Google Pixel 7", capturedHost.Host.HardwareModel)
+	})
+
+	t.Run("addNewHost uses IdP name when IdP UUID is present", func(t *testing.T) {
+		svc, mockDS := createAndroidService(t)
+
+		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
+			}, nil
+		}
+
+		mockDS.AndroidHostLiteFunc = func(ctx context.Context, esID string) (*fleet.AndroidHost, error) {
+			return nil, common_mysql.NotFound("android host")
+		}
+
+		mockDS.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+			return &fleet.EnrollSecret{Secret: secret}, nil
+		}
+
+		mockDS.GetMDMIdPAccountByUUIDFunc = func(ctx context.Context, uuid string) (*fleet.MDMIdPAccount, error) {
+			return &fleet.MDMIdPAccount{
+				UUID:     uuid,
+				Fullname: "Jane Doe",
+				Email:    "jane@test.com",
+			}, nil
+		}
+
+		var capturedHost *fleet.AndroidHost
+		mockDS.NewAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, companyOwned bool) (*fleet.AndroidHost, error) {
+			capturedHost = host
+			return &fleet.AndroidHost{Host: &fleet.Host{}}, nil
+		}
+
+		mockDS.AssociateHostMDMIdPAccountFunc = func(ctx context.Context, hostUUID, accountUUID string) error {
+			return nil
+		}
+		mockDS.MaybeAssociateHostWithScimUserFunc = func(ctx context.Context, hostID uint) error {
+			return nil
+		}
+
+		enrollmentToken := enrollmentTokenRequest{
+			EnrollSecret: "global",
+			IdpUUID:      "jane-idp-uuid",
+		}
+		enrollTokenData, err := json.Marshal(enrollmentToken)
+		require.NoError(t, err)
+
+		enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+			Name:                createAndroidDeviceId("test-idp-enroll"),
+			EnrollmentTokenData: string(enrollTokenData),
+		})
+
+		err = svc.ProcessPubSubPush(t.Context(), "value", enrollmentMessage)
+		require.NoError(t, err)
+		require.NotNil(t, capturedHost)
+
+		require.Equal(t, "Jane's TestModel", capturedHost.Host.ComputerName)
+		require.Equal(t, "Jane's TestModel", capturedHost.Host.Hostname)
+		require.Equal(t, "Testbrand TestModel", capturedHost.Host.HardwareModel)
+	})
+
+	t.Run("addNewHost falls back when IdP fullname is empty", func(t *testing.T) {
+		svc, mockDS := createAndroidService(t)
+
+		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
+			}, nil
+		}
+
+		mockDS.AndroidHostLiteFunc = func(ctx context.Context, esID string) (*fleet.AndroidHost, error) {
+			return nil, common_mysql.NotFound("android host")
+		}
+
+		mockDS.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+			return &fleet.EnrollSecret{Secret: secret}, nil
+		}
+
+		mockDS.GetMDMIdPAccountByUUIDFunc = func(ctx context.Context, uuid string) (*fleet.MDMIdPAccount, error) {
+			return &fleet.MDMIdPAccount{
+				UUID:     uuid,
+				Fullname: "",
+				Email:    "nofullname@test.com",
+			}, nil
+		}
+
+		var capturedHost *fleet.AndroidHost
+		mockDS.NewAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, companyOwned bool) (*fleet.AndroidHost, error) {
+			capturedHost = host
+			return &fleet.AndroidHost{Host: &fleet.Host{}}, nil
+		}
+
+		mockDS.AssociateHostMDMIdPAccountFunc = func(ctx context.Context, hostUUID, accountUUID string) error {
+			return nil
+		}
+		mockDS.MaybeAssociateHostWithScimUserFunc = func(ctx context.Context, hostID uint) error {
+			return nil
+		}
+
+		enrollmentToken := enrollmentTokenRequest{
+			EnrollSecret: "global",
+			IdpUUID:      "empty-name-uuid",
+		}
+		enrollTokenData, err := json.Marshal(enrollmentToken)
+		require.NoError(t, err)
+
+		enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+			Name:                createAndroidDeviceId("test-empty-name-enroll"),
+			EnrollmentTokenData: string(enrollTokenData),
+		})
+
+		err = svc.ProcessPubSubPush(t.Context(), "value", enrollmentMessage)
+		require.NoError(t, err)
+		require.NotNil(t, capturedHost)
+
+		// Falls back to Brand + Model when fullname is empty
+		require.Equal(t, "Testbrand TestModel", capturedHost.Host.ComputerName)
+		require.Equal(t, "Testbrand TestModel", capturedHost.Host.Hostname)
 	})
 }
 

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -1140,8 +1140,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 				Brand:                "samsung",
 				Model:                "SM-A176U1",
 			},
-			SoftwareInfo: &androidmanagement.SoftwareInfo{AndroidVersion: "15"},
-			MemoryInfo:   &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
+			SoftwareInfo:         &androidmanagement.SoftwareInfo{AndroidVersion: "15"},
+			MemoryInfo:           &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
 			LastStatusReportTime: "2024-01-01T12:00:00Z",
 		}
 
@@ -1156,8 +1156,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Konstantin's SM-A176U1", capturedHost.Host.ComputerName)
-		require.Equal(t, "Konstantin's SM-A176U1", capturedHost.Host.Hostname)
+		require.Equal(t, "Konstantin's Samsung SM-A176U1", capturedHost.Host.ComputerName)
+		require.Equal(t, "Konstantin's Samsung SM-A176U1", capturedHost.Host.Hostname)
 		require.Equal(t, "Samsung SM-A176U1", capturedHost.Host.HardwareModel)
 	})
 
@@ -1199,8 +1199,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 				Brand:                "google",
 				Model:                "Pixel 7",
 			},
-			SoftwareInfo: &androidmanagement.SoftwareInfo{AndroidVersion: "14"},
-			MemoryInfo:   &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
+			SoftwareInfo:         &androidmanagement.SoftwareInfo{AndroidVersion: "14"},
+			MemoryInfo:           &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
 			LastStatusReportTime: "2024-01-01T12:00:00Z",
 		}
 
@@ -1274,8 +1274,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Jane's TestModel", capturedHost.Host.ComputerName)
-		require.Equal(t, "Jane's TestModel", capturedHost.Host.Hostname)
+		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.ComputerName)
+		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.Hostname)
 		require.Equal(t, "Testbrand TestModel", capturedHost.Host.HardwareModel)
 	})
 

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -344,6 +344,65 @@ func TestPubSubEnrollment(t *testing.T) {
 			require.True(t, mockDS.NewAndroidHostFuncInvoked)
 		})
 	})
+
+	t.Run("re-enrollment updates IdP association", func(t *testing.T) {
+		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
+			}, nil
+		}
+
+		const existingHostUUID = "EXISTING-HOST-UUID"
+		// Return an existing host so enrollHost takes the re-enrollment path
+		mockDS.AndroidHostLiteFunc = func(ctx context.Context, esID string) (*fleet.AndroidHost, error) {
+			return &fleet.AndroidHost{
+				Host: &fleet.Host{
+					ID:   10,
+					UUID: existingHostUUID,
+				},
+				Device: &android.Device{
+					HostID:               10,
+					DeviceID:             "existing-device",
+					EnterpriseSpecificID: new(existingHostUUID),
+				},
+			}, nil
+		}
+
+		mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
+			return nil
+		}
+		mockDS.DeleteAllHostCertificateTemplatesFunc = func(ctx context.Context, hostUUID string) error {
+			return nil
+		}
+
+		var capturedHostUUID, capturedIdpUUID string
+		mockDS.AssociateHostMDMIdPAccountFuncInvoked = false
+		mockDS.AssociateHostMDMIdPAccountFunc = func(ctx context.Context, hostUUID, accountUUID string) error {
+			capturedHostUUID = hostUUID
+			capturedIdpUUID = accountUUID
+			return nil
+		}
+
+		enrollmentToken := enrollmentTokenRequest{
+			EnrollSecret: "global",
+			IdpUUID:      "new-user-idp-uuid",
+		}
+		enrollTokenData, err := json.Marshal(enrollmentToken)
+		require.NoError(t, err)
+		enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+			Name:                createAndroidDeviceId("test-re-enroll"),
+			EnrollmentTokenData: string(enrollTokenData),
+		})
+
+		err = svc.ProcessPubSubPush(t.Context(), "value", enrollmentMessage)
+		require.NoError(t, err)
+
+		require.True(t, mockDS.AssociateHostMDMIdPAccountFuncInvoked)
+		require.Equal(t, existingHostUUID, capturedHostUUID)
+		require.Equal(t, "new-user-idp-uuid", capturedIdpUUID)
+		// Should NOT have called NewAndroidHost (re-enrollment updates, not creates)
+		mockDS.NewAndroidHostFuncInvoked = false
+	})
 }
 
 func TestStatusReportPolicyValidation(t *testing.T) {

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -1182,7 +1182,7 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
 			return &fleet.MDMIdPAccount{
 				UUID:     "idp-acct-uuid",
-				Fullname: "Konstantin Sykulev",
+				Fullname: "John Smith",
 				Email:    "ksykulev@test.com",
 			}, nil
 		}
@@ -1216,8 +1216,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Konstantin's Samsung SM-A176U1", capturedHost.Host.ComputerName)
-		require.Equal(t, "Konstantin's Samsung SM-A176U1", capturedHost.Host.Hostname)
+		require.Equal(t, "John Smith's Samsung SM-A176U1", capturedHost.Host.ComputerName)
+		require.Equal(t, "John Smith's Samsung SM-A176U1", capturedHost.Host.Hostname)
 		require.Equal(t, "Samsung SM-A176U1", capturedHost.Host.HardwareModel)
 	})
 
@@ -1334,8 +1334,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.ComputerName)
-		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.Hostname)
+		require.Equal(t, "Jane Doe's Testbrand TestModel", capturedHost.Host.ComputerName)
+		require.Equal(t, "Jane Doe's Testbrand TestModel", capturedHost.Host.Hostname)
 		require.Equal(t, "Testbrand TestModel", capturedHost.Host.HardwareModel)
 	})
 

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -4368,7 +4368,7 @@ func (s *integrationMDMTestSuite) TestSetupExperienceAndroidCancelOnUnenroll() {
 	// activities got created as expected
 	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), fmt.Sprintf(`
 	{"enrollment_id": null, "host_display_name": %q, "host_serial": %q, "installed_from_dep": false, "platform": %q}`,
-		host1.DisplayName(), "", host1.Platform), 0) // for some reason the serial is force-set to empty string when we create this activity
+		host1.DisplayName(), host1.HardwareSerial, host1.Platform), 0)
 	s.lastActivityOfTypeMatches(fleet.ActivityInstalledAppStoreApp{}.ActivityName(), fmt.Sprintf(`{"app_store_id":%q,
 		"command_uuid":%q, "from_auto_update": false, "from_setup_experience": true, "host_display_name":%q, "host_id":%d, "host_platform":%q, "policy_id":null, "policy_name":null, "self_service":false, "software_title":%q,
 		"status":%q}`, app1.AdamID, app1CmdUUID, host1.DisplayName(), host1.ID, host1.Platform, app1.Name, fleet.SoftwareInstallFailed), 0)


### PR DESCRIPTION
**Related issue:** Resolves #41053

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android hosts associated with an IdP now display as "{IdP first name}'s {device model}" when IdP fullname is available.
  * Enrollment now links hosts to an MDM IdP account when enrollment payload includes IdP info.

* **Bug Fixes / Behavior**
  * Unenrollment records and host naming use device brand+model for hardware identification and sensible fallbacks when IdP data is missing.
  * Re-enrollment updates IdP association without creating duplicate hosts.

* **Tests**
  * Added tests covering display-name and hardware-model behavior with and without IdP data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->