### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bbedit/darwin.json
+++ b/ee/maintained-apps/outputs/bbedit/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "15.5.5",
+      "version": "16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.barebones.bbedit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.barebones.bbedit' AND version_compare(bundle_short_version, '15.5.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.barebones.bbedit' AND version_compare(bundle_short_version, '16.0') < 0);"
       },
-      "installer_url": "https://s3.amazonaws.com/BBSW-download/BBEdit_15.5.5.dmg",
+      "installer_url": "https://s3.amazonaws.com/BBSW-download/BBEdit_16.0.dmg",
       "install_script_ref": "c4ab4266",
       "uninstall_script_ref": "3e7616cd",
-      "sha256": "0ecac68f689df5751fde7e79b34387a099d7e00418e40aa23fdb24697cac8219",
+      "sha256": "c72d162800542ada299df33e1b8d72be17791fb0bdbec04dcde810980b75dd4f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/notion/windows.json
+++ b/ee/maintained-apps/outputs/notion/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.14.0",
+      "version": "7.18.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc' AND version_compare(version, '7.14.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc' AND version_compare(version, '7.18.0') < 0);"
       },
-      "installer_url": "https://desktop-release.notion-static.com/Notion%20Setup%207.14.0.exe",
+      "installer_url": "https://desktop-release.notion-static.com/Notion%20Setup%207.18.0.exe",
       "install_script_ref": "0803ad8c",
       "uninstall_script_ref": "a8fdd9b7",
-      "sha256": "5b36e13566332c20b1108f2d04aef94ccd697e83d662ee4a8c7aa7f1613594c8",
+      "sha256": "7e19a3a7c91aaafc1a996a8ce70bd052aaa37c4a0c2ddc1befece2eedb7d5132",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.12.14",
+      "version": "2.12.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.15') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.14/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.15/Stats.dmg",
       "install_script_ref": "f88ba8e0",
       "uninstall_script_ref": "732f0223",
-      "sha256": "63451c571af2ce2a3766f70d6a8ac8d545e9a365618fe9f204a25994aa3f7dbe",
+      "sha256": "80afcbaef90c68f95a9b9c3520c802e6bccfcded62b99bd84ce32a47177108ce",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version records for BBEdit macOS (15.5.5 → 16.0), Notion Windows (7.14.0 → 7.18.0), and Stats macOS (2.12.14 → 2.12.15). Each update includes refreshed installer downloads and updated verification checksums to maintain application security and integrity validation during installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->