### PR TITLE
support standard and none end user account types

### DIFF
--- a/changes/41781-macos-primary-account-type
+++ b/changes/41781-macos-primary-account-type
@@ -1,1 +1,1 @@
-- Added the feature to set the end user account type to `standard` for a non-admin privileged user or `none` for no end user account creation, both requiring a local admin account.
+- Added support for setting the end user account type to `standard` for a non-admin privileged user or `none` for no end user account creation, both requiring a local admin account.

--- a/changes/41781-macos-primary-account-type
+++ b/changes/41781-macos-primary-account-type
@@ -1,1 +1,1 @@
-- Added support for setting the end user account type to `standard` for a non-admin privileged user or `none` for no end user account creation, both requiring a local admin account.
+- Added support for setting the end user account type to `standard` for a standard (non-admin) user or `none` to skip end-user account creation, both requiring a local admin account.

--- a/changes/41781-macos-primary-account-type
+++ b/changes/41781-macos-primary-account-type
@@ -1,0 +1,1 @@
+- Added the feature to set the end user account type to `standard` for a non-admin privileged user or `none` for no end user account creation, both requiring a local admin account.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -284,14 +284,10 @@ func (svc *Service) updateAppConfigMDMAppleSetup(ctx context.Context, payload fl
 		}
 	}
 
-	if payload.EndUserLocalAccountType != nil {
-		if *payload.EndUserLocalAccountType != "admin" {
-			return fleet.NewInvalidArgumentError("end_user_local_account_type", `only "admin" is supported`)
-		}
-		if !ac.MDM.MacOSSetup.EndUserLocalAccountType.Valid || ac.MDM.MacOSSetup.EndUserLocalAccountType.Value != *payload.EndUserLocalAccountType {
-			ac.MDM.MacOSSetup.EndUserLocalAccountType = optjson.SetString(*payload.EndUserLocalAccountType)
-			didUpdate = true
-		}
+	if didUpdateFromValidation, err := payload.Validate(&ac.MDM.MacOSSetup); err != nil {
+		return err
+	} else if didUpdateFromValidation {
+		didUpdate = true
 	}
 
 	if didUpdate {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -2241,14 +2241,10 @@ func (svc *Service) updateTeamMDMAppleSetup(ctx context.Context, tm *fleet.Team,
 		}
 	}
 
-	if payload.EndUserLocalAccountType != nil {
-		if *payload.EndUserLocalAccountType != "admin" {
-			return fleet.NewInvalidArgumentError("end_user_local_account_type", `only "admin" is supported`)
-		}
-		if !tm.Config.MDM.MacOSSetup.EndUserLocalAccountType.Valid || tm.Config.MDM.MacOSSetup.EndUserLocalAccountType.Value != *payload.EndUserLocalAccountType {
-			tm.Config.MDM.MacOSSetup.EndUserLocalAccountType = optjson.SetString(*payload.EndUserLocalAccountType)
-			didUpdate = true
-		}
+	if didUpdateFromValidation, err := payload.Validate(&tm.Config.MDM.MacOSSetup); err != nil {
+		return err
+	} else if didUpdateFromValidation {
+		didUpdate = true
 	}
 
 	if didUpdate {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -324,6 +324,14 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			if !team.Config.MDM.MacOSSetup.EnableEndUserAuthentication && team.Config.MDM.MacOSSetup.LockEndUserInfo.Value {
 				return nil, fleet.NewInvalidArgumentError("setup_experience.lock_end_user_info", `"enable_end_user_authentication" must be set to "true" in order to enable "lock_end_user_info".`)
 			}
+
+			if err := payload.MDM.MacOSSetup.Validate(); err != nil {
+				return nil, err
+			}
+
+			// move over values that we just validated, so they get updated.
+			team.Config.MDM.MacOSSetup.EnableManagedLocalAccount = payload.MDM.MacOSSetup.EnableManagedLocalAccount
+			team.Config.MDM.MacOSSetup.EndUserLocalAccountType = payload.MDM.MacOSSetup.EndUserLocalAccountType
 		}
 	}
 

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -584,8 +584,12 @@ func (mos *MacOSSetup) Validate() error {
 		return NewInvalidArgumentError("setup_experience.macos_manual_agent_install", `Couldn't enable macos_manual_agent_install. To use this option, first specify a bootstrap package.`)
 	}
 
-	if mos.EndUserLocalAccountType.Valid && mos.EndUserLocalAccountType.Value != "admin" {
-		return NewInvalidArgumentError("end_user_local_account_type", `only "admin" is supported`)
+	if mos.EndUserLocalAccountType.Valid && !IsValidPrimaryAccountType(mos.EndUserLocalAccountType.Value) {
+		return NewInvalidArgumentError("end_user_local_account_type", `only "admin", "standard", and "none" are supported`)
+	}
+
+	if PrimaryAccountType(mos.EndUserLocalAccountType.Value).RequiresLocalAdminAccount() && (!mos.EnableManagedLocalAccount.Valid || !mos.EnableManagedLocalAccount.Value) {
+		return NewInvalidArgumentError("enable_create_local_admin_account", fmt.Sprintf(`enable_create_local_admin_account is required to be enabled when using %q for the end_user_local_account_type`, mos.EndUserLocalAccountType.Value))
 	}
 
 	return nil

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1270,6 +1270,33 @@ const (
 // feature is enabled.
 const ManagedLocalAccountUsername = "_fleetadmin"
 
+// PrimiaryAccountType represents the type of the primary account for MacOS going through setup experience.
+// Documented at https://developer.apple.com/documentation/devicemanagement/accountconfigurationcommand/command-data.dictionary
+// if `SetPrimarySetupAccountAsRegularUser` or `SkipPrimarySetupAccountCreation` is true, you must configure a local admin account.
+type PrimaryAccountType string
+
+const (
+	// The end user account will be created as an admin
+	PrimaryAccountTypeAdmin PrimaryAccountType = "admin"
+	// The end user account will be created as a standard user, but requires a local admin account to be configured.
+	PrimaryAccountTypeStandard PrimaryAccountType = "standard"
+	// The screen to setup a primary account will be skipped, and a local admin account must be configured.
+	PrimaryAccountTypeNone PrimaryAccountType = "none"
+)
+
+func IsValidPrimaryAccountType(accountType string) bool {
+	switch PrimaryAccountType(accountType) {
+	case PrimaryAccountTypeAdmin, PrimaryAccountTypeStandard, PrimaryAccountTypeNone:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t PrimaryAccountType) RequiresLocalAdminAccount() bool {
+	return t == PrimaryAccountTypeStandard || t == PrimaryAccountTypeNone
+}
+
 type HostLocationData struct {
 	HostID    uint    `db:"host_id"`
 	Latitude  float64 `db:"latitude"`

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/godep"
@@ -540,13 +541,32 @@ type MDMAppleSetupPayload struct {
 	RequireAllSoftware          *bool   `json:"require_all_software_macos"`
 	RequireAllSoftwareWindows   *bool   `json:"require_all_software_windows"`
 	LockEndUserInfo             *bool   `json:"lock_end_user_info"`
-	EnableManagedLocalAccount   *bool   `json:"enable_managed_local_account"`
+	EnableManagedLocalAccount   *bool   `json:"enable_managed_local_account" renameto:"enable_create_local_admin_account"`
 	EndUserLocalAccountType     *string `json:"end_user_local_account_type"`
 }
 
 // AuthzType implements authz.AuthzTyper.
 func (p MDMAppleSetupPayload) AuthzType() string {
 	return "mdm_apple_settings"
+}
+
+// Validate validates the MDMAppleSetupPayload and updates the provided MacOSSetup with the new values if they are valid.
+// It returns an error if any of the values are invalid, and a boolean indicating whether any updates were made to the MacOSSetup.
+func (p MDMAppleSetupPayload) Validate(macOSSetupConfig *MacOSSetup) (didUpdate bool, err error) {
+	if p.EndUserLocalAccountType != nil {
+		if !IsValidPrimaryAccountType(*p.EndUserLocalAccountType) {
+			return false, NewInvalidArgumentError("end_user_local_account_type", `only "admin", "standard", and "none" are supported`)
+		}
+		if PrimaryAccountType(*p.EndUserLocalAccountType).RequiresLocalAdminAccount() && (!macOSSetupConfig.EnableManagedLocalAccount.Valid || !macOSSetupConfig.EnableManagedLocalAccount.Value) {
+			return false, NewInvalidArgumentError("enable_create_local_admin_account", fmt.Sprintf(`enable_create_local_admin_account is required to be enabled when using %q for the end_user_local_account_type`, *p.EndUserLocalAccountType))
+		}
+
+		if !macOSSetupConfig.EndUserLocalAccountType.Valid || macOSSetupConfig.EndUserLocalAccountType.Value != *p.EndUserLocalAccountType {
+			macOSSetupConfig.EndUserLocalAccountType = optjson.SetString(*p.EndUserLocalAccountType)
+			didUpdate = true
+		}
+	}
+	return didUpdate, nil
 }
 
 // HostDEPAssignment represents a row in the host_dep_assignments table.
@@ -1270,7 +1290,7 @@ const (
 // feature is enabled.
 const ManagedLocalAccountUsername = "_fleetadmin"
 
-// PrimiaryAccountType represents the type of the primary account for MacOS going through setup experience.
+// PrimaryAccountType represents the type of the primary account for MacOS going through setup experience.
 // Documented at https://developer.apple.com/documentation/devicemanagement/accountconfigurationcommand/command-data.dictionary
 // if `SetPrimarySetupAccountAsRegularUser` or `SkipPrimarySetupAccountCreation` is true, you must configure a local admin account.
 type PrimaryAccountType string

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -343,10 +343,11 @@ type SSOAccountConfig struct {
 // AdminAccountConfig holds the parameters for an AutoSetupAdminAccounts entry
 // in an AccountConfiguration MDM command.
 type AdminAccountConfig struct {
-	ShortName    string // e.g. "_fleetadmin"
-	FullName     string // e.g. "Fleet Admin"
-	PasswordHash []byte // SALTED-SHA512-PBKDF2 plist from GenerateSaltedSHA512PBKDF2Hash
-	Hidden       bool   // true → hidden from login window
+	ShortName          string                   // e.g. "_fleetadmin"
+	FullName           string                   // e.g. "Fleet Admin"
+	PasswordHash       []byte                   // SALTED-SHA512-PBKDF2 plist from GenerateSaltedSHA512PBKDF2Hash
+	Hidden             bool                     // true → hidden from login window
+	PrimaryAccountType fleet.PrimaryAccountType // admin, standard, or none
 }
 
 func (svc *MDMAppleCommander) AccountConfiguration(ctx context.Context, hostUUIDs []string,
@@ -356,7 +357,8 @@ func (svc *MDMAppleCommander) AccountConfiguration(ctx context.Context, hostUUID
 ) error {
 	var payload string
 
-	if ssoAccount != nil {
+	// Send primay account info if we have an SSO account, and no adminAccount config or the primay account type is not "none"
+	if ssoAccount != nil && (adminAccount == nil || adminAccount.PrimaryAccountType != fleet.PrimaryAccountTypeNone) {
 		payload += fmt.Sprintf(`
       <key>PrimaryAccountFullName</key>
       <string>%s</string>
@@ -368,6 +370,21 @@ func (svc *MDMAppleCommander) AccountConfiguration(ctx context.Context, hostUUID
 	}
 
 	if adminAccount != nil {
+		switch adminAccount.PrimaryAccountType {
+		case fleet.PrimaryAccountTypeStandard:
+			payload += `
+      <key>SetPrimarySetupAccountAsRegularUser</key>
+      <true />
+		`
+		case fleet.PrimaryAccountTypeNone:
+			payload += `
+      <key>SkipPrimarySetupAccountCreation</key>
+      <true />
+		`
+		default:
+			// no-op for admin account type as that is default
+		}
+
 		passwordHashEncoded := base64.StdEncoding.EncodeToString(adminAccount.PasswordHash)
 		payload += fmt.Sprintf(`
       <key>AutoSetupAdminAccounts</key>

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -357,7 +357,7 @@ func (svc *MDMAppleCommander) AccountConfiguration(ctx context.Context, hostUUID
 ) error {
 	var payload string
 
-	// Send primay account info if we have an SSO account, and no adminAccount config or the primay account type is not "none"
+	// Send primay account info if we have an SSO account, and no adminAccount config or the primary account type is not "none"
 	if ssoAccount != nil && (adminAccount == nil || adminAccount.PrimaryAccountType != fleet.PrimaryAccountTypeNone) {
 		payload += fmt.Sprintf(`
       <key>PrimaryAccountFullName</key>

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -357,7 +357,7 @@ func (svc *MDMAppleCommander) AccountConfiguration(ctx context.Context, hostUUID
 ) error {
 	var payload string
 
-	// Send primay account info if we have an SSO account, and no adminAccount config or the primary account type is not "none"
+	// Send primary account info if we have an SSO account, and no adminAccount config or the primary account type is not "none"
 	if ssoAccount != nil && (adminAccount == nil || adminAccount.PrimaryAccountType != fleet.PrimaryAccountTypeNone) {
 		payload += fmt.Sprintf(`
       <key>PrimaryAccountFullName</key>

--- a/server/mdm/apple/commander_test.go
+++ b/server/mdm/apple/commander_test.go
@@ -828,6 +828,42 @@ func TestAccountConfigurationWithAdminAccount(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
 	})
+
+	t.Run("SSO + admin with none primary account", func(t *testing.T) {
+		mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+			raw := string(cmd.Raw)
+			require.NotContains(t, raw, "PrimaryAccountFullName")
+			require.Contains(t, raw, "AutoSetupAdminAccounts")
+			require.Contains(t, raw, "SkipPrimarySetupAccountCreation")
+			return nil, nil
+		}
+		mdmStorage.EnqueueCommandFuncInvoked = false
+
+		err := cmdr.AccountConfiguration(ctx, hostUUIDs, cmdUUID,
+			&SSOAccountConfig{FullName: "SSO User", UserName: "ssouser", LockPrimaryAccountInfo: false},
+			&AdminAccountConfig{ShortName: "_fleetadmin", FullName: "Fleet Admin", PasswordHash: []byte("fake-hash"), Hidden: true, PrimaryAccountType: fleet.PrimaryAccountTypeNone},
+		)
+		require.NoError(t, err)
+		require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
+	})
+
+	t.Run("SSO + admin with standard primary account", func(t *testing.T) {
+		mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+			raw := string(cmd.Raw)
+			require.Contains(t, raw, "PrimaryAccountFullName")
+			require.Contains(t, raw, "AutoSetupAdminAccounts")
+			require.Contains(t, raw, "SetPrimarySetupAccountAsRegularUser")
+			return nil, nil
+		}
+		mdmStorage.EnqueueCommandFuncInvoked = false
+
+		err := cmdr.AccountConfiguration(ctx, hostUUIDs, cmdUUID,
+			&SSOAccountConfig{FullName: "SSO User", UserName: "ssouser", LockPrimaryAccountInfo: false},
+			&AdminAccountConfig{ShortName: "_fleetadmin", FullName: "Fleet Admin", PasswordHash: []byte("fake-hash"), Hidden: true, PrimaryAccountType: fleet.PrimaryAccountTypeStandard},
+		)
+		require.NoError(t, err)
+		require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
+	})
 }
 
 func TestMDMAppleCommanderPassesCommandName(t *testing.T) {

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1387,7 +1387,7 @@ func TestMDMConfig(t *testing.T) {
 					EnableManagedLocalAccount: optjson.SetBool(false),
 				},
 			},
-			expectedError: `enable_managed_local_account is required to be enabled when using "standard" for the end_user_local_account_type`,
+			expectedError: `is required to be enabled when using "standard" for the end_user_local_account_type`,
 		},
 		{
 			name:        "end user account type none with disabled managed local account",
@@ -1398,7 +1398,7 @@ func TestMDMConfig(t *testing.T) {
 					EnableManagedLocalAccount: optjson.SetBool(false),
 				},
 			},
-			expectedError: `enable_managed_local_account is required to be enabled when using "none" for the end_user_local_account_type`,
+			expectedError: `is required to be enabled when using "none" for the end_user_local_account_type`,
 		},
 	}
 

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1378,6 +1378,28 @@ func TestMDMConfig(t *testing.T) {
 			},
 			expectedError: "mdmAppleServerURL must include a host",
 		},
+		{
+			name:        "end user account type standard with disabled managed local account",
+			licenseTier: "premium",
+			newMDM: fleet.MDM{
+				MacOSSetup: fleet.MacOSSetup{
+					EndUserLocalAccountType:   optjson.SetString("standard"),
+					EnableManagedLocalAccount: optjson.SetBool(false),
+				},
+			},
+			expectedError: `enable_managed_local_account is required to be enabled when using "standard" for the end_user_local_account_type`,
+		},
+		{
+			name:        "end user account type none with disabled managed local account",
+			licenseTier: "premium",
+			newMDM: fleet.MDM{
+				MacOSSetup: fleet.MacOSSetup{
+					EndUserLocalAccountType:   optjson.SetString("none"),
+					EnableManagedLocalAccount: optjson.SetBool(false),
+				},
+			},
+			expectedError: `enable_managed_local_account is required to be enabled when using "none" for the end_user_local_account_type`,
+		},
 	}
 
 	for _, tt := range testCases {

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -213,6 +213,7 @@ func (a *AppleMDM) runPostDEPEnrollment(ctx context.Context, args appleMDMArgs) 
 	awaitCmdUUIDs = append(awaitCmdUUIDs, cmdUUIDs...)
 
 	var ssoEnabled, managedAdminAccountEnabled, lockPrimaryAccountInfo bool
+	var primaryAccountType fleet.PrimaryAccountType
 	var ssoAccount *fleet.MDMIdPAccount
 	var adminAccount *apple_mdm.AdminAccountConfig
 
@@ -244,11 +245,13 @@ func (a *AppleMDM) runPostDEPEnrollment(ctx context.Context, args appleMDMArgs) 
 				return err
 			}
 			managedAdminAccountEnabled = appCfg.MDM.MacOSSetup.EnableManagedLocalAccount.Value
+			primaryAccountType = fleet.PrimaryAccountType(appCfg.MDM.MacOSSetup.EndUserLocalAccountType.Value)
 		} else {
 			if team, err = a.getTeamConfig(ctx, team, *args.TeamID); err != nil {
 				return err
 			}
 			managedAdminAccountEnabled = team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value
+			primaryAccountType = fleet.PrimaryAccountType(team.Config.MDM.MacOSSetup.EndUserLocalAccountType.Value)
 		}
 	}
 
@@ -264,11 +267,13 @@ func (a *AppleMDM) runPostDEPEnrollment(ctx context.Context, args appleMDMArgs) 
 			if err != nil {
 				return err
 			}
+
 			adminAccount = &apple_mdm.AdminAccountConfig{
-				ShortName:    fleet.ManagedLocalAccountUsername,
-				FullName:     fleetAdminFullName,
-				PasswordHash: passwordHash,
-				Hidden:       true,
+				ShortName:          fleet.ManagedLocalAccountUsername,
+				FullName:           fleetAdminFullName,
+				PasswordHash:       passwordHash,
+				Hidden:             true,
+				PrimaryAccountType: primaryAccountType,
 			}
 			// Save the password before sending the command so the plaintext is
 			// escrowed even if the command enqueue succeeds but a later step fails.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45286 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


Create local admin account = true
Primary account type = none
End user auth required = true
= No primary account setup screen shown - jumps straight to username/password login which I can login to with the password shown in the UI.
Running `dscacheutil -q user | grep -A 3 -B 2 -e uid:\ 5'[0-9][0-9]’` only returns `_fleetadmin`

**Note: EACAS is not available on this mac (or this user?)** - however it’s still possible to Wipe via MDM commands.

Create local admin account = true
Primary account type = standard
End user auth required = true
= Primary account setup screen shown (also works with IDP info being locked and populated).
Running `dscacheutil -q user | grep -A 3 -B 2 -e uid:\ 5'[0-9][0-9]’` returns `_fleetadmin` and my end user (IDP info locked in this case)
Opening Settings -> Users & Groups -> Shows my primary account as “Standard”

**Note: Benefit of the user can’t do EACAS** (Prompted: “Admin user required”)
__fleetadmin also can’t do EACAS_

Create local admin account = false
Primary Account type = N/A (but admin)
End user auth required = true
= Shown primary account setup screen with IDP info populated and locked
Running `dscacheutil -q user | grep -A 3 -B 2 -e uid:\ 5'[0-9][0-9]’` only returns my primary user
Opening Settings -> Users & groups -> shows my primary account as “Admin"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS setup now supports end-user account types: `admin`, `standard`, or `none`.
  * Setup flows and device commands respect the selected primary account type (e.g., create regular user or skip creation).

* **Validation**
  * Configuration now enforces that a local admin account exists/enabled when required by the chosen end-user account type.

* **Tests**
  * Added coverage for `standard` and `none` validation and command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->