### PR TITLE
Add Organic AI referrer attribution

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -324,6 +324,38 @@ module.exports = {
             'https://www.quora.com/',
           ];
 
+          let REFERRER_DOMAINS_FOR_ORGANIC_AI = [
+            // === MAJOR GLOBAL AI CHATBOTS ===
+            'https://chat.openai.com/',
+            'https://chatgpt.com/',
+            'https://claude.ai/',
+            'https://claude.com/',
+            'https://gemini.google.com/',
+            'https://bard.google.com/',
+            'https://copilot.microsoft.com/',
+            'https://copilot.cloud.microsoft/',
+            'https://www.bing.com/chat',
+            // === QWEN / ALIBABA ECOSYSTEM ===
+            'https://chat.qwen.ai/',
+            'https://chat.qwenlm.ai/',
+            'https://qwen.ai/',
+            // === AI SEARCH ENGINES ===
+            'https://www.perplexity.ai/',
+            'https://perplexity.ai/',
+            // === META / X / SOCIAL AI ===
+            'https://www.meta.ai/',
+            'https://ai.meta.com/',
+            'https://grok.com/',
+            'https://grok.x.ai/',
+            'https://x.ai/',
+            // === AGGREGATORS & MULTI-MODEL PLATFORMS ===
+            'https://poe.com/',
+            'https://www.poe.com/',
+            'https://huggingface.co/chat/',
+            'https://together.ai/',
+            'https://platform.mistral.ai/chat',
+          ];
+
           let referrer = typeof marketingAttributionCookie.referrer === 'string'
             ? marketingAttributionCookie.referrer
             : '';
@@ -336,6 +368,19 @@ module.exports = {
             // If social media » Organic social
             attributionDetails.sourceChannelDetails = 'Organic social (SOC)';
             attributionDetails.campaign = 'Default-SOC-Social';
+          } else if(REFERRER_DOMAINS_FOR_ORGANIC_AI.some((domain) => referrer.startsWith(domain))) {
+            // If AI/LLM » Organic AI
+            attributionDetails.sourceChannelDetails = 'Organic AI (AI)';
+            // Determine specific campaign based on which AI platform referred the visitor
+            if(['https://chat.openai.com/', 'https://chatgpt.com/'].some((domain) => referrer.startsWith(domain))) {
+              attributionDetails.campaign = 'Default-AI-ChatGPT';
+            } else if(['https://claude.ai/', 'https://claude.com/'].some((domain) => referrer.startsWith(domain))) {
+              attributionDetails.campaign = 'Default-AI-Claude';
+            } else if(['https://gemini.google.com/', 'https://bard.google.com/'].some((domain) => referrer.startsWith(domain))) {
+              attributionDetails.campaign = 'Default-AI-Gemini';
+            } else {
+              attributionDetails.campaign = 'Default-AI-Other';
+            }
           } else {
             // If not either of those » Web referral
             attributionDetails.sourceChannelDetails = 'Web referral (WR)';

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -286,7 +286,7 @@ module.exports = {
           // Otherwise, we'll check the referer value and attempt to categorize the referer.
           let REFERRER_DOMAINS_FOR_ORGANIC_SEARCH = [
             'https://www.google.',      // covers all ~190 country variants (google.com, google.co.uk, google.de, etc.)
-            'https://www.bing.com/',
+            'https://www.bing.com/search',
             'https://search.yahoo.com/',
             'https://duckduckgo.com/',
             'https://www.baidu.com/',


### PR DESCRIPTION
Detect AI/LLM referrers and classify them as an "Organic AI (AI)" source. Adds a REFERRER_DOMAINS_FOR_ORGANIC_AI list and branching logic to set attributionDetails.sourceChannelDetails and attributionDetails.campaign based on the referring AI platform (ChatGPT, Claude, Gemini, or Other) in website/api/helpers/salesforce/update-or-create-contact-and-account.js.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** 
resolves fleetdm/confidential#16034
 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved contact attribution: traffic from AI/LLM platforms (ChatGPT, Claude, Gemini, etc.) is now labeled "Organic AI (AI)" and assigned platform-specific default campaigns.
  * Refined organic search detection to better identify Bing search referrals.
  * Other non-digital/non-event referrers now default to "Web referral (WR)".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->