### PR TITLE
Add VEX entries for Docker test-only CVEs

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -5,6 +5,30 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/fleet` docker image
 
+### [CVE-2026-42306](https://nvd.nist.gov/vuln/detail/CVE-2026-42306)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.
+- **Products:** `fleet`,`pkg:golang/github.com/docker/docker`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-26 15:38:17
+
+### [CVE-2026-41568](https://nvd.nist.gov/vuln/detail/CVE-2026-41568)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.
+- **Products:** `fleet`,`pkg:golang/github.com/docker/docker`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-26 15:38:17
+
+### [CVE-2026-41567](https://nvd.nist.gov/vuln/detail/CVE-2026-41567)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.
+- **Products:** `fleet`,`pkg:golang/github.com/docker/docker`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-26 15:38:17
+
 ### [CVE-2026-40200](https://nvd.nist.gov/vuln/detail/CVE-2026-40200)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -20,6 +44,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `fleet`,`pkg:golang/go.opentelemetry.io/otel/sdk`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-04-27 15:03:59
+
+### [CVE-2026-33997](https://nvd.nist.gov/vuln/detail/CVE-2026-33997)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.
+- **Products:** `fleet`,`pkg:golang/github.com/docker/docker`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-26 15:38:16
 
 ### [CVE-2026-33487](https://nvd.nist.gov/vuln/detail/CVE-2026-33487)
 - **Author:** @lucasmrod

--- a/security/vex/fleet/CVE-2026-33997.vex.json
+++ b/security/vex/fleet/CVE-2026-33997.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-33997",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-26T00:00:00.000000-00:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33997"
+      },
+      "timestamp": "2026-05-26T00:00:00.000000-00:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable plugin installation path is never exercised.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-33997.vex.json
+++ b/security/vex/fleet/CVE-2026-33997.vex.json
@@ -1,15 +1,13 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-33997",
+  "@id": "https://openvex.dev/docs/public/vex-9b49895204a27c8295aa7229a83e8fc40f5476b759b2c142bde73adbc995ae43",
   "author": "@lucasmrod",
-  "timestamp": "2026-05-26T00:00:00.000000-00:00",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-33997"
       },
-      "timestamp": "2026-05-26T00:00:00.000000-00:00",
       "products": [
         {
           "@id": "fleet"
@@ -19,8 +17,10 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable plugin installation path is never exercised.",
-      "justification": "vulnerable_code_not_in_execute_path"
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-05-26T15:38:16.990744Z"
     }
-  ]
+  ],
+  "timestamp": "2026-05-26T15:38:16Z"
 }

--- a/security/vex/fleet/CVE-2026-41567.vex.json
+++ b/security/vex/fleet/CVE-2026-41567.vex.json
@@ -1,15 +1,13 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-41567",
+  "@id": "https://openvex.dev/docs/public/vex-85ac9218f7a3f9c7f104635a5a9a123e9d2776db0511100659b23ef16fce59be",
   "author": "@lucasmrod",
-  "timestamp": "2026-05-26T00:00:00.000000-00:00",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-41567"
       },
-      "timestamp": "2026-05-26T00:00:00.000000-00:00",
       "products": [
         {
           "@id": "fleet"
@@ -19,8 +17,10 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable docker cp archive endpoint path is never exercised.",
-      "justification": "vulnerable_code_not_in_execute_path"
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-05-26T15:38:17.019283Z"
     }
-  ]
+  ],
+  "timestamp": "2026-05-26T15:38:17Z"
 }

--- a/security/vex/fleet/CVE-2026-41567.vex.json
+++ b/security/vex/fleet/CVE-2026-41567.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-41567",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-26T00:00:00.000000-00:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "timestamp": "2026-05-26T00:00:00.000000-00:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable docker cp archive endpoint path is never exercised.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-41568.vex.json
+++ b/security/vex/fleet/CVE-2026-41568.vex.json
@@ -1,15 +1,13 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-41568",
+  "@id": "https://openvex.dev/docs/public/vex-8e68dde048d6149ae27bc31189aad00fd65ecfd808c4031e6e3d76b45f9e3fba",
   "author": "@lucasmrod",
-  "timestamp": "2026-05-26T00:00:00.000000-00:00",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-41568"
       },
-      "timestamp": "2026-05-26T00:00:00.000000-00:00",
       "products": [
         {
           "@id": "fleet"
@@ -19,8 +17,10 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable docker cp symlink swap race condition path is never exercised.",
-      "justification": "vulnerable_code_not_in_execute_path"
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-05-26T15:38:17.167065Z"
     }
-  ]
+  ],
+  "timestamp": "2026-05-26T15:38:17Z"
 }

--- a/security/vex/fleet/CVE-2026-41568.vex.json
+++ b/security/vex/fleet/CVE-2026-41568.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-41568",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-26T00:00:00.000000-00:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "timestamp": "2026-05-26T00:00:00.000000-00:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable docker cp symlink swap race condition path is never exercised.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-42306.vex.json
+++ b/security/vex/fleet/CVE-2026-42306.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-42306",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-26T00:00:00.000000-00:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "timestamp": "2026-05-26T00:00:00.000000-00:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable docker cp bind mount race condition path is never exercised.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-42306.vex.json
+++ b/security/vex/fleet/CVE-2026-42306.vex.json
@@ -1,15 +1,13 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-fleet-CVE-2026-42306",
+  "@id": "https://openvex.dev/docs/public/vex-0ea4c563f1cb4cda50b14078bc1010142b18828e25cd99d2b8c05e4c8a3d1f95",
   "author": "@lucasmrod",
-  "timestamp": "2026-05-26T00:00:00.000000-00:00",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-42306"
       },
-      "timestamp": "2026-05-26T00:00:00.000000-00:00",
       "products": [
         {
           "@id": "fleet"
@@ -19,8 +17,10 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary. The vulnerable docker cp bind mount race condition path is never exercised.",
-      "justification": "vulnerable_code_not_in_execute_path"
+      "status_notes": "github.com/docker/docker is only imported in test/upgrade/fleet_test.go and is never compiled into the fleet binary.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-05-26T15:38:17.313745Z"
     }
-  ]
+  ],
+  "timestamp": "2026-05-26T15:38:17Z"
 }


### PR DESCRIPTION
## Summary

- Adds VEX (Vulnerability Exploitability eXchange) entries for four Docker CVEs that don't affect Fleet
- `github.com/docker/docker` is only imported in `test/upgrade/fleet_test.go` and is never compiled into the `fleet` or `fleetctl` binaries
- Also dismissed the corresponding code-scanning alerts (#1811, #1817, #1818, #1819) as "used in tests"

### CVEs covered

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-33997 | MEDIUM | Privilege validation bypass during plugin installation |
| CVE-2026-41567 | HIGH | `PUT /containers/{id}/archive` executes container binary on host |
| CVE-2026-41568 | MEDIUM | Race condition in docker cp via symlink swap |
| CVE-2026-42306 | HIGH | Race condition in docker cp bind mount redirection |

## Test plan

- [x] Verified `github.com/docker/docker` is only imported in `test/upgrade/fleet_test.go`
- [x] VEX files follow existing format in `security/vex/fleet/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OpenVEX security declarations for four CVEs stating they do not affect the fleet product; each includes status notes explaining the vulnerable code is only referenced in tests and not included in the runtime, along with justifications and timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->