### PR TITLE
Ignore WiX CVEs on kerberos

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -691,6 +691,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:16:53
 
+### [CVE-2026-40356](https://nvd.nist.gov/vuln/detail/CVE-2026-40356)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use Kerberos when using fleetdm/wix to generate msi installers.
+- **Products:** `wix`,`pkg:deb/debian/libgssapi-krb5-2`,`pkg:deb/debian/libk5crypto3`,`pkg:deb/debian/libkrb5-3`,`pkg:deb/debian/libkrb5support0`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-05-26 10:42:11
+
 ### [CVE-2026-3833](https://nvd.nist.gov/vuln/detail/CVE-2026-3833)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/wix/CVE-2026-40356.vex.json
+++ b/security/vex/wix/CVE-2026-40356.vex.json
@@ -1,0 +1,35 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-3e17ee99d1248a0ad45a7c42554d6b1e8df616f307ad04c0f264230282d57f17",
+  "author": "@lucasmrod",
+  "timestamp": "2026-05-26T10:42:11.889571-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40356"
+      },
+      "timestamp": "2026-05-26T10:42:11.889571-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgssapi-krb5-2"
+        },
+        {
+          "@id": "pkg:deb/debian/libk5crypto3"
+        },
+        {
+          "@id": "pkg:deb/debian/libkrb5-3"
+        },
+        {
+          "@id": "pkg:deb/debian/libkrb5support0"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use Kerberos when using fleetdm/wix to generate msi installers",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/26437524407.

Run: https://github.com/fleetdm/fleet/actions/runs/26452111600.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added security vulnerability assessment documentation for CVE-2026-40356, confirming this application is not affected by the vulnerability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->