### PR TITLE
Update loadtest ALB TLS policy to TLS 1.3

### DIFF
--- a/infrastructure/loadtesting/terraform/shared/alb.tf
+++ b/infrastructure/loadtesting/terraform/shared/alb.tf
@@ -149,7 +149,7 @@ resource "aws_alb_listener" "https-fleetdm" {
   load_balancer_arn = aws_alb.main.arn
   port              = 443
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = aws_acm_certificate_validation.wildcard.certificate_arn
 
   default_action {


### PR DESCRIPTION
## Summary

- Upgrades the shared loadtest ALB `ssl_policy` from `ELBSecurityPolicy-FS-1-2-Res-2019-08` (2019) to `ELBSecurityPolicy-TLS13-1-2-2021-06`, matching the internal ALB that already uses the newer policy.

**Origin:** Flagged as critical by Aikido SAST scan ("Load balancer is using outdated TLS policy" in `internal_alb.tf` and `alb.tf`).

## Test plan

- [ ] Verify `terraform plan` shows only the ssl_policy change on the shared ALB listener
- [ ] Apply and confirm loadtest endpoints still accept TLS connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TLS/SSL security policy configuration for improved security posture and compatibility with modern encryption standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->