### PR TITLE
Fix missing tags for OPA policy

### DIFF
--- a/changes/46009-fix-missing-opa-policy-tags
+++ b/changes/46009-fix-missing-opa-policy-tags
@@ -1,0 +1,1 @@
+* Fixed permissions on host activity items for fleet-scoped users.

--- a/server/activity/host.go
+++ b/server/activity/host.go
@@ -8,7 +8,7 @@ import "context"
 // object.team_id (e.g. team-scoped admins reading host activities) will fail.
 type Host struct {
 	ID     uint  `json:"id"`
-	TeamID *uint `json:"team_id"`
+	TeamID *uint `json:"team_id"` //nolint apiparamcheck // internal struct, tag used by OPA policy engine, not emitted to user
 }
 
 // AuthzType returns the authorization type for hosts.

--- a/server/activity/host.go
+++ b/server/activity/host.go
@@ -3,9 +3,12 @@ package activity
 import "context"
 
 // Host represents minimal host info needed by the activity context for authorization.
+// The json tags must match the field names referenced by the OPA policy (see
+// server/authz/policy.rego), otherwise authorization checks that depend on
+// object.team_id (e.g. team-scoped admins reading host activities) will fail.
 type Host struct {
-	ID     uint
-	TeamID *uint
+	ID     uint  `json:"id"`
+	TeamID *uint `json:"team_id"`
 }
 
 // AuthzType returns the authorization type for hosts.

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/activity"
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
@@ -1216,6 +1217,76 @@ func TestAuthorizeHost(t *testing.T) {
 		{user: teamTechnician, object: hostTeam2, action: write, allow: false},
 		{user: teamTechnician, object: hostTeam2, action: cancelHostActivity, allow: false},
 		{user: teamTechnician, object: hostTeam2, action: transferHost, allow: false},
+	})
+}
+
+// TestAuthorizeActivityHost verifies that the bounded-context activity.Host
+// type is serialized with the json field names the OPA policy expects
+// (object.team_id, object.id). Without those tags, team-scoped users get a
+// 403 when listing host past activities (issue #46009).
+func TestAuthorizeActivityHost(t *testing.T) {
+	t.Parallel()
+
+	teamAdmin := &fleet.User{
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin},
+		},
+	}
+	teamMaintainer := &fleet.User{
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer},
+		},
+	}
+	teamObserver := &fleet.User{
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver},
+		},
+	}
+	teamTechnician := &fleet.User{
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleTechnician},
+		},
+	}
+	teamGitOps := &fleet.User{
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps},
+		},
+	}
+
+	globalHost := &activity.Host{}
+	hostTeam1 := &activity.Host{ID: 10, TeamID: new(uint(1))}
+	hostTeam2 := &activity.Host{ID: 11, TeamID: new(uint(2))}
+
+	runTestCases(t, []authTestCase{
+		// Global admin can read any host.
+		{user: test.UserAdmin, object: globalHost, action: list, allow: true},
+		{user: test.UserAdmin, object: hostTeam1, action: read, allow: true},
+		{user: test.UserAdmin, object: hostTeam2, action: read, allow: true},
+
+		// Team admin can read hosts on their team but not other teams.
+		{user: teamAdmin, object: globalHost, action: list, allow: true},
+		{user: teamAdmin, object: hostTeam1, action: read, allow: true},
+		{user: teamAdmin, object: hostTeam2, action: read, allow: false},
+
+		// Team maintainer / observer can also read hosts on their team.
+		{user: teamMaintainer, object: hostTeam1, action: read, allow: true},
+		{user: teamMaintainer, object: hostTeam2, action: read, allow: false},
+		{user: teamObserver, object: hostTeam1, action: read, allow: true},
+		{user: teamObserver, object: hostTeam2, action: read, allow: false},
+
+		// Team technician can also read hosts on their team.
+		{user: teamTechnician, object: globalHost, action: list, allow: true},
+		{user: teamTechnician, object: hostTeam1, action: read, allow: true},
+		{user: teamTechnician, object: hostTeam2, action: read, allow: false},
+
+		// Team gitops cannot list or read hosts (only selective variants).
+		{user: teamGitOps, object: globalHost, action: list, allow: false},
+		{user: teamGitOps, object: hostTeam1, action: read, allow: false},
+		{user: teamGitOps, object: hostTeam2, action: read, allow: false},
+
+		// Users with no roles or no user cannot read.
+		{user: nil, object: hostTeam1, action: read, allow: false},
+		{user: test.UserNoRoles, object: hostTeam1, action: read, allow: false},
 	})
 }
 


### PR DESCRIPTION
Resolves #46009.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permissions for host activity items by aligning serialized field names used by authorization rules, ensuring fleet-scoped users receive correct access rights when listing and reading host activities.

* **Tests**
  * Added authorization tests validating host activity access control across user roles and team scopes, including denial cases for unauthorized and GitOps-scoped users, and verifying policy evaluation depends on correct serialized field naming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->