### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/arduino-ide/darwin.json
+++ b/ee/maintained-apps/outputs/arduino-ide/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.3.8",
+      "version": "2.3.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2' AND version_compare(bundle_short_version, '2.3.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2' AND version_compare(bundle_short_version, '2.3.9') < 0);"
       },
-      "installer_url": "https://github.com/arduino/arduino-ide/releases/download/2.3.8/arduino-ide_2.3.8_macOS_ARM64.dmg",
+      "installer_url": "https://github.com/arduino/arduino-ide/releases/download/2.3.9/arduino-ide_2.3.9_macOS_ARM64.dmg",
       "install_script_ref": "b8e694ce",
       "uninstall_script_ref": "7daa5478",
-      "sha256": "8965919943d12dd68ca5ee20947bc2b37dc5aa297c5b30e22a890f84ef72c2ec",
+      "sha256": "88dcbe0360a6d96e811413110fc4c72e66e14e0c2fd93994bc1c82fc90ef3917",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8555.2",
+      "version": "1.9255.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.8555.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.9255.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.8555.2/Claude-a476c316c741715263e34f9c9d2bc45b6d0f21c7.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.9255.0/Claude-a22af1fabbbc85af5502e695ed8fbea9f74276fc.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "e555285c",
-      "sha256": "0036e1dc8182aedca17975ae5038217a1b8bf137c8f9a435c3af843eaea9050d",
+      "sha256": "a5945869a0968131a8768d83425a3ec969571940b16be646c7c8b16f889b0476",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/docker-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/docker-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.74.0",
+      "version": "4.75.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '4.74.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '4.75.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/mac/main/arm64/227015/Docker.dmg",
+      "installer_url": "https://desktop.docker.com/mac/main/arm64/227598/Docker.dmg",
       "install_script_ref": "2c3a200a",
       "uninstall_script_ref": "f8ed2624",
-      "sha256": "3878ec12155c530db007176499c7e751373e67672799c55921c593b8f2f9c0ad",
+      "sha256": "e0c3ef57125b17947e8af92624bd27594201fabb7a2320917e861739e00216d3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox/windows.json
+++ b/ee/maintained-apps/outputs/firefox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0.1",
+      "version": "151.0.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '151.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '151.0.2') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.1/win64/en-US/Firefox%20Setup%20151.0.1.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.2/win64/en-US/Firefox%20Setup%20151.0.2.exe",
       "install_script_ref": "80fb9175",
       "uninstall_script_ref": "8b5e20e4",
-      "sha256": "1275fd22df71bab098c19671d6c5037c424a1594359a721be20a642c827f6e71",
+      "sha256": "bf3ad3e5aca6d619785393920bc02ca81b8fe50e661fb8c50f9802868e2043b1",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/github/darwin.json
+++ b/ee/maintained-apps/outputs/github/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.10",
+      "version": "3.5.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.5.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.5.11') < 0);"
       },
-      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.10-497192a5/GitHubDesktop-arm64.zip",
+      "installer_url": "https://desktop.githubusercontent.com/releases/3.5.11-0435ec91/GitHubDesktop-arm64.zip",
       "install_script_ref": "98ab6ed8",
       "uninstall_script_ref": "ab6a6ca8",
-      "sha256": "af45420fc99b318233862855787d7e193ba0eef042ede17e7a072a95079d98f3",
+      "sha256": "b3c060c4e532931b2f811a82f3b1c4a191e82a11e8410bf9509758eb483dd9b5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/lens/darwin.json
+++ b/ee/maintained-apps/outputs/lens/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.5.181248-latest",
+      "version": "2026.5.250609-latest",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens' AND version_compare(bundle_short_version, '2026.5.181248-latest') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens' AND version_compare(bundle_short_version, '2026.5.250609-latest') < 0);"
       },
-      "installer_url": "https://api.k8slens.dev/binaries/Lens-2026.5.181248-latest-arm64.dmg",
+      "installer_url": "https://api.k8slens.dev/binaries/Lens-2026.5.250609-latest-arm64.dmg",
       "install_script_ref": "89ac64d8",
       "uninstall_script_ref": "95e6d734",
-      "sha256": "998056305efe76e5cf9943d54e66c67abdb948d9a0d615d2c997ed468f08ee03",
+      "sha256": "35422972067007a6d79b650a7142bfcd3447df6ec21ce2bd9f4c7e228c0fea04",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/nordvpn/darwin.json
+++ b/ee/maintained-apps/outputs/nordvpn/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "10.2.0",
+      "version": "10.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos' AND version_compare(bundle_short_version, '10.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos' AND version_compare(bundle_short_version, '10.3.0') < 0);"
       },
-      "installer_url": "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/10.2.0/NordVPN.pkg",
+      "installer_url": "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/10.3.0/NordVPN.pkg",
       "install_script_ref": "60b24e24",
       "uninstall_script_ref": "70d47f9b",
-      "sha256": "6eb85dc88a50dec2d9b58473e95153dad80a169a53ec1281315f36948be0d7f2",
+      "sha256": "a321e7abec9521ff07dbaabc49606f4adf8cc070112f1db7fd3ccbe16b49b1b4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tableplus/darwin.json
+++ b/ee/maintained-apps/outputs/tableplus/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.0.8",
+      "version": "7.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus' AND version_compare(bundle_short_version, '7.0.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus' AND version_compare(bundle_short_version, '7.1.0') < 0);"
       },
-      "installer_url": "https://files.tableplus.com/macos/708/TablePlus.dmg",
+      "installer_url": "https://files.tableplus.com/macos/710/TablePlus.dmg",
       "install_script_ref": "6ebc9cac",
       "uninstall_script_ref": "bc329865",
-      "sha256": "ccbcc494bd5367ac28ecefbf671fcc98ca3629e46e0b2d8d5dabd92ca6df9cfc",
+      "sha256": "e409a746cf45ac33d578b2c4062578c4edf090174c729304f901cafd1cd90ad3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/teamviewer/darwin.json
+++ b/ee/maintained-apps/outputs/teamviewer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "15.76.6",
+      "version": "15.78.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.teamviewer.TeamViewer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.teamviewer.TeamViewer' AND version_compare(bundle_short_version, '15.76.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.teamviewer.TeamViewer' AND version_compare(bundle_short_version, '15.78.3') < 0);"
       },
-      "installer_url": "https://dl.teamviewer.com/download/version_15x/update/15.76.6/TeamViewer.pkg",
+      "installer_url": "https://dl.teamviewer.com/download/version_15x/update/15.78.3/TeamViewer.pkg",
       "install_script_ref": "71f9d405",
       "uninstall_script_ref": "fd3bdba8",
-      "sha256": "53da43ca1b151b611baf2b5d305dec655c3e38084e5c3b5df1900f8542a1e47b",
+      "sha256": "a29a1fcbd7093df5b99439803b2b97d80d15d65a2f99be508a5202a7daff275a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.20.23",
+      "version": "26.21.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.20.23') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.21.15') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "a776e715",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata for maintained applications: Arduino IDE (2.3.9), Claude Desktop (1.9255.0), Docker Desktop (4.75.0), Firefox (151.0.2), GitHub Desktop (3.5.11), Lens (2026.5.250609-latest), NordVPN (10.3.0), TablePlus (7.1.0), TeamViewer (15.78.3), and WhatsApp (26.21.15).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->