### PR TITLE
Skip smtp4dev dev TLS key in Trivy secret scanner

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -138,9 +138,11 @@ jobs:
           # - website/config/custom.js: commented-out Stripe test-mode placeholders shown as example config.
           # - ee/fleet-agent-downloader/config/custom.js: same Sails template, commented-out Stripe test placeholders.
           # - tools/test-orbit-mtls/client.key: client private key used only by local/test mTLS tooling.
+          # - tools/smtp4dev/fleet.key: TLS key for the local smtp4dev development mail server.
           skip-files: |
             tools/osquery/in-a-box/osquery/fleet.key
             tools/osquery/fleet.key
+            tools/smtp4dev/fleet.key
             orbit/pkg/insecure/proxy.go
             ee/orbit/pkg/httpsigproxy/httpsigproxy.go
             website/config/custom.js


### PR DESCRIPTION
## Summary

- Adds `tools/smtp4dev/fleet.key` to the Trivy `skip-files` list in `trivy-scan.yml`
- This is a development-only TLS key for the local smtp4dev mail server, not a production secret
- Fixes the Trivy scan failure: https://github.com/fleetdm/fleet/actions/runs/26454082173/job/77882876080

## Test plan

- [ ] Verify the Trivy scan workflow passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD scanning configuration to exclude additional files from automated security scans. This change adjusts the scanner's exclusion list, consists of a small, focused update, and requires minimal review. Lines changed were limited and no exported or public entities were altered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->