### PR TITLE
Add YubiKey Manager Windows package and scripts

### DIFF
--- a/ee/maintained-apps/inputs/winget/scripts/yubikey_manager_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/yubikey_manager_install.ps1
@@ -1,0 +1,26 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+#
+# YubiKey Manager Qt ships as a Nullsoft (NSIS) installer; /S runs it silently.
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/S"
+  PassThru = $true
+  Wait = $true
+}
+
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/yubikey_manager_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/yubikey_manager_uninstall.ps1
@@ -1,0 +1,78 @@
+# Locates YubiKey Manager's NSIS uninstaller from the registry and runs it silently.
+
+$displayName = "YubiKey Manager"
+$publisher = "Yubico AB"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like "$displayName*") -and ($publisher -eq "" -or $_.Publisher -eq $publisher)
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or -not $uninstall.UninstallString) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+# Best-effort: stop the GUI so the uninstaller does not fail on locked files.
+Stop-Process -Name "yubikey-manager-qt" -Force -ErrorAction SilentlyContinue
+Stop-Process -Name "ykman" -Force -ErrorAction SilentlyContinue
+
+$uninstallString = $uninstall.UninstallString
+$exePath = ""
+$arguments = ""
+
+# Parse the uninstall string to extract executable path and existing arguments
+# Handles both quoted and unquoted paths
+if ($uninstallString -match '^"([^"]+)"(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} elseif ($uninstallString -match '^([^\s]+)(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} else {
+    Write-Host "Error: Could not parse uninstall string: $uninstallString"
+    Exit 1
+}
+
+# Build argument list array, preserving existing arguments and adding /S for silent
+# NSIS installers require /S flag for silent uninstall
+$argumentList = @()
+if ($arguments -ne '') {
+    $argumentList += $arguments -split '\s+'
+}
+if ($argumentList -notcontains "/S" -and $arguments -notmatch '\b/S\b') {
+    $argumentList += "/S"
+}
+
+Write-Host "Uninstall executable: $exePath"
+Write-Host "Uninstall arguments: $($argumentList -join ' ')"
+
+try {
+    $processOptions = @{
+        FilePath = $exePath
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+
+    if ($argumentList.Count -gt 0) {
+        $processOptions.ArgumentList = $argumentList
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/yubikey-manager.json
+++ b/ee/maintained-apps/inputs/winget/yubikey-manager.json
@@ -1,0 +1,12 @@
+{
+  "name": "Yubikey Manager",
+  "slug": "yubico-yubikey-manager/windows",
+  "package_identifier": "Yubico.YubikeyManager",
+  "unique_identifier": "YubiKey Manager",
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/yubikey_manager_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/yubikey_manager_uninstall.ps1",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -2018,6 +2018,13 @@
       "description": "YubiKey Manager is an application for configuring any YubiKey. Requires Rosetta 2. YubiKey Manager won't get security updates or bug fixes. It's End of Life: <a target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\">https://www.yubico.com/support/download/yubikey-manager</a>"
     },
     {
+      "name": "Yubikey Manager",
+      "slug": "yubico-yubikey-manager/windows",
+      "platform": "windows",
+      "unique_identifier": "YubiKey Manager",
+      "description": "YubiKey Manager is an application for configuring any YubiKey. YubiKey Manager won't get security updates or bug fixes. It's End of Life: <a target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\">https://www.yubico.com/support/download/yubikey-manager</a>"
+    },
+    {
       "name": "Zed",
       "slug": "zed/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/yubico-yubikey-manager/windows.json
+++ b/ee/maintained-apps/outputs/yubico-yubikey-manager/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "1.2.6",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'YubiKey Manager' AND publisher = 'Yubico AB';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'YubiKey Manager' AND publisher = 'Yubico AB' AND version_compare(version, '1.2.6') < 0);"
+      },
+      "installer_url": "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.6-win64.exe",
+      "install_script_ref": "7933331b",
+      "uninstall_script_ref": "528a9580",
+      "sha256": "fc8f1c992c5b9f5d542549072cf58178a45af31851561b22a768e35dbfd648b7",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "528a9580": "# Locates YubiKey Manager's NSIS uninstaller from the registry and runs it silently.\n\n$displayName = \"YubiKey Manager\"\n$publisher = \"Yubico AB\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like \"$displayName*\") -and ($publisher -eq \"\" -or $_.Publisher -eq $publisher)\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or -not $uninstall.UninstallString) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\n# Best-effort: stop the GUI so the uninstaller does not fail on locked files.\nStop-Process -Name \"yubikey-manager-qt\" -Force -ErrorAction SilentlyContinue\nStop-Process -Name \"ykman\" -Force -ErrorAction SilentlyContinue\n\n$uninstallString = $uninstall.UninstallString\n$exePath = \"\"\n$arguments = \"\"\n\n# Parse the uninstall string to extract executable path and existing arguments\n# Handles both quoted and unquoted paths\nif ($uninstallString -match '^\"([^\"]+)\"(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} elseif ($uninstallString -match '^([^\\s]+)(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} else {\n    Write-Host \"Error: Could not parse uninstall string: $uninstallString\"\n    Exit 1\n}\n\n# Build argument list array, preserving existing arguments and adding /S for silent\n# NSIS installers require /S flag for silent uninstall\n$argumentList = @()\nif ($arguments -ne '') {\n    $argumentList += $arguments -split '\\s+'\n}\nif ($argumentList -notcontains \"/S\" -and $arguments -notmatch '\\b/S\\b') {\n    $argumentList += \"/S\"\n}\n\nWrite-Host \"Uninstall executable: $exePath\"\nWrite-Host \"Uninstall arguments: $($argumentList -join ' ')\"\n\ntry {\n    $processOptions = @{\n        FilePath = $exePath\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n\n    if ($argumentList.Count -gt 0) {\n        $processOptions.ArgumentList = $argumentList\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n\n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n",
+    "7933331b": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n#\n# YubiKey Manager Qt ships as a Nullsoft (NSIS) installer; /S runs it silently.\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/S\"\n  PassThru = $true\n  Wait = $true\n}\n\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
Add a Winget package entry for YubiKey Manager with accompanying PowerShell install and uninstall scripts. The install script runs the NSIS installer silently with /S; the uninstall script locates the uninstaller via the registry, stops related processes, preserves existing args and appends /S for a silent uninstall. Update apps.json to include the Windows entry and add ee/maintained-apps/outputs/yubico-yubikey-manager/windows.json with version 1.2.6, installer URL, SHA256, and embedded script refs.
