### PR TITLE
Implement policy status CSV export endpoint

### DIFF
--- a/changes/45477-45478-policy-status-page-backend-models
+++ b/changes/45477-45478-policy-status-page-backend-models
@@ -2,3 +2,4 @@
 - Added `host_policy_runs` table — one row per `(policy, host)` pair — tracking `old_status`, `new_status`, and `consecutive_failures` as each host's policy state evolves.
 - Stamped a nullable `policy_run_id` on `host_script_results`, `host_software_installs`, `host_vpp_software_installs`, `script_upcoming_activities`, `software_install_upcoming_activities`, and `vpp_app_upcoming_activities` so script, software, and VPP installs triggered by a failing policy can be attributed back to a policy run.
 - Added GetPolicyStatus endpoint to provide paginated, filterable visibility into host policy states and their associated automation execution histories.
+- Added GET /api/_version_/fleet/policies/{policy_id}/status-export, a CSV export endpoint that returns all policy run data as a flat file.

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -343,6 +343,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.PATCH("/api/_version_/fleet/invites/{id:[0-9]+}", updateInviteEndpoint, updateInviteRequest{})
 
 	ue.GET("/api/_version_/fleet/policies/{policy_id}/status", getPolicyStatusEndpoint, fleet.GetPolicyStatusRequest{})
+	ue.GET("/api/_version_/fleet/policies/{policy_id}/status-export", exportPolicyStatusEndpoint, exportPolicyStatusRequest{})
 
 	ue.EndingAtVersion("v1").POST("/api/_version_/fleet/global/policies", globalPolicyEndpoint, fleet.GlobalPolicyRequest{})
 	ue.StartingAtVersion("2022-04").POST("/api/_version_/fleet/policies", globalPolicyEndpoint, fleet.GlobalPolicyRequest{})

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"database/sql"
+	"encoding/csv"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -31839,6 +31840,15 @@ func (s *integrationEnterpriseTestSuite) TestGetPolicyStatus() {
 		require.Equal(t, hA1.ID, resp.Runs[0].HostID)
 	})
 
+	t.Run("filter automation_error matches by substring", func(t *testing.T) {
+		var resp fleet.GetPolicyStatusResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d/status", policyID), nil, http.StatusOK,
+			&resp, "automation_error", "504")
+		require.Equal(t, 1, resp.Count)
+		require.Len(t, resp.Runs, 1)
+		require.Equal(t, hA1.ID, resp.Runs[0].HostID)
+	})
+
 	t.Run("filter hostname matches a single host", func(t *testing.T) {
 		var resp fleet.GetPolicyStatusResponse
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d/status", policyID), nil, http.StatusOK,
@@ -32068,5 +32078,207 @@ func (s *integrationEnterpriseTestSuite) TestGetPolicyStatus() {
 			}
 		}
 		require.True(t, seenA2, "expected not_in_target row for hA2 (outside label scope)")
+	})
+}
+
+// TestExportPolicyStatus exercises GET /api/latest/fleet/policies/:id/status-export
+// end-to-end: CSV format, all rows returned without pagination, team-scoping, and filters.
+func (s *integrationEnterpriseTestSuite) TestExportPolicyStatus() {
+	t := s.T()
+	ctx := context.Background()
+	defer func() { s.token = s.getTestAdminToken() }()
+
+	teamA, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "_teamA"})
+	require.NoError(t, err)
+	teamB, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "_teamB"})
+	require.NoError(t, err)
+
+	newHost := func(name string, teamID *uint) *fleet.Host {
+		h, err := s.ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			OsqueryHostID:   ptr.String(t.Name() + "-" + name),
+			NodeKey:         ptr.String(t.Name() + "-" + name),
+			UUID:            uuid.New().String(),
+			Hostname:        t.Name() + "-" + name,
+			Platform:        "darwin",
+			TeamID:          teamID,
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	hA1 := newHost("alpha", &teamA.ID)
+	hA2 := newHost("bravo", &teamA.ID)
+	hB1 := newHost("charlie", &teamB.ID)
+
+	gpResp := fleet.GlobalPolicyResponse{}
+	s.DoJSON("POST", "/api/latest/fleet/policies", fleet.GlobalPolicyRequest{
+		Name:  t.Name() + "_policy",
+		Query: "SELECT 1;",
+	}, http.StatusOK, &gpResp)
+	policyID := gpResp.Policy.ID
+
+	require.NoError(t, s.ds.AsyncBatchInsertPolicyMembership(ctx, []fleet.PolicyMembershipResult{
+		{HostID: hA1.ID, PolicyID: policyID, Passes: new(false)},
+		{HostID: hA2.ID, PolicyID: policyID, Passes: new(false)},
+		{HostID: hB1.ID, PolicyID: policyID, Passes: new(true)},
+	}))
+
+	failingMap := map[uint]*bool{policyID: new(false)}
+	_, err = s.ds.RecordPolicyTransitions(ctx, hA1.ID, failingMap, []uint{policyID}, nil)
+	require.NoError(t, err)
+	runsA1, err := s.ds.GetFailingPolicyRuns(ctx, []uint{policyID}, []uint{hA1.ID})
+	require.NoError(t, err)
+	require.Len(t, runsA1, 1)
+
+	batchA1, err := s.ds.CreatePolicyAutomationExecutions(ctx, fleet.PolicyAutomationWebhook, []fleet.PolicyRunRef{
+		{PolicyID: policyID, HostID: hA1.ID, RunID: runsA1[0].RunID},
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.ds.UpdatePolicyAutomationExecutions(ctx, batchA1, errors.New("integration timeout 504")))
+
+	_, err = s.ds.RecordPolicyTransitions(ctx, hA2.ID, failingMap, []uint{policyID}, nil)
+	require.NoError(t, err)
+	runsA2, err := s.ds.GetFailingPolicyRuns(ctx, []uint{policyID}, []uint{hA2.ID})
+	require.NoError(t, err)
+	require.Len(t, runsA2, 1)
+
+	batchA2, err := s.ds.CreatePolicyAutomationExecutions(ctx, fleet.PolicyAutomationJira, []fleet.PolicyRunRef{
+		{PolicyID: policyID, HostID: hA2.ID, RunID: runsA2[0].RunID},
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.ds.UpdatePolicyAutomationExecutions(ctx, batchA2, nil))
+
+	exportURL := fmt.Sprintf("/api/latest/fleet/policies/%d/status-export", policyID)
+
+	// parseExportCSV is a helper that calls the export endpoint, asserts HTTP 200,
+	// verifies the CSV content-type header, and returns the parsed rows (header row first).
+	parseExportCSV := func(queryParams ...string) [][]string {
+		t.Helper()
+		res := s.DoRaw("GET", exportURL, nil, http.StatusOK, queryParams...)
+		require.Contains(t, res.Header.Get("Content-Type"), "text/csv")
+		require.Contains(t, res.Header.Get("Content-Disposition"), "attachment")
+		rows, err := csv.NewReader(res.Body).ReadAll()
+		require.NoError(t, err)
+		return rows
+	}
+
+	// colIndex maps CSV header names to their column indices for the given row set.
+	colIndex := func(rows [][]string) map[string]int {
+		t.Helper()
+		require.NotEmpty(t, rows)
+		idx := make(map[string]int, len(rows[0]))
+		for i, h := range rows[0] {
+			idx[h] = i
+		}
+		return idx
+	}
+
+	s.token = s.getTestAdminToken()
+
+	t.Run("CSV headers and all hosts present", func(t *testing.T) {
+		rows := parseExportCSV()
+		// header row + hA1 (1 webhook row) + hA2 (1 jira row) + hB1 (1 empty automation row)
+		require.Len(t, rows, 4, "expected header + 3 data rows")
+
+		idx := colIndex(rows)
+		require.Contains(t, idx, "host_id")
+		require.Contains(t, idx, "host_name")
+		require.Contains(t, idx, "status")
+		require.Contains(t, idx, "consecutive_failures")
+		require.Contains(t, idx, "created_at")
+		require.Contains(t, idx, "automation_type")
+		require.Contains(t, idx, "automation_status")
+		require.Contains(t, idx, "automation_error")
+
+		hostIDs := make(map[string]struct{})
+		for _, row := range rows[1:] {
+			hostIDs[row[idx["host_id"]]] = struct{}{}
+		}
+		require.Contains(t, hostIDs, fmt.Sprint(hA1.ID))
+		require.Contains(t, hostIDs, fmt.Sprint(hA2.ID))
+		require.Contains(t, hostIDs, fmt.Sprint(hB1.ID))
+	})
+
+	t.Run("automation details in rows", func(t *testing.T) {
+		rows := parseExportCSV()
+		idx := colIndex(rows)
+
+		var hA1Row, hA2Row, hB1Row []string
+		for _, row := range rows[1:] {
+			switch row[idx["host_id"]] {
+			case fmt.Sprint(hA1.ID):
+				hA1Row = row
+			case fmt.Sprint(hA2.ID):
+				hA2Row = row
+			case fmt.Sprint(hB1.ID):
+				hB1Row = row
+			}
+		}
+
+		require.NotNil(t, hA1Row)
+		require.Equal(t, "failing", hA1Row[idx["status"]])
+		require.Equal(t, "webhook", hA1Row[idx["automation_type"]])
+		require.Equal(t, "failed", hA1Row[idx["automation_status"]])
+		require.Equal(t, "integration timeout 504", hA1Row[idx["automation_error"]])
+
+		require.NotNil(t, hA2Row)
+		require.Equal(t, "failing", hA2Row[idx["status"]])
+		require.Equal(t, "jira", hA2Row[idx["automation_type"]])
+		require.Equal(t, "success", hA2Row[idx["automation_status"]])
+
+		require.NotNil(t, hB1Row)
+		require.Equal(t, "passing", hB1Row[idx["status"]])
+		require.Empty(t, hB1Row[idx["automation_type"]])
+		require.Empty(t, hB1Row[idx["automation_status"]])
+	})
+
+	t.Run("filter run_status=policy_failed returns only failing hosts", func(t *testing.T) {
+		rows := parseExportCSV("run_status", "policy_failed")
+		idx := colIndex(rows)
+		// hA1 + hA2 are failing; hB1 is passing
+		require.Len(t, rows, 3, "expected header + 2 failing host rows")
+		for _, row := range rows[1:] {
+			require.Equal(t, "failing", row[idx["status"]])
+		}
+	})
+
+	t.Run("filter hostname matches a single host", func(t *testing.T) {
+		rows := parseExportCSV("hostname", "charlie")
+		idx := colIndex(rows)
+		require.Len(t, rows, 2, "expected header + 1 row")
+		require.Equal(t, fmt.Sprint(hB1.ID), rows[1][idx["host_id"]])
+	})
+
+	t.Run("filter automation_error isolates hA1", func(t *testing.T) {
+		rows := parseExportCSV("automation_error", "504")
+		idx := colIndex(rows)
+		require.Len(t, rows, 2, "expected header + 1 row")
+		require.Equal(t, fmt.Sprint(hA1.ID), rows[1][idx["host_id"]])
+	})
+
+	t.Run("team observer sees only own team hosts", func(t *testing.T) {
+		teamAObserver := &fleet.User{
+			Name:  "team A observer export",
+			Email: t.Name() + "_teamA_obs_export@example.com",
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: teamA.ID}, Role: fleet.RoleObserver}},
+		}
+		require.NoError(t, teamAObserver.SetPassword(test.GoodPassword, 10, 10))
+		_, err := s.ds.NewUser(ctx, teamAObserver)
+		require.NoError(t, err)
+		s.token = s.getTestToken(teamAObserver.Email, test.GoodPassword)
+		defer func() { s.token = s.getTestAdminToken() }()
+
+		rows := parseExportCSV()
+		idx := colIndex(rows)
+		// teamA observer should see hA1 and hA2 but not hB1
+		require.Len(t, rows, 3, "expected header + 2 teamA rows")
+		for _, row := range rows[1:] {
+			hid := row[idx["host_id"]]
+			require.NotEqual(t, fmt.Sprint(hB1.ID), hid, "teamB host should not appear for teamA observer")
+		}
 	})
 }

--- a/server/service/policy_status.go
+++ b/server/service/policy_status.go
@@ -1,11 +1,19 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/gocarina/gocsv"
 )
 
 // ///////////////////////////////////////////////////////////////////////////////
@@ -60,4 +68,106 @@ func (svc Service) GetPolicyStatus(ctx context.Context, policy *fleet.Policy, re
 		Count: count,
 		Meta:  meta,
 	}, nil
+}
+
+// ///////////////////////////////////////////////////////////////////////////////
+// Export policy status (CSV)
+// ///////////////////////////////////////////////////////////////////////////////
+
+type exportPolicyStatusRequest struct {
+	PolicyID             uint   `url:"policy_id"`
+	HostNameQuery        string `query:"hostname,optional"`
+	AutomationErrorQuery string `query:"automation_error,optional"`
+	RunStatus            string `query:"run_status,optional"`
+}
+
+type policyStatusCSVRow struct {
+	HostID              uint      `csv:"host_id"`
+	HostName            string    `csv:"host_name"`
+	Status              string    `csv:"status"`
+	ConsecutiveFailures uint      `csv:"consecutive_failures"`
+	CreatedAt           time.Time `csv:"created_at"`
+	AutomationType      string    `csv:"automation_type"`
+	AutomationStatus    string    `csv:"automation_status"`
+	AutomationError     string    `csv:"automation_error"`
+}
+
+type exportPolicyStatusResponse struct {
+	Rows []policyStatusCSVRow
+	Err  error `json:"error,omitempty"`
+}
+
+func (r exportPolicyStatusResponse) Error() error { return r.Err }
+
+func (r exportPolicyStatusResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
+	// Marshal into a buffer first so that if encoding fails we can still
+	// return an error response — once WriteHeader(200) is called we can
+	// no longer change the status code.
+	var buf bytes.Buffer
+	if err := gocsv.Marshal(r.Rows, &buf); err != nil {
+		logging.WithErr(ctx, err)
+		encodeError(ctx, ctxerr.New(ctx, "failed to generate CSV file"), w)
+		return
+	}
+	w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="Policy Status %s.csv"`, time.Now().Format("2006-01-02")))
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	if _, err := io.Copy(w, &buf); err != nil {
+		logging.WithErr(ctx, err)
+	}
+}
+
+func exportPolicyStatusEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	if !license.IsPremium(ctx) {
+		return nil, fleet.ErrMissingLicense
+	}
+	req := request.(*exportPolicyStatusRequest)
+	policy, err := svc.GetPolicyByID(ctx, req.PolicyID)
+	if err != nil {
+		return exportPolicyStatusResponse{Err: err}, nil
+	}
+	statusReq := fleet.GetPolicyStatusRequest{
+		PolicyID:             req.PolicyID,
+		HostNameQuery:        req.HostNameQuery,
+		AutomationErrorQuery: req.AutomationErrorQuery,
+		RunStatus:            req.RunStatus,
+		// ListOptions zero-value → PerPage=0, which GetPerPage() maps to
+		// fleet.DefaultPerPage (1,000,000). This is Fleet's "effectively unbounded"
+		// convention used across all list endpoints — sufficient for real fleets.
+	}
+	resp, err := svc.GetPolicyStatus(ctx, policy, statusReq)
+	if err != nil {
+		return exportPolicyStatusResponse{Err: err}, nil
+	}
+	return exportPolicyStatusResponse{Rows: flattenPolicyStatusToCSV(resp.Runs)}, nil
+}
+
+func flattenPolicyStatusToCSV(runs []fleet.GetPolicyStatusPolicyRun) []policyStatusCSVRow {
+	rows := make([]policyStatusCSVRow, 0, len(runs))
+	for _, run := range runs {
+		status := "passing"
+		if !run.NewStatus {
+			status = "failing"
+		}
+		base := policyStatusCSVRow{
+			HostID:              run.HostID,
+			HostName:            run.HostName,
+			Status:              status,
+			ConsecutiveFailures: run.ConsecutiveFailures,
+			CreatedAt:           run.CreatedAt,
+		}
+		if len(run.AutomationExecutions) == 0 {
+			rows = append(rows, base)
+			continue
+		}
+		for _, a := range run.AutomationExecutions {
+			row := base
+			row.AutomationType = a.Type
+			row.AutomationStatus = a.Status
+			row.AutomationError = a.ErrorMessage
+			rows = append(rows, row)
+		}
+	}
+	return rows
 }

--- a/server/service/policy_status_test.go
+++ b/server/service/policy_status_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/gocarina/gocsv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,5 +74,135 @@ func TestGetPolicyStatus(t *testing.T) {
 		require.Equal(t, 1, resp.Count)
 		require.Equal(t, expectedMeta, resp.Meta)
 		require.Equal(t, expectedRuns, resp.Runs)
+	})
+}
+
+func TestExportPolicyStatus(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	policyID := uint(7)
+	now := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	runsWithAutomations := []fleet.GetPolicyStatusPolicyRun{
+		{
+			HostID:              1,
+			HostName:            "host-fail",
+			NewStatus:           false,
+			ConsecutiveFailures: 3,
+			CreatedAt:           now,
+			AutomationExecutions: []fleet.GetPolicyStatusAutomationExecution{
+				{Type: "webhook", Status: "failed", ErrorMessage: "timeout 504"},
+				{Type: "jira", Status: "success", ErrorMessage: ""},
+			},
+		},
+		{
+			HostID:              2,
+			HostName:            "host-pass",
+			NewStatus:           true,
+			ConsecutiveFailures: 0,
+			CreatedAt:           now,
+			// no automations
+		},
+	}
+
+	ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+		return &fleet.Policy{PolicyData: fleet.PolicyData{ID: id}}, nil
+	}
+
+	adminViewer := viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}}
+
+	t.Run("endpoint enforces premium license", func(t *testing.T) {
+		freeCtx := viewer.NewContext(ctx, adminViewer)
+		freeCtx = license.NewContext(freeCtx, &fleet.LicenseInfo{Tier: fleet.TierFree})
+		_, err := exportPolicyStatusEndpoint(freeCtx, &exportPolicyStatusRequest{PolicyID: policyID}, svc)
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
+	})
+
+	t.Run("pagination is bypassed (PerPage=0 forwarded)", func(t *testing.T) {
+		var capturedReq fleet.GetPolicyStatusRequest
+		ds.GetPolicyStatusFunc = func(ctx context.Context, pid uint, filter fleet.TeamFilter, req fleet.GetPolicyStatusRequest) ([]fleet.GetPolicyStatusPolicyRun, int, *fleet.PaginationMetadata, error) {
+			capturedReq = req
+			return nil, 0, &fleet.PaginationMetadata{}, nil
+		}
+		premCtx := viewer.NewContext(ctx, adminViewer)
+		premCtx = license.NewContext(premCtx, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		_, err := exportPolicyStatusEndpoint(premCtx, &exportPolicyStatusRequest{
+			PolicyID:             policyID,
+			HostNameQuery:        "myhost",
+			AutomationErrorQuery: "timeout",
+			RunStatus:            "policy_failed",
+		}, svc)
+		require.NoError(t, err)
+		require.Equal(t, uint(0), capturedReq.ListOptions.PerPage)
+		require.Equal(t, "myhost", capturedReq.HostNameQuery)
+		require.Equal(t, "timeout", capturedReq.AutomationErrorQuery)
+		require.Equal(t, "policy_failed", capturedReq.RunStatus)
+	})
+
+	t.Run("flatten: host with automations yields one row per automation", func(t *testing.T) {
+		rows := flattenPolicyStatusToCSV(runsWithAutomations)
+		// host-fail has 2 automations → 2 rows; host-pass has none → 1 row
+		require.Len(t, rows, 3)
+
+		// first two rows belong to host-fail
+		require.Equal(t, uint(1), rows[0].HostID)
+		require.Equal(t, "host-fail", rows[0].HostName)
+		require.Equal(t, "failing", rows[0].Status)
+		require.Equal(t, uint(3), rows[0].ConsecutiveFailures)
+		require.Equal(t, "webhook", rows[0].AutomationType)
+		require.Equal(t, "failed", rows[0].AutomationStatus)
+		require.Equal(t, "timeout 504", rows[0].AutomationError)
+
+		require.Equal(t, uint(1), rows[1].HostID)
+		require.Equal(t, "jira", rows[1].AutomationType)
+		require.Equal(t, "success", rows[1].AutomationStatus)
+		require.Empty(t, rows[1].AutomationError)
+
+		// third row belongs to host-pass with blank automation columns
+		require.Equal(t, uint(2), rows[2].HostID)
+		require.Equal(t, "passing", rows[2].Status)
+		require.Empty(t, rows[2].AutomationType)
+		require.Empty(t, rows[2].AutomationStatus)
+		require.Empty(t, rows[2].AutomationError)
+	})
+
+	t.Run("GetPolicyStatus error is surfaced in response", func(t *testing.T) {
+		dsErr := errors.New("db unavailable")
+		ds.GetPolicyStatusFunc = func(ctx context.Context, pid uint, filter fleet.TeamFilter, req fleet.GetPolicyStatusRequest) ([]fleet.GetPolicyStatusPolicyRun, int, *fleet.PaginationMetadata, error) {
+			return nil, 0, nil, dsErr
+		}
+		premCtx := viewer.NewContext(ctx, adminViewer)
+		premCtx = license.NewContext(premCtx, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		respRaw, err := exportPolicyStatusEndpoint(premCtx, &exportPolicyStatusRequest{PolicyID: policyID}, svc)
+		require.NoError(t, err)
+		resp, ok := respRaw.(exportPolicyStatusResponse)
+		require.True(t, ok)
+		require.Error(t, resp.Err)
+	})
+
+	t.Run("HijackRender writes CSV headers and valid CSV body", func(t *testing.T) {
+		ds.GetPolicyStatusFunc = func(ctx context.Context, pid uint, filter fleet.TeamFilter, req fleet.GetPolicyStatusRequest) ([]fleet.GetPolicyStatusPolicyRun, int, *fleet.PaginationMetadata, error) {
+			return runsWithAutomations, len(runsWithAutomations), &fleet.PaginationMetadata{}, nil
+		}
+		premCtx := viewer.NewContext(ctx, adminViewer)
+		premCtx = license.NewContext(premCtx, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+
+		respRaw, err := exportPolicyStatusEndpoint(premCtx, &exportPolicyStatusRequest{PolicyID: policyID}, svc)
+		require.NoError(t, err)
+
+		resp, ok := respRaw.(exportPolicyStatusResponse)
+		require.True(t, ok)
+		require.NoError(t, resp.Err)
+
+		w := httptest.NewRecorder()
+		resp.HijackRender(premCtx, w)
+
+		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+
+		var parsed []policyStatusCSVRow
+		require.NoError(t, gocsv.UnmarshalBytes(w.Body.Bytes(), &parsed))
+		require.Len(t, parsed, 3)
 	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Closes #45479

Introduces GET /api/_version_/fleet/policies/:id/status-export, a premium-only endpoint that streams the full policy run dataset as a CSV file (one row per host × automation) without pagination limits. Reuses the existing GetPolicyStatus service method and datastore query with identical auth, team-scoping, and filter support.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV export endpoint for policy status data with filtering by run status, hostname, and automation errors.
  * Exports include policy run results, automation execution type, status, and error details.
  * Enforces team-scoped access controls and premium licensing requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->