### PR TITLE
Document file-local sub-component pattern as preferred over render*() helpers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,7 +64,14 @@ module.exports = {
     // note you must disable the base rule as it can report incorrect errors. more info here:
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
     "no-use-before-define": "off",
-    "@typescript-eslint/no-use-before-define": ["error"],
+    // Allow referencing functions and variables (e.g. React components defined
+    // at the bottom of the file) before they are declared. This supports the
+    // "main component on top, helper sub-components below" pattern documented
+    // in frontend/docs/patterns.md.
+    "@typescript-eslint/no-use-before-define": [
+      "error",
+      { functions: false, variables: false },
+    ],
     // turn off and override to not run this on js and jsx files. More info here:
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md#configuring-in-a-mixed-jsts-codebase
     "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,14 +64,7 @@ module.exports = {
     // note you must disable the base rule as it can report incorrect errors. more info here:
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
     "no-use-before-define": "off",
-    // Allow referencing functions and variables (e.g. React components defined
-    // at the bottom of the file) before they are declared. This supports the
-    // "main component on top, helper sub-components below" pattern documented
-    // in frontend/docs/patterns.md.
-    "@typescript-eslint/no-use-before-define": [
-      "error",
-      { functions: false, variables: false },
-    ],
+    "@typescript-eslint/no-use-before-define": ["error"],
     // turn off and override to not run this on js and jsx files. More info here:
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md#configuring-in-a-mixed-jsts-codebase
     "@typescript-eslint/explicit-module-boundary-types": "off",
@@ -88,7 +81,19 @@ module.exports = {
     "jsx-a11y/heading-has-content": "off",
     "jsx-a11y/anchor-has-content": "off",
   },
-  overrides: [],
+  overrides: [
+    {
+      // Allow referencing React components before they are declared.
+      // This supports the "main component on top, helper sub-components below" pattern documented in frontend/docs/patterns.md.
+      files: ["*.tsx", "*.jsx"],
+      rules: {
+        "@typescript-eslint/no-use-before-define": [
+          "error",
+          { functions: false, variables: false },
+        ],
+      },
+    },
+  ],
   settings: {
     "import/resolver": {
       webpack: {

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -470,68 +470,6 @@ const SelectTargets = ({
     );
   };
 
-  const renderTargetsCount = (): JSX.Element | null => {
-    if (isFetchingCounts) {
-      return (
-        <>
-          <Spinner
-            size="x-small"
-            includeContainer={false}
-            centered={false}
-            className={`${baseClass}__count-spinner`}
-          />
-          <i style={{ color: "#8b8fa2" }}>Counting hosts</i>
-        </>
-      );
-    }
-
-    if (errorCounts) {
-      return (
-        <b style={{ color: "#d66c7b", margin: 0 }}>
-          There was a problem counting hosts. Please try again later.
-        </b>
-      );
-    }
-
-    if (!counts) {
-      return null;
-    }
-
-    const { targets_count: total, targets_online: online } = counts;
-    const onlinePercentage = () => {
-      if (total === 0 || online === 0) {
-        return 0;
-      }
-      // If at least 1 host is online, displays <1% instead of 0%
-      const roundPercentage =
-        Math.round((online / total) * 100) === 0
-          ? "<1"
-          : Math.round((online / total) * 100);
-      return roundPercentage;
-    };
-
-    return (
-      <>
-        <b>{total.toLocaleString()}</b>&nbsp;host
-        {total > 1 || total === 0 ? `s` : ``} targeted&nbsp; (
-        {onlinePercentage()}
-        %&nbsp;
-        <TooltipWrapper
-          tipContent={
-            <>
-              Hosts are online if they <br />
-              have recently checked <br />
-              into Fleet.
-            </>
-          }
-        >
-          online
-        </TooltipWrapper>
-        ){" "}
-      </>
-    );
-  };
-
   if (errorLabels || errorTeams) {
     return (
       <div className={`${baseClass}__wrapper`}>
@@ -639,10 +577,88 @@ const SelectTargets = ({
           Cancel
         </Button>
         <div className={`${baseClass}__targets-total-count`}>
-          {renderTargetsCount()}
+          <TargetsCount
+            baseClass={baseClass}
+            isFetchingCounts={isFetchingCounts}
+            errorCounts={errorCounts}
+            counts={counts}
+          />
         </div>
       </div>
     </div>
+  );
+};
+
+interface ITargetsCountProps {
+  baseClass: string;
+  isFetchingCounts: boolean;
+  errorCounts: Error | null;
+  counts: ITargetsCountResponse | undefined;
+}
+
+const TargetsCount = ({
+  baseClass,
+  isFetchingCounts,
+  errorCounts,
+  counts,
+}: ITargetsCountProps): JSX.Element | null => {
+  if (isFetchingCounts) {
+    return (
+      <>
+        <Spinner
+          size="x-small"
+          includeContainer={false}
+          centered={false}
+          className={`${baseClass}__count-spinner`}
+        />
+        <i style={{ color: "#8b8fa2" }}>Counting hosts</i>
+      </>
+    );
+  }
+
+  if (errorCounts) {
+    return (
+      <b style={{ color: "#d66c7b", margin: 0 }}>
+        There was a problem counting hosts. Please try again later.
+      </b>
+    );
+  }
+
+  if (!counts) {
+    return null;
+  }
+
+  const { targets_count: total, targets_online: online } = counts;
+  const onlinePercentage = () => {
+    if (total === 0 || online === 0) {
+      return 0;
+    }
+    // If at least 1 host is online, displays <1% instead of 0%
+    const roundPercentage =
+      Math.round((online / total) * 100) === 0
+        ? "<1"
+        : Math.round((online / total) * 100);
+    return roundPercentage;
+  };
+
+  return (
+    <>
+      <b>{total.toLocaleString()}</b>&nbsp;host
+      {total > 1 || total === 0 ? `s` : ``} targeted&nbsp; ({onlinePercentage()}
+      %&nbsp;
+      <TooltipWrapper
+        tipContent={
+          <>
+            Hosts are online if they <br />
+            have recently checked <br />
+            into Fleet.
+          </>
+        }
+      >
+        online
+      </TooltipWrapper>
+      ){" "}
+    </>
   );
 };
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -181,6 +181,84 @@ or
 />
 ```
 
+### File-local sub-components (preferred over `render*()` helpers)
+
+When a component's JSX has a branching section that's complex enough to feel
+like its own piece of UI, prefer defining a **file-local sub-component** below
+the main component over a `renderSomething()` helper method on the closure.
+
+**Preferred — sub-component in the same file:**
+
+```tsx
+const ParentComponent = ({ a, b, c }: IParentProps) => {
+  // ...hooks, derived state, etc.
+
+  return (
+    <Modal>
+      <ModalContent a={a} b={b} c={c} />
+    </Modal>
+  );
+};
+
+interface IModalContentProps {
+  a: string;
+  b: number;
+  c: () => void;
+}
+
+const ModalContent = ({ a, b, c }: IModalContentProps) => {
+  if (/* ... */) return <Spinner />;
+  // ...
+  return <SomeUI />;
+};
+
+export default ParentComponent;
+```
+
+**Legacy / acceptable — `renderSomething()` closure helper:**
+
+```tsx
+const ParentComponent = ({ a, b, c }: IParentProps) => {
+  // ...
+
+  const renderModalContent = () => {
+    if (/* ... */) return <Spinner />;
+    // closes over a, b, c implicitly
+    return <SomeUI />;
+  };
+
+  return <Modal>{renderModalContent()}</Modal>;
+};
+```
+
+Why the sub-component form is preferred:
+
+- **Explicit data flow.** Props make every value the sub-component depends on
+  visible at the call site. `render*()` closures pull from the enclosing scope,
+  so a reader has to scan the whole parent to know what the section actually
+  uses.
+- **Stable identity across renders.** `renderFoo` is recreated on every parent
+  render. A top-level sub-component declaration is created once per module.
+- **Easier to extract later.** When the sub-component grows enough to deserve
+  its own file, it already has a defined props interface — moving it is a
+  cut-and-paste, not a refactor.
+- **Lower cognitive load when reading top-down.** The parent reads as a small,
+  declarative tree; details live below where you can skip them unless needed.
+
+Conventions:
+
+- Declare the main exported component at the top of the file (after imports,
+  constants, and interfaces).
+- Place file-local sub-components **below** the main component. This is
+  intentional — the main component is the entry point a reader cares about
+  first, and the sub-components are implementation detail.
+- Keep file-local sub-components specific to the parent. If a sub-component
+  starts being imported elsewhere, promote it to its own 4-file component
+  directory (see the [Fleet Frontend Conventions](../../.claude/rules/fleet-frontend.md)).
+- `render*()` helpers are still acceptable, especially in existing code — don't
+  refactor an entire page just to migrate. New code should prefer the
+  sub-component pattern.
+
 ### Page component pattern
 
 When creating a **top level page** (e.g. dashboard page, hosts page, policies page)

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -183,11 +183,10 @@ or
 
 ### File-local sub-components (preferred over `render*()` helpers)
 
-When a component's JSX has a branching section that's complex enough to feel
-like its own piece of UI, prefer defining a **file-local sub-component** below
-the main component over a `renderSomething()` helper method on the closure.
-
-**Preferred — sub-component in the same file:**
+When a component's JSX has a branching section complex enough to feel like its
+own piece of UI, prefer defining a **file-local sub-component** below the main
+component over a `renderSomething()` helper closure. This improves readability
+and makes it easier to extract the sub-component into a separate file if needed.
 
 ```tsx
 const ParentComponent = ({ a, b, c }: IParentProps) => {
@@ -214,50 +213,6 @@ const ModalContent = ({ a, b, c }: IModalContentProps) => {
 
 export default ParentComponent;
 ```
-
-**Legacy / acceptable — `renderSomething()` closure helper:**
-
-```tsx
-const ParentComponent = ({ a, b, c }: IParentProps) => {
-  // ...
-
-  const renderModalContent = () => {
-    if (/* ... */) return <Spinner />;
-    // closes over a, b, c implicitly
-    return <SomeUI />;
-  };
-
-  return <Modal>{renderModalContent()}</Modal>;
-};
-```
-
-Why the sub-component form is preferred:
-
-- **Explicit data flow.** Props make every value the sub-component depends on
-  visible at the call site. `render*()` closures pull from the enclosing scope,
-  so a reader has to scan the whole parent to know what the section actually
-  uses.
-- **Stable identity across renders.** `renderFoo` is recreated on every parent
-  render. A top-level sub-component declaration is created once per module.
-- **Easier to extract later.** When the sub-component grows enough to deserve
-  its own file, it already has a defined props interface — moving it is a
-  cut-and-paste, not a refactor.
-- **Lower cognitive load when reading top-down.** The parent reads as a small,
-  declarative tree; details live below where you can skip them unless needed.
-
-Conventions:
-
-- Declare the main exported component at the top of the file (after imports,
-  constants, and interfaces).
-- Place file-local sub-components **below** the main component. This is
-  intentional — the main component is the entry point a reader cares about
-  first, and the sub-components are implementation detail.
-- Keep file-local sub-components specific to the parent. If a sub-component
-  starts being imported elsewhere, promote it to its own 4-file component
-  directory (see the [Fleet Frontend Conventions](../../.claude/rules/fleet-frontend.md)).
-- `render*()` helpers are still acceptable, especially in existing code — don't
-  refactor an entire page just to migrate. New code should prefer the
-  sub-component pattern.
 
 ### Page component pattern
 


### PR DESCRIPTION
Modified patterns.md to document that we'll prefer plain JSX components over `render*()` closure functions for inner components.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting rules to add an override for JSX/TSX files that allows using functions and variables before declaration while retaining error severity.

* **Refactor**
  * Extracted the targets counting UI/logic into a dedicated component to improve structure and props-driven rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->