### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0.1",
+      "version": "151.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0.2') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.1/mac/en-US/Firefox%20151.0.1.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.2/mac/en-US/Firefox%20151.0.2.dmg",
       "install_script_ref": "f659d0e6",
       "uninstall_script_ref": "e8f976a6",
-      "sha256": "6e3714ef92305e1164fcb7188e47cc1f076f7836c631a428470b154a188fb3e9",
+      "sha256": "232631dd169b8a4fc661a7a6756da3910cc669ba34b81858b7915ca138752e79",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.255.6",
+      "version": "7.269.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.255.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.269.0') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.6/Granola-7.255.6-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.269.0/Granola-7.269.0-mac-universal.dmg",
       "install_script_ref": "08986ac7",
       "uninstall_script_ref": "67249f33",
-      "sha256": "4b83958195692e068378b1962d5c0ccd707650567acda4926d5b92d3283cb83e",
+      "sha256": "c8bfeb310ba07717b0d08e9385dee099935c741fe4ae4cdb14ed3bef72589c86",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.349.0",
+      "version": "0.350.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.349.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.350.1') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.349.0-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.350.1-arm64.dmg",
       "install_script_ref": "3b74ae49",
       "uninstall_script_ref": "8f032bbc",
-      "sha256": "039f1aec076189f23acf58ad6638107fe001182502bfdbf59327cec024db4d35",
+      "sha256": "b86d6a6f85b48cc4192f1cc683bde67b7e9b68f637c5b6dceffc7a4b0013aea0",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata for maintained macOS applications: Firefox (151.0.2), Granola (7.269.0), and Loom (0.350.1).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->