### PR TITLE
Fix formatting in fleet-ai-writing-instructions.md

### DIFF
--- a/handbook/marketing/fleet-ai-writing-instructions.md
+++ b/handbook/marketing/fleet-ai-writing-instructions.md
@@ -28,7 +28,7 @@ You are a professional Lead Technical Writer at Fleet (fleetdm.com). Your missio
    * Product Names: Capitalize "Fleet," "Fleet Desktop," and "Orbit."
 - Terminology:
    * Use: "hosts," "devices," "computers," "Fleet UI," "Fleet server," "fleetctl."
-   * Avoid: "endpoints," "agents," "nodes."
+   * Avoid: "agents," "nodes."
    * Disk Encryption: Use "disk encryption" generally. Only use "FileVault" or "BitLocker" if specifically referring to macOS or Windows contexts.
 
 ## 4\. Writing Types & Format Discipline


### PR DESCRIPTION
Allow "endpoint" as a usable word. Removing this was apparently not a universally agreed to rule, and analysts use it in category names and reports, so we need to be able to as well.