### PR TITLE
Add macos_applications filter for host software list

### DIFF
--- a/changes/43722-macos_applications-filter-backend
+++ b/changes/43722-macos_applications-filter-backend
@@ -1,0 +1,1 @@
+- Added macos_applications filter for host software list

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4940,6 +4940,7 @@ A `fleet_id` of `0` returns the statistics for hosts that are "Unassigned". A `n
 | min_cvss_score | integer | query | _Available in Fleet Premium_. Filters to include only software with vulnerabilities that have a CVSS version 3.x base score higher than the specified value.   |
 | max_cvss_score | integer | query | _Available in Fleet Premium_. Filters to only include software with vulnerabilities that have a CVSS version 3.x base score lower than what's specified.   |
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
+| macos_applications | boolean | query | If `true`, filters to only include software at the top level of the `/Applications` folder. This parameter applies only to macOS hosts, and is ignored for hosts on other platforms. Default is `false`.  |
 | after | string | query | The value to get results after. This needs `order_key` defined, as that's the column that would be used. |
 
 On macOS hosts, `last_opened_at` is supported for software from the `apps` source and is the last open time of the most recently installed version of the software. After an update, it may be empty until the software is opened again.

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -12,7 +12,12 @@ import deviceAPI, {
   IGetDeviceSoftwareResponse,
 } from "services/entities/device_user";
 import { IHostSoftware, ISoftware } from "interfaces/software";
-import { HostPlatform, isAndroid, isIPadOrIPhone } from "interfaces/platform";
+import {
+  HostPlatform,
+  isAndroid,
+  isIPadOrIPhone,
+  isMacOS,
+} from "interfaces/platform";
 import { MdmEnrollmentStatus } from "interfaces/mdm";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -82,6 +87,7 @@ export const parseHostSoftwareQueryParams = (queryParams: {
   self_service?: string;
   category_id?: string;
   fleet_id?: string;
+  macos_applications?: string;
 }) => {
   const searchQuery = queryParams?.query ?? DEFAULT_SEARCH_QUERY;
   const sortHeader = queryParams?.order_key ?? DEFAULT_SORT_HEADER;
@@ -100,6 +106,14 @@ export const parseHostSoftwareQueryParams = (queryParams: {
   const teamId = queryParams?.fleet_id
     ? parseInt(queryParams.fleet_id, 10)
     : undefined;
+  // Tri-state: true/false when explicitly set in the URL, otherwise undefined so
+  // the platform-specific default can be applied where the platform is known.
+  let macosApplications: boolean | undefined;
+  if (queryParams?.macos_applications === "true") {
+    macosApplications = true;
+  } else if (queryParams?.macos_applications === "false") {
+    macosApplications = false;
+  }
 
   return {
     page,
@@ -115,6 +129,7 @@ export const parseHostSoftwareQueryParams = (queryParams: {
     available_for_install: false, // always false for host software
     category_id: categoryId,
     fleet_id: teamId,
+    macos_applications: macosApplications,
   };
 };
 
@@ -132,6 +147,14 @@ const HostSoftware = ({
   hostMdmEnrollmentStatus = null,
 }: IHostSoftwareProps) => {
   const { isPremiumTier } = useContext(AppContext);
+
+  // The /Applications filter only applies to macOS hosts, and defaults to ON
+  // (only top-level applications) when the host is macOS and no explicit value
+  // is set in the URL. It is left undefined for other platforms so the param is
+  // not sent to the API.
+  const macosApplicationsFilter = isMacOS(platform)
+    ? queryParams.macos_applications ?? true
+    : undefined;
 
   const isUnsupported = isIPadOrIPhone(platform) && queryParams.vulnerable; // no Android software and no vulnerable software for iOS
 
@@ -156,6 +179,7 @@ const HostSoftware = ({
         id: id as number,
         softwareUpdatedAt,
         ...queryParams,
+        macos_applications: macosApplicationsFilter,
       },
     ],
     ({ queryKey }) => {
@@ -311,6 +335,7 @@ const HostSoftware = ({
               max_cvss_score: queryParams.max_cvss_score,
             })}
             teamId={queryParams.fleet_id}
+            macosApplicationsFilter={macosApplicationsFilter}
             onAddFiltersClick={toggleSoftwareFiltersModal}
             // for my device software details modal toggling
             isMyDevicePage={isMyDevicePage}

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -258,6 +258,10 @@ const HostSoftware = ({
       perPage: queryParams.per_page,
       page: 0, // resets page index
       fleet_id: queryParams.fleet_id,
+      // Preserve an explicit macOS /Applications filter selection across vuln
+      // filter changes. Left undefined when not set so the platform default
+      // continues to apply.
+      macos_applications: queryParams.macos_applications,
       ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
     };
 

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
@@ -114,4 +114,32 @@ describe("HostSoftwareTable", () => {
 
     expect(screen.getByText("No software found")).toBeInTheDocument();
   });
+
+  it("renders the /Applications filter for macOS hosts with the filter on by default", () => {
+    renderWithContext({
+      platform: "darwin",
+      macosApplicationsFilter: true,
+    });
+
+    // The selected option label is shown in the dropdown
+    expect(screen.getByText("Applications")).toBeInTheDocument();
+  });
+
+  it("shows 'Full inventory' selected when the /Applications filter is off", () => {
+    renderWithContext({
+      platform: "darwin",
+      macosApplicationsFilter: false,
+    });
+
+    expect(screen.getByText("Full inventory")).toBeInTheDocument();
+  });
+
+  it("does not render the /Applications filter for non-macOS hosts", () => {
+    renderWithContext({
+      platform: "windows",
+    });
+
+    expect(screen.queryByText("Applications")).not.toBeInTheDocument();
+    expect(screen.queryByText("Full inventory")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
 import { InjectedRouter } from "react-router";
+import { SingleValue } from "react-select-5";
 
 import { IGetHostSoftwareResponse } from "services/entities/hosts";
 import { IGetDeviceSoftwareResponse } from "services/entities/device_user";
@@ -15,6 +16,7 @@ import {
 import {
   HostPlatform,
   PLATFORM_DISPLAY_NAMES,
+  isMacOS,
   isVulnUnsupportedPlatform,
 } from "interfaces/platform";
 
@@ -23,6 +25,9 @@ import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
+import DropdownWrapper, {
+  CustomOptionType,
+} from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import EmptyState from "components/EmptyState";
 import EmptySoftwareTable from "pages/SoftwarePage/components/tables/EmptySoftwareTable";
@@ -73,6 +78,8 @@ interface IHostSoftwareTableProps {
   pagePath: string;
   vulnFilters: ISoftwareVulnFiltersParams;
   teamId?: number;
+  /** Current value of the macOS /Applications filter. Only defined for macOS hosts. */
+  macosApplicationsFilter?: boolean;
   onAddFiltersClick: () => void;
   isMyDevicePage?: boolean;
   onShowInventoryVersions: (software: IHostSoftware) => void;
@@ -91,6 +98,7 @@ const HostSoftwareTable = ({
   pagePath,
   vulnFilters,
   teamId,
+  macosApplicationsFilter,
   onAddFiltersClick,
   isMyDevicePage,
   onShowInventoryVersions,
@@ -204,8 +212,68 @@ const HostSoftwareTable = ({
     );
   };
 
+  // The /Applications filter is only relevant for macOS hosts.
+  const showApplicationsFilter =
+    !isMyDevicePage &&
+    isMacOS(platform) &&
+    macosApplicationsFilter !== undefined;
+
+  const applicationsFilterOptions: CustomOptionType[] = [
+    { label: "Full inventory", value: "false" },
+    { label: "Applications", value: "true" },
+  ];
+
+  const onApplicationsFilterChange = (
+    newValue: SingleValue<CustomOptionType>
+  ) => {
+    if (!newValue) return;
+    router.replace(
+      getNextLocationPath({
+        pathPrefix: pagePath,
+        routeTemplate: "",
+        queryParams: {
+          query: searchQuery,
+          order_direction: sortDirection,
+          order_key: sortHeader,
+          page: 0, // resets page index
+          fleet_id: teamId,
+          macos_applications: newValue.value,
+          ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
+        },
+      })
+    );
+  };
+
+  const renderApplicationsFilter = () => (
+    <DropdownWrapper
+      name="host-software-applications-filter"
+      className={`${baseClass}__software-filter`}
+      options={applicationsFilterOptions}
+      value={macosApplicationsFilter ? "true" : "false"}
+      onChange={onApplicationsFilterChange}
+      variant="table-filter"
+      isSearchable={false}
+      iconName="filter-alt"
+    />
+  );
+
+  // Visual order is search, dropdown, filters button. The dropdown and filters
+  // button are rendered here in DOM order; the search (rendered by
+  // TableContainer after these controls) is moved ahead of them via CSS when
+  // the `--with-applications-filter` modifier is present.
+  const renderCustomControls = () => (
+    <>
+      {showApplicationsFilter && renderApplicationsFilter()}
+      {renderCustomFiltersButton()}
+    </>
+  );
+
   return (
-    <div className={baseClass}>
+    <div
+      className={`${baseClass}${
+        showApplicationsFilter ? ` ${baseClass}--with-applications-filter` : ""
+      }`}
+    >
       <TableContainer
         renderCount={memoizedSoftwareCount}
         columnConfigs={tableConfig}
@@ -233,9 +301,7 @@ const HostSoftwareTable = ({
             />
           )
         }
-        customControl={
-          showFilterHeaders ? renderCustomFiltersButton : undefined
-        }
+        customControl={showFilterHeaders ? renderCustomControls : undefined}
         stackControls
         showMarkAllPages={false}
         isAllPagesSelected={false}

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -30,6 +30,26 @@
   }
 
   .host-software-table {
+    // When the macOS /Applications dropdown is shown, lay the controls out as
+    // search (left) ... dropdown, filters button (right). The dropdown and
+    // filters render in that DOM order; the search is rendered last by
+    // TableContainer, so pull it to the front of the flex row. Keep the search
+    // a fixed size at the start of the line rather than stretching, and push
+    // the dropdown + filters button to the end of the line.
+    &--with-applications-filter {
+      .top-shift-header {
+        .table-container__search {
+          order: -1;
+          flex: 0 0 auto;
+          width: auto;
+        }
+
+        .host-software-table__software-filter {
+          margin-left: auto;
+        }
+      }
+    }
+
     &__software-filter {
       min-width: 240px;
       width: 240px; // Override .form-field 100%

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -244,6 +244,7 @@ export interface IHostSoftwareQueryParams extends QueryParams {
   min_cvss_score?: number;
   max_cvss_score?: number;
   exploit?: boolean;
+  macos_applications?: boolean;
 }
 
 export interface IHostSoftwareQueryKey extends IHostSoftwareQueryParams {

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -151,6 +151,33 @@ func (ds *Datastore) getHostSoftwareInstalledPaths(
 	return result, nil
 }
 
+// macOSTopLevelApplicationTitleIDs returns the set of software title IDs that
+// have at least one macOS app installed at the top level of the /Applications
+// folder on the given host (e.g. /Applications/Foo.app). Nested helper apps,
+// system apps, and user-local apps are excluded.
+func (ds *Datastore) macOSTopLevelApplicationTitleIDs(ctx context.Context, hostID uint) (map[uint]struct{}, error) {
+	const stmt = `
+		SELECT DISTINCT s.title_id
+		FROM host_software_installed_paths hsip
+		JOIN software s ON s.id = hsip.software_id
+		WHERE hsip.host_id = ?
+			AND s.source = 'apps'
+			AND hsip.installed_path LIKE '/Applications/%'
+			AND hsip.installed_path NOT LIKE '/Applications/%/%'
+			AND s.title_id IS NOT NULL`
+
+	var ids []uint
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &ids, stmt, hostID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "select macos top-level application title ids")
+	}
+
+	set := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, nil
+}
+
 // hostSoftwareInstalledPathsDelta returns what should be inserted and deleted to keep the
 // 'host_software_installed_paths' table in-sync with the osquery reported query results.
 // 'reported' is a set of 'installed_path-software.UniqueStr' strings, built from the osquery
@@ -5646,6 +5673,37 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 	for key, value := range otherInHouseAppsInInventory {
 		if _, ok := filteredByInHouseID[key]; !ok {
 			filteredByInHouseID[key] = value
+		}
+	}
+
+	// Filter to apps installed at the top level of the macOS /Applications
+	// folder. Ignored for non-macOS hosts. Pruning the in-memory maps (rather
+	// than the SQL) keeps the count and main queries consistent and applies
+	// uniformly across software, VPP, and in-house apps.
+	if opts.MacOSApplicationsOnly && fleet.IsMacOSPlatform(host.Platform) {
+		qualifyingTitleIDs, err := ds.macOSTopLevelApplicationTitleIDs(ctx, host.ID)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "filter macos applications")
+		}
+		for titleID := range bySoftwareTitleID {
+			if _, ok := qualifyingTitleIDs[titleID]; !ok {
+				delete(bySoftwareTitleID, titleID)
+			}
+		}
+		for softwareID, s := range bySoftwareID {
+			if _, ok := qualifyingTitleIDs[s.ID]; !ok {
+				delete(bySoftwareID, softwareID)
+			}
+		}
+		for adamID, s := range byVPPAdamID {
+			if _, ok := qualifyingTitleIDs[s.ID]; !ok {
+				delete(byVPPAdamID, adamID)
+			}
+		}
+		for inHouseID, s := range byInHouseID {
+			if _, ok := qualifyingTitleIDs[s.ID]; !ok {
+				delete(byInHouseID, inHouseID)
+			}
 		}
 	}
 

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -85,6 +85,7 @@ func TestSoftware(t *testing.T) {
 		{"InsertHostSoftwareInstalledPaths", testInsertHostSoftwareInstalledPaths},
 		{"VerifySoftwareChecksum", testVerifySoftwareChecksum},
 		{"ListHostSoftware", testListHostSoftware},
+		{"ListHostSoftwareMacOSApplicationsFilter", testListHostSoftwareMacOSApplicationsFilter},
 		{"ListHostSoftwarePaginationWithMultipleInstallers", testListHostSoftwarePaginationWithMultipleInstallers},
 		{"ListLinuxHostSoftware", testListLinuxHostSoftware},
 		{"ListIOSHostSoftware", testListIOSHostSoftware},
@@ -4051,6 +4052,74 @@ func testVerifySoftwareChecksum(t *testing.T, ds *Datastore) {
 		})
 		require.Equal(t, software[i], got)
 	}
+}
+
+func testListHostSoftwareMacOSApplicationsFilter(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host := test.NewHost(t, ds, "macos-apps-host", "", "macappskey", "macappsuuid", time.Now(), test.WithPlatform("darwin"))
+	linuxHost := test.NewHost(t, ds, "linux-apps-host", "", "linuxappskey", "linuxappsuuid", time.Now(), test.WithPlatform("ubuntu"))
+
+	// All source 'apps' so the installed path is the only differentiator.
+	software := []fleet.Software{
+		{Name: "TopLevel", Version: "1.0", Source: "apps", BundleIdentifier: "com.example.toplevel"},
+		{Name: "Helper", Version: "1.0", Source: "apps", BundleIdentifier: "com.example.helper"},
+		{Name: "SystemApp", Version: "1.0", Source: "apps", BundleIdentifier: "com.example.system"},
+		{Name: "UserApp", Version: "1.0", Source: "apps", BundleIdentifier: "com.example.user"},
+	}
+	mutationResults, err := ds.UpdateHostSoftware(ctx, host.ID, software)
+	require.NoError(t, err)
+	require.NoError(t, ds.LoadHostSoftware(ctx, host, false))
+
+	pathByName := map[string]string{
+		"TopLevel":  "/Applications/TopLevel.app",                             // kept
+		"Helper":    "/Applications/TopLevel.app/Contents/Helpers/Helper.app", // nested, dropped
+		"SystemApp": "/System/Applications/SystemApp.app",                     // system, dropped
+		"UserApp":   "/Users/alice/Applications/UserApp.app",                  // user-local, dropped
+	}
+
+	swPaths := map[string]struct{}{}
+	for _, hs := range host.Software {
+		path, ok := pathByName[hs.Name]
+		require.True(t, ok)
+		key := fmt.Sprintf("%s%s%s%s%s%s%s%s%s%s%s", path, fleet.SoftwareFieldSeparator, "", fleet.SoftwareFieldSeparator, "", fleet.SoftwareFieldSeparator, "", fleet.SoftwareFieldSeparator, "", fleet.SoftwareFieldSeparator, hs.ToUniqueStr())
+		swPaths[key] = struct{}{}
+	}
+	require.NoError(t, ds.UpdateHostSoftwareInstalledPaths(ctx, host.ID, swPaths, mutationResults))
+
+	baseOpts := fleet.HostSoftwareTitleListOptions{ListOptions: fleet.ListOptions{PerPage: 20, IncludeMetadata: true, OrderKey: "name"}}
+
+	// filter off: all four apps returned
+	opts := baseOpts
+	sw, meta, err := ds.ListHostSoftware(ctx, host, opts)
+	require.NoError(t, err)
+	require.Len(t, sw, 4)
+	require.EqualValues(t, 4, meta.TotalResults)
+
+	// filter on: only the top-level /Applications app
+	opts = baseOpts
+	opts.MacOSApplicationsOnly = true
+	sw, meta, err = ds.ListHostSoftware(ctx, host, opts)
+	require.NoError(t, err)
+	require.Len(t, sw, 1)
+	require.Equal(t, "TopLevel", sw[0].Name)
+	require.EqualValues(t, 1, meta.TotalResults)
+
+	// filter is ignored on a non-macOS host
+	linuxSoftware := []fleet.Software{
+		{Name: "vim", Version: "1.0", Source: "deb_packages"},
+		{Name: "curl", Version: "1.0", Source: "deb_packages"},
+	}
+	_, err = ds.UpdateHostSoftware(ctx, linuxHost.ID, linuxSoftware)
+	require.NoError(t, err)
+	require.NoError(t, ds.LoadHostSoftware(ctx, linuxHost, false))
+
+	opts = baseOpts
+	opts.MacOSApplicationsOnly = true
+	sw, meta, err = ds.ListHostSoftware(ctx, linuxHost, opts)
+	require.NoError(t, err)
+	require.Len(t, sw, 2)
+	require.EqualValues(t, 2, meta.TotalResults)
 }
 
 func testListHostSoftware(t *testing.T, ds *Datastore) {

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -563,6 +563,10 @@ type HostSoftwareTitleListOptions struct {
 	MinimumCVSS    float64 `query:"min_cvss_score,optional"`
 	MaximumCVSS    float64 `query:"max_cvss_score,optional"`
 
+	// MacOSApplicationsOnly limits the returned software to apps installed at the
+	// top level of the macOS /Applications folder. Ignored for non-macOS hosts.
+	MacOSApplicationsOnly bool `query:"macos_applications,optional"`
+
 	// Non-MDM-enabled hosts cannot install VPP apps
 	IsMDMEnrolled bool
 }


### PR DESCRIPTION
Adds a `macos_applications` boolean query parameter to the list host software endpoint (`GET /api/_version_/fleet/hosts/{id}/software`). When true, results are restricted to apps installed at the top level of the macOS /Applications folder, hiding helper apps, system apps, command-line tools, and user-local apps. The filter applies only to macOS hosts and is ignored on other platforms.

The filter is applied by pruning the in-memory software maps in ListHostSoftware down to the title IDs that have a top-level `/Applications` bundle, so the count and paginated queries stay consistent and the filter applies uniformly across regular, VPP, and in-house apps. Top-level is determined from `host_software_installed_paths` via
`installed_path LIKE '/Applications/%' AND NOT LIKE '/Applications/%/%' on source 'apps'`.

**Related issue:** Resolves #39017

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS applications filter to host software lists that shows only apps installed in the top-level /Applications folder on macOS hosts.

* **Backend / API**
  * API accepts an optional macOS-only query flag to enable the /Applications filter for macOS hosts.

* **UI / Styles**
  * Host software table displays a macOS-only “/Applications” dropdown and layout adjustments when applicable.

* **Tests**
  * Added unit and UI tests verifying the macOS filter behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->