### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bruno/darwin.json
+++ b/ee/maintained-apps/outputs/bruno/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.1",
+      "version": "3.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '3.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '3.4.2') < 0);"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.4.1/bruno_3.4.1_arm64_mac.dmg",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.4.2/bruno_3.4.2_arm64_mac.dmg",
       "install_script_ref": "162ba575",
       "uninstall_script_ref": "334673a8",
-      "sha256": "c86e9bde676edcb628f5f78f538861782278798e576df9d5382b039240fca7b0",
+      "sha256": "4878884cca0a03db2ff293eb5463e1d73ae24e82a168d37eb0314c21516f5ee4",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8555.2",
+      "version": "1.9255.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.8555.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.9255.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.8555.2/Claude-a476c316c741715263e34f9c9d2bc45b6d0f21c7.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.9255.0/Claude-a22af1fabbbc85af5502e695ed8fbea9f74276fc.msix",
       "install_script_ref": "218aa85b",
       "uninstall_script_ref": "03f72055",
-      "sha256": "1c1c645f170314588e9249307a251ab77cdd007f5d5bc85ddf645cd7009c10b8",
+      "sha256": "0cb8ea99eab90cc6347b2553eec1f7799ff228187b1c04b69eecfbc7c7c08815",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.255.6",
+      "version": "7.269.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.255.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.269.0') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.255.6/Granola-7.255.6-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.269.0/Granola-7.269.0-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "d5d47b969639bba37af72b9d826dc6f65fa4084945d8eb568f3e88abed56a698",
+      "sha256": "ecd407e1ea46bc3ec25275ef73b37308cf357b29e8a96e052f22d260579bf274",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/openvpn-connect/darwin.json
+++ b/ee/maintained-apps/outputs/openvpn-connect/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.8.1",
+      "version": "3.8.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.openvpn.client.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.openvpn.client.app' AND version_compare(bundle_short_version, '3.8.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.openvpn.client.app' AND version_compare(bundle_short_version, '3.8.2') < 0);"
       },
-      "installer_url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-3.8.1.5790_signed.dmg",
+      "installer_url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-3.8.2.6009_signed.dmg",
       "install_script_ref": "2ebecc60",
       "uninstall_script_ref": "d66adb9e",
-      "sha256": "8dbf5f3cc82d8214fcdbdb1257cdb5dcae891d1ec1859d64b6e8aa7ee9d8a983",
+      "sha256": "8d50036510859956d20d1f50e43171be53417431104c6befb1352ff5187c248a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "46.5.0.34931",
+      "version": "46.5.0.35006",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.5.0.34931') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.5.0.35006') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "1fe5b1af",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata and installation checksums for five maintained applications: Bruno, Claude, Granola, OpenVPN Connect, and Webex, reflecting their latest release information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->