### PR TITLE
Add Beyond Compare as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/beyond-compare.json
+++ b/ee/maintained-apps/inputs/winget/beyond-compare.json
@@ -1,0 +1,13 @@
+{
+  "name": "Beyond Compare",
+  "slug": "beyond-compare/windows",
+  "package_identifier": "ScooterSoftware.BeyondCompare.5",
+  "unique_identifier": "Beyond Compare",
+  "fuzzy_match_name": true,
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/beyond_compare_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/beyond_compare_uninstall.ps1",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"]
+}

--- a/ee/maintained-apps/inputs/winget/scripts/beyond_compare_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/beyond_compare_install.ps1
@@ -1,0 +1,31 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+#
+# Beyond Compare uses an Inno Setup installer.
+#   /ALLUSERS         - machine-wide install (winget's machine-scope switch)
+#   /VERYSILENT       - no UI, no progress
+#   /SUPPRESSMSGBOXES - suppress message boxes
+#   /NORESTART        - do not reboot
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/ALLUSERS /VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
+  PassThru = $true
+  Wait = $true
+  NoNewWindow = $true
+}
+
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/beyond_compare_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/beyond_compare_uninstall.ps1
@@ -1,0 +1,83 @@
+# Locates Beyond Compare's Inno Setup uninstaller from the registry and runs it
+# silently. Beyond Compare's DisplayName embeds the version, so match by prefix
+# and require the Scooter Software publisher.
+
+$softwareNameLike = "Beyond Compare*"
+$publisherLike = "*Scooter Software*"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$exitCode = 0
+
+try {
+
+[array]$uninstallKeys = Get-ChildItem `
+    -Path $paths `
+    -ErrorAction SilentlyContinue |
+        ForEach-Object { Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue }
+
+$selected = $null
+foreach ($key in $uninstallKeys) {
+    if ($key.DisplayName -and $key.DisplayName -like $softwareNameLike -and $key.Publisher -like $publisherLike) {
+        $selected = $key
+        break
+    }
+}
+
+if (-not $selected -or -not $selected.UninstallString) {
+    Write-Host "Uninstall entry not found for $softwareNameLike"
+    Exit 1
+}
+
+# Best-effort: stop the app so the uninstaller doesn't fail on locked files.
+Stop-Process -Name "BCompare" -Force -ErrorAction SilentlyContinue
+
+$uninstallCommand = $selected.UninstallString
+
+# Split the uninstall string into exe + args. Handle both quoted and unquoted
+# exe paths.
+$exePath = ""
+$existingArgs = ""
+if ($uninstallCommand -match '^\s*"([^"]+)"\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} elseif ($uninstallCommand -match '^\s*(\S+)\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} else {
+    Throw "Could not parse uninstall string: $uninstallCommand"
+}
+
+# Inno Setup silent uninstall flags.
+foreach ($flag in @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART')) {
+    if ($existingArgs -notmatch [regex]::Escape($flag)) {
+        $existingArgs = ("$existingArgs $flag").Trim()
+    }
+}
+
+Write-Host "Uninstall command: $exePath"
+Write-Host "Uninstall args: $existingArgs"
+
+$processOptions = @{
+    FilePath = $exePath
+    PassThru = $true
+    Wait = $true
+}
+
+if ($existingArgs -ne '') {
+    $processOptions.ArgumentList = $existingArgs
+}
+
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+Write-Host "Uninstall exit code: $exitCode"
+
+Exit $exitCode
+
+} catch {
+    Write-Host "Error: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -275,6 +275,13 @@
       "description": "Beyond Compare is an app used to compare files and folders."
     },
     {
+      "name": "Beyond Compare",
+      "slug": "beyond-compare/windows",
+      "platform": "windows",
+      "unique_identifier": "Beyond Compare",
+      "description": "Beyond Compare is an app used to compare files and folders."
+    },
+    {
       "name": "Bitwarden",
       "slug": "bitwarden/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/beyond-compare/windows.json
+++ b/ee/maintained-apps/outputs/beyond-compare/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "5.2.2.32209",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name LIKE 'Beyond Compare %' AND publisher = 'Scooter Software';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Beyond Compare %' AND publisher = 'Scooter Software' AND version_compare(version, '5.2.2.32209') < 0);"
+      },
+      "installer_url": "https://www.scootersoftware.com/files/BCompare-5.2.2.32209.exe",
+      "install_script_ref": "5a25199c",
+      "uninstall_script_ref": "7bf824a3",
+      "sha256": "11cdb99770d2c8db50c68cf557db4641d1a162bd4362c9b18286ab7a405cf6a1",
+      "default_categories": [
+        "Developer tools"
+      ]
+    }
+  ],
+  "refs": {
+    "5a25199c": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n#\n# Beyond Compare uses an Inno Setup installer.\n#   /ALLUSERS         - machine-wide install (winget's machine-scope switch)\n#   /VERYSILENT       - no UI, no progress\n#   /SUPPRESSMSGBOXES - suppress message boxes\n#   /NORESTART        - do not reboot\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/ALLUSERS /VERYSILENT /SUPPRESSMSGBOXES /NORESTART\"\n  PassThru = $true\n  Wait = $true\n  NoNewWindow = $true\n}\n\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "7bf824a3": "# Locates Beyond Compare's Inno Setup uninstaller from the registry and runs it\n# silently. Beyond Compare's DisplayName embeds the version, so match by prefix\n# and require the Scooter Software publisher.\n\n$softwareNameLike = \"Beyond Compare*\"\n$publisherLike = \"*Scooter Software*\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$exitCode = 0\n\ntry {\n\n[array]$uninstallKeys = Get-ChildItem `\n    -Path $paths `\n    -ErrorAction SilentlyContinue |\n        ForEach-Object { Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue }\n\n$selected = $null\nforeach ($key in $uninstallKeys) {\n    if ($key.DisplayName -and $key.DisplayName -like $softwareNameLike -and $key.Publisher -like $publisherLike) {\n        $selected = $key\n        break\n    }\n}\n\nif (-not $selected -or -not $selected.UninstallString) {\n    Write-Host \"Uninstall entry not found for $softwareNameLike\"\n    Exit 1\n}\n\n# Best-effort: stop the app so the uninstaller doesn't fail on locked files.\nStop-Process -Name \"BCompare\" -Force -ErrorAction SilentlyContinue\n\n$uninstallCommand = $selected.UninstallString\n\n# Split the uninstall string into exe + args. Handle both quoted and unquoted\n# exe paths.\n$exePath = \"\"\n$existingArgs = \"\"\nif ($uninstallCommand -match '^\\s*\"([^\"]+)\"\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} elseif ($uninstallCommand -match '^\\s*(\\S+)\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} else {\n    Throw \"Could not parse uninstall string: $uninstallCommand\"\n}\n\n# Inno Setup silent uninstall flags.\nforeach ($flag in @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART')) {\n    if ($existingArgs -notmatch [regex]::Escape($flag)) {\n        $existingArgs = (\"$existingArgs $flag\").Trim()\n    }\n}\n\nWrite-Host \"Uninstall command: $exePath\"\nWrite-Host \"Uninstall args: $existingArgs\"\n\n$processOptions = @{\n    FilePath = $exePath\n    PassThru = $true\n    Wait = $true\n}\n\nif ($existingArgs -ne '') {\n    $processOptions.ArgumentList = $existingArgs\n}\n\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\nWrite-Host \"Uninstall exit code: $exitCode\"\n\nExit $exitCode\n\n} catch {\n    Write-Host \"Error: $_\"\n    Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
Introduce Beyond Compare Windows package metadata and scripts for winget. Adds input manifest (ee/maintained-apps/inputs/winget/beyond-compare.json) plus install and uninstall PowerShell scripts that handle Inno Setup silent install flags and registry-based uninstaller discovery. Updates outputs: registers the app in ee/maintained-apps/outputs/apps.json and adds a versioned output file with installer URL, sha256, and script refs (ee/maintained-apps/outputs/beyond-compare/windows.json).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beyond Compare (version 5.2.2.32209) is now available as a managed application on Windows platforms
  * Automated installation and uninstallation workflows enable seamless deployment and removal across Windows systems
  * Configured for silent, system-wide installation with minimal user intervention
  * Precategorized as a Developer tool for improved discoverability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->