### PR TITLE
Dedup app_store_id in VPP error messages

### DIFF
--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -410,14 +410,23 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 				assetMap[asset.AdamID] = struct{}{}
 			}
 
+			// incomingAppleApps has one entry per (AdamID, platform); without
+			// dedup, a single missing app would repeat in the error.
+			seenMissing := map[string]struct{}{}
 			for _, vppAppID := range incomingAppleApps {
-				if _, ok := assetMap[vppAppID.AdamID]; !ok {
-					missingAssets = append(missingAssets, vppAppID.AdamID)
+				if _, ok := assetMap[vppAppID.AdamID]; ok {
+					continue
 				}
+				if _, dup := seenMissing[vppAppID.AdamID]; dup {
+					continue
+				}
+				seenMissing[vppAppID.AdamID] = struct{}{}
+				missingAssets = append(missingAssets, vppAppID.AdamID)
 			}
 
 			if len(missingAssets) != 0 {
-				reqErr := ctxerr.Errorf(ctx, "requested app not available on vpp account: %s", strings.Join(missingAssets, ","))
+				sort.Strings(missingAssets)
+				reqErr := ctxerr.Errorf(ctx, "requested app not available on vpp account: %s", strings.Join(missingAssets, ", "))
 				return nil, fleet.NewUserMessageError(reqErr, http.StatusUnprocessableEntity)
 			}
 		}

--- a/ee/server/service/vpp_test.go
+++ b/ee/server/service/vpp_test.go
@@ -8,11 +8,13 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -287,4 +289,59 @@ func TestGetAppStoreAppsDoesNotWriteMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, apps, "already-assigned apps must be filtered out of the picker list")
 	require.False(t, batchInsertCalled, "picker must not write metadata back")
+}
+
+// A no-platform numeric Adam ID expands to multiple (AdamID, platform)
+// rows; the missing-asset error must surface each AdamID only once.
+func TestBatchAssociateVPPAppsDedupsMissingAssetsError(t *testing.T) {
+	// dev_mode.SetOverride uses t.Setenv, which is incompatible with t.Parallel.
+
+	vppSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"assets":[]}`))
+	}))
+	t.Cleanup(vppSrv.Close)
+	dev_mode.SetOverride("FLEET_DEV_VPP_URL", vppSrv.URL, t)
+
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.GetVPPTokenByTeamIDFunc = func(ctx context.Context, _ *uint) (*fleet.VPPTokenDB, error) {
+		return &fleet.VPPTokenDB{
+			ID:          1,
+			OrgName:     "us-org",
+			Token:       "us-secret",
+			RenewDate:   time.Now().Add(24 * time.Hour),
+			CountryCode: "us",
+		}, nil
+	}
+	ds.GetSoftwareCategoryIDsFunc = func(ctx context.Context, _ []string) ([]uint, error) {
+		return nil, nil
+	}
+
+	svc := newTestService(t, ds)
+
+	// ValidateSoftwareLabels inside the loop requires a present authz context
+	// for Authorize to mark it checked.
+	ctx := authz_ctx.NewContext(t.Context(), &authz_ctx.AuthorizationContext{})
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+
+	const adamID = "1107542306"
+	_, err := svc.BatchAssociateVPPApps(ctx, "", []fleet.VPPBatchPayload{
+		{
+			AppStoreID:       adamID,
+			LabelsExcludeAny: []string{},
+			LabelsIncludeAny: []string{},
+			LabelsIncludeAll: []string{},
+			Categories:       []string{},
+			// Empty Platform triggers the auto-expansion to multiple
+			// (AdamID, platform) rows — the multiplier this test guards.
+		},
+	}, false)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "requested app not available on vpp account: "+adamID)
+	require.Equal(t, 1, strings.Count(err.Error(), adamID),
+		"missing-asset error must dedup by AdamID, got: %s", err.Error())
 }


### PR DESCRIPTION
Fixes #46042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where error messages for missing VPP apps incorrectly displayed duplicate app identifiers. Each missing app ID now appears only once with improved formatting for better readability.

* **Tests**
  * Added new test to verify that missing app assets are properly deduplicated when multiple entries share the same identifier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->