### PR TITLE
Add P4V as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/p4v.json
+++ b/ee/maintained-apps/inputs/winget/p4v.json
@@ -1,0 +1,11 @@
+{
+  "name": "P4V",
+  "slug": "p4v/windows",
+  "package_identifier": "Perforce.P4V",
+  "unique_identifier": "P4 Apps",
+  "program_publisher": "Perforce Software",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1437,6 +1437,13 @@
       "description": "P4V is an app for accessing and managing Perforce version control repositories via a graphical interface."
     },
     {
+      "name": "P4V",
+      "slug": "p4v/windows",
+      "platform": "windows",
+      "unique_identifier": "P4 Apps",
+      "description": "P4V is an app for accessing and managing Perforce version control repositories via a graphical interface."
+    },
+    {
       "name": "Parallels Desktop",
       "slug": "parallels/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/p4v/windows.json
+++ b/ee/maintained-apps/outputs/p4v/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "242.61.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'P4 Apps' AND publisher = 'Perforce Software';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'P4 Apps' AND publisher = 'Perforce Software' AND version_compare(version, '242.61.2') < 0);"
+      },
+      "installer_url": "https://filehost.perforce.com/perforce/r26.1/bin.ntx64/p4vinst64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "480c1bf0",
+      "sha256": "3f5d210db394cc78f11cfe03637c92c1bcd86c47b6156108d6887e6a7d111e9a",
+      "default_categories": [
+        "Developer tools"
+      ],
+      "upgrade_code": "{70A9FDC7-885B-4D6D-BAFD-CB2D27AB2963}"
+    }
+  ],
+  "refs": {
+    "480c1bf0": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts('{70A9FDC7-885B-4D6D-BAFD-CB2D27AB2963}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
Add P4V (Perforce) Windows package: new winget input (Perforce.P4V) and a dedicated outputs/p4v/windows.json describing version 242.61.2 with installer URL, sha256, upgrade code, and embedded PowerShell install/uninstall scripts. Also update outputs/apps.json to register the P4V/windows app entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * P4V application is now available for Windows platform with automated installation support
  * Version 242.61.2 installation and management configuration has been added for Windows environments
  * Users can seamlessly install, manage, and uninstall P4V on Windows systems through the platform

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->