### PR TITLE
Disable gomod proxy in snapshot builds to fix Vanta false positives

### DIFF
--- a/.goreleaser-snapshot.yml
+++ b/.goreleaser-snapshot.yml
@@ -14,8 +14,8 @@ before:
     - make deps
     - make generate
 
-gomod:
-  proxy: true
+# gomod:
+#   proxy: true
 
 builds:
   - id: fleet


### PR DESCRIPTION
## Summary

- Disables `gomod.proxy` in `.goreleaser-snapshot.yml`, matching the release config (`.goreleaser.yml`) which already has it disabled.

## Problem

When `gomod.proxy: true` is set, GoReleaser proxies the Go module during build. This causes Go to embed pseudo-version metadata into the binary, e.g.:

```
github.com/fleetdm/fleet/v4 v4.0.0-20260521202532-16931880f5de
```

Vanta scans our Docker images, finds this module string, and interprets `v4.0.0` as the Fleet version. It then flags the image with CVEs for Fleet v4.0.0 (an ancient version), even though the actual Fleet version is much newer.

This was previously fixed for release builds by commenting out `gomod.proxy` in `.goreleaser.yml`, but the snapshot config (`.goreleaser-snapshot.yml`) was missed. Snapshot images are built on every push to `main` and RC branches, so these are the images that Vanta keeps flagging.

## Fix

Comment out `gomod.proxy: true` in `.goreleaser-snapshot.yml`. The Fleet version is still correctly injected via ldflags (`-X ...version.version={{ .Version }}`), so this change only removes the misleading pseudo-version from the binary's Go module metadata.

## Test plan

- [ ] Verify the snapshot Docker publish workflow still succeeds after merge
- [ ] Confirm with `go version -m /usr/bin/fleet` on a newly built snapshot image that the `github.com/fleetdm/fleet/v4` module no longer shows a `v4.0.0-*` pseudo-version
- [ ] Monitor Vanta to confirm the false positive clears after the next image scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings for snapshot releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->