### PR TITLE
Open Manage automations modal for policies without automations + inherited policies

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -26,7 +26,11 @@ import {
   IPoliciesCountResponse,
   OtherAutomationType,
 } from "interfaces/policy";
-import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
+import {
+  API_ALL_TEAMS_ID,
+  APP_CONTEXT_ALL_TEAMS_ID,
+  ITeamConfig,
+} from "interfaces/team";
 
 import configAPI from "services/entities/config";
 import globalPoliciesAPI, {
@@ -95,6 +99,23 @@ const AUTOMATION_TYPES: AutomationType[] = [
 ];
 
 const GLOBAL_AUTOMATION_TYPES: GlobalPoliciesAutomationType[] = ["other"];
+
+// NOTE: backend uses webhook_settings to store automated policy ids for both
+// webhooks and integrations.
+const getWebhookOrTicketPolicyIds = (
+  config: IConfig | ITeamConfig | undefined
+): number[] => {
+  if (!config) return [];
+  const webhook = config.webhook_settings?.failing_policies_webhook;
+  const { jira, zendesk } = config.integrations ?? {};
+  const isIntegrationEnabled =
+    !!jira?.some((j) => j.enable_failing_policies) ||
+    !!zendesk?.some((z) => z.enable_failing_policies);
+  if (isIntegrationEnabled || webhook?.enable_failing_policies_webhook) {
+    return webhook?.policy_ids || [];
+  }
+  return [];
+};
 
 const baseClass = "manage-policies-page";
 
@@ -959,19 +980,36 @@ const ManagePolicyPage = ({
             onExit={toggleAutomationsModal}
           />
         )}
-        {selectedPolicyForAutomations && (
-          <ManageAutomationsModal
-            policy={selectedPolicyForAutomations}
-            fleetName={currentTeamSummary?.name ?? ""}
-            isGlobalPolicy={isAllTeamsSelected}
-            teamIdForApi={teamIdForApi}
-            automationsConfig={automationsConfig}
-            globalConfig={globalConfig}
-            webhookOrTicketPolicyIds={currentAutomatedPolicies}
-            refetchPolicies={() => refetchPolicies(teamIdForApi)}
-            onExit={onCloseManageAutomationsModal}
-          />
-        )}
+        {selectedPolicyForAutomations &&
+          (() => {
+            // An inherited policy (team_id === null) is global even when viewed
+            // from within a fleet's list — its automations live on the global
+            // config, so route the modal there.
+            const isInheritedGlobal =
+              selectedPolicyForAutomations.team_id === null;
+            const modalAutomationsConfig = isInheritedGlobal
+              ? globalConfig
+              : automationsConfig;
+            return (
+              <ManageAutomationsModal
+                policy={selectedPolicyForAutomations}
+                fleetName={
+                  isInheritedGlobal
+                    ? "All fleets"
+                    : currentTeamSummary?.name ?? ""
+                }
+                isGlobalPolicy={isInheritedGlobal}
+                teamIdForApi={teamIdForApi}
+                automationsConfig={modalAutomationsConfig}
+                globalConfig={globalConfig}
+                webhookOrTicketPolicyIds={getWebhookOrTicketPolicyIds(
+                  modalAutomationsConfig
+                )}
+                refetchPolicies={() => refetchPolicies(teamIdForApi)}
+                onExit={onCloseManageAutomationsModal}
+              />
+            );
+          })()}
       </>
     </MainContent>
   );

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -631,32 +631,41 @@ const ManagePolicyPage = ({
     hasPoliciesToAutomate || (isPrimoMode && (teamPolicies?.length ?? 0) > 0); // in Primo mode, allow deleting inherited policies, which will be included in teamPolicies, from this view
 
   // NOTE: backend uses webhook_settings to store automated policy ids for both webhooks and integrations
-  let currentAutomatedPolicies: number[] = [];
-  let otherAutomationType: OtherAutomationType | undefined;
-  if (automationsConfig) {
+  const getAutomationInfoFromConfig = (
+    cfg: IConfig | ITeamConfig | undefined
+  ): { policyIds: number[]; type: OtherAutomationType | undefined } => {
+    if (!cfg) return { policyIds: [], type: undefined };
     const {
-      webhook_settings: { failing_policies_webhook: webhook },
+      webhook_settings: { failing_policies_webhook: webhook } = {},
       integrations,
-    } = automationsConfig;
-
-    let isIntegrationEnabled = false;
-    if (integrations) {
-      const { jira, zendesk } = integrations;
-      isIntegrationEnabled =
-        !!jira?.find((j) => j.enable_failing_policies) ||
-        !!zendesk?.find((z) => z.enable_failing_policies);
-    }
-
-    if (isIntegrationEnabled || webhook?.enable_failing_policies_webhook) {
-      currentAutomatedPolicies = webhook?.policy_ids || [];
-    }
-
-    if (isIntegrationEnabled) {
-      otherAutomationType = "ticket";
-    } else if (webhook?.enable_failing_policies_webhook) {
-      otherAutomationType = "webhook";
-    }
-  }
+    } = cfg;
+    const isIntegrationEnabled =
+      !!integrations?.jira?.find((j) => j.enable_failing_policies) ||
+      !!integrations?.zendesk?.find((z) => z.enable_failing_policies);
+    const isWebhookEnabled = !!webhook?.enable_failing_policies_webhook;
+    const policyIds =
+      isIntegrationEnabled || isWebhookEnabled ? webhook?.policy_ids ?? [] : [];
+    let type: OtherAutomationType | undefined;
+    if (isIntegrationEnabled) type = "ticket";
+    else if (isWebhookEnabled) type = "webhook";
+    return { policyIds, type };
+  };
+  const fleetAutomationInfo = getAutomationInfoFromConfig(automationsConfig);
+  // Inherited (global) policies are listed in team views, but their webhook
+  // membership lives on the *global* config — not the team's.
+  // Union both so an inherited policy with a global-config webhook/ticket
+  // still shows the correct data.
+  const inheritedAutomationInfo = !isAllTeamsSelected
+    ? getAutomationInfoFromConfig(globalConfig)
+    : { policyIds: [], type: undefined as OtherAutomationType | undefined };
+  const currentAutomatedPolicies: number[] = Array.from(
+    new Set([
+      ...fleetAutomationInfo.policyIds,
+      ...inheritedAutomationInfo.policyIds,
+    ])
+  );
+  const otherAutomationType: OtherAutomationType | undefined =
+    fleetAutomationInfo.type ?? inheritedAutomationInfo.type;
 
   const renderPoliciesCountAndLastUpdated = (
     count?: number,

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -3,6 +3,7 @@
 // definitions for the selection row for some reason when we dont really need it.
 import React from "react";
 import { millisecondsToHours, millisecondsToMinutes } from "date-fns";
+import classnames from "classnames";
 // @ts-ignore
 import Checkbox from "components/forms/fields/Checkbox";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
@@ -87,6 +88,43 @@ const AUTOMATION_ICON_RENDERERS: Record<
   other: () => <Icon name="settings" />,
 };
 
+interface IEditableAutomationsCellProps {
+  ariaLabel: string;
+  onEdit: () => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const EditableAutomationsCell = ({
+  ariaLabel,
+  onEdit,
+  className,
+  children,
+}: IEditableAutomationsCellProps): JSX.Element => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onEdit();
+    }
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={classnames("automations__cell-content", className)}
+      onClick={onEdit}
+      onKeyDown={handleKeyDown}
+      aria-label={ariaLabel}
+    >
+      {children}
+      <span className="automations__edit-button" aria-hidden="true">
+        <Icon name="pencil" />
+      </span>
+    </div>
+  );
+};
+
 interface IAutomationsCellProps {
   policy: IPolicyStats;
   selectedTeamId?: number | null;
@@ -102,13 +140,7 @@ const AutomationsCell = ({
 }: IAutomationsCellProps): JSX.Element => {
   const automations = getAutomationsForPolicy(policy, otherAutomationType);
 
-  const handleClick = () => onOpenManageAutomationsModal?.(policy);
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleClick();
-    }
-  };
+  const handleEdit = () => onOpenManageAutomationsModal?.(policy);
 
   if (automations.length === 0) {
     // Read-only users (no edit callback) keep the plain, non-interactive "---".
@@ -120,19 +152,13 @@ const AutomationsCell = ({
       );
     }
     return (
-      <div
-        role="button"
-        tabIndex={0}
-        className="automations__cell-content automations__cell-content--none"
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        aria-label="Add automation"
+      <EditableAutomationsCell
+        ariaLabel="Add automation"
+        onEdit={handleEdit}
+        className="automations__cell-content--none"
       >
         <span className="automations__name">{DEFAULT_EMPTY_CELL_VALUE}</span>
-        <span className="automations__edit-button" aria-hidden="true">
-          <Icon name="pencil" />
-        </span>
-      </div>
+      </EditableAutomationsCell>
     );
   }
 
@@ -159,35 +185,21 @@ const AutomationsCell = ({
   if (automations.length === 1) {
     const automation = automations[0];
     return (
-      <div
-        role="button"
-        tabIndex={0}
-        className="automations__cell-content"
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        aria-label={`Edit automation: ${automation.name}`}
+      <EditableAutomationsCell
+        ariaLabel={`Edit automation: ${automation.name}`}
+        onEdit={handleEdit}
       >
         <TooltipTruncatedTextCell
           prefix={renderAutomationIcon(automation)}
           value={automation.name}
           className="automations__name"
         />
-        <span className="automations__edit-button" aria-hidden="true">
-          <Icon name="pencil" />
-        </span>
-      </div>
+      </EditableAutomationsCell>
     );
   }
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      className="automations__cell-content"
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      aria-label="Edit automations"
-    >
+    <EditableAutomationsCell ariaLabel="Edit automations" onEdit={handleEdit}>
       <TooltipWrapper
         className="automations__count"
         position="top"
@@ -198,10 +210,7 @@ const AutomationsCell = ({
       >
         {automations.length} automations
       </TooltipWrapper>
-      <span className="automations__edit-button" aria-hidden="true">
-        <Icon name="pencil" />
-      </span>
-    </div>
+    </EditableAutomationsCell>
   );
 };
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -102,14 +102,6 @@ const AutomationsCell = ({
 }: IAutomationsCellProps): JSX.Element => {
   const automations = getAutomationsForPolicy(policy, otherAutomationType);
 
-  if (automations.length === 0) {
-    return (
-      <span className="automations__cell-content automations__cell-content--none">
-        {DEFAULT_EMPTY_CELL_VALUE}
-      </span>
-    );
-  }
-
   const handleClick = () => onOpenManageAutomationsModal?.(policy);
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -117,6 +109,32 @@ const AutomationsCell = ({
       handleClick();
     }
   };
+
+  if (automations.length === 0) {
+    // Read-only users (no edit callback) keep the plain, non-interactive "---".
+    if (!onOpenManageAutomationsModal) {
+      return (
+        <span className="automations__cell-content automations__cell-content--none">
+          {DEFAULT_EMPTY_CELL_VALUE}
+        </span>
+      );
+    }
+    return (
+      <div
+        role="button"
+        tabIndex={0}
+        className="automations__cell-content automations__cell-content--none"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        aria-label="Add automation"
+      >
+        <span className="automations__name">{DEFAULT_EMPTY_CELL_VALUE}</span>
+        <span className="automations__edit-button" aria-hidden="true">
+          <Icon name="pencil" />
+        </span>
+      </div>
+    );
+  }
 
   const renderAutomationIcon = ({
     type,

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/_styles.scss
@@ -41,8 +41,13 @@
 
   &--none {
     color: $ui-fleet-black-50;
-    cursor: default;
   }
+}
+
+// The read-only empty cell is a plain <span> (no role="button"); keep it
+// non-interactive. The editable empty cell is a <div role="button">.
+span.automations__cell-content--none {
+  cursor: default;
 }
 
 .automations__name {


### PR DESCRIPTION
**Related issue:** #45148 and #45145 

## Summary
Stacked on top of the Manage automations modal PR (#46254). Two follow-up tweaks:

- **Open the modal from the empty ("---") automations cell.** Policies with no automations configured were previously a non-interactive cell. Now, for users who can edit, the empty cell is clickable.
- **Handle inherited policies opened from a fleet's list.** An inherited policy has `team_id === null` even when viewed from within a specific fleet. It's now treated as global (only the webhook/ticket row, no continuous-retry option) and the modal is routed to the **global** config for its automations, instead of inferring "global" from the selected-team view.

## Testing

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/9a927373-e1d2-4326-92cc-a97f26d85962


https://github.com/user-attachments/assets/9ff9c393-56c7-4631-9052-477a8736af7a

