### PR TITLE
Fix spacing on Controls > Setup experience > Users page

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/_styles.scss
@@ -1,8 +1,6 @@
 .setup-experience-users {
   @include vertical-card-layout;
 
-  gap: $gap-page-component-inner;
-
   &__section-description {
     margin: 0;
   }


### PR DESCRIPTION
Resolves #45991. Spacing on Controls > Setup experience > Users is 16px instead of 24px.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the user management section of the setup experience by removing an unnecessary gap between container elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->