### PR TITLE
Update homepage comparison table

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -257,7 +257,7 @@
               <div purpose="feature-name">
                 <p>
                   Device reporting (&lt;30 seconds)
-                  <img class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info" data-toggle="tooltip" tabindex="0" data-placement="top" title="Unlike traditional system that can take from 1 - 6 hours to respond. Fleet can talk to thousands of devices in seconds.">
+                  <img class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info" data-toggle="tooltip" tabindex="0" data-placement="top" title="Unlike traditional systems that can take from 1 - 6 hours to respond. Fleet can talk to thousands of devices in seconds.">
                 </p>
 
               </div>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -194,45 +194,13 @@
               </div>
             </div>
           </div>
-          <div purpose="comparison-table" class="d-sm-flex d-none flex-column">
-            <div purpose="table-row">
-              <div purpose="feature-name"><p>Cloud or self-host with no restrictions</p></div>
-              <div purpose="fleet-column">
-                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-              <div purpose="comparison-column" v-if="comparisonModeForIt === 'jamf'">
-                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some key features, like Apple Declarative Device Management (DDM), are cloud-only.">On-prem limited</a></p>
-              </div>
-              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'tanium'">
-                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some modern modules and integrations are cloud-only.">On-prem limited</a></p>
-              </div>
-              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'intune'">
-                <p>Cloud-only</p>
-              </div>
-              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'sccm'">
-                <p>On-prem only</p>
-              </div>
-              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'omnissa'">
-                <p>On-prem discouraged</p>
-              </div>
-              <div purpose="comparison-column" v-else>
-                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-            </div>
-
-
+          <div purpose="comparison-table" class="d-sm-flex d-none flex-column"> 
             <div purpose="table-row">
               <div purpose="feature-name">
-                <p>Complete device inventory <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Fleet gives you data down to the chip level on every endpoint, server, and cloud instance. Access over 300 tables of system state data. Use presets or create your own reports."></p>
+                <p>Complete device inventory <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Fleet gives you complete software inventory and hardware data down to the chip level on Apple, Linux, Windows, and ChromeOS devices."></p>
 
               </div>
-              <div purpose="fleet-column">
-                <img src="/images/os-macos-black-50-16x16@2x.png" alt="macOS logo" >
-                <img src="/images/os-windows-black-50-16x16@2x.png" alt="Windows logo">
-                <img src="/images/os-linux-black-50-16x16@2x.png" alt="Linux logo">
-                <img src="/images/icon-android-16x16@2x.png" alt="Android" >
-                <img src="/images/icon-ios-16x16@2x.png" alt="iOS">
-              </div>
+              <div purpose="fleet-column"><img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png"></div>
               <div purpose="comparison-column" v-if="comparisonModeForIt === 'tanium'">
                 <p>Mobile not supported</p>
               </div>
@@ -242,12 +210,9 @@
             </div>
 
             <div purpose="table-row">
-              <div purpose="feature-name"><p>Operating system updates</p></div>
+              <div purpose="feature-name"><p>Software updates <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Auto-patch policies keep software and OS versions up to date across macOS, Windows, Linux, iOS, and iPadOS. Deploy from a catalog of Fleet-maintained apps, upload custom packages, or let end users self-serve."></p></div>
               <div purpose="fleet-column">
-                <img src="/images/os-macos-black-50-16x16@2x.png" alt="macOS logo" >
-                <img src="/images/os-windows-black-50-16x16@2x.png" alt="Windows logo">
-                <img src="/images/icon-android-16x16@2x.png" alt="Android" >
-                <img src="/images/icon-ios-16x16@2x.png" alt="iOS">
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
               <div purpose="comparison-column" v-if="comparisonModeForIt === 'sccm'">
                 <p>Windows only</p>
@@ -267,13 +232,9 @@
             </div>
 
             <div purpose="table-row">
-              <div purpose="feature-name"><p>Configuration management and scripting</p></div>
+              <div purpose="feature-name"><p>Configuration, scripting, and diagnostics</p></div>
               <div purpose="fleet-column">
-                <img src="/images/os-macos-black-50-16x16@2x.png" alt="macOS logo" >
-                <img src="/images/os-windows-black-50-16x16@2x.png" alt="Windows logo">
-                <img src="/images/os-linux-black-50-16x16@2x.png" alt="Linux logo">
-                <img src="/images/icon-android-16x16@2x.png" alt="Android" >
-                <img src="/images/icon-ios-16x16@2x.png" alt="iOS">
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
               <div purpose="comparison-column" v-if="comparisonModeForIt === 'sccm'">
                 <p>Windows only</p>
@@ -289,35 +250,6 @@
               </div>
               <div purpose="comparison-column" v-else-if="['omnissa', 'intune'].includes(comparisonModeForIt)">
                 <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-            </div>
-
-
-            <div purpose="table-row">
-              <div purpose="feature-name"><p>REST API</p></div>
-              <div purpose="fleet-column"><img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png"></div>
-              <div purpose="comparison-column" v-if="comparisonModeForIt === 'sccm'">
-                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'intune'">
-                <p>Microsoft Graph API</p>
-              </div>
-              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'patchmypc'">
-                <p>Intune or SCCM integration</p>
-              </div>
-              <div purpose="comparison-column" v-else>
-                <p>Multiple APIs required</p>
-              </div>
-            </div>
-
-            <div purpose="table-row">
-              <div purpose="feature-name"><p>Infrastructure as code</p></div>
-              <div purpose="fleet-column"><img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png"></div>
-              <div purpose="comparison-column" v-if="['puppet', 'chef', 'ansible'].includes(comparisonModeForIt)">
-                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-              <div purpose="comparison-column" v-else>
-                <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
               </div>
             </div>
 
@@ -348,15 +280,55 @@
 
 
             <div purpose="table-row">
-              <div purpose="feature-name"><p>Open source</p></div>
-              <div purpose="fleet-column">
+              <div purpose="feature-name"><p>Single API</p></div>
+              <div purpose="fleet-column"><img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png"></div>
+              <div purpose="comparison-column" v-if="comparisonModeForIt === 'sccm'">
                 <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
+              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'intune'">
+                <p>Microsoft Graph API</p>
+              </div>
+              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'patchmypc'">
+                <p>Intune or SCCM integration</p>
+              </div>
+              <div purpose="comparison-column" v-else>
+                <p>Multiple APIs required</p>
+              </div>
+            </div>
+
+            <div purpose="table-row">
+              <div purpose="feature-name"><p>Infrastructure as code</p></div>
+              <div purpose="fleet-column"><img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png"></div>
               <div purpose="comparison-column" v-if="['puppet', 'chef', 'ansible'].includes(comparisonModeForIt)">
-                <p>Only free version</p>
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
               <div purpose="comparison-column" v-else>
                 <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
+              </div>
+            </div>
+
+            <div purpose="table-row">
+              <div purpose="feature-name"><p>Cloud or self-host</p></div>
+              <div purpose="fleet-column">
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+              </div>
+              <div purpose="comparison-column" v-if="comparisonModeForIt === 'jamf'">
+                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some key features, like Apple Declarative Device Management (DDM), are cloud-only.">On-prem limited</a></p>
+              </div>
+              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'tanium'">
+                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some modern modules and integrations are cloud-only.">On-prem limited</a></p>
+              </div>
+              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'intune'">
+                <p>Cloud-only</p>
+              </div>
+              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'sccm'">
+                <p>On-prem only</p>
+              </div>
+              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'omnissa'">
+                <p>On-prem discouraged</p>
+              </div>
+              <div purpose="comparison-column" v-else>
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
             </div>
           </div>
@@ -377,48 +349,15 @@
           </div>
 
           <div purpose="feature-table">
-            <div purpose="feature-name"><p>Cloud or self-host with no restrictions</p></div>
-            <div purpose="feature-table-row">
-              <div>Fleet</div>
-              <div purpose="feature-status">
-                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-            </div>
-            <div purpose="feature-table-row">
-              <div>{{comparisonModeFriendlyNames[comparisonModeForIt]}}</div>
-              <div purpose="feature-status" v-if="comparisonModeForIt === 'jamf'">
-                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some key features, like Apple Declarative Device Management (DDM), are cloud-only.">On-prem limited</a></p>
-              </div>
-              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'tanium'">
-                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some modern modules and integrations are cloud-only.">On-prem limited</a></p>
-              </div>
-              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'intune'">
-                <p>Cloud-only</p>
-              </div>
-              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'sccm'">
-                <p>On-prem only</p>
-              </div>
-              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'omnissa'">
-                <p>On-prem discouraged</p>
-              </div>
-              <div purpose="feature-status" v-else>
-                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-            </div>
-          </div>
-          <div purpose="feature-table">
             <div purpose="feature-name">
               <p>Complete device inventory </p>
-              <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Fleet gives you data down to the chip level on every endpoint. Access over 300 tables of system state data. Use presets or create your own reports.">
+              <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Fleet gives you complete software inventory and hardware data down to the chip level on Apple, Linux, Windows, and ChromeOS devices.">
             </div>
             <div purpose="feature-table-row">
               <div>Fleet</div>
               <div purpose="feature-status">
-                <img src="/images/os-macos-black-50-16x16@2x.png" alt="macOS logo" >
-                <img src="/images/os-windows-black-50-16x16@2x.png" alt="Windows logo">
-                <img src="/images/os-linux-black-50-16x16@2x.png" alt="Linux logo">
-                <img src="/images/icon-android-16x16@2x.png" alt="Android" >
-                <img src="/images/icon-ios-16x16@2x.png" alt="iOS">              </div>
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">              
+              </div>
             </div>
             <div purpose="feature-table-row">
               <div>{{comparisonModeFriendlyNames[comparisonModeForIt]}}</div>
@@ -431,14 +370,14 @@
             </div>
           </div>
           <div purpose="feature-table">
-            <div purpose="feature-name"><p>Operating system updates</p></div>
+            <div purpose="feature-name">
+              <p>Software updates</p>
+              <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Auto-patch policies keep software and OS versions up to date across macOS, Windows, Linux, iOS, and iPadOS. Deploy from a catalog of Fleet-maintained apps, upload custom packages, or let end users self-serve.">
+            </div>
             <div purpose="feature-table-row">
               <div>Fleet</div>
               <div purpose="feature-status">
-                <img src="/images/os-macos-black-50-16x16@2x.png" alt="macOS logo" >
-                <img src="/images/os-windows-black-50-16x16@2x.png" alt="Windows logo">
-                <img src="/images/icon-android-16x16@2x.png" alt="Android" >
-                <img src="/images/icon-ios-16x16@2x.png" alt="iOS">
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
             </div>
             <div purpose="feature-table-row">
@@ -461,15 +400,11 @@
             </div>
           </div>
           <div purpose="feature-table">
-            <div purpose="feature-name"><p purpose="long-feature-name">Configuration management & scripting</p></div>
+            <div purpose="feature-name"><p purpose="long-feature-name">Configuration, scripting, and diagnostics</p></div>
             <div purpose="feature-table-row">
               <div>Fleet</div>
               <div purpose="feature-status">
-                <img src="/images/os-macos-black-50-16x16@2x.png" alt="macOS logo" >
-                <img src="/images/os-windows-black-50-16x16@2x.png" alt="Windows logo">
-                <img src="/images/os-linux-black-50-16x16@2x.png" alt="Linux logo">
-                <img src="/images/icon-android-16x16@2x.png" alt="Android" >
-                <img src="/images/icon-ios-16x16@2x.png" alt="iOS">
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
             </div>
             <div purpose="feature-table-row">
@@ -491,8 +426,37 @@
               </div>
             </div>
           </div>
+
           <div purpose="feature-table">
-            <div purpose="feature-name"><p>REST API</p></div>
+            <div purpose="feature-name">
+              <p>Device reporting (&lt;30 seconds)</p>
+              <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Unlike traditional system that can take from 1 - 6 hours to respond. Fleet can talk to thousands of devices in seconds.">
+            </div>
+            <div purpose="feature-table-row">
+              <div>Fleet</div>
+              <div purpose="feature-status">
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+              </div>
+            </div>
+            <div purpose="feature-table-row">
+              <div>{{comparisonModeFriendlyNames[comparisonModeForIt]}}</div>
+              <div purpose="feature-status" v-if="comparisonModeForIt === 'tanium'">
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+              </div>
+              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'intune'">
+                <p>6 Hours</p>
+              </div>
+              <div purpose="feature-status" v-else-if="['puppet', 'chef', 'ansible'].includes(comparisonModeForIt)">
+                <p>One-off scripts</p>
+              </div>
+              <div purpose="feature-status" v-else>
+                <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
+              </div>
+            </div>
+          </div>
+
+          <div purpose="feature-table">
+            <div purpose="feature-name"><p>Single API</p></div>
             <div purpose="feature-table-row">
               <div>Fleet</div>
               <div purpose="feature-status">
@@ -536,10 +500,7 @@
           </div>
 
           <div purpose="feature-table">
-            <div purpose="feature-name">
-              <p>Device reporting (&lt;30 seconds)</p>
-              <img style="margin-left: 6px;" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info"  data-toggle="tooltip" tabindex="0" data-placement="top" title="Unlike traditional system that can take from 1 - 6 hours to respond. Fleet can talk to thousands of devices in seconds.">
-            </div>
+            <div purpose="feature-name"><p>Cloud or self-host</p></div>
             <div purpose="feature-table-row">
               <div>Fleet</div>
               <div purpose="feature-status">
@@ -548,37 +509,23 @@
             </div>
             <div purpose="feature-table-row">
               <div>{{comparisonModeFriendlyNames[comparisonModeForIt]}}</div>
-              <div purpose="feature-status" v-if="comparisonModeForIt === 'tanium'">
-                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+              <div purpose="feature-status" v-if="comparisonModeForIt === 'jamf'">
+                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some key features, like Apple Declarative Device Management (DDM), are cloud-only.">On-prem limited</a></p>
+              </div>
+              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'tanium'">
+                <p><a purpose="tooltip" data-toggle="tooltip" tabindex="0" data-placement="top" title="On-prem supported, but some modern modules and integrations are cloud-only.">On-prem limited</a></p>
               </div>
               <div purpose="feature-status" v-else-if="comparisonModeForIt === 'intune'">
-                <p>6 Hours</p>
+                <p>Cloud-only</p>
               </div>
-              <div purpose="feature-status" v-else-if="['puppet', 'chef', 'ansible'].includes(comparisonModeForIt)">
-                <p>One-off scripts</p>
+              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'sccm'">
+                <p>On-prem only</p>
+              </div>
+              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'omnissa'">
+                <p>On-prem discouraged</p>
               </div>
               <div purpose="feature-status" v-else>
-                <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
-              </div>
-            </div>
-          </div>
-
-
-          <div purpose="feature-table">
-            <div purpose="feature-name"><p>Open source</p></div>
-            <div purpose="feature-table-row">
-              <div>Fleet</div>
-              <div purpose="feature-status">
                 <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-              </div>
-            </div>
-            <div purpose="feature-table-row">
-              <div>{{comparisonModeFriendlyNames[comparisonModeForIt]}}</div>
-              <div purpose="feature-status" v-if="['puppet', 'chef', 'ansible'].includes(comparisonModeForIt)">
-                <p>Only free version</p>
-              </div>
-              <div purpose="feature-status" v-else>
-                <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
               </div>
             </div>
           </div>


### PR DESCRIPTION
Resolves https://github.com/fleetdm/confidential/issues/16119

- Re-orders and removes rows
- Replaces platform icons for easier-to-scan checkmarks
- Adds additional context in tooltips

I decided against adding tabs. They added visual weight without enough benefit. The dropdown is clear enough on its own, and it's already the second-most-clicked button on the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated product comparison tables (desktop and mobile) with reordered rows and clearer layout
  * Added distinct "Complete device inventory" and "Cloud or self-host" entries with competitor-specific outcomes
  * Renamed and clarified features: "Software updates"; "Configuration, scripting, and diagnostics"; "Single API"; "Infrastructure as code"
  * Revised competitor status displays and tooltip copy, including standardized timing labels and outcome mappings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->