### PR TITLE
Fleet UI: Fix self-service page > 0 toggle

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTable.tsx
@@ -276,7 +276,6 @@ const SoftwareLibraryTable = ({
         disableSearch={controlsDisabled}
         inputPlaceHolder="Search by name"
         onQueryChange={onQueryChange}
-        additionalQueries={String(selfServiceOnly)}
         customControl={renderCustomControls}
         stackControls
         renderCount={renderSoftwareCount}


### PR DESCRIPTION
## Issue
Closes #45868

## Description
-  The thing the prop was doing for us — "reset to page 0 when the toggle flips" — is already done explicitly by
  `handleSelfServiceToggle` setting page: 0 on `line 152`. Removing the duplicate path that raced with resetting the page.
- Will need cherry-pick to 4.86.0

## Screen recording of test (used pagination of 4 in my test)


https://github.com/user-attachments/assets/e79f051b-d6f2-4d2f-9c43-dc0643de4cf5



## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified component prop handling by removing unnecessary parameter passing to improve code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->