### PR TITLE
Adding create vpp user recovery if the user is missing from db

### DIFF
--- a/ee/server/service/install_vpp_associate_test.go
+++ b/ee/server/service/install_vpp_associate_test.go
@@ -61,6 +61,10 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
 				assert.Equal(t, "Bearer "+bearerToken, r.Header.Get("Authorization"))
 				_, _ = w.Write([]byte(`{"assignments": []}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/users":
+				// ensureVPPClientUser now consults Apple before registering, so
+				// brand-new users go through this path returning an empty list.
+				_, _ = w.Write([]byte(`{"users":[]}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				assert.Equal(t, "Bearer "+bearerToken, r.Header.Get("Authorization"))
 				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
@@ -164,6 +168,8 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
 				assignmentsQuery = r.URL.RawQuery
 				_, _ = w.Write([]byte(`{"assignments": []}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/users":
+				_, _ = w.Write([]byte(`{"users":[]}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
 			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
@@ -192,6 +198,8 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
 				// User already has the asset — Apple returns a non-empty assignment list.
 				_, _ = fmt.Fprintf(w, `{"assignments":[{"adamId":%q,"pricingParam":"STDQ"}]}`, adamID)
+			case r.Method == http.MethodGet && r.URL.Path == "/users":
+				_, _ = w.Write([]byte(`{"users":[]}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				t.Errorf("/assets must not be queried when assignments already exist")
 			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
@@ -219,6 +227,8 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 			switch {
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
 				_, _ = w.Write([]byte(`{"assignments": []}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/users":
+				_, _ = w.Write([]byte(`{"users":[]}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
 			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
@@ -299,10 +309,22 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 			}
 		})
 
-		// Override managed-apple-id so the GET /users assertion above can pin it.
+		// Stale local cache: registered row points at a clientUserId Apple no
+		// longer recognizes. This is the cache-drift scenario where the
+		// associate-time 9609 self-heal kicks in — ensureVPPClientUser returns
+		// the stale UUID on the cache hit without consulting Apple.
+		const staleUUID = "stale-cached-uuid"
 		ds := setupDS(t, true)
 		ds.GetHostManagedAppleIDFunc = func(_ context.Context, _ uint) (string, error) {
 			return "user@example.com", nil
+		}
+		ds.GetVPPClientUserFunc = func(_ context.Context, _ uint, _ string) (*fleet.VPPClientUser, error) {
+			return &fleet.VPPClientUser{
+				VPPTokenID:     99,
+				ManagedAppleID: "user@example.com",
+				ClientUserID:   staleUUID,
+				Status:         fleet.VPPClientUserStatusRegistered,
+			}, nil
 		}
 		var upserts []*fleet.VPPClientUser
 		ds.InsertVPPClientUserFunc = func(_ context.Context, row *fleet.VPPClientUser) error {
@@ -316,15 +338,15 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 		require.NotEmpty(t, cmdUUID)
 
 		require.Equal(t, 2, associateCalls, "associate must be retried exactly once")
-		require.Equal(t, 1, getUsersCalls, "must look up the user by managed apple id before deciding to re-register")
-		require.Equal(t, 1, registerCalls, "only the initial ensureVPPClientUser register; no second register since Apple still has the user")
+		require.Equal(t, 1, getUsersCalls, "self-heal looks up the user by managed apple id once after 9609")
+		require.Equal(t, 0, registerCalls, "Apple still has the user — must resync, not register")
 
-		require.NotEqual(t, capturedFirstClientUserID, capturedSecondClientUser, "second associate must use the recovered clientUserId")
+		require.Equal(t, staleUUID, capturedFirstClientUserID, "first associate uses the stale cached clientUserId")
 		require.Equal(t, recoveredUUID, capturedSecondClientUser, "second associate must use the clientUserId returned by Apple's GET /users")
 
-		require.Len(t, upserts, 2, "initial register + cache resync from Apple")
-		require.Equal(t, recoveredUUID, upserts[1].ClientUserID)
-		require.Equal(t, fleet.VPPClientUserStatusRegistered, upserts[1].Status)
+		require.Len(t, upserts, 1, "cache resync from Apple is the only write")
+		require.Equal(t, recoveredUUID, upserts[0].ClientUserID)
+		require.Equal(t, fleet.VPPClientUserStatusRegistered, upserts[0].Status)
 		require.True(t, ds.InsertHostVPPSoftwareInstallFuncInvoked)
 	})
 
@@ -370,7 +392,11 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 		_, err := svc.InstallVPPAppPostValidation(context.Background(), host, vppApp, bearerToken, fleet.HostSoftwareInstallOptions{})
 		require.NoError(t, err)
 
-		require.Equal(t, 1, getUsersCalls)
+		// ensureVPPClientUser now consults Apple before registering, so the
+		// lookup fires twice: once during ensure (resolves to Retired-only,
+		// falls through to register) and once during the self-heal recovery
+		// after associate fails with 9609.
+		require.Equal(t, 2, getUsersCalls)
 		require.Equal(t, 2, registerCalls, "initial ensure + fallback re-register")
 		require.Equal(t, 2, associateCalls, "associate retried after re-register")
 	})
@@ -383,6 +409,8 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 			switch {
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assignments"):
 				_, _ = w.Write([]byte(`{"assignments": []}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/users":
+				_, _ = w.Write([]byte(`{"users":[]}`))
 			case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/assets"):
 				_, _ = fmt.Fprintf(w, `{"assets":[{"adamId":%q,"pricingParam":"STDQ","availableCount":5}]}`, adamID)
 			case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":

--- a/ee/server/service/vpp_users.go
+++ b/ee/server/service/vpp_users.go
@@ -54,28 +54,29 @@ func (svc *Service) ensureVPPClientUser(ctx context.Context, host *fleet.Host, t
 		return existing.ClientUserID, nil
 	}
 
-	// Non-registered row. Apple enforces uniqueness on
-	// (location, managedAppleId), so blindly calling
-	// registerVPPClientUser with a fresh UUID will collide with any existing
-	// Apple-side user. Ask Apple first; if a user already exists, resync the
-	// local cache to its clientUserId rather than minting a new one.
-	if existing != nil {
-		appleUser, lookupErr := vpp.GetUserByManagedAppleID(ctx, token.Token, managedAppleID)
-		if lookupErr != nil {
-			return "", ctxerr.Wrapf(ctx, lookupErr, "looking up vpp user by managed apple id for token %d", token.ID)
+	// No registered row — either pending, or the row was removed entirely
+	// (e.g. operator wiped vpp_client_users while Apple still has the user
+	// registered). Apple enforces uniqueness on (location, managedAppleId),
+	// so calling registerVPPClientUser with a fresh UUID would collide with
+	// the existing Apple-side user and trip error 9635 ("Apple Account can't
+	// be associated with registered user"). Ask Apple first; if a user
+	// already exists, resync the local cache to its clientUserId rather than
+	// minting a new one.
+	appleUser, lookupErr := vpp.GetUserByManagedAppleID(ctx, token.Token, managedAppleID)
+	if lookupErr != nil {
+		return "", ctxerr.Wrapf(ctx, lookupErr, "looking up vpp user by managed apple id for token %d", token.ID)
+	}
+	if appleUser != nil {
+		row := &fleet.VPPClientUser{
+			VPPTokenID:     token.ID,
+			ManagedAppleID: managedAppleID,
+			ClientUserID:   appleUser.ClientUserID,
+			Status:         fleet.VPPClientUserStatusRegistered,
 		}
-		if appleUser != nil {
-			row := &fleet.VPPClientUser{
-				VPPTokenID:     token.ID,
-				ManagedAppleID: managedAppleID,
-				ClientUserID:   appleUser.ClientUserID,
-				Status:         fleet.VPPClientUserStatusRegistered,
-			}
-			if err := svc.ds.InsertVPPClientUser(ctx, row); err != nil {
-				return "", ctxerr.Wrap(ctx, err, "resyncing vpp client user cache from Apple")
-			}
-			return appleUser.ClientUserID, nil
+		if err := svc.ds.InsertVPPClientUser(ctx, row); err != nil {
+			return "", ctxerr.Wrap(ctx, err, "resyncing vpp client user cache from Apple")
 		}
+		return appleUser.ClientUserID, nil
 	}
 
 	return svc.registerVPPClientUser(ctx, token.ID, managedAppleID, token.Token)

--- a/ee/server/service/vpp_users_test.go
+++ b/ee/server/service/vpp_users_test.go
@@ -34,33 +34,40 @@ func TestEnsureVPPClientUser_NewUser(t *testing.T) {
 	tokenDB := &fleet.VPPTokenDB{ID: 42, Token: "valid-token"}
 	host := &fleet.Host{ID: hostID}
 
-	var registerCalls int
+	var registerCalls, lookupCalls int
 	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
-		registerCalls++
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/registerVPPUserSrv", r.URL.Path)
-		// v1 puts the token in the body, not the Authorization header.
-		assert.Empty(t, r.Header.Get("Authorization"))
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/users":
+			lookupCalls++
+			assert.Equal(t, managedAppleID, r.URL.Query().Get("managedAppleId"))
+			_, _ = fmt.Fprint(w, `{"users":[]}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/registerVPPUserSrv":
+			registerCalls++
+			// v1 puts the token in the body, not the Authorization header.
+			assert.Empty(t, r.Header.Get("Authorization"))
 
-		var got struct {
-			SToken            string `json:"sToken"`
-			ClientUserIDStr   string `json:"clientUserIdStr"`
-			ManagedAppleIDStr string `json:"managedAppleIDStr"`
-		}
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
-		assert.Equal(t, "valid-token", got.SToken)
-		assert.NotEmpty(t, got.ClientUserIDStr)
-		assert.Equal(t, managedAppleID, got.ManagedAppleIDStr)
-
-		_, _ = fmt.Fprintf(w, `{
-			"status": 0,
-			"user": {
-				"userId": 98765,
-				"status": "Registered",
-				"clientUserIdStr": %q,
-				"managedAppleIDStr": %q
+			var got struct {
+				SToken            string `json:"sToken"`
+				ClientUserIDStr   string `json:"clientUserIdStr"`
+				ManagedAppleIDStr string `json:"managedAppleIDStr"`
 			}
-		}`, got.ClientUserIDStr, managedAppleID)
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+			assert.Equal(t, "valid-token", got.SToken)
+			assert.NotEmpty(t, got.ClientUserIDStr)
+			assert.Equal(t, managedAppleID, got.ManagedAppleIDStr)
+
+			_, _ = fmt.Fprintf(w, `{
+				"status": 0,
+				"user": {
+					"userId": 98765,
+					"status": "Registered",
+					"clientUserIdStr": %q,
+					"managedAppleIDStr": %q
+				}
+			}`, got.ClientUserIDStr, managedAppleID)
+		default:
+			t.Fatalf("unexpected Apple call %s %s", r.Method, r.URL.Path)
+		}
 	})
 
 	ds := new(mock.Store)
@@ -83,6 +90,7 @@ func TestEnsureVPPClientUser_NewUser(t *testing.T) {
 	clientUserID, err := svc.ensureVPPClientUser(context.Background(), host, tokenDB)
 	require.NoError(t, err)
 	require.NotEmpty(t, clientUserID)
+	require.Equal(t, 1, lookupCalls)
 	require.Equal(t, 1, registerCalls)
 
 	require.NotNil(t, insertedRow)
@@ -156,6 +164,50 @@ func TestEnsureVPPClientUser_PendingRowAppleHasUser(t *testing.T) {
 			ClientUserID:   "stale-pending-uuid",
 			Status:         fleet.VPPClientUserStatusPending,
 		}, nil
+	}
+	var insertedRow *fleet.VPPClientUser
+	ds.InsertVPPClientUserFunc = func(_ context.Context, row *fleet.VPPClientUser) error {
+		insertedRow = row
+		return nil
+	}
+
+	svc := newTestServiceWithDS(ds)
+	clientUserID, err := svc.ensureVPPClientUser(context.Background(), host, tokenDB)
+	require.NoError(t, err)
+	require.Equal(t, appleClientID, clientUserID)
+	require.NotNil(t, insertedRow)
+	require.Equal(t, appleClientID, insertedRow.ClientUserID)
+	require.Equal(t, fleet.VPPClientUserStatusRegistered, insertedRow.Status)
+}
+
+// No local cache row at all, but Apple still has the Managed Apple ID
+// registered (e.g. an operator deleted the vpp_client_users row while Apple
+// retained the user). Without the Apple-side lookup the next install would
+// hit error 9635 ("Apple Account can't be associated with registered user")
+// from /registerVPPUserSrv. The lookup must run and resync the cache.
+func TestEnsureVPPClientUser_NoRowAppleHasUser(t *testing.T) {
+	const (
+		managedAppleID = "user@example.com"
+		appleClientID  = "apple-side-uuid"
+	)
+	tokenDB := &fleet.VPPTokenDB{ID: 1, Token: "tok"}
+	host := &fleet.Host{ID: 1}
+
+	setupFakeVPPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/users" {
+			assert.Equal(t, managedAppleID, r.URL.Query().Get("managedAppleId"))
+			_, _ = fmt.Fprintf(w, `{"users":[{"clientUserId":%q,"status":"Registered"}]}`, appleClientID)
+			return
+		}
+		t.Fatalf("unexpected Apple call %s %s — no local row + Apple-side user should resync without re-registering", r.Method, r.URL.Path)
+	})
+
+	ds := new(mock.Store)
+	ds.GetHostManagedAppleIDFunc = func(_ context.Context, _ uint) (string, error) {
+		return managedAppleID, nil
+	}
+	ds.GetVPPClientUserFunc = func(_ context.Context, _ uint, _ string) (*fleet.VPPClientUser, error) {
+		return nil, &notFoundError{}
 	}
 	var insertedRow *fleet.VPPClientUser
 	ds.InsertVPPClientUserFunc = func(_ context.Context, row *fleet.VPPClientUser) error {


### PR DESCRIPTION
Fixing unreleased behavior where if a user was missing from the vpp users db that it would retrieve the current vpp user from apple to continue installing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPP user synchronization by querying Apple's records when no locally cached registered user exists, ensuring users already registered with Apple are properly recognized and synced.

* **Tests**
  * Added test coverage for VPP user recovery from Apple's system and updated existing tests to verify proper synchronization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->