### PR TITLE
Enable "Show example payload" buttons in GitOps mode

### DIFF
--- a/changes/fix-show-example-payload-gitops-mode
+++ b/changes/fix-show-example-payload-gitops-mode
@@ -1,0 +1,1 @@
+* Fixed "Show example payload" button being incorrectly disabled in GitOps mode on the "Other workflows" and "Calendar events" policy automation modals.

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -275,7 +275,7 @@ const CalendarEventsModal = ({
               onClick={() => {
                 setShowExamplePayload(!showExamplePayload);
               }}
-              disabled={!formData.enabled || gitOpsModeEnabled}
+              disabled={!formData.enabled}
             />
             {showExamplePayload && renderExamplePayload()}
           </>

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -253,7 +253,7 @@ const OtherWorkflowsModal = ({
           showText="Show example payload"
           caretPosition="after"
           onClick={() => setShowExamplePayload(!showExamplePayload)}
-          disabled={!isPolicyAutomationsEnabled || gitOpsModeEnabled}
+          disabled={!isPolicyAutomationsEnabled}
         />
         {showExamplePayload && <ExamplePayload />}
       </>


### PR DESCRIPTION
We allow this already with "Preview payload" under Settings > Integrations > MDM > End user migration workflow.

**Related issue:** Resolves #44719

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] QA'd all new/changed functionality manually
  - I was able to test the "Other workflows" modal, but not the "Calendar events" modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the "Show example payload" button being incorrectly disabled in GitOps mode for policy automation configurations across calendar events and other workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->