### PR TITLE
Fix SSRF response body leak in integration error messages

### DIFF
--- a/changes/14276-ssrf-response-body-sanitization
+++ b/changes/14276-ssrf-response-body-sanitization
@@ -1,0 +1,1 @@
+- Sanitized error messages from external service integrations (Jira, Zendesk, DigiCert, EST) to prevent leaking response body content from admin-configured URLs.

--- a/ee/server/service/digicert/digicert.go
+++ b/ee/server/service/digicert/digicert.go
@@ -218,20 +218,20 @@ func (s *Service) GetCertificate(ctx context.Context, config fleet.DigiCertCA) (
 			return nil, ctxerr.Errorf(ctx, "unexpected DigiCert status code for POST request: %d", resp.StatusCode)
 		}
 
+		// Log response body content at debug level only — do not include in
+		// returned errors to prevent leaking internal service data (SSRF).
 		combinedErrorMessages := make([]string, len(errResp.Errors))
 		for i, e := range errResp.Errors {
 			combinedErrorMessages[i] = e.Message
 		}
+		s.logger.DebugContext(ctx, "DigiCert error response", "status_code", resp.StatusCode, "errors", strings.Join(combinedErrorMessages, "; "))
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
-			return nil, ctxerr.Errorf(ctx, errMessageInvalidAPIToken+", errors: %s", config.Name, resp.StatusCode,
-				strings.Join(combinedErrorMessages, "; "))
+			return nil, ctxerr.Errorf(ctx, errMessageInvalidAPIToken, config.Name, resp.StatusCode)
 		case http.StatusForbidden:
-			return nil, ctxerr.Errorf(ctx, errMessageInvalidProfile+", errors: %s", config.Name, resp.StatusCode,
-				strings.Join(combinedErrorMessages, "; "))
+			return nil, ctxerr.Errorf(ctx, errMessageInvalidProfile, config.Name, resp.StatusCode)
 		}
-		return nil, ctxerr.Errorf(ctx, "unexpected DigiCert status code for POST request: %d, errors: %s", resp.StatusCode,
-			strings.Join(combinedErrorMessages, "; "))
+		return nil, ctxerr.Errorf(ctx, "unexpected DigiCert status code for POST request: %d", resp.StatusCode)
 	}
 
 	type certificateResponse struct {

--- a/ee/server/service/est/est.go
+++ b/ee/server/service/est/est.go
@@ -120,12 +120,13 @@ func (s *Service) GetCertificate(ctx context.Context, estCA fleet.ESTProxyCA, cs
 		return nil, ctxerr.Wrap(ctx, err, "reading EST CA response body")
 	}
 	if resp.StatusCode != http.StatusOK {
+		// Log response body at debug level only — do not log at error level
+		// to prevent leaking internal service data (SSRF).
 		bytesToLog := bytes
-		// Limit logged data in case we get a huge response(a certificate perhaps?)
 		if len(bytes) > 1000 {
 			bytesToLog = bytes[:1000]
 		}
-		s.logger.ErrorContext(ctx, "unexpected EST CA status code", "status_code", resp.StatusCode, "response_body", string(bytesToLog))
+		s.logger.DebugContext(ctx, "unexpected EST CA status code", "status_code", resp.StatusCode, "response_body", string(bytesToLog))
 		return nil, ctxerr.Errorf(ctx, "unexpected EST CA status code: %d", resp.StatusCode)
 	}
 

--- a/server/fleet/integrations.go
+++ b/server/fleet/integrations.go
@@ -272,7 +272,9 @@ func makeTestJiraRequest(ctx context.Context, intg *JiraIntegration) error {
 		return IntegrationTestError{Err: fmt.Errorf("Jira integration request failed: %w", err)}
 	}
 	if _, err := client.GetProject(ctx); err != nil {
-		return IntegrationTestError{Err: fmt.Errorf("Jira integration request failed: %w", err)}
+		// Do not include the raw error — it may contain response body content
+		// from the configured URL, which could leak internal service data (SSRF).
+		return IntegrationTestError{Err: errors.New("Jira integration request failed: verify the URL, credentials, and project key")}
 	}
 	return nil
 }
@@ -376,7 +378,9 @@ func makeTestZendeskRequest(ctx context.Context, intg *ZendeskIntegration) error
 	}
 	grp, err := client.GetGroup(ctx)
 	if err != nil {
-		return IntegrationTestError{Err: fmt.Errorf("Zendesk integration request failed: %w", err)}
+		// Do not include the raw error — it may contain response body content
+		// from the configured URL, which could leak internal service data (SSRF).
+		return IntegrationTestError{Err: errors.New("Zendesk integration request failed: verify the URL, credentials, and group ID")}
 	}
 	if grp.ID != intg.GroupID {
 		return IntegrationTestError{Err: fmt.Errorf("Zendesk integration request failed: no matching group id: received %d, expected %d", grp.ID, intg.GroupID)}


### PR DESCRIPTION
## Summary

- Sanitize error messages from external service integrations (Jira, Zendesk, DigiCert, EST) to prevent leaking response body content from admin-configured URLs
- Relates to fleetdm/confidential#14276

### Problem

When an admin configures an integration URL (Jira, Zendesk, etc.) pointing to an internal service, Fleet makes a server-side request to that URL. Some code paths return the response body back to the admin in the API error message, enabling data exfiltration via SSRF.

### Reproduction

1. Start a fake internal service on `127.0.0.1:9999` that returns sensitive data (e.g. fake AWS credentials) in JSON format
2. As a Fleet admin, configure a Jira integration with URL `http://127.0.0.1:9999`
3. Fleet makes a GET to `http://127.0.0.1:9999/rest/api/2/project/PROJ`
4. The go-jira library includes the full response body in its error
5. Fleet returns the error (with the response body) in the API response:
```json
{
  "message": "Bad request",
  "errors": [{
    "name": "base",
    "reason": "Jira integration at index 0: Jira integration request failed: Access denied. Internal metadata: aws_access_key_id=AKIAIOSFODNN7EXAMPLE..."
  }]
}
```
The leaked content is also persisted in `/debug/errors`.

A reproduction script (`repro_ssrf.sh`) was used to validate this locally.

### Changes

- **Jira/Zendesk** (`server/fleet/integrations.go`): return a generic error message instead of wrapping raw library errors that contain response body content
- **DigiCert** (`ee/server/service/digicert/digicert.go`): move response body error details to debug log, keep only status code in returned errors
- **EST** (`ee/server/service/est/est.go`): downgrade response body logging from error to debug level

### Note

This PR addresses response body leakage only (defense-in-depth). A separate PR for transport-level IP blocking (DialContext) is pending product sign-off -- see fleetdm/confidential#14276 for discussion.

## Test plan

- [ ] Configure Jira integration with an invalid/internal URL -- verify error message does not contain response body
- [ ] Configure Zendesk integration with an invalid/internal URL -- verify error message does not contain response body
- [ ] Verify existing Jira/Zendesk integrations still work with valid URLs
- [ ] Verify DigiCert and EST certificate flows still work


🤖 Generated with [Claude Code](https://claude.com/claude-code)