### PR TITLE
Fix Salesforce login URL formatting

### DIFF
--- a/handbook/finance/gtm-architecture.md
+++ b/handbook/finance/gtm-architecture.md
@@ -73,7 +73,7 @@ We track certian social posts from the [LinkedIn company page](https://www.linke
 
 ### SFDC access
 
-Fleet uses Okta SSO for Salesforce authentication. All Fleet employees (`@fleetdm.com`) authenticate through Okta — Salesforce credential login is disabled for SSO-enabled profiles. All Fleet employees must login at our custom domain [fleetdm.my.salesforce.com](fleetdm.my.salesforce.com) or by clicking the Salesforce app tile in Okta. For users and accounts that cannot use SSO (e.g., integration users, external collaborators), Fleet has created custom cloned profiles with SSO disabled that must login at [login.salesforce.com](login.salesforce.com).
+Fleet uses Okta SSO for Salesforce authentication. All Fleet employees (`@fleetdm.com`) authenticate through Okta — Salesforce credential login is disabled for SSO-enabled profiles. All Fleet employees must login at our custom domain [fleetdm.my.salesforce.com](https://fleetdm.my.salesforce.com) or by clicking the Salesforce app tile in Okta. For users and accounts that cannot use SSO (e.g., integration users, external collaborators), Fleet has created custom cloned profiles with SSO disabled that must login at [login.salesforce.com](login.salesforce.com).
 
 
 #### Profiles and when to use them


### PR DESCRIPTION
Updated Salesforce login URL. Without the HTTPS, the generated link was https://fleetdm.com/handbook/finance/fleetdm.my.salesforce.com and lead to a 404.
