### PR TITLE
Use new MDM status on hosts page and show tooltip; show "Not supported" for Linux

### DIFF
--- a/changes/46066-fix-on-automatic-mdm-status-display
+++ b/changes/46066-fix-on-automatic-mdm-status-display
@@ -1,1 +1,2 @@
 * Fixed MDM status column in the host table showing "On (automatic)" instead of "On (company-owned)".
+* Added hosts page tooltip to MDM status on hover.

--- a/changes/46066-fix-on-automatic-mdm-status-display
+++ b/changes/46066-fix-on-automatic-mdm-status-display
@@ -1,0 +1,1 @@
+* Fixed MDM status column in the host table showing "On (automatic)" instead of "On (company-owned)".

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tests.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import createMockHost from "__mocks__/hostMock";
+import { MdmEnrollmentStatus } from "interfaces/mdm";
+import HostMdmStatusCell from "./HostMdmStatusCell";
+
+const renderCell = (platform: string, value?: MdmEnrollmentStatus) => {
+  const host = createMockHost({ platform } as any);
+  return render(
+    <HostMdmStatusCell
+      row={{ original: host }}
+      cell={{ value } as any}
+    />
+  );
+};
+
+describe("HostMdmStatusCell", () => {
+  it("renders 'Not supported' for Chrome hosts", () => {
+    renderCell("chrome");
+    expect(screen.getByText("Not supported")).toBeInTheDocument();
+  });
+
+  it("renders 'Not supported' for Linux hosts", () => {
+    renderCell("ubuntu");
+    expect(screen.getByText("Not supported")).toBeInTheDocument();
+  });
+
+  it("renders 'On (manual)' for Apple hosts with manual enrollment", () => {
+    renderCell("darwin", "On (manual)");
+    expect(screen.getByText("On (manual)")).toBeInTheDocument();
+  });
+
+  it("renders 'On (company-owned)' for Apple hosts with automatic enrollment", () => {
+    renderCell("darwin", "On (automatic)");
+    expect(screen.getByText("On (company-owned)")).toBeInTheDocument();
+  });
+
+  it("renders 'On (personal)' for iOS hosts with personal enrollment", () => {
+    renderCell("ios", "On (personal)");
+    expect(screen.getByText("On (personal)")).toBeInTheDocument();
+  });
+
+  it("renders 'Pending' for macOS hosts with pending enrollment", () => {
+    renderCell("darwin", "Pending");
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("renders the MDM status for Android hosts", () => {
+    renderCell("android", "On (personal)");
+    expect(screen.getByText("On (personal)")).toBeInTheDocument();
+  });
+
+  it("renders the MDM status for Windows hosts", () => {
+    renderCell("windows", "On (manual)");
+    expect(screen.getByText("On (manual)")).toBeInTheDocument();
+  });
+
+  it("renders 'Off' for Windows hosts with no MDM enrollment", () => {
+    renderCell("windows", "Off");
+    expect(screen.getByText("Off")).toBeInTheDocument();
+  });
+
+
+
+});

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tests.tsx
@@ -8,10 +8,7 @@ import HostMdmStatusCell from "./HostMdmStatusCell";
 const renderCell = (platform: string, value?: MdmEnrollmentStatus) => {
   const host = createMockHost({ platform } as any);
   return render(
-    <HostMdmStatusCell
-      row={{ original: host }}
-      cell={{ value } as any}
-    />
+    <HostMdmStatusCell row={{ original: host }} cell={{ value } as any} />
   );
 };
 
@@ -60,7 +57,4 @@ describe("HostMdmStatusCell", () => {
     renderCell("windows", "Off");
     expect(screen.getByText("Off")).toBeInTheDocument();
   });
-
-
-
 });

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
@@ -6,6 +6,7 @@ import CustomLink from "components/CustomLink";
 import NotSupported from "components/NotSupported";
 import TooltipWrapper from "components/TooltipWrapper";
 import { IHost } from "interfaces/host";
+import { MDM_ENROLLMENT_STATUS_UI_MAP, MdmEnrollmentStatus } from "interfaces/mdm";
 
 const baseClass = "host-mdm-status-cell";
 
@@ -26,9 +27,13 @@ const HostMdmStatusCell = ({
     return <span className={`${baseClass}`}>{DEFAULT_EMPTY_CELL_VALUE}</span>;
   }
 
+  const displayValue =
+    MDM_ENROLLMENT_STATUS_UI_MAP[value as MdmEnrollmentStatus]?.displayName ??
+    value;
+
   return (
     <span className={`${baseClass}`}>
-      {value}
+      {displayValue}
       {mdm?.dep_profile_error && (
         <TooltipWrapper
           tipContent={

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
+import { DEFAULT_EMPTY_CELL_VALUE, MDM_STATUS_TOOLTIP } from "utilities/constants";
 import paths from "router/paths";
 import Icon from "components/Icon";
 import CustomLink from "components/CustomLink";
@@ -33,7 +33,16 @@ const HostMdmStatusCell = ({
 
   return (
     <span className={`${baseClass}`}>
-      {displayValue}
+      {!MDM_STATUS_TOOLTIP[value as MdmEnrollmentStatus] ? (
+        displayValue
+      ) : (
+        <TooltipWrapper
+          className="mdm-status-tooltip"
+          tipContent={MDM_STATUS_TOOLTIP[value as MdmEnrollmentStatus]}
+        >
+          {displayValue}
+        </TooltipWrapper>
+      )}
       {mdm?.dep_profile_error && (
         <TooltipWrapper
           tipContent={

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
@@ -13,6 +13,7 @@ import {
   MDM_ENROLLMENT_STATUS_UI_MAP,
   MdmEnrollmentStatus,
 } from "interfaces/mdm";
+import { isChrome, isLinuxLike } from "interfaces/platform";
 
 const baseClass = "host-mdm-status-cell";
 
@@ -25,7 +26,7 @@ const HostMdmStatusCell = ({
   row: { original: IHost };
   cell: { value: MdmEnrollmentStatus };
 }): JSX.Element => {
-  if (platform === "chrome") {
+  if (isChrome(platform) || isLinuxLike(platform)) {
     return NotSupported;
   }
 

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
@@ -17,7 +17,7 @@ const HostMdmStatusCell = ({
   cell: { value },
 }: {
   row: { original: IHost };
-  cell: { value: string };
+  cell: { value: MdmEnrollmentStatus };
 }): JSX.Element => {
   if (platform === "chrome") {
     return NotSupported;
@@ -28,17 +28,16 @@ const HostMdmStatusCell = ({
   }
 
   const displayValue =
-    MDM_ENROLLMENT_STATUS_UI_MAP[value as MdmEnrollmentStatus]?.displayName ??
-    value;
+    MDM_ENROLLMENT_STATUS_UI_MAP[value]?.displayName ?? value;
 
   return (
     <span className={`${baseClass}`}>
-      {!MDM_STATUS_TOOLTIP[value as MdmEnrollmentStatus] ? (
+      {!MDM_STATUS_TOOLTIP[value] ? (
         displayValue
       ) : (
         <TooltipWrapper
           className="mdm-status-tooltip"
-          tipContent={MDM_STATUS_TOOLTIP[value as MdmEnrollmentStatus]}
+          tipContent={MDM_STATUS_TOOLTIP[value]}
         >
           {displayValue}
         </TooltipWrapper>

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
@@ -1,12 +1,18 @@
 import React from "react";
-import { DEFAULT_EMPTY_CELL_VALUE, MDM_STATUS_TOOLTIP } from "utilities/constants";
+import {
+  DEFAULT_EMPTY_CELL_VALUE,
+  MDM_STATUS_TOOLTIP,
+} from "utilities/constants";
 import paths from "router/paths";
 import Icon from "components/Icon";
 import CustomLink from "components/CustomLink";
 import NotSupported from "components/NotSupported";
 import TooltipWrapper from "components/TooltipWrapper";
 import { IHost } from "interfaces/host";
-import { MDM_ENROLLMENT_STATUS_UI_MAP, MdmEnrollmentStatus } from "interfaces/mdm";
+import {
+  MDM_ENROLLMENT_STATUS_UI_MAP,
+  MdmEnrollmentStatus,
+} from "interfaces/mdm";
 
 const baseClass = "host-mdm-status-cell";
 

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
@@ -36,7 +36,7 @@ const HostMdmStatusCell = ({
         displayValue
       ) : (
         <TooltipWrapper
-          className="mdm-status-tooltip"
+          className={`${baseClass}__tooltip`}
           tipContent={MDM_STATUS_TOOLTIP[value]}
         >
           {displayValue}

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/_styles.scss
@@ -5,3 +5,8 @@
   gap: $gap-icon-text;
   align-items: center;
 }
+
+.host-mdm-status-cell .component__tooltip-wrapper.mdm-status-tooltip .component__tooltip-wrapper__element {
+  // prevent status name from wrapping to multiple lines
+  white-space: nowrap;
+}

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/_styles.scss
@@ -6,7 +6,7 @@
   align-items: center;
 }
 
-.host-mdm-status-cell .component__tooltip-wrapper.mdm-status-tooltip .component__tooltip-wrapper__element {
+.host-mdm-status-cell .component__tooltip-wrapper.host-mdm-status-cell__tooltip .component__tooltip-wrapper__element {
   // prevent status name from wrapping to multiple lines
   white-space: nowrap;
 }


### PR DESCRIPTION
**Related issue:** Resolves #46066

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MDM status label in the hosts table so enrollment states display accurately.
  * Fixed platform handling so "Not supported" appears appropriately for Chrome and Linux hosts.

* **New Features**
  * Added a hover tooltip on the MDM status in the hosts table to show additional context.

* **Style**
  * Improved tooltip text wrapping to keep status names on a single line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->