### PR TITLE
[Docs] Document failure_reason on install activities (#45851, #45854)

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -1508,6 +1508,7 @@ This activity contains the following fields:
 - "policy_name": Name of the policy whose failure triggered installation. Null if no associated policy.
 - "command_uuid": ID of the in-house app installation.
 - "from_setup_experience": Whether the installation was triggered as part of the setup experience.
+- "failure_reason": Reason the installation failed before reaching the device (e.g. an unresolvable Fleet variable in the managed app configuration). Only present when "status" is "failed_install" and Fleet failed the install pre-flight; omitted otherwise.
 
 
 #### Example
@@ -1789,6 +1790,7 @@ This activity contains the following fields:
 - "policy_id": ID of the policy whose failure triggered the install. Null if no associated policy.
 - "policy_name": Name of the policy whose failure triggered the install. Null if no associated policy.
 - "from_setup_experience": Whether the app was installed as part of the setup experience.
+- "failure_reason": Reason the installation failed before reaching the device (e.g. an unresolvable Fleet variable in the managed app configuration). Only present when "status" is "failed_install" and Fleet failed the install pre-flight; omitted otherwise.
 
 #### Example
 


### PR DESCRIPTION
Adds the new `failure_reason` field on the `installed_software` and
  `installed_app_store_app` audit-log entries. Code PR: #46332 / cherry-pick: #46379.