### PR TITLE
Website: Update application form submission action

### DIFF
--- a/website/api/controllers/admin/view-email-template-preview.js
+++ b/website/api/controllers/admin/view-email-template-preview.js
@@ -217,7 +217,6 @@ module.exports = {
         layout = 'layout-email';
         fakeData = {
           firstName: 'Sage',
-          emailAddress: 'sage@example.com',
         };
         break;
       default:

--- a/website/api/controllers/admin/view-email-template-preview.js
+++ b/website/api/controllers/admin/view-email-template-preview.js
@@ -213,6 +213,13 @@ module.exports = {
           emailAddress: 'sage@example.com',
         };
         break;
+      case 'email-application-submitted':
+        layout = 'layout-email';
+        fakeData = {
+          firstName: 'Sage',
+          emailAddress: 'sage@example.com',
+        };
+        break;
       default:
         layout = 'layout-email-newsletter';
         fakeData = {

--- a/website/api/controllers/deliver-application-submission.js
+++ b/website/api/controllers/deliver-application-submission.js
@@ -52,19 +52,33 @@ module.exports = {
       description: 'The applican\'ts cover letter in plain text.',
     },
 
+    websiteUrl: {
+      type: 'string',
+      description: 'Honeypot field. If filled, the submission is silently discarded.'
+    }
+
   },
 
 
   exits: {
     success: {
       description: 'A job application was successfully submitted.',
-    }
+    },
+    invalidEmailDomain: {
+      description: 'This email address is on a denylist of domains and was not delivered.',
+      responseType: 'badRequest'
+    },
   },
 
 
-  fn: async function ({ firstName, lastName, emailAddress, position, linkedinProfileUrl, location, message,}) {
+  fn: async function ({ firstName, lastName, emailAddress, position, linkedinProfileUrl, location, message, websiteUrl}) {
 
+    if (websiteUrl) { return; }// Honeypot input provided — return a success response
 
+    let emailDomain = emailAddress.split('@')[1];
+    if(_.includes(sails.config.custom.bannedEmailDomainsForContactFormSubmissions, emailDomain.toLowerCase())){
+      throw 'invalidEmailDomain';
+    }
 
 
     // Send the submitted information to a Zapier webhook.

--- a/website/api/controllers/deliver-application-submission.js
+++ b/website/api/controllers/deliver-application-submission.js
@@ -89,6 +89,21 @@ module.exports = {
     });
 
 
+    // Send a "Thanks for applying to Fleet" email to the user who submitted the form.
+    await sails.helpers.sendTemplateEmail.with({
+      to: emailAddress,
+      subject: 'Thanks for applying to Fleet',
+      template: 'email-application-submitted',
+      layout: 'layout-email',
+      from: sails.config.custom.applicationReplyEmailAddress,
+      templateData: {
+        firstName: firstName,
+        contactEmail: emailAddress
+      },
+      ensureAck: true,
+    });
+
+
     // All done.
     return;
 

--- a/website/api/controllers/deliver-application-submission.js
+++ b/website/api/controllers/deliver-application-submission.js
@@ -112,7 +112,6 @@ module.exports = {
       from: sails.config.custom.applicationReplyEmailAddress,
       templateData: {
         firstName: firstName,
-        contactEmail: emailAddress
       },
       ensureAck: true,
     });

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -502,6 +502,9 @@ module.exports.custom = {
   // Deal registration form
   // dealRegistrationContactEmailAddress: '…',
 
+  // Apply form
+  // applicationReplyEmailAddress: '…',
+
   // Render instance trials
   // renderOwnerId: '…',
   // renderApiToken: '…',

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1383,7 +1383,7 @@ module.exports.routes = {
   'GET /status': 'https://status.fleetdm.com',
   'GET /hall-of-fame': 'https://github.com/fleetdm/fleet/pulse',
   'GET /apply': '/jobs',
-  'GET /jobs': 'https://fleetdm.com/handbook/company#open-positions',
+  'GET /jobs': '/handbook/company#open-positions',
   'GET /company/stewardship': 'https://github.com/fleetdm/fleet', // FUTURE: page about how we approach open source and our commitments to the community
   'GET /logout': '/api/v1/account/logout',
   'GET /defcon': 'https://kqphpqst851.typeform.com/to/Y6NYxM5A',

--- a/website/views/emails/email-application-submitted.ejs
+++ b/website/views/emails/email-application-submitted.ejs
@@ -1,7 +1,7 @@
 <% /* Note: This is injected into `views/layouts/layout-email.ejs` */ %>
 <div style="padding: 0px 0px 0px 0px;">
   <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">Hi <%= firstName %>,</p>
-  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">We are so glad to hear your interest in working together at Fleet.</p>
-  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">If your background is a good fit for the positions we have open currently and we are able to schedule an interview with you, we’ll be in touch again within about ~7 days. If you don’t hear from us by then, please feel free to apply again in the future.</p>
-  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">PS. You can read more about Fleet and how we work at <a style="color: #009A7D; line-height: 24px; text-decoration: none;" href="<%= url.resolve(sails.config.custom.baseUrl,'/handbook/company/why-this-way')%>">fleetdm.com/handbook/company/why-this-way</a>.</p>
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">Thanks for applying to Fleet.</p>
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">If your background fits one of our open roles, we'll be in touch within ~7 days to schedule an interview. If you don't hear from us by then, you're welcome to apply again in the future.</p>
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">PS. Read more about Fleet and how we work at <a style="color: #009A7D; line-height: 24px; text-decoration: none;" href="<%= url.resolve(sails.config.custom.baseUrl,'/handbook/company/why-this-way')%>">fleetdm.com/handbook/company/why-this-way</a>.</p>
 </div>

--- a/website/views/emails/email-application-submitted.ejs
+++ b/website/views/emails/email-application-submitted.ejs
@@ -1,0 +1,7 @@
+<% /* Note: This is injected into `views/layouts/layout-nurture-email.ejs` */ %>
+<div style="padding: 0px 0px 0px 0px;">
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">Hi <%- firstName %>,</p>
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">We are so glad to hear your interest in working together at Fleet.</p>
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">If your background is a good fit for the positions we have open currently and we are able to schedule an interview with you, we’ll be in touch again within about ~7 days. If you don’t hear from us by then, please feel free to apply again in the future.</p>
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">PS. You can read more about Fleet and how we work at <a style="color: #009A7D; line-height: 24px; text-decoration: none;" href="<%= url.resolve(sails.config.custom.baseUrl,'/handbook/company/why-this-way')%>">fleetdm.com/handbook/company/why-this-way</a>.</p>
+</div>

--- a/website/views/emails/email-application-submitted.ejs
+++ b/website/views/emails/email-application-submitted.ejs
@@ -1,6 +1,6 @@
-<% /* Note: This is injected into `views/layouts/layout-nurture-email.ejs` */ %>
+<% /* Note: This is injected into `views/layouts/layout-email.ejs` */ %>
 <div style="padding: 0px 0px 0px 0px;">
-  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">Hi <%- firstName %>,</p>
+  <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">Hi <%= firstName %>,</p>
   <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">We are so glad to hear your interest in working together at Fleet.</p>
   <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">If your background is a good fit for the positions we have open currently and we are able to schedule an interview with you, we’ll be in touch again within about ~7 days. If you don’t hear from us by then, please feel free to apply again in the future.</p>
   <p style=" font-size: 16px; line-height: 24px; margin-bottom: 24px; margin-top: 0px">PS. You can read more about Fleet and how we work at <a style="color: #009A7D; line-height: 24px; text-decoration: none;" href="<%= url.resolve(sails.config.custom.baseUrl,'/handbook/company/why-this-way')%>">fleetdm.com/handbook/company/why-this-way</a>.</p>

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -198,7 +198,14 @@
             <textarea class="form-control" id="apply-message" name="message" :class="[formErrors.message ? 'is-invalid' : '']" v-model.trim="formData.message" autocomplete="none"></textarea>
             <div class="invalid-feedback" v-if="formErrors.message">Cover letter cannot be empty.</div>
           </div>
-          <cloud-error v-if="cloudError"></cloud-error>
+          <div purpose="hp-input" aria-hidden="true">
+            <label>Website</label>
+            <input name="website-url" type="text" tabindex="-1" autocomplete="off" v-model.trim="formData.websiteUrl">
+          </div>
+          <cloud-error v-if="cloudError && cloudError === 'invalidEmailDomain'">
+            <p>Please enter a valid email address</p>
+          </cloud-error>
+          <cloud-error v-else-if="cloudError"></cloud-error>
           <div class="form-group btn-container">
             <ajax-button purpose="submit-button" type="submit" :syncing="syncing" class="btn btn-primary">Send</ajax-button>
           </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/16057

Changes:
- Added `email-application-submitted`, an email template that is used to reply to users who fill out the "Apply" form
- Updated the `deliver-application-submission` action to return an `invalidEmailDomain` response if a user's email address is on the bannedEmailDomainsForContactFormSubmissions list, and to send a "Thank you for applying to Fleet" email to the user who submitted the form.
- Stubbed a new custom config variable: `applicationReplyEmailAddress`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applicants receive a "Thanks for applying to Fleet" confirmation email with a personalized greeting and ~7-day expectation.
  * Added an application-submitted email template and preview using the email layout.

* **Improvements**
  * Added a hidden honeypot field to the application form; submissions with it filled are silently discarded.
  * Added email-domain validation with a specific form error and clearer error rendering.
  * Redirected jobs to the internal handbook open-positions section.

* **Chores**
  * Added a commented placeholder for an application reply email setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->