### PR TITLE
Normalize app names: pgAdmin 4 and Sourcetree

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/pgadmin4.json
+++ b/ee/maintained-apps/inputs/homebrew/pgadmin4.json
@@ -1,5 +1,5 @@
 {
-  "name": "pgAdmin4",
+  "name": "pgAdmin 4",
   "unique_identifier": "org.pgadmin.pgadmin4",
   "token": "pgadmin4",
   "installer_format": "dmg",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1710,7 +1710,7 @@
       "description": "Parallels Desktop is virtualization software."
     },
     {
-      "name": "pgAdmin4",
+      "name": "pgAdmin 4",
       "slug": "pgadmin4/darwin",
       "platform": "darwin",
       "unique_identifier": "org.pgadmin.pgadmin4",
@@ -2039,7 +2039,7 @@
       "description": "Snagit is screen capture software."
     },
     {
-      "name": "SourceTree",
+      "name": "Sourcetree",
       "slug": "sourcetree/darwin",
       "platform": "darwin",
       "unique_identifier": "com.torusknot.SourceTreeNotMAS",


### PR DESCRIPTION
Update display names for consistency/branding: change "pgAdmin4" to "pgAdmin 4" in ee/maintained-apps/inputs/homebrew/pgadmin4.json and ee/maintained-apps/outputs/apps.json, and change "SourceTree" to "Sourcetree" in ee/maintained-apps/outputs/apps.json. These edits align app names with official branding and ensure consistent naming across input and output manifests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pgAdmin 4 display name formatting
  * Updated Sourcetree display name formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->