### PR TITLE
Redis cache improvements

### DIFF
--- a/changes/46338-host-cache-ttl-and-invalidation
+++ b/changes/46338-host-cache-ttl-and-invalidation
@@ -1,0 +1,1 @@
+* Raised the default `FLEET_REDIS_HOST_CACHE_TTL` from 60s to 180s and removed the reverse-index GETs that the host-update invalidation path. Together these reduce DB reader load and lower Redis CPU usage.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1323,7 +1323,7 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("redis.host_cache_enabled", true,
 		"Enable Redis-backed cache for host lookups on the osquery and orbit auth paths. Disable to bypass the cache "+
 			"and serve every check-in from MySQL.")
-	man.addConfigDuration("redis.host_cache_ttl", 60*time.Second,
+	man.addConfigDuration("redis.host_cache_ttl", 180*time.Second,
 		"Base TTL for Redis-backed host lookup cache entries. Actual per-entry TTL is jittered by ±10% to avoid "+
 			"synchronized expiry waves. Must be > 0 when redis.host_cache_enabled is true; set "+
 			"redis.host_cache_enabled=false to disable the cache.")

--- a/server/datastore/mysqlredis/host_cache.go
+++ b/server/datastore/mysqlredis/host_cache.go
@@ -126,9 +126,9 @@ var (
 )
 
 // jitteredHostCacheTTL returns the configured base TTL perturbed by
-// ±(hostCacheTTLJitterFraction / 2). With the default 0.2 and a 60s base, the
-// result falls in [54s, 66s], yielding ~5 cache hits per miss at the default
-// 10s osquery check-in interval (~83% hit rate).
+// ±(hostCacheTTLJitterFraction / 2). With the default 0.2 and a 180s base, the
+// result falls in [162s, 198s], yielding ~17 cache hits per miss at the default
+// 10s osquery check-in interval (~94% hit rate).
 func (d *Datastore) jitteredHostCacheTTL() time.Duration {
 	if d.hostCacheTTL <= 0 {
 		return 0

--- a/server/datastore/mysqlredis/host_cache_writes.go
+++ b/server/datastore/mysqlredis/host_cache_writes.go
@@ -131,18 +131,46 @@ func (d *Datastore) UpdateHostIdentityCertHostIDBySerial(ctx context.Context, se
 }
 
 // invalidateAfterHostUpdate is the common tail for write paths that update an already-existing host
-// (UpdateHost, SerialUpdateHost). Clears the cache via the reverse index on the host's ID, which covers
-// both osquery and orbit families.
+// (UpdateHost, SerialUpdateHost). Clears the cache by DEL'ing the known node keys directly.
 //
-// This path does NOT clear by direct keys: an already-cached host's reverse index is populated, so the
-// by-ID path finds and DELs every related key. The pre-enrollment-negative-cache race that motivates
-// invalidateAfterHostEnroll's direct-keys clear cannot apply to UpdateHost callers (you cannot UPDATE a
-// host that doesn't exist yet), so the extra DELs would be wasted Redis ops.
+// If neither NodeKey nor OrbitNodeKey is set on the struct we fall back to hostCacheDeleteByID so callers
+// that pass a sparsely-populated host still get correct invalidation.
+//
+// This path does NOT clear by direct keys to cover the pre-enrollment-negative-cache race that motivates
+// invalidateAfterHostEnroll's direct-keys clear: that race cannot apply to UpdateHost callers (you cannot
+// UPDATE a host that doesn't exist yet), so no negative entry from a probe-before-row can survive here.
 func (d *Datastore) invalidateAfterHostUpdate(ctx context.Context, host *fleet.Host, reason string) {
-	if host == nil || host.ID == 0 {
+	if host == nil || host.ID == 0 || !d.hostCacheEnabled {
 		return
 	}
-	d.hostCacheDeleteByID(ctx, host.ID, reason)
+
+	nk := ""
+	if host.NodeKey != nil {
+		nk = *host.NodeKey
+	}
+	onk := ""
+	if host.OrbitNodeKey != nil {
+		onk = *host.OrbitNodeKey
+	}
+
+	if nk == "" && onk == "" {
+		// No node-key info on the struct; fall through to the by-ID path so we still pick up cached
+		// entries via the reverse indices.
+		d.hostCacheDeleteByID(ctx, host.ID, reason)
+		return
+	}
+
+	keys := make([]string, 0, 6)
+	if nk != "" {
+		keys = append(keys, hostCacheKeyByNodeKey(nk), hostCacheKeyMiss(nk))
+	}
+	if onk != "" {
+		keys = append(keys, hostCacheKeyByOrbitNodeKey(onk), hostCacheKeyOrbitMiss(onk))
+	}
+	keys = append(keys, hostCacheIndexByID(host.ID), hostCacheOrbitIndexByID(host.ID))
+
+	d.pipelinedDEL(ctx, keys)
+	d.recordHostCacheInvalidation(ctx, reason)
 }
 
 // invalidateAfterHostEnroll is the common tail for write paths that may CREATE a host or rotate its

--- a/server/datastore/mysqlredis/host_cache_writes_test.go
+++ b/server/datastore/mysqlredis/host_cache_writes_test.go
@@ -329,6 +329,55 @@ func TestWritePathInvalidation(t *testing.T) {
 			assert.Equal(t, hostCacheLookupMiss, res)
 		})
 
+		t.Run("UpdateHost with only orbit_node_key clears orbit cache", func(t *testing.T) {
+			// Mirror of the dual-key test for the orbit-only side: a host running only Orbit (no osquery
+			// node_key, or one that the caller didn't populate) should still get its onk entry cleared via
+			// the direct-DEL path in invalidateAfterHostUpdate.
+			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+			ds := new(mock.Store)
+			ds.UpdateHostFunc = func(_ context.Context, _ *fleet.Host) error { return nil }
+			d := New(ds, pool, WithHostCache(30*time.Second))
+
+			onk := "onk-orbit-only"
+			host := &fleet.Host{ID: 110, OrbitNodeKey: &onk, Hostname: "orbit-only"}
+			d.hostCachePutByOrbitNodeKey(ctx, host)
+			_, res := d.hostCacheGetByOrbitNodeKey(ctx, onk)
+			require.Equal(t, hostCacheLookupHit, res)
+
+			require.NoError(t, d.UpdateHost(ctx, host))
+
+			_, res = d.hostCacheGetByOrbitNodeKey(ctx, onk)
+			assert.Equal(t, hostCacheLookupMiss, res)
+		})
+
+		t.Run("UpdateHost with no node keys falls back to by-ID invalidation", func(t *testing.T) {
+			// When the caller passes a sparse *fleet.Host (no NodeKey, no OrbitNodeKey) we cannot DEL
+			// directly because we do not know the cached keys. invalidateAfterHostUpdate must fall back to
+			// hostCacheDeleteByID, which resolves the cached keys via the id2nk/id2onk reverse indices.
+			// Cache is primed via the helpers, then UpdateHost is called with a host struct that has only
+			// ID populated.
+			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+			ds := new(mock.Store)
+			ds.UpdateHostFunc = func(_ context.Context, _ *fleet.Host) error { return nil }
+			d := New(ds, pool, WithHostCache(30*time.Second))
+
+			nk := "nk-sparse"
+			onk := "onk-sparse"
+			d.hostCachePutByNodeKey(ctx, &fleet.Host{ID: 120, NodeKey: &nk})
+			d.hostCachePutByOrbitNodeKey(ctx, &fleet.Host{ID: 120, OrbitNodeKey: &onk})
+			_, res := d.hostCacheGetByNodeKey(ctx, nk)
+			require.Equal(t, hostCacheLookupHit, res)
+			_, res = d.hostCacheGetByOrbitNodeKey(ctx, onk)
+			require.Equal(t, hostCacheLookupHit, res)
+
+			require.NoError(t, d.UpdateHost(ctx, &fleet.Host{ID: 120}))
+
+			_, res = d.hostCacheGetByNodeKey(ctx, nk)
+			assert.Equal(t, hostCacheLookupMiss, res)
+			_, res = d.hostCacheGetByOrbitNodeKey(ctx, onk)
+			assert.Equal(t, hostCacheLookupMiss, res)
+		})
+
 		t.Run("inner error preserves cache", func(t *testing.T) {
 			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
 			ds := new(mock.Store)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46338 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Infrastructure**
  * Extended host cache retention from 60 seconds to 180 seconds, improving lookup performance and reducing redundant database operations.
  * Optimized host cache invalidation strategy to significantly reduce database reader load and Redis CPU consumption through more efficient key deletion.
  * Enhanced test coverage for cache invalidation behavior across various host key configurations to ensure consistent reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->