### PR TITLE
Fix S3 carve cleanup never running and panic on empty carves (#43045)

### DIFF
--- a/changes/43045-s3-carve-cleanup-never-runs
+++ b/changes/43045-s3-carve-cleanup-never-runs
@@ -1,0 +1,1 @@
+* Fixed a bug where the carve cleanup cron job called the MySQL implementation instead of the S3-aware implementation on S3-configured deployments, meaning expired carves were never marked as expired in S3. Also fixed a panic in S3 carve cleanup that occurred when there were no non-expired carves.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1248,6 +1248,7 @@ func newCleanupsAndAggregationSchedule(
 	ctx context.Context,
 	instanceID string,
 	ds fleet.Datastore,
+	carveStore fleet.CarveStore,
 	svc fleet.Service,
 	logger *slog.Logger,
 	enrollHostLimiter fleet.EnrollHostLimiter,
@@ -1307,7 +1308,7 @@ func newCleanupsAndAggregationSchedule(
 		schedule.WithJob(
 			"carves",
 			func(ctx context.Context) error {
-				_, err := ds.CleanupCarves(ctx, time.Now())
+				_, err := carveStore.CleanupCarves(ctx, time.Now())
 				return err
 			},
 		),

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1064,7 +1064,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		func() (fleet.CronSchedule, error) {
 			commander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
 			return newCleanupsAndAggregationSchedule(
-				ctx, instanceID, ds, svc, logger, redisWrapperDS, &config, commander, softwareInstallStore, bootstrapPackageStore, softwareTitleIconStore, androidSvc, activitySvc, acmeSvc, chartSvc,
+				ctx, instanceID, ds, carveStore, svc, logger, redisWrapperDS, &config, commander, softwareInstallStore, bootstrapPackageStore, softwareTitleIconStore, androidSvc, activitySvc, acmeSvc, chartSvc,
 			)
 		},
 	); err != nil {

--- a/server/datastore/s3/carves.go
+++ b/server/datastore/s3/carves.go
@@ -138,7 +138,6 @@ func (c *CarveStore) listS3Carves(ctx context.Context, lastPrefix string, maxKey
 // metadata present in the database and mark as expired the carves no longer
 // available in S3 (ignores the `now` argument)
 func (c *CarveStore) CleanupCarves(ctx context.Context, now time.Time) (int, error) {
-	var err error
 	// Get the 1000 oldest carves
 	nonExpiredCarves, err := c.ListCarves(ctx, fleet.CarveListOptions{
 		ListOptions: fleet.ListOptions{PerPage: cleanupSize},
@@ -146,6 +145,9 @@ func (c *CarveStore) CleanupCarves(ctx context.Context, now time.Time) (int, err
 	})
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "s3 carve cleanup")
+	}
+	if len(nonExpiredCarves) == 0 {
+		return 0, nil
 	}
 	// List carves in S3 up to a hour+1 prefix
 	lastCarveNextHour := nonExpiredCarves[len(nonExpiredCarves)-1].CreatedAt.Add(time.Hour)
@@ -156,14 +158,18 @@ func (c *CarveStore) CleanupCarves(ctx context.Context, now time.Time) (int, err
 	}
 	// Compare carve metadata in DB with S3 listing and update expiration flag
 	cleanCount := 0
+	var retErr error
 	for _, carve := range nonExpiredCarves {
 		if _, ok := carveKeys[c.generateS3Key(carve)]; !ok {
 			carve.Expired = true
-			err = c.UpdateCarve(ctx, carve)
+			if uerr := c.UpdateCarve(ctx, carve); uerr != nil {
+				retErr = errors.Join(retErr, ctxerr.Wrap(ctx, uerr, "marking carve expired"))
+				continue
+			}
 			cleanCount++
 		}
 	}
-	return cleanCount, err
+	return cleanCount, retErr
 }
 
 // Carve returns carve metadata by ID

--- a/server/datastore/s3/carves.go
+++ b/server/datastore/s3/carves.go
@@ -163,7 +163,7 @@ func (c *CarveStore) CleanupCarves(ctx context.Context, now time.Time) (int, err
 		if _, ok := carveKeys[c.generateS3Key(carve)]; !ok {
 			carve.Expired = true
 			if uerr := c.UpdateCarve(ctx, carve); uerr != nil {
-				retErr = errors.Join(retErr, ctxerr.Wrap(ctx, uerr, "marking carve expired"))
+				retErr = errors.Join(retErr, ctxerr.Wrap(ctx, uerr, fmt.Sprintf("marking carve %d expired", carve.ID)))
 				continue
 			}
 			cleanCount++

--- a/server/datastore/s3/carves_test.go
+++ b/server/datastore/s3/carves_test.go
@@ -1,1 +1,114 @@
 package s3
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCarveMetadataStore implements fleet.CarveStore using only in-memory
+// state. It is used by tests that do not require a real S3 backend.
+type stubCarveMetadataStore struct {
+	carves []*fleet.CarveMetadata
+}
+
+func (s *stubCarveMetadataStore) NewCarve(_ context.Context, metadata *fleet.CarveMetadata) (*fleet.CarveMetadata, error) {
+	return metadata, nil
+}
+func (s *stubCarveMetadataStore) UpdateCarve(_ context.Context, _ *fleet.CarveMetadata) error {
+	return nil
+}
+func (s *stubCarveMetadataStore) Carve(_ context.Context, _ int64) (*fleet.CarveMetadata, error) {
+	return nil, nil
+}
+func (s *stubCarveMetadataStore) CarveBySessionId(_ context.Context, _ string) (*fleet.CarveMetadata, error) {
+	return nil, nil
+}
+func (s *stubCarveMetadataStore) CarveByName(_ context.Context, _ string) (*fleet.CarveMetadata, error) {
+	return nil, nil
+}
+func (s *stubCarveMetadataStore) ListCarves(_ context.Context, _ fleet.CarveListOptions) ([]*fleet.CarveMetadata, error) {
+	return s.carves, nil
+}
+func (s *stubCarveMetadataStore) NewBlock(_ context.Context, _ *fleet.CarveMetadata, _ int64, _ []byte) error {
+	return nil
+}
+func (s *stubCarveMetadataStore) GetBlock(_ context.Context, _ *fleet.CarveMetadata, _ int64) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubCarveMetadataStore) CleanupCarves(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
+}
+
+// TestCleanupCarvesEmptyNonExpired verifies that CleanupCarves returns (0, nil)
+// and does not panic when there are no non-expired carves in the metadata store.
+func TestCleanupCarvesEmptyNonExpired(t *testing.T) {
+	store := &CarveStore{
+		metadatadb: &stubCarveMetadataStore{carves: nil},
+	}
+	cleaned, err := store.CleanupCarves(t.Context(), time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 0, cleaned)
+}
+
+// TestCleanupCarvesMarksS3AbsentCarvesExpired verifies the comparison path:
+// carves whose S3 object no longer exists are marked expired, while carves
+// that are still present in S3 are left untouched.
+//
+// Requires a running S3-compatible endpoint (set S3_STORAGE_TEST env var).
+func TestCleanupCarvesMarksS3AbsentCarvesExpired(t *testing.T) {
+	checkTestEnv(t)
+	ctx := t.Context()
+
+	const bucket = "carves-cleanup-test"
+	const prefix = "carvetest/"
+
+	// Two carves ordered by created_at ascending (matching the OrderKey fix).
+	// carve1 will have a corresponding S3 object; carve2 will not.
+	baseTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	carve1 := &fleet.CarveMetadata{ID: 1, Name: "session-with-s3", CreatedAt: baseTime}
+	carve2 := &fleet.CarveMetadata{ID: 2, Name: "session-without-s3", CreatedAt: baseTime.Add(30 * time.Minute)}
+
+	stub := &stubCarveMetadataStore{carves: []*fleet.CarveMetadata{carve1, carve2}}
+
+	store, err := NewCarveStore(config.S3Config{
+		CarvesBucket:           bucket,
+		CarvesPrefix:           prefix,
+		CarvesRegion:           "localhost",
+		CarvesEndpointURL:      testEndpoint,
+		CarvesAccessKeyID:      testAccessKeyID,
+		CarvesSecretAccessKey:  testSecretAccessKey,
+		CarvesForceS3PathStyle: true,
+		CarvesDisableSSL:       true,
+	}, stub)
+	require.NoError(t, err)
+
+	require.NoError(t, store.CreateTestBucket(ctx, bucket))
+	t.Cleanup(func() {
+		if err := store.CleanupTestBucket(context.Background()); err != nil {
+			t.Errorf("cleanup s3 bucket %q: %v", bucket, err)
+		}
+	})
+
+	// Put carve1's object in S3 so it looks like it was uploaded.
+	key1 := store.generateS3Key(carve1)
+	_, err = store.s3Client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: &store.bucket,
+		Key:    &key1,
+		Body:   strings.NewReader("dummy-carve-data"),
+	})
+	require.NoError(t, err)
+
+	cleaned, err := store.CleanupCarves(ctx, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 1, cleaned, "only carve2 (absent from S3) should be counted")
+
+	require.False(t, carve1.Expired, "carve1 has an S3 object and must not be marked expired")
+	require.True(t, carve2.Expired, "carve2 has no S3 object and must be marked expired")
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43045 

Fixed a bug where the carve cleanup cron job called the MySQL implementation instead of the S3-aware implementation on S3-configured deployments, meaning expired carves were never marked as expired in S3. Also fixed a panic in S3 carve cleanup that occurred when there were no non-expired carves.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup now uses the S3-aware path on S3-configured deployments (no longer the MySQL path)
  * Prevented a panic when no non-expired carves are present during cleanup
  * Improved error aggregation so all cleanup failures are reported
  * Cleanup counters now increment only for successfully updated carves

* **Tests**
  * Added tests covering S3 carve cleanup behavior, including empty and S3-absent cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->