### PR TITLE
Fix GA4 consent mode to grant analytics for non-EU/UK visitors

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -278,7 +278,17 @@ module.exports = {
         // If no medium was provided via utm parameter, set the source channel to "Organic".
         attributionDetails.sourceChannel = 'Organic';
 
-        if(!marketingAttributionCookie.referrer || marketingAttributionCookie.referrer.startsWith('https://fleetdm.com')) {
+        let isFleetReferrer = false;
+        if(marketingAttributionCookie.referrer) {
+          try {
+            let parsedReferrerUrl = new URL(marketingAttributionCookie.referrer);
+            let referrerHost = parsedReferrerUrl.hostname.toLowerCase();
+            isFleetReferrer = (referrerHost === 'fleetdm.com' || referrerHost.endsWith('.fleetdm.com'));
+          } catch (err) {
+            isFleetReferrer = false;
+          }
+        }
+        if(!marketingAttributionCookie.referrer || isFleetReferrer) {
           // If no referrer is set, or the referrer is any fleetdm.com page, we'll assume this user came to the website directly
           attributionDetails.sourceChannelDetails = 'Direct traffic (DT)';
           attributionDetails.campaign = 'Default-DT-Direct';

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -278,8 +278,8 @@ module.exports = {
         // If no medium was provided via utm parameter, set the source channel to "Organic".
         attributionDetails.sourceChannel = 'Organic';
 
-        if(!marketingAttributionCookie.referrer || marketingAttributionCookie.referrer === 'https://fleetdm.com/') {
-          // If no referrer is set, or the referrer is set to the Fleet website, we'll assume this user came to the website directly
+        if(!marketingAttributionCookie.referrer || marketingAttributionCookie.referrer.startsWith('https://fleetdm.com')) {
+          // If no referrer is set, or the referrer is any fleetdm.com page, we'll assume this user came to the website directly
           attributionDetails.sourceChannelDetails = 'Direct traffic (DT)';
           attributionDetails.campaign = 'Default-DT-Direct';
         } else {

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -284,7 +284,7 @@ module.exports = {
             let parsedReferrerUrl = new URL(marketingAttributionCookie.referrer);
             let referrerHost = parsedReferrerUrl.hostname.toLowerCase();
             isFleetReferrer = (referrerHost === 'fleetdm.com' || referrerHost.endsWith('.fleetdm.com'));
-          } catch (err) {
+          } catch (unused) {
             isFleetReferrer = false;
           }
         }

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -40,15 +40,27 @@
       function gtag() {
           dataLayer.push(arguments);
       }
+      // Non-EU/UK visitors: grant analytics immediately (no consent banner shown)
       gtag("consent", "default", {
           ad_storage: "denied",
-          ad_user_data: "denied", 
+          ad_user_data: "denied",
+          ad_personalization: "denied",
+          analytics_storage: "granted",
+          functionality_storage: "granted",
+          personalization_storage: "denied",
+          security_storage: "granted",
+      });
+      // EU/EEA/UK/Switzerland: deny everything, wait for CookieYes banner
+      gtag("consent", "default", {
+          ad_storage: "denied",
+          ad_user_data: "denied",
           ad_personalization: "denied",
           analytics_storage: "denied",
           functionality_storage: "denied",
           personalization_storage: "denied",
           security_storage: "granted",
           wait_for_update: 2000,
+          region: ["AT","BE","BG","HR","CY","CZ","DK","EE","FI","FR","DE","GR","HU","IE","IT","LV","LT","LU","MT","NL","PL","PT","RO","SK","SI","ES","SE","IS","LI","NO","GB","CH"],
       });
       gtag("set", "ads_data_redaction", true);
     </script>


### PR DESCRIPTION
Previously, the GA4 consent defaults denied analytics_storage for all visitors globally and set wait_for_update: 2000, meaning GA4 would wait up to 2 seconds for CookieYes to resolve geolocation before firing. For visitors on slower connections (mobile, slower CPUs) CookieYes often didn't respond in time, causing GA4 to drop the session entirely and record no pageview. Since ~95% of fleetdm.com's audience is outside the EU/UK and never sees the CookieYes consent banner, this wait was unnecessary for the vast majority of visitors.

Replaces the single global consent default with two region-scoped calls:
- All visitors: analytics_storage granted immediately (no wait_for_update)
- EU/EEA/UK/Switzerland only: analytics_storage denied, wait_for_update: 2000

This matches how CookieYes Advanced Consent Mode is intended to work — the consent banner and its associated wait only apply where legally required (GDPR/UK GDPR).

Also fixes the internal referrer check in the Salesforce attribution helper, which was using strict equality against 'https://fleetdm.com/' and missing any visitor whose last internal page was /pricing, /blog, etc. Changed to startsWith so any fleetdm.com referrer is correctly classified as direct traffic.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribution logic to better recognize site-origin referrers and avoid misclassifying parsing failures as direct traffic.
  * Updated Google Consent Mode defaults to apply stricter consent behavior for EU/EEA/UK/Switzerland and more permissive defaults for visitors elsewhere, honoring regional consent handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->