### PR TITLE
Update error message in GitOps when unknown env vars are encountered

### DIFF
--- a/changes/44053-improve-env-var-error-msg
+++ b/changes/44053-improve-env-var-error-msg
@@ -1,0 +1,1 @@
+- Updated the error displayed when GitOps encounters an unknown env var to account for cases where the string is a literal that needs escaping.

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -814,7 +814,7 @@ reports:
 `
 	_, err = gitOpsFromString(t, config)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "environment variable \"NOT_DEFINED\" not set")
+	require.Contains(t, err.Error(), `environment variable "NOT_DEFINED" not set; if you intended the literal string $NOT_DEFINED then please escape it as \$NOT_DEFINED.`)
 }
 
 func TestMixingGlobalAndTeamConfig(t *testing.T) {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -384,7 +384,13 @@ func expandEnv(s string, secretMode secretHandling) (string, error) {
 
 		v, ok := lookupEnv(env)
 		if !ok {
-			err = multierror.Append(err, fmt.Errorf("environment variable %q not set", env))
+			// If the source used ${var} braced syntax, the hint should reflect that.
+			ref := "$" + env
+			if startPos+1 < len(s) && s[startPos+1] == '{' {
+				ref = "${" + env + "}"
+			}
+			err = multierror.Append(err, fmt.Errorf("environment variable %q not set; if you intended the literal string %s then please escape it as \\%s.",
+				env, ref, ref))
 			return "", false
 		}
 		escaped, escErr := escapeValue(v, env)

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -163,17 +163,20 @@ func TestExpandEnv(t *testing.T) {
 		{map[string]string{"foo": "1"}, `$foo $FLEET_VAR_BAR ${FLEET_VAR_BAR}x ${foo}`, `1 $FLEET_VAR_BAR ${FLEET_VAR_BAR}x 1`, nil},
 		{map[string]string{"foo": ""}, `$foo`, ``, nil},
 		{map[string]string{"foo": "", "bar": "", "zoo": ""}, `$foo${bar}$zoo`, ``, nil},
-		{map[string]string{}, `$foo`, ``, checkMultiErrors(t, "environment variable \"foo\" not set")},
-		{map[string]string{"foo": "1"}, `$foo$bar`, ``, checkMultiErrors(t, "environment variable \"bar\" not set")},
+		{map[string]string{}, `$foo`, ``, checkMultiErrors(t, `environment variable "foo" not set; if you intended the literal string $foo then please escape it as \$foo.`)},
+		{map[string]string{"foo": "1"}, `$foo$bar`, ``, checkMultiErrors(t, `environment variable "bar" not set; if you intended the literal string $bar then please escape it as \$bar.`)},
 		{
 			map[string]string{"bar": "1"},
 			`$foo $bar $zoo`, ``,
-			checkMultiErrors(t, "environment variable \"foo\" not set", "environment variable \"zoo\" not set"),
+			checkMultiErrors(t,
+				`environment variable "foo" not set; if you intended the literal string $foo then please escape it as \$foo.`,
+				`environment variable "zoo" not set; if you intended the literal string $zoo then please escape it as \$zoo.`,
+			),
 		},
 		{map[string]string{"foo": "4", "bar": "2"}, `$foo$bar`, `42`, nil},
 		{map[string]string{"foo": "42", "bar": ""}, `$foo$bar`, `42`, nil},
-		{map[string]string{}, `$$`, ``, checkMultiErrors(t, "environment variable \"$\" not set")},
-		{map[string]string{"foo": "1"}, `$$foo`, ``, checkMultiErrors(t, "environment variable \"$\" not set")},
+		{map[string]string{}, `$$`, ``, checkMultiErrors(t, `environment variable "$" not set; if you intended the literal string $$ then please escape it as \$$.`)},
+		{map[string]string{"foo": "1"}, `$$foo`, ``, checkMultiErrors(t, `environment variable "$" not set; if you intended the literal string $$ then please escape it as \$$.`)},
 		{map[string]string{"foo": "1"}, `\$${foo}`, `$1`, nil},
 		{map[string]string{}, `\$foo`, `$foo`, nil},                     // escaped
 		{map[string]string{"foo": "1"}, `\\$foo`, `\\1`, nil},           // not escaped
@@ -185,7 +188,7 @@ func TestExpandEnv(t *testing.T) {
 		{map[string]string{"foo": "1"}, `\${foo}var`, `${foo}var`, nil}, // escaped
 		{map[string]string{"foo": ""}, `${foo}var`, `var`, nil},
 		{map[string]string{"foo": "", "$": "2"}, `${$}${foo}var`, `2var`, nil},
-		{map[string]string{}, `${foo}var`, ``, checkMultiErrors(t, "environment variable \"foo\" not set")},
+		{map[string]string{}, `${foo}var`, ``, checkMultiErrors(t, `environment variable "foo" not set; if you intended the literal string ${foo} then please escape it as \${foo}.`)},
 		{map[string]string{}, `foo PREVENT_ESCAPING_bar $ FLEET_VAR_`, `foo PREVENT_ESCAPING_bar $ FLEET_VAR_`, nil}, // nothing to replace
 		{
 			map[string]string{"foo": "BAR"},


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44053

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for undefined environment variables in GitOps configurations now include clearer, actionable guidance with examples of how to escape literal dollar-sign syntax (e.g., showing escaped forms). This improves clarity when a variable is missing and helps users distinguish between intended variable references and literal values, reducing confusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->