### PR TITLE
Validate SSO settings correctly for GitOps

### DIFF
--- a/changes/43371-gitops-sso-validation
+++ b/changes/43371-gitops-sso-validation
@@ -1,1 +1,1 @@
-- Fixed `fleetctl gitops` silently wiping working SSO config when applying a YAML that enables SSO without `metadata` or `metadata_url`.
+- Fixed `fleetctl gitops` to refuse to apply SSO / EUA config that is missing required fields, if SSO is enabled globally or EUA is enabled on any team.

--- a/changes/43371-gitops-sso-validation
+++ b/changes/43371-gitops-sso-validation
@@ -1,1 +1,1 @@
-* Fixed `fleetctl gitops` silently wiping working SSO config when applying a YAML that enables SSO without `metadata` or `metadata_url`. Such payloads now fail validation with a clear error at apply time, both client-side and on the server.
+- Fixed `fleetctl gitops` silently wiping working SSO config when applying a YAML that enables SSO without `metadata` or `metadata_url`.

--- a/changes/43371-gitops-sso-validation
+++ b/changes/43371-gitops-sso-validation
@@ -1,0 +1,1 @@
+* Fixed `fleetctl gitops` silently wiping working SSO config when applying a YAML that enables SSO without `metadata` or `metadata_url`. Such payloads now fail validation with a clear error at apply time, both client-side and on the server.

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -761,7 +761,7 @@ func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfi
 		}
 		if !idpConfigured {
 			return fmt.Errorf(
-				"%s: controls.macos_setup.enable_end_user_authentication is true but no IdP is configured. Set org_settings.mdm.end_user_authentication.metadata or metadata_url in your global config, or configure it on the server first.",
+				"%s: controls.setup_experience.enable_end_user_authentication is true but no IdP is configured. Set org_settings.mdm.end_user_authentication.metadata or metadata_url in your global config, or configure it on the server first.",
 				cf.Filename,
 			)
 		}

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -362,7 +362,7 @@ func gitopsCommand() *cli.Command {
 			// Without this check, a partial gitops run can enable EUA on a
 			// team while leaving the IdP unconfigured — locking ADE
 			// enrollment for that team's hosts. See issue #43371.
-			if err := validateGitOpsGroupEUA(configs, appConfig, fleetClient.ListTeams); err != nil {
+			if err := validateGitOpsGroupEUA(configs, appConfig, fleetClient.ListTeams, flDeleteOtherTeams); err != nil {
 				return err
 			}
 
@@ -735,7 +735,7 @@ type ConfigFile struct {
 
 // Verify that if any fleet has EUA enabled after this GitOps run, then the IdP for EUA will be fully configured
 // after this run. This checks all fleets whether they're being modified in this run or not.
-func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfig, listTeams func(query string) ([]fleet.Team, error)) error {
+func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfig, listTeams func(query string) ([]fleet.Team, error), deleteOtherTeams bool) error {
 	// Compute the effective post-apply IdP state. Start from stored state; if a
 	// global file is in this run, its incoming org_settings override stored
 	// state (overwrite mode), so an empty/incomplete/missing block leaves the
@@ -794,7 +794,18 @@ func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfi
 	// Then any stored team NOT present in this run that still has EUA enabled —
 	// the case where a global-only run degrades the IdP while a team keeps EUA
 	// on (issue #43371). Teams are premium-only, so skip the lookup otherwise.
-	if appCfg.License.IsPremium() {
+	//
+	// With --delete-other-fleets, teams omitted from the run are deleted rather
+	// than preserved, so they can't lock anyone out post-apply; consulting their
+	// stored EUA state would be a false positive.
+	//
+	// Note there is an edge case here where a fleet has EUA enabled but not
+	// supplied in a --delete-other-fleets GitOps run, but the fleet CAN'T
+	// be deleted due to its being in ABM or VPP. This could lead to EUA being
+	// degraded (since that API call happens first) while EUA is still enabled
+	// on that fleet. This would be better handled by detecting un-deletable
+	// fleets early when --delete-other-fleets is used.
+	if appCfg.License.IsPremium() && !deleteOtherTeams {
 		teams, err := listTeams("")
 		if err != nil {
 			return fmt.Errorf("listing fleets to validate end user authentication: %w", err)

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -733,9 +733,8 @@ type ConfigFile struct {
 	IsGlobalConfig bool
 }
 
-// Verify that if any config file in this run enables MDM end-user authentication,
-// then an IdP is configured either in the global config of this run or in the server's
-// current state.
+// Verify that if any fleet has EUA enabled after this GitOps run, then the IdP for EUA will be fully configured
+// after this run. This checks all fleets whether they're being modified in this run or not.
 func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfig, listTeams func(query string) ([]fleet.Team, error)) error {
 	// Compute the effective post-apply IdP state. Start from stored state; if a
 	// global file is in this run, its incoming org_settings override stored

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -829,7 +829,7 @@ func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfi
 	// no-team state in overwrite mode, and is covered by the file loop above).
 	if !globalInRun && appCfg.MDM.MacOSSetup.EnableEndUserAuthentication {
 		return fmt.Errorf(
-			"end user authentication is enabled but the IdP is not fully configured. %s.",
+			"end user authentication is enabled in Unassigned but the IdP is not fully configured. %s.",
 			idpHint,
 		)
 	}

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -263,13 +263,6 @@ func gitopsCommand() *cli.Command {
 			// Used for keeping track of all label changes in this run.
 			labelChanges := make(map[string][]spec.LabelChange) // team name -> label changes
 
-			// Parsed a config and filename pair
-			type ConfigFile struct {
-				Config         *spec.GitOps
-				Filename       string
-				IsGlobalConfig bool
-			}
-
 			// Load all configs in before processing them
 			configs := make([]ConfigFile, 0, len(flFilenames.Value()))
 
@@ -361,6 +354,16 @@ func gitopsCommand() *cli.Command {
 					)
 				}
 				seenTeamNames[key] = cf.Filename
+			}
+
+			// Cross-file invariant: if any file in this run enables MDM
+			// end-user authentication, the IdP must be configured either in
+			// this run's global file or in the server's current state.
+			// Without this check, a partial gitops run can enable EUA on a
+			// team while leaving the IdP unconfigured — locking ADE
+			// enrollment for that team's hosts. See issue #43371.
+			if err := validateGitOpsGroupEUA(configs, appConfig); err != nil {
+				return err
 			}
 
 			labelMoves, err := computeLabelMoves(labelChanges)
@@ -720,6 +723,50 @@ func gitopsCommand() *cli.Command {
 			return nil
 		},
 	}
+}
+
+// ConfigFile pairs a parsed gitops config with its source filename, used
+// while orchestrating a multi-file gitops run.
+type ConfigFile struct {
+	Config         *spec.GitOps
+	Filename       string
+	IsGlobalConfig bool
+}
+
+// Verify that if any config file in this run enables MDM end-user authentication,
+// then an IdP is configured either in the global config of this run or in the server's
+// current state.
+func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfig) error {
+	idpConfigured := appCfg.MDM.EndUserAuthentication.Metadata != "" ||
+		appCfg.MDM.EndUserAuthentication.MetadataURL != ""
+
+	// If a global file is in this run, its incoming org_settings overrides
+	// stored state for the purposes of effective post-apply IdP state.
+	for _, cf := range configs {
+		if !cf.IsGlobalConfig {
+			continue
+		}
+		mdm, _ := cf.Config.OrgSettings["mdm"].(map[string]any)
+		eua, _ := mdm["end_user_authentication"].(map[string]any)
+		md, _ := eua["metadata"].(string)
+		mdURL, _ := eua["metadata_url"].(string)
+		idpConfigured = md != "" || mdURL != ""
+		break
+	}
+
+	for _, cf := range configs {
+		if cf.Config.Controls.MacOSSetup == nil ||
+			!cf.Config.Controls.MacOSSetup.EnableEndUserAuthentication {
+			continue
+		}
+		if !idpConfigured {
+			return fmt.Errorf(
+				"%s: controls.macos_setup.enable_end_user_authentication is true but no IdP is configured. Set org_settings.mdm.end_user_authentication.metadata or metadata_url in your global config, or configure it on the server first.",
+				cf.Filename,
+			)
+		}
+	}
+	return nil
 }
 
 // Computes label moves and validates that there is no funny business around label changes,

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -362,7 +362,7 @@ func gitopsCommand() *cli.Command {
 			// Without this check, a partial gitops run can enable EUA on a
 			// team while leaving the IdP unconfigured — locking ADE
 			// enrollment for that team's hosts. See issue #43371.
-			if err := validateGitOpsGroupEUA(configs, appConfig); err != nil {
+			if err := validateGitOpsGroupEUA(configs, appConfig, fleetClient.ListTeams); err != nil {
 				return err
 			}
 
@@ -736,35 +736,92 @@ type ConfigFile struct {
 // Verify that if any config file in this run enables MDM end-user authentication,
 // then an IdP is configured either in the global config of this run or in the server's
 // current state.
-func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfig) error {
-	idpConfigured := appCfg.MDM.EndUserAuthentication.Metadata != "" ||
-		appCfg.MDM.EndUserAuthentication.MetadataURL != ""
-
-	// If a global file is in this run, its incoming org_settings overrides
-	// stored state for the purposes of effective post-apply IdP state.
+func validateGitOpsGroupEUA(configs []ConfigFile, appCfg *fleet.EnrichedAppConfig, listTeams func(query string) ([]fleet.Team, error)) error {
+	// Compute the effective post-apply IdP state. Start from stored state; if a
+	// global file is in this run, its incoming org_settings override stored
+	// state (overwrite mode), so an empty/incomplete/missing block leaves the
+	// IdP incomplete.
+	idpName := appCfg.MDM.EndUserAuthentication.IDPName
+	entityID := appCfg.MDM.EndUserAuthentication.EntityID
+	metadata := appCfg.MDM.EndUserAuthentication.Metadata
+	metadataURL := appCfg.MDM.EndUserAuthentication.MetadataURL
+	globalInRun := false
 	for _, cf := range configs {
 		if !cf.IsGlobalConfig {
 			continue
 		}
+		globalInRun = true
 		mdm, _ := cf.Config.OrgSettings["mdm"].(map[string]any)
 		eua, _ := mdm["end_user_authentication"].(map[string]any)
-		md, _ := eua["metadata"].(string)
-		mdURL, _ := eua["metadata_url"].(string)
-		idpConfigured = md != "" || mdURL != ""
+		idpName, _ = eua["idp_name"].(string)
+		entityID, _ = eua["entity_id"].(string)
+		metadata, _ = eua["metadata"].(string)
+		metadataURL, _ = eua["metadata_url"].(string)
 		break
 	}
 
+	// An IdP is complete only when idp_name, entity_id, and one of
+	// metadata/metadata_url are all set (mirrors the server-side complete-IdP
+	// predicate). If the effective IdP is complete, EUA may be enabled anywhere.
+	idpComplete := idpName != "" && entityID != "" && (metadata != "" || metadataURL != "")
+	if idpComplete {
+		return nil
+	}
+
+	const idpHint = "Set org_settings.mdm.end_user_authentication idp_name, entity_id, and metadata or metadata_url in your global config, or configure a complete IdP on the server first"
+
+	// The effective IdP is incomplete: EUA must not be enabled at any effective
+	// post-apply scope. First, any file in this run that enables it. Track the
+	// teams present in this run so their stored state is not double-counted
+	// below — the in-run file's value wins (including a file that disables EUA).
+	teamsInRun := make(map[string]struct{})
 	for _, cf := range configs {
+		if cf.Config.TeamName != nil {
+			key := norm.NFC.String(strings.ToLower(strings.TrimSpace(*cf.Config.TeamName)))
+			if key != "" {
+				teamsInRun[key] = struct{}{}
+			}
+		}
 		if cf.Config.Controls.MacOSSetup == nil ||
 			!cf.Config.Controls.MacOSSetup.EnableEndUserAuthentication {
 			continue
 		}
-		if !idpConfigured {
-			return fmt.Errorf(
-				"%s: controls.setup_experience.enable_end_user_authentication is true but no IdP is configured. Set org_settings.mdm.end_user_authentication.metadata or metadata_url in your global config, or configure it on the server first.",
-				cf.Filename,
-			)
+		return fmt.Errorf(
+			"%s: controls.setup_experience.enable_end_user_authentication is true but the IdP is not fully configured. %s.",
+			cf.Filename, idpHint,
+		)
+	}
+
+	// Then any stored team NOT present in this run that still has EUA enabled —
+	// the case where a global-only run degrades the IdP while a team keeps EUA
+	// on (issue #43371). Teams are premium-only, so skip the lookup otherwise.
+	if appCfg.License.IsPremium() {
+		teams, err := listTeams("")
+		if err != nil {
+			return fmt.Errorf("listing fleets to validate end user authentication: %w", err)
 		}
+		for _, tm := range teams {
+			key := norm.NFC.String(strings.ToLower(strings.TrimSpace(tm.Name)))
+			if _, ok := teamsInRun[key]; ok {
+				continue
+			}
+			if tm.Config.MDM.MacOSSetup.EnableEndUserAuthentication {
+				return fmt.Errorf(
+					"fleet %q has end user authentication enabled but the IdP is not fully configured. %s, or disable end user authentication for that fleet.",
+					tm.Name, idpHint,
+				)
+			}
+		}
+	}
+
+	// Finally, the stored no-team/global EUA flag survives only when no global
+	// file is in this run (a global file in the run authoritatively redefines
+	// no-team state in overwrite mode, and is covered by the file loop above).
+	if !globalInRun && appCfg.MDM.MacOSSetup.EnableEndUserAuthentication {
+		return fmt.Errorf(
+			"end user authentication is enabled but the IdP is not fully configured. %s.",
+			idpHint,
+		)
 	}
 	return nil
 }

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7640,3 +7640,130 @@ software:
 	assert.Empty(t, added)
 	assert.ElementsMatch(t, []uint{200, 201, 202}, deleted)
 }
+
+func TestValidateGitOpsGroupEUA(t *testing.T) {
+	t.Parallel()
+
+	// Stored server state: pretend the IdP is configured.
+	storedConfigured := &fleet.EnrichedAppConfig{
+		AppConfig: fleet.AppConfig{
+			MDM: fleet.MDM{
+				EndUserAuthentication: fleet.MDMEndUserAuthentication{
+					SSOProviderSettings: fleet.SSOProviderSettings{
+						EntityID:    "fleet",
+						IDPName:     "Okta",
+						MetadataURL: "https://idp.example.com/metadata",
+					},
+				},
+			},
+		},
+	}
+	storedEmpty := &fleet.EnrichedAppConfig{AppConfig: fleet.AppConfig{}}
+
+	// Helpers that build a parsed GitOps config with the bits we need.
+	globalConfig := func(orgSettings map[string]any) ConfigFile {
+		return ConfigFile{
+			Filename:       "default.yml",
+			IsGlobalConfig: true,
+			Config: &spec.GitOps{
+				OrgSettings: orgSettings,
+			},
+		}
+	}
+	teamConfig := func(filename string, euaEnabled bool) ConfigFile {
+		teamName := "TeamA"
+		cf := ConfigFile{
+			Filename:       filename,
+			IsGlobalConfig: false,
+			Config: &spec.GitOps{
+				TeamName: &teamName,
+			},
+		}
+		if euaEnabled {
+			cf.Config.Controls.MacOSSetup = &fleet.MacOSSetup{
+				EnableEndUserAuthentication: true,
+			}
+		}
+		return cf
+	}
+
+	t.Run("no EUA enabled anywhere is accepted", func(t *testing.T) {
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", false)}, storedEmpty)
+		assert.NoError(t, err)
+	})
+
+	t.Run("team enables EUA, stored has IdP, no global file: accepted", func(t *testing.T) {
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedConfigured)
+		assert.NoError(t, err)
+	})
+
+	t.Run("team enables EUA, stored has no IdP, no global file: rejected", func(t *testing.T) {
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedEmpty)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "teams/a.yml")
+		require.ErrorContains(t, err, "enable_end_user_authentication is true but no IdP is configured")
+	})
+
+	t.Run("team enables EUA, global file adds IdP: accepted", func(t *testing.T) {
+		global := globalConfig(map[string]any{
+			"mdm": map[string]any{
+				"end_user_authentication": map[string]any{
+					"idp_name":     "Okta",
+					"metadata_url": "https://idp.example.com/metadata",
+				},
+			},
+		})
+		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedEmpty)
+		assert.NoError(t, err)
+	})
+
+	t.Run("team enables EUA, global file omits IdP, stored has IdP: rejected (overwrite clears)", func(t *testing.T) {
+		// Global file in this run with no mdm.end_user_authentication block means
+		// overwrite mode would clear the stored IdP. With EUA enabled somewhere,
+		// that's the lockout scenario.
+		global := globalConfig(map[string]any{})
+		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedConfigured)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "teams/a.yml")
+	})
+
+	t.Run("global file enables EUA at no-team and has IdP: accepted", func(t *testing.T) {
+		global := globalConfig(map[string]any{
+			"mdm": map[string]any{
+				"end_user_authentication": map[string]any{
+					"metadata": "<xml/>",
+				},
+			},
+		})
+		global.Config.Controls.MacOSSetup = &fleet.MacOSSetup{EnableEndUserAuthentication: true}
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedEmpty)
+		assert.NoError(t, err)
+	})
+
+	t.Run("global file enables EUA at no-team and has empty IdP: rejected", func(t *testing.T) {
+		// This is the original issue #43371 scenario — `fleetctl generate-gitops`
+		// emits `metadata: # TODO: ...` which parses to empty, plus the user
+		// (perhaps inadvertently) has EUA enabled at no-team.
+		global := globalConfig(map[string]any{
+			"mdm": map[string]any{
+				"end_user_authentication": map[string]any{
+					"idp_name":     "Okta",
+					"metadata":     "",
+					"metadata_url": "",
+				},
+			},
+		})
+		global.Config.Controls.MacOSSetup = &fleet.MacOSSetup{EnableEndUserAuthentication: true}
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "default.yml")
+	})
+
+	t.Run("EUA disabled everywhere: stored IdP empty is fine", func(t *testing.T) {
+		err := validateGitOpsGroupEUA([]ConfigFile{
+			globalConfig(map[string]any{}),
+			teamConfig("teams/a.yml", false),
+		}, storedEmpty)
+		assert.NoError(t, err)
+	})
+}

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7644,7 +7644,10 @@ software:
 func TestValidateGitOpsGroupEUA(t *testing.T) {
 	t.Parallel()
 
-	// Stored server state: pretend the IdP is configured.
+	premium := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+
+	// Stored server state: pretend the IdP is fully configured (idp_name,
+	// entity_id, and a metadata source all present).
 	storedConfigured := &fleet.EnrichedAppConfig{
 		AppConfig: fleet.AppConfig{
 			MDM: fleet.MDM{
@@ -7658,7 +7661,19 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 			},
 		},
 	}
+	storedConfigured.License = premium
 	storedEmpty := &fleet.EnrichedAppConfig{AppConfig: fleet.AppConfig{}}
+	storedEmpty.License = premium
+
+	// listTeams stubs.
+	noTeams := func(string) ([]fleet.Team, error) { return nil, nil }
+	teamWithEUA := func(name string) func(string) ([]fleet.Team, error) {
+		return func(string) ([]fleet.Team, error) {
+			tm := fleet.Team{Name: name}
+			tm.Config.MDM.MacOSSetup.EnableEndUserAuthentication = true
+			return []fleet.Team{tm}, nil
+		}
+	}
 
 	// Helpers that build a parsed GitOps config with the bits we need.
 	globalConfig := func(orgSettings map[string]any) ConfigFile {
@@ -7670,8 +7685,17 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 			},
 		}
 	}
-	teamConfig := func(filename string, euaEnabled bool) ConfigFile {
-		teamName := "TeamA"
+	// completeIdP is the org_settings.mdm shape for a fully-configured IdP.
+	completeIdP := map[string]any{
+		"mdm": map[string]any{
+			"end_user_authentication": map[string]any{
+				"idp_name":     "Okta",
+				"entity_id":    "fleet",
+				"metadata_url": "https://idp.example.com/metadata",
+			},
+		},
+	}
+	teamConfigNamed := func(filename, teamName string, euaEnabled bool) ConfigFile {
 		cf := ConfigFile{
 			Filename:       filename,
 			IsGlobalConfig: false,
@@ -7686,25 +7710,34 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 		}
 		return cf
 	}
+	teamConfig := func(filename string, euaEnabled bool) ConfigFile {
+		return teamConfigNamed(filename, "TeamA", euaEnabled)
+	}
 
 	t.Run("no EUA enabled anywhere is accepted", func(t *testing.T) {
-		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", false)}, storedEmpty)
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", false)}, storedEmpty, noTeams)
 		assert.NoError(t, err)
 	})
 
 	t.Run("team enables EUA, stored has IdP, no global file: accepted", func(t *testing.T) {
-		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedConfigured)
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedConfigured, noTeams)
 		assert.NoError(t, err)
 	})
 
 	t.Run("team enables EUA, stored has no IdP, no global file: rejected", func(t *testing.T) {
-		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedEmpty)
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedEmpty, noTeams)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "teams/a.yml")
-		require.ErrorContains(t, err, "enable_end_user_authentication is true but no IdP is configured")
+		require.ErrorContains(t, err, "enable_end_user_authentication is true but the IdP is not fully configured")
 	})
 
-	t.Run("team enables EUA, global file adds IdP: accepted", func(t *testing.T) {
+	t.Run("team enables EUA, global file adds complete IdP: accepted", func(t *testing.T) {
+		err := validateGitOpsGroupEUA([]ConfigFile{globalConfig(completeIdP), teamConfig("teams/a.yml", true)}, storedEmpty, noTeams)
+		assert.NoError(t, err)
+	})
+
+	t.Run("team enables EUA, global file adds IdP missing entity_id: rejected", func(t *testing.T) {
+		// idp_name + metadata_url but no entity_id is not a complete IdP.
 		global := globalConfig(map[string]any{
 			"mdm": map[string]any{
 				"end_user_authentication": map[string]any{
@@ -7713,8 +7746,9 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 				},
 			},
 		})
-		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedEmpty)
-		assert.NoError(t, err)
+		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedEmpty, noTeams)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "teams/a.yml")
 	})
 
 	t.Run("team enables EUA, global file omits IdP, stored has IdP: rejected (overwrite clears)", func(t *testing.T) {
@@ -7722,21 +7756,15 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 		// overwrite mode would clear the stored IdP. With EUA enabled somewhere,
 		// that's the lockout scenario.
 		global := globalConfig(map[string]any{})
-		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedConfigured)
+		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedConfigured, noTeams)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "teams/a.yml")
 	})
 
-	t.Run("global file enables EUA at no-team and has IdP: accepted", func(t *testing.T) {
-		global := globalConfig(map[string]any{
-			"mdm": map[string]any{
-				"end_user_authentication": map[string]any{
-					"metadata": "<xml/>",
-				},
-			},
-		})
+	t.Run("global file enables EUA at no-team and has complete IdP: accepted", func(t *testing.T) {
+		global := globalConfig(completeIdP)
 		global.Config.Controls.MacOSSetup = &fleet.MacOSSetup{EnableEndUserAuthentication: true}
-		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedEmpty)
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedEmpty, noTeams)
 		assert.NoError(t, err)
 	})
 
@@ -7748,22 +7776,60 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 			"mdm": map[string]any{
 				"end_user_authentication": map[string]any{
 					"idp_name":     "Okta",
+					"entity_id":    "fleet",
 					"metadata":     "",
 					"metadata_url": "",
 				},
 			},
 		})
 		global.Config.Controls.MacOSSetup = &fleet.MacOSSetup{EnableEndUserAuthentication: true}
-		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured)
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured, noTeams)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "default.yml")
+	})
+
+	t.Run("global-only run degrades IdP while a stored team keeps EUA on: rejected (#43371)", func(t *testing.T) {
+		// The reported lockout: a global-only run keeps idp_name/entity_id but
+		// blanks metadata/metadata_url (so the server's IsEmpty() guard is
+		// dodged), while a team not in this run still has EUA enabled.
+		global := globalConfig(map[string]any{
+			"mdm": map[string]any{
+				"end_user_authentication": map[string]any{
+					"idp_name":     "Okta",
+					"entity_id":    "fleet",
+					"metadata":     "",
+					"metadata_url": "",
+				},
+			},
+		})
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured, teamWithEUA("Workstations"))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Workstations")
+		require.ErrorContains(t, err, "has end user authentication enabled")
+	})
+
+	t.Run("global-only run degrades IdP but the team's in-run file disables EUA: accepted", func(t *testing.T) {
+		global := globalConfig(map[string]any{
+			"mdm": map[string]any{
+				"end_user_authentication": map[string]any{
+					"idp_name":     "Okta",
+					"entity_id":    "fleet",
+					"metadata":     "",
+					"metadata_url": "",
+				},
+			},
+		})
+		// In-run file for the same team disables EUA; its value wins over stored.
+		team := teamConfigNamed("teams/workstations.yml", "Workstations", false)
+		err := validateGitOpsGroupEUA([]ConfigFile{global, team}, storedConfigured, teamWithEUA("Workstations"))
+		assert.NoError(t, err)
 	})
 
 	t.Run("EUA disabled everywhere: stored IdP empty is fine", func(t *testing.T) {
 		err := validateGitOpsGroupEUA([]ConfigFile{
 			globalConfig(map[string]any{}),
 			teamConfig("teams/a.yml", false),
-		}, storedEmpty)
+		}, storedEmpty, noTeams)
 		assert.NoError(t, err)
 	})
 }

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7715,24 +7715,24 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 	}
 
 	t.Run("no EUA enabled anywhere is accepted", func(t *testing.T) {
-		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", false)}, storedEmpty, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", false)}, storedEmpty, noTeams, false)
 		assert.NoError(t, err)
 	})
 
 	t.Run("team enables EUA, stored has IdP, no global file: accepted", func(t *testing.T) {
-		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedConfigured, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedConfigured, noTeams, false)
 		assert.NoError(t, err)
 	})
 
 	t.Run("team enables EUA, stored has no IdP, no global file: rejected", func(t *testing.T) {
-		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedEmpty, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{teamConfig("teams/a.yml", true)}, storedEmpty, noTeams, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "teams/a.yml")
 		require.ErrorContains(t, err, "enable_end_user_authentication is true but the IdP is not fully configured")
 	})
 
 	t.Run("team enables EUA, global file adds complete IdP: accepted", func(t *testing.T) {
-		err := validateGitOpsGroupEUA([]ConfigFile{globalConfig(completeIdP), teamConfig("teams/a.yml", true)}, storedEmpty, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{globalConfig(completeIdP), teamConfig("teams/a.yml", true)}, storedEmpty, noTeams, false)
 		assert.NoError(t, err)
 	})
 
@@ -7746,7 +7746,7 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 				},
 			},
 		})
-		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedEmpty, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedEmpty, noTeams, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "teams/a.yml")
 	})
@@ -7756,7 +7756,7 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 		// overwrite mode would clear the stored IdP. With EUA enabled somewhere,
 		// that's the lockout scenario.
 		global := globalConfig(map[string]any{})
-		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedConfigured, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{global, teamConfig("teams/a.yml", true)}, storedConfigured, noTeams, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "teams/a.yml")
 	})
@@ -7764,7 +7764,7 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 	t.Run("global file enables EUA at no-team and has complete IdP: accepted", func(t *testing.T) {
 		global := globalConfig(completeIdP)
 		global.Config.Controls.MacOSSetup = &fleet.MacOSSetup{EnableEndUserAuthentication: true}
-		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedEmpty, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedEmpty, noTeams, false)
 		assert.NoError(t, err)
 	})
 
@@ -7783,7 +7783,7 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 			},
 		})
 		global.Config.Controls.MacOSSetup = &fleet.MacOSSetup{EnableEndUserAuthentication: true}
-		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured, noTeams)
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured, noTeams, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "default.yml")
 	})
@@ -7802,10 +7802,36 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 				},
 			},
 		})
-		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured, teamWithEUA("Workstations"))
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured, teamWithEUA("Workstations"), false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "Workstations")
 		require.ErrorContains(t, err, "has end user authentication enabled")
+	})
+
+	t.Run("global-only run degrades IdP, stored team keeps EUA, but --delete-other-fleets is set: accepted", func(t *testing.T) {
+		// Same shape as the #43371 case above, but with --delete-other-fleets the
+		// omitted team will be deleted, so it can't lock anyone out. The stored-team
+		// lookup must be skipped: ListTeams must not be consulted.
+		global := globalConfig(map[string]any{
+			"mdm": map[string]any{
+				"end_user_authentication": map[string]any{
+					"idp_name":     "Okta",
+					"entity_id":    "fleet",
+					"metadata":     "",
+					"metadata_url": "",
+				},
+			},
+		})
+		listTeamsCalled := false
+		listTeams := func(string) ([]fleet.Team, error) {
+			listTeamsCalled = true
+			tm := fleet.Team{Name: "Workstations"}
+			tm.Config.MDM.MacOSSetup.EnableEndUserAuthentication = true
+			return []fleet.Team{tm}, nil
+		}
+		err := validateGitOpsGroupEUA([]ConfigFile{global}, storedConfigured, listTeams, true)
+		require.NoError(t, err)
+		assert.False(t, listTeamsCalled, "ListTeams should not be consulted when --delete-other-fleets is set")
 	})
 
 	t.Run("global-only run degrades IdP but the team's in-run file disables EUA: accepted", func(t *testing.T) {
@@ -7821,7 +7847,7 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 		})
 		// In-run file for the same team disables EUA; its value wins over stored.
 		team := teamConfigNamed("teams/workstations.yml", "Workstations", false)
-		err := validateGitOpsGroupEUA([]ConfigFile{global, team}, storedConfigured, teamWithEUA("Workstations"))
+		err := validateGitOpsGroupEUA([]ConfigFile{global, team}, storedConfigured, teamWithEUA("Workstations"), false)
 		assert.NoError(t, err)
 	})
 
@@ -7829,7 +7855,7 @@ func TestValidateGitOpsGroupEUA(t *testing.T) {
 		err := validateGitOpsGroupEUA([]ConfigFile{
 			globalConfig(map[string]any{}),
 			teamConfig("teams/a.yml", false),
-		}, storedEmpty, noTeams)
+		}, storedEmpty, noTeams, false)
 		assert.NoError(t, err)
 	})
 }

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1757,7 +1757,9 @@ func (svc *Service) editTeamFromSpec(
 
 	didUpdateMacOSEndUserAuth := spec.MDM.MacOSSetup.EnableEndUserAuthentication != oldMacOSSetup.EnableEndUserAuthentication
 	if didUpdateMacOSEndUserAuth && spec.MDM.MacOSSetup.EnableEndUserAuthentication {
-		if appCfg.MDM.EndUserAuthentication.IsEmpty() {
+		// Skip the precondition during dry-run that end-user auth SSO must be configured,
+		// since we can't tell here if the GitOps run is also doing that configuration.
+		if !opts.DryRun && appCfg.MDM.EndUserAuthentication.IsEmpty() {
 			// TODO: update this error message to include steps to resolve the issue once docs for IdP
 			// config are available
 			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("setup_experience.enable_end_user_authentication",

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -688,13 +688,32 @@ func validateOrgInfoLogo(orgSettings map[string]any, multiError *multierror.Erro
 	return multiError
 }
 
-// Verify that if SSO is enabled, either metadata or metadata_url is provided.
+// Verify that if SSO is enabled, the IdP is completely configured: idp_name,
+// entity_id, and at least one of metadata/metadata_url must all be set. This
+// mirrors the server-side complete-IdP predicate enforced by
+// validateSSOProviderSettings in overwrite (gitops) mode, so the user gets the
+// same rejection early at parse time. One error is emitted per missing piece.
 func validateSSOConfig(orgSettings map[string]any, multiError *multierror.Error) *multierror.Error {
 	if sso, ok := orgSettings["sso_settings"].(map[string]any); ok {
 		enabled, _ := sso["enable_sso"].(bool)
+		if !enabled {
+			return multiError
+		}
+		idpName, _ := sso["idp_name"].(string)
+		entityID, _ := sso["entity_id"].(string)
 		metadata, _ := sso["metadata"].(string)
 		metadataURL, _ := sso["metadata_url"].(string)
-		if enabled && metadata == "" && metadataURL == "" {
+		if idpName == "" {
+			multiError = multierror.Append(multiError, errors.New(
+				"When org_settings.sso_settings.enable_sso is true, idp_name must be set",
+			))
+		}
+		if entityID == "" {
+			multiError = multierror.Append(multiError, errors.New(
+				"When org_settings.sso_settings.enable_sso is true, entity_id must be set",
+			))
+		}
+		if metadata == "" && metadataURL == "" {
 			multiError = multierror.Append(multiError, errors.New(
 				"When org_settings.sso_settings.enable_sso is true, either metadata or metadata_url must be set",
 			))

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -690,16 +690,7 @@ func validateOrgInfoLogo(orgSettings map[string]any, multiError *multierror.Erro
 	return multiError
 }
 
-// validateSSOConfig rejects YAML payloads that declare SSO intent without the
-// metadata needed to make SSO work. The server's REST PATCH validator allows
-// empty incoming metadata when the existing server value is set (partial
-// update semantics), but GitOps is declarative — the YAML is the full state —
-// so we reject the broken declaration before it reaches the server and
-// silently wipes the working SSO config. See issue #43371.
-//
-// MDM end-user authentication is checked separately in
-// validateMDMEndUserAuthConfig because the enable flag lives in a different
-// top-level block (`controls`) than the IdP settings (`org_settings.mdm`).
+// Verify that if SSO is enabled, either metadata or metadata_url is provided.
 func validateSSOConfig(orgSettings map[string]any, multiError *multierror.Error) *multierror.Error {
 	if sso, ok := orgSettings["sso_settings"].(map[string]any); ok {
 		enabled, _ := sso["enable_sso"].(bool)
@@ -714,14 +705,7 @@ func validateSSOConfig(orgSettings map[string]any, multiError *multierror.Error)
 	return multiError
 }
 
-// validateMDMEndUserAuthConfig checks the cross-block invariant: when
-// `controls.macos_setup.enable_end_user_authentication` (alias
-// `setup_experience.enable_end_user_authentication`) is true, the IdP
-// settings under `org_settings.mdm.end_user_authentication` must include
-// metadata or metadata_url. Without that, ADE enrollment can't complete.
-// By the time this runs, key renames in the `controls` block have already
-// been normalized into result.Controls.MacOSSetup, so the check is the same
-// regardless of which YAML alias the user wrote.
+// Verify that if end-user auth is enabled, either metadata or metadata_url is provided.
 func validateMDMEndUserAuthConfig(result *GitOps, multiError *multierror.Error) *multierror.Error {
 	if result.Controls.MacOSSetup == nil || !result.Controls.MacOSSetup.EnableEndUserAuthentication {
 		return multiError

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -544,8 +544,6 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	}
 	// Get other top-level entities.
 	multiError = parseControls(top, result, logFn, filePath, multiError)
-	// Cross-block check: needs both org_settings (parsed above) and controls.
-	multiError = validateMDMEndUserAuthConfig(result, multiError)
 	multiError = parseAgentOptions(top, result, baseDir, logFn, filePath, multiError)
 	multiError = parseReports(top, result, baseDir, logFn, filePath, multiError)
 
@@ -701,24 +699,6 @@ func validateSSOConfig(orgSettings map[string]any, multiError *multierror.Error)
 				"When org_settings.sso_settings.enable_sso is true, either metadata or metadata_url must be set",
 			))
 		}
-	}
-	return multiError
-}
-
-// Verify that if end-user auth is enabled, either metadata or metadata_url is provided.
-func validateMDMEndUserAuthConfig(result *GitOps, multiError *multierror.Error) *multierror.Error {
-	if result.Controls.MacOSSetup == nil || !result.Controls.MacOSSetup.EnableEndUserAuthentication {
-		return multiError
-	}
-	// The flag is enabled — the IdP settings must be present in org_settings.
-	mdm, _ := result.OrgSettings["mdm"].(map[string]any)
-	eua, _ := mdm["end_user_authentication"].(map[string]any)
-	metadata, _ := eua["metadata"].(string)
-	metadataURL, _ := eua["metadata_url"].(string)
-	if metadata == "" && metadataURL == "" {
-		multiError = multierror.Append(multiError, errors.New(
-			"When controls.macos_setup.enable_end_user_authentication is true, mdm.end_user_authentication.metadata or mdm.end_user_authentication.metadata_url must be set on org_settings",
-		))
 	}
 	return multiError
 }

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -656,6 +656,7 @@ func parseOrgSettings(raw json.RawMessage, result *GitOps, baseDir string, fileP
 			multiError = parseSecrets(result, multiError)
 			multiError = validateOrgInfoLogo(result.OrgSettings, multiError)
 			multiError = validateGitOpsConfig(result.OrgSettings, multiError)
+			multiError = validateSSOConfig(result.OrgSettings, multiError)
 		}
 		// Validate unknown keys in org_settings section.
 		multiError = multierror.Append(multiError, validateYAMLKeys(raw, reflect.TypeFor[GitOpsOrgSettings](), settingsFilePath, []string{"org_settings"})...)
@@ -684,6 +685,39 @@ func validateOrgInfoLogo(orgSettings map[string]any, multiError *multierror.Erro
 	}
 	check("dark", "org_logo_path_dark_mode", "org_logo_url_dark_mode")
 	check("light", "org_logo_path_light_mode", "org_logo_url_light_mode")
+	return multiError
+}
+
+// Validate that if SSO (or MDM EUA) is enabled, either metadata or metadata_url is set.
+func validateSSOConfig(orgSettings map[string]any, multiError *multierror.Error) *multierror.Error {
+	if sso, ok := orgSettings["sso_settings"].(map[string]any); ok {
+		enabled, _ := sso["enable_sso"].(bool)
+		metadata, _ := sso["metadata"].(string)
+		metadataURL, _ := sso["metadata_url"].(string)
+		if enabled && metadata == "" && metadataURL == "" {
+			multiError = multierror.Append(multiError, errors.New(
+				"When org_settings.sso_settings.enable_sso is true, either metadata or metadata_url must be set",
+			))
+		}
+	}
+
+	// MDM end-user authentication embeds SSOProviderSettings flat (no nested
+	// sso_settings, no explicit enable flag — the presence of provider fields
+	// is the declaration of intent).
+	if mdm, ok := orgSettings["mdm"].(map[string]any); ok {
+		if eua, ok := mdm["end_user_authentication"].(map[string]any); ok {
+			entityID, _ := eua["entity_id"].(string)
+			idpName, _ := eua["idp_name"].(string)
+			metadata, _ := eua["metadata"].(string)
+			metadataURL, _ := eua["metadata_url"].(string)
+			if (entityID != "" || idpName != "") && metadata == "" && metadataURL == "" {
+				multiError = multierror.Append(multiError, errors.New(
+					"When mdm.end_user_authentication has SSO provider settings configured, either metadata or metadata_url must be set",
+				))
+			}
+		}
+	}
+
 	return multiError
 }
 

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -544,6 +544,8 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	}
 	// Get other top-level entities.
 	multiError = parseControls(top, result, logFn, filePath, multiError)
+	// Cross-block check: needs both org_settings (parsed above) and controls.
+	multiError = validateMDMEndUserAuthConfig(result, multiError)
 	multiError = parseAgentOptions(top, result, baseDir, logFn, filePath, multiError)
 	multiError = parseReports(top, result, baseDir, logFn, filePath, multiError)
 
@@ -688,7 +690,16 @@ func validateOrgInfoLogo(orgSettings map[string]any, multiError *multierror.Erro
 	return multiError
 }
 
-// Validate that if SSO (or MDM EUA) is enabled, either metadata or metadata_url is set.
+// validateSSOConfig rejects YAML payloads that declare SSO intent without the
+// metadata needed to make SSO work. The server's REST PATCH validator allows
+// empty incoming metadata when the existing server value is set (partial
+// update semantics), but GitOps is declarative — the YAML is the full state —
+// so we reject the broken declaration before it reaches the server and
+// silently wipes the working SSO config. See issue #43371.
+//
+// MDM end-user authentication is checked separately in
+// validateMDMEndUserAuthConfig because the enable flag lives in a different
+// top-level block (`controls`) than the IdP settings (`org_settings.mdm`).
 func validateSSOConfig(orgSettings map[string]any, multiError *multierror.Error) *multierror.Error {
 	if sso, ok := orgSettings["sso_settings"].(map[string]any); ok {
 		enabled, _ := sso["enable_sso"].(bool)
@@ -700,24 +711,31 @@ func validateSSOConfig(orgSettings map[string]any, multiError *multierror.Error)
 			))
 		}
 	}
+	return multiError
+}
 
-	// MDM end-user authentication embeds SSOProviderSettings flat (no nested
-	// sso_settings, no explicit enable flag — the presence of provider fields
-	// is the declaration of intent).
-	if mdm, ok := orgSettings["mdm"].(map[string]any); ok {
-		if eua, ok := mdm["end_user_authentication"].(map[string]any); ok {
-			entityID, _ := eua["entity_id"].(string)
-			idpName, _ := eua["idp_name"].(string)
-			metadata, _ := eua["metadata"].(string)
-			metadataURL, _ := eua["metadata_url"].(string)
-			if (entityID != "" || idpName != "") && metadata == "" && metadataURL == "" {
-				multiError = multierror.Append(multiError, errors.New(
-					"When mdm.end_user_authentication has SSO provider settings configured, either metadata or metadata_url must be set",
-				))
-			}
-		}
+// validateMDMEndUserAuthConfig checks the cross-block invariant: when
+// `controls.macos_setup.enable_end_user_authentication` (alias
+// `setup_experience.enable_end_user_authentication`) is true, the IdP
+// settings under `org_settings.mdm.end_user_authentication` must include
+// metadata or metadata_url. Without that, ADE enrollment can't complete.
+// By the time this runs, key renames in the `controls` block have already
+// been normalized into result.Controls.MacOSSetup, so the check is the same
+// regardless of which YAML alias the user wrote.
+func validateMDMEndUserAuthConfig(result *GitOps, multiError *multierror.Error) *multierror.Error {
+	if result.Controls.MacOSSetup == nil || !result.Controls.MacOSSetup.EnableEndUserAuthentication {
+		return multiError
 	}
-
+	// The flag is enabled — the IdP settings must be present in org_settings.
+	mdm, _ := result.OrgSettings["mdm"].(map[string]any)
+	eua, _ := mdm["end_user_authentication"].(map[string]any)
+	metadata, _ := eua["metadata"].(string)
+	metadataURL, _ := eua["metadata_url"].(string)
+	if metadata == "" && metadataURL == "" {
+		multiError = multierror.Append(multiError, errors.New(
+			"When controls.macos_setup.enable_end_user_authentication is true, mdm.end_user_authentication.metadata or mdm.end_user_authentication.metadata_url must be set on org_settings",
+		))
+	}
 	return multiError
 }
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1438,6 +1438,117 @@ org_settings:
 	})
 }
 
+func TestGitOpsSSOValidation(t *testing.T) {
+	t.Parallel()
+
+	withSSO := func(body string) string {
+		config := getGlobalConfig([]string{"org_settings"})
+		config += `
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: Test Org
+  secrets:
+  sso_settings:
+` + body
+		return config
+	}
+
+	withMDMEUA := func(body string) string {
+		config := getGlobalConfig([]string{"org_settings"})
+		config += `
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: Test Org
+  secrets:
+  mdm:
+    end_user_authentication:
+` + body
+		return config
+	}
+
+	t.Run("sso_settings absent is accepted", func(t *testing.T) {
+		config := getGlobalConfig(nil)
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("enable_sso true with both metadata fields empty is rejected", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    idp_name: Okta\n    entity_id: https://example.com\n    metadata: \"\"\n    metadata_url: \"\"\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "When org_settings.sso_settings.enable_sso is true, either metadata or metadata_url must be set")
+	})
+
+	t.Run("enable_sso true with both metadata fields absent is rejected", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    idp_name: Okta\n    entity_id: https://example.com\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "When org_settings.sso_settings.enable_sso is true, either metadata or metadata_url must be set")
+	})
+
+	t.Run("enable_sso true with metadata only is accepted", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    idp_name: Okta\n    entity_id: https://example.com\n    metadata: \"<xml/>\"\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("enable_sso true with metadata_url only is accepted", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    idp_name: Okta\n    entity_id: https://example.com\n    metadata_url: https://idp.example.com/metadata\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("enable_sso false with empty metadata is accepted", func(t *testing.T) {
+		config := withSSO("    enable_sso: false\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("MDM EUA with provider fields but no metadata is rejected", func(t *testing.T) {
+		config := withMDMEUA("      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"\"\n      metadata_url: \"\"\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "When mdm.end_user_authentication has SSO provider settings configured, either metadata or metadata_url must be set")
+	})
+
+	t.Run("MDM EUA with metadata only is accepted", func(t *testing.T) {
+		config := withMDMEUA("      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"<xml/>\"\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("MDM EUA with metadata_url only is accepted", func(t *testing.T) {
+		config := withMDMEUA("      idp_name: Okta\n      entity_id: https://example.com\n      metadata_url: https://idp.example.com/metadata\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("MDM EUA fully empty is accepted", func(t *testing.T) {
+		config := withMDMEUA("      idp_name: \"\"\n      entity_id: \"\"\n      metadata: \"\"\n      metadata_url: \"\"\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	// Regression guard: the YAML that `fleetctl generate-gitops` produces
+	// renders the metadata fields as `metadata: # TODO: ...` (a YAML key with
+	// a trailing comment, which parses to nil/empty). This is exactly the
+	// state that nearly locked out the reporter in issue #43371 — and is
+	// what the validation here is designed to catch. If this test ever
+	// stops failing, the safety net is gone.
+	t.Run("generate-gitops rendered TODO comment form is rejected", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    idp_name: Okta\n    entity_id: https://example.com\n    metadata: # TODO: Add your SSO metadata here\n    metadata_url: # TODO: Add your SSO metadata URL here\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "When org_settings.sso_settings.enable_sso is true, either metadata or metadata_url must be set")
+	})
+}
+
 func TestGitOpsPaths(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1456,36 +1456,6 @@ org_settings:
 		return config
 	}
 
-	// withMDMEUA composes a YAML where:
-	//   controls.macos_setup.enable_end_user_authentication = euaEnabled
-	//   org_settings.mdm.end_user_authentication = euaBody
-	// This matches the actual GitOps surface: the *enable* flag lives in the
-	// controls block, the *IdP settings* live under org_settings.mdm.
-	withMDMEUA := func(euaEnabled bool, euaBody string) string {
-		config := getGlobalConfig([]string{"org_settings", "controls"})
-		if euaEnabled {
-			config += `
-controls:
-  macos_setup:
-    enable_end_user_authentication: true
-`
-		} else {
-			config += "\ncontrols:\n"
-		}
-		config += `
-org_settings:
-  server_settings:
-    server_url: https://fleet.example.com
-  org_info:
-    contact_url: https://example.com/contact
-    org_name: Test Org
-  secrets:
-  mdm:
-    end_user_authentication:
-` + euaBody
-		return config
-	}
-
 	t.Run("sso_settings absent is accepted", func(t *testing.T) {
 		config := getGlobalConfig(nil)
 		_, err := gitOpsFromString(t, config)
@@ -1524,64 +1494,11 @@ org_settings:
 		require.NoError(t, err)
 	})
 
-	t.Run("MDM EUA enabled with no metadata is rejected", func(t *testing.T) {
-		config := withMDMEUA(true, "      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"\"\n      metadata_url: \"\"\n")
-		_, err := gitOpsFromString(t, config)
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "When controls.macos_setup.enable_end_user_authentication is true, mdm.end_user_authentication.metadata or mdm.end_user_authentication.metadata_url must be set")
-	})
-
-	t.Run("MDM EUA enabled with setup_experience alias is also rejected", func(t *testing.T) {
-		// setup_experience is the YAML rename for macos_setup; the parser
-		// normalizes it before reaching validation, so the same check fires.
-		config := getGlobalConfig([]string{"org_settings", "controls"})
-		config += `
-controls:
-  setup_experience:
-    enable_end_user_authentication: true
-
-org_settings:
-  server_settings:
-    server_url: https://fleet.example.com
-  org_info:
-    contact_url: https://example.com/contact
-    org_name: Test Org
-  secrets:
-  mdm:
-    end_user_authentication:
-      idp_name: Okta
-      entity_id: https://example.com
-`
-		_, err := gitOpsFromString(t, config)
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "When controls.macos_setup.enable_end_user_authentication is true")
-	})
-
-	t.Run("MDM EUA enabled with metadata is accepted", func(t *testing.T) {
-		config := withMDMEUA(true, "      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"<xml/>\"\n")
-		_, err := gitOpsFromString(t, config)
-		require.NoError(t, err)
-	})
-
-	t.Run("MDM EUA enabled with metadata_url is accepted", func(t *testing.T) {
-		config := withMDMEUA(true, "      idp_name: Okta\n      entity_id: https://example.com\n      metadata_url: https://idp.example.com/metadata\n")
-		_, err := gitOpsFromString(t, config)
-		require.NoError(t, err)
-	})
-
-	t.Run("MDM EUA disabled with empty IdP settings is accepted", func(t *testing.T) {
-		config := withMDMEUA(false, "      idp_name: \"\"\n      entity_id: \"\"\n      metadata: \"\"\n      metadata_url: \"\"\n")
-		_, err := gitOpsFromString(t, config)
-		require.NoError(t, err)
-	})
-
-	t.Run("MDM EUA disabled with IdP settings present is accepted", func(t *testing.T) {
-		// IdP settings sitting in org_settings without the enable flag is
-		// benign — the IdP isn't being used yet. Don't reject.
-		config := withMDMEUA(false, "      idp_name: Okta\n      entity_id: https://example.com\n")
-		_, err := gitOpsFromString(t, config)
-		require.NoError(t, err)
-	})
+	// Note: MDM end-user authentication validation lives at the gitops
+	// CLI group level (cmd/fleetctl/fleetctl/gitops.go), not here in the
+	// per-file parser, because the enable flag and the IdP settings can
+	// live in different files (controls in team files, org_settings in
+	// the global file only). See TestValidateGitOpsGroupEUA.
 
 	// Regression guard: the YAML that `fleetctl generate-gitops` produces
 	// renders the metadata fields as `metadata: # TODO: ...` (a YAML key with

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1494,6 +1494,28 @@ org_settings:
 		require.NoError(t, err)
 	})
 
+	t.Run("enable_sso true with empty idp_name is rejected", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    idp_name: \"\"\n    entity_id: https://example.com\n    metadata_url: https://idp.example.com/metadata\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "When org_settings.sso_settings.enable_sso is true, idp_name must be set")
+	})
+
+	t.Run("enable_sso true with empty entity_id is rejected", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    idp_name: Okta\n    entity_id: \"\"\n    metadata_url: https://idp.example.com/metadata\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "When org_settings.sso_settings.enable_sso is true, entity_id must be set")
+	})
+
+	t.Run("enable_sso true missing idp_name and entity_id reports both", func(t *testing.T) {
+		config := withSSO("    enable_sso: true\n    metadata_url: https://idp.example.com/metadata\n")
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "idp_name must be set")
+		require.ErrorContains(t, err, "entity_id must be set")
+	})
+
 	// Note: MDM end-user authentication validation lives at the gitops
 	// CLI group level (cmd/fleetctl/fleetctl/gitops.go), not here in the
 	// per-file parser, because the enable flag and the IdP settings can

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1456,8 +1456,22 @@ org_settings:
 		return config
 	}
 
-	withMDMEUA := func(body string) string {
-		config := getGlobalConfig([]string{"org_settings"})
+	// withMDMEUA composes a YAML where:
+	//   controls.macos_setup.enable_end_user_authentication = euaEnabled
+	//   org_settings.mdm.end_user_authentication = euaBody
+	// This matches the actual GitOps surface: the *enable* flag lives in the
+	// controls block, the *IdP settings* live under org_settings.mdm.
+	withMDMEUA := func(euaEnabled bool, euaBody string) string {
+		config := getGlobalConfig([]string{"org_settings", "controls"})
+		if euaEnabled {
+			config += `
+controls:
+  macos_setup:
+    enable_end_user_authentication: true
+`
+		} else {
+			config += "\ncontrols:\n"
+		}
 		config += `
 org_settings:
   server_settings:
@@ -1468,7 +1482,7 @@ org_settings:
   secrets:
   mdm:
     end_user_authentication:
-` + body
+` + euaBody
 		return config
 	}
 
@@ -1510,27 +1524,61 @@ org_settings:
 		require.NoError(t, err)
 	})
 
-	t.Run("MDM EUA with provider fields but no metadata is rejected", func(t *testing.T) {
-		config := withMDMEUA("      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"\"\n      metadata_url: \"\"\n")
+	t.Run("MDM EUA enabled with no metadata is rejected", func(t *testing.T) {
+		config := withMDMEUA(true, "      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"\"\n      metadata_url: \"\"\n")
 		_, err := gitOpsFromString(t, config)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "When mdm.end_user_authentication has SSO provider settings configured, either metadata or metadata_url must be set")
+		assert.ErrorContains(t, err, "When controls.macos_setup.enable_end_user_authentication is true, mdm.end_user_authentication.metadata or mdm.end_user_authentication.metadata_url must be set")
 	})
 
-	t.Run("MDM EUA with metadata only is accepted", func(t *testing.T) {
-		config := withMDMEUA("      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"<xml/>\"\n")
+	t.Run("MDM EUA enabled with setup_experience alias is also rejected", func(t *testing.T) {
+		// setup_experience is the YAML rename for macos_setup; the parser
+		// normalizes it before reaching validation, so the same check fires.
+		config := getGlobalConfig([]string{"org_settings", "controls"})
+		config += `
+controls:
+  setup_experience:
+    enable_end_user_authentication: true
+
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: Test Org
+  secrets:
+  mdm:
+    end_user_authentication:
+      idp_name: Okta
+      entity_id: https://example.com
+`
+		_, err := gitOpsFromString(t, config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "When controls.macos_setup.enable_end_user_authentication is true")
+	})
+
+	t.Run("MDM EUA enabled with metadata is accepted", func(t *testing.T) {
+		config := withMDMEUA(true, "      idp_name: Okta\n      entity_id: https://example.com\n      metadata: \"<xml/>\"\n")
 		_, err := gitOpsFromString(t, config)
 		require.NoError(t, err)
 	})
 
-	t.Run("MDM EUA with metadata_url only is accepted", func(t *testing.T) {
-		config := withMDMEUA("      idp_name: Okta\n      entity_id: https://example.com\n      metadata_url: https://idp.example.com/metadata\n")
+	t.Run("MDM EUA enabled with metadata_url is accepted", func(t *testing.T) {
+		config := withMDMEUA(true, "      idp_name: Okta\n      entity_id: https://example.com\n      metadata_url: https://idp.example.com/metadata\n")
 		_, err := gitOpsFromString(t, config)
 		require.NoError(t, err)
 	})
 
-	t.Run("MDM EUA fully empty is accepted", func(t *testing.T) {
-		config := withMDMEUA("      idp_name: \"\"\n      entity_id: \"\"\n      metadata: \"\"\n      metadata_url: \"\"\n")
+	t.Run("MDM EUA disabled with empty IdP settings is accepted", func(t *testing.T) {
+		config := withMDMEUA(false, "      idp_name: \"\"\n      entity_id: \"\"\n      metadata: \"\"\n      metadata_url: \"\"\n")
+		_, err := gitOpsFromString(t, config)
+		require.NoError(t, err)
+	})
+
+	t.Run("MDM EUA disabled with IdP settings present is accepted", func(t *testing.T) {
+		// IdP settings sitting in org_settings without the enable flag is
+		// benign — the IdP isn't being used yet. Don't reject.
+		config := withMDMEUA(false, "      idp_name: Okta\n      entity_id: https://example.com\n")
 		_, err := gitOpsFromString(t, config)
 		require.NoError(t, err)
 	})

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -587,8 +587,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		// on. This rejects `enable_sso: true` with empty metadata regardless of
 		// what's currently stored on the server — preventing the silent SSO
 		// wipe described in issue #43371.
-		allowExistingFallback := !applyOpts.Overwrite
-		validateSSOSettings(newAppConfig, appConfig, invalid, lic, allowExistingFallback)
+		validateSSOSettings(newAppConfig, appConfig, invalid, lic, applyOpts.Overwrite)
 		if invalid.HasErrors() {
 			return nil, ctxerr.Wrap(ctx, invalid)
 		}
@@ -848,7 +847,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.Integrations.ConditionalAccessEnabled = newAppConfig.Integrations.ConditionalAccessEnabled
 	}
 
-	if err := svc.validateMDM(ctx, lic, &oldAppConfig.MDM, &appConfig.MDM, invalid, !applyOpts.Overwrite); err != nil {
+	if err := svc.validateMDM(ctx, lic, &oldAppConfig.MDM, &appConfig.MDM, invalid, applyOpts.Overwrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "validating MDM config")
 	}
 
@@ -1632,7 +1631,7 @@ func (svc *Service) validateMDM(
 	oldMdm *fleet.MDM,
 	mdm *fleet.MDM,
 	invalid *fleet.InvalidArgumentError,
-	allowExistingFallback bool,
+	overwrite bool,
 ) error {
 	if mdm.EnableDiskEncryption.Value && !lic.IsPremium() {
 		invalid.Append("apple_settings.enable_disk_encryption", ErrMissingLicense.Error())
@@ -1801,7 +1800,7 @@ func (svc *Service) validateMDM(
 			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
 			return nil
 		}
-		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, allowExistingFallback)
+		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, overwrite)
 	}
 
 	// MacOSSetup validation
@@ -2114,27 +2113,29 @@ func (svc *Service) validateVPPAssignments(
 
 // validateSSOProviderSettings validates an incoming SSOProviderSettings payload.
 //
-// When allowExistingFallback is true (the default for REST PATCH partial-update
-// semantics), required fields are permitted to be empty in the incoming payload
-// if the corresponding existing server value is non-empty — the partial update
+// When overwrite is false (REST PATCH partial-update semantics), required
+// fields are permitted to be empty in the incoming payload if the
+// corresponding existing server value is non-empty — the partial update
 // inherits them.
 //
-// When allowExistingFallback is false (the GitOps code path, where the YAML is
-// the full declared state), empty required fields always fail validation,
-// since GitOps is declarative and overwrites existing state.
-func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, invalid *fleet.InvalidArgumentError, allowExistingFallback bool) {
+// When overwrite is true (the GitOps code path, where the YAML is the full
+// declared state), the existing-state fallback is skipped: empty required
+// fields fail validation regardless of existing server state. This closes
+// the `enable_sso: true` + empty metadata footgun that would otherwise
+// silently wipe the working SSO config on apply.
+func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, invalid *fleet.InvalidArgumentError, overwrite bool) {
 	if incoming.Metadata == "" && incoming.MetadataURL == "" {
-		if !allowExistingFallback || (existing.Metadata == "" && existing.MetadataURL == "") {
+		if overwrite || (existing.Metadata == "" && existing.MetadataURL == "") {
 			invalid.Append("metadata", "either metadata or metadata_url must be defined")
 		}
 	}
 	if incoming.EntityID == "" {
-		if !allowExistingFallback || existing.EntityID == "" {
+		if overwrite || existing.EntityID == "" {
 			invalid.Append("entity_id", "required")
 		}
 	}
 	if incoming.IDPName == "" {
-		if !allowExistingFallback || existing.IDPName == "" {
+		if overwrite || existing.IDPName == "" {
 			invalid.Append("idp_name", "required")
 		}
 	}
@@ -2148,14 +2149,14 @@ func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, i
 	}
 }
 
-func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *fleet.InvalidArgumentError, lic *fleet.LicenseInfo, allowExistingFallback bool) {
+func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *fleet.InvalidArgumentError, lic *fleet.LicenseInfo, overwrite bool) {
 	if p.SSOSettings != nil && p.SSOSettings.EnableSSO {
 
 		var existingSSOProviderSettings fleet.SSOProviderSettings
 		if existing.SSOSettings != nil {
 			existingSSOProviderSettings = existing.SSOSettings.SSOProviderSettings
 		}
-		validateSSOProviderSettings(p.SSOSettings.SSOProviderSettings, existingSSOProviderSettings, invalid, allowExistingFallback)
+		validateSSOProviderSettings(p.SSOSettings.SSOProviderSettings, existingSSOProviderSettings, invalid, overwrite)
 
 		if !lic.IsPremium() {
 			if p.SSOSettings.EnableJITProvisioning {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1800,7 +1800,11 @@ func (svc *Service) validateMDM(
 			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
 			return nil
 		}
-		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, overwrite)
+		// In GitOps (overwrite=true), strict validation should only fire when
+		// EUA is actually being enabled at the global level. Otherwise it's
+		// valid to clear these fields out.
+		euaStrict := overwrite && mdm.MacOSSetup.EnableEndUserAuthentication
+		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, euaStrict)
 	}
 
 	// MacOSSetup validation

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1789,51 +1789,43 @@ func (svc *Service) validateMDM(
 	}
 
 	// EndUserAuthentication
-	//
-	// Determine whether any team currently has setup-experience EUA enabled.
-	// This drives both the strict-validation decision and the IdP-cleared
-	// guard below. We only look at non-zero team IDs since the global/no-team
-	// scope (id=0) is covered by the incoming request's MacOSSetup flag. The
-	// query is only needed in overwrite (gitops) mode when the EUA SSO
-	// settings change, or when the IdP is being fully cleared, so it's
-	// computed lazily to avoid an extra read on unrelated app-config saves.
-	euaSSOChanged := mdm.EndUserAuthentication.SSOProviderSettings != oldMdm.EndUserAuthentication.SSOProviderSettings
-	idpBeingCleared := mdm.EndUserAuthentication.IsEmpty() && !oldMdm.EndUserAuthentication.IsEmpty()
-	anyTeamEUAEnabled := false
-	if (overwrite && euaSSOChanged) || idpBeingCleared {
+	// only validate SSO settings if they changed
+	if mdm.EndUserAuthentication.SSOProviderSettings != oldMdm.EndUserAuthentication.SSOProviderSettings {
+		if !lic.IsPremium() {
+			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
+			return nil
+		}
+		// In GitOps (overwrite=true), strict validation only fires when EUA is
+		// being enabled at the global/no-team level in this same request.
+		//
+		// We deliberately do NOT widen this to "any team has EUA enabled in
+		// stored state": ApplyAppConfig runs before ApplyTeams in a gitops run,
+		// so stored team state is stale here — a run that disables a team's EUA
+		// and degrades the IdP in one shot would false-reject. The cross-file
+		// invariant (a team that keeps EUA while the global IdP is degraded) is
+		// enforced client-side in validateGitOpsGroupEUA, which can see the
+		// whole plan. See issue #43371.
+		euaStrict := overwrite && mdm.MacOSSetup.EnableEndUserAuthentication
+		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, euaStrict)
+	}
+
+	// MacOSSetup validation
+	if mdm.EndUserAuthentication.IsEmpty() && !oldMdm.EndUserAuthentication.IsEmpty() {
+		// IdP is being cleared: block if global EUA will still be enabled after this update
+		// (mdm.MacOSSetup.EnableEndUserAuthentication reflects the incoming request's value),
+		// or if any team has EUA enabled. We only look at non-zero team IDs since global (id=0)
+		// is covered by the incoming request value.
 		teamIDs, err := svc.ds.TeamIDsWithSetupExperienceIdPEnabled(ctx)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "checking teams with EUA enabled")
 		}
+		anyTeamEUAEnabled := false
 		for _, id := range teamIDs {
 			if id != 0 {
 				anyTeamEUAEnabled = true
 				break
 			}
 		}
-	}
-
-	// only validate SSO settings if they changed
-	if euaSSOChanged {
-		if !lic.IsPremium() {
-			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
-			return nil
-		}
-		// In GitOps (overwrite=true), strict validation fires when EUA is
-		// enabled at any scope: the global/no-team flag in the incoming config
-		// OR any team that already has setup-experience EUA enabled in stored
-		// state. Keying off the global flag alone let a global-only gitops run
-		// degrade the IdP (e.g. clear metadata while entity_id/idp_name remain,
-		// so IsEmpty() is false) while a team still had EUA enabled. See #43371.
-		euaStrict := overwrite && (mdm.MacOSSetup.EnableEndUserAuthentication || anyTeamEUAEnabled)
-		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, euaStrict)
-	}
-
-	// MacOSSetup validation
-	if idpBeingCleared {
-		// IdP is being fully cleared: block if global EUA will still be enabled
-		// after this update (mdm.MacOSSetup.EnableEndUserAuthentication reflects
-		// the incoming request's value), or if any team has EUA enabled.
 		if anyTeamEUAEnabled || mdm.MacOSSetup.EnableEndUserAuthentication {
 			invalid.Append("end_user_authentication",
 				`End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again`)

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1789,36 +1789,51 @@ func (svc *Service) validateMDM(
 	}
 
 	// EndUserAuthentication
-	// only validate SSO settings if they changed
-	if mdm.EndUserAuthentication.SSOProviderSettings != oldMdm.EndUserAuthentication.SSOProviderSettings {
-		if !lic.IsPremium() {
-			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
-			return nil
-		}
-		// In GitOps (overwrite=true), strict validation should only fire when
-		// EUA is actually being enabled at the global level. Otherwise it's
-		// valid to clear these fields out.
-		euaStrict := overwrite && mdm.MacOSSetup.EnableEndUserAuthentication
-		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, euaStrict)
-	}
-
-	// MacOSSetup validation
-	if mdm.EndUserAuthentication.IsEmpty() && !oldMdm.EndUserAuthentication.IsEmpty() {
-		// IdP is being cleared: block if global EUA will still be enabled after this update
-		// (mdm.MacOSSetup.EnableEndUserAuthentication reflects the incoming request's value),
-		// or if any team has EUA enabled. We only look at non-zero team IDs since global (id=0)
-		// is covered by the incoming request value.
+	//
+	// Determine whether any team currently has setup-experience EUA enabled.
+	// This drives both the strict-validation decision and the IdP-cleared
+	// guard below. We only look at non-zero team IDs since the global/no-team
+	// scope (id=0) is covered by the incoming request's MacOSSetup flag. The
+	// query is only needed in overwrite (gitops) mode when the EUA SSO
+	// settings change, or when the IdP is being fully cleared, so it's
+	// computed lazily to avoid an extra read on unrelated app-config saves.
+	euaSSOChanged := mdm.EndUserAuthentication.SSOProviderSettings != oldMdm.EndUserAuthentication.SSOProviderSettings
+	idpBeingCleared := mdm.EndUserAuthentication.IsEmpty() && !oldMdm.EndUserAuthentication.IsEmpty()
+	anyTeamEUAEnabled := false
+	if (overwrite && euaSSOChanged) || idpBeingCleared {
 		teamIDs, err := svc.ds.TeamIDsWithSetupExperienceIdPEnabled(ctx)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "checking teams with EUA enabled")
 		}
-		anyTeamEUAEnabled := false
 		for _, id := range teamIDs {
 			if id != 0 {
 				anyTeamEUAEnabled = true
 				break
 			}
 		}
+	}
+
+	// only validate SSO settings if they changed
+	if euaSSOChanged {
+		if !lic.IsPremium() {
+			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
+			return nil
+		}
+		// In GitOps (overwrite=true), strict validation fires when EUA is
+		// enabled at any scope: the global/no-team flag in the incoming config
+		// OR any team that already has setup-experience EUA enabled in stored
+		// state. Keying off the global flag alone let a global-only gitops run
+		// degrade the IdP (e.g. clear metadata while entity_id/idp_name remain,
+		// so IsEmpty() is false) while a team still had EUA enabled. See #43371.
+		euaStrict := overwrite && (mdm.MacOSSetup.EnableEndUserAuthentication || anyTeamEUAEnabled)
+		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, euaStrict)
+	}
+
+	// MacOSSetup validation
+	if idpBeingCleared {
+		// IdP is being fully cleared: block if global EUA will still be enabled
+		// after this update (mdm.MacOSSetup.EnableEndUserAuthentication reflects
+		// the incoming request's value), or if any team has EUA enabled.
 		if anyTeamEUAEnabled || mdm.MacOSSetup.EnableEndUserAuthentication {
 			invalid.Append("end_user_authentication",
 				`End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again`)

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1796,15 +1796,13 @@ func (svc *Service) validateMDM(
 			return nil
 		}
 		// In GitOps (overwrite=true), strict validation only fires when EUA is
-		// being enabled at the global/no-team level in this same request.
+		// being enabled at the global/no-team level in this same request, because
+		// we can't tell if teams are changing their EUA settings in the same GitOps run.
+		// We rely on client-side validation in GitOps to catch cases of teams keeping EUA enabled
+		// while the global/no-team setting is disabled/cleared in the same run.
 		//
-		// We deliberately do NOT widen this to "any team has EUA enabled in
-		// stored state": ApplyAppConfig runs before ApplyTeams in a gitops run,
-		// so stored team state is stale here — a run that disables a team's EUA
-		// and degrades the IdP in one shot would false-reject. The cross-file
-		// invariant (a team that keeps EUA while the global IdP is degraded) is
-		// enforced client-side in validateGitOpsGroupEUA, which can see the
-		// whole plan. See issue #43371.
+		// TODO: look into blocking the case of a user-created API call that clears required EUA
+		// settings while a team still has EUA enabled.
 		euaStrict := overwrite && mdm.MacOSSetup.EnableEndUserAuthentication
 		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, euaStrict)
 	}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -582,7 +582,13 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	if newAppConfig.SSOSettings != nil {
-		validateSSOSettings(newAppConfig, appConfig, invalid, lic)
+		// In GitOps (Overwrite=true), the YAML is the full declared state, so
+		// disallow the "existing-state has it" fallback that REST PATCH relies
+		// on. This rejects `enable_sso: true` with empty metadata regardless of
+		// what's currently stored on the server — preventing the silent SSO
+		// wipe described in issue #43371.
+		allowExistingFallback := !applyOpts.Overwrite
+		validateSSOSettings(newAppConfig, appConfig, invalid, lic, allowExistingFallback)
 		if invalid.HasErrors() {
 			return nil, ctxerr.Wrap(ctx, invalid)
 		}
@@ -842,7 +848,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.Integrations.ConditionalAccessEnabled = newAppConfig.Integrations.ConditionalAccessEnabled
 	}
 
-	if err := svc.validateMDM(ctx, lic, &oldAppConfig.MDM, &appConfig.MDM, invalid); err != nil {
+	if err := svc.validateMDM(ctx, lic, &oldAppConfig.MDM, &appConfig.MDM, invalid, !applyOpts.Overwrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "validating MDM config")
 	}
 
@@ -1626,6 +1632,7 @@ func (svc *Service) validateMDM(
 	oldMdm *fleet.MDM,
 	mdm *fleet.MDM,
 	invalid *fleet.InvalidArgumentError,
+	allowExistingFallback bool,
 ) error {
 	if mdm.EnableDiskEncryption.Value && !lic.IsPremium() {
 		invalid.Append("apple_settings.enable_disk_encryption", ErrMissingLicense.Error())
@@ -1794,7 +1801,7 @@ func (svc *Service) validateMDM(
 			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
 			return nil
 		}
-		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid)
+		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid, allowExistingFallback)
 	}
 
 	// MacOSSetup validation
@@ -2105,19 +2112,29 @@ func (svc *Service) validateVPPAssignments(
 	return tokensToSave, nil
 }
 
-func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, invalid *fleet.InvalidArgumentError) {
+// validateSSOProviderSettings validates an incoming SSOProviderSettings payload.
+//
+// When allowExistingFallback is true (the default for REST PATCH partial-update
+// semantics), required fields are permitted to be empty in the incoming payload
+// if the corresponding existing server value is non-empty — the partial update
+// inherits them.
+//
+// When allowExistingFallback is false (the GitOps code path, where the YAML is
+// the full declared state), empty required fields always fail validation,
+// since GitOps is declarative and overwrites existing state.
+func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, invalid *fleet.InvalidArgumentError, allowExistingFallback bool) {
 	if incoming.Metadata == "" && incoming.MetadataURL == "" {
-		if existing.Metadata == "" && existing.MetadataURL == "" {
+		if !allowExistingFallback || (existing.Metadata == "" && existing.MetadataURL == "") {
 			invalid.Append("metadata", "either metadata or metadata_url must be defined")
 		}
 	}
 	if incoming.EntityID == "" {
-		if existing.EntityID == "" {
+		if !allowExistingFallback || existing.EntityID == "" {
 			invalid.Append("entity_id", "required")
 		}
 	}
 	if incoming.IDPName == "" {
-		if existing.IDPName == "" {
+		if !allowExistingFallback || existing.IDPName == "" {
 			invalid.Append("idp_name", "required")
 		}
 	}
@@ -2131,14 +2148,14 @@ func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, i
 	}
 }
 
-func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *fleet.InvalidArgumentError, lic *fleet.LicenseInfo) {
+func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *fleet.InvalidArgumentError, lic *fleet.LicenseInfo, allowExistingFallback bool) {
 	if p.SSOSettings != nil && p.SSOSettings.EnableSSO {
 
 		var existingSSOProviderSettings fleet.SSOProviderSettings
 		if existing.SSOSettings != nil {
 			existingSSOProviderSettings = existing.SSOSettings.SSOProviderSettings
 		}
-		validateSSOProviderSettings(p.SSOSettings.SSOProviderSettings, existingSSOProviderSettings, invalid)
+		validateSSOProviderSettings(p.SSOSettings.SSOProviderSettings, existingSSOProviderSettings, invalid, allowExistingFallback)
 
 		if !lic.IsPremium() {
 			if p.SSOSettings.EnableJITProvisioning {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -582,11 +582,6 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	if newAppConfig.SSOSettings != nil {
-		// In GitOps (Overwrite=true), the YAML is the full declared state, so
-		// disallow the "existing-state has it" fallback that REST PATCH relies
-		// on. This rejects `enable_sso: true` with empty metadata regardless of
-		// what's currently stored on the server — preventing the silent SSO
-		// wipe described in issue #43371.
 		validateSSOSettings(newAppConfig, appConfig, invalid, lic, applyOpts.Overwrite)
 		if invalid.HasErrors() {
 			return nil, ctxerr.Wrap(ctx, invalid)
@@ -2115,18 +2110,10 @@ func (svc *Service) validateVPPAssignments(
 	return tokensToSave, nil
 }
 
-// validateSSOProviderSettings validates an incoming SSOProviderSettings payload.
-//
-// When overwrite is false (REST PATCH partial-update semantics), required
-// fields are permitted to be empty in the incoming payload if the
-// corresponding existing server value is non-empty — the partial update
-// inherits them.
-//
-// When overwrite is true (the GitOps code path, where the YAML is the full
-// declared state), the existing-state fallback is skipped: empty required
-// fields fail validation regardless of existing server state. This closes
-// the `enable_sso: true` + empty metadata footgun that would otherwise
-// silently wipe the working SSO config on apply.
+// Validate incoming SSO provider settings.
+// If this is a GitOps run (overwrite=true), all required fields must be present.
+// Otherwise we're doing a patch, so it's ok for fields to be missing as long
+// as we have persisted values for them.
 func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, invalid *fleet.InvalidArgumentError, overwrite bool) {
 	if incoming.Metadata == "" && incoming.MetadataURL == "" {
 		if overwrite || (existing.Metadata == "" && existing.MetadataURL == "") {

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -397,7 +397,7 @@ func setupCertificateChain(t *testing.T) (server *httptest.Server, teardown func
 func TestSSONotPresent(t *testing.T) {
 	invalid := &fleet.InvalidArgumentError{}
 	var p fleet.AppConfig
-	validateSSOSettings(p, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
+	validateSSOSettings(p, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, false)
 	assert.False(t, invalid.HasErrors())
 }
 
@@ -413,7 +413,7 @@ func TestNeedFieldsPresent(t *testing.T) {
 			},
 		},
 	}
-	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
+	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, false)
 	assert.False(t, invalid.HasErrors())
 }
 
@@ -430,7 +430,7 @@ func TestShortIDPName(t *testing.T) {
 			},
 		},
 	}
-	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
+	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, false)
 	assert.False(t, invalid.HasErrors())
 }
 
@@ -445,19 +445,19 @@ func TestMissingMetadata(t *testing.T) {
 			},
 		},
 	}
-	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
+	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, false)
 	require.True(t, invalid.HasErrors())
 	assert.Contains(t, invalid.Error(), "metadata")
 	assert.Contains(t, invalid.Error(), "either metadata or metadata_url must be defined")
 }
 
-// TestSSOAllowExistingFallback verifies the partial-update vs declarative-
-// overwrite split introduced for issue #43371. REST PATCH (fallback=true)
-// permits empty incoming required fields when the existing server value is
-// set — that's how the UI can send {enable_sso_idp_login: true} without
-// repeating metadata. GitOps (fallback=false) rejects them, preventing the
-// silent SSO wipe described in the issue.
-func TestSSOAllowExistingFallback(t *testing.T) {
+// TestSSOOverwrite verifies the partial-update vs declarative-overwrite split
+// introduced for issue #43371. REST PATCH (overwrite=false) permits empty
+// incoming required fields when the existing server value is set — that's
+// how the UI can send {enable_sso_idp_login: true} without repeating
+// metadata. GitOps (overwrite=true) rejects them, preventing the silent
+// SSO wipe described in the issue.
+func TestSSOOverwrite(t *testing.T) {
 	existing := &fleet.AppConfig{
 		SSOSettings: &fleet.SSOSettings{
 			EnableSSO: true,
@@ -478,13 +478,13 @@ func TestSSOAllowExistingFallback(t *testing.T) {
 
 	t.Run("REST PATCH preserves partial-update behavior", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(incomingMissingMetadata, existing, invalid, &fleet.LicenseInfo{}, true /* allowExistingFallback */)
+		validateSSOSettings(incomingMissingMetadata, existing, invalid, &fleet.LicenseInfo{}, false /* overwrite */)
 		assert.False(t, invalid.HasErrors(), "PATCH with partial update should succeed; existing metadata fills the gap")
 	})
 
 	t.Run("GitOps overwrite rejects empty metadata", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(incomingMissingMetadata, existing, invalid, &fleet.LicenseInfo{}, false /* allowExistingFallback */)
+		validateSSOSettings(incomingMissingMetadata, existing, invalid, &fleet.LicenseInfo{}, true /* overwrite */)
 		require.True(t, invalid.HasErrors(), "GitOps overwrite must reject the broken declaration")
 		// InvalidArgumentError.Error() truncates after the first error; check the
 		// underlying field list via Invalid() so we can assert all three required
@@ -506,7 +506,7 @@ func TestSSOAllowExistingFallback(t *testing.T) {
 		// translates to "validator is a no-op when SSOSettings is nil"; assert
 		// that contract here.
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(fleet.AppConfig{SSOSettings: nil}, existing, invalid, &fleet.LicenseInfo{}, false)
+		validateSSOSettings(fleet.AppConfig{SSOSettings: nil}, existing, invalid, &fleet.LicenseInfo{}, true /* overwrite */)
 		assert.False(t, invalid.HasErrors())
 	})
 
@@ -522,15 +522,15 @@ func TestSSOAllowExistingFallback(t *testing.T) {
 				},
 			},
 		}
-		validateSSOSettings(fullConfig, existing, invalid, &fleet.LicenseInfo{}, false /* allowExistingFallback */)
+		validateSSOSettings(fullConfig, existing, invalid, &fleet.LicenseInfo{}, true /* overwrite */)
 		assert.False(t, invalid.HasErrors())
 	})
 }
 
-// TestSSOProviderSettingsAllowExistingFallbackMDM exercises the same split for
-// the MDM end-user authentication SSO code path, which goes through
+// TestSSOProviderSettingsOverwriteMDM exercises the same split for the MDM
+// end-user authentication SSO code path, which goes through
 // validateSSOProviderSettings directly (no validateSSOSettings wrapper).
-func TestSSOProviderSettingsAllowExistingFallbackMDM(t *testing.T) {
+func TestSSOProviderSettingsOverwriteMDM(t *testing.T) {
 	existing := fleet.SSOProviderSettings{
 		EntityID:    "fleet",
 		IDPName:     "onelogin",
@@ -543,13 +543,13 @@ func TestSSOProviderSettingsAllowExistingFallbackMDM(t *testing.T) {
 
 	t.Run("REST PATCH preserves partial-update behavior", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOProviderSettings(incomingMissingMetadata, existing, invalid, true /* allowExistingFallback */)
+		validateSSOProviderSettings(incomingMissingMetadata, existing, invalid, false /* overwrite */)
 		assert.False(t, invalid.HasErrors())
 	})
 
 	t.Run("GitOps overwrite rejects empty metadata", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOProviderSettings(incomingMissingMetadata, existing, invalid, false /* allowExistingFallback */)
+		validateSSOProviderSettings(incomingMissingMetadata, existing, invalid, true /* overwrite */)
 		require.True(t, invalid.HasErrors())
 		assert.Contains(t, invalid.Error(), "either metadata or metadata_url must be defined")
 	})
@@ -573,7 +573,7 @@ func TestSSOValidationValidatesSchemaInMetadataURL(t *testing.T) {
 			},
 		}
 
-		validateSSOSettings(sut, &fleet.AppConfig{}, actual, &fleet.LicenseInfo{}, true)
+		validateSSOSettings(sut, &fleet.AppConfig{}, actual, &fleet.LicenseInfo{}, false)
 
 		require.Equal(t, scheme == "http" || scheme == "https", !actual.HasErrors())
 		require.Equal(t, scheme == "http" || scheme == "https", !strings.Contains(actual.Error(), "metadata_url"))
@@ -596,7 +596,7 @@ func TestJITProvisioning(t *testing.T) {
 
 	t.Run("doesn't allow to enable JIT provisioning without a premium license", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
+		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, false)
 		require.True(t, invalid.HasErrors())
 		assert.Contains(t, invalid.Error(), "enable_jit_provisioning")
 		assert.Contains(t, invalid.Error(), "missing or invalid license")
@@ -604,7 +604,7 @@ func TestJITProvisioning(t *testing.T) {
 
 	t.Run("allows JIT provisioning to be enabled with a premium license", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{Tier: fleet.TierPremium}, true)
+		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{Tier: fleet.TierPremium}, false)
 		require.False(t, invalid.HasErrors())
 	})
 
@@ -616,7 +616,7 @@ func TestJITProvisioning(t *testing.T) {
 			},
 		}
 		config.SSOSettings.EnableJITProvisioning = false
-		validateSSOSettings(config, oldConfig, invalid, &fleet.LicenseInfo{}, true)
+		validateSSOSettings(config, oldConfig, invalid, &fleet.LicenseInfo{}, false)
 		require.False(t, invalid.HasErrors())
 	})
 }

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1670,9 +1670,11 @@ func TestModifyAppConfigWindowsEntraClientIDNormalization(t *testing.T) {
 }
 
 // TestValidateMDMEndUserAuthScope exercises the GitOps (overwrite) MDM
-// end-user-auth validation: strict IdP validation must fire when EUA is
-// enabled at ANY scope — including a team that has it enabled in stored state
-// while the run only touches the global config. See issue #43371.
+// end-user-auth IdP validation. Strict validation is keyed on the incoming
+// global/no-team EUA flag only — NOT on stored team state, because
+// ApplyAppConfig runs before ApplyTeams so stored team EUA is stale here. The
+// cross-file/stored-team invariant lives client-side in validateGitOpsGroupEUA.
+// See issue #43371.
 func TestValidateMDMEndUserAuthScope(t *testing.T) {
 	ds := new(mock.Store)
 	// validateMDM only touches svc.ds, so a minimal core *Service is enough
@@ -1692,19 +1694,33 @@ func TestValidateMDMEndUserAuthScope(t *testing.T) {
 		}
 	}
 
-	t.Run("overwrite degrades IdP while a stored team has EUA: rejected on metadata", func(t *testing.T) {
+	t.Run("overwrite enables global EUA with incomplete IdP: rejected", func(t *testing.T) {
+		// metadata_url present but missing entity_id and idp_name, with global
+		// EUA on (unchanged true->true, to avoid the setup-assistant web URL
+		// check that fires only when the flag changes) -> euaStrict fires.
+		incoming := fleet.SSOProviderSettings{MetadataURL: "https://idp.example.com/metadata"}
+		invalid := &fleet.InvalidArgumentError{}
+		err := svc.validateMDM(ctx, premium, mkMDM(completeIdP, true), mkMDM(incoming, true), invalid, true)
+		require.NoError(t, err)
+		require.True(t, invalid.HasErrors())
+		require.Contains(t, errFields(invalid), "entity_id")
+		require.Contains(t, errFields(invalid), "idp_name")
+	})
+
+	t.Run("overwrite degrades IdP, global EUA off, stored team EUA on: accepted (no false reject)", func(t *testing.T) {
+		// Regression guard for the apply-ordering false positive: ApplyAppConfig
+		// runs before ApplyTeams, so a run that degrades the IdP while disabling
+		// a team's EUA in the same plan must NOT be rejected server-side based on
+		// stale stored team state. validateMDM should not consult stored team EUA
+		// for the SSO-settings check at all.
 		ds.TeamIDsWithSetupExperienceIdPEnabledFunc = func(ctx context.Context) ([]uint, error) {
-			return []uint{1}, nil
+			return []uint{1}, nil // a stored team has EUA (stale)
 		}
-		// Incoming keeps entity_id/idp_name but blanks metadata + metadata_url,
-		// so SSOProviderSettings.IsEmpty() is false (the IsEmpty() guard alone
-		// would miss this). No-team EUA is off; only the stored team has it on.
-		degraded := fleet.SSOProviderSettings{EntityID: "fleet", IDPName: "Okta"}
+		degraded := fleet.SSOProviderSettings{EntityID: "fleet", IDPName: "Okta"} // metadata/url blank
 		invalid := &fleet.InvalidArgumentError{}
 		err := svc.validateMDM(ctx, premium, mkMDM(completeIdP, false), mkMDM(degraded, false), invalid, true)
 		require.NoError(t, err)
-		require.True(t, invalid.HasErrors())
-		require.Contains(t, errFields(invalid), "either metadata or metadata_url must be defined")
+		require.False(t, invalid.HasErrors())
 	})
 
 	t.Run("overwrite clears IdP with no scope enabled: accepted", func(t *testing.T) {
@@ -1715,20 +1731,6 @@ func TestValidateMDMEndUserAuthScope(t *testing.T) {
 		err := svc.validateMDM(ctx, premium, mkMDM(completeIdP, false), mkMDM(fleet.SSOProviderSettings{}, false), invalid, true)
 		require.NoError(t, err)
 		require.False(t, invalid.HasErrors())
-	})
-
-	t.Run("overwrite with EUA enabled requires entity_id and idp_name", func(t *testing.T) {
-		ds.TeamIDsWithSetupExperienceIdPEnabledFunc = func(ctx context.Context) ([]uint, error) {
-			return []uint{1}, nil
-		}
-		// metadata_url present but missing entity_id and idp_name.
-		incoming := fleet.SSOProviderSettings{MetadataURL: "https://idp.example.com/metadata"}
-		invalid := &fleet.InvalidArgumentError{}
-		err := svc.validateMDM(ctx, premium, mkMDM(completeIdP, false), mkMDM(incoming, false), invalid, true)
-		require.NoError(t, err)
-		require.True(t, invalid.HasErrors())
-		require.Contains(t, errFields(invalid), "entity_id")
-		require.Contains(t, errFields(invalid), "idp_name")
 	})
 }
 

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -397,7 +397,7 @@ func setupCertificateChain(t *testing.T) (server *httptest.Server, teardown func
 func TestSSONotPresent(t *testing.T) {
 	invalid := &fleet.InvalidArgumentError{}
 	var p fleet.AppConfig
-	validateSSOSettings(p, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{})
+	validateSSOSettings(p, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
 	assert.False(t, invalid.HasErrors())
 }
 
@@ -413,7 +413,7 @@ func TestNeedFieldsPresent(t *testing.T) {
 			},
 		},
 	}
-	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{})
+	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
 	assert.False(t, invalid.HasErrors())
 }
 
@@ -430,7 +430,7 @@ func TestShortIDPName(t *testing.T) {
 			},
 		},
 	}
-	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{})
+	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
 	assert.False(t, invalid.HasErrors())
 }
 
@@ -445,10 +445,114 @@ func TestMissingMetadata(t *testing.T) {
 			},
 		},
 	}
-	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{})
+	validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
 	require.True(t, invalid.HasErrors())
 	assert.Contains(t, invalid.Error(), "metadata")
 	assert.Contains(t, invalid.Error(), "either metadata or metadata_url must be defined")
+}
+
+// TestSSOAllowExistingFallback verifies the partial-update vs declarative-
+// overwrite split introduced for issue #43371. REST PATCH (fallback=true)
+// permits empty incoming required fields when the existing server value is
+// set — that's how the UI can send {enable_sso_idp_login: true} without
+// repeating metadata. GitOps (fallback=false) rejects them, preventing the
+// silent SSO wipe described in the issue.
+func TestSSOAllowExistingFallback(t *testing.T) {
+	existing := &fleet.AppConfig{
+		SSOSettings: &fleet.SSOSettings{
+			EnableSSO: true,
+			SSOProviderSettings: fleet.SSOProviderSettings{
+				EntityID:    "fleet",
+				IDPName:     "onelogin",
+				MetadataURL: "https://idp.example.com/metadata",
+			},
+		},
+	}
+	incomingMissingMetadata := fleet.AppConfig{
+		SSOSettings: &fleet.SSOSettings{
+			EnableSSO: true,
+			// No metadata, no metadata_url — and no entity_id / idp_name either,
+			// matching the partial-update shape a UI PATCH might send.
+		},
+	}
+
+	t.Run("REST PATCH preserves partial-update behavior", func(t *testing.T) {
+		invalid := &fleet.InvalidArgumentError{}
+		validateSSOSettings(incomingMissingMetadata, existing, invalid, &fleet.LicenseInfo{}, true /* allowExistingFallback */)
+		assert.False(t, invalid.HasErrors(), "PATCH with partial update should succeed; existing metadata fills the gap")
+	})
+
+	t.Run("GitOps overwrite rejects empty metadata", func(t *testing.T) {
+		invalid := &fleet.InvalidArgumentError{}
+		validateSSOSettings(incomingMissingMetadata, existing, invalid, &fleet.LicenseInfo{}, false /* allowExistingFallback */)
+		require.True(t, invalid.HasErrors(), "GitOps overwrite must reject the broken declaration")
+		// InvalidArgumentError.Error() truncates after the first error; check the
+		// underlying field list via Invalid() so we can assert all three required
+		// fields fail when the existing-state fallback is disabled.
+		fields := make(map[string]string)
+		for _, m := range invalid.Invalid() {
+			fields[m["name"]] = m["reason"]
+		}
+		require.Contains(t, fields, "metadata")
+		assert.Equal(t, "either metadata or metadata_url must be defined", fields["metadata"])
+		assert.Contains(t, fields, "entity_id")
+		assert.Contains(t, fields, "idp_name")
+	})
+
+	t.Run("GitOps overwrite accepts sso_settings absent (validator no-op)", func(t *testing.T) {
+		// When the GitOps YAML omits sso_settings entirely, ModifyAppConfig
+		// short-circuits before reaching validateSSOSettings (see appconfig.go
+		// `if newAppConfig.SSOSettings != nil`). At the validator level this
+		// translates to "validator is a no-op when SSOSettings is nil"; assert
+		// that contract here.
+		invalid := &fleet.InvalidArgumentError{}
+		validateSSOSettings(fleet.AppConfig{SSOSettings: nil}, existing, invalid, &fleet.LicenseInfo{}, false)
+		assert.False(t, invalid.HasErrors())
+	})
+
+	t.Run("GitOps overwrite accepts valid full declaration", func(t *testing.T) {
+		invalid := &fleet.InvalidArgumentError{}
+		fullConfig := fleet.AppConfig{
+			SSOSettings: &fleet.SSOSettings{
+				EnableSSO: true,
+				SSOProviderSettings: fleet.SSOProviderSettings{
+					EntityID:    "fleet",
+					IDPName:     "onelogin",
+					MetadataURL: "https://idp.example.com/metadata",
+				},
+			},
+		}
+		validateSSOSettings(fullConfig, existing, invalid, &fleet.LicenseInfo{}, false /* allowExistingFallback */)
+		assert.False(t, invalid.HasErrors())
+	})
+}
+
+// TestSSOProviderSettingsAllowExistingFallbackMDM exercises the same split for
+// the MDM end-user authentication SSO code path, which goes through
+// validateSSOProviderSettings directly (no validateSSOSettings wrapper).
+func TestSSOProviderSettingsAllowExistingFallbackMDM(t *testing.T) {
+	existing := fleet.SSOProviderSettings{
+		EntityID:    "fleet",
+		IDPName:     "onelogin",
+		MetadataURL: "https://idp.example.com/metadata",
+	}
+	incomingMissingMetadata := fleet.SSOProviderSettings{
+		// All fields empty — simulating a GitOps overwrite that clears MDM EUA
+		// metadata while leaving the flag on.
+	}
+
+	t.Run("REST PATCH preserves partial-update behavior", func(t *testing.T) {
+		invalid := &fleet.InvalidArgumentError{}
+		validateSSOProviderSettings(incomingMissingMetadata, existing, invalid, true /* allowExistingFallback */)
+		assert.False(t, invalid.HasErrors())
+	})
+
+	t.Run("GitOps overwrite rejects empty metadata", func(t *testing.T) {
+		invalid := &fleet.InvalidArgumentError{}
+		validateSSOProviderSettings(incomingMissingMetadata, existing, invalid, false /* allowExistingFallback */)
+		require.True(t, invalid.HasErrors())
+		assert.Contains(t, invalid.Error(), "either metadata or metadata_url must be defined")
+	})
 }
 
 func TestSSOValidationValidatesSchemaInMetadataURL(t *testing.T) {
@@ -469,7 +573,7 @@ func TestSSOValidationValidatesSchemaInMetadataURL(t *testing.T) {
 			},
 		}
 
-		validateSSOSettings(sut, &fleet.AppConfig{}, actual, &fleet.LicenseInfo{})
+		validateSSOSettings(sut, &fleet.AppConfig{}, actual, &fleet.LicenseInfo{}, true)
 
 		require.Equal(t, scheme == "http" || scheme == "https", !actual.HasErrors())
 		require.Equal(t, scheme == "http" || scheme == "https", !strings.Contains(actual.Error(), "metadata_url"))
@@ -492,7 +596,7 @@ func TestJITProvisioning(t *testing.T) {
 
 	t.Run("doesn't allow to enable JIT provisioning without a premium license", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{})
+		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{}, true)
 		require.True(t, invalid.HasErrors())
 		assert.Contains(t, invalid.Error(), "enable_jit_provisioning")
 		assert.Contains(t, invalid.Error(), "missing or invalid license")
@@ -500,7 +604,7 @@ func TestJITProvisioning(t *testing.T) {
 
 	t.Run("allows JIT provisioning to be enabled with a premium license", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
-		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{Tier: fleet.TierPremium}, true)
 		require.False(t, invalid.HasErrors())
 	})
 
@@ -512,7 +616,7 @@ func TestJITProvisioning(t *testing.T) {
 			},
 		}
 		config.SSOSettings.EnableJITProvisioning = false
-		validateSSOSettings(config, oldConfig, invalid, &fleet.LicenseInfo{})
+		validateSSOSettings(config, oldConfig, invalid, &fleet.LicenseInfo{}, true)
 		require.False(t, invalid.HasErrors())
 	})
 }

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1669,6 +1669,69 @@ func TestModifyAppConfigWindowsEntraClientIDNormalization(t *testing.T) {
 	require.Equal(t, want, modified.MDM.WindowsEntraClientIDs.Value)
 }
 
+// TestValidateMDMEndUserAuthScope exercises the GitOps (overwrite) MDM
+// end-user-auth validation: strict IdP validation must fire when EUA is
+// enabled at ANY scope — including a team that has it enabled in stored state
+// while the run only touches the global config. See issue #43371.
+func TestValidateMDMEndUserAuthScope(t *testing.T) {
+	ds := new(mock.Store)
+	// validateMDM only touches svc.ds, so a minimal core *Service is enough
+	// (newTestService returns the EE-wrapped service, whose unexported core
+	// isn't reachable for calling the unexported validateMDM).
+	svc := &Service{ds: ds}
+	ctx := t.Context()
+	premium := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+
+	completeIdP := fleet.SSOProviderSettings{EntityID: "fleet", IDPName: "Okta", MetadataURL: "https://idp.example.com/metadata"}
+	// errFields renders all (name: reason) pairs since Error() only summarizes.
+	errFields := func(e *fleet.InvalidArgumentError) string { return fmt.Sprintf("%+v", e.Errors) }
+	mkMDM := func(sso fleet.SSOProviderSettings, noTeamEUA bool) *fleet.MDM {
+		return &fleet.MDM{
+			EndUserAuthentication: fleet.MDMEndUserAuthentication{SSOProviderSettings: sso},
+			MacOSSetup:            fleet.MacOSSetup{EnableEndUserAuthentication: noTeamEUA},
+		}
+	}
+
+	t.Run("overwrite degrades IdP while a stored team has EUA: rejected on metadata", func(t *testing.T) {
+		ds.TeamIDsWithSetupExperienceIdPEnabledFunc = func(ctx context.Context) ([]uint, error) {
+			return []uint{1}, nil
+		}
+		// Incoming keeps entity_id/idp_name but blanks metadata + metadata_url,
+		// so SSOProviderSettings.IsEmpty() is false (the IsEmpty() guard alone
+		// would miss this). No-team EUA is off; only the stored team has it on.
+		degraded := fleet.SSOProviderSettings{EntityID: "fleet", IDPName: "Okta"}
+		invalid := &fleet.InvalidArgumentError{}
+		err := svc.validateMDM(ctx, premium, mkMDM(completeIdP, false), mkMDM(degraded, false), invalid, true)
+		require.NoError(t, err)
+		require.True(t, invalid.HasErrors())
+		require.Contains(t, errFields(invalid), "either metadata or metadata_url must be defined")
+	})
+
+	t.Run("overwrite clears IdP with no scope enabled: accepted", func(t *testing.T) {
+		ds.TeamIDsWithSetupExperienceIdPEnabledFunc = func(ctx context.Context) ([]uint, error) {
+			return []uint{}, nil
+		}
+		invalid := &fleet.InvalidArgumentError{}
+		err := svc.validateMDM(ctx, premium, mkMDM(completeIdP, false), mkMDM(fleet.SSOProviderSettings{}, false), invalid, true)
+		require.NoError(t, err)
+		require.False(t, invalid.HasErrors())
+	})
+
+	t.Run("overwrite with EUA enabled requires entity_id and idp_name", func(t *testing.T) {
+		ds.TeamIDsWithSetupExperienceIdPEnabledFunc = func(ctx context.Context) ([]uint, error) {
+			return []uint{1}, nil
+		}
+		// metadata_url present but missing entity_id and idp_name.
+		incoming := fleet.SSOProviderSettings{MetadataURL: "https://idp.example.com/metadata"}
+		invalid := &fleet.InvalidArgumentError{}
+		err := svc.validateMDM(ctx, premium, mkMDM(completeIdP, false), mkMDM(incoming, false), invalid, true)
+		require.NoError(t, err)
+		require.True(t, invalid.HasErrors())
+		require.Contains(t, errFields(invalid), "entity_id")
+		require.Contains(t, errFields(invalid), "idp_name")
+	})
+}
+
 func TestDiskEncryptionSetting(t *testing.T) {
 	ds := new(mock.Store)
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43371 

# Details

* Ensures that if `enable_sso: true` is set in a global config, then all required sso keys (`entity_id`, `idp_name` and one of `metadata`/`metadata_url`) are provided
* Ensures that if `end_user_authentication: true` is set on a fleet, then all required sso keys (`entity_id`, `idp_name` and one of `metadata`/`metadata_url`) are provided, _even if the fleet's config file is not provided in the gitops run_.
* Ensures that if `end_user_authentication: true` is set in a fleet config in a gitops run, then all required sso keys (`entity_id`, `idp_name` and one of `metadata`/`metadata_url`) are provided, _even if the global config file is not provided in the gitops run_.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  ### Org SSO — gitops client validation (`fleetctl gitops`)
  - [x] `enable_sso: true` with **empty `metadata` and `metadata_url`** → fails (metadata-or-url)
  - [x] `enable_sso: true` with **empty `idp_name`** → fails (idp_name)
  - [x] `enable_sso: true` with **empty `entity_id`** → fails (entity_id)
  - [x] Multiple fields missing at once → **one error line per missing field**
  - [x] `enable_sso: true` + complete IdP (`metadata_url`) → succeeds
  - [x] `enable_sso: true` + complete IdP using inline `metadata` (no url) → succeeds
  - [x] `enable_sso: false` + empty IdP fields → succeeds
  - [x] `sso_settings` key **omitted entirely** → succeeds, and apply **clears** stored SSO
  - [x] The literal `generate-gitops` output (`metadata: # TODO: ...`) applied as-is → **rejected**

  ### MDM EUA — gitops group cross-file validation
  - [x] Team file enables EUA **+** global file **omits** the EUA IdP block → fails
  - [x] **#43371 core repro:** stored team EUA on, file NOT in run, global-only run blanks metadata → fails, names the team
  - [x] Same but the team's file **is** in the run with EUA `false` → succeeds
  - [x] EUA disabled everywhere + **empty** stored IdP → succeeds

  ### `--delete-other-fleets`
  - [x] Run with `--delete-other-fleets` degrading the IdP while a stored not-in-run team has EUA on → succeeds
  - [x] Confirm the omitted team is actually deleted on apply
  - [x] Known corner: `--delete-other-fleets` + omitted ABM/VPP team with EUA on + degraded IdP → fails at apply time

  ### Server-side backstop (REST API)
  - [x] `PATCH /config` (overwrite=false), `enable_sso:true`, metadata omitted, existing has metadata → **200**, metadata preserved
  - [x] `PATCH /config?overwrite=true`, `enable_sso:true` + empty metadata/url → **422** field `metadata`
  - [x] `?overwrite=true`, metadata_url set, empty `entity_id`/`idp_name` → **422** both `required`
  - [x] `?overwrite=true`, `enable_sso:false` → **200** (no IdP required when disabled); `sso_settings` omitted entirely → clears (covered by gitops POS-2)

  ### Server-side EUA (`euaStrict` keyed on incoming global flag only)
  - [x] `?overwrite=true` + incoming **global** EUA enabled + incomplete IdP → **422** `entity_id`/`idp_name`
  - [x] `?overwrite=true` + global EUA **off** + stored team EUA + payload degrades IdP → **succeeds** (via gitops #43371-OVERRIDE)
  - [x] `?overwrite=true` + global EUA off + payload **fully clears** IdP while a team has EUA → **422** `end_user_authentication` (IsEmpty guard)

  ### Regression / false-positive guards
  - [x] Multi-file gitops `--dry-run` configuring IdP AND enabling team EUA (empty stored IdP) → dry-run passes (EE dry-run skip)
  - [x] A previously-working gitops run with a complete SSO/EUA config → still applies cleanly

  ### End state verification
  - [x] After any **rejected** run, stored SSO/EUA config **unchanged**
  - [ ] After a valid complete-IdP run, SSO login + ADE/EUA enrollment works end-to-end (live device)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitOps now validates SSO and MDM end-user authentication (EUA) configs before applying changes, rejecting incomplete settings when SSO/EUA are enabled globally or for any team. Overwrite (GitOps) mode enforces stricter validation than standard updates; dry-run behavior adjusted to avoid spurious EUA rejections.

* **Tests**
  * Added comprehensive tests covering SSO/EUA validation, overwrite vs patch semantics, cross-file EUA scenarios, and delete-other-fleets behavior.

* **Refactor**
  * Reorganized validation and config-parsing helpers for reuse in GitOps checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->