### PR TITLE
Simple fix in the rewriter to exclude renaming on software items

### DIFF
--- a/changes/44970-fix-apply
+++ b/changes/44970-fix-apply
@@ -1,0 +1,1 @@
+* Fixed bug in `apply` to prevent `setup_experience` in software items from being renamed to `macos_setup`.

--- a/server/platform/endpointer/json_key_rewriter.go
+++ b/server/platform/endpointer/json_key_rewriter.go
@@ -159,6 +159,14 @@ func RewriteOldToNewKeys(data []byte, rules []AliasRule) ([]byte, error) {
 	return result, err
 }
 
+// softwareScopeKey marks the JSON object/array container whose contents are
+// the values of TeamSpec.Software — i.e. SoftwarePackageSpec /
+// TeamSpecAppStoreApp / MaintainedAppSpec items. The literal `setup_experience`
+// install flag on those items collides with the `macos_setup`↔`setup_experience`
+// rename on the MDM section, so renames are skipped under this subtree. See
+// https://github.com/fleetdm/fleet/issues/44970.
+const softwareScopeKey = "software"
+
 // rewrite reads tokens from src, rewrites deprecated keys, checks for alias
 // conflicts, and writes the transformed JSON to w.
 func (r *JSONKeyRewriteReader) rewrite(src io.Reader, w io.Writer) error {
@@ -168,6 +176,24 @@ func (r *JSONKeyRewriteReader) rewrite(src io.Reader, w io.Writer) error {
 	// Stack of per-object-scope key sets for conflict detection.
 	// Pushed on '{', popped on '}'.
 	var keyScopes []map[string]bool
+
+	// Track whether we are currently inside the `software` subtree.
+	// pendingKey is the most-recent object key whose value has not yet been
+	// read; openContainer/closeContainer maintain softwareDepth by checking
+	// whether the container being opened lives under `software`.
+	pendingKey := ""
+	softwareDepth := 0
+	openContainer := func() {
+		if softwareDepth > 0 || pendingKey == softwareScopeKey {
+			softwareDepth++
+		}
+		pendingKey = ""
+	}
+	closeContainer := func() {
+		if softwareDepth > 0 {
+			softwareDepth--
+		}
+	}
 
 	for {
 		tok, err := dec.ReadToken()
@@ -183,6 +209,7 @@ func (r *JSONKeyRewriteReader) rewrite(src io.Reader, w io.Writer) error {
 		switch kind {
 		case '{':
 			keyScopes = append(keyScopes, make(map[string]bool))
+			openContainer()
 			if err := enc.WriteToken(tok); err != nil {
 				return err
 			}
@@ -191,6 +218,19 @@ func (r *JSONKeyRewriteReader) rewrite(src io.Reader, w io.Writer) error {
 			if len(keyScopes) > 0 {
 				keyScopes = keyScopes[:len(keyScopes)-1]
 			}
+			closeContainer()
+			if err := enc.WriteToken(tok); err != nil {
+				return err
+			}
+
+		case '[':
+			openContainer()
+			if err := enc.WriteToken(tok); err != nil {
+				return err
+			}
+
+		case ']':
+			closeContainer()
 			if err := enc.WriteToken(tok); err != nil {
 				return err
 			}
@@ -213,6 +253,18 @@ func (r *JSONKeyRewriteReader) rewrite(src io.Reader, w io.Writer) error {
 			if isKey {
 				keyName := tok.String()
 
+				// Inside the `software` subtree, all inner keys are literal —
+				// most notably each item's `setup_experience` is a bool
+				// install flag, not the renamed `macos_setup` container. Pass
+				// them through untouched.
+				if softwareDepth > 0 {
+					pendingKey = keyName
+					if err := enc.WriteToken(tok); err != nil {
+						return err
+					}
+					continue
+				}
+
 				// Use OldKey as the canonical key for scope tracking.
 				// Both OldKey (pass-through) and NewKey (rewrite) resolve
 				// to the same canonical key for conflict detection.
@@ -233,6 +285,7 @@ func (r *JSONKeyRewriteReader) rewrite(src io.Reader, w io.Writer) error {
 						scope[canonicalKey] = true
 					}
 
+					pendingKey = keyName
 					// Write the key as-is (old name, which the struct expects).
 					if err := enc.WriteToken(tok); err != nil {
 						return err
@@ -251,25 +304,29 @@ func (r *JSONKeyRewriteReader) rewrite(src io.Reader, w io.Writer) error {
 						scope[canonicalKey] = true
 					}
 
+					pendingKey = canonicalKey
 					// Write the rewritten (old) key.
 					if err := enc.WriteToken(jsontext.String(canonicalKey)); err != nil {
 						return err
 					}
 				} else {
 					// Not an aliased key — pass through unchanged.
+					pendingKey = keyName
 					if err := enc.WriteToken(tok); err != nil {
 						return err
 					}
 				}
 			} else {
 				// String value — pass through unchanged.
+				pendingKey = ""
 				if err := enc.WriteToken(tok); err != nil {
 					return err
 				}
 			}
 
 		default:
-			// All other tokens: [, ], numbers, bools, null — pass through.
+			// All other tokens: numbers, bools, null — scalar values.
+			pendingKey = ""
 			if err := enc.WriteToken(tok); err != nil {
 				return err
 			}

--- a/server/platform/endpointer/json_key_rewriter_test.go
+++ b/server/platform/endpointer/json_key_rewriter_test.go
@@ -205,6 +205,99 @@ func TestJSONKeyRewriteReader_ArrayOfObjects(t *testing.T) {
 	}
 }
 
+// TestJSONKeyRewriteReader_SoftwareSubtreeSkipsRules verifies that keys inside
+// the `software` subtree are not subject to rename rules. The literal
+// `setup_experience` install flag on SoftwarePackageSpec / TeamSpecAppStoreApp
+// / MaintainedAppSpec items collides with the `macos_setup`↔`setup_experience`
+// rename on the MDM section, and must be passed through untouched.
+// Regression test for https://github.com/fleetdm/fleet/issues/44970.
+func TestJSONKeyRewriteReader_SoftwareSubtreeSkipsRules(t *testing.T) {
+	input := `{
+		"setup_experience": {"enable_end_user_authentication": true},
+		"software": {
+			"packages": [
+				{"url": "http://foo", "setup_experience": true},
+				{"url": "http://bar", "setup_experience": false}
+			],
+			"app_store_apps": [
+				{"app_store_id": "1", "setup_experience": null}
+			],
+			"fleet_maintained_apps": [
+				{"slug": "foo", "setup_experience": true}
+			]
+		}
+	}`
+	rules := []AliasRule{{OldKey: "macos_setup", NewKey: "setup_experience"}}
+
+	r := NewJSONKeyRewriteReader(strings.NewReader(input), rules)
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// Top-level `setup_experience` (the object) is rewritten to `macos_setup`.
+	assert.NotNil(t, result["macos_setup"], "top-level container key must be rewritten")
+	_, hasNewAtRoot := result["setup_experience"]
+	assert.False(t, hasNewAtRoot, "new key should have been rewritten at the root")
+
+	// Literal `setup_experience` flags inside software entries must NOT have
+	// been rewritten to `macos_setup`.
+	sw := result["software"].(map[string]any)
+	pkgs := sw["packages"].([]any)
+	assert.Equal(t, true, pkgs[0].(map[string]any)["setup_experience"])
+	assert.Equal(t, false, pkgs[1].(map[string]any)["setup_experience"])
+	_, hasMacOSSetupOnPkg := pkgs[0].(map[string]any)["macos_setup"]
+	assert.False(t, hasMacOSSetupOnPkg, "literal setup_experience inside software must not be rewritten")
+
+	apps := sw["app_store_apps"].([]any)
+	assert.Nil(t, apps[0].(map[string]any)["setup_experience"])
+	_, hasMacOSSetupOnApp := apps[0].(map[string]any)["macos_setup"]
+	assert.False(t, hasMacOSSetupOnApp, "null setup_experience inside software must not be rewritten")
+
+	fmas := sw["fleet_maintained_apps"].([]any)
+	assert.Equal(t, true, fmas[0].(map[string]any)["setup_experience"])
+	_, hasMacOSSetupOnFMA := fmas[0].(map[string]any)["macos_setup"]
+	assert.False(t, hasMacOSSetupOnFMA, "literal setup_experience on FMA must not be rewritten")
+}
+
+// TestRewriteOldToNewKeys_SoftwareSubtreeSkipsRules verifies the same software-
+// scope skip in the reverse direction (old→new). A client posting a YAML with
+// `setup_experience: true` on software items must not have those flags clobbered
+// to `macos_setup` during client-side normalization.
+func TestRewriteOldToNewKeys_SoftwareSubtreeSkipsRules(t *testing.T) {
+	input := `{
+		"macos_setup": {"enable_end_user_authentication": true},
+		"software": {
+			"packages": [{"url": "http://foo", "setup_experience": true}],
+			"app_store_apps": [{"app_store_id": "1", "setup_experience": true}],
+			"fleet_maintained_apps": [{"slug": "foo", "setup_experience": true}]
+		}
+	}`
+	rules := []AliasRule{{OldKey: "macos_setup", NewKey: "setup_experience"}}
+
+	out, err := RewriteOldToNewKeys([]byte(input), rules)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// Top-level old `macos_setup` is rewritten to new `setup_experience`.
+	assert.NotNil(t, result["setup_experience"], "top-level old key must be rewritten to new")
+	_, hasOldAtRoot := result["macos_setup"]
+	assert.False(t, hasOldAtRoot, "old key should have been rewritten at the root")
+
+	// Literal `setup_experience` flags inside software entries must remain.
+	sw := result["software"].(map[string]any)
+	for _, key := range []string{"packages", "app_store_apps", "fleet_maintained_apps"} {
+		items := sw[key].([]any)
+		first := items[0].(map[string]any)
+		assert.Equal(t, true, first["setup_experience"], "literal flag on %s must be preserved", key)
+		_, hasOld := first["macos_setup"]
+		assert.False(t, hasOld, "literal setup_experience on %s must not be renamed to macos_setup", key)
+	}
+}
+
 func TestJSONKeyRewriteReader_MultipleRules(t *testing.T) {
 	input := `{"team_id": 1, "team_name": "Engineering"}`
 	rules := []AliasRule{


### PR DESCRIPTION
Resolves #44970 (2/2).

The issue is that in `fleetctl apply` the `setup_experience` field in software items was being converted to `macos_setup` (which we don't want because that rename should only happen in MDM).

I tried to make the change as simple as possible and isolated to `software` (I checked and it seems there are no renames under `software` spec). Supporting some context aware renaming (or prevention of renaming) requires a bigger refactor on the rewriter functionality.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually