### PR TITLE
Website: Workspace ONE no longer supports on-prem (EOL 2027)

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -519,7 +519,7 @@
                 <p>On-prem only</p>
               </div>
               <div purpose="feature-status" v-else-if="comparisonModeForIt === 'omnissa'">
-                <p>On-prem discouraged</p>
+                <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
               </div>
               <div purpose="feature-status" v-else>
                 <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -322,7 +322,7 @@
                 <p>On-prem only</p>
               </div>
               <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'omnissa'">
-                <p>On-prem discouraged</p>
+                <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
               </div>
               <div purpose="comparison-column" v-else>
                 <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">


### PR DESCRIPTION
 - Update homepage.ejs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the "Cloud or self-host" comparison on the homepage: the Omnissa (WS1) option now shows a red "x" icon instead of the phrase "On‑prem discouraged" in both desktop and mobile tables for clearer, more consistent visuals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->