### PR TITLE
Cherry-pick #46015: Adding changes for Fleet v4.85.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Fleet 4.85.1 (May 22, 2026)
+
+### Bug fixes
+
+- Fixed `fleetctl gitops` rejecting Android or Windows configuration profiles when editing an existing team, even when the corresponding MDM platform was configured.
+- Implemented roaring bitmaps in historical data collection for improved performance.
+- Fixed dynamic SCEP certificate issuance failing with an "Invalid NDES admin credentials" error when the NDES Admin URL is fronted by Okta or another gateway that uses HTTP Basic auth instead of NTLM.
+- Removed unneeded call to get tracked CVEs when reading CVE chart data.
+
 ## Fleet 4.85.0 (May 13, 2026)
 
 ### IT Admins

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v7.0.2
+version: v7.0.3
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.85.0
+appVersion: v4.85.1
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.85.0"
+  default     = "fleetdm/fleet:v4.85.1"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/.terraform.lock.hcl
+++ b/infrastructure/dogfood/terraform/gcp/.terraform.lock.hcl
@@ -22,7 +22,7 @@ provider "registry.terraform.io/hashicorp/google" {
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "4.85.0"
+  version     = "4.85.1"
   constraints = ">= 3.45.0, >= 3.53.0, >= 3.62.0, < 5.0.0, < 6.0.0"
   hashes = [
     "h1:YkCDGkP0AUZoNobLoxRnM52Pi4alYE9EFXalEu8p8E8=",

--- a/infrastructure/dogfood/terraform/gcp/.terraform.lock.hcl
+++ b/infrastructure/dogfood/terraform/gcp/.terraform.lock.hcl
@@ -22,7 +22,7 @@ provider "registry.terraform.io/hashicorp/google" {
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "4.85.1"
+  version     = "4.85.0"
   constraints = ">= 3.45.0, >= 3.53.0, >= 3.62.0, < 5.0.0, < 6.0.0"
   hashes = [
     "h1:YkCDGkP0AUZoNobLoxRnM52Pi4alYE9EFXalEu8p8E8=",

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.85.0"
+  default = "fleetdm/fleet:v4.85.1"
 }
 
 variable "software_installers_bucket_name" {

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.85.0",
+  "version": "v4.85.1",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/github-manage/cmd/gm/releases.go
+++ b/tools/github-manage/cmd/gm/releases.go
@@ -207,7 +207,7 @@ Size mapping (low-high):
   XL:  75-100
 
 Usage:
-  gm releases forecast --milestone "Fleet 4.85.0"`,
+  gm releases forecast --milestone "Fleet 4.85.1"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		releasesProjectID := 87 // fleet Releases project
 		milestoneTitle, _ := cmd.Flags().GetString("milestone")
@@ -319,5 +319,5 @@ func init() {
 	releasesSyncEstimatesCmd.Flags().BoolP("overwrite", "o", false, "Overwrite existing Releases estimates (by default, issues with estimates are skipped)")
 	releasesSyncEstimatesCmd.Flags().StringP("milestone", "m", "", "Only process issues in this milestone, e.g., Fleet 4.77.0")
 
-	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.85.0 (required)")
+	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.85.1 (required)")
 }


### PR DESCRIPTION
Cherry-pick of #46015 into the v4.86.0 RC branch.

Brings the v4.85.1 CHANGELOG entry and version metadata bumps into the v4.86.0 RC, since v4.85.1 was published (2026-05-22) after the RC branched from main (2026-05-18). The v4.85.1 code fixes themselves were already cherry-picked individually.

### Conflict resolution
- `charts/fleet/values.yaml`: kept the RC's version (still `imageTag: v4.85.0` without the new imagePullPolicy comments). The v4.86.0 release PR (#45742) will replace this with `v4.86.0` anyway.