### PR TITLE
Cherry-pick #45742: Adding changes for Fleet v4.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,150 @@
+## Fleet 4.86.0 (May 29, 2026)
+
+### IT Admins
+
+- Added ability to upload a custom org logo (light and dark variants) hosted directly by the Fleet instance; configurable via the UI, API, `fleetctl`, and GitOps.
+- Added "Cancel setup if software fails" toggle for Windows setup experience; when enabled, Autopilot and OOBE enrollments display a failure screen and prompt a restart if any setup experience software fails to install.
+- Added "Rotate password" button to the managed local admin account modal on the Host details page; password auto-rotates roughly one hour after being viewed, with activity logged for both manual and automatic rotations.
+- Added support for configuring Platform SSO during macOS Setup Assistant (ADE) so end users can log in with their IdP credentials.
+- Added ability to install VPP and in-house (`.ipa`) apps on Account-based User Enrolled iOS and iPadOS hosts, including self-service; setup experience software installs automatically on user enrollment.
+- Added support for VPP apps from non-US Apple App Stores; the VPP settings page now shows the country for each token, and apps are fetched from the storefront matching the token's country.
+- Added managed app configuration (XML) for iOS and iPadOS VPP and `.ipa` apps; configurable via the UI, API, and GitOps.
+- Added Fleet Desktop app for end users' macOS Dock, with a red badge when the host is failing policies.
+- Added clearing of labels, pending scripts, pending software installs, and pending MDM commands when an ABM host re-enrolls; added a "Preserve host activities on re-enrollment" option in Settings > Organization settings > Advanced options to retain historical activity and MDM command history.
+- Provisioned a VPP client user per Managed Apple Account on first install, and associated VPP licenses to the user rather than the device, supporting Apple's up-to-5-devices-per-user licensing semantics.
+- Added `include_all` label scope to policies, and `include_all` and `include_any` label scopes to reports, including support via GitOps and `fleetctl`.
+- Added a "Custom" target dropdown when creating or updating reports under the premium tier.
+- Added an "Include all" option to the "Custom" target dropdown on Policies for premium users only.
+- Added permissions for the GitOps user to list software titles.
+- Added support for setting `gitops_mode_enabled` and `repository_url` via GitOps.
+- Added output to GitOps for scripts, indicating how many scripts would be applied (dry run) or were applied.
+- Added activity entries for retried software installs and script runs from policy automations.
+- Added an activity when hosts fail enrollment profile renewal.
+- Added activities when users create, edit, or delete labels (`created_label`, `edited_label`, and `deleted_label`).
+- Added "Hosts online", "Hosts enrolled", and "Vulnerability exposure" charts to the dashboard.
+- Added an option to convert and return a PEM-encoded X.509 certificate instead of a PEM-encoded PKCS7 envelope from the Request a Certificate endpoint.
+- Added a deprecation warning when using `setup_experience.software` or `macos_setup.software` keys in config.
+- Released `fleetctl` as a `pkg` for macOS.
+- Released `fleetctl` as an `msi` for Windows.
+- Enabled wiping a host to cancel all of its upcoming activities.
+- Updated the default automatic enrollment profile, and added the ability to download and view the applied default profile.
+- Updated OS version reporting for iOS and iPadOS to include the Rapid Security Response suffix (e.g. `(a)`) when the device reports a `SupplementalOSVersionExtra` field via MDM.
+- Updated fleetd and MDM enroll activities to display the serial number and preserve the osquery-provided display name.
+- Required the `--host` flag for `fleetctl get mdm-commands`, and deprecated `GET /api/v1/fleet/commands` without a `host_identifier`.
+
+### Security Engineers
+
+- Added automatic re-push of configuration profiles for SCEP and ACME certificates not proxied through Fleet before expiration; supports Okta conditional access (SCEP), Okta Verify (SCEP with static challenge), and hardware-attested ACME certificates.
+- Added support for subject alternative name (SAN) attributes, including UPN, email (rfc822Name), and DNS, in Android certificate profiles, enabling Wi-Fi connectivity requiring SAN-based authentication.
+- Added ingestion of MDM-delivered certificates (including hardware-bound ACME) via the `CertificateList` MDM command on macOS; ACME certificates now appear on the Host details page alongside osquery-ingested certificates, deduplicated by SHA-1 fingerprint.
+- Added macOS 26 CIS Benchmark v1.0.0.
+- Updated CIS Windows 11 Enterprise benchmark policies from v4.0.0 to v5.0.1, adding 17 new L1 policies and updating 42 existing policy titles.
+- Added SVG support for custom organization logos, with strict server-side sanitization to reject scripts and other unsafe SVG content.
+- Optimized OSV vulnerability scanning to query distinct software per OS version rather than per host, reducing redundant database queries for many hosts sharing the same packages.
+- Improved vulnerability scanning performance by using a per-vendor product cache during CVE matching to optimize `translate_cpe_to_cve`.
+
+### Bug fixes and improvements
+
+- Updated Go to 1.26.3.
+- Removed debug symbols from fleet and fleetctl executables to reduce binary size.
+- Reduced database load from `GET /api/latest/fleet/device/{token}/desktop` and other Fleet Desktop endpoints when invalid or expired device auth tokens are presented, by resolving the token to a host ID with a single-table indexed lookup before running the multi-join host-details query.
+- Improved Windows MDM performance when transferring large numbers of hosts between teams or applying bulk profile changes. These operations now return quickly and roll out profile updates to Windows hosts in the background, so host check-ins and other MDM activity are no longer slowed down while a large change is in progress.
+- Added a Redis-backed cache for host lookups on the osquery and orbit authentication paths. Successful lookups are cached for 60s (±10% jitter) and invalidated on writes that mutate cached host fields. Reduces reader-side DB load at scale without changing the HTTP contract. Requires Redis 6.2 or later.
+- Added a missing uninstall option on the host software library even when an installer has no matching software in the host's inventory.
+- Improved Windows MDM profile removal performance by scoping the desired-state subquery.
+- Improved Windows MDM profile removal performance by skipping redundant database writes for verified-remove ACKs.
+- Consolidated non-variable templated Windows MDM profile command inserts from one per-profile to a single bulk insert.
+- Added a periodic cron job to clean up the Windows MDM command queue, reducing write pressure during ACK transactions.
+- Made host team assignment sticky across orbit and osquery re-enrollments.
+- Improved errors returned from the API when running fleetctl commands by dropping path and status code.
+- Improved validation of order parameters on list endpoints.
+- Added the `orbit.debug_logging_on_enroll_duration` agent option to enable orbit debug logging for a specified time period after enrollment.
+- Improved validation for invalid `order_key` values in `/api/v1/fleet/commands`, `/api/v1/fleet/mdm/commands`, and `/api/v1/fleet/mdm/apple/commands` endpoints.
+- Improved the error message when the `name` key is omitted from a GitOps YAML file.
+- Improved the error message when deleting a label used for targeting a software installation.
+- Updated `fleetctl gitops` to warn when `labels:` is specified in no-team or unassigned files, where it is not supported.
+- Updated the expired Fleet Premium license CLI banner to link to https://fleetdm.com/learn-more-about/downgrading instead of a stale FAQ anchor.
+- Updated the Edit label page to reference "fleets" instead of "teams" when a label is associated with a fleet.
+- Updated the setup experience Users card with a link to PSSO local account documentation.
+- Updated empty state copy to be action-oriented. Headers describe the current state ("No hosts", "No policies for this fleet") instead of prompting action. Body text explains what to expect. CTA buttons are explicit ("Add policy", "Schedule a report") and permission-gated.
+- Updated empty states on Hosts, Reports, Policies, and Software pages so search bars, filters, and dropdowns remain visible but disabled when empty, avoiding layout shift when the first item is added. Item count remains visible.
+- Updated Settings, Fleets, Ticket destinations, Certificates, and Identity provider pages with consistent page descriptions and learn-more links.
+- Updated empty state visuals to a fresher, consistent design.
+- Updated timestamps with tooltips on the host Vitals component to always use `cursor: pointer`.
+- Updated the version of the checkout action in the `fleetctl new` template to avoid Node warnings.
+- Updated the MSI builder to skip packaging the unusable "dummy" secret value when building `fleetd-base.msi` for Autopilot installs.
+- Scoped install commands for user-enrolled hosts to the host's Managed Apple Account (`clientUserIds`) instead of `serialNumbers`, so apps install on the correct user account on the device.
+- Surfaced a clear host-level error when license association fails during install (for example, no licenses available or the user has reached the 5-device limit) instead of failing silently.
+- Made `created_at` upper-bound filtering consistent on the list activities API. The endpoint now caps results at `now` by default whether or not `start_created_at` is provided, matching the documented behavior of `end_created_at`.
+- Unified access to global and team policies in the UI by using the now-generic `GET /api/latest/fleet/policies/:id` endpoint.
+- Wrapped `Get-ItemProperty` calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. `System.InvalidCastException`) from malformed registry entries, logging the offending path instead of aborting.
+- Replaced the cryptic "startTLS error: ..." flash with a prescriptive message when saving SMTP settings fails because SSL/TLS is disabled but STARTTLS is still enabled. Added a tooltip on the SSL/TLS checkbox pointing to the STARTTLS toggle in Advanced options.
+- Removed a dead SQL condition in `hostVPPInstalls` that was misleading but harmless. Android VPP apps never produce `nano_command_results` entries (they use Google's Android Management API, not nanoMDM), so the previous `(hvsi.platform != 'android' OR ncr.id IS NULL)` guard was a tautology. Replaced with a clarifying comment.
+- Fixed filtering on the `/api/v1/fleet/labels/:id/hosts` endpoint.
+- Fixed the `usage_statistics` cron failing against fleetdm.com when a large number of near-identical network errors accumulated in the error store.
+- Fixed `fleetctl gitops` failing with HTTP 500 on subsequent runs when a custom software icon's bytes were missing or had failed integrity in the icon store. The server now returns a 409 Conflict from the metadata-only icon update path, and the gitops client falls back to a full upload to recover the bytes automatically.
+- Fixed SAML JIT provisioning so `FLEET_JIT_USER_ROLE_*` attributes with empty, whitespace-only, or missing values are treated as `null` and ignored instead of failing SSO login.
+- Fixed an issue where GitOps controls with only certain keys would not be seen as set.
+- Fixed recovery lock password not being retrievable for hosts transferred to a team with recovery lock disabled.
+- Fixed Fleet's Docker image failing to start in Kubernetes with an `unknown userid` error, triggered by a fleetctl dependency side effect.
+- Fixed a GitOps failure ("converting NULL to uint is unsupported") when moving labels from global to fleet scope, caused by deleted label associations with NULL `label_id` values in `mdm_configuration_profile_labels` and `mdm_declaration_labels`.
+- Fixed `fleetctl gitops --dry-run` intermittently failing with "Resource Not Found" when a team's `software` config was empty.
+- Fixed the MDM SSO callback returning a "missing profile" error for Android enrollment when Apple MDM is not configured.
+- Fixed the team PATCH endpoint rejecting `mdm.enable_disk_encryption` on Fleet deployments where only Windows MDM is configured. Team-level BitLocker enforcement can now be toggled when either Apple MDM or Windows MDM is configured.
+- Fixed an issue where the disk encryption table on the Controls > Disk encryption page did not support horizontal scrolling at narrow viewport widths.
+- Fixed Linux total disk space being double-counted when a filesystem was bind-mounted at multiple paths (e.g. snap-confine's `/tmp/snap.rootfs_*`).
+- Fixed `fleetctl gitops` rejecting `path:` values whose actual filenames contained glob metacharacters even when the file existed at that literal path.
+- Fixed GitOps failing when it attempted to create a label and a consumer of that label (e.g. a profile) in the same run.
+- Fixed `gitops --dry-run` to reject label specs with invalid `platform` values.
+- Fixed the SSO invite acceptance flow by resolving the email from the invite token.
+- Fixed batch script endpoints to return 404 Not Found instead of 200 when the batch execution ID does not exist: `/api/v1/fleet/scripts/batch/:id`, `/api/v1/fleet/scripts/batch/summary/:id`, and `/api/v1/fleet/scripts/batch/:id/cancel`.
+- Fixed a class of silent SCEP managed-certificate renewal failures by recovering `host_mdm_managed_certificates` rows that previously got stuck after the cert ingest matcher missed linking a renewed certificate.
+- Fixed the upcoming activity count on the host details page not updating after installing or uninstalling software.
+- Fixed an issue where GitOps incorrectly rejected keys in Google Calendar API key JSON.
+- Fixed 500 errors on `POST /api/v1/fleet/scim/Users` when the matched host was already mapped to a SCIM user. The host now gets reassigned to the newly-created SCIM user.
+- Fixed an incorrect CPE match on the "slate" Homebrew program.
+- Fixed a bug where applying GitOps to a script-only package by `hash_sha256` reference would wipe the install script, causing self-service installs to silently no-op.
+- Fixed `fleetctl vulnerability-data-stream` to also download OSV (Ubuntu and RHEL) artifacts.
+- Fixed a missing `deleted_policy` activity when a patch policy is removed by GitOps as a result of its underlying Fleet-maintained app installer being removed from the YAML.
+- Fixed a nil-pointer panic in the Android Enterprise Pub/Sub endpoint that occurred when Google's Android Management API sent a device payload missing `hardwareInfo`, `softwareInfo`, or `memoryInfo`.
+- Fixed an issue where, if a custom Apple MDM URL was set, SSO for end user auth would fail.
+- Fixed slow load times and timeouts on the list MDM commands API (`GET /api/v1/fleet/commands`) on Fleet deployments with many Windows hosts. The endpoint now caps `per_page` at 1,000 (default 10) and `page` at 100. Requests above either limit return HTTP 400. To traverse beyond 100 pages, use cursor pagination via the `after` query parameter.
+- Fixed GitOps dry-run to correctly detect the conflict when both `macos_manual_agent_install` and `macos_script` are configured under `setup_experience`. Previously, the dry-run would succeed while the actual GitOps run would fail.
+- Fixed `fleetctl gitops apply` not clearing stale broken `mdm_configuration_profile_labels` rows after a referenced label was deleted, which caused profiles to remain enforced on hosts regardless of updated label targeting.
+- Fixed `GET /api/v1/fleet/commands` returning a SQL error when called with `host_identifier` and the `after` cursor parameter, particularly with `order_key=command_uuid` or `order_key=hostname`.
+- Fixed a UI bug where editing an existing global user to enable two-factor authentication failed with a 422 error.
+- Fixed an issue where an old APNs cert would stay in memory until a restart, instead of correctly updating in place.
+- Fixed a UI inconsistency with non-center-aligned Fleet premium messages on Fleet Free.
+- Fixed a bug where duplicate software installers for Linux could be added.
+- Fixed the "Back to host details" button on a report's details page navigating to the reports list instead of the host's details page after creating a report from a host.
+- Fixed IdP host vitals (full name, department, groups) not populating on the host details page for macOS devices migrated from another MDM via the Tahoe (macOS 26+) end-user-authentication flow.
+- Fixed `POST /api/v1/fleet/queries` returning HTTP 500 when `name` or `query` is JSON `null`. The endpoint now returns HTTP 400.
+- Fixed `GET /api/latest/fleet/policies/:id` (and alias `GET /api/v1/fleet/global/policies/:id`) to return and properly populate team policies, and to perform an authorization check on team policies before returning.
+- Fixed an issue where GitOps dry-run would not validate Apple config profile payload scope conflicts or the use of unknown Fleet variables in all types of profiles.
+- Fixed Android hosts being auto-deleted by host expiry on every cleanup tick after re-enrolling, which previously caused an hourly enroll/delete loop while host expiry was enabled.
+- Fixed an issue where replica lag could lead to devices not being assigned a setup experience profile on device sync from DEP.
+- Fixed the Location and MDM status vitals on the My device page rendering as clickable links even though they had no associated modal, by rendering them as plain text in read-only contexts.
+- Fixed the Export hosts button to always reflect the current sort, search, and filter state instead of potentially using stale values.
+- Fixed a false-positive `update_conditional_access_bypass` activity that was created whenever any app config setting was changed while Okta conditional access was already configured with `bypass_disabled: true`. Also stopped the related side effect of clearing existing conditional access bypass records on those unrelated saves.
+- Fixed UI elements in the script library not respecting GitOps mode when enabled.
+- Fixed `POST /packs` with a JSON null name silently creating a pack with an empty name. The endpoint now returns a 400 Bad Request, matching the behavior for an empty-string name.
+- Fixed stale "Selected hosts" on the Edit label page after a previous edit by invalidating the related query caches on success, and when navigating between manual labels by scoping the hosts cache per label and keying the form on the actual host set.
+- Fixed subtle text alignment issues in the UI.
+- Fixed a file descriptor leak in vulnerability processing where deleted `goval_dictionary` sqlite files were kept open until Fleet server restart.
+- Fixed setup experience remaining stuck for up to 90 minutes after a software installer was edited or deleted while a host was installing it.
+- Fixed the Policy details modal not closing when navigating back to the Host details page with the browser's back button.
+- Fixed software titles list sorting to use display name instead of installer filename when a custom display name is set.
+- Fixed the missing "Conditional access" section header on the Settings > Integrations > Conditional access page on Fleet Free.
+- Fixed `fleetctl gitops` silently accepting labels with invalid parameter combinations (e.g. manual labels with query/criteria/platform).
+- Fixed validation that rejected enabling end user authentication on Fleet deployments without Apple MDM configured. End user authentication covers macOS Setup Assistant, Windows MDM, and Linux Orbit enrollment, so the toggle now works on Windows-only and Linux-only fleets as long as the IdP is configured.
+- Fixed an issue where the MDM solution name reported for a host could flip between values across osquery ingestions when the MDM server URL contained substrings matching multiple known MDM vendors.
+- Fixed a bug where `enable_host_users` defaulted to `false` on a fresh Fleet install instead of the documented default `true`, causing the host details page to show "User collection has been disabled."
+- Fixed the IdP "Department" host vital not populating for users whose IdP-to-SCIM mapping included enterprise extension attributes that Fleet does not store.
+- Fixed the Actions dropdown in the Run script modal within the Host details page automatically closing after 2-3s.
+- Fixed GitOps dry runs failing when a VPP app references a label that was added in the same run.
+- Fixed a bug where enrolling an Android device on a Fleet instance with Apple MDM disabled produced a duplicate host record.
+- Fixed Fleet-scoped users getting a 403 when viewing past activities on a host that has user-initiated activities (e.g. lock/wipe/run script/install software), and fixed missing permissions on host activity items for fleet-scoped users.
+
 ## Fleet 4.85.1 (May 22, 2026)
 
 ### Bug fixes

--- a/changes/31138-user-enrolled-software-install
+++ b/changes/31138-user-enrolled-software-install
@@ -1,6 +1,0 @@
-- Added support for installing VPP and in-house (`.ipa`) apps on iOS and iPadOS hosts enrolled via Account-Driven User Enrollment with a Managed Apple Account. Previously Fleet returned "Couldn't install. Currently, software install isn't supported on personal (BYOD) iOS and iPadOS hosts."
-- Enabled self-service software installs from My device for user-enrolled iOS and iPadOS hosts.
-- Setup experience software selected in Controls > Setup experience now installs automatically on user-enrolled iOS and iPadOS hosts at enrollment.
-- Fleet now provisions a VPP client user per Managed Apple Account on first install and associates VPP licenses to the user rather than the device, supporting Apple's up-to-5-devices-per-user licensing semantics.
-- Install commands for user-enrolled hosts are now scoped to the host's Managed Apple Account (`clientUserIds`) instead of `serialNumbers`, so apps install on the correct user account on the device.
-- Surfaced a clear host-level error when license association fails during install (for example, no licenses available or the user has reached the 5-device limit) instead of failing silently.

--- a/changes/33555-better-error-handling-of-win-pre-install-setup
+++ b/changes/33555-better-error-handling-of-win-pre-install-setup
@@ -1,1 +1,0 @@
-* Wrapped Get-ItemProperty calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. System.InvalidCastException) from malformed registry entries, logging the offending path instead of aborting.

--- a/changes/34103-sso-invite-accept
+++ b/changes/34103-sso-invite-accept
@@ -1,1 +1,0 @@
-- Fixed SSO invite acceptance flow by resolving the email from the invite token.

--- a/changes/34104-smtp-starttls-error-message
+++ b/changes/34104-smtp-starttls-error-message
@@ -1,1 +1,0 @@
-- Replaced the cryptic "startTLS error: ..." flash with a prescriptive message when saving SMTP settings fails because SSL/TLS is disabled but STARTTLS is still enabled, and added a tooltip on the SSL/TLS checkbox pointing to the STARTTLS toggle in Advanced options.

--- a/changes/34229-gitops-label-validation
+++ b/changes/34229-gitops-label-validation
@@ -1,1 +1,0 @@
-* Fixed `fleetctl gitops` silently accepting labels with invalid parameter combinations (e.g. manual labels with query/criteria/platform).

--- a/changes/34464-gitops-dry-run-manual-agent-install-script-conflict
+++ b/changes/34464-gitops-dry-run-manual-agent-install-script-conflict
@@ -1,1 +1,0 @@
-- Fixed GitOps dry-run to correctly detect the conflict when both `macos_manual_agent_install` and `macos_script` are configured under `setup_experience`. Previously, the dry-run would succeed while the actual GitOps run would fail.

--- a/changes/34924-expired-license-cli-banner
+++ b/changes/34924-expired-license-cli-banner
@@ -1,1 +1,0 @@
-* Updated the expired Fleet Premium license CLI banner to link to https://fleetdm.com/learn-more-about/downgrading instead of a stale FAQ anchor.

--- a/changes/35089-fleetctl-released-as-pkg
+++ b/changes/35089-fleetctl-released-as-pkg
@@ -1,1 +1,0 @@
-- `fleetctl` is now also released as a `pkg` for macOS

--- a/changes/35173-cis-macos-26-v1
+++ b/changes/35173-cis-macos-26-v1
@@ -1,1 +1,0 @@
-- Added macOS 26 CIS Benchmark v1.0.0

--- a/changes/35195-slate-homebrew-cpe-mismatch
+++ b/changes/35195-slate-homebrew-cpe-mismatch
@@ -1,1 +1,0 @@
-- Fixed incorrect CPE match on "slate" homebrew program

--- a/changes/35483-empty-states
+++ b/changes/35483-empty-states
@@ -1,1 +1,0 @@
-* Fleet UI: Updated empty state to a fresher, consistent design

--- a/changes/36417-update-enrolling-activities-display-name
+++ b/changes/36417-update-enrolling-activities-display-name
@@ -1,1 +1,0 @@
-* Updated fleetd and MDM enroll activities to display the serial number and preserve osquery provided display name.

--- a/changes/36976-activities-for-labels
+++ b/changes/36976-activities-for-labels
@@ -1,1 +1,0 @@
-* Added generation of activities when users create, edit, or delete labels (`created_label`, `edited_label`, and `deleted_label` respectively).

--- a/changes/37012-host-details-activity-upcoming-count
+++ b/changes/37012-host-details-activity-upcoming-count
@@ -1,1 +1,0 @@
-- Fixed an issue where the upcoming activity count on the host details page was not updated after installing or uninstalling software.

--- a/changes/37142-local-admin-password-rotation
+++ b/changes/37142-local-admin-password-rotation
@@ -1,1 +1,0 @@
-* Added automatic rotation of managed local admin account passwords after they have been viewed

--- a/changes/37682-clear-state-on-abm-re-enrollment
+++ b/changes/37682-clear-state-on-abm-re-enrollment
@@ -1,1 +1,0 @@
-- Implemented clearing host vitals on AB host re-enrollment, with a config option to preserve past host activities.

--- a/changes/38437-activity-list-date-filter-consistency
+++ b/changes/38437-activity-list-date-filter-consistency
@@ -1,1 +1,0 @@
-- Made `created_at` upper-bound filtering consistent on the list activities API. The endpoint now caps results at `now` by default whether or not `start_created_at` is provided, matching the documented behavior of `end_created_at`.

--- a/changes/38785-windows-setup-experience-cancel
+++ b/changes/38785-windows-setup-experience-cancel
@@ -1,1 +1,0 @@
-- Added `require_all_software_windows` setting to cancel the Windows setup experience if any software install fails during Autopilot enrollment, matching the existing macOS behavior.

--- a/changes/38790-ios-ipados-managed-app-configuration
+++ b/changes/38790-ios-ipados-managed-app-configuration
@@ -1,1 +1,0 @@
-- Added managed app configuration for iOS and iPadOS apps (VPP and in-house), configurable via UI, REST API, and GitOps, with `$FLEET_VAR_*` substitution.

--- a/changes/39016-upload-custom-org-logo
+++ b/changes/39016-upload-custom-org-logo
@@ -1,1 +1,0 @@
-* Added the ability to upload a custom organization logo for light and dark modes, hosted by Fleet, replacing the previous URL-only flow on the setup screen and organization settings page.

--- a/changes/39096-cis-win11-v5
+++ b/changes/39096-cis-win11-v5
@@ -1,1 +1,0 @@
-* Updated CIS Windows 11 Enterprise benchmark policies from v4.0.0 to v5.0.1, adding 17 new L1 policies and updating 42 existing policy titles.

--- a/changes/39727-creating-queries-back-to-hosts-bug
+++ b/changes/39727-creating-queries-back-to-hosts-bug
@@ -1,1 +1,0 @@
-* Fixed an issue where the "Back to host details" button on a report's details page navigated to the reports list instead of the host's details page after creating a report from a host.

--- a/changes/40459-wipe-host-cancels-upcoming-activities
+++ b/changes/40459-wipe-host-cancels-upcoming-activities
@@ -1,1 +1,0 @@
-- Wiping a host now cancels all of its upcoming activities.

--- a/changes/40623-failed-enrollment-renewal
+++ b/changes/40623-failed-enrollment-renewal
@@ -1,1 +1,0 @@
-- Added activity when hosts fail enrollment profile renewal.

--- a/changes/40905-update-default-automatic-enrollment-profile
+++ b/changes/40905-update-default-automatic-enrollment-profile
@@ -1,1 +1,0 @@
-- Updated default automatic enrollment profile, and added the ability to download and see what default profile is applied.

--- a/changes/41472-android-cert-san-server
+++ b/changes/41472-android-cert-san-server
@@ -1,1 +1,0 @@
-* Added support for the `subject_alternative_name` field on Android certificate templates.

--- a/changes/415640-policy-reports-new-custom-option
+++ b/changes/415640-policy-reports-new-custom-option
@@ -1,2 +1,0 @@
-- Added include_all label scope to policies.
-- Added include_all and include_any scope to reports.

--- a/changes/41565-policy-report-new-scopes-frontend
+++ b/changes/41565-policy-report-new-scopes-frontend
@@ -1,2 +1,0 @@
-- Added a "Custom" target dropdown when creating/updating reports under premium tier.
-- Added "Include All" to "Custom" target dropdown on Policies for premium users only.

--- a/changes/41566-policy-report-labels-gitops
+++ b/changes/41566-policy-report-labels-gitops
@@ -1,1 +1,0 @@
-- Wires labels_include_all to GitOps/fleetctl for policies and reports.

--- a/changes/41592-eua-broken-with-custom-apple-mdm-url‎
+++ b/changes/41592-eua-broken-with-custom-apple-mdm-url‎
@@ -1,1 +1,0 @@
-- Fixed an issue where if a custom Apple MDM URL was set, SSO for end user auth would fail.

--- a/changes/41985-idp-host-vitals-tahoe-migration
+++ b/changes/41985-idp-host-vitals-tahoe-migration
@@ -1,1 +1,0 @@
-- Fixed IdP host vitals (full name, department, groups) not populating on the host details page for macOS devices migrated from another MDM via the Tahoe (macOS 26+) end-user-authentication flow.

--- a/changes/41996-department-idp-host-vital-not-populating-for-some-users
+++ b/changes/41996-department-idp-host-vital-not-populating-for-some-users
@@ -1,1 +1,0 @@
-- Fixed an issue where the IdP "Department" host vital would not populate for users whose IdP-to-SCIM mapping included enterprise extension attributes that Fleet does not store.

--- a/changes/42026-show-uninstall-button
+++ b/changes/42026-show-uninstall-button
@@ -1,1 +1,0 @@
-- Added missing uninstall option on host software library even when an installer has no matching software in the host's inventory.

--- a/changes/42218-ios-supplemental-os-version-extra
+++ b/changes/42218-ios-supplemental-os-version-extra
@@ -1,1 +1,0 @@
-- Fleet now includes the Rapid Security Response suffix (e.g. `(a)`) in the OS version for iOS and iPadOS devices that report a `SupplementalOSVersionExtra` field via MDM.

--- a/changes/42477-gitops-dry-run-label-platform
+++ b/changes/42477-gitops-dry-run-label-platform
@@ -1,1 +1,0 @@
-- Fixed gitops `--dry-run` so it now rejects label specs with invalid `platform` values.

--- a/changes/42503-deprecate-software-under-setup-experience
+++ b/changes/42503-deprecate-software-under-setup-experience
@@ -1,1 +1,0 @@
-- Added deprecation warning when using `setup_experience.software` or `macos_setup.software` keys in config

--- a/changes/42522-labels-not-supported-in-no-team
+++ b/changes/42522-labels-not-supported-in-no-team
@@ -1,1 +1,0 @@
-- Improved `fleetctl gitops` to warn when `labels:` is specified in no-team/unassigned files, where it is not supported.

--- a/changes/42545-windows-profile-reconciliation-batching
+++ b/changes/42545-windows-profile-reconciliation-batching
@@ -1,1 +1,0 @@
-* Improved Windows MDM performance when transferring large numbers of hosts between teams or applying bulk profile changes. These operations now return quickly and roll out profile updates to Windows hosts in the background, so host check-ins and other MDM activity are no longer slowed down while a large change is in progress.

--- a/changes/42607-gitops-dry-run-empty-software
+++ b/changes/42607-gitops-dry-run-empty-software
@@ -1,1 +1,0 @@
-- Fixed `fleetctl gitops --dry-run` intermittently failing with "Resource Not Found" when a team's `software` config was empty.

--- a/changes/42613-dedupe-network-errors-in-error-store
+++ b/changes/42613-dedupe-network-errors-in-error-store
@@ -1,1 +1,0 @@
-- Fixed the `usage_statistics` cron failing against fleetdm.com when a large number of near-identical network errors accumulated in the error store.

--- a/changes/42637-clear-stale-broken-label-associations
+++ b/changes/42637-clear-stale-broken-label-associations
@@ -1,1 +1,0 @@
-* Fixed `fleetctl gitops apply` not clearing stale broken `mdm_configuration_profile_labels` rows after a referenced label was deleted, which caused profiles to remain enforced on hosts regardless of updated label targeting.

--- a/changes/42741-fix-goval-dictionary-fd-leak
+++ b/changes/42741-fix-goval-dictionary-fd-leak
@@ -1,1 +1,0 @@
-* Fixed file descriptor leak in vulnerability processing where deleted goval_dictionary sqlite files were kept open until Fleet server restart.

--- a/changes/42827-macos-mdm-certificate-ingestion
+++ b/changes/42827-macos-mdm-certificate-ingestion
@@ -1,1 +1,0 @@
-* Surface hardware-bound ACME certificates on macOS host vitals by retrieving them via the MDM `CertificateList` command when an ACME-bearing configuration profile is installed or re-installed.

--- a/changes/42874-saml-jit-empty-role-values
+++ b/changes/42874-saml-jit-empty-role-values
@@ -1,1 +1,0 @@
-- Fixed SAML JIT provisioning so `FLEET_JIT_USER_ROLE_*` attributes with empty, whitespace-only, or missing values are treated as `null` and ignored instead of failing SSO login.

--- a/changes/42886-fix-google-cal-gitops-validation
+++ b/changes/42886-fix-google-cal-gitops-validation
@@ -1,1 +1,0 @@
-- Fixed issue where GitOps would incorrectly reject keys in Google Calendar API key JSON

--- a/changes/42930-show-retries-script-software-automations-host-details
+++ b/changes/42930-show-retries-script-software-automations-host-details
@@ -1,1 +1,0 @@
-* Added host activity entries for retried software installs and script runs from policy automations.

--- a/changes/42972-add-fleetctl-msi-to-release
+++ b/changes/42972-add-fleetctl-msi-to-release
@@ -1,1 +1,0 @@
-- `fleetctl` is now also released as an `msi` for Windows

--- a/changes/43027-return-404-for-missing-resources
+++ b/changes/43027-return-404-for-missing-resources
@@ -1,1 +1,0 @@
-- Fixed an issue where these endpoints returned 200 instead of 404 Not Found when the batch execution ID didn't exist: `/api/v1/fleet/scripts/batch/:id`, `/api/v1/fleet/scripts/batch/summary/:id`, and `/api/v1/fleet/scripts/batch/:id/cancel`

--- a/changes/43031-post-queries-null-name-or-query-500
+++ b/changes/43031-post-queries-null-name-or-query-500
@@ -1,1 +1,0 @@
-* Fixed `POST /api/v1/fleet/queries` returning HTTP 500 when `name` or `query` is JSON `null`; the endpoint now returns HTTP 400.

--- a/changes/43032-post-packs-null-name
+++ b/changes/43032-post-packs-null-name
@@ -1,1 +1,0 @@
-- Fixed an issue where `POST /packs` with a JSON null name silently created a pack with an empty name; the endpoint now returns a 400 Bad Request, matching the behavior for an empty-string name.

--- a/changes/43091-inaccurate-total-disk-space
+++ b/changes/43091-inaccurate-total-disk-space
@@ -1,1 +1,0 @@
-* Fixed Linux total disk space being double-counted when a filesystem was bind-mounted at multiple paths (e.g. snap-confine's `/tmp/snap.rootfs_*`).

--- a/changes/43135-fix-stale-label-hosts
+++ b/changes/43135-fix-stale-label-hosts
@@ -1,2 +1,0 @@
-* Fixed stale "Selected hosts" on the edit label page after a previous edit by invalidating the related query caches on success.
-* Fixed stale "Selected hosts" on the edit label page when navigating between manual labels by scoping the hosts cache per label and keying the form on the actual host set.

--- a/changes/43279-my-device-page-location-vital-looks-clickable
+++ b/changes/43279-my-device-page-location-vital-looks-clickable
@@ -1,1 +1,0 @@
-- Fleet UI: Fixed the Location and MDM status vitals on the My device page rendering as clickable links even though they had no associated modal, by rendering them as plain text in read-only contexts.

--- a/changes/43294-sticky-team-enrollment
+++ b/changes/43294-sticky-team-enrollment
@@ -1,1 +1,0 @@
-* Made host team assignment sticky across orbit and osquery re-enrollments

--- a/changes/43511-gitops-icon-update-recovers
+++ b/changes/43511-gitops-icon-update-recovers
@@ -1,1 +1,0 @@
-- Fixed `fleetctl gitops` failing with HTTP 500 on subsequent runs when a custom software icon's bytes were missing or had failed integrity in the icon store. The server now returns a 409 Conflict from the metadata-only icon update path, and the gitops client falls back to a full upload to recover the bytes automatically.

--- a/changes/43598-fix-gitops-glob-path-validation
+++ b/changes/43598-fix-gitops-glob-path-validation
@@ -1,1 +1,0 @@
-- Fixed an issue where `fleetctl gitops` rejected `path:` values whose actual filenames contained glob metacharacters even when the file existed at that literal path.

--- a/changes/43609-gitops-mode-false-positive-activity
+++ b/changes/43609-gitops-mode-false-positive-activity
@@ -1,1 +1,0 @@
-- Fixed a false-positive `update_conditional_access_bypass` activity that was created whenever any app config setting was changed while Okta conditional access was already configured with `bypass_disabled: true`. Also stops the related side effect of clearing existing conditional access bypass records on those unrelated saves.

--- a/changes/43637-disk-encryption-table-horizontal-scroll
+++ b/changes/43637-disk-encryption-table-horizontal-scroll
@@ -1,1 +1,0 @@
-* Fixed an issue where the disk encryption table on the Controls > Disk encryption page did not support horizontal scrolling at narrow viewport widths.

--- a/changes/43640-actions-dropdown-auto-closing
+++ b/changes/43640-actions-dropdown-auto-closing
@@ -1,1 +1,0 @@
-* Fixed an issue where the Actions dropdown in the Run script modal within the Host details page would automatically close after 2-3s.

--- a/changes/43643-conditional-access-header-fleet-free
+++ b/changes/43643-conditional-access-header-fleet-free
@@ -1,1 +1,0 @@
-- Fixed missing "Conditional access" section header on the Settings > Integrations > Conditional access page on Fleet Free.

--- a/changes/43645-timestamps-are-not-consistently-styled-as-hoverable-missing-dotted-underlines
+++ b/changes/43645-timestamps-are-not-consistently-styled-as-hoverable-missing-dotted-underlines
@@ -1,1 +1,0 @@
-- Updated timestamps w/ tooltips on host's Vitals component to always have cursor: pointer.

--- a/changes/43646-inconsistent-alignment-fleet-premium
+++ b/changes/43646-inconsistent-alignment-fleet-premium
@@ -1,1 +1,0 @@
-- Fixed a UI inconsistency with non-center aligned Fleet premium messages on Fleet free.

--- a/changes/43647-close-policy-details-modal-when-navigating-back-to-host-details
+++ b/changes/43647-close-policy-details-modal-when-navigating-back-to-host-details
@@ -1,1 +1,0 @@
-* Fixed an issue where the Policy details modal would not close when navigating back to the Host details page with the browser's back button.

--- a/changes/43656-scim-users-duplicate-host-id
+++ b/changes/43656-scim-users-duplicate-host-id
@@ -1,1 +1,0 @@
-* Fixed 500 errors on `POST /api/v1/fleet/scim/Users` when the matched host was already mapped to a SCIM user; the host now gets reassigned to the newly-created SCIM user.

--- a/changes/43659-script-only-hash-ref-preserves-install-script
+++ b/changes/43659-script-only-hash-ref-preserves-install-script
@@ -1,1 +1,0 @@
-- Fixed a bug where applying GitOps to a script-only package by `hash_sha256` reference would wipe the install script, causing self-service installs to silently no-op.

--- a/changes/43673-sort-software-titles-by-display-name
+++ b/changes/43673-sort-software-titles-by-display-name
@@ -1,1 +1,0 @@
-- Fixed software titles list sorting to use display name instead of installer filename when a custom display name is set.

--- a/changes/43688-fix-text-alignment-issues
+++ b/changes/43688-fix-text-alignment-issues
@@ -1,1 +1,0 @@
-* Fleet UI: Fix subtle text alignment issues

--- a/changes/43721-clean-up-gitops-errors
+++ b/changes/43721-clean-up-gitops-errors
@@ -1,1 +1,0 @@
-- Improved errors returned from API when running fleetctl commands by dropping path / status code.

--- a/changes/43767-delete-label-error-msg
+++ b/changes/43767-delete-label-error-msg
@@ -1,1 +1,0 @@
-- Fleet UI: Improved error message when deleting a label that is for targeting a software installation

--- a/changes/43769-added-charts-to-dashboard
+++ b/changes/43769-added-charts-to-dashboard
@@ -1,1 +1,0 @@
-- Added "Hosts online" and "Hosts enrolled" charts to dashboard.

--- a/changes/43846-vpp-app-store-non-us-abm
+++ b/changes/43846-vpp-app-store-non-us-abm
@@ -1,1 +1,0 @@
-* Added support for VPP apps purchased from non-US based Apple Business accounts.

--- a/changes/43857-improve-error-on-missing-gitops-name
+++ b/changes/43857-improve-error-on-missing-gitops-name
@@ -1,1 +1,0 @@
-- Improved error when `name` key is omitted from a GitOps YAML file.

--- a/changes/43928-host-by-nodekey-cache
+++ b/changes/43928-host-by-nodekey-cache
@@ -1,1 +1,0 @@
-* Added a Redis-backed cache for the host lookups on the osquery and orbit authentication paths. Successful lookups are cached for 60s (±10% jitter) and invalidated on writes that mutate cached host fields. Reduces reader-side DB load at scale without changing the HTTP contract. Requires Redis 6.2 or later.

--- a/changes/43959-duplicate-installers
+++ b/changes/43959-duplicate-installers
@@ -1,1 +1,0 @@
-- Fixed a bug where duplicate software installers for linux could be added.

--- a/changes/43984-setup-experience-users-ui-updates
+++ b/changes/43984-setup-experience-users-ui-updates
@@ -1,1 +1,0 @@
-- Fleet UI: Updated setup experience Users card with link to PSSO local account documentation

--- a/changes/43997-orbit-debug-logging-on-enroll
+++ b/changes/43997-orbit-debug-logging-on-enroll
@@ -1,1 +1,0 @@
-- Added the `orbit.debug_logging_on_enroll_duration` agent option to allow enabling orbit debug logging for a specified time period after enrollment

--- a/changes/44046-create-team-labels-before-consumers
+++ b/changes/44046-create-team-labels-before-consumers
@@ -1,1 +1,0 @@
-- Fixed an issue where GitOps would fail if it attempted to create a label and a consumer of that label (e.g. a profile) in the same run.

--- a/changes/44082-add-script-output-to-gitops
+++ b/changes/44082-add-script-output-to-gitops
@@ -1,1 +1,0 @@
-- Added output to GitOps for scripts, indicating how many scripts would be applied (dry run) or were applied.

--- a/changes/44084-fix-install-loop-on-deleted-installer
+++ b/changes/44084-fix-install-loop-on-deleted-installer
@@ -1,1 +1,0 @@
-- Fixed a bug where setup experience could remain stuck for up to 90 minutes after a software installer was edited or deleted while a host was installing it.

--- a/changes/44111-scep-autorenew-fail
+++ b/changes/44111-scep-autorenew-fail
@@ -1,1 +1,0 @@
-- Fixed a class of silent SCEP managed-certificate renewal failures by recovering host_mdm_managed_certificates rows that previously got stuck after the cert ingest matcher missed linking a renewed certificate.

--- a/changes/44124-add-vulnerabilities-chart
+++ b/changes/44124-add-vulnerabilities-chart
@@ -1,1 +1,0 @@
-- Added chart showing host vulnerability exposure to dashboard

--- a/changes/44170-fleetctl-mdm-commands-require-host
+++ b/changes/44170-fleetctl-mdm-commands-require-host
@@ -1,1 +1,0 @@
-* `fleetctl get mdm-commands` now requires the `--host` flag. Using `GET /api/v1/fleet/commands` without a host_identifier has been deprecated.

--- a/changes/44170-list-mdm-commands-perf
+++ b/changes/44170-list-mdm-commands-perf
@@ -1,1 +1,0 @@
-- Fixed slow load times and timeouts on the list MDM commands API (`GET /api/v1/fleet/commands`) on Fleet deployments with many Windows hosts. The endpoint now caps `per_page` at 1,000 (default 10) and `page` at 100; requests above either limit return HTTP 400. To traverse beyond 100 pages, use cursor pagination via the `after` query parameter.

--- a/changes/44189-host-profile-perf
+++ b/changes/44189-host-profile-perf
@@ -1,1 +1,0 @@
-* Improved Windows MDM profile removal performance by skipping redundant database writes for verified-remove ACKs.

--- a/changes/44190-mdm-queue-cleanup
+++ b/changes/44190-mdm-queue-cleanup
@@ -1,1 +1,0 @@
-* Added periodic cron job to clean up the Windows MDM command queue, reducing write pressure during ACK transactions.

--- a/changes/44194-team-bitlocker-windows-only
+++ b/changes/44194-team-bitlocker-windows-only
@@ -1,1 +1,0 @@
-- Fixed the team PATCH endpoint rejecting `mdm.enable_disk_encryption` on Fleet deployments where only Windows MDM is configured. Team-level BitLocker enforcement can now be toggled when either Apple MDM or Windows MDM is configured.

--- a/changes/44196-script-library-gitops-fixes
+++ b/changes/44196-script-library-gitops-fixes
@@ -1,1 +1,0 @@
-- Fixed UI elements in script library not respecting GitOps mode when enabled. 

--- a/changes/44242-fleetctl-vuln-data-stream-osv
+++ b/changes/44242-fleetctl-vuln-data-stream-osv
@@ -1,1 +1,0 @@
-- Fixed `fleetctl vulnerability-data-stream` to also download OSV (Ubuntu and RHEL) artifacts.

--- a/changes/44252-unable-to-edit-existing-user-to-use-2fa-422-error
+++ b/changes/44252-unable-to-edit-existing-user-to-use-2fa-422-error
@@ -1,1 +1,0 @@
-- Fixed a UI bug where editing an existing global user to enable two-factor authentication failed with a 422 error.

--- a/changes/44286-deleted-policy-activity-for-patch-policies
+++ b/changes/44286-deleted-policy-activity-for-patch-policies
@@ -1,1 +1,0 @@
-* Fixed missing `deleted_policy` activity when a patch policy is removed by gitops as a result of its underlying Fleet-maintained app installer being removed from the YAML.

--- a/changes/44298-fix-goquery-dependency-side-effects
+++ b/changes/44298-fix-goquery-dependency-side-effects
@@ -1,1 +1,0 @@
-* Fixed Fleet's Docker image failing to start in Kubernetes with an `unknown userid` error, triggered by a fleetctl dependency side effect.

--- a/changes/44326-empty-states
+++ b/changes/44326-empty-states
@@ -1,3 +1,0 @@
-- UI table controls stay visible when empty. On Hosts, Reports, Policies, and Software pages, search bars, filters, dropdowns, remain visible but disabled when empty — avoids layout shift when the first item is added. Item count remains visible.
-- UI has action-oriented empty state copy. Headers describe current state ("No hosts", "No policies for this fleet") instead of prompting action. Body text explains what to expect. CTA buttons are explicit ("Add policy", "Schedule a report") and permission gated.
-- UI shows consistent page descriptions and learn more links (added to Settings. Fleets, Ticket destinations, Certificates, and Identity provider pages).

--- a/changes/44333-gitops-custom-org-logo-upload
+++ b/changes/44333-gitops-custom-org-logo-upload
@@ -1,1 +1,0 @@
-* Added gitops support for uploading custom org logos: `fleetctl gitops` accepts `org_logo_path_dark_mode`/`org_logo_path_light_mode` keys to upload local files, and `fleetctl generate-gitops` exports Fleet-hosted logos as local files alongside path keys while keeping external URLs as `org_logo_url_*_mode` keys.

--- a/changes/44376-stale-apns-push-cert-not-updated
+++ b/changes/44376-stale-apns-push-cert-not-updated
@@ -1,1 +1,0 @@
-- Fixed an issue where an old APNs cert would stay in memory until a restart, instead of correctly updating in place.

--- a/changes/44391-osv-vuln-optimizations
+++ b/changes/44391-osv-vuln-optimizations
@@ -1,1 +1,0 @@
-* Optimized OSV vulnerability scanning to query distinct software per OS version rather than per host, reducing redundant database queries for many hosts sharing the same packages.

--- a/changes/44391-vuln-scan-product-index
+++ b/changes/44391-vuln-scan-product-index
@@ -1,1 +1,0 @@
-* Improved vulnerability scanning performance by using a per-vendor product cache during CVE matching to optimize translate_cpe_to_cve.

--- a/changes/44422-list-mdm-commands-host-identifier-after
+++ b/changes/44422-list-mdm-commands-host-identifier-after
@@ -1,1 +1,0 @@
-- Fixed `GET /api/v1/fleet/commands` returning a SQL error when called with `host_identifier` and the `after` cursor parameter, particularly with `order_key=command_uuid` or `order_key=hostname`.

--- a/changes/44456-validate-payload-scope-dry-run
+++ b/changes/44456-validate-payload-scope-dry-run
@@ -1,1 +1,0 @@
-- Fixed an issue where GitOps dry-run would not validate Apple config profile payload scope conflicts, and use of unknown Fleet variables in all types of profiles.

--- a/changes/44459-recovery-password-key-team-transfer
+++ b/changes/44459-recovery-password-key-team-transfer
@@ -1,1 +1,0 @@
-- Fixed recovery lock password not being retrievable for hosts transferred to a team with recovery lock disabled.

--- a/changes/44533-request-pem-certificate
+++ b/changes/44533-request-pem-certificate
@@ -1,1 +1,0 @@
-* Added an option to convert and return a PEM-encoded X.509 certificate instead of a PEM-encoded PKCS7 envelope from the Request a Certificate endpoint.

--- a/changes/44630-fix-enable-host-users-default
+++ b/changes/44630-fix-enable-host-users-default
@@ -1,1 +1,0 @@
-* Fixed a bug where `enable_host_users` defaulted to `false` on a fresh Fleet install instead of the documented default `true`, causing the host details page to show "User collection has been disabled."

--- a/changes/44696-add-list-software-perms-for-gitops
+++ b/changes/44696-add-list-software-perms-for-gitops
@@ -1,1 +1,0 @@
-- Added permissions for GitOps user to list software titles

--- a/changes/44798-scope-windows-mdm-profiles-query
+++ b/changes/44798-scope-windows-mdm-profiles-query
@@ -1,1 +1,0 @@
-* Improved Windows MDM profile removal performance by scoping the desired-state subquery.

--- a/changes/44801-end-user-auth-windows-linux-only
+++ b/changes/44801-end-user-auth-windows-linux-only
@@ -1,1 +1,0 @@
-- Fixed validation that rejected enabling end user authentication on Fleet deployments without Apple MDM configured. End user authentication covers macOS Setup Assistant, Windows MDM, and Linux Orbit enrollment, so the toggle now works on Windows-only and Linux-only fleets as long as the IdP is configured.

--- a/changes/44804-win-mdm-profile-bulk-insert
+++ b/changes/44804-win-mdm-profile-bulk-insert
@@ -1,1 +1,0 @@
-* Consolidate non-variable templated Windows MDM profile command inserts from N per-profile to a single bulk insert.

--- a/changes/44816-fast-fail-device-auth
+++ b/changes/44816-fast-fail-device-auth
@@ -1,1 +1,0 @@
-- Reduced database load from `GET /api/latest/fleet/device/{token}/desktop` and other Fleet Desktop endpoints when invalid or expired device auth tokens are presented, by resolving the token to a host id with a single-table indexed lookup before running the multi-join host-details query.

--- a/changes/44950-gitops-null-label-id
+++ b/changes/44950-gitops-null-label-id
@@ -1,1 +1,0 @@
-* Fixed a GitOps failure ("converting NULL to uint is unsupported") when moving labels from global to fleet scope, caused by deleted label associations with NULL `label_id` values in `mdm_configuration_profile_labels` and `mdm_declaration_labels`.

--- a/changes/44980-always-assign-profile-missing-devices
+++ b/changes/44980-always-assign-profile-missing-devices
@@ -1,1 +1,0 @@
-- Fixed an issue where replica lag could lead to devices not being assigned a setup experience profile, on device sync from DEP.

--- a/changes/45018-export-host-bug
+++ b/changes/45018-export-host-bug
@@ -1,1 +1,0 @@
-- Fleet UI: Export hosts button now always reflects the current sort, search, and filter state instead of potentially using stale values.

--- a/changes/45024-android-sso-missing-profile
+++ b/changes/45024-android-sso-missing-profile
@@ -1,1 +1,0 @@
-Fixed MDM SSO callback returning "missing profile" error for Android enrollment when Apple MDM is not configured.

--- a/changes/45141-edit-label-form-mention-fleets
+++ b/changes/45141-edit-label-form-mention-fleets
@@ -1,1 +1,0 @@
-* Mention "fleets" instead of "teams" in the Edit label page when it's associated with a fleet.

--- a/changes/45256-reduce-fleet-and-fleetctl-binary-sizes
+++ b/changes/45256-reduce-fleet-and-fleetctl-binary-sizes
@@ -1,1 +1,0 @@
-* Removed debug symbols from fleet and fleetctl executables to reduce binary size.

--- a/changes/45258-android-host-expiry-loop
+++ b/changes/45258-android-host-expiry-loop
@@ -1,1 +1,0 @@
-- Fixed Android hosts being auto-deleted by host expiry on every cleanup tick after re-enrolling, which previously caused an hourly enroll/delete loop while host expiry was enabled.

--- a/changes/45330-gitops-mode-from-yaml
+++ b/changes/45330-gitops-mode-from-yaml
@@ -1,1 +1,0 @@
-- Added support for setting `gitops_mode_enabled` and `repository_url` via GitOps.

--- a/changes/45491-mdm-name-from-server-url-nondeterministic
+++ b/changes/45491-mdm-name-from-server-url-nondeterministic
@@ -1,1 +1,0 @@
-- Fixed an issue where the MDM solution name reported for a host could flip between values across osquery ingestions when the MDM server URL contained substrings matching multiple known MDM vendors.

--- a/changes/45520-nil-pointer-panic-in-android-enterprise-pubsub-endpoint
+++ b/changes/45520-nil-pointer-panic-in-android-enterprise-pubsub-endpoint
@@ -1,1 +1,0 @@
-- Fixed a nil-pointer panic in the Android Enterprise Pub/Sub endpoint that occurred when Google's Android Management API sent a device payload missing `hardwareInfo`, `softwareInfo`, or `memoryInfo`.

--- a/changes/45705-android-gitops-fix
+++ b/changes/45705-android-gitops-fix
@@ -1,1 +1,0 @@
-- Fixed `fleetctl gitops` rejecting Android or Windows configuration profiles when editing an existing team, even when the corresponding MDM platform was configured.

--- a/changes/45715-implement-roaring-bitmaps
+++ b/changes/45715-implement-roaring-bitmaps
@@ -1,1 +1,0 @@
-- Implement roaring bitmaps in historical data collection for improved performance.

--- a/changes/45720-remove-unneeded-query
+++ b/changes/45720-remove-unneeded-query
@@ -1,1 +1,0 @@
-- Remove unneeded call to get tracked CVEs when reading CVE chart data

--- a/changes/45763-unable-to-issue-dynamic-scep-certificates-after-4850-upgrade
+++ b/changes/45763-unable-to-issue-dynamic-scep-certificates-after-4850-upgrade
@@ -1,1 +1,0 @@
-- Fixed dynamic SCEP certificate issuance failing with an "Invalid NDES admin credentials" error when the NDES Admin URL is fronted by Okta or another gateway that uses HTTP Basic auth instead of NTLM.

--- a/changes/45844-gitops-vpp-dry-run-label-validation
+++ b/changes/45844-gitops-vpp-dry-run-label-validation
@@ -1,1 +1,0 @@
-- Fixed GitOps dry runs failing when a VPP app references a label that was added in the same run.

--- a/changes/46001-android-orbit-enroll-duplicate-host
+++ b/changes/46001-android-orbit-enroll-duplicate-host
@@ -1,1 +1,0 @@
-- Fixed a bug where enrolling an Android device on a Fleet instance with Apple MDM disabled produced a duplicate host record.

--- a/changes/46009-fix-host-activity-user-enrichment-authz
+++ b/changes/46009-fix-host-activity-user-enrichment-authz
@@ -1,1 +1,0 @@
-* Fixed Fleet-scoped users getting a 403 when viewing past activities on a host that has user-initiated activities (e.g. lock/wipe/run script/install software).

--- a/changes/46009-fix-missing-opa-policy-tags
+++ b/changes/46009-fix-missing-opa-policy-tags
@@ -1,1 +1,0 @@
-* Fixed permissions on host activity items for fleet-scoped users.

--- a/changes/add-svg-support-custom-logos
+++ b/changes/add-svg-support-custom-logos
@@ -1,1 +1,0 @@
-* Added SVG support for custom organization logos, with strict server-side sanitization to reject scripts and other unsafe SVG content.

--- a/changes/cleanup-list-opts
+++ b/changes/cleanup-list-opts
@@ -1,1 +1,0 @@
-* Improved validation of order parameters on list endpoints

--- a/changes/fix-android-host-software-filter
+++ b/changes/fix-android-host-software-filter
@@ -1,1 +1,0 @@
-* Fixed a dead SQL condition in `hostVPPInstalls` that was misleading but harmless: Android VPP apps never produce `nano_command_results` entries (they use Google's Android Management API, not nanoMDM), so the previous `(hvsi.platform != 'android' OR ncr.id IS NULL)` guard was a tautology. Replaced with a clarifying comment.

--- a/changes/fix-fleetctl-new-checkout-action
+++ b/changes/fix-fleetctl-new-checkout-action
@@ -1,1 +1,0 @@
-- Updated the version of the checkout action in the `fleetctl new` template to avoid Node warnings.

--- a/changes/fix-get-policy-id-endpoint-and-unify-access-in-ui
+++ b/changes/fix-get-policy-id-endpoint-and-unify-access-in-ui
@@ -1,3 +1,0 @@
-- Fixed `GET /api/latest/fleet/policies/:id` endpoint (and alias `GET /api/v1/fleet/global/policies/:id`) to return (and properly populate) team policies.
-- Fixed `GET /api/latest/fleet/policies/:id` endpoint (and alias `GET /api/v1/fleet/global/policies/:id`) to perform authorization check on team policies before returning.
-- Unify access to global and team policies in UI by using the now generic `GET /api/latest/fleet/policies/:id` endpoint.

--- a/changes/fix-gitops-controls-set-criteria
+++ b/changes/fix-gitops-controls-set-criteria
@@ -1,1 +1,0 @@
-- Fixed an issue where a GitOps controls with only certain keys would not be seen as set.

--- a/changes/fix-hosts-in-label-filtering
+++ b/changes/fix-hosts-in-label-filtering
@@ -1,1 +1,0 @@
-* Fixed filtering in `/api/v1/fleet/labels/:id/hosts` endpoint.

--- a/changes/fix-mdm-commands-filtering
+++ b/changes/fix-mdm-commands-filtering
@@ -1,1 +1,0 @@
-* Improved validation for invalid `order_key` values in `/api/v1/fleet/commands`, `/api/v1/fleet/mdm/commands` and `/api/v1/fleet/mdm/apple/commands` endpoints.

--- a/changes/fleetd-base-windows-secret
+++ b/changes/fleetd-base-windows-secret
@@ -1,1 +1,0 @@
-* Modified the MSI builder to not package the unusable "dummy" secret value when building fleetd-base.msi for Autopilot installs

--- a/changes/update-go-1.26.3
+++ b/changes/update-go-1.26.3
@@ -1,1 +1,0 @@
-* Updated go to 1.26.3

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v7.0.3
+version: v7.0.4
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.85.1
+appVersion: v4.86.0
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.85.1 # Version of Fleet to deploy
+imageTag: v4.86.0 # Version of Fleet to deploy
 # imagePullPolicy is optional. If unset, Kubernetes defaults to IfNotPresent
 # for tagged images and Always for the :latest tag. Valid values: Always,
 # IfNotPresent, Never.

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.85.1"
+  default     = "fleetdm/fleet:v4.86.0"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.85.1"
+  default = "fleetdm/fleet:v4.86.0"
 }
 
 variable "software_installers_bucket_name" {

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.85.1",
+  "version": "v4.86.0",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/github-manage/cmd/gm/releases.go
+++ b/tools/github-manage/cmd/gm/releases.go
@@ -207,7 +207,7 @@ Size mapping (low-high):
   XL:  75-100
 
 Usage:
-  gm releases forecast --milestone "Fleet 4.85.1"`,
+  gm releases forecast --milestone "Fleet 4.86.0"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		releasesProjectID := 87 // fleet Releases project
 		milestoneTitle, _ := cmd.Flags().GetString("milestone")
@@ -319,5 +319,5 @@ func init() {
 	releasesSyncEstimatesCmd.Flags().BoolP("overwrite", "o", false, "Overwrite existing Releases estimates (by default, issues with estimates are skipped)")
 	releasesSyncEstimatesCmd.Flags().StringP("milestone", "m", "", "Only process issues in this milestone, e.g., Fleet 4.77.0")
 
-	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.85.1 (required)")
+	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.86.0 (required)")
 }


### PR DESCRIPTION
Cherry-picks `c94e74bcde` (PR #45742) from `rc-minor-fleet-v4.86.0` into `main` so main reflects the v4.86.0 version bump (CHANGELOG, Helm chart, dogfood terraform, fleetctl-npm, release tooling).

## Conflict resolution

`charts/fleet/values.yaml`: kept the new `imagePullPolicy` comment block from main and applied the version bump (`v4.85.1` → `v4.86.0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iOS/iPadOS software install support for user-enrolled devices via Account-Driven User Enrollment.
  * Custom organization logo uploads (light/dark variants) now hosted by Fleet.
  * Dashboard now displays "Hosts online" and "Hosts enrolled" charts.
  * SVG support for custom logos with security sanitization.
  * "Include all" and "Custom" label scope options for policies and reports.

* **Bug Fixes**
  * Improved SMTP error messaging for SSL/TLS configuration issues.
  * Fixed export hosts to match current UI filters, sort, and search state.
  * Corrected host activity permissions for fleet-scoped users.

* **Improvements**
  * Reduced fleet and fleetctl binary sizes.
  * Enhanced UI empty-state consistency across pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->