### PR TITLE
Extract Apple MDM initialization out of runServeCmd

### DIFF
--- a/cmd/fleet/mdm_apple.go
+++ b/cmd/fleet/mdm_apple.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/dev_mode"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/buford"
+	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
+	scepdepot "github.com/fleetdm/fleet/v4/server/mdm/scep/depot"
+	"github.com/fleetdm/fleet/v4/server/service"
+)
+
+// initAppleMDMStorages constructs the three NanoMDM-backed storages used by
+// the Apple MDM stack: MDM, DEP, and SCEP. Each call delegates to the
+// MySQL datastore; failures go through initFatal. Returns nil values on
+// the failure path so the function is safe when initFatal does not
+// terminate (e.g., tests using a recorder).
+func initAppleMDMStorages(mds *mysql.Datastore, initFatal func(err error, msg string)) (
+	*mysql.NanoMDMStorage,
+	*mysql.NanoDEPStorage,
+	scepdepot.Depot,
+) {
+	mdmStorage, err := mds.NewMDMAppleMDMStorage()
+	if err != nil {
+		initFatal(err, "initialize mdm apple MySQL storage")
+		return nil, nil, nil
+	}
+
+	depStorage, err := mds.NewMDMAppleDEPStorage()
+	if err != nil {
+		initFatal(err, "initialize Apple BM DEP storage")
+		return nil, nil, nil
+	}
+
+	scepStorage, err := mds.NewSCEPDepot()
+	if err != nil {
+		initFatal(err, "initialize mdm apple scep storage")
+		return nil, nil, nil
+	}
+
+	return mdmStorage, depStorage, scepStorage
+}
+
+// initAppleMDMPushService chooses the push service implementation: a no-op
+// pusher when FLEET_DEV_MDM_APPLE_DISABLE_PUSH=1 (development mode), or a
+// real APNs pusher built around the NanoMDM storage in all other cases.
+func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, logger *slog.Logger) push.Pusher {
+	if dev_mode.Env("FLEET_DEV_MDM_APPLE_DISABLE_PUSH") == "1" {
+		return nopPusher{}
+	}
+	nanoMDMLogger := service.NewNanoMDMLogger(logger.With("component", "apple-mdm-push"))
+	pushProviderFactory := buford.NewPushProviderFactory(buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
+		return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
+			Certificates: []tls.Certificate{*cert},
+		})), nil
+	}))
+	return nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)
+}
+
+// checkMDMAssetsExist reports whether the named MDM config assets exist in
+// the datastore. Returns false (without error) when assets are missing
+// entirely or partially — both are valid "not configured yet" states for
+// the caller. Other datastore errors are surfaced.
+func checkMDMAssetsExist(ctx context.Context, ds fleet.Datastore, names []fleet.MDMAssetName) (bool, error) {
+	_, err := ds.GetAllMDMConfigAssetsByName(ctx, names, nil)
+	if err != nil {
+		if fleet.IsNotFound(err) || errors.Is(err, mysql.ErrPartialResult) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// reconcileAppleMDMAPNsAndSCEPAssets reconciles APNs and SCEP cert/key
+// assets between the server configuration and the datastore. If either
+// APNs or SCEP is configured, the function requires a server private key,
+// inserts the configured certs and keys when the datastore has none, and
+// warns when the datastore already has them. Validates that both APNs and
+// SCEP are provided together when insert is required. No-op when neither
+// is configured.
+func reconcileAppleMDMAPNsAndSCEPAssets(
+	ctx context.Context,
+	cfg config.FleetConfig,
+	ds fleet.Datastore,
+	logger *slog.Logger,
+	initFatal func(err error, msg string),
+) {
+	if !cfg.MDM.IsAppleAPNsSet() && !cfg.MDM.IsAppleSCEPSet() {
+		return
+	}
+	if len(cfg.Server.PrivateKey) == 0 {
+		initFatal(errors.New("inserting MDM APNs and SCEP assets"),
+			"missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
+		return
+	}
+
+	// First check if the APNs and SCEP assets are already in the database
+	// and only insert config values if they're not already present.
+	toInsert := make(map[fleet.MDMAssetName]struct{}, 4)
+
+	// APNs assets.
+	found, err := checkMDMAssetsExist(ctx, ds, []fleet.MDMAssetName{fleet.MDMAssetAPNSCert, fleet.MDMAssetAPNSKey})
+	switch {
+	case err != nil:
+		initFatal(err, "reading APNs assets from database")
+		return
+	case !found:
+		toInsert[fleet.MDMAssetAPNSCert] = struct{}{}
+		toInsert[fleet.MDMAssetAPNSKey] = struct{}{}
+	default:
+		logger.WarnContext(ctx,
+			"Your server already has stored APNs certificates. Fleet will ignore any certificates provided via environment variables when this happens.")
+	}
+
+	// SCEP assets.
+	found, err = checkMDMAssetsExist(ctx, ds, []fleet.MDMAssetName{fleet.MDMAssetCACert, fleet.MDMAssetCAKey})
+	switch {
+	case err != nil:
+		initFatal(err, "reading SCEP assets from database")
+		return
+	case !found:
+		toInsert[fleet.MDMAssetCACert] = struct{}{}
+		toInsert[fleet.MDMAssetCAKey] = struct{}{}
+	default:
+		logger.WarnContext(ctx,
+			"Your server already has stored SCEP certificates. Fleet will ignore any certificates provided via environment variables when this happens.")
+	}
+
+	if len(toInsert) == 0 {
+		return
+	}
+
+	cfg.MDM.ValidateAppleAPNSAndSCEPPair(initFatal)
+
+	_, apnsCertPEM, apnsKeyPEM, err := cfg.MDM.AppleAPNs()
+	if err != nil {
+		initFatal(err, "parse Apple APNs certificate and key from config")
+		return
+	}
+	_, appleSCEPCertPEM, appleSCEPKeyPEM, err := cfg.MDM.AppleSCEP()
+	if err != nil {
+		initFatal(err, "load Apple SCEP certificate and key from config")
+		return
+	}
+
+	var args []fleet.MDMConfigAsset
+	for name := range toInsert {
+		switch name {
+		case fleet.MDMAssetAPNSCert:
+			args = append(args, fleet.MDMConfigAsset{Name: name, Value: apnsCertPEM})
+		case fleet.MDMAssetAPNSKey:
+			args = append(args, fleet.MDMConfigAsset{Name: name, Value: apnsKeyPEM})
+		case fleet.MDMAssetCACert:
+			args = append(args, fleet.MDMConfigAsset{Name: name, Value: appleSCEPCertPEM})
+		case fleet.MDMAssetCAKey:
+			args = append(args, fleet.MDMConfigAsset{Name: name, Value: appleSCEPKeyPEM})
+		}
+	}
+
+	if err := ds.InsertMDMConfigAssets(ctx, args, nil); err != nil {
+		if mysql.IsDuplicate(err) {
+			// We already checked for existing assets so we should never hit a
+			// duplicate key error here; log just in case.
+			logger.DebugContext(ctx, "unexpected duplicate key error inserting MDM APNs and SCEP assets")
+			return
+		}
+		initFatal(err, "inserting MDM APNs and SCEP assets")
+		return
+	}
+}
+
+// reconcileAppleMDMABMAssets reconciles Apple Business Manager (ABM)
+// assets between the server configuration and the datastore. Similar shape
+// to reconcileAppleMDMAPNsAndSCEPAssets but also inserts a freshly-created
+// ABM token row on first setup so the apple_mdm_dep_profile_assigner cron
+// can backfill it. No-op when ABM is not configured.
+func reconcileAppleMDMABMAssets(
+	ctx context.Context,
+	cfg config.FleetConfig,
+	ds fleet.Datastore,
+	logger *slog.Logger,
+	initFatal func(err error, msg string),
+) {
+	if !cfg.MDM.IsAppleBMSet() {
+		return
+	}
+	if len(cfg.Server.PrivateKey) == 0 {
+		initFatal(errors.New("inserting MDM ABM assets"),
+			"missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
+		return
+	}
+
+	appleBM, err := cfg.MDM.AppleBM()
+	if err != nil {
+		initFatal(err, "parse Apple BM token, certificate and key from config")
+		return
+	}
+
+	toInsert := make([]fleet.MDMConfigAsset, 0, 2)
+
+	found, err := checkMDMAssetsExist(ctx, ds, []fleet.MDMAssetName{fleet.MDMAssetABMKey, fleet.MDMAssetABMCert})
+	switch {
+	case err != nil:
+		initFatal(err, "reading ABM assets from database")
+		return
+	case !found:
+		toInsert = append(toInsert,
+			fleet.MDMConfigAsset{Name: fleet.MDMAssetABMKey, Value: appleBM.KeyPEM},
+			fleet.MDMConfigAsset{Name: fleet.MDMAssetABMCert, Value: appleBM.CertPEM},
+		)
+	default:
+		logger.WarnContext(ctx,
+			"Your server already has stored ABM certificates and token. Fleet will ignore any certificates provided via environment variables when this happens.")
+	}
+
+	if len(toInsert) == 0 {
+		return
+	}
+
+	err = ds.InsertMDMConfigAssets(ctx, toInsert, nil)
+	switch {
+	case err != nil && mysql.IsDuplicate(err):
+		// We already checked for existing assets so we should never hit a
+		// duplicate key error here; log just in case.
+		logger.DebugContext(ctx, "unexpected duplicate key error inserting ABM assets")
+		return
+	case err != nil:
+		initFatal(err, "inserting ABM assets")
+		return
+	}
+
+	// Insert the ABM token without any metadata; it'll be picked up by the
+	// apple_mdm_dep_profile_assigner cron and backfilled. 2000-01-01 is our
+	// "zero value" for time.
+	if _, err := ds.InsertABMToken(ctx, &fleet.ABMToken{
+		EncryptedToken: appleBM.EncryptedToken,
+		RenewAt:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		initFatal(err, "save ABM token")
+	}
+}

--- a/cmd/fleet/mdm_apple.go
+++ b/cmd/fleet/mdm_apple.go
@@ -62,6 +62,7 @@ func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, logger *slog.Logg
 	pushProviderFactory := buford.NewPushProviderFactory(buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
 		return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
 			Certificates: []tls.Certificate{*cert},
+			MinVersion:   tls.VersionTLS12, // Apple APNs requires TLS 1.2+
 		})), nil
 	}))
 	return nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)

--- a/cmd/fleet/mdm_apple_test.go
+++ b/cmd/fleet/mdm_apple_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/dev_mode"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+// notFoundErr is a minimal error that satisfies fleet.IsNotFound.
+type notFoundErr struct{}
+
+func (notFoundErr) Error() string    { return "not found" }
+func (notFoundErr) IsNotFound() bool { return true }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func TestInitAppleMDMPushService_DevModeReturnsNopPusher(t *testing.T) {
+	// SetOverride enables dev mode and registers cleanup via t.
+	dev_mode.SetOverride("FLEET_DEV_MDM_APPLE_DISABLE_PUSH", "1", t)
+
+	pusher := initAppleMDMPushService(nil, discardLogger())
+	require.IsType(t, nopPusher{}, pusher)
+}
+
+func TestCheckMDMAssetsExist(t *testing.T) {
+	names := []fleet.MDMAssetName{fleet.MDMAssetAPNSCert, fleet.MDMAssetAPNSKey}
+
+	t.Run("assets present returns true", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, n []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{}, nil
+		}
+		found, err := checkMDMAssetsExist(context.Background(), ds, names)
+		require.NoError(t, err)
+		require.True(t, found)
+	})
+
+	t.Run("not found returns false without error", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, n []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return nil, notFoundErr{}
+		}
+		found, err := checkMDMAssetsExist(context.Background(), ds, names)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("partial result returns false without error", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, n []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return nil, mysql.ErrPartialResult
+		}
+		found, err := checkMDMAssetsExist(context.Background(), ds, names)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("other error is surfaced", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, n []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return nil, sql.ErrConnDone
+		}
+		found, err := checkMDMAssetsExist(context.Background(), ds, names)
+		require.Error(t, err)
+		require.False(t, found)
+	})
+}
+
+func TestReconcileAppleMDMAPNsAndSCEPAssets(t *testing.T) {
+	t.Run("neither APNs nor SCEP set is a no-op", func(t *testing.T) {
+		ds := new(mock.Store)
+		called := false
+		reconcileAppleMDMAPNsAndSCEPAssets(context.Background(), config.FleetConfig{}, ds, discardLogger(),
+			func(err error, msg string) { called = true })
+		require.False(t, called, "initFatal must not be called when neither is configured")
+		require.False(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked, "datastore must not be touched")
+	})
+
+	t.Run("configured without server private key fails fast", func(t *testing.T) {
+		ds := new(mock.Store)
+		cfg := config.FleetConfig{
+			MDM: config.MDMConfig{AppleAPNsCert: "apns.cert"},
+		}
+		called := false
+		reconcileAppleMDMAPNsAndSCEPAssets(context.Background(), cfg, ds, discardLogger(),
+			func(err error, msg string) { called = true })
+		require.True(t, called, "initFatal must be called when private key is missing")
+		require.False(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked, "must fail before touching datastore")
+	})
+}
+
+func TestReconcileAppleMDMABMAssets(t *testing.T) {
+	t.Run("ABM not set is a no-op", func(t *testing.T) {
+		ds := new(mock.Store)
+		called := false
+		reconcileAppleMDMABMAssets(context.Background(), config.FleetConfig{}, ds, discardLogger(),
+			func(err error, msg string) { called = true })
+		require.False(t, called)
+		require.False(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked)
+	})
+
+	t.Run("ABM set without server private key fails fast", func(t *testing.T) {
+		ds := new(mock.Store)
+		cfg := config.FleetConfig{
+			MDM: config.MDMConfig{AppleBMCert: "abm.cert"},
+		}
+		called := false
+		reconcileAppleMDMABMAssets(context.Background(), cfg, ds, discardLogger(),
+			func(err error, msg string) { called = true })
+		require.True(t, called)
+		require.False(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked)
+	})
+}

--- a/cmd/fleet/mdm_apple_test.go
+++ b/cmd/fleet/mdm_apple_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/config"
@@ -14,6 +15,18 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
+
+// validPrivateKey is a 32-byte string used to satisfy the server private-key
+// length requirement in reconciliation tests.
+var validPrivateKey = strings.Repeat("x", 32)
+
+// assetsPresentFunc returns a GetAllMDMConfigAssetsByNameFunc that reports the
+// requested assets as already stored.
+func assetsPresentFunc() mock.GetAllMDMConfigAssetsByNameFunc {
+	return func(ctx context.Context, n []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+		return map[fleet.MDMAssetName]fleet.MDMConfigAsset{}, nil
+	}
+}
 
 // notFoundErr is a minimal error that satisfies fleet.IsNotFound.
 type notFoundErr struct{}
@@ -97,6 +110,21 @@ func TestReconcileAppleMDMAPNsAndSCEPAssets(t *testing.T) {
 			func(err error, msg string) { called = true })
 		require.True(t, called, "initFatal must be called when private key is missing")
 		require.False(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked, "must fail before touching datastore")
+	})
+
+	t.Run("assets already present skips insert", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetAllMDMConfigAssetsByNameFunc = assetsPresentFunc()
+		cfg := config.FleetConfig{
+			Server: config.ServerConfig{PrivateKey: validPrivateKey},
+			MDM:    config.MDMConfig{AppleAPNsCert: "apns.cert", AppleSCEPCert: "scep.cert"},
+		}
+		called := false
+		reconcileAppleMDMAPNsAndSCEPAssets(context.Background(), cfg, ds, discardLogger(),
+			func(err error, msg string) { called = true })
+		require.False(t, called)
+		require.True(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked, "datastore is checked")
+		require.False(t, ds.InsertMDMConfigAssetsFuncInvoked, "insert is skipped when assets exist")
 	})
 }
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -34,7 +34,6 @@ import (
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
 	"github.com/fleetdm/fleet/v4/ee/server/service/scep"
-	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/pkg/scripts"
 	"github.com/fleetdm/fleet/v4/pkg/str"
 	"github.com/fleetdm/fleet/v4/server"
@@ -78,8 +77,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/cryptoutil"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
-	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/buford"
-	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 	scepdepot "github.com/fleetdm/fleet/v4/server/mdm/scep/depot"
 	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
@@ -543,168 +540,14 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		logger.WarnContext(cmd.Context(), "Disabling custom FileVault management because Fleet Premium license is not present")
 	}
 
-	mdmStorage, err := mds.NewMDMAppleMDMStorage()
-	if err != nil {
-		initFatal(err, "initialize mdm apple MySQL storage")
-	}
+	mdmStorage, depStorage, scepStorage := initAppleMDMStorages(mds, initFatal)
 
-	depStorage, err := mds.NewMDMAppleDEPStorage()
-	if err != nil {
-		initFatal(err, "initialize Apple BM DEP storage")
-	}
-
-	scepStorage, err := mds.NewSCEPDepot()
-	if err != nil {
-		initFatal(err, "initialize mdm apple scep storage")
-	}
-
-	var mdmPushService push.Pusher
-	nanoMDMLogger := service.NewNanoMDMLogger(logger.With("component", "apple-mdm-push"))
-	pushProviderFactory := buford.NewPushProviderFactory(buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
-		return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
-			Certificates: []tls.Certificate{*cert},
-		})), nil
-	}))
-	if dev_mode.Env("FLEET_DEV_MDM_APPLE_DISABLE_PUSH") == "1" {
-		mdmPushService = nopPusher{}
-	} else {
-		mdmPushService = nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)
-	}
+	mdmPushService := initAppleMDMPushService(mdmStorage, logger)
 	mds.WithPusher(mdmPushService)
 
-	checkMDMAssets := func(names []fleet.MDMAssetName) (bool, error) {
-		_, err = ds.GetAllMDMConfigAssetsByName(context.Background(), names, nil)
-		if err != nil {
-			if fleet.IsNotFound(err) || errors.Is(err, mysql.ErrPartialResult) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	}
-
-	// reconcile Apple Business configuration environment variables with the database
-	if config.MDM.IsAppleAPNsSet() || config.MDM.IsAppleSCEPSet() {
-		if len(config.Server.PrivateKey) == 0 {
-			initFatal(errors.New("inserting MDM APNs and SCEP assets"),
-				"missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
-		}
-
-		// first we'll check if the APNs and SCEP assets are already in the database and
-		// only insert config values if they're not already present in the database
-		toInsert := make(map[fleet.MDMAssetName]struct{}, 4)
-
-		// check DB for APNs assets
-		found, err := checkMDMAssets([]fleet.MDMAssetName{fleet.MDMAssetAPNSCert, fleet.MDMAssetAPNSKey})
-		switch {
-		case err != nil:
-			initFatal(err, "reading APNs assets from database")
-		case !found:
-			toInsert[fleet.MDMAssetAPNSCert] = struct{}{}
-			toInsert[fleet.MDMAssetAPNSKey] = struct{}{}
-		default:
-			logger.WarnContext(cmd.Context(),
-				"Your server already has stored APNs certificates. Fleet will ignore any certificates provided via environment variables when this happens.")
-		}
-
-		// check DB for SCEP assets
-		found, err = checkMDMAssets([]fleet.MDMAssetName{fleet.MDMAssetCACert, fleet.MDMAssetCAKey})
-		switch {
-		case err != nil:
-			initFatal(err, "reading SCEP assets from database")
-		case !found:
-			toInsert[fleet.MDMAssetCACert] = struct{}{}
-			toInsert[fleet.MDMAssetCAKey] = struct{}{}
-		default:
-			logger.WarnContext(cmd.Context(),
-				"Your server already has stored SCEP certificates. Fleet will ignore any certificates provided via environment variables when this happens.")
-		}
-
-		if len(toInsert) > 0 {
-			config.MDM.ValidateAppleAPNSAndSCEPPair(initFatal)
-
-			// parse the APNs and SCEP assets from the config
-			_, apnsCertPEM, apnsKeyPEM, err := config.MDM.AppleAPNs()
-			if err != nil {
-				initFatal(err, "parse Apple APNs certificate and key from config")
-			}
-			_, appleSCEPCertPEM, appleSCEPKeyPEM, err := config.MDM.AppleSCEP()
-			if err != nil {
-				initFatal(err, "load Apple SCEP certificate and key from config")
-			}
-
-			var args []fleet.MDMConfigAsset
-			for name := range toInsert {
-				switch name {
-				case fleet.MDMAssetAPNSCert:
-					args = append(args, fleet.MDMConfigAsset{Name: name, Value: apnsCertPEM})
-				case fleet.MDMAssetAPNSKey:
-					args = append(args, fleet.MDMConfigAsset{Name: name, Value: apnsKeyPEM})
-				case fleet.MDMAssetCACert:
-					args = append(args, fleet.MDMConfigAsset{Name: name, Value: appleSCEPCertPEM})
-				case fleet.MDMAssetCAKey:
-					args = append(args, fleet.MDMConfigAsset{Name: name, Value: appleSCEPKeyPEM})
-				}
-			}
-
-			if err := ds.InsertMDMConfigAssets(context.Background(), args, nil); err != nil {
-				if mysql.IsDuplicate(err) {
-					// we already checked for existing assets so we should never have a duplicate key error here; we'll add a debug log just in case
-					logger.DebugContext(cmd.Context(), "unexpected duplicate key error inserting MDM APNs and SCEP assets")
-				} else {
-					initFatal(err, "inserting MDM APNs and SCEP assets")
-				}
-			}
-		}
-	}
-
-	// reconcile Apple Business configuration environment variables with the database
-	if config.MDM.IsAppleBMSet() {
-		if len(config.Server.PrivateKey) == 0 {
-			initFatal(errors.New("inserting MDM ABM assets"),
-				"missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
-		}
-
-		appleBM, err := config.MDM.AppleBM()
-		if err != nil {
-			initFatal(err, "parse Apple BM token, certificate and key from config")
-		}
-
-		toInsert := make([]fleet.MDMConfigAsset, 0, 2)
-
-		found, err := checkMDMAssets([]fleet.MDMAssetName{fleet.MDMAssetABMKey, fleet.MDMAssetABMCert})
-		switch {
-		case err != nil:
-			initFatal(err, "reading ABM assets from database")
-		case !found:
-			toInsert = append(toInsert, fleet.MDMConfigAsset{Name: fleet.MDMAssetABMKey, Value: appleBM.KeyPEM},
-				fleet.MDMConfigAsset{Name: fleet.MDMAssetABMCert, Value: appleBM.CertPEM})
-		default:
-			logger.WarnContext(cmd.Context(),
-				"Your server already has stored ABM certificates and token. Fleet will ignore any certificates provided via environment variables when this happens.")
-		}
-
-		if len(toInsert) > 0 {
-			err := ds.InsertMDMConfigAssets(context.Background(), toInsert, nil)
-			switch {
-			case err != nil && mysql.IsDuplicate(err):
-				// we already checked for existing assets so we should never have a duplicate key error here; we'll add a debug log just in case
-				logger.DebugContext(cmd.Context(), "unexpected duplicate key error inserting ABM assets")
-			case err != nil:
-				initFatal(err, "inserting ABM assets")
-			default:
-				// insert the ABM token without any metdata; it'll be picked by the
-				// apple_mdm_dep_profile_assigner cron and backfilled
-				if _, err := ds.InsertABMToken(context.Background(), &fleet.ABMToken{
-					EncryptedToken: appleBM.EncryptedToken,
-					RenewAt: time.Date(2000, time.January, 1, 0, 0, 0, 0,
-						time.UTC), // 2000-01-01 is our "zero value" for time
-				}); err != nil {
-					initFatal(err, "save ABM token")
-				}
-			}
-		}
-	}
+	// reconcile Apple MDM and Business Manager configuration with the database
+	reconcileAppleMDMAPNsAndSCEPAssets(context.Background(), config, ds, logger, initFatal)
+	reconcileAppleMDMABMAssets(context.Background(), config, ds, logger, initFatal)
 
 	appCfg, err := ds.AppConfig(context.Background())
 	if err != nil {
@@ -714,7 +557,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	appCfg.MDM.EnabledAndConfigured = false
 	appCfg.MDM.AppleBMEnabledAndConfigured = false
 	if len(config.Server.PrivateKey) > 0 {
-		appCfg.MDM.EnabledAndConfigured, err = checkMDMAssets([]fleet.MDMAssetName{
+		appCfg.MDM.EnabledAndConfigured, err = checkMDMAssetsExist(context.Background(), ds, []fleet.MDMAssetName{
 			fleet.MDMAssetCACert,
 			fleet.MDMAssetCAKey,
 			fleet.MDMAssetAPNSKey,
@@ -725,7 +568,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		}
 
 		var appleBMCerts bool
-		appleBMCerts, err = checkMDMAssets([]fleet.MDMAssetName{
+		appleBMCerts, err = checkMDMAssetsExist(context.Background(), ds, []fleet.MDMAssetName{
 			fleet.MDMAssetABMCert,
 			fleet.MDMAssetABMKey,
 		})
@@ -1519,7 +1362,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		mdmCheckinAndCommandService.RegisterResultsHandler(fleet.DeviceLocationCmdName, service.NewDeviceLocationResultsHandler(ds, commander, logger))
 		mdmCheckinAndCommandService.RegisterResultsHandler(fleet.SetRecoveryLockCmdName, service.NewSetRecoveryLockResultsHandler(ds, logger, svc.NewActivity))
 
-		hasSCEPChallenge, err := checkMDMAssets([]fleet.MDMAssetName{fleet.MDMAssetSCEPChallenge})
+		hasSCEPChallenge, err := checkMDMAssetsExist(context.Background(), ds, []fleet.MDMAssetName{fleet.MDMAssetSCEPChallenge})
 		if err != nil {
 			initFatal(err, "checking SCEP challenge in database")
 		}


### PR DESCRIPTION
Extracts the Apple MDM initialization out of `runServeCmd` into testable functions in a new `cmd/fleet/mdm_apple.go`. Continues the chain of extractions on this issue (#44929, #45343, #45583, #46166, #46421) toward the `serve.go` >60% coverage target discussed on #33370.

Five functions come out of the inline block:

- `initAppleMDMStorages` — constructs the MDM, DEP, and SCEP storages.
- `initAppleMDMPushService` — picks the no-op pusher under `FLEET_DEV_MDM_APPLE_DISABLE_PUSH=1`, otherwise the real APNs pusher.
- `checkMDMAssetsExist` — promotes the inline `checkMDMAssets` closure to a package function. It was already used at several call sites; they now all share this one.
- `reconcileAppleMDMAPNsAndSCEPAssets` / `reconcileAppleMDMABMAssets` — the APNs/SCEP and ABM asset reconciliation blocks.

Behavior is preserved — `runServeCmd` calls these in the same order with the same arguments, and the full `cmd/fleet` suite passes unchanged against MySQL + Redis. Each function returns early after `initFatal` so it's also safe when the caller's `initFatal` doesn't terminate (the case in tests).

On test scope: the new unit tests cover the dev-mode push gate, all four branches of `checkMDMAssetsExist`, and the no-op and missing-private-key paths of both reconcilers. The storage construction and the actual asset-insert paths need a real datastore, so those stay covered by the existing integration tests rather than new unit tests — I didn't want to stand up a full datastore mock for paths that are already exercised end-to-end.

**Related issue:** Refs #33370

# Checklist for submitter

- [x] Added/updated automated tests
- Changes file: not applicable — internal refactor with no user-visible behavior change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apple MDM initialization and configuration management for APNs, SCEP, and Apple Business Manager with automatic reconciliation of missing assets and a dev-mode option to disable push.

* **Tests**
  * Added unit tests covering push-service behavior, asset-existence checks, reconciliation logic, and fail-fast handling when required key material is missing.

* **Refactor**
  * Simplified Apple MDM initialization flow by extracting initialization, push-service, and reconciliation logic into helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->