### PR TITLE
Create ~/.fleet on first `make serve`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ else
 serve:
 	@if [[ "$(NO_BUILD)" != "true" ]]; then make fleet; fi
 	$(call filter_args)
+	@mkdir -p ~/.fleet
 # If FORWARDED_ARGS is not empty, run the command with the forwarded arguments.
 # Unless NO_SAVE is set to true, save the command to the last invocation file.
 # IF FORWARDED_ARGS is empty, attempt to repeat the last invocation.


### PR DESCRIPTION
## Summary
- `make serve` writes to `~/.fleet/last-serve-invocation` in both branches of its main recipe (save-invocation when `FORWARDED_ARGS` is set, default-seed when it's empty), but neither branch creates the `~/.fleet` directory first.
- On a fresh machine the redirect fails with `No such file or directory` and the target aborts before `./build/fleet` is ever invoked.
- Adds a single `mkdir -p ~/.fleet` to the recipe so both branches have a directory to write into.

## Test plan
- [x] On a machine without `~/.fleet`, `make serve` previously failed with `No such file or directory`; with this patch it creates the directory, seeds the default invocation, and starts fleet.
- [x] On a machine with an existing `~/.fleet/last-serve-invocation`, behavior is unchanged (`mkdir -p` is a no-op).

## Follow-ups (not in this PR)
- The `RESET` branch (`make serve RESET=1`, line 180) uses `touch ~/.fleet/last-serve-invocation && rm ...` which has the same gap on a fresh machine. Worth fixing in a follow-up if anyone hits it.
- The `SHOW` branch (line 170) handles missing files via `$?` and gracefully no-ops, so it's fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability by ensuring required directories are properly initialized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->