### PR TITLE
Fix Fleet Desktop KDE detection on hybrid Linux installs

### DIFF
--- a/orbit/changes/45963-use-plasmashell-for-kde-detection
+++ b/orbit/changes/45963-use-plasmashell-for-kde-detection
@@ -1,0 +1,1 @@
+- Fixed Fleet Desktop tray icon appearing oversized in KDE Plasma on Linux installs where fleetd runs as root.

--- a/orbit/changes/45963-use-plasmashell-for-kde-detection
+++ b/orbit/changes/45963-use-plasmashell-for-kde-detection
@@ -1,1 +1,1 @@
-- Fixed Fleet Desktop tray icon appearing oversized in KDE Plasma on Linux installs where fleetd runs as root.
+- Fixed Fleet Desktop tray icon appearing oversized in KDE Plasma on Linux installs when hosts have kde-plasma-desktop installed alongside another windows manager.

--- a/orbit/cmd/desktop/desktop_linux.go
+++ b/orbit/cmd/desktop/desktop_linux.go
@@ -40,7 +40,11 @@ func isKDE() bool {
 		return false
 	}
 	uid := strconv.FormatInt(guiUser.ID, 10)
-	return exec.Command("pgrep", "-u", uid, "-x", "plasmashell").Run() == nil
+	if err := exec.Command("pgrep", "-u", uid, "-x", "plasmashell").Run(); err != nil {
+		log.Debug().Err(err).Str("uid", uid).Msg("isKDE: plasmashell not found for user")
+		return false
+	}
+	return true
 }
 
 func blockWaitForStopEvent(_ string) error {

--- a/orbit/cmd/desktop/desktop_linux.go
+++ b/orbit/cmd/desktop/desktop_linux.go
@@ -4,8 +4,9 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"os/exec"
 	"slices"
-	"strings"
+	"strconv"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/user"
 	"github.com/godbus/dbus/v5"
@@ -27,12 +28,19 @@ func getIcon() []byte {
 	return iconDarkDefault
 }
 
+// isKDE reports whether the user with the active GUI session is running KDE
+// Plasma process.
 func isKDE() bool {
-	session, err := user.GetCurrentUserDisplaySession()
+	guiUser, err := user.LoggedInGuiUser()
 	if err != nil {
+		log.Debug().Err(err).Msg("isKDE: look up logged-in GUI user")
 		return false
 	}
-	return session != nil && strings.ToLower(session.Desktop) == "kde"
+	if guiUser == nil {
+		return false
+	}
+	uid := strconv.FormatInt(guiUser.ID, 10)
+	return exec.Command("pgrep", "-u", uid, "-x", "plasmashell").Run() == nil
 }
 
 func blockWaitForStopEvent(_ string) error {

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"os/user"
 	"strconv"
 	"strings"
 
@@ -23,7 +22,7 @@ type User struct {
 func getDisplaySessionFor(user User) *UserDisplaySession {
 	// Skip system/display manager users since they aren't GUI users.
 	// User gdm-greeter is active during the GUI log-in prompt (GNOME 49).
-	if user.Name == "gdm" || user.Name == "root" || user.Name == "gdm-greeter" {
+	if user.Name == "gdm" || user.Name == "root" || user.Name == "gdm-greeter" || user.Name == "sddm" {
 		return nil
 	}
 	// Check if the user has an active GUI session.
@@ -47,41 +46,25 @@ func getDisplaySessionFor(user User) *UserDisplaySession {
 // UserLoggedInViaGui returns the username that has an active GUI session.
 // It returns nil, nil if there's no user with an active GUI session.
 func UserLoggedInViaGui() (*string, error) {
+	u, err := LoggedInGuiUser()
+	if err != nil || u == nil {
+		return nil, err
+	}
+	return &u.Name, nil
+}
+
+// LoggedInGuiUser returns the User (name and UID) with an active GUI session,
+// or nil if none.
+func LoggedInGuiUser() (*User, error) {
 	users, err := getLoginUsers()
 	if err != nil {
 		return nil, fmt.Errorf("get login users: %w", err)
 	}
-
 	for _, u := range users {
 		if session := getDisplaySessionFor(u); session != nil {
-			return &u.Name, nil
+			return &u, nil
 		}
 	}
-
-	// No valid user found
-	return nil, nil
-}
-
-// GetCurrentUserDisplaySession returns the Display session of the user associated with the current process
-func GetCurrentUserDisplaySession() (*UserDisplaySession, error) {
-	currentUser, err := user.Current()
-	if err != nil {
-		return nil, fmt.Errorf("get current user: %w", err)
-	}
-	if currentUser == nil {
-		return nil, nil
-	}
-
-	uid, err := strconv.ParseInt(currentUser.Uid, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("parse uid: %w", err)
-	}
-
-	if session := getDisplaySessionFor(User{Name: currentUser.Username, ID: uid}); session != nil {
-		return session, nil
-	}
-
-	// No valid user found
 	return nil, nil
 }
 

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -109,13 +109,12 @@ func parseLoginctlUsersOutput(s string) ([]User, error) {
 
 // UserDisplaySession holds the display session type and active status for a user.
 type UserDisplaySession struct {
-	Type    GuiSessionType
-	Active  bool
-	Desktop string
+	Type   GuiSessionType
+	Active bool
 }
 
-// GetUserDisplaySessionType returns the display session type (X11 or Wayland),
-// active status, and desktop session env var of the given user. Returns an error if the user doesn't have
+// GetUserDisplaySessionType returns the display session type (X11 or Wayland)
+// and active status of the given user. Returns an error if the user doesn't have
 // a Display session.
 func GetUserDisplaySessionType(uid string) (*UserDisplaySession, error) {
 	// Get the "Display" session ID of the user.
@@ -160,20 +159,9 @@ func GetUserDisplaySessionType(uid string) (*UserDisplaySession, error) {
 	}
 	active := strings.TrimSpace(stdout.String()) == "yes"
 
-	// Get the "Desktop" property of the session.
-	cmd = exec.Command("loginctl", "show-session", guiSessionID, "-p", "Desktop", "--value")
-	stdout.Reset()
-	cmd.Stdout = &stdout
-	desktop := ""
-	if err := cmd.Run(); err != nil {
-		log.Debug().Err(err).Msgf("failed to get desktop session for user %s", uid)
-	} else {
-		desktop = strings.TrimSpace(stdout.String())
-	}
 	return &UserDisplaySession{
-		Type:    sessionType,
-		Active:  active,
-		Desktop: desktop,
+		Type:   sessionType,
+		Active: active,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #45963 

isKDE() previously matched loginctl's Desktop metadata field, which can falsely report KDE on hosts that have kde-plasma-desktop installed alongside another, detect the live plasmashell process owned by the logged-in GUI user instead.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KDE Plasma detection on Linux, fixing oversized Fleet Desktop system tray icon on KDE installations.
  * Enhanced GUI session identification to better detect interactive desktop users and ignore display-manager/service accounts.
* **Changelog**
  * Added note describing the KDE Plasma tray icon sizing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->