### PR TITLE
Add ritual for checking new hardware & OS releases

### DIFF
--- a/handbook/engineering/engineering.rituals.yml
+++ b/handbook/engineering/engineering.rituals.yml
@@ -196,5 +196,14 @@
   autoIssue:  
     labels: [ "#g-website" ] 
     repo: "fleet"
-
+- 
+  task: "Check for new hardware & OS releases"
+  startedOn: "2026-06-01"
+  frequency: "Triweekly"
+  description: "Check for newly announced or released hardware (CPUs/chips, devices) and OS versions across all Fleet-supported platforms (macOS, Windows, Linux, iOS, iPadOS, Android, ChromeOS), and pre-order devices as needed so compatibility issues are caught before customers hit them."
+  moreInfoUrl: 
+  dri: "AndreyKizimenko"
+  autoIssue:
+    labels: [ ":help-qa" ]
+    repo: "fleet"
 


### PR DESCRIPTION
Added a new ritual to check for hardware and OS releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new engineering ritual for triweekly checks of newly announced hardware and operating system releases across supported platforms, with automated issue tracking enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->