### PR TITLE
Add dummy go.mod files to exclude directories from Go module

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,0 +1,3 @@
+// No Go code here. Marks this dir as a separate module so it is excluded
+// from the published github.com/fleetdm/fleet/v4 module zip. See issue #42818.
+module fleetdm-docs

--- a/handbook/go.mod
+++ b/handbook/go.mod
@@ -1,0 +1,3 @@
+// No Go code here. Marks this dir as a separate module so it is excluded
+// from the published github.com/fleetdm/fleet/v4 module zip. See issue #42818.
+module fleetdm-handbook

--- a/website/go.mod
+++ b/website/go.mod
@@ -1,0 +1,3 @@
+// No Go code here. Marks this dir as a separate module so it is excluded
+// from the published github.com/fleetdm/fleet/v4 module zip. See issue #42818.
+module fleetdm-website


### PR DESCRIPTION
Resolves #42818.

(I explicitly removed all checklist items.)

This is the least destructing approach to solve the issue.
Other approaches require like moving all Go code under a sub-directory or keeping these docs/ directories free from invalid characters.

## Problem

[Publishing of Fleet's go module](https://github.com/fleetdm/fleet/actions/runs/23857371168/job/69554220876) is failing with the following error:
```
Run GOPROXY=proxy.golang.org go list -m github.com/fleetdm/fleet/v4@v4.83.0
go: github.com/fleetdm/fleet/v4@v4.83.0: reading https://proxy.golang.org/github.com/fleetdm/fleet/v4/@v/v4.83.0.info: 404 Not Found
	server response:
	not found: create zip: docs/solutions/windows/configuration-profiles/allow network connectivity during connected standby – [ACConnectivityInStandby_2, DCConnectivityInStandby_2].xml: malformed file path "docs/solutions/windows/configuration-profiles/allow network connectivity during connected standby – [ACConnectivityInStandby_2, DCConnectivityInStandby_2].xml": invalid char '–'
	[Truncated: too long.]
```

## Summary

Root cause

The [publish go module step](https://github.com/fleetdm/fleet/blob/main/.github/workflows/publish-go-module.yml) asks proxy.golang.org to build a module zip for the v4.X.Y tag. That build was failing on two independent, each-fatal issues — both stemming from the monorepo carrying non-Go content that violates Go module zip rules:

1. Invalid path characters — 35 tracked files with characters Go module zips forbid: en-dash – in 32 docs/solutions/windows/configuration-profiles/*.xml files (the one in your error), emoji 📜 in 2 handbook/company/legal/ files, and an apostrophe in 1 website/assets/ image. This is the literal create zip: … invalid char '–' error.
2. Source tree too large — 582 MiB tracked vs Go's hard 500 MiB limit; website/ alone is 318.7 MiB.

## Fix

Added a go.mod to website/, docs/, and handbook/, turning each into a nested module that x/mod/zip omits from the published v4 module — the same pattern Fleet already uses under tools/. One move solves both: all 35 bad filenames live in those three dirs, and excluding them drops the module to 207 MiB tracked → 112 MiB zipped.

Files created:
- website/go.mod, docs/go.mod, handbook/go.mod (module markers, each with a comment explaining why)

Verified safe: no .go files and no //go:embed references in those dirs, and go list ./... still resolves all 491 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standalone module configurations for documentation, handbook, and website directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->