### PR TITLE
Fixed the `mdm_unenrolled` activity not appearing in host details page

### DIFF
--- a/changes/46119-mdm-unenrolled-host-activity
+++ b/changes/46119-mdm-unenrolled-host-activity
@@ -1,0 +1,1 @@
+* Fixed the `mdm_unenrolled` activity not appearing in a host's activity timeline on the host details page.

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -189,6 +189,7 @@ export type IHostPastActivityType =
   | ActivityType.LockedHost
   | ActivityType.WipedHost
   | ActivityType.FailedWipe
+  | ActivityType.MdmUnenrolled
   | ActivityType.ReadHostDiskEncryptionKey
   | ActivityType.RetrievedHostMyDeviceURL
   | ActivityType.ViewedHostRecoveryLockPassword

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -33,6 +33,7 @@ import CreatedManagedLocalAccountActivityItem from "./ActivityItems/CreatedManag
 import RotatedManagedLocalAccountPasswordActivityItem from "./ActivityItems/RotatedManagedLocalAccountPassword";
 import FailedToRotateManagedLocalAccountPasswordActivityItem from "./ActivityItems/FailedToRotateManagedLocalAccountPassword";
 import FailedEnrollmentProfileRenewalActivityItem from "./ActivityItems/FailedEnrollmentProfileRenewalActivityItem";
+import MdmUnenrolledActivityItem from "./ActivityItems/MdmUnenrolledActivityItem";
 
 /** The component props that all host activity items must adhere to */
 export interface IHostActivityItemComponentProps {
@@ -86,6 +87,7 @@ export const pastActivityComponentMap: Record<
   [ActivityType.RotatedManagedLocalAccountPassword]: RotatedManagedLocalAccountPasswordActivityItem,
   [ActivityType.FailedToRotateManagedLocalAccountPassword]: FailedToRotateManagedLocalAccountPasswordActivityItem,
   [ActivityType.FailedEnrollmentProfileRenewal]: FailedEnrollmentProfileRenewalActivityItem,
+  [ActivityType.MdmUnenrolled]: MdmUnenrolledActivityItem,
 };
 
 export const upcomingActivityComponentMap: Record<

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tests.tsx
@@ -7,6 +7,22 @@ import { ActivityType } from "interfaces/activity";
 import MdmUnenrolledActivityItem from "./MdmUnenrolledActivityItem";
 
 describe("MdmUnenrolledActivityItem", () => {
+  it("renders mobile unenrollment copy for iOS/iPadOS", () => {
+    render(
+      <MdmUnenrolledActivityItem
+        activity={createMockHostPastActivity({
+          type: ActivityType.MdmUnenrolled,
+          actor_full_name: "Admin User",
+          details: { platform: "ios" },
+        })}
+        tab="past"
+      />
+    );
+
+    expect(screen.getByText("Admin User")).toBeVisible();
+    expect(screen.getByText(/told Fleet to unenroll this host/i)).toBeVisible();
+  });
+
   it("renders admin-initiated unenrollment copy for Apple/macOS", () => {
     render(
       <MdmUnenrolledActivityItem

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tests.tsx
@@ -3,112 +3,48 @@ import { render, screen } from "@testing-library/react";
 import { createMockHostPastActivity } from "__mocks__/activityMock";
 
 import { ActivityType } from "interfaces/activity";
+import { Platform } from "interfaces/platform";
 
 import MdmUnenrolledActivityItem from "./MdmUnenrolledActivityItem";
 
+const renderItem = (platform: Platform, actor: string) =>
+  render(
+    <MdmUnenrolledActivityItem
+      activity={createMockHostPastActivity({
+        type: ActivityType.MdmUnenrolled,
+        actor_full_name: actor,
+        actor_id: actor ? 1 : 0,
+        details: { platform },
+      })}
+      tab="past"
+    />
+  );
+
 describe("MdmUnenrolledActivityItem", () => {
-  it("renders mobile unenrollment copy for iOS/iPadOS", () => {
-    render(
-      <MdmUnenrolledActivityItem
-        activity={createMockHostPastActivity({
-          type: ActivityType.MdmUnenrolled,
-          actor_full_name: "Admin User",
-          details: { platform: "ios" },
-        })}
-        tab="past"
-      />
-    );
+  const cases: Array<[Platform, string, RegExp]> = [
+    ["ios", "Admin User", /told Fleet to unenroll this host/i],
+    ["android", "Admin User", /told Fleet to unenroll this host/i],
+    ["android", "", /This host is unenrolled from Fleet/i],
+    [
+      "darwin",
+      "Admin User",
+      /told Fleet to turn off mobile device management \(MDM\) for this host/i,
+    ],
+    [
+      "darwin",
+      "",
+      /Mobile device management \(MDM\) was turned off for this host/i,
+    ],
+  ];
 
-    expect(screen.getByText("Admin User")).toBeVisible();
-    expect(screen.getByText(/told Fleet to unenroll this host/i)).toBeVisible();
-  });
-
-  it("renders admin-initiated unenrollment copy for Apple/macOS", () => {
-    render(
-      <MdmUnenrolledActivityItem
-        activity={createMockHostPastActivity({
-          type: ActivityType.MdmUnenrolled,
-          actor_full_name: "Admin User",
-          details: { platform: "darwin" },
-        })}
-        tab="past"
-      />
-    );
-
-    expect(screen.getByText("Admin User")).toBeVisible();
-    expect(
-      screen.getByText(
-        /told Fleet to turn off mobile device management \(MDM\) for this host/i
-      )
-    ).toBeVisible();
-  });
-
-  it("renders end-user-initiated unenrollment copy for macOS (no actor)", () => {
-    render(
-      <MdmUnenrolledActivityItem
-        activity={createMockHostPastActivity({
-          type: ActivityType.MdmUnenrolled,
-          actor_full_name: "",
-          actor_id: 0,
-          details: { platform: "darwin" },
-        })}
-        tab="past"
-      />
-    );
-
-    expect(
-      screen.getByText(
-        /Mobile device management \(MDM\) was turned off for this host/i
-      )
-    ).toBeVisible();
-  });
-
-  it("renders Android-specific copy when actor is set", () => {
-    render(
-      <MdmUnenrolledActivityItem
-        activity={createMockHostPastActivity({
-          type: ActivityType.MdmUnenrolled,
-          actor_full_name: "Admin User",
-          details: { platform: "android" },
-        })}
-        tab="past"
-      />
-    );
-
-    expect(screen.getByText("Admin User")).toBeVisible();
-    expect(screen.getByText(/told Fleet to unenroll this host/i)).toBeVisible();
-  });
-
-  it("renders Android-specific copy when no actor", () => {
-    render(
-      <MdmUnenrolledActivityItem
-        activity={createMockHostPastActivity({
-          type: ActivityType.MdmUnenrolled,
-          actor_full_name: "",
-          actor_id: 0,
-          details: { platform: "android" },
-        })}
-        tab="past"
-      />
-    );
-
-    expect(
-      screen.getByText(/This host is unenrolled from Fleet/i)
-    ).toBeVisible();
+  it.each(cases)("renders %s copy (actor=%j)", (platform, actor, expected) => {
+    renderItem(platform, actor);
+    if (actor) expect(screen.getByText(actor)).toBeVisible();
+    expect(screen.getByText(expected)).toBeVisible();
   });
 
   it("does not render the cancel or show-details icons", () => {
-    render(
-      <MdmUnenrolledActivityItem
-        activity={createMockHostPastActivity({
-          type: ActivityType.MdmUnenrolled,
-          actor_full_name: "Admin User",
-          details: { platform: "darwin" },
-        })}
-        tab="past"
-      />
-    );
-
+    renderItem("darwin", "Admin User");
     expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
     expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
   });

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tests.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+
+import { ActivityType } from "interfaces/activity";
+
+import MdmUnenrolledActivityItem from "./MdmUnenrolledActivityItem";
+
+describe("MdmUnenrolledActivityItem", () => {
+  it("renders admin-initiated unenrollment copy for Apple/macOS", () => {
+    render(
+      <MdmUnenrolledActivityItem
+        activity={createMockHostPastActivity({
+          type: ActivityType.MdmUnenrolled,
+          actor_full_name: "Admin User",
+          details: { platform: "darwin" },
+        })}
+        tab="past"
+      />
+    );
+
+    expect(screen.getByText("Admin User")).toBeVisible();
+    expect(
+      screen.getByText(
+        /told Fleet to turn off mobile device management \(MDM\) for this host/i
+      )
+    ).toBeVisible();
+  });
+
+  it("renders end-user-initiated unenrollment copy for macOS (no actor)", () => {
+    render(
+      <MdmUnenrolledActivityItem
+        activity={createMockHostPastActivity({
+          type: ActivityType.MdmUnenrolled,
+          actor_full_name: "",
+          actor_id: 0,
+          details: { platform: "darwin" },
+        })}
+        tab="past"
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /Mobile device management \(MDM\) was turned off for this host/i
+      )
+    ).toBeVisible();
+  });
+
+  it("renders Android-specific copy when actor is set", () => {
+    render(
+      <MdmUnenrolledActivityItem
+        activity={createMockHostPastActivity({
+          type: ActivityType.MdmUnenrolled,
+          actor_full_name: "Admin User",
+          details: { platform: "android" },
+        })}
+        tab="past"
+      />
+    );
+
+    expect(screen.getByText("Admin User")).toBeVisible();
+    expect(screen.getByText(/told Fleet to unenroll this host/i)).toBeVisible();
+  });
+
+  it("renders Android-specific copy when no actor", () => {
+    render(
+      <MdmUnenrolledActivityItem
+        activity={createMockHostPastActivity({
+          type: ActivityType.MdmUnenrolled,
+          actor_full_name: "",
+          actor_id: 0,
+          details: { platform: "android" },
+        })}
+        tab="past"
+      />
+    );
+
+    expect(
+      screen.getByText(/This host is unenrolled from Fleet/i)
+    ).toBeVisible();
+  });
+
+  it("does not render the cancel or show-details icons", () => {
+    render(
+      <MdmUnenrolledActivityItem
+        activity={createMockHostPastActivity({
+          type: ActivityType.MdmUnenrolled,
+          actor_full_name: "Admin User",
+          details: { platform: "darwin" },
+        })}
+        tab="past"
+      />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tsx
@@ -12,7 +12,7 @@ const MdmUnenrolledActivityItem = ({
   activity,
 }: IHostActivityItemComponentProps) => {
   const { actor_full_name } = activity;
-  const platform = activity.details?.platform || "";
+  const platform = activity.details?.platform ?? "";
 
   let content: React.ReactNode;
   if (isAndroid(platform) || isIPadOrIPhone(platform)) {

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/MdmUnenrolledActivityItem.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
+
+import ActivityItem from "components/ActivityItem";
+
+import { IHostActivityItemComponentProps } from "../../ActivityConfig";
+
+const baseClass = "mdm-unenrolled-activity-item";
+
+const MdmUnenrolledActivityItem = ({
+  activity,
+}: IHostActivityItemComponentProps) => {
+  const { actor_full_name } = activity;
+  const platform = activity.details?.platform || "";
+
+  let content: React.ReactNode;
+  if (isAndroid(platform) || isIPadOrIPhone(platform)) {
+    content = actor_full_name ? (
+      <>
+        <b>{actor_full_name}</b> told Fleet to unenroll this host.
+      </>
+    ) : (
+      <>This host is unenrolled from Fleet.</>
+    );
+  } else {
+    content = actor_full_name ? (
+      <>
+        <b>{actor_full_name}</b> told Fleet to turn off mobile device management
+        (MDM) for this host.
+      </>
+    ) : (
+      <>Mobile device management (MDM) was turned off for this host.</>
+    );
+  }
+
+  return (
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel
+      hideShowDetails
+    >
+      {content}
+    </ActivityItem>
+  );
+};
+
+export default MdmUnenrolledActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmUnenrolledActivityItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MdmUnenrolledActivityItem";

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -416,6 +416,7 @@ func (a ActivityTypeMDMEnrolled) ActivityName() string {
 
 // TODO(BMAA): Should we add enrollment_id for BYOD unenrollments?
 type ActivityTypeMDMUnenrolled struct {
+	HostID           uint    `json:"host_id"`
 	HostSerial       string  `json:"host_serial"`
 	EnrollmentID     *string `json:"enrollment_id"`
 	HostDisplayName  string  `json:"host_display_name"`
@@ -425,6 +426,16 @@ type ActivityTypeMDMUnenrolled struct {
 
 func (a ActivityTypeMDMUnenrolled) ActivityName() string {
 	return "mdm_unenrolled"
+}
+
+// HostIDs links this activity to the host on the host details timeline. Returns nil when the host
+// is unknown (eg the host record was already deleted at unenroll time) so the global activity is
+// still recorded but no activity_host_past row is inserted.
+func (a ActivityTypeMDMUnenrolled) HostIDs() []uint {
+	if a.HostID == 0 {
+		return nil
+	}
+	return []uint{a.HostID}
 }
 
 type ActivityTypeEditedMacOSMinVersion struct {

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -271,6 +271,7 @@ func (svc *Service) handleAndroidWipeAckUnenroll(ctx context.Context, cmd *andro
 		displayName = hosts[0].DisplayName()
 	}
 	if err := svc.newActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
+		HostID:           ah.Host.ID,
 		HostDisplayName:  displayName,
 		InstalledFromDEP: false,
 		Platform:         "android",
@@ -422,6 +423,7 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 				serial = hosts[0].HardwareSerial
 			}
 			_ = svc.newActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
+				HostID:           host.Host.ID,
 				HostSerial:       serial,
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,
@@ -576,6 +578,7 @@ func (svc *Service) handlePubSubEnrollment(ctx context.Context, token string, ra
 				serial = hosts[0].HardwareSerial
 			}
 			_ = svc.newActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
+				HostID:           host.Host.ID,
 				HostSerial:       serial,
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,

--- a/server/mdm/android/service/reconcile_devices.go
+++ b/server/mdm/android/service/reconcile_devices.go
@@ -96,6 +96,7 @@ func ReconcileAndroidDevices(ctx context.Context, ds fleet.Datastore, logger *sl
 				serial = hosts[0].HardwareSerial
 			}
 			if aerr := newActivityFn(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
+				HostID:           dev.HostID,
 				HostSerial:       serial,
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3967,6 +3967,7 @@ func (svc *MDMAppleCheckinAndCommandService) CheckOut(r *mdm.Request, m *mdm.Che
 
 	return svc.newActivityFn(
 		r.Context, nil, &fleet.ActivityTypeMDMUnenrolled{
+			HostID:           info.HostID,
 			HostSerial:       info.HardwareSerial,
 			HostDisplayName:  info.DisplayName,
 			InstalledFromDEP: info.InstalledFromDEP,

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2472,6 +2472,7 @@ func TestMDMCheckout(t *testing.T) {
 	}
 	ctx := context.Background()
 	uuid, serial, installedFromDEP, displayName, platform := "ABC-DEF-GHI", "XYZABC", true, "Test's MacBook", "darwin"
+	hostID := uint(42)
 
 	ds.MDMTurnOffFunc = func(ctx context.Context, hostUUID string) ([]*fleet.User, []fleet.ActivityDetails, error) {
 		require.Equal(t, uuid, hostUUID)
@@ -2481,6 +2482,7 @@ func TestMDMCheckout(t *testing.T) {
 	ds.GetHostMDMCheckinInfoFunc = func(ct context.Context, hostUUID string) (*fleet.HostMDMCheckinInfo, error) {
 		require.Equal(t, uuid, hostUUID)
 		return &fleet.HostMDMCheckinInfo{
+			HostID:           hostID,
 			HardwareSerial:   serial,
 			DisplayName:      displayName,
 			InstalledFromDEP: installedFromDEP,
@@ -2499,10 +2501,12 @@ func TestMDMCheckout(t *testing.T) {
 		require.True(t, ok)
 		require.Nil(t, user)
 		require.Equal(t, "mdm_unenrolled", activity.ActivityName())
+		require.Equal(t, hostID, a.HostID)
 		require.Equal(t, serial, a.HostSerial)
 		require.Equal(t, displayName, a.HostDisplayName)
 		require.True(t, a.InstalledFromDEP)
 		require.Equal(t, platform, a.Platform)
+		require.Equal(t, []uint{hostID}, a.HostIDs())
 		return nil
 	}
 

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -4369,8 +4369,8 @@ func (s *integrationMDMTestSuite) TestSetupExperienceAndroidCancelOnUnenroll() {
 
 	// activities got created as expected
 	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), fmt.Sprintf(`
-	{"enrollment_id": null, "host_display_name": %q, "host_serial": %q, "installed_from_dep": false, "platform": %q}`,
-		host1.DisplayName(), host1.HardwareSerial, host1.Platform), 0)
+	{"host_id": %d, "enrollment_id": null, "host_display_name": %q, "host_serial": %q, "installed_from_dep": false, "platform": %q}`,
+		host1.ID, host1.DisplayName(), host1.HardwareSerial, host1.Platform), 0)
 	s.lastActivityOfTypeMatches(fleet.ActivityInstalledAppStoreApp{}.ActivityName(), fmt.Sprintf(`{"app_store_id":%q,
 		"command_uuid":%q, "from_auto_update": false, "from_setup_experience": true, "host_display_name":%q, "host_id":%d, "host_platform":%q, "policy_id":null, "policy_name":null, "self_service":false, "software_title":%q,
 		"status":%q}`, app1.AdamID, app1CmdUUID, host1.DisplayName(), host1.ID, host1.Platform, app1.Name, fleet.SoftwareInstallFailed), 0)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1930,10 +1930,15 @@ func (s *integrationMDMTestSuite) TestAppleMDMDeviceEnrollment() {
 			found = true
 			require.Nil(t, activity.ActorID)
 			require.Nil(t, activity.ActorFullName)
-			require.JSONEq(t, fmt.Sprintf(`{"enrollment_id": null, "host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "platform": "darwin"}`, mdmDeviceA.SerialNumber, mdmDeviceA.Model, mdmDeviceA.SerialNumber), string(*activity.Details))
+			require.JSONEq(t, fmt.Sprintf(`{"host_id": %d, "enrollment_id": null, "host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "platform": "darwin"}`, targetHostID, mdmDeviceA.SerialNumber, mdmDeviceA.Model, mdmDeviceA.SerialNumber), string(*activity.Details))
 		}
 	}
 	require.True(t, found)
+
+	// The unenroll activity must also show on the host details page activity timeline.
+	s.lastHostActivityMatches(targetHostID, "mdm_unenrolled",
+		fmt.Sprintf(`{"host_id": %d, "enrollment_id": null, "host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "platform": "darwin"}`,
+			targetHostID, mdmDeviceA.SerialNumber, mdmDeviceA.Model, mdmDeviceA.SerialNumber), 0)
 }
 
 func (s *integrationMDMTestSuite) TestDeviceMultipleAuthMessages() {

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -1318,7 +1318,7 @@ func (s *integrationMDMTestSuite) TestVPPAppActivitiesOnCancelInstall() {
 
 	// turn off MDM for the host
 	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", mdmHost.ID), nil, http.StatusNoContent)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), fmt.Sprintf(`{"enrollment_id": null, "host_display_name":%q, "host_serial":%q, "installed_from_dep":false, "platform": "darwin"}`, mdmHost.DisplayName(), mdmHost.HardwareSerial), 0)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "enrollment_id": null, "host_display_name":%q, "host_serial":%q, "installed_from_dep":false, "platform": "darwin"}`, mdmHost.ID, mdmHost.DisplayName(), mdmHost.HardwareSerial), 0)
 
 	// upcoming activities now have only the script
 	listResp = listHostUpcomingActivitiesResponse{}
@@ -1381,7 +1381,7 @@ func (s *integrationMDMTestSuite) TestVPPAppActivitiesOnCancelInstall() {
 
 	// turn off MDM for the host
 	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", mdmHost2.ID), nil, http.StatusNoContent)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), fmt.Sprintf(`{"enrollment_id": null, "host_display_name":%q, "host_serial":%q, "installed_from_dep":false, "platform": "darwin"}`, mdmHost2.DisplayName(), mdmHost2.HardwareSerial), 0)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "enrollment_id": null, "host_display_name":%q, "host_serial":%q, "installed_from_dep":false, "platform": "darwin"}`, mdmHost2.ID, mdmHost2.DisplayName(), mdmHost2.HardwareSerial), 0)
 
 	// upcoming activities are now empty
 	listResp = listHostUpcomingActivitiesResponse{}

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -1388,16 +1388,18 @@ func (s *integrationMDMTestSuite) TestVPPAppActivitiesOnCancelInstall() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities/upcoming", mdmHost2.ID), nil, http.StatusOK, &listResp)
 	require.Len(t, listResp.Activities, 0)
 
-	// host's past activities should have the first VPP app cancellation because it was activated
+	// host's past activities should have mdm_unenrolled at the head (emitted last in the unenroll
+	// flow, descending order) followed by the first VPP app cancellation because it was activated.
 	listPastResp = listActivitiesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", mdmHost2.ID), nil, http.StatusOK, &listPastResp)
-	require.GreaterOrEqual(t, len(listPastResp.Activities), 1)
-	require.Equal(t, fleet.ActivityInstalledAppStoreApp{}.ActivityName(), listPastResp.Activities[0].Type)
-	require.Contains(t, string(*listPastResp.Activities[0].Details), fmt.Sprintf(`"app_store_id": %q`, app1.AdamID))
-	require.Contains(t, string(*listPastResp.Activities[0].Details), `"status": "failed_install"`)
-	if len(listPastResp.Activities) > 1 {
-		// the second activity should not be the cancellation of the second app
-		require.Equal(t, fleet.ActivityInstalledAppStoreApp{}.ActivityName(), listPastResp.Activities[1].Type)
+	require.GreaterOrEqual(t, len(listPastResp.Activities), 2)
+	require.Equal(t, fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), listPastResp.Activities[0].Type)
+	require.Equal(t, fleet.ActivityInstalledAppStoreApp{}.ActivityName(), listPastResp.Activities[1].Type)
+	require.Contains(t, string(*listPastResp.Activities[1].Details), fmt.Sprintf(`"app_store_id": %q`, app1.AdamID))
+	require.Contains(t, string(*listPastResp.Activities[1].Details), `"status": "failed_install"`)
+	if len(listPastResp.Activities) > 2 {
+		// the third activity should not be the cancellation of the second app
+		require.Equal(t, fleet.ActivityInstalledAppStoreApp{}.ActivityName(), listPastResp.Activities[2].Type)
 	}
 
 	// listing the host's software available for install shows the cancelled app as failed

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3748,6 +3748,7 @@ func (svc *Service) UnenrollMDM(ctx context.Context, hostID uint) error {
 
 	if err := svc.NewActivity(
 		ctx, authz.UserFromContext(ctx), &fleet.ActivityTypeMDMUnenrolled{
+			HostID:           host.ID,
 			HostSerial:       host.HardwareSerial,
 			HostDisplayName:  host.DisplayName(),
 			InstalledFromDEP: installedFromDEP,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46119 

New activities visible on host details page:
<img width="482" height="424" alt="image" src="https://github.com/user-attachments/assets/8b8b33b2-c135-4061-b258-473fcc109d89" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MDM unenrollment events now appear on the host activity timeline in host details.

* **New Features**
  * Host activity entries for MDM unenroll show platform- and actor-aware messaging and appropriate action/icon visibility.

* **Tests**
  * Added tests to verify rendering and messaging for various platforms and actor presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->