### PR TITLE
Revert "Support default pkg install script when cask lacks pkg artifact and URL override is used"

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/scripts.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts.go
@@ -11,15 +11,6 @@ import (
 	"github.com/micromdm/plist"
 )
 
-func caskHasPkgArtifact(cask *brewCask) bool {
-	for _, artifact := range cask.Artifacts {
-		if len(artifact.Pkg) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 func installScriptForApp(app inputApp, cask *brewCask) (string, error) {
 	sb := newScriptBuilder()
 
@@ -27,19 +18,6 @@ func installScriptForApp(app inputApp, cask *brewCask) (string, error) {
 	sb.AddVariable("APPDIR", `"/Applications/"`)
 
 	sb.Extract(app.InstallerFormat)
-
-	// Some FMAs (e.g. Slack, 1Password) use a universal PKG download URL while the
-	// Homebrew cask still describes a zip/dmg + .app copy flow. When installer_format
-	// is pkg but the cask has no pkg artifact, install the downloaded PKG directly.
-	if app.InstallerFormat == "pkg" && !caskHasPkgArtifact(cask) {
-		sb.AddFunction("quit_and_track_application", quitAndTrackApplicationFunc)
-		sb.AddFunction("relaunch_application", relaunchApplicationFunc)
-		sb.Write("# install pkg files")
-		sb.Writef("quit_and_track_application '%s'", app.UniqueIdentifier)
-		sb.InstallPkgFromInstallerPath()
-		sb.RelaunchAndPropagateInstallStatus(app.UniqueIdentifier)
-		return sb.String(), nil
-	}
 
 	// Add quit/relaunch functions if we have App or Pkg artifacts
 	var needsQuitRelaunch bool
@@ -91,9 +69,8 @@ fi`, appPath)
 			default:
 				return "", fmt.Errorf("application %s has unknown directive format for pkg", app.Token)
 			}
-			// Relaunch the app if it was running before installation, then
-			// propagate a failed install so it isn't reported as successful.
-			sb.RelaunchAndPropagateInstallStatus(app.UniqueIdentifier)
+			// Relaunch the app if it was running before installation
+			sb.Writef("relaunch_application '%s'", app.UniqueIdentifier)
 
 		case len(artifact.Binary) > 0:
 			if len(artifact.Binary) == 2 {
@@ -415,26 +392,6 @@ func (s *scriptBuilder) RemoveFile(file string) {
 	s.Writef(`sudo rm -rf %s`, file)
 }
 
-// InstallPkgFromInstallerPath writes a command to install the package at INSTALLER_PATH.
-// Used when installer_format is pkg but the Homebrew cask has no pkg artifact (the
-// downloaded file name may not match the cask).
-func (s *scriptBuilder) InstallPkgFromInstallerPath() {
-	s.Write(`sudo installer -pkg "$INSTALLER_PATH" -target /`)
-}
-
-// RelaunchAndPropagateInstallStatus captures the exit status of the preceding
-// install command, relaunches the app if it was running before the install,
-// and then exits with the install's status when it failed. The relaunch call
-// must not become the script's final command: it almost always succeeds, so it
-// would otherwise mask a failed install and report a failed update as installed.
-func (s *scriptBuilder) RelaunchAndPropagateInstallStatus(uniqueIdentifier string) {
-	s.Write("INSTALL_EXIT_CODE=$?")
-	s.Writef("relaunch_application '%s'", uniqueIdentifier)
-	s.Write(`if [ "$INSTALL_EXIT_CODE" -ne 0 ]; then
-  exit "$INSTALL_EXIT_CODE"
-fi`)
-}
-
 // InstallPkg writes a command to install a package using the macOS `installer` utility.
 // 'pkg' is the package file to install. Optionally, 'choices' can be provided to specify
 // installation options.
@@ -579,27 +536,17 @@ const quitApplicationFunc = `quit_application() {
   local bundle_id="$1"
   local timeout_duration=10
 
-  # Determine the console user up front. osascript must target the logged-in
-  # user's GUI session; when this script runs as root, Apple Events won't reach
-  # the user's apps unless we bootstrap into their session with
-  # 'launchctl asuser' + 'sudo -u'.
+  # check if the application is running
+  local app_running
+  app_running=$(osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
+  if [[ "$app_running" != "true" ]]; then
+    return
+  fi
+
   local console_user
   console_user=$(stat -f "%Su" /dev/console)
   if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "loginwindow" ]]; then
     echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
-    return
-  fi
-  local console_uid
-  console_uid=$(id -u "$console_user")
-
-  # check if the application is running
-  local app_running
-  if [[ $EUID -eq 0 ]]; then
-    app_running=$(/bin/launchctl asuser "$console_uid" sudo -u "$console_user" osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
-  else
-    app_running=$(osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
-  fi
-  if [[ "$app_running" != "true" ]]; then
     return
   fi
 
@@ -609,13 +556,7 @@ const quitApplicationFunc = `quit_application() {
   local quit_success=false
   SECONDS=0
   while (( SECONDS < timeout_duration )); do
-    local quit_ok=false
-    if [[ $EUID -eq 0 ]]; then
-      /bin/launchctl asuser "$console_uid" sudo -u "$console_user" osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 && quit_ok=true
-    else
-      osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 && quit_ok=true
-    fi
-    if [[ "$quit_ok" = true ]]; then
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
       if ! pgrep -f "$bundle_id" >/dev/null 2>&1; then
         echo "Application '$bundle_id' quit successfully."
         quit_success=true
@@ -638,28 +579,18 @@ const quitAndTrackApplicationFunc = `quit_and_track_application() {
   local var_name="APP_WAS_RUNNING_$(echo "$bundle_id" | tr '.-' '__')"
   local timeout_duration=10
 
-  # Determine the console user up front. osascript must target the logged-in
-  # user's GUI session; when this script runs as root, Apple Events won't reach
-  # the user's apps unless we bootstrap into their session with
-  # 'launchctl asuser' + 'sudo -u' (the same wrapper relaunch_application uses).
+  # check if the application is running
+  local app_running
+  app_running=$(osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
+  if [[ "$app_running" != "true" ]]; then
+    eval "export $var_name=0"
+    return
+  fi
+
   local console_user
   console_user=$(stat -f "%Su" /dev/console)
   if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "loginwindow" ]]; then
     echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
-    eval "export $var_name=0"
-    return
-  fi
-  local console_uid
-  console_uid=$(id -u "$console_user")
-
-  # check if the application is running
-  local app_running
-  if [[ $EUID -eq 0 ]]; then
-    app_running=$(/bin/launchctl asuser "$console_uid" sudo -u "$console_user" osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
-  else
-    app_running=$(osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
-  fi
-  if [[ "$app_running" != "true" ]]; then
     eval "export $var_name=0"
     return
   fi
@@ -674,13 +605,7 @@ const quitAndTrackApplicationFunc = `quit_and_track_application() {
   local quit_success=false
   SECONDS=0
   while (( SECONDS < timeout_duration )); do
-    local quit_ok=false
-    if [[ $EUID -eq 0 ]]; then
-      /bin/launchctl asuser "$console_uid" sudo -u "$console_user" osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 && quit_ok=true
-    else
-      osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 && quit_ok=true
-    fi
-    if [[ "$quit_ok" = true ]]; then
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
       if ! pgrep -f "$bundle_id" >/dev/null 2>&1; then
         echo "Application '$bundle_id' quit successfully."
         quit_success=true

--- a/ee/maintained-apps/ingesters/homebrew/scripts_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts_test.go
@@ -1,7 +1,6 @@
 package homebrew
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
@@ -28,74 +27,4 @@ func TestInstallScriptDmgExtractUsesYesPipe(t *testing.T) {
 	require.Contains(t, script, "yes | hdiutil attach -plist -nobrowse -readonly -mountpoint")
 	require.Contains(t, script, `|| exit 1`)
 	require.Contains(t, script, `hdiutil detach "$MOUNT_POINT" || true`)
-}
-
-func TestInstallScriptForPkgWithoutPkgArtifact(t *testing.T) {
-	cask := &brewCask{
-		Artifacts: []*brewArtifact{
-			{
-				App: []optjson.StringOr[*brewAppTarget]{
-					{String: "Slack.app"},
-				},
-			},
-		},
-	}
-
-	script, err := installScriptForApp(inputApp{
-		Token:            "slack",
-		UniqueIdentifier: "com.tinyspeck.slackmacgap",
-		InstallerFormat:  "pkg",
-	}, cask)
-	require.NoError(t, err)
-	require.Contains(t, script, `quit_and_track_application 'com.tinyspeck.slackmacgap'`)
-	require.Contains(t, script, `sudo installer -pkg "$INSTALLER_PATH" -target /`)
-	require.Contains(t, script, `relaunch_application 'com.tinyspeck.slackmacgap'`)
-	require.NotContains(t, script, "unzip")
-	require.NotContains(t, script, "cp -R")
-	// A failed install must propagate its exit code rather than being masked by
-	// the trailing relaunch_application call.
-	requirePropagatesInstallFailure(t, script)
-}
-
-func TestInstallScriptForPkgWithPkgArtifact(t *testing.T) {
-	cask := &brewCask{
-		Artifacts: []*brewArtifact{
-			{
-				Pkg: []optjson.StringOr[*brewPkgChoices]{
-					{String: "ZoomInstallerIT.pkg"},
-				},
-			},
-		},
-	}
-
-	script, err := installScriptForApp(inputApp{ //nolint:gosec // homebrew cask token, not a credential
-		Token:            "zoom-for-it-admins",
-		UniqueIdentifier: "us.zoom.xos",
-		InstallerFormat:  "pkg",
-	}, cask)
-	require.NoError(t, err)
-	require.Contains(t, script, `sudo installer -pkg "$TMPDIR/ZoomInstallerIT.pkg" -target /`)
-	require.NotContains(t, script, `sudo installer -pkg "$INSTALLER_PATH" -target /`)
-	// Assert on the actual invocation, not just the function definition, so the
-	// test fails if the relaunch call is ever dropped from the generated script.
-	require.Contains(t, script, `relaunch_application 'us.zoom.xos'`)
-	// A failed install must propagate its exit code rather than being masked by
-	// the trailing relaunch_application call.
-	requirePropagatesInstallFailure(t, script)
-}
-
-// requirePropagatesInstallFailure asserts that the generated script captures the
-// install command's exit status and exits with it on failure, so the trailing
-// relaunch_application call cannot mask a failed install.
-func requirePropagatesInstallFailure(t *testing.T, script string) {
-	t.Helper()
-	installIdx := strings.Index(script, "sudo installer -pkg")
-	require.NotEqual(t, -1, installIdx, "expected an installer command in the script")
-	relaunchIdx := strings.Index(script[installIdx:], "relaunch_application '")
-	require.NotEqual(t, -1, relaunchIdx, "expected a relaunch_application call after the installer")
-	captureIdx := strings.Index(script[installIdx:], "INSTALL_EXIT_CODE=$?")
-	require.NotEqual(t, -1, captureIdx, "expected the installer exit code to be captured")
-	// The exit code must be captured before the relaunch runs.
-	require.Less(t, captureIdx, relaunchIdx, "exit code must be captured before relaunch")
-	require.Contains(t, script, `exit "$INSTALL_EXIT_CODE"`)
 }

--- a/ee/maintained-apps/inputs/homebrew/1password.json
+++ b/ee/maintained-apps/inputs/homebrew/1password.json
@@ -4,5 +4,6 @@
   "token": "1password",
   "installer_format": "pkg",
   "slug": "1password/darwin",
-  "default_categories": ["Productivity"]
+  "default_categories": ["Productivity"],
+  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/1password_install.sh"
 }

--- a/ee/maintained-apps/inputs/homebrew/scripts/1password_install.sh
+++ b/ee/maintained-apps/inputs/homebrew/scripts/1password_install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+quit_application() {
+  local bundle_id="$1"
+  local timeout_duration=10
+
+  # check if the application is running
+  if ! osascript -e "application id \"$bundle_id\" is running" 2>/dev/null; then
+    return
+  fi
+
+  local console_user
+  console_user=$(stat -f "%Su" /dev/console)
+  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+    echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
+    return
+  fi
+
+  echo "Quitting application '$bundle_id'..."
+
+  # try to quit the application within the timeout period
+  local quit_success=false
+  SECONDS=0
+  while (( SECONDS < timeout_duration )); do
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
+      if ! pgrep -f "$bundle_id" >/dev/null 2>&1; then
+        echo "Application '$bundle_id' quit successfully."
+        quit_success=true
+        break
+      fi
+    fi
+    sleep 1
+  done
+
+  if [[ "$quit_success" = false ]]; then
+    echo "Application '$bundle_id' did not quit."
+  fi
+}
+
+quit_application 'com.1password.1password'
+installer -pkg "$INSTALLER_PATH" -target /
+

--- a/ee/maintained-apps/inputs/homebrew/scripts/slack_install.sh
+++ b/ee/maintained-apps/inputs/homebrew/scripts/slack_install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+quit_application() {
+  local bundle_id="$1"
+  local timeout_duration=10
+
+  # check if the application is running
+  if ! osascript -e "application id \"$bundle_id\" is running" 2>/dev/null; then
+    return
+  fi
+
+  local console_user
+  console_user=$(stat -f "%Su" /dev/console)
+  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+    echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
+    return
+  fi
+
+  echo "Quitting application '$bundle_id'..."
+
+  # try to quit the application within the timeout period
+  local quit_success=false
+  SECONDS=0
+  while (( SECONDS < timeout_duration )); do
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
+      if ! pgrep -f "$bundle_id" >/dev/null 2>&1; then
+        echo "Application '$bundle_id' quit successfully."
+        quit_success=true
+        break
+      fi
+    fi
+    sleep 1
+  done
+
+  if [[ "$quit_success" = false ]]; then
+    echo "Application '$bundle_id' did not quit."
+  fi
+}
+
+quit_application 'com.tinyspeck.slackmacgap'
+installer -pkg "$INSTALLER_PATH" -target /
+

--- a/ee/maintained-apps/inputs/homebrew/scripts/zoom_install.sh
+++ b/ee/maintained-apps/inputs/homebrew/scripts/zoom_install.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+quit_application() {
+  local bundle_id="$1"
+  local console_user="$2"
+  local timeout_duration=10
+
+  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+    echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
+    return
+  fi
+
+  echo "Quitting application '$bundle_id'..."
+
+  # try to quit the application within the timeout period
+  local quit_success=false
+  SECONDS=0
+  while (( SECONDS < timeout_duration )); do
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
+      if ! pgrep -f "$bundle_id" >/dev/null 2>&1; then
+        echo "Application '$bundle_id' quit successfully."
+        quit_success=true
+        break
+      fi
+    fi
+    sleep 1
+  done
+
+  if [[ "$quit_success" = false ]]; then
+    echo "Application '$bundle_id' did not quit."
+  fi
+}
+
+restart_zoom() {
+  local console_user="$1"
+  
+  if [[ -n "$console_user" && "$console_user" != "root" ]]; then
+    echo "Restarting Zoom for user: $console_user"
+    sudo -u "$console_user" open -a "zoom.us"
+  else
+    echo "No console user found, attempting direct Zoom start..."
+    open -a "zoom.us"
+  fi
+}
+
+# Get console user once (used by both quit and restart)
+CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || echo "")
+
+# Check if Zoom is running
+ZOOM_WAS_RUNNING=false
+if osascript -e "application id \"us.zoom.xos\" is running" 2>/dev/null; then
+  ZOOM_WAS_RUNNING=true
+  quit_application 'us.zoom.xos' "$CONSOLE_USER"
+fi
+
+installer -pkg "$INSTALLER_PATH" -target /
+
+# Restart Zoom if it was running before installation
+if [[ "$ZOOM_WAS_RUNNING" == "true" ]]; then
+  sleep 2
+  restart_zoom "$CONSOLE_USER" || true
+fi
+

--- a/ee/maintained-apps/inputs/homebrew/slack.json
+++ b/ee/maintained-apps/inputs/homebrew/slack.json
@@ -4,5 +4,6 @@
   "token": "slack",
   "installer_format": "pkg",
   "slug": "slack/darwin",
-  "default_categories": ["Communication"]
+  "default_categories": ["Communication"],
+  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/slack_install.sh"
 }

--- a/ee/maintained-apps/inputs/homebrew/zoom.json
+++ b/ee/maintained-apps/inputs/homebrew/zoom.json
@@ -4,5 +4,6 @@
   "unique_identifier": "us.zoom.xos",
   "token": "zoom-for-it-admins",
   "installer_format": "pkg",
-  "default_categories": ["Communication"]
+  "default_categories": ["Communication"],
+  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/zoom_install.sh"
 }


### PR DESCRIPTION
Reverts fleetdm/fleet#45893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application installation for 1Password, Slack, and Zoom by implementing graceful application shutdown before installation and automatic restart after completion.
  * Enhanced installation reliability by simplifying application lifecycle management during package updates, reducing potential conflicts from running applications during installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->