### PR TITLE
Show tooltip for long model names on Hosts page

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -190,7 +190,7 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
     accessor: "hardware_model",
     id: "hardware_model",
     Cell: (cellProps: IHostTableStringCellProps) => (
-      <TooltipTruncatedTextCell value={cellProps.cell.value} />
+      <TooltipTruncatedTextCell value={cellProps.cell.value} className="w250" />
     ),
   },
   // User email

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -190,7 +190,7 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
     accessor: "hardware_model",
     id: "hardware_model",
     Cell: (cellProps: IHostTableStringCellProps) => (
-      <TextCell value={cellProps.cell.value} />
+      <TooltipTruncatedTextCell value={cellProps.cell.value} />
     ),
   },
   // User email


### PR DESCRIPTION
While testing for #46482, I noticed that the model name on the Hosts page is truncated, but a tooltip doesn't show on hover. This felt inconsistent, since the Host details page truncates the model and does show a tooltip.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of hardware model information in the hosts management table with better text truncation and tooltip support for enhanced readability.
  * Adjusted column styling to ensure consistent width and reliable tooltip behavior for long hardware model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->