### PR TITLE
Corrected configuration profiles endpoint handler

### DIFF
--- a/changes/46283-android-mdm-routing-bug
+++ b/changes/46283-android-mdm-routing-bug
@@ -1,0 +1,1 @@
+Fixed an issue where the "Get host's OS settings" API endpoint returned an error when only Android MDM was enabled.

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -721,8 +721,6 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// Deprecated: GET /mdm/hosts/:id/profiles is now deprecated, replaced by
 	// GET /hosts/:id/configuration_profiles.
 	mdmAppleMW.GET("/api/_version_/fleet/mdm/hosts/{id:[0-9]+}/profiles", getHostProfilesEndpoint, getHostProfilesRequest{})
-	// TODO: Confirm if response should be updated to include Windows profiles and use mdmAnyMW
-	mdmAppleMW.GET("/api/_version_/fleet/hosts/{id:[0-9]+}/configuration_profiles", getHostProfilesEndpoint, getHostProfilesRequest{})
 
 	// Deprecated: GET /mdm/apple is now deprecated, replaced by the
 	// GET /apns endpoint.
@@ -757,6 +755,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	mdmAppleMW.POST("/api/_version_/fleet/mdm/apple/profiles/match", matchMDMApplePreassignmentEndpoint, matchMDMApplePreassignmentRequest{})
 
 	mdmAnyMW := ue.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAnyMDM())
+
+	mdmAnyMW.GET("/api/_version_/fleet/hosts/{id:[0-9]+}/configuration_profiles", getHostProfilesEndpoint, getHostProfilesRequest{})
 
 	// Deprecated: POST /mdm/commands/run is now deprecated, replaced by the
 	// POST /commands/run endpoint.

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -2055,6 +2055,62 @@ func (s *integrationMDMTestSuite) TestMDMAppleListConfigProfiles() {
 	})
 }
 
+func (s *integrationMDMTestSuite) TestGetHostConfigurationProfilesSingleMDM() {
+	t := s.T()
+	ctx := context.Background()
+
+	// save original config for cleanup
+	appCfg, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	originalCopy := appCfg.Copy()
+	t.Cleanup(func() {
+		require.NoError(t, s.ds.SaveAppConfig(ctx, originalCopy))
+	})
+
+	// create hosts for each platform
+	appleHost := createOrbitEnrolledHost(t, "darwin", "apple-cfg-profiles", s.ds)
+	windowsHost := createOrbitEnrolledHost(t, "windows", "windows-cfg-profiles", s.ds)
+
+	checkEndpoint := func(t *testing.T, hostID uint, expectedStatus int) {
+		var resp getHostProfilesResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d/configuration_profiles", hostID), nil, expectedStatus, &resp)
+		if expectedStatus == http.StatusOK {
+			require.NotNil(t, resp.Profiles)
+			require.EqualValues(t, hostID, resp.HostID)
+		}
+	}
+
+	setMDMConfig := func(apple, windows, android bool) {
+		appCfg, err := s.ds.AppConfig(ctx)
+		require.NoError(t, err)
+		appCfg.MDM.EnabledAndConfigured = apple
+		appCfg.MDM.WindowsEnabledAndConfigured = windows
+		appCfg.MDM.AndroidEnabledAndConfigured = android
+		require.NoError(t, s.ds.SaveAppConfig(ctx, appCfg))
+	}
+
+	t.Run("apple only", func(t *testing.T) {
+		setMDMConfig(true, false, false)
+		checkEndpoint(t, appleHost.ID, http.StatusOK)
+	})
+
+	t.Run("windows only", func(t *testing.T) {
+		setMDMConfig(false, true, false)
+		checkEndpoint(t, windowsHost.ID, http.StatusOK)
+	})
+
+	t.Run("android only", func(t *testing.T) {
+		setMDMConfig(false, false, true)
+		// use apple host ID; the endpoint should still be reachable
+		checkEndpoint(t, appleHost.ID, http.StatusOK)
+	})
+
+	t.Run("none configured", func(t *testing.T) {
+		setMDMConfig(false, false, false)
+		checkEndpoint(t, appleHost.ID, http.StatusBadRequest)
+	})
+}
+
 func (s *integrationMDMTestSuite) TestAppConfigMDMCustomSettings() {
 	t := s.T()
 

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -2076,7 +2076,7 @@ func (s *integrationMDMTestSuite) TestGetHostConfigurationProfilesSingleMDM() {
 		s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d/configuration_profiles", hostID), nil, expectedStatus, &resp)
 		if expectedStatus == http.StatusOK {
 			require.NotNil(t, resp.Profiles)
-			require.EqualValues(t, hostID, resp.HostID)
+			require.Equal(t, hostID, resp.HostID)
 		}
 	}
 


### PR DESCRIPTION
**Related issue:** Resolves #46283

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error in the "Get host's OS settings" API so it no longer fails when only Android MDM is enabled.
  * Configuration profiles endpoint now correctly responds when Android or Windows MDM is the active platform, in addition to Apple MDM.

* **Tests**
  * Added tests covering configuration profiles behavior across Apple, Windows, and Android MDM configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->