### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.167.1",
+      "version": "1.167.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.167.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.167.2') < 0);"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.167.1.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.167.2.0/Grammarly.dmg",
       "install_script_ref": "20d5bd8f",
       "uninstall_script_ref": "e14b2d61",
-      "sha256": "936125dcbdd9909964641af908b5ae7f9b9489d52bf53c0acd286f3fea268752",
+      "sha256": "f4bb02c9614051c3ec2c0d580108d48d9009dd792c17e336bc0adb6e08393aeb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nordvpn/darwin.json
+++ b/ee/maintained-apps/outputs/nordvpn/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "10.3.0",
+      "version": "10.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos' AND version_compare(bundle_short_version, '10.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos' AND version_compare(bundle_short_version, '10.3.1') < 0);"
       },
-      "installer_url": "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/10.3.0/NordVPN.pkg",
+      "installer_url": "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/10.3.1/NordVPN.pkg",
       "install_script_ref": "60b24e24",
       "uninstall_script_ref": "c0f6be08",
-      "sha256": "a321e7abec9521ff07dbaabc49606f4adf8cc070112f1db7fd3ccbe16b49b1b4",
+      "sha256": "bbbc672e6e210039a7d9fb9dc327e2ee02a68128341753997ad8957657a80f80",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/sourcetree/darwin.json
+++ b/ee/maintained-apps/outputs/sourcetree/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.2.17",
+      "version": "4.2.18",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.torusknot.SourceTreeNotMAS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.torusknot.SourceTreeNotMAS' AND version_compare(bundle_short_version, '4.2.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.torusknot.SourceTreeNotMAS' AND version_compare(bundle_short_version, '4.2.18') < 0);"
       },
-      "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_4.2.17_311.zip",
+      "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_4.2.18_313.zip",
       "install_script_ref": "524920c6",
       "uninstall_script_ref": "16a85b1d",
-      "sha256": "0e8afca4f01f63c67fe519821f7f8fd0ef8f8ba4e690e47c23915cfd2dc76708",
+      "sha256": "e4e3f7fe7f8e833ef8beb3e801b2a77170a4679605edc5a901aa65f150f8c316",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grammarly Desktop macOS package from version 1.167.1 to 1.167.2 with new installer URL and verification checksum.
  * Updated NordVPN macOS package from version 10.3.0 to 10.3.1 with new installer URL and verification checksum.
  * Updated Sourcetree macOS package from version 4.2.17 to 4.2.18 with new installer URL and verification checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->