### PR TITLE
Fleet UI: Add dynamic categories to edit software modal

### DIFF
--- a/frontend/components/TargetLabelSelector/_styles.scss
+++ b/frontend/components/TargetLabelSelector/_styles.scss
@@ -20,7 +20,9 @@
 
   &__checkboxes {
     display: flex;
-    max-height: 189px; // Fits 5 options before scrolling
+    // 210px shows about 4.5 rows so the last row is half-visible, hinting
+    // there is more to scroll to
+    max-height: 210px;
     flex-direction: column;
     border-radius: $border-radius;
     border: 1px solid $ui-fleet-black-10;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -376,6 +376,7 @@ const EditSoftwareModal = ({
           defaultSelfService={softwarePackage.self_service}
           defaultCategories={softwarePackage.categories}
           gitopsCompatible={isGitOpsCompatible}
+          teamId={teamId}
         />
       );
     }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/helpers.tsx
@@ -33,6 +33,15 @@ export const getErrorMessage = (
     );
   } else if (reason.includes("Secret variable")) {
     return generateSecretErrMsg(err).replace("Couldn't add", "Couldn't edit");
+  } else if (reason.includes("some or all of the categories provided")) {
+    return (
+      <>
+        Couldn&apos;t edit{" "}
+        <b>{getDisplayedSoftwareName(software.name, software.display_name)}</b>.{" "}
+        Some or all of the categories provided were not found. Please refresh
+        the page and try again.
+      </>
+    );
   }
 
   return reason || DEFAULT_ERROR_MESSAGE;

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -152,6 +152,8 @@ interface IPackageFormProps {
   className?: string;
   /** Indicates that this PackageForm deals with an entity that can be managed by GitOps, and so should be disabled when gitops mode is enabled */
   gitopsCompatible?: boolean;
+  /** When provided, the categories list is fetched dynamically for this fleet. */
+  teamId?: number;
 }
 // application/gzip is used for .tar.gz files because browsers can't handle double-extensions correctly
 const ACCEPTED_EXTENSIONS =
@@ -175,6 +177,7 @@ const PackageForm = ({
   defaultCategories,
   className,
   gitopsCompatible = false,
+  teamId,
 }: IPackageFormProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { gitOpsModeEnabled, repoURL } = useGitOpsMode("software");
@@ -420,6 +423,7 @@ const PackageForm = ({
       onClickPreviewEndUserExperience={() =>
         onClickPreviewEndUserExperience(isIpaPackage)
       }
+      teamId={teamId}
     />
   );
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -1,6 +1,12 @@
 import React from "react";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
+import mockServer from "test/mock-server";
+import {
+  emptySelfServiceCategoriesHandler,
+  listSelfServiceCategoriesErrorHandler,
+  listSelfServiceCategoriesHandler,
+} from "test/handlers/self-service-categories-handlers";
 
 import SoftwareOptionsSelector from "./SoftwareOptionsSelector";
 
@@ -31,7 +37,7 @@ const getSwitchByLabelText = (text: string) => {
 
 describe("SoftwareOptionsSelector", () => {
   const renderComponent = (props = {}) => {
-    return createCustomRenderer({ context: {} })(
+    return createCustomRenderer({ context: {}, withBackendMock: true })(
       <SoftwareOptionsSelector {...defaultProps} {...props} />
     );
   };
@@ -68,5 +74,160 @@ describe("SoftwareOptionsSelector", () => {
     const selfServiceSwitch = getSwitchByLabelText("Self-service");
 
     expect(selfServiceSwitch.disabled).toBe(true);
+  });
+
+  describe("dynamic categories (teamId provided)", () => {
+    const selfServiceEditingProps = {
+      ...defaultProps,
+      formData: { ...defaultProps.formData, selfService: true },
+      isEditingSoftware: true,
+      teamId: 1,
+    };
+
+    it("renders categories returned by the API as checkboxes", async () => {
+      mockServer.use(
+        listSelfServiceCategoriesHandler([
+          { id: 1, name: "🌎 Browsers" },
+          { id: 2, name: "🔐 Security" },
+        ])
+      );
+
+      renderComponent(selfServiceEditingProps);
+
+      expect(await screen.findByText("🌎 Browsers")).toBeInTheDocument();
+      expect(screen.getByText("🔐 Security")).toBeInTheDocument();
+    });
+
+    it("shows the empty state with an Add category link when no categories exist", async () => {
+      mockServer.use(emptySelfServiceCategoriesHandler);
+
+      renderComponent(selfServiceEditingProps);
+
+      const link = await screen.findByRole("link", { name: /add category/i });
+      expect(link).toHaveAttribute("href", "/software/library/categories");
+      expect(screen.getByText("to assign software to it.")).toBeInTheDocument();
+    });
+
+    it("does not render the empty state while categories are loading", () => {
+      mockServer.use(emptySelfServiceCategoriesHandler);
+
+      renderComponent(selfServiceEditingProps);
+
+      expect(
+        screen.queryByText("to assign software to it.")
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders a data error and not the empty state when the API errors", async () => {
+      mockServer.use(listSelfServiceCategoriesErrorHandler);
+
+      renderComponent(selfServiceEditingProps);
+
+      expect(
+        await screen.findByText(/something's gone wrong/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("to assign software to it.")
+      ).not.toBeInTheDocument();
+    });
+
+    it("fires onSelectCategory with the API category name when a checkbox is toggled", async () => {
+      mockServer.use(
+        listSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+      );
+      const onSelectCategory = jest.fn();
+
+      renderComponent({ ...selfServiceEditingProps, onSelectCategory });
+
+      const checkbox = await screen.findByRole("checkbox", {
+        name: "🌎 Browsers",
+      });
+      fireEvent.click(checkbox);
+
+      expect(onSelectCategory).toHaveBeenCalledTimes(1);
+      expect(onSelectCategory).toHaveBeenCalledWith({
+        name: "🌎 Browsers",
+        value: true,
+      });
+    });
+
+    it("renders pre-selected categories as checked", async () => {
+      mockServer.use(
+        listSelfServiceCategoriesHandler([
+          { id: 1, name: "🌎 Browsers" },
+          { id: 2, name: "🔐 Security" },
+        ])
+      );
+
+      renderComponent({
+        ...selfServiceEditingProps,
+        formData: {
+          ...selfServiceEditingProps.formData,
+          categories: ["🔐 Security"],
+        },
+      });
+
+      const security = await screen.findByRole("checkbox", {
+        name: "🔐 Security",
+      });
+      const browsers = await screen.findByRole("checkbox", {
+        name: "🌎 Browsers",
+      });
+
+      expect(security).toHaveAttribute("aria-checked", "true");
+      expect(browsers).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  describe("category list visibility (canSelectSoftwareCategories)", () => {
+    it("does not render the categories list when self-service is off, even with a teamId", () => {
+      mockServer.use(
+        listSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+      );
+
+      renderComponent({
+        ...defaultProps,
+        formData: { ...defaultProps.formData, selfService: false },
+        isEditingSoftware: true,
+        teamId: 1,
+      });
+
+      expect(screen.queryByText("Categories")).not.toBeInTheDocument();
+      expect(screen.queryByText("🌎 Browsers")).not.toBeInTheDocument();
+    });
+
+    it("does not render the categories list when not in edit mode, even with self-service on and a teamId", () => {
+      mockServer.use(
+        listSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+      );
+
+      renderComponent({
+        ...defaultProps,
+        formData: { ...defaultProps.formData, selfService: true },
+        isEditingSoftware: false,
+        teamId: 1,
+      });
+
+      expect(screen.queryByText("Categories")).not.toBeInTheDocument();
+      expect(screen.queryByText("🌎 Browsers")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("static categories (no teamId)", () => {
+    it("renders the hardcoded category list when teamId is not provided", async () => {
+      const props = {
+        ...defaultProps,
+        formData: { ...defaultProps.formData, selfService: true },
+        isEditingSoftware: true,
+      };
+
+      renderComponent(props);
+
+      // Wait a tick so any pending dynamic fetch would have surfaced
+      await waitFor(() =>
+        expect(screen.getByText("🌎 Browsers")).toBeInTheDocument()
+      );
+      expect(screen.getByText("👬 Communication")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import classnames from "classnames";
+import { useQuery } from "react-query";
 
 import Checkbox from "components/forms/fields/Checkbox";
 import Slider from "components/forms/fields/Slider";
 import CustomLink from "components/CustomLink";
+import DataError from "components/DataError";
+import Spinner from "components/Spinner";
 
 import paths from "router/paths";
+import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { getSelfServiceTooltip } from "pages/SoftwarePage/helpers";
 import { ISoftwareVppFormData } from "pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm";
 import { IFleetMaintainedAppFormData } from "pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm";
@@ -17,13 +21,25 @@ import {
 } from "pages/hosts/details/cards/Software/SelfService/helpers";
 import Button from "components/buttons/Button";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
+import selfServiceCategoriesAPI, {
+  ISelfServiceCategoriesResponse,
+} from "services/entities/self_service_categories";
 
 const baseClass = "software-options-selector";
+
+interface ICategoryOption {
+  id: number | string;
+  label: string;
+  value: string;
+}
 
 interface ICategoriesSelector {
   onSelectCategory: ({ name, value }: { name: string; value: boolean }) => void;
   selectedCategories: string[];
   onClickPreviewEndUserExperience: () => void;
+  /** When provided, categories are fetched from the self-service categories API
+   * for this fleet. When undefined, the hardcoded list is used. */
+  teamId?: number;
 }
 
 export const AndroidOptionsDescription = () => (
@@ -43,27 +59,95 @@ const CategoriesSelector = ({
   onSelectCategory,
   selectedCategories,
   onClickPreviewEndUserExperience,
+  teamId,
 }: ICategoriesSelector) => {
+  const isDynamic = teamId !== undefined;
+
+  const { data: dynamicCategories, isLoading, isError } = useQuery<
+    ISelfServiceCategoriesResponse,
+    Error,
+    ICategoryOption[]
+  >(
+    ["selfServiceCategories", teamId],
+    () => selfServiceCategoriesAPI.getCategories(teamId as number),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      // Don't retry on failure — a stale picker is worse than a fast error
+      retry: false,
+      enabled: isDynamic,
+      select: (res) =>
+        res.self_service_categories.map((c) => ({
+          id: c.id,
+          label: c.name,
+          value: c.name,
+        })),
+    }
+  );
+
+  const categories: ICategoryOption[] = isDynamic
+    ? dynamicCategories || []
+    : CATEGORIES_ITEMS.map((c: ICategory) => ({
+        id: c.id,
+        label: c.label,
+        value: c.value,
+      }));
+
+  const showEmptyState =
+    isDynamic && !isLoading && !isError && categories.length === 0;
+
+  const renderList = () => {
+    if (isDynamic && isLoading) {
+      return (
+        <div className={`${baseClass}__categories-loading`}>
+          <Spinner centered={false} small />
+        </div>
+      );
+    }
+
+    if (isDynamic && isError) {
+      return (
+        <DataError
+          className={`${baseClass}__categories-error`}
+          verticalPaddingSize="pad-large"
+        />
+      );
+    }
+
+    if (showEmptyState) {
+      return (
+        <div className={`${baseClass}__categories-empty`}>
+          <CustomLink
+            url={paths.SOFTWARE_LIBRARY_CATEGORIES}
+            text="Add category"
+          />
+          <span>to assign software to it.</span>
+        </div>
+      );
+    }
+
+    return (
+      <div className={`${baseClass}__categories-selector`}>
+        {categories.map((cat) => (
+          <div className={`${baseClass}__label`} key={cat.id}>
+            <Checkbox
+              className={`${baseClass}__checkbox`}
+              name={cat.value}
+              value={selectedCategories.includes(cat.value)}
+              onChange={onSelectCategory}
+              parseTarget
+            >
+              <div className={`${baseClass}__label-name`}>{cat.label}</div>
+            </Checkbox>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
   return (
     <>
       <div className="form-field__label">Categories</div>
-      <div className={`${baseClass}__categories-selector`}>
-        {CATEGORIES_ITEMS.map((cat: ICategory) => {
-          return (
-            <div className={`${baseClass}__label`} key={cat.id}>
-              <Checkbox
-                className={`${baseClass}__checkbox`}
-                name={cat.value}
-                value={selectedCategories.includes(cat.value)}
-                onChange={onSelectCategory}
-                parseTarget
-              >
-                <div className={`${baseClass}__label-name`}>{cat.label}</div>
-              </Checkbox>
-            </div>
-          );
-        })}
-      </div>
+      {renderList()}
       <Button
         variant="inverse"
         onClick={onClickPreviewEndUserExperience}
@@ -90,6 +174,9 @@ interface ISoftwareOptionsSelector {
   isIpaPackage?: boolean;
   isEditingSoftware?: boolean;
   disableOptions?: boolean;
+  /** When provided, the categories list is fetched dynamically from the
+   * self-service categories API for this fleet. */
+  teamId?: number;
 }
 
 const SoftwareOptionsSelector = ({
@@ -102,6 +189,7 @@ const SoftwareOptionsSelector = ({
   isIpaPackage,
   isEditingSoftware,
   disableOptions = false,
+  teamId,
 }: ISoftwareOptionsSelector) => {
   const classNames = classnames(baseClass, className);
 
@@ -140,6 +228,7 @@ const SoftwareOptionsSelector = ({
             onSelectCategory={onSelectCategory}
             selectedCategories={formData.categories}
             onClickPreviewEndUserExperience={onClickPreviewEndUserExperience}
+            teamId={teamId}
           />
         )}
       </div>

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/_styles.scss
@@ -5,6 +5,17 @@
     border-radius: $border-radius;
     border: 1px solid $ui-fleet-black-10;
     overflow-y: auto;
+    // 210px shows about 4.5 rows so the last row is half-visible, hinting
+    // there is more to scroll to
+    max-height: 210px;
+  }
+
+  &__categories-loading,
+  &__categories-empty {
+    display: flex;
+    align-items: center;
+    gap: $pad-xsmall;
+    font-size: $x-small;
   }
 
   &__label {

--- a/frontend/test/handlers/self-service-categories-handlers.ts
+++ b/frontend/test/handlers/self-service-categories-handlers.ts
@@ -45,6 +45,15 @@ export const emptySelfServiceCategoriesHandler = http.get(categoriesUrl, () =>
   HttpResponse.json({ self_service_categories: [] })
 );
 
+export const listSelfServiceCategoriesErrorHandler = http.get(
+  categoriesUrl,
+  () =>
+    HttpResponse.json(
+      { errors: [{ name: "base", reason: "Internal Server Error" }] },
+      { status: 500 }
+    )
+);
+
 // POST /software/self_service_categories
 export const addSelfServiceCategoryHandler = http.post(
   categoriesUrl,


### PR DESCRIPTION
## Issue
Part of #39018 
Closes #46371

## Description
- Replace hardcoded category list in CategoriesSelector with a useQuery fetch against the self-service categories API for the current fleet.
- Add empty state with an "Add category" link to /software/library/categories when the fleet has no categories.
- Render DataError when the categories fetch fails (retry: false so users see the error fast instead of waiting through 4 retries).
- Handle "some or all of the categories provided" BE error on edit save.
- Cap the categories list at 210px max-height with inner scroll so the last row peeks; apply the same 210px to TargetLabelSelector's checkbox list per Figma dev note.
- Static fallback path (no teamId passed) preserves the existing hardcoded list for VPP/Android/FMA forms until they're wired up separately.

## Screen recording


https://github.com/user-attachments/assets/ee42f167-30a1-477b-a79e-1c743462f69a



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
