### PR TITLE
Clean up policy query to use parameter binding for platform filter

### DIFF
--- a/changes/clean-up-policy-query-builder
+++ b/changes/clean-up-policy-query-builder
@@ -1,0 +1,1 @@
+* Updated conditional access policy query to use parameter binding for platform filter.

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -2538,9 +2538,9 @@ func (ds *Datastore) GetCalendarPolicies(ctx context.Context, teamID uint) ([]fl
 
 func (ds *Datastore) GetPoliciesForConditionalAccess(ctx context.Context, teamID uint, platform string) ([]uint, error) {
 	// Currently, the "Conditional access" feature is for macOS hosts only.
-	query := `SELECT id FROM policies WHERE team_id = ? AND conditional_access_enabled AND (platforms LIKE '%` + platform + `%' OR platforms = '');`
+	query := `SELECT id FROM policies WHERE team_id = ? AND conditional_access_enabled AND (platforms LIKE CONCAT('%', ?, '%') OR platforms = '');`
 	var policyIDs []uint
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &policyIDs, query, teamID)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &policyIDs, query, teamID, platform)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get policies for conditional access")
 	}


### PR DESCRIPTION
## Summary
- Refactored the conditional access policy query to use `CONCAT('%', ?, '%')` with a bound parameter instead of string concatenation for the platform `LIKE` clause, consistent with how other queries in this file handle string filters.

## Test plan
- [ ] Verify conditional access policy lookup still returns correct results for macOS/Windows hosts.
- [ ] Confirm no regression in policy filtering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved platform filtering in conditional access policy queries to enhance query reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->