### PR TITLE
Add 'Website - Swag request' to webhook options

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -35,6 +35,7 @@ module.exports = {
         'Website - Contact forms',
         'Website - Sign up',
         'Website - Newsletter',
+        'Website - Swag request',
         'Event',
         'GitHub - Stared fleetdm/fleet',
         'GitHub - Forked fleetdm/fleet',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for website swag request contacts in webhook processing, enabling the system to accept and validate requests from this new contact source type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->