### PR TITLE
resend config profiles on no device mapping user

### DIFF
--- a/changes/34668-resend-config-profiles-on-no-idp-user
+++ b/changes/34668-resend-config-profiles-on-no-idp-user
@@ -1,0 +1,1 @@
+* Fixed an issue where updating the device mapping for a host with no user, or a non existent IdP user, would not resend config profiles using IdP variables.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4755,7 +4755,9 @@ func (ds *Datastore) SetOrUpdateHostSCIMUserMapping(ctx context.Context, hostID 
 }
 
 func (ds *Datastore) DeleteHostSCIMUserMapping(ctx context.Context, hostID uint) error {
-	return deleteHostSCIMUserMapping(ctx, ds.writer(ctx), hostID)
+	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		return deleteHostSCIMUserMapping(ctx, tx, hostID)
+	})
 }
 
 func (ds *Datastore) GetHostEmails(ctx context.Context, hostUUID string, source string) ([]string, error) {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4727,12 +4727,20 @@ func associateHostWithScimUser(ctx context.Context, tx sqlx.ExtContext, hostID u
 }
 
 // deleteHostSCIMUserMapping is a helper function to delete SCIM user mapping for a host
-func deleteHostSCIMUserMapping(ctx context.Context, exec sqlx.ExecerContext, hostID uint) error {
+func deleteHostSCIMUserMapping(ctx context.Context, exec sqlx.ExtContext, hostID uint) error {
 	_, err := exec.ExecContext(ctx, `DELETE FROM host_scim_user WHERE host_id = ?`, hostID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "delete host SCIM user mapping")
 	}
-	return nil
+
+	return triggerResendProfilesUsingVariables(ctx, exec, []uint{hostID},
+		[]fleet.FleetVarName{
+			fleet.FleetVarHostEndUserIDPUsername,
+			fleet.FleetVarHostEndUserIDPUsernameLocalPart,
+			fleet.FleetVarHostEndUserIDPGroups,
+			fleet.FleetVarHostEndUserIDPDepartment,
+			fleet.FleetVarHostEndUserIDPFullname,
+		})
 }
 
 func (ds *Datastore) SetOrUpdateHostSCIMUserMapping(ctx context.Context, hostID uint, scimUserID uint) error {

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1287,6 +1287,7 @@ func triggerResendProfilesUsingVariables(ctx context.Context, tx sqlx.ExtContext
 			ON mcpv.fleet_variable_id = fv.id
 	SET
 		hmap.status = NULL,
+		hmap.detail = NULL,
 		hmap.command_uuid = ''
 	WHERE
 		h.id IN (:host_ids) AND
@@ -1309,7 +1310,8 @@ func triggerResendProfilesUsingVariables(ctx context.Context, tx sqlx.ExtContext
 			ON mcpv.fleet_variable_id = fv.id
 	SET
 		hmwp.status = NULL,
-		hmwp.command_uuid = ''
+		hmwp.command_uuid = '',
+		hmwp.detail = NULL
 	WHERE
 		h.id IN (:host_ids) AND
 		hmwp.operation_type = :operation_type_install AND
@@ -1330,7 +1332,8 @@ func triggerResendProfilesUsingVariables(ctx context.Context, tx sqlx.ExtContext
 		JOIN fleet_variables fv
 			ON mcpv.fleet_variable_id = fv.id
 	SET
-		hmad.status = NULL
+		hmad.status = NULL,
+		hmad.detail = NULL
 	WHERE
 		h.id IN (:host_ids) AND
 		hmad.operation_type = :operation_type_install AND

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -8834,6 +8834,7 @@ func (s *integrationMDMTestSuite) TestAppleProfileResendRaceCondition() {
 	}, http.StatusOK)
 	hostProfiles, err = s.ds.GetHostMDMAppleProfiles(ctx, host.UUID)
 	require.NoError(t, err)
+	testProfile = nil
 	for _, p := range hostProfiles {
 		if p.Identifier == "com.test.profile" {
 			testProfile = &p
@@ -8842,6 +8843,13 @@ func (s *integrationMDMTestSuite) TestAppleProfileResendRaceCondition() {
 	}
 	require.NotNil(t, testProfile)
 	require.EqualValues(t, fleet.MDMDeliveryPending, *testProfile.Status) // Should be pending again due to device mapping deletion
+
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		var status *fleet.MDMDeliveryStatus
+		err := sqlx.GetContext(t.Context(), q, &status, `SELECT status FROM host_mdm_apple_profiles WHERE host_uuid = ? AND profile_identifier = ?`, host.UUID, testProfile.Identifier)
+		require.Nil(t, status)
+		return err
+	})
 }
 
 func (s *integrationMDMTestSuite) TestWindowsProfileRetry() {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -8842,7 +8842,7 @@ func (s *integrationMDMTestSuite) TestAppleProfileResendRaceCondition() {
 		}
 	}
 	require.NotNil(t, testProfile)
-	require.EqualValues(t, fleet.MDMDeliveryPending, *testProfile.Status) // Should be pending again due to device mapping deletion
+	require.Equal(t, fleet.MDMDeliveryPending, *testProfile.Status) // Should be pending again due to device mapping deletion
 
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		var status *fleet.MDMDeliveryStatus

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -8725,7 +8725,6 @@ func (s *integrationMDMTestSuite) TestAppleProfileResendRaceCondition() {
 
 	for _, p := range hostProfiles {
 		if p.Identifier == "com.test.profile" {
-			fmt.Printf("%v\n", p.Status)
 			testProfile = &p
 			break
 		}
@@ -8827,6 +8826,22 @@ func (s *integrationMDMTestSuite) TestAppleProfileResendRaceCondition() {
 	}
 	require.NotNil(t, testProfile)
 	require.EqualValues(t, fleet.MDMDeliveryVerifying, *testProfile.Status)
+
+	// Verify deleting the device mapping also triggers a resend
+	s.Do("PUT", "/api/latest/fleet/hosts/"+hostIdStr+"/device_mapping", putHostDeviceMappingRequest{
+		Email:  "",
+		Source: "idp",
+	}, http.StatusOK)
+	hostProfiles, err = s.ds.GetHostMDMAppleProfiles(ctx, host.UUID)
+	require.NoError(t, err)
+	for _, p := range hostProfiles {
+		if p.Identifier == "com.test.profile" {
+			testProfile = &p
+			break
+		}
+	}
+	require.NotNil(t, testProfile)
+	require.EqualValues(t, fleet.MDMDeliveryPending, *testProfile.Status) // Should be pending again due to device mapping deletion
 }
 
 func (s *integrationMDMTestSuite) TestWindowsProfileRetry() {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34668 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile resend behavior so configuration profiles are retried using available identity attributes when a host has no linked IdP user or the referenced IdP user is missing.
  * Ensured profile resend markers are cleaned so pending resends behave correctly after identity changes.

* **Tests**
  * Improved test coverage to validate profile resend and status reset when device mappings or identity links change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->