### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.167.2",
+      "version": "1.168.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.167.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.168.0') < 0);"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.167.2.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.168.0.0/Grammarly.dmg",
       "install_script_ref": "20d5bd8f",
       "uninstall_script_ref": "e14b2d61",
-      "sha256": "f4bb02c9614051c3ec2c0d580108d48d9009dd792c17e336bc0adb6e08393aeb",
+      "sha256": "858906acf4bdb42395a0ecb301312a52e4f595ae88d14c99c21d25acd16f186e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.277.1",
+      "version": "7.290.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.277.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.290.0') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.277.1/Granola-7.277.1-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.290.0/Granola-7.290.0-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "b507e28072833fed1b10f6c4611e2801f86eb16ba69880e3f4a1af0c6a98e19c",
+      "sha256": "9e3ffddf70ebdb545d00e628bda5c35e69d3503c9b1be00b21d76ab4c868f457",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/krita/windows.json
+++ b/ee/maintained-apps/outputs/krita/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.3.2.0",
+      "version": "5.3.2.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation' AND version_compare(version, '5.3.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation' AND version_compare(version, '5.3.2.1') < 0);"
       },
-      "installer_url": "https://download.kde.org/stable/krita/5.3.2/krita-x64-5.3.2-setup.exe",
+      "installer_url": "https://download.kde.org/stable/krita/5.3.2.1/krita-x64-5.3.2.1-setup.exe",
       "install_script_ref": "4899cb9d",
       "uninstall_script_ref": "1259500a",
-      "sha256": "7542ddcfe4f75d9ad81337f053e81a4f3740b1d40e4e388a2ba489cfa29113f2",
+      "sha256": "b68c3c1000a0660c79ccb82f7a85e9ede0b9dde055561ceacd0ff2a147040fb8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '132.0') < 0);"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/132.0.5905.11/mac/Opera_132.0.5905.11_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/132.0.5905.19/mac/Opera_132.0.5905.19_Setup.dmg",
       "install_script_ref": "e9e947a7",
       "uninstall_script_ref": "566d9846",
-      "sha256": "cf8aa5619bdcad7d0df548331dcf8b574782ea2607f71d8991aa80bbdc8fba6c",
+      "sha256": "e1fc083948f474efefd7f0c6468207184aeeab9f608b1fe647939efe2445e30a",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated version metadata for Grammarly macOS (1.168.0), Granola macOS (7.290.0), Krita Windows (5.3.2.1), and Opera macOS (132.0.5905.19) with new installer URLs and SHA-256 checksums. Patching eligibility thresholds were updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->