### PR TITLE
Changed semantics around api_endpoints init.

### DIFF
--- a/changes/46190-change-semantics-around-api-endpoints-init
+++ b/changes/46190-change-semantics-around-api-endpoints-init
@@ -1,0 +1,1 @@
+* Fixed a data race in `api_endpoints.Init()` that caused flaky test failures when parallel integration tests each started their own test server concurrently.

--- a/changes/46190-change-semantics-around-api-endpoints-init
+++ b/changes/46190-change-semantics-around-api-endpoints-init
@@ -1,1 +1,1 @@
-* Fixed a data race in `api_endpoints.Init()` that caused flaky test failures when parallel integration tests each started their own test server concurrently.
+* Updated initialization semantics around api_endpoints. The catalog is now loaded from the embedded YAML once at package initialization time.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1389,7 +1389,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		apiHandler = service.MakeHandler(svc, config, httpLogger, limiterStore, redisPool, carveStore,
 			[]endpointer.HandlerRoutesFunc{android_service.GetRoutes(svc, androidSvc), activityRoutes, acmeRoutes, chartRoutes}, extra...)
 
-		if err := apiendpoints.Init(apiHandler); err != nil {
+		if err := apiendpoints.Validate(apiHandler); err != nil {
 			panic(fmt.Sprintf("error initializing API endpoints: %v", err))
 		}
 		apiHandler = service.WithMDMSSOCallbackRedirect(svc, logger, apiHandler)

--- a/server/api_endpoints/api_endpoints.go
+++ b/server/api_endpoints/api_endpoints.go
@@ -22,6 +22,19 @@ var apiEndpoints []fleet.APIEndpoint
 
 var apiEndpointsSet map[string]struct{}
 
+func init() {
+	loaded, err := loadAPIEndpoints()
+	if err != nil {
+		panic(err)
+	}
+	set := make(map[string]struct{}, len(loaded))
+	for _, e := range loaded {
+		set[e.Fingerprint()] = struct{}{}
+	}
+	apiEndpoints = loaded
+	apiEndpointsSet = set
+}
+
 // GetAPIEndpoints returns a copy of the embedded API endpoints slice.
 func GetAPIEndpoints() []fleet.APIEndpoint {
 	result := make([]fleet.APIEndpoint, len(apiEndpoints))
@@ -35,11 +48,11 @@ func IsInCatalog(fingerprint string) bool {
 	return ok
 }
 
-// Init validates that every endpoint in the embedded catalog is registered
+// Validate checks that every endpoint in the embedded catalog is registered
 // on the provided handler or one of the given feature routes. Feature routes
 // are walked on a throwaway router so callers can validate routes that are
 // declared elsewhere.
-func Init(h http.Handler, featureRoutes ...FeatureRouteFunc) error {
+func Validate(h http.Handler, featureRoutes ...FeatureRouteFunc) error {
 	r, ok := h.(*mux.Router)
 	if !ok {
 		return fmt.Errorf("expected *mux.Router, got %T", h)
@@ -75,13 +88,8 @@ func Init(h http.Handler, featureRoutes ...FeatureRouteFunc) error {
 		collect(tmp)
 	}
 
-	loadedApiEndpoints, err := loadAPIEndpoints()
-	if err != nil {
-		return err
-	}
-
 	var missing []string
-	for _, e := range loadedApiEndpoints {
+	for _, e := range apiEndpoints {
 		if _, ok := registered[e.Fingerprint()]; !ok {
 			missing = append(missing, e.Method+" "+e.Path)
 		}
@@ -90,14 +98,6 @@ func Init(h http.Handler, featureRoutes ...FeatureRouteFunc) error {
 	if len(missing) > 0 {
 		return fmt.Errorf("the following API endpoints are unknown: %v", missing)
 	}
-
-	apiEndpoints = loadedApiEndpoints
-
-	set := make(map[string]struct{}, len(loadedApiEndpoints))
-	for _, e := range loadedApiEndpoints {
-		set[e.Fingerprint()] = struct{}{}
-	}
-	apiEndpointsSet = set
 
 	return nil
 }

--- a/server/api_endpoints/api_endpoints_test.go
+++ b/server/api_endpoints/api_endpoints_test.go
@@ -12,22 +12,16 @@ import (
 )
 
 func TestValidateAPIEndpoints(t *testing.T) {
-	originalYAML := apiEndpointsYAML
+	originalEndpoints := apiEndpoints
 	t.Cleanup(func() {
-		apiEndpointsYAML = originalYAML
+		apiEndpoints = originalEndpoints
 	})
 
 	endpoints := []fleet.APIEndpoint{
 		fleet.NewAPIEndpointFromTpl("GET", "/api/v1/fleet/hosts"),
 		fleet.NewAPIEndpointFromTpl("POST", "/api/v1/fleet/hosts/:id/refetch"),
 	}
-	apiEndpointsYAML = []byte(`
-- method: "GET"
-  path: "/api/v1/fleet/hosts"
-  display_name: "Route 1"
-- method: "POST"
-  path: "/api/v1/fleet/hosts/:id/refetch"
-  display_name: "Route 2"`)
+	apiEndpoints = endpoints
 
 	routerWithEndpoints := func(endpoints []fleet.APIEndpoint) *mux.Router {
 		r := mux.NewRouter()
@@ -39,28 +33,28 @@ func TestValidateAPIEndpoints(t *testing.T) {
 	}
 
 	t.Run("all routes present", func(t *testing.T) {
-		err := Init(routerWithEndpoints(endpoints))
+		err := Validate(routerWithEndpoints(endpoints))
 		require.NoError(t, err)
 	})
 
 	t.Run("missing route returns error", func(t *testing.T) {
-		err := Init(routerWithEndpoints(endpoints[:1]))
+		err := Validate(routerWithEndpoints(endpoints[:1]))
 		require.ErrorContains(t, err, endpoints[1].Method+" "+endpoints[1].Path)
 	})
 
 	t.Run("no routes registered returns error listing all missing", func(t *testing.T) {
-		err := Init(mux.NewRouter())
+		err := Validate(mux.NewRouter())
 		require.ErrorContains(t, err, "the following API endpoints are unknown")
 	})
 
 	t.Run("non-mux handler returns error", func(t *testing.T) {
-		err := Init(http.NewServeMux())
+		err := Validate(http.NewServeMux())
 		require.ErrorContains(t, err, "expected *mux.Router")
 	})
 
 	t.Run("empty endpoint list always passes", func(t *testing.T) {
-		apiEndpointsYAML = []byte(``)
-		err := Init(mux.NewRouter())
+		apiEndpoints = nil
+		err := Validate(mux.NewRouter())
 		require.NoError(t, err)
 	})
 }

--- a/server/service/svctest/server.go
+++ b/server/service/svctest/server.go
@@ -86,7 +86,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 
 	// Activity routes. If DBConns is provided, wire the real bounded context into
 	// the main handler. Otherwise, build a path-only stub from the same registration
-	// code and surface it to apiendpoints.Init for catalog validation only.
+	// code and surface it to apiendpoints.Validate for catalog validation only.
 	var extraInitFeatureRoutes []apiendpoints.FeatureRouteFunc
 	if len(opts) > 0 && opts[0].DBConns != nil {
 		legacyAuthorizer, err := authz.NewAuthorizer()
@@ -222,7 +222,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	}
 	var carveStore fleet.CarveStore = ds // In tests, we use MySQL as storage for carves.
 	apiHandler := service.MakeHandler(svc, cfg, logger, limitStore, redisPool, carveStore, featureRoutes, extra...)
-	if err := apiendpoints.Init(apiHandler, extraInitFeatureRoutes...); err != nil {
+	if err := apiendpoints.Validate(apiHandler, extraInitFeatureRoutes...); err != nil {
 		t.Fatalf("error initializing API endpoints: %v", err)
 	}
 	rootMux.Handle("/api/", apiHandler)

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -435,7 +435,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 
 	// Activity routes. If DBConns is provided, wire the real bounded context into
 	// the main handler. Otherwise, build a path-only stub from the same registration
-	// code and surface it to apiendpoints.Init for catalog validation only.
+	// code and surface it to apiendpoints.Validate for catalog validation only.
 	var extraInitFeatureRoutes []apiendpoints.FeatureRouteFunc
 	if len(opts) > 0 && opts[0].DBConns != nil {
 		legacyAuthorizer, err := authz.NewAuthorizer()
@@ -577,7 +577,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	}
 	var carveStore fleet.CarveStore = ds // In tests, we use MySQL as storage for carves.
 	apiHandler := MakeHandler(svc, cfg, logger, limitStore, redisPool, carveStore, featureRoutes, extra...)
-	if err := apiendpoints.Init(apiHandler, extraInitFeatureRoutes...); err != nil {
+	if err := apiendpoints.Validate(apiHandler, extraInitFeatureRoutes...); err != nil {
 		t.Fatalf("error initializing API endpoints: %v", err)
 	}
 	rootMux.Handle("/api/", apiHandler)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #46190

- Added a package init() to load the catalog from the embedded YAML once.
- Init() now no longer runs any initialization logic just validation, so it was renamed to Validate.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized API endpoint initialization by loading the catalog once at startup rather than on each validation check, improving application initialization efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->