### PR TITLE
Add icon_url to policy software automations

### DIFF
--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -63,6 +63,7 @@ export interface IPolicySoftwareToInstall {
   name: string;
   display_name?: string;
   software_title_id: number;
+  icon_url?: string | null;
 }
 
 // Used on the manage hosts page and other places where aggregate stats are displayed

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -15,7 +15,6 @@ import Graphic from "components/Graphic";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import { IPolicyStats, OtherAutomationType } from "interfaces/policy";
 import PATHS from "router/paths";
-import ENDPOINTS from "utilities/endpoints";
 
 import { getPathWithQueryParams } from "utilities/url";
 import sortUtils from "utilities/sort";

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -127,14 +127,12 @@ const EditableAutomationsCell = ({
 
 interface IAutomationsCellProps {
   policy: IPolicyStats;
-  selectedTeamId?: number | null;
   otherAutomationType?: OtherAutomationType;
   onOpenManageAutomationsModal?: (policy: IPolicyStats) => void;
 }
 
 const AutomationsCell = ({
   policy,
-  selectedTeamId,
   otherAutomationType,
   onOpenManageAutomationsModal,
 }: IAutomationsCellProps): JSX.Element => {
@@ -162,24 +160,11 @@ const AutomationsCell = ({
     );
   }
 
-  const renderAutomationIcon = ({
-    type,
-    name,
-    softwareTitleId,
-  }: IAutomationData) => {
-    const iconUrl =
-      type === "software" && softwareTitleId != null
-        ? `/api${getPathWithQueryParams(
-            ENDPOINTS.SOFTWARE_ICON(softwareTitleId),
-            {
-              fleet_id:
-                selectedTeamId != null && selectedTeamId !== -1
-                  ? selectedTeamId
-                  : undefined,
-            }
-          )}`
-        : undefined;
-    return AUTOMATION_ICON_RENDERERS[type]({ name, iconUrl });
+  const renderAutomationIcon = ({ type, name, iconUrl }: IAutomationData) => {
+    return AUTOMATION_ICON_RENDERERS[type]({
+      name,
+      iconUrl: iconUrl ?? undefined,
+    });
   };
 
   if (automations.length === 1) {
@@ -310,7 +295,6 @@ const generateTableHeaders = (
       Cell: (cellProps: ICellProps): JSX.Element => (
         <AutomationsCell
           policy={cellProps.row.original}
-          selectedTeamId={selectedTeamId}
           otherAutomationType={otherAutomationType}
           onOpenManageAutomationsModal={onOpenManageAutomationsModal}
         />

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
@@ -302,6 +302,30 @@ describe("getAutomationsForPolicy", () => {
     });
   });
 
+  it("carries the custom icon_url onto the software automation", () => {
+    const result = getAutomationsForPolicy({
+      ...basePolicy,
+      install_software: {
+        name: "Chrome.app",
+        software_title_id: 42,
+        icon_url: "/api/latest/fleet/software/titles/42/icon?fleet_id=1",
+      },
+    });
+    expect(result[0]).toMatchObject({
+      type: "software",
+      iconUrl: "/api/latest/fleet/software/titles/42/icon?fleet_id=1",
+    });
+  });
+
+  it("leaves iconUrl undefined when no custom icon exists", () => {
+    const result = getAutomationsForPolicy({
+      ...basePolicy,
+      install_software: { name: "Chrome.app", software_title_id: 42 },
+    });
+    expect(result[0]).toMatchObject({ type: "software" });
+    expect((result[0] as { iconUrl?: string | null }).iconUrl).toBeUndefined();
+  });
+
   it("falls back to name when display_name is absent", () => {
     const result = getAutomationsForPolicy({
       ...basePolicy,

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
@@ -16,12 +16,14 @@ interface ISoftwareAutomationData {
   type: "software";
   name: string;
   softwareTitleId: number;
+  iconUrl?: string | null;
 }
 
 interface INonSoftwareAutomationData {
   type: Exclude<AutomationDisplayType, "software">;
   name: string;
   softwareTitleId?: never;
+  iconUrl?: never;
 }
 
 export type IAutomationData =
@@ -48,6 +50,7 @@ export const getAutomationsForPolicy = (
       name:
         policy.install_software.display_name || policy.install_software.name,
       softwareTitleId: policy.install_software.software_title_id,
+      iconUrl: policy.install_software.icon_url,
     });
   }
   if (policy.run_script) {

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
@@ -4,9 +4,12 @@ import { render, screen } from "@testing-library/react";
 import { IPolicy } from "interfaces/policy";
 import PolicyAutomationsList from "./PolicyAutomationsList";
 
-// Stub SoftwareIcon to avoid asset resolution in tests
+// Stub SoftwareIcon to avoid asset resolution in tests; surface the url prop so
+// we can assert the custom icon path is forwarded.
 jest.mock("pages/SoftwarePage/components/icons/SoftwareIcon", () => {
-  return () => <span data-testid="software-icon" />;
+  return ({ url }: { url?: string | null }) => (
+    <span data-testid="software-icon" data-url={url ?? ""} />
+  );
 });
 
 const createMockPolicy = (overrides?: Partial<IPolicy>): IPolicy => ({
@@ -54,6 +57,43 @@ describe("PolicyAutomationsList", () => {
 
       expect(screen.getByText("Zoom")).toBeInTheDocument();
       expect(screen.queryByText("No automations")).not.toBeInTheDocument();
+    });
+
+    it("forwards the custom software icon_url to SoftwareIcon", () => {
+      const iconUrl = "/api/latest/fleet/software/titles/42/icon?fleet_id=1";
+      render(
+        <PolicyAutomationsList
+          storedPolicy={createMockPolicy({
+            install_software: {
+              name: "Zoom",
+              software_title_id: 42,
+              icon_url: iconUrl,
+            },
+          })}
+          currentAutomatedPolicies={[]}
+        />
+      );
+
+      expect(screen.getByTestId("software-icon")).toHaveAttribute(
+        "data-url",
+        iconUrl
+      );
+    });
+
+    it("renders SoftwareIcon with no url when there is no custom icon", () => {
+      render(
+        <PolicyAutomationsList
+          storedPolicy={createMockPolicy({
+            install_software: { name: "Zoom", software_title_id: 42 },
+          })}
+          currentAutomatedPolicies={[]}
+        />
+      );
+
+      expect(screen.getByTestId("software-icon")).toHaveAttribute(
+        "data-url",
+        ""
+      );
     });
 
     it("shows script automation row", () => {

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 
 import { IPolicy } from "interfaces/policy";
+import ENDPOINTS from "utilities/endpoints";
+
 import PolicyAutomationsList from "./PolicyAutomationsList";
 
 // Stub SoftwareIcon to avoid asset resolution in tests; surface the url prop so
@@ -60,7 +62,7 @@ describe("PolicyAutomationsList", () => {
     });
 
     it("forwards the custom software icon_url to SoftwareIcon", () => {
-      const iconUrl = "/api/latest/fleet/software/titles/42/icon?fleet_id=1";
+      const iconUrl = ENDPOINTS.SOFTWARE_ICON(42);
       render(
         <PolicyAutomationsList
           storedPolicy={createMockPolicy({

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
@@ -124,7 +124,7 @@ const PolicyAutomationsList = ({
                 {row.isSoftware ? (
                   <SoftwareIcon
                     name={row.name}
-                    url={row.iconUrl ?? undefined}
+                    url={row.iconUrl}
                     size="small"
                   />
                 ) : (

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
@@ -21,6 +21,7 @@ interface IAutomationDisplayRow {
   type: string;
   graphicName?: GraphicNames;
   isSoftware?: boolean;
+  iconUrl?: string | null;
   link?: string;
   sortOrder: number;
   sortName: string;
@@ -47,6 +48,7 @@ const PolicyAutomationsList = ({
       name: storedPolicy.install_software.name,
       type: "Software",
       isSoftware: true,
+      iconUrl: storedPolicy.install_software.icon_url,
       link: getPathWithQueryParams(
         PATHS.SOFTWARE_TITLE_DETAILS(
           storedPolicy.install_software.software_title_id.toString()
@@ -120,7 +122,11 @@ const PolicyAutomationsList = ({
             >
               <div className={`${baseClass}__row-name`}>
                 {row.isSoftware ? (
-                  <SoftwareIcon name={row.name} size="small" />
+                  <SoftwareIcon
+                    name={row.name}
+                    url={row.iconUrl ?? undefined}
+                    size="small"
+                  />
                 ) : (
                   row.graphicName && (
                     <Graphic

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -546,6 +546,10 @@ type PolicySoftwareTitle struct {
 	// (not the package name, but the installed software title).
 	Name        string `json:"name" db:"name"`
 	DisplayName string `json:"display_name" db:"display_name"`
+	// IconURL is the API path to the custom icon uploaded for this software
+	// title in the policy's team. It is nil when no custom icon exists, in
+	// which case clients fall back to a default icon for the software title.
+	IconURL *string `json:"icon_url"`
 }
 
 // PolicyScript contains script data for policies.

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -546,10 +546,11 @@ type PolicySoftwareTitle struct {
 	// (not the package name, but the installed software title).
 	Name        string `json:"name" db:"name"`
 	DisplayName string `json:"display_name" db:"display_name"`
-	// IconURL is the API path to the custom icon uploaded for this software
-	// title in the policy's team. It is nil when no custom icon exists, in
-	// which case clients fall back to a default icon for the software title.
-	IconURL *string `json:"icon_url"`
+	// IconURL is the API path to this software title's icon in the policy's
+	// team. It is set when a custom icon was uploaded for the title, or for VPP
+	// apps (whose icon endpoint redirects to the App Store icon), and is nil
+	// otherwise.
+	IconURL *string `json:"icon_url,omitempty"`
 }
 
 // PolicyScript contains script data for policies.

--- a/server/service/policies.go
+++ b/server/service/policies.go
@@ -38,6 +38,9 @@ func (svc Service) GetPolicyByID(ctx context.Context, policyID uint) (*fleet.Pol
 	if err := svc.populateAutomationsForTeamPolicy(ctx, policy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate automations")
 	}
+	if err := svc.populateSoftwareIconURLs(ctx, []*fleet.Policy{policy}); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate software icon urls")
+	}
 
 	return policy, nil
 }

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"strconv"
@@ -204,6 +205,73 @@ func (svc *Service) populatePolicyPatchSoftware(ctx context.Context, p *fleet.Po
 	return nil
 }
 
+func getPolicySoftwareTitleIconURL(teamID, titleID uint) string {
+	icon := fleet.SoftwareTitleIcon{TeamID: teamID, SoftwareTitleID: titleID}
+	return icon.IconUrl()
+}
+
+// Sets the IconURL for any policy whose software title has a custom icon uploaded.
+func (svc *Service) populateSoftwareIconURLs(ctx context.Context, policies []*fleet.Policy) error {
+	titleIDsByTeam := make(map[uint]map[uint]struct{})
+	for _, p := range policies {
+		// Merged team-policy lists can include inherited/global policies (nil TeamID).
+		// They should not have software automation, so skip them.
+		if p.TeamID == nil {
+			continue
+		}
+		teamID := *p.TeamID
+		for _, t := range []*fleet.PolicySoftwareTitle{p.InstallSoftware, p.PatchSoftware} {
+			if t == nil {
+				continue
+			}
+			if titleIDsByTeam[teamID] == nil {
+				titleIDsByTeam[teamID] = make(map[uint]struct{})
+			}
+			titleIDsByTeam[teamID][t.SoftwareTitleID] = struct{}{}
+		}
+	}
+	if len(titleIDsByTeam) == 0 {
+		return nil
+	}
+
+	iconsByTeam := make(map[uint]map[uint]fleet.SoftwareTitleIcon, len(titleIDsByTeam))
+	for teamID, set := range titleIDsByTeam {
+		titleIDs := slices.Collect(maps.Keys(set))
+		icons, err := svc.ds.GetSoftwareIconsByTeamAndTitleIds(ctx, teamID, titleIDs)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "get software icons for policies")
+		}
+		iconsByTeam[teamID] = icons
+	}
+
+	for _, p := range policies {
+		if p.TeamID == nil {
+			continue
+		}
+		teamID := *p.TeamID
+		icons := iconsByTeam[teamID]
+
+		if t := p.InstallSoftware; t != nil {
+			_, hasCustomIcon := icons[t.SoftwareTitleID]
+			// VPP apps always have an App Store icon the icon endpoint redirects
+			// to (see getPolicySoftwareTitleIconURL), so it's safe to point at it
+			// without risking a 404.
+			if hasCustomIcon || p.VPPAppsTeamsID != nil {
+				t.IconURL = new(getPolicySoftwareTitleIconURL(teamID, t.SoftwareTitleID))
+			}
+		}
+
+		if t := p.PatchSoftware; t != nil {
+			// Patch software is always a package installer (never a VPP app), so
+			// it only gets an icon URL when a custom icon was uploaded.
+			if _, ok := icons[t.SoftwareTitleID]; ok {
+				t.IconURL = new(getPolicySoftwareTitleIconURL(teamID, t.SoftwareTitleID))
+			}
+		}
+	}
+	return nil
+}
+
 func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, teamID uint, p fleet.NewTeamPolicyPayload) (fleet.PolicyPayload, error) {
 	policyType := fleet.PolicyTypeDynamic
 
@@ -275,12 +343,18 @@ func (svc *Service) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 
 	if mergeInherited {
 		policies, err := svc.ds.ListMergedTeamPolicies(ctx, teamID, opts, automationFilter)
+		if err != nil {
+			return nil, nil, err
+		}
 		for i := range policies {
 			if err := svc.populateAutomationsForTeamPolicy(ctx, policies[i]); err != nil {
 				return nil, nil, ctxerr.Wrapf(ctx, err, "populate automations for policy_id: %d", policies[i].ID)
 			}
 		}
-		return policies, nil, err
+		if err := svc.populateSoftwareIconURLs(ctx, policies); err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "populate software icon urls")
+		}
+		return policies, nil, nil
 	}
 
 	teamPolicies, inheritedPolicies, err = svc.ds.ListTeamPolicies(ctx, teamID, opts, iopts, automationFilter)
@@ -292,6 +366,9 @@ func (svc *Service) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 		if err := svc.populateAutomationsForTeamPolicy(ctx, teamPolicies[i]); err != nil {
 			return nil, nil, ctxerr.Wrapf(ctx, err, "populate automations for policy_id: %d", teamPolicies[i].ID)
 		}
+	}
+	if err := svc.populateSoftwareIconURLs(ctx, teamPolicies); err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "populate software icon urls")
 	}
 
 	return teamPolicies, inheritedPolicies, nil
@@ -373,6 +450,9 @@ func (svc Service) GetTeamPolicyByID(ctx context.Context, teamID uint, policyID 
 
 	if err := svc.populateAutomationsForTeamPolicy(ctx, teamPolicy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate automations")
+	}
+	if err := svc.populateSoftwareIconURLs(ctx, []*fleet.Policy{teamPolicy}); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate software icon urls")
 	}
 
 	return teamPolicy, nil

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -210,7 +210,10 @@ func getPolicySoftwareTitleIconURL(teamID, titleID uint) string {
 	return icon.IconUrl()
 }
 
-// Sets the IconURL for any policy whose software title has a custom icon uploaded.
+// populateSoftwareIconURLs sets the IconURL on each policy's software automation
+// when the software title has an icon to serve: a custom icon uploaded for the
+// title, or a VPP app (whose icon endpoint redirects to the App Store icon).
+// Otherwise the IconURL is left nil.
 func (svc *Service) populateSoftwareIconURLs(ctx context.Context, policies []*fleet.Policy) error {
 	titleIDsByTeam := make(map[uint]map[uint]struct{})
 	for _, p := range policies {

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
@@ -223,6 +224,11 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 		patchSoftwareDisplay   = "Patchable App.app"
 	)
 
+	wantInstallIconURL := fmt.Sprintf(
+		"/api/latest/fleet/software/titles/%d/icon?fleet_id=%d",
+		softwareInstallerTitle, teamID,
+	)
+
 	// Returns a fresh team-scoped policy with all three automation IDs set.
 	// Each test gets a separate copy to prevent cross-test mutation.
 	freshPolicy := func() *fleet.Policy {
@@ -283,6 +289,16 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 				DisplayName:   patchSoftwareDisplay,
 			}, nil
 		}
+		ds.GetSoftwareIconsByTeamAndTitleIdsFunc = func(ctx context.Context, tID uint, titleIDs []uint) (map[uint]fleet.SoftwareTitleIcon, error) {
+			require.Equal(t, teamID, tID)
+			// Only the install-software title has a custom icon uploaded.
+			return map[uint]fleet.SoftwareTitleIcon{
+				softwareInstallerTitle: {
+					TeamID:          teamID,
+					SoftwareTitleID: softwareInstallerTitle,
+				},
+			}, nil
+		}
 		return ds
 	}
 
@@ -302,6 +318,19 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 		assert.Equal(t, patchInstallerTitleID, p.PatchSoftware.SoftwareTitleID)
 		assert.Equal(t, patchSoftwareTitleName, p.PatchSoftware.Name)
 		assert.Equal(t, patchSoftwareDisplay, p.PatchSoftware.DisplayName)
+	}
+
+	// requireSoftwareIconURLs verifies that install_software.icon_url is set to the
+	// custom icon path when one exists, and that patch_software.icon_url stays nil
+	// when the title has no custom icon.
+	requireSoftwareIconURLs := func(t *testing.T, p *fleet.Policy) {
+		t.Helper()
+		require.NotNil(t, p.InstallSoftware, "install_software should be populated")
+		require.NotNil(t, p.InstallSoftware.IconURL, "install_software icon_url should be set when a custom icon exists")
+		assert.Equal(t, wantInstallIconURL, *p.InstallSoftware.IconURL)
+
+		require.NotNil(t, p.PatchSoftware, "patch_software should be populated")
+		assert.Nil(t, p.PatchSoftware.IconURL, "patch_software icon_url should be nil when no custom icon exists")
 	}
 
 	adminCtx := func(ctx context.Context) context.Context {
@@ -336,6 +365,7 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 		policy, err := svc.GetTeamPolicyByID(ctx, teamID, policyID)
 		require.NoError(t, err)
 		requireAutomationsPopulated(t, policy)
+		requireSoftwareIconURLs(t, policy)
 	})
 
 	t.Run("GetPolicyByID", func(t *testing.T) {
@@ -346,6 +376,7 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 		policy, err := svc.GetPolicyByID(ctx, policyID)
 		require.NoError(t, err)
 		requireAutomationsPopulated(t, policy)
+		requireSoftwareIconURLs(t, policy)
 	})
 
 	t.Run("ListTeamPolicies", func(t *testing.T) {
@@ -357,6 +388,7 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, teamPols, 1)
 		requireAutomationsPopulated(t, teamPols[0])
+		requireSoftwareIconURLs(t, teamPols[0])
 	})
 
 	t.Run("ListTeamPolicies_mergeInherited", func(t *testing.T) {
@@ -368,6 +400,7 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, merged, 1)
 		requireAutomationsPopulated(t, merged[0])
+		requireSoftwareIconURLs(t, merged[0])
 	})
 
 	t.Run("ModifyTeamPolicy", func(t *testing.T) {
@@ -385,6 +418,96 @@ func TestTeamPolicyAutomationsPopulated(t *testing.T) {
 		require.NoError(t, err)
 		requireAutomationsPopulated(t, policy)
 	})
+}
+
+// TestPopulateSoftwareIconURLs verifies how the software automation icon_url is derived:
+// - Titles with a custom uploaded icon and VPP apps both get the icon endpoint URL (which serves the custom icon or redirects to the App Store icon).
+// - Package installers with no custom icon get a nil URL (so clients use the default icon and avoid a 404).
+// - Inherited policies (nil team, no software, present in merged lists) are skipped.
+func TestPopulateSoftwareIconURLs(t *testing.T) {
+	const (
+		teamID               = uint(7)
+		customInstallerTitle = uint(11)
+		plainInstallerTitle  = uint(12)
+		vppPlainTitle        = uint(13)
+		vppCustomTitle       = uint(14)
+		patchCustomTitle     = uint(15)
+		vppAppsTeamsID       = uint(900)
+	)
+
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+	// populateSoftwareIconURLs is unexported, so reach the concrete service.
+	svcImpl := svc.(validationMiddleware).Service.(*Service)
+
+	var requestedTitleIDs []uint
+	ds.GetSoftwareIconsByTeamAndTitleIdsFunc = func(ctx context.Context, tID uint, titleIDs []uint) (map[uint]fleet.SoftwareTitleIcon, error) {
+		require.Equal(t, teamID, tID)
+		requestedTitleIDs = titleIDs
+		// Custom icons exist for one installer, one VPP app, and one patch title.
+		return map[uint]fleet.SoftwareTitleIcon{
+			customInstallerTitle: {TeamID: teamID, SoftwareTitleID: customInstallerTitle},
+			vppCustomTitle:       {TeamID: teamID, SoftwareTitleID: vppCustomTitle},
+			patchCustomTitle:     {TeamID: teamID, SoftwareTitleID: patchCustomTitle},
+		}, nil
+	}
+
+	tID := teamID
+	teamPolicy := func(install *fleet.PolicySoftwareTitle, vppAppsTeamsID *uint, patch *fleet.PolicySoftwareTitle) *fleet.Policy {
+		return &fleet.Policy{
+			PolicyData:      fleet.PolicyData{TeamID: &tID, VPPAppsTeamsID: vppAppsTeamsID},
+			InstallSoftware: install,
+			PatchSoftware:   patch,
+		}
+	}
+
+	customInstaller := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: customInstallerTitle}, nil, nil)
+	plainInstaller := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: plainInstallerTitle}, nil, nil)
+	vppPlain := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: vppPlainTitle}, ptr.Uint(vppAppsTeamsID), nil)
+	vppCustom := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: vppCustomTitle}, ptr.Uint(vppAppsTeamsID), nil)
+	patchPolicy := teamPolicy(nil, nil, &fleet.PolicySoftwareTitle{SoftwareTitleID: patchCustomTitle})
+	inheritedPolicy := &fleet.Policy{PolicyData: fleet.PolicyData{TeamID: nil}}
+
+	policies := []*fleet.Policy{customInstaller, plainInstaller, vppPlain, vppCustom, patchPolicy, inheritedPolicy}
+	require.NoError(t, svcImpl.populateSoftwareIconURLs(ctx, policies))
+
+	require.True(t, ds.GetSoftwareIconsByTeamAndTitleIdsFuncInvoked)
+	// The inherited policy has no team and no software, so it contributes nothing.
+	require.ElementsMatch(t,
+		[]uint{customInstallerTitle, plainInstallerTitle, vppPlainTitle, vppCustomTitle, patchCustomTitle},
+		requestedTitleIDs,
+	)
+
+	// Custom installer icon → canonical endpoint URL.
+	require.NotNil(t, customInstaller.InstallSoftware.IconURL)
+	assert.Equal(t,
+		fmt.Sprintf("/api/latest/fleet/software/titles/%d/icon?fleet_id=%d", customInstallerTitle, teamID),
+		*customInstaller.InstallSoftware.IconURL,
+	)
+
+	// Plain installer, no custom icon → nil (client uses default icon, no 404).
+	assert.Nil(t, plainInstaller.InstallSoftware.IconURL)
+
+	// VPP app, no custom icon → endpoint URL (redirects to App Store icon).
+	require.NotNil(t, vppPlain.InstallSoftware.IconURL)
+	assert.Equal(t,
+		fmt.Sprintf("/api/latest/fleet/software/titles/%d/icon?fleet_id=%d", vppPlainTitle, teamID),
+		*vppPlain.InstallSoftware.IconURL,
+	)
+
+	// VPP app with a custom icon → still gets the endpoint URL (custom icon served).
+	require.NotNil(t, vppCustom.InstallSoftware.IconURL)
+	assert.Equal(t,
+		fmt.Sprintf("/api/latest/fleet/software/titles/%d/icon?fleet_id=%d", vppCustomTitle, teamID),
+		*vppCustom.InstallSoftware.IconURL,
+	)
+
+	// Patch software with a custom icon → endpoint URL.
+	require.NotNil(t, patchPolicy.PatchSoftware.IconURL)
+	assert.Equal(t,
+		fmt.Sprintf("/api/latest/fleet/software/titles/%d/icon?fleet_id=%d", patchCustomTitle, teamID),
+		*patchPolicy.PatchSoftware.IconURL,
+	)
 }
 
 func checkAuthErr(t *testing.T, shouldFail bool, err error) {

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -463,8 +463,8 @@ func TestPopulateSoftwareIconURLs(t *testing.T) {
 
 	customInstaller := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: customInstallerTitle}, nil, nil)
 	plainInstaller := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: plainInstallerTitle}, nil, nil)
-	vppPlain := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: vppPlainTitle}, ptr.Uint(vppAppsTeamsID), nil)
-	vppCustom := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: vppCustomTitle}, ptr.Uint(vppAppsTeamsID), nil)
+	vppPlain := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: vppPlainTitle}, new(vppAppsTeamsID), nil)
+	vppCustom := teamPolicy(&fleet.PolicySoftwareTitle{SoftwareTitleID: vppCustomTitle}, new(vppAppsTeamsID), nil)
 	patchPolicy := teamPolicy(nil, nil, &fleet.PolicySoftwareTitle{SoftwareTitleID: patchCustomTitle})
 	inheritedPolicy := &fleet.Policy{PolicyData: fleet.PolicyData{TeamID: nil}}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46722

This PR modifies both the FE and BE so that we do not fire a single request for each software policy automation row. Instead, we build the custom icon url (if any) into the main `policies` endpoint response. This also prevents 404ing when there's no custom icon uploaded for the associated software title.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

#### Before (main branch)


https://github.com/user-attachments/assets/fa358e90-dc08-45e0-8c4d-b8a8b57a6c98

#### After


https://github.com/user-attachments/assets/4ca7b931-a10b-4d57-96b1-ba5a88e04de5



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Policy automations now show software icons when available (custom installer icons, VPP app icons, and patch icons), sourced from the server with graceful fallback when missing.
* **Tests**
  * Added/updated tests to verify icon propagation and rendering behavior across policy lists and automation views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->