### PR TITLE
Removed TODO from the Playwright automation checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -123,5 +123,5 @@ It is [planned and ready](https://fleetdm.com/handbook/company/development-group
 2. [ ] QA: Added comment to user story confirming successful completion of test plan.
 3. [ ] QA: Determined whether this story needs Playwright automation.
    - Needs automation: Yes / No
-   - If yes, filed a follow-up issue in the :help-qa project with status "Needs automation": TODO <!-- link -->
+   - If yes, filed a follow-up issue in the :help-qa project with status "Needs automation": <!-- link -->
 


### PR DESCRIPTION
This was getting flagged by automation when filtering for TODOs on issues. This is one of the final things that QA needs to do before wrapping up their work, so we'll remove the TODO from it for parity with other "Confirmation" steps
