### PR TITLE
Enable "Turn off MDM" button for offline macOS devices

### DIFF
--- a/changes/25217-turn-off-mdm-offline-macos
+++ b/changes/25217-turn-off-mdm-offline-macos
@@ -1,0 +1,1 @@
+- Enabled "Turn off MDM" button for offline macOS hosts. The unenroll command is now queued and delivered when the device comes back online, consistent with iOS/iPadOS behavior.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -574,7 +574,7 @@ describe("Host Actions Dropdown", () => {
       expect(screen.queryByText("Turn off MDM")).not.toBeInTheDocument();
     });
 
-    it("renders as disabled when the host is offline", async () => {
+    it("renders as enabled when the host is offline", async () => {
       const render = createCustomRenderer({
         context: {
           app: {
@@ -600,7 +600,7 @@ describe("Host Actions Dropdown", () => {
 
       await user.click(screen.getByText("Actions"));
 
-      expect(screen.getByText("Turn off MDM").parentElement).toHaveClass(
+      expect(screen.getByText("Turn off MDM").parentElement).not.toHaveClass(
         "actions-dropdown-select__option--is-disabled"
       );
     });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -614,13 +614,6 @@ const modifyOptions = (
     optionsToDisable = optionsToDisable.concat(
       options.filter((option) => option.value === "query")
     );
-
-    // Disable "Turn off MDM" (Unenroll) when offline for all platforms except iOS/iPadOS and Android
-    if (!isIPadOrIPhone(hostPlatform) && !isAndroid(hostPlatform)) {
-      optionsToDisable = optionsToDisable.concat(
-        options.filter((option) => option.value === "mdmOff")
-      );
-    }
   }
 
   // While device status is updating, or device is locked/wiped, disable Query and Turn off MDM


### PR DESCRIPTION
The original implementation (#8206) explicitly disabled this for offline hosts until MDM command queueing was supported. That work has since been completed, so offline macOS hosts now behave the same as iOS/iPadOS: the unenroll command is queued and delivered when the device comes back online.

**Related issue:** Resolves #25217

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Turn off MDM" action is now enabled for offline macOS hosts. Unenroll commands can be queued while a device is offline and will be delivered automatically when it reconnects, matching the behavior for iOS and iPadOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->