### PR TITLE
Fixed/enabled cache-poisoning zizmor check

### DIFF
--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -47,6 +47,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Import signing keys
         env:
@@ -116,6 +118,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Generate fleet-desktop.exe
         run: |
@@ -162,6 +166,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Generate fleet-desktop.exe
         run: |
@@ -209,6 +215,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Generate desktop.tar.gz
         run: |
@@ -243,6 +251,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Generate desktop.tar.gz
         run: |

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -58,8 +58,6 @@ jobs:
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version-file: package.json
-          # Security best practice to disable caching in release/publish workflows
-          package-manager-cache: false
 
       - name: Install JS Dependencies
         run: make deps-js

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -58,6 +58,8 @@ jobs:
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version-file: package.json
+          # Security best practice to disable caching in release/publish workflows
+          package-manager-cache: false
 
       - name: Install JS Dependencies
         run: make deps-js

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -51,11 +51,15 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version-file: package.json
+          # Security best practice to disable caching in release/publish workflows
+          package-manager-cache: false
 
       - name: Install JS Dependencies
         run: make deps-js

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -55,6 +55,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-macos.yml # v2.4.4
@@ -103,6 +105,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Install musl tools
         run: sudo apt update && sudo apt install -y musl-tools
@@ -148,6 +152,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-linux-arm64.yml # v2.4.4
@@ -190,6 +196,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-windows.yml # v2.4.4
@@ -244,6 +252,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-windows-arm64.yml # v2.4.4

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -69,6 +69,8 @@ jobs:
         with:
           node-version-file: package.json
           check-latest: true
+          # Security best practice to disable caching in release/publish workflows
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: make deps

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -69,8 +69,6 @@ jobs:
         with:
           node-version-file: package.json
           check-latest: true
-          # Security best practice to disable caching in release/publish workflows
-          package-manager-cache: false
 
       - name: Install Dependencies
         run: make deps

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -60,6 +60,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       # Set the Node.js version
       - name: Set up Node.js
@@ -67,6 +69,8 @@ jobs:
         with:
           node-version-file: package.json
           check-latest: true
+          # Security best practice to disable caching in release/publish workflows
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: make deps

--- a/.github/workflows/publish-go-module.yml
+++ b/.github/workflows/publish-go-module.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Publish go module
         run: |

--- a/.github/workflows/release-fleetctl-docker-deps.yaml
+++ b/.github/workflows/release-fleetctl-docker-deps.yaml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
+          # Security best practice to disable caching in release/publish workflows
+          cache: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0

--- a/.github/zizmor-gate.yml
+++ b/.github/zizmor-gate.yml
@@ -14,8 +14,6 @@
 rules:
   artipacked: # 125 findings
     disable: true
-  cache-poisoning: # 16 findings
-    disable: true
   dependabot-cooldown: # 2 findings
     disable: true
   excessive-permissions: # 20 findings


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41198 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled Go toolchain/module caching across CI build, release, and publish workflows.
  * Disabled Node package-manager caching in relevant publish workflows.
* **Security**
  * Re-enabled the cache-poisoning gate rule so cache-poisoning checks can now block failing runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->