### PR TITLE
Fix VPP API retry recursion causing server OOM

### DIFF
--- a/changes/46656-vpp-api-derecursion-oom
+++ b/changes/46656-vpp-api-derecursion-oom
@@ -1,0 +1,1 @@
+* Fixed a server out-of-memory crash that could occur when Apple's VPP (App and Book Management) API repeatedly returned transient errors (HTTP 500 with Retry-After, or error 9646) during app installs.

--- a/changes/46656-vpp-api-derecursion-oom
+++ b/changes/46656-vpp-api-derecursion-oom
@@ -1,1 +1,1 @@
-* Fixed a server out-of-memory crash that could occur when Apple's VPP (App and Book Management) API repeatedly returned transient errors (HTTP 500 with Retry-After, or error 9646) during app installs.
+* Fixed a server out-of-memory crash that could occur when Apple's VPP (App and Book Management) API repeatedly returned transient errors (HTTP 500 with Retry-After, or error 9646) during VPP API operations (e.g., app installs, user registration, license seat releases).

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1709,7 +1709,7 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 		// must release it — otherwise the seat leaks (no install will ever use
 		// it). Best-effort: log and continue returning the original error.
 		if assocReq != nil {
-			if _, dErr := vpp.DisassociateAssets(ctx, token, assocReq); dErr != nil {
+			if _, dErr := vpp.DisassociateAssets(token, assocReq); dErr != nil {
 				svc.logger.ErrorContext(ctx, "failed to release reserved VPP license after install insert failure",
 					"err", dErr, "host_id", host.ID, "adam_id", vppApp.AdamID)
 			}

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1614,7 +1614,7 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 	} else {
 		assignmentFilter.SerialNumber = host.HardwareSerial
 	}
-	assignments, err := vpp.GetAssignments(token, assignmentFilter)
+	assignments, err := vpp.GetAssignments(ctx, token, assignmentFilter)
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "getting assignments from VPP API")
 	}
@@ -1670,7 +1670,7 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 			req.SerialNumbers = []string{host.HardwareSerial}
 		}
 
-		eventID, err = vpp.AssociateAssets(token, req)
+		eventID, err = vpp.AssociateAssets(ctx, token, req)
 		if err == nil {
 			// We reserved a seat; remember the request so we can release it if a
 			// later step fails.
@@ -1709,7 +1709,7 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 		// must release it — otherwise the seat leaks (no install will ever use
 		// it). Best-effort: log and continue returning the original error.
 		if assocReq != nil {
-			if _, dErr := vpp.DisassociateAssets(token, assocReq); dErr != nil {
+			if _, dErr := vpp.DisassociateAssets(ctx, token, assocReq); dErr != nil {
 				svc.logger.ErrorContext(ctx, "failed to release reserved VPP license after install insert failure",
 					"err", dErr, "host_id", host.ID, "adam_id", vppApp.AdamID)
 			}

--- a/ee/server/service/vpp_users.go
+++ b/ee/server/service/vpp_users.go
@@ -66,7 +66,7 @@ func (svc *Service) registerVPPClientUser(ctx context.Context, tokenID uint, man
 
 	// v1 registerVPPUserSrv is synchronous — a successful response means the
 	// user is registered and ready to receive license associations.
-	appleUserID, err := vpp.RegisterUser(token, clientUserID, managedAppleID)
+	appleUserID, err := vpp.RegisterUser(ctx, token, clientUserID, managedAppleID)
 	if err != nil {
 		return "", ctxerr.Wrapf(ctx, err, "registering vpp user for managed apple id %q", managedAppleID)
 	}

--- a/server/mdm/apple/vpp/api.go
+++ b/server/mdm/apple/vpp/api.go
@@ -233,7 +233,7 @@ type DisassociateAssetsRequest = AssociateAssetsRequest
 // cancelled before reaching the device).
 //
 // https://developer.apple.com/documentation/devicemanagement/disassociate_assets
-func DisassociateAssets(ctx context.Context, token string, params *DisassociateAssetsRequest) (string, error) {
+func DisassociateAssets(token string, params *DisassociateAssetsRequest) (string, error) {
 	if err := params.Validate(); err != nil {
 		return "", err
 	}
@@ -243,7 +243,7 @@ func DisassociateAssets(ctx context.Context, token string, params *DisassociateA
 		return "", fmt.Errorf("encoding params as JSON: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, getBaseURL()+"/assets/disassociate", &reqBody)
+	req, err := http.NewRequest(http.MethodPost, getBaseURL()+"/assets/disassociate", &reqBody)
 	if err != nil {
 		return "", fmt.Errorf("creating request to Apple VPP endpoint: %w", err)
 	}
@@ -590,7 +590,9 @@ func do[T any](req *http.Request, token string, dest *T) error {
 		}
 	}
 
-	return fmt.Errorf("Apple VPP endpoint still failing after %d attempts (last: %s)", vppMaxAttempts, lastReason)
+	return &ErrorResponse{
+		ErrorMessage: fmt.Sprintf("gave up after %d attempts (last: %s)", vppMaxAttempts, lastReason),
+	}
 }
 
 func doVPPAttempt[T any](req *http.Request, dest *T) (done bool, retryAfter time.Duration, err error) {

--- a/server/mdm/apple/vpp/api.go
+++ b/server/mdm/apple/vpp/api.go
@@ -192,7 +192,7 @@ func (r *AssociateAssetsRequest) Validate() error {
 // according the the request parameters provided.
 //
 // https://developer.apple.com/documentation/devicemanagement/associate_assets
-func AssociateAssets(token string, params *AssociateAssetsRequest) (string, error) {
+func AssociateAssets(ctx context.Context, token string, params *AssociateAssetsRequest) (string, error) {
 	if err := params.Validate(); err != nil {
 		return "", err
 	}
@@ -202,7 +202,7 @@ func AssociateAssets(token string, params *AssociateAssetsRequest) (string, erro
 		return "", fmt.Errorf("encoding params as JSON: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, getBaseURL()+"/assets/associate", &reqBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, getBaseURL()+"/assets/associate", &reqBody)
 	if err != nil {
 		return "", fmt.Errorf("creating request to Apple VPP endpoint: %w", err)
 	}
@@ -233,7 +233,7 @@ type DisassociateAssetsRequest = AssociateAssetsRequest
 // cancelled before reaching the device).
 //
 // https://developer.apple.com/documentation/devicemanagement/disassociate_assets
-func DisassociateAssets(token string, params *DisassociateAssetsRequest) (string, error) {
+func DisassociateAssets(ctx context.Context, token string, params *DisassociateAssetsRequest) (string, error) {
 	if err := params.Validate(); err != nil {
 		return "", err
 	}
@@ -243,7 +243,7 @@ func DisassociateAssets(token string, params *DisassociateAssetsRequest) (string
 		return "", fmt.Errorf("encoding params as JSON: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, getBaseURL()+"/assets/disassociate", &reqBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, getBaseURL()+"/assets/disassociate", &reqBody)
 	if err != nil {
 		return "", fmt.Errorf("creating request to Apple VPP endpoint: %w", err)
 	}
@@ -295,7 +295,7 @@ type RegisterUserResponse struct {
 // (e.g. invalid Managed Apple ID).
 //
 // https://developer.apple.com/documentation/devicemanagement/registervppuserrequest
-func RegisterUser(token, clientUserID, managedAppleID string) (string, error) {
+func RegisterUser(ctx context.Context, token, clientUserID, managedAppleID string) (string, error) {
 	if clientUserID == "" || managedAppleID == "" {
 		return "", errors.New("RegisterUser: clientUserId and managedAppleId are required")
 	}
@@ -320,7 +320,7 @@ func RegisterUser(token, clientUserID, managedAppleID string) (string, error) {
 		return "", fmt.Errorf("encoding params as JSON: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, getV1BaseURL()+"/registerVPPUserSrv", &reqBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, getV1BaseURL()+"/registerVPPUserSrv", &reqBody)
 	if err != nil {
 		return "", fmt.Errorf("creating request to Apple VPP endpoint: %w", err)
 	}
@@ -479,7 +479,7 @@ type Assignment struct {
 // GetAssignments fetches the assets from Apple's VPP API with optional filters.
 //
 // https://developer.apple.com/documentation/devicemanagement/get_assignments-o3j
-func GetAssignments(token string, filter *AssignmentFilter) ([]Assignment, error) {
+func GetAssignments(ctx context.Context, token string, filter *AssignmentFilter) ([]Assignment, error) {
 	baseURL := getBaseURL() + "/assignments"
 	reqURL, err := url.Parse(baseURL)
 	if err != nil {
@@ -496,7 +496,7 @@ func GetAssignments(token string, filter *AssignmentFilter) ([]Assignment, error
 		reqURL.RawQuery = query.Encode()
 	}
 
-	req, err := http.NewRequest(http.MethodGet, reqURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request to Apple VPP endpoint: %w", err)
 	}
@@ -517,6 +517,20 @@ func GetAssignments(token string, filter *AssignmentFilter) ([]Assignment, error
 	return bodyResp.Assignments, nil
 }
 
+const (
+	errorNumberTooManyRequests int32 = 9646
+)
+
+var (
+	// vppMaxAttempts is the initial attempt plus retries (4 = 1 + 3).
+	vppMaxAttempts = 4
+	maxVPPBackoff  = 30 * time.Second
+	// Backoff for the "too many requests" (rate-limited) case, which has no
+	// Apple-provided Retry-After to honor.
+	vppRateLimitInterval          = 5 * time.Second
+	vppRateLimitBackoffMultiplier = 3
+)
+
 func do[T any](req *http.Request, token string, dest *T) error {
 	// v1 endpoints carry the token in the request body, so callers pass an
 	// empty string to skip the Authorization header.
@@ -524,67 +538,98 @@ func do[T any](req *http.Request, token string, dest *T) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 
-	// Reset the request body for retries. After client.Do reads the body,
-	// it's consumed. GetBody (set by http.NewRequest for *bytes.Buffer)
-	// returns a fresh reader over the original bytes.
-	if req.GetBody != nil {
-		body, err := req.GetBody()
-		if err != nil {
-			return fmt.Errorf("resetting request body for VPP retry: %w", err)
+	ctx := req.Context()
+	var lastReason string
+
+	for attempt := 0; attempt < vppMaxAttempts; attempt++ {
+		// Reset the request body for each attempt. After client.Do reads the
+		// body it's consumed; GetBody (set by http.NewRequest for *bytes.Buffer)
+		// returns a fresh reader over the original bytes.
+		if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return fmt.Errorf("resetting request body for VPP retry: %w", err)
+			}
+			req.Body = body
 		}
-		req.Body = body
+
+		done, retryAfter, err := doVPPAttempt(req, dest)
+		if done {
+			// Terminal outcome: success (err == nil, dest populated) or a
+			// non-retryable error.
+			return err
+		}
+
+		// Record why we're retrying for the eventual "exhausted" error.
+		if retryAfter > 0 {
+			lastReason = fmt.Sprintf("HTTP 500 with Retry-After %s", retryAfter)
+		} else {
+			lastReason = "rate limited (too many requests)"
+		}
+
+		// No need to back off after the final attempt — we're about to give up.
+		if attempt == vppMaxAttempts-1 {
+			break
+		}
+
+		// Compute the capped wait. For HTTP 500 we honor Apple's Retry-After
+		// (capped); for the rate-limited case Apple gives no wait, so we use our
+		// own incremental backoff.
+		wait := retryAfter
+		if wait <= 0 {
+			wait = vppRateLimitInterval
+			for i := 0; i < attempt; i++ {
+				wait *= time.Duration(vppRateLimitBackoffMultiplier)
+			}
+		}
+		if wait > maxVPPBackoff {
+			wait = maxVPPBackoff
+		}
+		if err := sleepContext(ctx, wait); err != nil {
+			return fmt.Errorf("waiting to retry Apple VPP endpoint: %w", err)
+		}
 	}
 
+	return fmt.Errorf("Apple VPP endpoint still failing after %d attempts (last: %s)", vppMaxAttempts, lastReason)
+}
+
+func doVPPAttempt[T any](req *http.Request, dest *T) (done bool, retryAfter time.Duration, err error) {
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("making request to Apple VPP endpoint: %w", err)
+		return true, 0, fmt.Errorf("making request to Apple VPP endpoint: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("reading response body from Apple VPP endpoint: %w", err)
+		return true, 0, fmt.Errorf("reading response body from Apple VPP endpoint: %w", err)
 	}
 
-	// For HTTP 5xx server error responses, a Retry-After header indicates
-	// how long the client must wait before making additional requests.
+	// For HTTP 5xx server error responses, a Retry-After header indicates how
+	// long the client must wait before making additional requests.
 	//
 	// https://developer.apple.com/documentation/devicemanagement/app_and_book_management/handling_error_responses#3742679
-	retryAfter := resp.Header.Get("Retry-After")
-	if resp.StatusCode == http.StatusInternalServerError && retryAfter != "" {
-		seconds, err := strconv.ParseInt(retryAfter, 10, 0)
-		if err != nil {
-			return fmt.Errorf("parsing retry-after header: %w", err)
+	if ra := resp.Header.Get("Retry-After"); resp.StatusCode == http.StatusInternalServerError && ra != "" {
+		seconds, perr := strconv.ParseInt(ra, 10, 0)
+		if perr != nil {
+			return true, 0, fmt.Errorf("parsing retry-after header: %w", perr)
 		}
-
-		ticker := time.NewTicker(time.Duration(seconds) * time.Second)
-		defer ticker.Stop()
-		<-ticker.C
-		return do(req, token, dest)
+		return false, time.Duration(seconds) * time.Second, nil
 	}
 
 	// For some reason, Apple returns 200 OK even if you pass an invalid token in the Auth header.
 	// We will need to parse the response and check to see if it contains an error.
 	var errResp ErrorResponse
-	if err := json.Unmarshal(body, &errResp); err == nil && (errResp.ErrorMessage != "" || errResp.ErrorNumber != 0) {
-		switch errResp.ErrorNumber {
-		// 9646: There are too many requests for the current
-		// Organization and the request has been rejected, either due
-		// to high server volume or an MDM issue. Use an
-		// incremental/exponential backoff strategy to retry the
-		// request until successful.
+	if uerr := json.Unmarshal(body, &errResp); uerr == nil && (errResp.ErrorMessage != "" || errResp.ErrorNumber != 0) {
+		// Too many requests for the current Organization: the request was
+		// rejected due to high server volume or an MDM issue. Retry with
+		// incremental backoff.
 		//
 		// https://developer.apple.com/documentation/devicemanagement/app_and_book_management/handling_error_responses#3783126
-		case 9646:
-			return retry.Do(
-				func() error { return do(req, token, dest) },
-				retry.WithBackoffMultiplier(3),
-				retry.WithInterval(5*time.Second),
-				retry.WithMaxAttempts(3),
-			)
-		default:
-			return &errResp
+		if errResp.ErrorNumber == errorNumberTooManyRequests {
+			return false, 0, nil
 		}
+		return true, 0, &errResp
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -592,16 +637,32 @@ func do[T any](req *http.Request, token string, dest *T) error {
 		if len(limitedBody) > 1000 {
 			limitedBody = limitedBody[:1000]
 		}
-		return fmt.Errorf("calling Apple VPP endpoint failed with status %d: %s", resp.StatusCode, string(limitedBody))
+		return true, 0, fmt.Errorf("calling Apple VPP endpoint failed with status %d: %s", resp.StatusCode, string(limitedBody))
 	}
 
 	if dest != nil {
-		if err := json.Unmarshal(body, dest); err != nil {
-			return fmt.Errorf("decoding response data from Apple VPP endpoint: %w", err)
+		if jerr := json.Unmarshal(body, dest); jerr != nil {
+			return true, 0, fmt.Errorf("decoding response data from Apple VPP endpoint: %w", jerr)
 		}
 	}
 
-	return nil
+	return true, 0, nil
+}
+
+// sleepContext waits for d to elapse or for ctx to be done, whichever comes
+// first, returning ctx.Err() if the context is canceled before the wait elapses.
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func getBaseURL() string {

--- a/server/mdm/apple/vpp/api.go
+++ b/server/mdm/apple/vpp/api.go
@@ -189,7 +189,7 @@ func (r *AssociateAssetsRequest) Validate() error {
 }
 
 // AssociateAssets associates assets to serial numbers or client user IDs
-// according the the request parameters provided.
+// according to the request parameters provided.
 //
 // https://developer.apple.com/documentation/devicemanagement/associate_assets
 func AssociateAssets(ctx context.Context, token string, params *AssociateAssetsRequest) (string, error) {
@@ -605,7 +605,7 @@ func doVPPAttempt[T any](req *http.Request, dest *T) (done bool, retryAfter time
 		return true, 0, fmt.Errorf("reading response body from Apple VPP endpoint: %w", err)
 	}
 
-	// For HTTP 5xx server error responses, a Retry-After header indicates how
+	// For an HTTP 500 server error response, a Retry-After header indicates how
 	// long the client must wait before making additional requests.
 	//
 	// https://developer.apple.com/documentation/devicemanagement/app_and_book_management/handling_error_responses#3742679
@@ -613,6 +613,14 @@ func doVPPAttempt[T any](req *http.Request, dest *T) (done bool, retryAfter time
 		seconds, perr := strconv.ParseInt(ra, 10, 0)
 		if perr != nil {
 			return true, 0, fmt.Errorf("parsing retry-after header: %w", perr)
+		}
+		// Clamp to our backoff cap before scaling to a Duration: do() caps the
+		// wait at maxVPPBackoff anyway, and converting an absurdly large value
+		// would overflow the int64 Duration math (potentially wrapping negative).
+		// Non-positive values are left as-is and fall through to do()'s default
+		// backoff.
+		if maxSeconds := int64(maxVPPBackoff / time.Second); seconds > maxSeconds {
+			seconds = maxSeconds
 		}
 		return false, time.Duration(seconds) * time.Second, nil
 	}

--- a/server/mdm/apple/vpp/api_test.go
+++ b/server/mdm/apple/vpp/api_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -779,6 +780,40 @@ func TestDoRetryIsBoundedAndNonRecursive(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "context")
 		require.Less(t, time.Since(start), 2*time.Second, "ctx cancellation should abort the backoff sleep")
+	})
+
+	t.Run("applies a growing backoff between retries", func(t *testing.T) {
+		// Override for measurable, non-flaky spacing; restore afterward.
+		oa, oi, om, ob := vppMaxAttempts, vppRateLimitInterval, vppRateLimitBackoffMultiplier, maxVPPBackoff
+		t.Cleanup(func() {
+			vppMaxAttempts, vppRateLimitInterval, vppRateLimitBackoffMultiplier, maxVPPBackoff = oa, oi, om, ob
+		})
+		vppMaxAttempts = 3
+		vppRateLimitInterval = 30 * time.Millisecond
+		vppRateLimitBackoffMultiplier = 2
+		maxVPPBackoff = time.Second // generous, so capping doesn't interfere here
+
+		var mu sync.Mutex
+		var times []time.Time
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			times = append(times, time.Now())
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"errorMessage":"Too many requests","errorNumber":9646}`))
+		})
+
+		_, err := AssociateAssets(t.Context(), "tok", associateAssetsParams())
+		require.Error(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, times, 3)
+		// The backoff is actually applied between attempts (not skipped) and
+		// grows (30ms, then 60ms). Timers fire at-or-after their interval, so
+		// these lower bounds are not flaky.
+		require.GreaterOrEqual(t, times[1].Sub(times[0]), 30*time.Millisecond)
+		require.GreaterOrEqual(t, times[2].Sub(times[1]), 60*time.Millisecond)
 	})
 }
 

--- a/server/mdm/apple/vpp/api_test.go
+++ b/server/mdm/apple/vpp/api_test.go
@@ -782,6 +782,28 @@ func TestDoRetryIsBoundedAndNonRecursive(t *testing.T) {
 	})
 }
 
+// TestDoVPPAttemptClampsRetryAfter verifies that an absurdly large Retry-After
+// value is clamped to the backoff cap before being scaled to a time.Duration,
+// rather than overflowing the int64 nanosecond math (which could wrap negative
+// and bypass the cap). Uses the default maxVPPBackoff and calls doVPPAttempt
+// directly (it doesn't sleep), so the test is instant.
+func TestDoVPPAttemptClampsRetryAfter(t *testing.T) {
+	setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// ~1e14 seconds: seconds * 1e9 ns overflows int64 if not clamped first.
+		w.Header().Set("Retry-After", "99999999999999")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, dev_mode.Env("FLEET_DEV_VPP_URL"), nil)
+	require.NoError(t, err)
+
+	done, retryAfter, err := doVPPAttempt[any](req, nil)
+	require.NoError(t, err)
+	require.False(t, done, "a 500 + Retry-After should be retryable, not terminal")
+	require.Greater(t, retryAfter, time.Duration(0), "clamped Retry-After must stay positive (no overflow to negative)")
+	require.Equal(t, maxVPPBackoff, retryAfter, "an over-cap Retry-After should clamp to the backoff cap")
+}
+
 func TestIsMaxDevicesPerUserError(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/server/mdm/apple/vpp/api_test.go
+++ b/server/mdm/apple/vpp/api_test.go
@@ -1,6 +1,7 @@
 package vpp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -284,7 +285,7 @@ func TestAssociateAssets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			setupFakeServer(t, tt.handler)
 
-			_, err := AssociateAssets(tt.token, tt.params)
+			_, err := AssociateAssets(t.Context(), tt.token, tt.params)
 			if tt.expectedErrMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErrMsg)
@@ -543,7 +544,7 @@ func TestDoRetry(t *testing.T) {
 			_, _ = w.Write([]byte(`{"eventId": "evt-123"}`))
 		})
 
-		eventID, err := AssociateAssets("test-token", &AssociateAssetsRequest{
+		eventID, err := AssociateAssets(t.Context(), "test-token", &AssociateAssetsRequest{
 			Assets:        []Asset{{AdamID: "462054704", PricingParam: "STDQ"}},
 			SerialNumbers: []string{"GXH409KH7X"},
 		})
@@ -584,7 +585,7 @@ func TestDoRetry(t *testing.T) {
 			_, _ = w.Write([]byte(`{"eventId": "evt-456"}`))
 		})
 
-		eventID, err := AssociateAssets("test-token", &AssociateAssetsRequest{
+		eventID, err := AssociateAssets(t.Context(), "test-token", &AssociateAssetsRequest{
 			Assets:        []Asset{{AdamID: "462054704", PricingParam: "STDQ"}},
 			SerialNumbers: []string{"GXH409KH7X"},
 		})
@@ -596,10 +597,10 @@ func TestDoRetry(t *testing.T) {
 
 func TestRegisterUser(t *testing.T) {
 	t.Run("rejects empty client user id or managed apple id", func(t *testing.T) {
-		_, err := RegisterUser("tok", "", "user@example.com")
+		_, err := RegisterUser(t.Context(), "tok", "", "user@example.com")
 		require.Error(t, err)
 
-		_, err = RegisterUser("tok", "uuid-1", "")
+		_, err = RegisterUser(t.Context(), "tok", "uuid-1", "")
 		require.Error(t, err)
 	})
 
@@ -638,7 +639,7 @@ func TestRegisterUser(t *testing.T) {
 			}`))
 		})
 
-		appleUserID, err := RegisterUser("valid_token", "uuid-1", "user1@example.com")
+		appleUserID, err := RegisterUser(t.Context(), "valid_token", "uuid-1", "user1@example.com")
 		require.NoError(t, err)
 		require.Equal(t, "12345", appleUserID)
 	})
@@ -653,7 +654,7 @@ func TestRegisterUser(t *testing.T) {
 			}`))
 		})
 
-		_, err := RegisterUser("valid_token", "uuid-1", "missing@example.com")
+		_, err := RegisterUser(t.Context(), "valid_token", "uuid-1", "missing@example.com")
 		require.Error(t, err)
 
 		var appleErr *ErrorResponse
@@ -668,7 +669,7 @@ func TestRegisterUser(t *testing.T) {
 			_, _ = w.Write([]byte(`{"errorMessage":"Bad Request","errorNumber":400}`))
 		})
 
-		_, err := RegisterUser("valid_token", "uuid-1", "user1@example.com")
+		_, err := RegisterUser(t.Context(), "valid_token", "uuid-1", "user1@example.com")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error number: 400")
 	})
@@ -678,9 +679,106 @@ func TestRegisterUser(t *testing.T) {
 			_, _ = w.Write([]byte(`{"status": 0}`))
 		})
 
-		_, err := RegisterUser("valid_token", "uuid-1", "user1@example.com")
+		_, err := RegisterUser(t.Context(), "valid_token", "uuid-1", "user1@example.com")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no user record")
+	})
+}
+
+// associateAssetsParams is a small valid request used by the retry tests below.
+func associateAssetsParams() *AssociateAssetsRequest {
+	return &AssociateAssetsRequest{
+		Assets:        []Asset{{AdamID: "1", PricingParam: "STDQ"}},
+		SerialNumbers: []string{"SN1"},
+	}
+}
+
+// TestDoRetryIsBoundedAndNonRecursive verifies that when Apple persistently
+// returns a retryable condition, do() retries a BOUNDED number of times and
+// returns — it must never recurse (which previously stacked open response
+// bodies / cancel-watcher goroutines / spans / timers per level and OOM'd the
+// server). It also verifies a sustained Retry-After stays bounded and that
+// context cancellation aborts the backoff promptly.
+// See https://github.com/fleetdm/fleet/issues/46656.
+func TestDoRetryIsBoundedAndNonRecursive(t *testing.T) {
+	// Shrink the retry knobs so the bounded loop runs fast.
+	origAttempts, origBackoff, origInterval, origMult := vppMaxAttempts, maxVPPBackoff, vppRateLimitInterval, vppRateLimitBackoffMultiplier
+	t.Cleanup(func() {
+		vppMaxAttempts, maxVPPBackoff, vppRateLimitInterval, vppRateLimitBackoffMultiplier = origAttempts, origBackoff, origInterval, origMult
+	})
+	vppMaxAttempts = 4
+	vppRateLimitInterval = 1 * time.Millisecond
+	maxVPPBackoff = 5 * time.Millisecond
+	vppRateLimitBackoffMultiplier = 2
+
+	t.Run("rate-limited (too many requests) retries a bounded number of times then fails", func(t *testing.T) {
+		var calls int32
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"errorMessage":"Too many requests","errorNumber":9646}`))
+		})
+
+		ctx := t.Context()
+		done := make(chan error, 1)
+		go func() {
+			_, err := AssociateAssets(ctx, "tok", associateAssetsParams())
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "rate limited")
+		case <-time.After(5 * time.Second):
+			t.Fatal("AssociateAssets did not return — the retry loop is not bounded")
+		}
+
+		require.EqualValues(t, vppMaxAttempts, atomic.LoadInt32(&calls),
+			"expected exactly vppMaxAttempts requests; more means the retries are nesting/recursing")
+	})
+
+	t.Run("HTTP 500 + Retry-After is honored but capped and bounded", func(t *testing.T) {
+		var calls int32
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			w.Header().Set("Retry-After", "600") // Apple asks for 10 minutes
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		start := time.Now()
+		_, err := AssociateAssets(t.Context(), "tok", associateAssetsParams())
+		require.Error(t, err)
+		// Bounded to vppMaxAttempts — a sustained Retry-After must NOT loop forever.
+		require.EqualValues(t, vppMaxAttempts, atomic.LoadInt32(&calls))
+		// Retry-After is honored but capped at maxVPPBackoff (5ms here), so the
+		// call finishes far under the 600s Apple requested — a multi-minute value
+		// can't pin a synchronous request open.
+		require.Less(t, time.Since(start), 2*time.Second)
+	})
+
+	t.Run("context cancellation aborts the backoff promptly", func(t *testing.T) {
+		// Use a long backoff so that, without ctx cancellation, the call would block.
+		vppRateLimitInterval = 30 * time.Second
+		maxVPPBackoff = 30 * time.Second
+		t.Cleanup(func() {
+			vppRateLimitInterval = 1 * time.Millisecond
+			maxVPPBackoff = 5 * time.Millisecond
+		})
+
+		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"errorMessage":"Too many requests","errorNumber":9646}`))
+		})
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err := AssociateAssets(ctx, "tok", associateAssetsParams())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "context")
+		require.Less(t, time.Since(start), 2*time.Second, "ctx cancellation should abort the backoff sleep")
 	})
 }
 

--- a/server/mdm/apple/vpp/api_test.go
+++ b/server/mdm/apple/vpp/api_test.go
@@ -712,9 +712,9 @@ func TestDoRetryIsBoundedAndNonRecursive(t *testing.T) {
 	vppRateLimitBackoffMultiplier = 2
 
 	t.Run("rate-limited (too many requests) retries a bounded number of times then fails", func(t *testing.T) {
-		var calls int32
+		var calls atomic.Int32
 		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(&calls, 1)
+			calls.Add(1)
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"errorMessage":"Too many requests","errorNumber":9646}`))
 		})
@@ -734,14 +734,14 @@ func TestDoRetryIsBoundedAndNonRecursive(t *testing.T) {
 			t.Fatal("AssociateAssets did not return — the retry loop is not bounded")
 		}
 
-		require.EqualValues(t, vppMaxAttempts, atomic.LoadInt32(&calls),
+		require.EqualValues(t, vppMaxAttempts, calls.Load(),
 			"expected exactly vppMaxAttempts requests; more means the retries are nesting/recursing")
 	})
 
 	t.Run("HTTP 500 + Retry-After is honored but capped and bounded", func(t *testing.T) {
-		var calls int32
+		var calls atomic.Int32
 		setupFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(&calls, 1)
+			calls.Add(1)
 			w.Header().Set("Retry-After", "600") // Apple asks for 10 minutes
 			w.WriteHeader(http.StatusInternalServerError)
 		})
@@ -750,7 +750,7 @@ func TestDoRetryIsBoundedAndNonRecursive(t *testing.T) {
 		_, err := AssociateAssets(t.Context(), "tok", associateAssetsParams())
 		require.Error(t, err)
 		// Bounded to vppMaxAttempts — a sustained Retry-After must NOT loop forever.
-		require.EqualValues(t, vppMaxAttempts, atomic.LoadInt32(&calls))
+		require.EqualValues(t, vppMaxAttempts, calls.Load())
 		// Retry-After is honored but capped at maxVPPBackoff (5ms here), so the
 		// call finishes far under the 600s Apple requested — a multi-minute value
 		// can't pin a synchronous request open.

--- a/server/service/activities.go
+++ b/server/service/activities.go
@@ -241,7 +241,7 @@ func (svc *Service) releaseVPPSeat(ctx context.Context, host *fleet.Host, info *
 		req.SerialNumbers = []string{host.HardwareSerial}
 	}
 
-	if _, err := vpp.DisassociateAssets(tokenDB.Token, req); err != nil {
+	if _, err := vpp.DisassociateAssets(ctx, tokenDB.Token, req); err != nil {
 		return ctxerr.Wrap(ctx, err, "disassociate vpp assets on cancel")
 	}
 	return nil

--- a/server/service/activities.go
+++ b/server/service/activities.go
@@ -241,7 +241,7 @@ func (svc *Service) releaseVPPSeat(ctx context.Context, host *fleet.Host, info *
 		req.SerialNumbers = []string{host.HardwareSerial}
 	}
 
-	if _, err := vpp.DisassociateAssets(ctx, tokenDB.Token, req); err != nil {
+	if _, err := vpp.DisassociateAssets(tokenDB.Token, req); err != nil {
 		return ctxerr.Wrap(ctx, err, "disassociate vpp assets on cancel")
 	}
 	return nil


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46656

`server/mdm/apple/vpp.do` retried transient Apple errors by **calling itself recursively**, with the rate-limit branch nesting `retry.Do` inside `retry.Do`. 

This change replaces the recursion with a single retry loop (respecting the prior 1 initial attempt + 3 retries), closes each response before retrying, honors Apple's `Retry-After` capped at 30s so that a multi-minute value can't block a synchronous request, and threads `context` through the VPP calls so the backoff is cancellable. The retry timings are otherwise unchanged from before.

Following @sgress454 suggestion, I considered routing this through the shared `retry.Do` helper (a single attempt wrapped in `retry.Do` + an error filter) but figured out that:
- retry.Do` owns its own wait schedule and its error filter returns an outcome enum rather than a duration, so it can't honor Apple's per-response `Retry-After` value.
- also, I'd have to change the `retry` package to receive an extra `ctx` param so that the backoff is context-aware (which IMHO is more blast radius than this incident fix should carry).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

**What was verified.** The new automated test cannot run against `main` (the fix changes the VPP function signatures and adds the retry knobs), so to confirm the actual failure mode I checked out `main` and ran a small repro that drives the VPP client against an Apple endpoint that always returns the rate-limit error. On `main`, the call **never returns** — `do()` recurses without bound — and the repro times out:

```
--- FAIL: TestReproUnboundedRecursionOnMain (10.00s)
    zz_repro_main_test.go:30: AssociateAssets did NOT return within 10s — unbounded retry recursion in do() on main
FAIL
FAIL	github.com/fleetdm/fleet/v4/server/mdm/apple/vpp	10.642s
```

[vpp-retry-repro.md](https://github.com/user-attachments/files/28523518/vpp-retry-repro.md)


On this branch the same scenario returns a bounded error promptly. That behavior is covered by the new `TestDoRetryIsBoundedAndNonRecursive` (bounded rate-limit retries, `Retry-After` honored-but-capped, and context cancellation), and the full `server/mdm/apple/vpp` package passes.
**I did not perform an end-to-end QA against a live Apple endpoint**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a server out-of-memory crash that occurred when Apple VPP API repeatedly returned transient errors during VPP operations, including app installs, user registration, and license seat releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->