### PR TITLE
Fixed a couple small issues on why-this-way page of handbook

### DIFF
--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -35,7 +35,7 @@ The Fleet handbook provides team members with up-to-date information about how t
 
 At Fleet, we make changes to the handbook first.  That means, before any change to how we run the business is "live" or "official", it is first changed in the relevant [handbook pages](https://fleetdm.com/handbook) and [issue templates](https://github.com/fleetdm/confidential/tree/main/.github/ISSUE_TEMPLATE).
 
-Making changes to the handbook first [encourages](https://www.youtube.com/watch?v=aZrK8AQM8Ro) a culture of self-reliance, which is essential for daily asynchronous work as part of an all-remote team.  It keeps everyone in sync across the all-remote team in different timezones, avoids miscommunications, and ensures the right people have reviewed every change. 
+Making changes to the handbook first encourages a culture of self-reliance, which is essential for daily asynchronous work as part of an all-remote team.  It keeps everyone in sync across the all-remote team in different timezones, avoids miscommunications, and ensures the right people have reviewed every change. 
 
 > The Fleet handbook is inspired by the [GitLab team handbook](https://about.gitlab.com/handbook/about/).  It shares the same [advantages](https://about.gitlab.com/handbook/about/#advantages) and will probably undergo a similar [evolution](https://about.gitlab.com/handbook/ceo/#evolution-of-the-handbook).
 

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -39,7 +39,7 @@ Making changes to the handbook first encourages a culture of self-reliance, whic
 
 > The Fleet handbook is inspired by the [GitLab team handbook](https://about.gitlab.com/handbook/about/).  It shares the same [advantages](https://about.gitlab.com/handbook/about/#advantages) and will probably undergo a similar [evolution](https://about.gitlab.com/handbook/ceo/#evolution-of-the-handbook).
 
-To contribute to the handbook, click "Edit this page" and make your [edits in Markdown](https://fleetdm.com/handbook/company).
+To contribute to the handbook, click "Edit this page" and make your [edits in Markdown](https://fleetdm.com/handbook/company/writing#writing).
 
 
 ## Why read documentation?


### PR DESCRIPTION
- "encourages" in the "Why handbook-first strategy?" section was linked to a youtube video that is now set to private, so the link should be removed.
- Link describing editing in markdown was linking to the main company page instead of to the markdown section of the writing page.

### Not sure if small text changes need to be documented in the changelog? I can add this item if needed.
- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Noting for next time: I'll make sure to give my branch an actual name that means something. 🤣 