### PR TITLE
Add migration upgrade-path CI gate to catch out-of-order migrations

### DIFF
--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -112,7 +112,15 @@ jobs:
         # finds an FK to hosts in one of the migrations files.
         #
         # grep prints the matches, which will help figure out where those references are.
-        if git diff --name-only origin/main | grep "migrations/" | xargs grep -i -E 'references\s*hosts\s*\(\s*id\s*\)' ; then
+        #
+        # Diff against the branch's actual base (not a hardcoded origin/main) so this
+        # only scans migrations introduced by this branch. On release/RC branches a
+        # diff against main would include unrelated drift and cause false failures.
+        base_ref=origin/${{github.base_ref}}
+        if [ "${{github.event_name}}" == "push" ]; then
+          base_ref=$(git tag --list "fleet-v*" --sort=-creatordate | head -n 1)
+        fi
+        if git diff --name-only "$base_ref" -- 'server/datastore/mysql/migrations/' | grep "migrations/" | xargs -r grep -i -E 'references\s*hosts\s*\(\s*id\s*\)' ; then
         	echo "❌ fail: hosts foreign keys are not allowed"
         	echo "Ref: https://github.com/fleetdm/fleet/blob/main/handbook/engineering/scaling-fleet.md#foreign-keys-and-locking"
         	exit 1
@@ -141,7 +149,16 @@ jobs:
         # the latest minor plus recent patches, which is where the incidents came from.
         GA_TAG_COUNT: "3"
       run: |
-        git fetch --tags --quiet --force || true
+        # checkout (fetch-depth: 0) already provides tags; refresh in case, but don't
+        # let a transient fetch failure fail the gate when tags are already present.
+        git fetch --tags --quiet --force || echo "warning: 'git fetch --tags' failed; relying on tags from checkout"
+        # If no release tags exist at all, the gate cannot run -> fail loudly rather
+        # than skip silently. (An empty *eligible* set after the version cap below is a
+        # legitimate skip, e.g. the first release, where there is nothing to upgrade from.)
+        if [ "$(git tag --list 'fleet-v*' | wc -l)" -eq 0 ]; then
+          echo "❌ fail: no fleet-v* release tags available; cannot run the migration upgrade gate"
+          exit 1
+        fi
 
         # On a PR, skip when no migrations changed (keeps non-migration PRs fast).
         # Always run on push / manual dispatch.
@@ -168,7 +185,7 @@ jobs:
 
         # GA release versions, ascending. Strip the "fleet-v" prefix first, then drop
         # pre-releases / RCs (whose version, e.g. 4.86.0-rc.1, contains a "-").
-        ga_versions=$(git tag --list 'fleet-v*' | sed -E 's/^fleet-v//' | grep -vE '\-' | sort -V)
+        ga_versions=$(git tag --list 'fleet-v*' | sed -E 's/^fleet-v//' | grep -vE '\-' | sort -V || true)
 
         # On a release/RC branch (e.g. rc-minor-fleet-v4.86.0, rc-patch-fleet-v4.85.2)
         # only simulate upgrading FROM GA releases older than this branch's target
@@ -204,10 +221,19 @@ jobs:
             | mysql_root upgrade_sim
           echo "released base max table-migration version: $(mysql_root -N -e 'SELECT MAX(version_id) FROM migration_status_tables;' upgrade_sim)"
 
-          # Apply this branch's migrations on top, twice (the second run must be a no-op).
+          # Apply this branch's migrations on top, twice. Capture each run's exit code:
+          # a non-zero exit (a failed data migration, or a hard apply error such as a
+          # duplicate column) must fail the gate rather than be masked, and the second
+          # run must be a clean no-op.
+          # rc capture must use the `|| rc=$?` form: under `set -e` a bare
+          # `out=$(cmd)` with a non-zero cmd aborts the whole step before we can
+          # inspect the code.
           export FLEET_MYSQL_DATABASE=upgrade_sim
-          /tmp/fleet prepare db --dev --no-prompt || true
-          /tmp/fleet prepare db --dev --no-prompt 2>&1 | tail -n 5 || true
+          run1_rc=0; run2_rc=0
+          run1_out=$(/tmp/fleet prepare db --dev --no-prompt 2>&1) || run1_rc=$?
+          if [ "$run1_rc" -ne 0 ]; then echo "$run1_out" | tail -n 15; fi
+          run2_out=$(/tmp/fleet prepare db --dev --no-prompt 2>&1) || run2_rc=$?
+          echo "$run2_out" | tail -n 5
 
           applied=$(mysql_root -N -e "SELECT version_id FROM migration_status_tables WHERE version_id > 0 AND is_applied;" upgrade_sim | sort -u)
           # missing: known in this branch but never applied -> goose skipped them.
@@ -216,16 +242,22 @@ jobs:
           # renumbered migration), minus tolerated legacy migrations.
           unknown=$(comm -13 <(echo "$known_versions") <(echo "$applied") | grep -vxFf <(echo "$legacy_unknown") || true)
 
+          # Collect every reason this base does not reach a clean state.
+          reasons=""
+          if [ "$run1_rc" -ne 0 ] || [ "$run2_rc" -ne 0 ]; then
+            reasons="${reasons}  'fleet prepare db' exited non-zero (${run1_rc}/${run2_rc}); see the output above for the failing migration.\n"
+          fi
           if [ -n "$unknown" ]; then
+            reasons="${reasons}  applied in ${tag} but missing or renumbered in this branch (server would re-run or block on these): $(echo "$unknown" | head -n 20 | tr '\n' ' ')\n"
+          fi
+          if [ -n "$missing" ]; then
+            reasons="${reasons}  in this branch but older than ${tag}'s newest applied migration, so goose would never run them: $(echo "$missing" | head -n 20 | tr '\n' ' ')\n"
+          fi
+
+          if [ -n "$reasons" ]; then
             overall_rc=1
-            echo "❌ fail: ${tag} has applied migrations that are missing or renumbered in this branch:"
-            echo "$unknown" | head -n 20 | sed 's/^/    - /'
-            echo "  A Fleet server on ${tag} would try to re-run or block on these after upgrading."
-          elif [ -n "$missing" ]; then
-            overall_rc=1
-            echo "❌ fail: these migrations are older than one already applied in ${tag} and would never run on upgrade:"
-            echo "$missing" | head -n 20 | sed 's/^/    - /'
-            echo "  Fix: bump the migration timestamp so it sorts after every released migration (see the /bump-migration skill)."
+            echo "❌ fail: ${tag} -> this branch does not reach a clean migration state:"
+            printf "%b" "$reasons"
           else
             echo "✅ ${tag} -> this branch upgrades to a clean migration state"
           fi
@@ -234,6 +266,7 @@ jobs:
 
         if [ "$overall_rc" -ne 0 ]; then
           echo "❌ Out-of-order migration detected. This can prevent Fleet from starting after an upgrade."
-          echo "See https://github.com/fleetdm/fleet/blob/main/server/datastore/mysql/migrations/README.md"
+          echo "Fix: bump the offending migration so its timestamp sorts after every released migration"
+          echo "(see the /bump-migration skill), or make it idempotent with the columnExists/tableExists helpers."
         fi
         exit $overall_rc

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -162,7 +162,8 @@ jobs:
         echo "Building fleet from this branch..."
         go build -o /tmp/fleet ./cmd/fleet
 
-        mysql_root() { docker compose exec -T mysql_test mysql -uroot -ptoor "$@"; }
+        # Password via MYSQL_PWD rather than -p to keep the client's "password on the command line" warning out of every log line.
+        mysql_root() { docker compose exec -T -e MYSQL_PWD=toor mysql_test mysql -uroot "$@"; }
 
         # Table-migration versions known to this branch (extracted from filenames).
         known_versions=$(ls server/datastore/mysql/migrations/tables/20*_*.go | grep -v '_test.go' | sed -E 's#.*/([0-9]+)_.*#\1#' | sort -u)
@@ -202,18 +203,29 @@ jobs:
           mysql_root -e "DROP DATABASE IF EXISTS upgrade_sim; CREATE DATABASE upgrade_sim;"
           { echo "SET FOREIGN_KEY_CHECKS=0;"; git show "${tag}:server/datastore/mysql/schema.sql"; } \
             | mysql_root upgrade_sim
-          echo "released base max table-migration version: $(mysql_root -N -e 'SELECT MAX(version_id) FROM migration_status_tables;' upgrade_sim)"
+          base_max=$(mysql_root -N -e 'SELECT MAX(version_id) FROM migration_status_tables;' upgrade_sim)
+          echo "released base max table-migration version: ${base_max}"
 
           # Apply this branch's migrations on top, twice. Capture each run's exit code: a non-zero exit (a failed data migration, or
           # a hard apply error such as a duplicate column) must fail the gate rather than be masked, and the second run must be a
           # clean no-op. rc capture must use the `|| rc=$?` form: under `set -e` a bare `out=$(cmd)` with a non-zero cmd aborts the
-          # whole step before we can inspect the code.
+          # whole step before we can inspect the code. stdin is redirected from /dev/null because fleet treats piped stdin (which CI
+          # provides) as extra CLI arguments and logs noise about it.
           export FLEET_MYSQL_DATABASE=upgrade_sim
           run1_rc=0; run2_rc=0
-          run1_out=$(/tmp/fleet prepare db --dev --no-prompt 2>&1) || run1_rc=$?
-          if [ "$run1_rc" -ne 0 ]; then echo "$run1_out" | tail -n 15; fi
-          run2_out=$(/tmp/fleet prepare db --dev --no-prompt 2>&1) || run2_rc=$?
-          echo "$run2_out" | tail -n 5
+          run1_out=$(/tmp/fleet prepare db --dev --no-prompt </dev/null 2>&1) || run1_rc=$?
+          if [ "$run1_rc" -ne 0 ]; then
+            echo "run 1 (upgrade) failed:"; echo "$run1_out" | tail -n 15
+          else
+            applied_count=$(mysql_root -N -e "SELECT COUNT(*) FROM migration_status_tables WHERE version_id > ${base_max} AND is_applied;" upgrade_sim)
+            echo "run 1 (upgrade): applied ${applied_count} table migrations newer than ${tag}'s max"
+          fi
+          run2_out=$(/tmp/fleet prepare db --dev --no-prompt </dev/null 2>&1) || run2_rc=$?
+          if [ "$run2_rc" -ne 0 ]; then
+            echo "run 2 (must be a no-op) failed:"; echo "$run2_out" | tail -n 15
+          else
+            echo "run 2 (must be a no-op): $(echo "$run2_out" | tail -n 1)"
+          fi
 
           applied=$(mysql_root -N -e "SELECT version_id FROM migration_status_tables WHERE version_id > 0 AND is_applied;" upgrade_sim | sort -u)
           # missing: known in this branch but never applied -> goose skipped them.

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -6,6 +6,13 @@ on:
       - main
       - patch-*
       - prepare-*
+      # Release branches. The out-of-order migration incidents surfaced on RC
+      # branches (e.g. rc-minor-fleet-v4.86.0), so the migration checks below
+      # need to run there too, not just on main.
+      - minor-fleet-*
+      - patch-fleet-*
+      - rc-minor-*
+      - rc-patch-*
   pull_request:
     paths:
       - '**.go'
@@ -40,14 +47,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    # TODO: This doesn't cover all scenarios since other PRs might
-    # be merged into `main` after this check has passed.
-    #
-    # We should add a Slack notification or something similar for
-    # when this check fails on `main`.
-    #
-    # TODO: This only checks for added files, we should also check for renames,
-    # which should be more of an edge case, but they might still happen
+    # This catches a new or renumbered migration whose timestamp is older than a
+    # migration already present on the base ref. The "Migration upgrade
+    # simulation" step below is the stronger backstop: it detects out-of-order
+    # migrations against released versions, including ones this filename-only
+    # check cannot see.
     - name: Check migration order
       run: |
         # if the workflow is run during a push event (on merges to main and
@@ -58,7 +62,10 @@ jobs:
         fi
 
         all_migrations=($(ls server/datastore/mysql/migrations/tables/20*_*.go | sort -r | grep -v '_test.go'))
-        new_migrations=($(git diff --find-renames --name-only --diff-filter=A $base_ref -- server/datastore/mysql/migrations/tables/20\*_\*.go ':(exclude,glob)server/datastore/mysql/migrations/tables/20*_*_test.go' | sort -r))
+        # --diff-filter=AR + --name-status catches both added (A) and renamed (R)
+        # migrations; a renumber shows up as a rename, and "{print $NF}" takes the
+        # new path (the destination of the rename, or the added file).
+        new_migrations=($(git diff --find-renames --name-status --diff-filter=AR $base_ref -- server/datastore/mysql/migrations/tables/20\*_\*.go ':(exclude,glob)server/datastore/mysql/migrations/tables/20*_*_test.go' | awk '{print $NF}' | sort -r))
 
         index=0
         for migration in "${new_migrations[@]}"; do
@@ -110,3 +117,123 @@ jobs:
         	echo "Ref: https://github.com/fleetdm/fleet/blob/main/handbook/engineering/scaling-fleet.md#foreign-keys-and-locking"
         	exit 1
         fi
+
+    # Simulates upgrading a real released Fleet database to this branch's code and
+    # fails if the result is not a clean migration state. This catches out-of-order
+    # migrations: goose only applies migrations whose timestamp is greater than the
+    # newest already-applied one, so a migration older than what a released version
+    # already applied is skipped forever and the server refuses to start.
+    #
+    # Both incidents surfaced on RC branches (a cherry-pick / patch migration that
+    # diverged from what a GA release already applied), which is why this also runs
+    # on release branches, simulating the upgrade from the most recent GA releases.
+    #
+    # Released DB state is reconstructed from each tag's committed schema.sql, which
+    # records every applied table migration in migration_status_tables (no need to
+    # build old binaries). FK checks are disabled while loading the dump because it
+    # has forward references between tables.
+    - name: Migration upgrade simulation
+      env:
+        FLEET_MYSQL_ADDRESS: 127.0.0.1:3307
+        FLEET_MYSQL_USERNAME: root
+        FLEET_MYSQL_PASSWORD: toor
+        # Number of most-recent GA release tags to simulate upgrading FROM. Covers
+        # the latest minor plus recent patches, which is where the incidents came from.
+        GA_TAG_COUNT: "3"
+      run: |
+        git fetch --tags --quiet --force || true
+
+        # On a PR, skip when no migrations changed (keeps non-migration PRs fast).
+        # Always run on push / manual dispatch.
+        if [ "${{github.event_name}}" == "pull_request" ]; then
+          if [ -z "$(git diff --name-only "origin/${{github.base_ref}}" -- 'server/datastore/mysql/migrations/')" ]; then
+            echo "No migration changes in this PR; skipping upgrade simulation."
+            exit 0
+          fi
+        fi
+
+        echo "Building fleet from this branch..."
+        go build -o /tmp/fleet ./cmd/fleet
+
+        mysql_root() { docker compose exec -T mysql_test mysql -uroot -ptoor "$@"; }
+
+        # Table-migration versions known to this branch (extracted from filenames).
+        known_versions=$(ls server/datastore/mysql/migrations/tables/20*_*.go \
+          | grep -v '_test.go' | sed -E 's#.*/([0-9]+)_.*#\1#' | sort -u)
+
+        # Migrations intentionally removed from code and tolerated as "unknown" on
+        # old databases. Mirror knownUnknownTableMigrations in
+        # server/datastore/mysql/mysql.go.
+        legacy_unknown=$(printf '%s\n' 20210924114500)
+
+        # GA release versions, ascending. Strip the "fleet-v" prefix first, then drop
+        # pre-releases / RCs (whose version, e.g. 4.86.0-rc.1, contains a "-").
+        ga_versions=$(git tag --list 'fleet-v*' | sed -E 's/^fleet-v//' | grep -vE '\-' | sort -V)
+
+        # On a release/RC branch (e.g. rc-minor-fleet-v4.86.0, rc-patch-fleet-v4.85.2)
+        # only simulate upgrading FROM GA releases older than this branch's target
+        # version. Simulating from a newer line would be a nonsensical "downgrade"
+        # and a false positive (it would flag that line's newer migrations as unknown).
+        # On main (no version in the ref name) there is no cap.
+        target_ref="${{ github.base_ref || github.ref_name }}"
+        target_ver=$(printf '%s' "$target_ref" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+        if [ -n "$target_ver" ]; then
+          ga_versions=$(echo "$ga_versions" | awk -v t="$target_ver" '
+            { split($0,a,"."); split(t,b,".");
+              for (i=1; i<=3; i++) { if (a[i]+0 < b[i]+0) { print; break } if (a[i]+0 > b[i]+0) break } }')
+        fi
+
+        base_tags=$(echo "$ga_versions" | sed '/^$/d' | tail -n "$GA_TAG_COUNT" | sed 's/^/fleet-v/')
+        if [ -z "$base_tags" ]; then
+          echo "No eligible GA tags found to simulate from; skipping."
+          exit 0
+        fi
+        echo "Simulating upgrade to this branch from: $(echo $base_tags | tr '\n' ' ')"
+
+        overall_rc=0
+        for tag in $base_tags; do
+          echo "::group::Upgrade simulation: ${tag} -> this branch"
+          if ! git cat-file -e "${tag}:server/datastore/mysql/schema.sql" 2>/dev/null; then
+            echo "no schema.sql at ${tag}, skipping"
+            echo "::endgroup::"
+            continue
+          fi
+
+          mysql_root -e "DROP DATABASE IF EXISTS upgrade_sim; CREATE DATABASE upgrade_sim;"
+          { echo "SET FOREIGN_KEY_CHECKS=0;"; git show "${tag}:server/datastore/mysql/schema.sql"; } \
+            | mysql_root upgrade_sim
+          echo "released base max table-migration version: $(mysql_root -N -e 'SELECT MAX(version_id) FROM migration_status_tables;' upgrade_sim)"
+
+          # Apply this branch's migrations on top, twice (the second run must be a no-op).
+          export FLEET_MYSQL_DATABASE=upgrade_sim
+          /tmp/fleet prepare db --dev --no-prompt || true
+          /tmp/fleet prepare db --dev --no-prompt 2>&1 | tail -n 5 || true
+
+          applied=$(mysql_root -N -e "SELECT version_id FROM migration_status_tables WHERE version_id > 0 AND is_applied;" upgrade_sim | sort -u)
+          # missing: known in this branch but never applied -> goose skipped them.
+          missing=$(comm -23 <(echo "$known_versions") <(echo "$applied"))
+          # unknown: applied on the released DB but absent from this branch (e.g. a
+          # renumbered migration), minus tolerated legacy migrations.
+          unknown=$(comm -13 <(echo "$known_versions") <(echo "$applied") | grep -vxFf <(echo "$legacy_unknown") || true)
+
+          if [ -n "$unknown" ]; then
+            overall_rc=1
+            echo "❌ fail: ${tag} has applied migrations that are missing or renumbered in this branch:"
+            echo "$unknown" | head -n 20 | sed 's/^/    - /'
+            echo "  A Fleet server on ${tag} would try to re-run or block on these after upgrading."
+          elif [ -n "$missing" ]; then
+            overall_rc=1
+            echo "❌ fail: these migrations are older than one already applied in ${tag} and would never run on upgrade:"
+            echo "$missing" | head -n 20 | sed 's/^/    - /'
+            echo "  Fix: bump the migration timestamp so it sorts after every released migration (see the /bump-migration skill)."
+          else
+            echo "✅ ${tag} -> this branch upgrades to a clean migration state"
+          fi
+          echo "::endgroup::"
+        done
+
+        if [ "$overall_rc" -ne 0 ]; then
+          echo "❌ Out-of-order migration detected. This can prevent Fleet from starting after an upgrade."
+          echo "See https://github.com/fleetdm/fleet/blob/main/server/datastore/mysql/migrations/README.md"
+        fi
+        exit $overall_rc

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -6,11 +6,8 @@ on:
       - main
       - patch-*
       - prepare-*
-      # Release branches. The out-of-order migration incidents surfaced on RC
-      # branches (e.g. rc-minor-fleet-v4.86.0), so the migration checks below
-      # need to run there too, not just on main.
-      - minor-fleet-*
-      - patch-fleet-*
+      # Release branches. The out-of-order migration incidents surfaced on RC branches (e.g. rc-minor-fleet-v4.86.0),
+      # so the migration checks below need to run there too, not just on main.
       - rc-minor-*
       - rc-patch-*
   pull_request:
@@ -18,6 +15,11 @@ on:
       - '**.go'
       - 'server/datastore/mysql/schema.sql'
       - '.github/workflows/test-db-changes.yml'
+  schedule:
+    # Nightly safety net for the migration upgrade simulation: a newly cut GA tag can make migrations already on main out-of-order
+    # or unknown without any push happening. Note: scheduled runs only execute on the default branch (main); release branches are
+    # covered by their creation push, migration-bearing cherry-picks, and manual dispatch.
+    - cron: '0 7 * * *'
   workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs
@@ -47,24 +49,18 @@ jobs:
       with:
         fetch-depth: 0
 
-    # This catches a new or renumbered migration whose timestamp is older than a
-    # migration already present on the base ref. The "Migration upgrade
-    # simulation" step below is the stronger backstop: it detects out-of-order
-    # migrations against released versions, including ones this filename-only
-    # check cannot see.
+    # This catches a new or renumbered migration whose timestamp is older than a migration already present on the base ref.
     - name: Check migration order
       run: |
-        # if the workflow is run during a push event (on merges to main and
-        # tags,) use the latest created tag as a reference
+        # On non-PR events (push, nightly schedule, manual dispatch) there is no base ref, so use the latest created tag as the reference.
         base_ref=origin/${{github.base_ref}}
-        if [ "${{github.event_name}}" == "push" ]; then
+        if [ "${{github.event_name}}" != "pull_request" ]; then
           base_ref=$(git tag --list "fleet-v*" --sort=-creatordate | head -n 1)
         fi
 
         all_migrations=($(ls server/datastore/mysql/migrations/tables/20*_*.go | sort -r | grep -v '_test.go'))
-        # --diff-filter=AR + --name-status catches both added (A) and renamed (R)
-        # migrations; a renumber shows up as a rename, and "{print $NF}" takes the
-        # new path (the destination of the rename, or the added file).
+        # --diff-filter=AR + --name-status catches both added (A) and renamed (R) migrations; a renumber shows up as a rename,
+        # and "{print $NF}" takes the new path (the destination of the rename, or the added file).
         new_migrations=($(git diff --find-renames --name-status --diff-filter=AR $base_ref -- server/datastore/mysql/migrations/tables/20\*_\*.go ':(exclude,glob)server/datastore/mysql/migrations/tables/20*_*_test.go' | awk '{print $NF}' | sort -r))
 
         index=0
@@ -112,12 +108,8 @@ jobs:
         # finds an FK to hosts in one of the migrations files.
         #
         # grep prints the matches, which will help figure out where those references are.
-        #
-        # Diff against the branch's actual base (not a hardcoded origin/main) so this
-        # only scans migrations introduced by this branch. On release/RC branches a
-        # diff against main would include unrelated drift and cause false failures.
         base_ref=origin/${{github.base_ref}}
-        if [ "${{github.event_name}}" == "push" ]; then
+        if [ "${{github.event_name}}" != "pull_request" ]; then
           base_ref=$(git tag --list "fleet-v*" --sort=-creatordate | head -n 1)
         fi
         if git diff --name-only "$base_ref" -- 'server/datastore/mysql/migrations/' | grep "migrations/" | xargs -r grep -i -E 'references\s*hosts\s*\(\s*id\s*\)' ; then
@@ -126,20 +118,13 @@ jobs:
         	exit 1
         fi
 
-    # Simulates upgrading a real released Fleet database to this branch's code and
-    # fails if the result is not a clean migration state. This catches out-of-order
-    # migrations: goose only applies migrations whose timestamp is greater than the
-    # newest already-applied one, so a migration older than what a released version
-    # already applied is skipped forever and the server refuses to start.
+    # Simulates upgrading a real released Fleet database to this branch's code and fails if the result is not a clean migration state. This
+    # catches out-of-order migrations: goose only applies migrations whose timestamp is greater than the newest already-applied one, so a
+    # migration older than what a released version already applied is skipped forever and the server refuses to start.
     #
-    # Both incidents surfaced on RC branches (a cherry-pick / patch migration that
-    # diverged from what a GA release already applied), which is why this also runs
-    # on release branches, simulating the upgrade from the most recent GA releases.
-    #
-    # Released DB state is reconstructed from each tag's committed schema.sql, which
-    # records every applied table migration in migration_status_tables (no need to
-    # build old binaries). FK checks are disabled while loading the dump because it
-    # has forward references between tables.
+    # Released DB state is reconstructed from each tag's committed schema.sql, which records every applied table migration in
+    # migration_status_tables (no need to build old binaries). FK checks are disabled while loading the dump because it has forward
+    # references between tables.
     - name: Migration upgrade simulation
       env:
         FLEET_MYSQL_ADDRESS: 127.0.0.1:3307
@@ -149,22 +134,25 @@ jobs:
         # the latest minor plus recent patches, which is where the incidents came from.
         GA_TAG_COUNT: "3"
       run: |
-        # checkout (fetch-depth: 0) already provides tags; refresh in case, but don't
-        # let a transient fetch failure fail the gate when tags are already present.
-        git fetch --tags --quiet --force || echo "warning: 'git fetch --tags' failed; relying on tags from checkout"
-        # If no release tags exist at all, the gate cannot run -> fail loudly rather
-        # than skip silently. (An empty *eligible* set after the version cap below is a
-        # legitimate skip, e.g. the first release, where there is nothing to upgrade from.)
-        if [ "$(git tag --list 'fleet-v*' | wc -l)" -eq 0 ]; then
-          echo "❌ fail: no fleet-v* release tags available; cannot run the migration upgrade gate"
-          exit 1
-        fi
+        # checkout (fetch-depth: 0) already provides tags; refresh them in case a release was tagged since.
+        git fetch --tags --quiet --force
 
-        # On a PR, skip when no migrations changed (keeps non-migration PRs fast).
-        # Always run on push / manual dispatch.
+        # Skip when the change under test contains no migration changes, to keep non-migration PRs and pushes fast. The nightly
+        # scheduled run (and manual dispatch) always simulates, as the safety net for drift that arrives without a push, e.g. a
+        # newly cut GA tag making migrations already on the branch out-of-order.
         if [ "${{github.event_name}}" == "pull_request" ]; then
           if [ -z "$(git diff --name-only "origin/${{github.base_ref}}" -- 'server/datastore/mysql/migrations/')" ]; then
             echo "No migration changes in this PR; skipping upgrade simulation."
+            exit 0
+          fi
+        elif [ "${{github.event_name}}" == "push" ]; then
+          # Diff only what this push introduced. rev-parse rejects event.before when it doesn't resolve to a commit: it is the
+          # all-zeros null SHA on branch creation (the RC-cut push, which must be validated in full) and an unreachable commit
+          # after a force push. In both cases the diff cannot be scoped, so run the simulation.
+          before="${{github.event.before}}"
+          if git rev-parse --quiet --verify "${before}^{commit}" >/dev/null \
+              && [ -z "$(git diff --name-only "$before" "${{github.sha}}" -- 'server/datastore/mysql/migrations/')" ]; then
+            echo "No migration changes in this push; skipping upgrade simulation."
             exit 0
           fi
         fi
@@ -175,23 +163,16 @@ jobs:
         mysql_root() { docker compose exec -T mysql_test mysql -uroot -ptoor "$@"; }
 
         # Table-migration versions known to this branch (extracted from filenames).
-        known_versions=$(ls server/datastore/mysql/migrations/tables/20*_*.go \
-          | grep -v '_test.go' | sed -E 's#.*/([0-9]+)_.*#\1#' | sort -u)
+        known_versions=$(ls server/datastore/mysql/migrations/tables/20*_*.go | grep -v '_test.go' | sed -E 's#.*/([0-9]+)_.*#\1#' | sort -u)
 
-        # Migrations intentionally removed from code and tolerated as "unknown" on
-        # old databases. Mirror knownUnknownTableMigrations in
-        # server/datastore/mysql/mysql.go.
-        legacy_unknown=$(printf '%s\n' 20210924114500)
-
-        # GA release versions, ascending. Strip the "fleet-v" prefix first, then drop
-        # pre-releases / RCs (whose version, e.g. 4.86.0-rc.1, contains a "-").
+        # GA release versions, ascending. Strip the "fleet-v" prefix first, then drop dash-suffixed tags: one-off special builds
+        # (e.g. fleet-v4.9.1-nostats) that duplicate their GA counterpart's migrations, and any future pre-release-style tag. Only
+        # GA states reach customers, so only GA states are valid upgrade bases.
         ga_versions=$(git tag --list 'fleet-v*' | sed -E 's/^fleet-v//' | grep -vE '\-' | sort -V || true)
 
-        # On a release/RC branch (e.g. rc-minor-fleet-v4.86.0, rc-patch-fleet-v4.85.2)
-        # only simulate upgrading FROM GA releases older than this branch's target
-        # version. Simulating from a newer line would be a nonsensical "downgrade"
-        # and a false positive (it would flag that line's newer migrations as unknown).
-        # On main (no version in the ref name) there is no cap.
+        # On a release/RC branch (e.g. rc-minor-fleet-v4.86.0, rc-patch-fleet-v4.85.2) only simulate upgrading FROM GA releases older
+        # than this branch's target version. Simulating from a newer line would be a nonsensical "downgrade" and a false positive (it
+        # would flag that line's newer migrations as unknown). On main (no version in the ref name) there is no cap.
         target_ref="${{ github.base_ref || github.ref_name }}"
         target_ver=$(printf '%s' "$target_ref" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
         if [ -n "$target_ver" ]; then
@@ -221,13 +202,10 @@ jobs:
             | mysql_root upgrade_sim
           echo "released base max table-migration version: $(mysql_root -N -e 'SELECT MAX(version_id) FROM migration_status_tables;' upgrade_sim)"
 
-          # Apply this branch's migrations on top, twice. Capture each run's exit code:
-          # a non-zero exit (a failed data migration, or a hard apply error such as a
-          # duplicate column) must fail the gate rather than be masked, and the second
-          # run must be a clean no-op.
-          # rc capture must use the `|| rc=$?` form: under `set -e` a bare
-          # `out=$(cmd)` with a non-zero cmd aborts the whole step before we can
-          # inspect the code.
+          # Apply this branch's migrations on top, twice. Capture each run's exit code: a non-zero exit (a failed data migration, or
+          # a hard apply error such as a duplicate column) must fail the gate rather than be masked, and the second run must be a
+          # clean no-op. rc capture must use the `|| rc=$?` form: under `set -e` a bare `out=$(cmd)` with a non-zero cmd aborts the
+          # whole step before we can inspect the code.
           export FLEET_MYSQL_DATABASE=upgrade_sim
           run1_rc=0; run2_rc=0
           run1_out=$(/tmp/fleet prepare db --dev --no-prompt 2>&1) || run1_rc=$?
@@ -238,9 +216,8 @@ jobs:
           applied=$(mysql_root -N -e "SELECT version_id FROM migration_status_tables WHERE version_id > 0 AND is_applied;" upgrade_sim | sort -u)
           # missing: known in this branch but never applied -> goose skipped them.
           missing=$(comm -23 <(echo "$known_versions") <(echo "$applied"))
-          # unknown: applied on the released DB but absent from this branch (e.g. a
-          # renumbered migration), minus tolerated legacy migrations.
-          unknown=$(comm -13 <(echo "$known_versions") <(echo "$applied") | grep -vxFf <(echo "$legacy_unknown") || true)
+          # unknown: applied on the released DB but absent from this branch (e.g. a renumbered migration).
+          unknown=$(comm -13 <(echo "$known_versions") <(echo "$applied"))
 
           # Collect every reason this base does not reach a clean state.
           reasons=""

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -247,3 +247,26 @@ jobs:
           echo "(see the /bump-migration skill), or make it idempotent with the columnExists/tableExists helpers."
         fi
         exit $overall_rc
+
+    # Nightly runs have no PR or push author watching them, so route failures to Slack (same channel as the nightly Go test
+    # failures). Gate on event_name rather than the exact cron string so the notification survives cron-time edits.
+    - name: Slack notification on scheduled-run failure
+      if: github.event_name == 'schedule' && failure()
+      uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+      with:
+        payload: |
+          {
+            "text": "Nightly DB migration checks failed",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "⚠️ Nightly DB migration checks failed, possibly an out-of-order migration relative to a newly released GA tag.\nhttps://github.com/fleetdm/fleet/actions/runs/${{ github.run_id }}"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -137,12 +137,14 @@ jobs:
         # checkout (fetch-depth: 0) already provides tags; refresh them in case a release was tagged since.
         git fetch --tags --quiet --force
 
-        # Skip when the change under test contains no migration changes, to keep non-migration PRs and pushes fast. The nightly
-        # scheduled run (and manual dispatch) always simulates, as the safety net for drift that arrives without a push, e.g. a
-        # newly cut GA tag making migrations already on the branch out-of-order.
+        # Skip when the change under test contains no migration changes, to keep non-migration PRs and pushes fast. Changes to this
+        # workflow file also count, since they change the simulation itself and need to be exercised. The nightly scheduled run
+        # (and manual dispatch) always simulates, as the safety net for drift that arrives without a push, e.g. a newly cut GA tag
+        # making migrations already on the branch out-of-order.
+        relevant_paths=('server/datastore/mysql/migrations/' '.github/workflows/test-db-changes.yml')
         if [ "${{github.event_name}}" == "pull_request" ]; then
-          if [ -z "$(git diff --name-only "origin/${{github.base_ref}}" -- 'server/datastore/mysql/migrations/')" ]; then
-            echo "No migration changes in this PR; skipping upgrade simulation."
+          if [ -z "$(git diff --name-only "origin/${{github.base_ref}}" -- "${relevant_paths[@]}")" ]; then
+            echo "No migration or workflow changes in this PR; skipping upgrade simulation."
             exit 0
           fi
         elif [ "${{github.event_name}}" == "push" ]; then
@@ -151,8 +153,8 @@ jobs:
           # after a force push. In both cases the diff cannot be scoped, so run the simulation.
           before="${{github.event.before}}"
           if git rev-parse --quiet --verify "${before}^{commit}" >/dev/null \
-              && [ -z "$(git diff --name-only "$before" "${{github.sha}}" -- 'server/datastore/mysql/migrations/')" ]; then
-            echo "No migration changes in this push; skipping upgrade simulation."
+              && [ -z "$(git diff --name-only "$before" "${{github.sha}}" -- "${relevant_paths[@]}")" ]; then
+            echo "No migration or workflow changes in this push; skipping upgrade simulation."
             exit 0
           fi
         fi


### PR DESCRIPTION
Out-of-order migrations caused issues twice in two weeks, both on RC branches: the 4.85.1 patch shipped a migration whose timestamp sorted above the rc-minor-fleet-v4.86.0 migrations, and an earlier rc-minor-fleet-v4.83.0 was missing a migration present in a released patch.

Migration upgrade simulation (new step):
Reconstructs recent GA releases' DB state from each tag's committed schema.sql (which records every applied table migration in migration_status_tables, so no old binaries are built), applies this branch's migrations on top, and fails if the result is not a clean migration state (a migration that would never apply, or one renumbered/removed since the release). Runs on PRs and on release branches, since the incidents surfaced on RC branches. Base releases are capped to versions older than the branch's target so backport PRs into an old patch line do not falsely simulate from a newer release.

Hardening of the existing order check:
"Check migration order" now uses --diff-filter=AR with --name-status so it also catches renumbers (renames), not just added files. That is the class that slipped through in the roaring-bitmaps renumber.

Validated against a real MySQL: upgrades from 4.84.3 / 4.85.0 / 4.85.1 / 4.86.0 to current main pass, and an injected out-of-order migration is detected and pinpointed.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46883

<img width="668" height="362" alt="image" src="https://github.com/user-attachments/assets/7ff9cd6d-3604-47ec-80d7-3c915c410844" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced database migration validation to run on additional release branch patterns.
  * Improved migration detection to handle renamed or moved migration files more robustly.
  * Added upgrade-simulation testing to verify migrations apply cleanly across release bases and to detect out-of-order or missing migrations.
  * Added scheduled-run failure notifications to Slack for quicker operational awareness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->