### PR TITLE
Fleet UI: Allow horizontal scroll on manage labels table

### DIFF
--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
@@ -6,4 +6,14 @@
     font-weight: initial;
     font-size: $x-small;
   }
+
+  // Scroll horizontally at narrow widths instead of truncating Name/Description.
+  .data-table-block .data-table__wrapper {
+    overflow-x: auto;
+  }
+
+  .name__cell,
+  .description__cell {
+    min-width: $col-md;
+  }
 }

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
@@ -7,7 +7,6 @@
     font-size: $x-small;
   }
 
-  // Scroll horizontally at narrow widths instead of truncating Name/Description.
   .data-table-block .data-table__wrapper {
     overflow-x: auto;
   }


### PR DESCRIPTION
## Issue
Closes #46051

## Description
- Table contents no longer bleed off right side of page on low widths
- Created Engineering initiated story to move all these one off horizontal scroll fixes to a prop on TableContainer #46665 

## Screenrecording of fix

https://github.com/user-attachments/assets/9195dfb1-3c38-4767-9c06-42b6e39ec673


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved labels table layout with enhanced horizontal scrolling behavior and optimized column sizing for better readability and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->