### PR TITLE
Fleet UI: Fix height shift on updating from self-service

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/_styles.scss
@@ -71,6 +71,9 @@
     align-items: center;
     gap: $pad-small;
     font-size: $x-small;
+    // Match the small Button's height so height doesn't shift when the
+    // button is replaced with spinner/"Updating..." or icon/"Updated" text.
+    min-height: 28px;
   }
 
   &__status-content {


### PR DESCRIPTION
## Issue
Closes #46575 

## Description
- Row height would decrease when update button is clicked and being replaced with Updating... text
- Fixed

## Screenrecording of fix

https://github.com/user-attachments/assets/20324408-b9ba-4776-8671-faf731b9b423


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout consistency for software update controls by ensuring uniform height during state transitions (pending, updating, and completed states).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->