### PR TITLE
Add rules to deal with some python CVE false positives

### DIFF
--- a/changes/35148-python-cve-false-positives
+++ b/changes/35148-python-cve-false-positives
@@ -1,0 +1,3 @@
+* Fixed false positive vulnerability CVE-2017-17522 reported for Python (this CVE is disputed and not exploitable).
+* Fixed false positive vulnerability CVE-2023-36632 reported for Python (this CVE is disputed; the reported behavior is intentional).
+* Fixed false positive vulnerability CVE-2024-3219 reported for Python on macOS and Linux hosts (this CVE only affects Windows).

--- a/server/vulnerabilities/nvd/cpe_matching_rule_test.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rule_test.go
@@ -262,6 +262,38 @@ func TestGetKnownNVDBugRules(t *testing.T) {
 	ok = rule.CPEMatches(cpeMeta)
 	require.False(t, ok)
 
+	// Test that CVE-2017-17522 (disputed Python webbrowser CVE) never matches. See #35148.
+	pythonCPEMeta, err := wfn.Parse("cpe:2.3:a:python:python:3.9.6:*:*:*:*:*:*:*")
+	require.NoError(t, err)
+	rule, ok = cpeMatchingRules.FindMatch("CVE-2017-17522")
+	require.True(t, ok)
+	require.False(t, rule.CPEMatches(pythonCPEMeta), "CVE-2017-17522 should be ignored for all Python versions")
+
+	// Test that CVE-2023-36632 (disputed Python email.utils.parseaddr CVE) never matches. See #35148.
+	rule, ok = cpeMatchingRules.FindMatch("CVE-2023-36632")
+	require.True(t, ok)
+	require.False(t, rule.CPEMatches(pythonCPEMeta), "CVE-2023-36632 should be ignored for all Python versions")
+
+	// Test that CVE-2024-3219 (Python socket.socketpair) only matches on Windows. See #35148.
+	rule, ok = cpeMatchingRules.FindMatch("CVE-2024-3219")
+	require.True(t, ok)
+
+	pythonWindows, err := wfn.Parse("cpe:2.3:a:python:python:3.11.0:*:*:*:*:windows:*:*")
+	require.NoError(t, err)
+	require.True(t, rule.CPEMatches(pythonWindows), "CVE-2024-3219 should match Python on Windows")
+
+	pythonMacOS, err := wfn.Parse("cpe:2.3:a:python:python:3.11.0:*:*:*:*:macos:*:*")
+	require.NoError(t, err)
+	require.False(t, rule.CPEMatches(pythonMacOS), "CVE-2024-3219 should not match Python on macOS")
+
+	pythonLinux, err := wfn.Parse("cpe:2.3:a:python:python:3.11.0:*:*:*:*:linux:*:*")
+	require.NoError(t, err)
+	require.False(t, rule.CPEMatches(pythonLinux), "CVE-2024-3219 should not match Python on Linux")
+
+	pythonAnyTargetSW, err := wfn.Parse("cpe:2.3:a:python:python:3.11.0:*:*:*:*:*:*:*")
+	require.NoError(t, err)
+	require.False(t, rule.CPEMatches(pythonAnyTargetSW), "CVE-2024-3219 should not match Python with target_sw=*")
+
 	// Test that gitk CVEs don't match the base git package
 	gitCPEMeta, err := wfn.Parse("cpe:2.3:a:git:git:2.47.1:*:*:*:*:*:*:*")
 	require.NoError(t, err)

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -185,6 +185,40 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				},
 			},
 		},
+		// CVE-2017-17522 is DISPUTED. NVD lists python:python up to (and including) 3.6.3 as
+		// vulnerable, but the CPE criteria is broad and matches modern Python installs (e.g. it was
+		// reported against Python 3.9.6). Python maintainers reject the report: exploitation is
+		// impossible because webbrowser.py relies on subprocess.Popen with the default shell=False.
+		// Following the same approach as CVE-2013-0340, we ignore it entirely. See #35148.
+		CPEMatchingRule{
+			IgnoreAll: true,
+			CVEs: map[string]struct{}{
+				"CVE-2017-17522": {},
+			},
+		},
+		// CVE-2023-36632 is DISPUTED. NVD/Python state it is "neither a vulnerability nor a bug": the
+		// legacy email.utils.parseaddr function raises a RecursionError on crafted input, which is
+		// the email package's intended behavior of throwing an exception when size limits are
+		// exceeded. It matches python:python up to 3.11.4 with a 7.5 score. Following the same
+		// approach as CVE-2013-0340, we ignore it entirely. See #35148.
+		CPEMatchingRule{
+			IgnoreAll: true,
+			CVEs: map[string]struct{}{
+				"CVE-2023-36632": {},
+			},
+		},
+		// CVE-2024-3219 affects CPython's pure-Python socket.socketpair() implementation, which is
+		// only used on platforms lacking AF_UNIX support (Windows). Linux and macOS use the native
+		// AF_UNIX implementation and are not affected, but the NVD/VulnCheck CPE data uses
+		// target_sw=* causing false positives on macOS and Linux. See #35148.
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2024-3219": {},
+			},
+			IgnoreIf: func(cpeMeta *wfn.Attributes) bool {
+				return cpeMeta.TargetSW != "windows"
+			},
+		},
 		// These vulnerabilities in the MongoDB client incorrectly match
 		// the VS Code extension.
 		CPEMatchingRule{


### PR DESCRIPTION
**Related issue:** Resolves #35148

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

## What was added

| CVE | Rule | Reason |
|-----|------|--------|
| **CVE-2017-17522** | `IgnoreAll` | DISPUTED by Python maintainers; not exploitable (`webbrowser.py` uses `subprocess.Popen` with `shell=False`). Broad NVD CPE matched modern Python. |
| **CVE-2023-36632** | `IgnoreAll` | NVD-DISPUTED — Python states it's "neither a vulnerability nor a bug" (intentional `RecursionError` in `email.utils.parseaddr`). |
| **CVE-2024-3219** | `IgnoreIf target_sw != "windows"` | Only affects platforms lacking AF_UNIX (Windows). Linux/macOS unaffected, but NVD/VulnCheck CPE uses `target_sw=*`. |

**Files touched:**
- `cpe_matching_rules.go` — three new rules
- `cpe_matching_rule_test.go` — assertions covering all three (incl. Windows-vs-macOS/Linux distinction for CVE-2024-3219)
- `changes/35148-python-cve-false-positives` — changelog

**Correctness note:** `target_sw` derives from software *source* (`apps`/`homebrew_packages` → `macos`, `programs` → `windows`), so the CVE-2024-3219 rule suppresses on macOS while preserving the genuine Windows
positive.

## What was skipped, and why

| CVE | Why skipped |
|-----|-------------|
| **CVE-2024-12718** | Conflicting evidence: getvictor confirmed it's a **true positive** (3.9.22 < fixed 3.9.23), contradicting the customer's "only 3.12+ affected" reasoning. Needs a product/security ruling, not a code change. |
| **CVE-2025-1795** | Likely a VulnCheck patch-level miss (customer says 3.10.17 has the backported fix). Needs the actual VulnCheck version range to fix safely. |
| **CVE-2023-32681** | Affects `python:requests` and is **correctly matched**; the customer dismissed it on deployment grounds ("corporate servers only"). Not a detection bug. |
| **CVE-2007-4559** | Real tarfile path-traversal (CVSS 9.8, **not disputed**); the customer labeled it "Other issue," not a false positive. Suppressing it would hide a genuine vulnerability. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positive CVE vulnerability detections for Python: CVE-2017-17522 and CVE-2023-36632 are now recognized as disputed, and CVE-2024-3219 is correctly restricted to Windows only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->