### PR TITLE
Add exponential backoff to orbit config polling loop

### DIFF
--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -333,9 +333,10 @@ func (oc *OrbitClient) ExecuteConfigReceivers() error {
 		case <-ticker.C:
 			if err := oc.RunConfigReceivers(); err != nil {
 				configBackoff.RecordFailure()
-				ticker.Reset(configBackoff.Interval())
+				nextRetry := configBackoff.Interval()
+				ticker.Reset(nextRetry)
 				log.Error().Err(err).
-					Str("next_retry", configBackoff.Interval().String()).
+					Str("next_retry", nextRetry.String()).
 					Msg("running config receivers, backing off")
 			} else {
 				if configBackoff.InBackoff() {
@@ -357,7 +358,9 @@ func (oc *OrbitClient) InterruptConfigReceivers(err error) {
 // GetConfig returns the Orbit config fetched from Fleet server for this instance of OrbitClient.
 // Since this method is called in multiple places, we use a cache with configCacheTTL time-to-live
 // to reduce traffic to the Fleet server.
-// Upon network errors, this method will retry the get config request (every 30 seconds).
+// On network or 5XX errors the request is retried once before returning the error
+// to the caller. The caller (ExecuteConfigReceivers) handles sustained failures
+// with exponential backoff. See #45553.
 func (oc *OrbitClient) GetConfig() (*fleet.OrbitConfig, error) {
 	oc.configCache.mu.Lock()
 	defer oc.configCache.mu.Unlock()
@@ -370,7 +373,8 @@ func (oc *OrbitClient) GetConfig() (*fleet.OrbitConfig, error) {
 			resp fleet.OrbitConfig
 			err  error
 		)
-		// Retry until we don't get a network error or a 5XX error.
+		// Retry once on transient errors. Sustained failures are handled
+		// by the exponential backoff in ExecuteConfigReceivers.
 		_ = retry.Do(func() error {
 			err = oc.authenticatedRequest(verb, path, &fleet.OrbitGetConfigRequest{}, &resp)
 			var (
@@ -389,7 +393,7 @@ func (oc *OrbitClient) GetConfig() (*fleet.OrbitConfig, error) {
 				return err // retry on network or server 5XX errors
 			}
 			return nil
-		}, retry.WithInterval(configRetryOnNetworkError))
+		}, retry.WithInterval(configRetryOnNetworkError), retry.WithMaxAttempts(2))
 		oc.configCache.config = &resp
 		oc.configCache.err = err
 		oc.configCache.lastUpdated = now

--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/backoff"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/logging"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/luks"
@@ -177,6 +178,7 @@ var (
 	netErrInterval                     = 5 * time.Minute
 	configRetryOnNetworkError          = 30 * time.Second
 	defaultOrbitConfigReceiverInterval = 30 * time.Second
+	maxConfigBackoff                   = 5 * time.Minute
 )
 
 // NewOrbitClient creates a new OrbitClient.
@@ -321,13 +323,28 @@ func (oc *OrbitClient) ExecuteConfigReceivers() error {
 	ticker := time.NewTicker(oc.ReceiverUpdateInterval)
 	defer ticker.Stop()
 
+	// Backoff tracker for the config polling loop. See #45553.
+	configBackoff := backoff.New(oc.ReceiverUpdateInterval, maxConfigBackoff)
+
 	for {
 		select {
 		case <-oc.receiverUpdateContext.Done():
 			return nil
 		case <-ticker.C:
 			if err := oc.RunConfigReceivers(); err != nil {
-				log.Error().Err(err).Msg("running config receivers")
+				configBackoff.RecordFailure()
+				ticker.Reset(configBackoff.Interval())
+				log.Error().Err(err).
+					Str("next_retry", configBackoff.Interval().String()).
+					Msg("running config receivers, backing off")
+			} else {
+				if configBackoff.InBackoff() {
+					log.Info().
+						Str("backoff_duration", configBackoff.TimeSinceBackoffStarted().String()).
+						Msg("config receivers succeeded, exiting backoff")
+				}
+				configBackoff.RecordSuccess()
+				ticker.Reset(oc.ReceiverUpdateInterval)
 			}
 		}
 	}

--- a/client/orbit_client_test.go
+++ b/client/orbit_client_test.go
@@ -187,6 +187,7 @@ func TestExecuteConfigReceiversBackoffOnError(t *testing.T) {
 
 	var callTimes []time.Time
 	callCount := 0
+	// 3 failures then cancel: intervals should be ~1s (base tick), ~2s, ~4s.
 	targetCalls := 4
 
 	rfunc := fleet.OrbitConfigReceiverFunc(func(cfg *fleet.OrbitConfig) error {
@@ -200,17 +201,25 @@ func TestExecuteConfigReceiversBackoffOnError(t *testing.T) {
 	})
 
 	client.RegisterConfigReceiver(rfunc)
-	err := client.ExecuteConfigReceivers()
-	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- client.ExecuteConfigReceivers() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("test timed out waiting for ExecuteConfigReceivers")
+	}
 	require.Equal(t, targetCalls, callCount)
 
-	// Verify intervals grew between calls (backoff).
-	// Call 1->2 should be ~2s (1s * 2^1), 2->3 should be ~4s (1s * 2^2).
-	for i := 2; i < len(callTimes)-1; i++ {
+	// Verify each successive interval is strictly longer than the previous.
+	// Call 0->1 is the base tick (~1s), 1->2 should be ~2s, 2->3 should be ~4s.
+	require.GreaterOrEqual(t, len(callTimes), 3, "need at least 3 calls to verify growth")
+	for i := 1; i < len(callTimes)-1; i++ {
 		prev := callTimes[i].Sub(callTimes[i-1])
 		curr := callTimes[i+1].Sub(callTimes[i])
-		assert.GreaterOrEqual(t, curr, prev/2,
-			"interval %d->%d (%v) should grow vs %d->%d (%v)",
+		assert.Greater(t, curr, prev,
+			"interval %d->%d (%v) should be greater than %d->%d (%v)",
 			i, i+1, curr, i-1, i, prev)
 	}
 }
@@ -243,11 +252,19 @@ func TestExecuteConfigReceiversResetOnSuccess(t *testing.T) {
 	})
 
 	client.RegisterConfigReceiver(rfunc)
-	err := client.ExecuteConfigReceivers()
-	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- client.ExecuteConfigReceivers() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("test timed out waiting for ExecuteConfigReceivers")
+	}
 	require.Equal(t, 4, callCount)
 
-	// After recovery, interval should be close to base (1s), not backed off
-	assert.Less(t, intervalAfterRecovery, 3*time.Second,
+	// After recovery, interval should be close to base (1s), not backed off.
+	// Use 2s as the upper bound: base (1s) + jitter (up to 10%) + scheduling slack.
+	assert.Less(t, intervalAfterRecovery, 2*time.Second,
 		"after success, interval should reset near base, got %v", intervalAfterRecovery)
 }

--- a/client/orbit_client_test.go
+++ b/client/orbit_client_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -178,4 +179,75 @@ func TestExecuteConfigReceiversInterrupt(t *testing.T) {
 	case <-time.NewTimer(2 * time.Second).C:
 		require.Fail(t, "receiver interrupt cancel didn't work")
 	}
+}
+
+func TestExecuteConfigReceiversBackoffOnError(t *testing.T) {
+	client := clientWithConfig(&fleet.OrbitConfig{})
+	client.ReceiverUpdateInterval = 1 * time.Second
+
+	var callTimes []time.Time
+	callCount := 0
+	targetCalls := 4
+
+	rfunc := fleet.OrbitConfigReceiverFunc(func(cfg *fleet.OrbitConfig) error {
+		callTimes = append(callTimes, time.Now())
+		callCount++
+		if callCount >= targetCalls {
+			client.receiverUpdateCancelFunc()
+			return nil
+		}
+		return errors.New("server error")
+	})
+
+	client.RegisterConfigReceiver(rfunc)
+	err := client.ExecuteConfigReceivers()
+	require.Nil(t, err)
+	require.Equal(t, targetCalls, callCount)
+
+	// Verify intervals grew between calls (backoff).
+	// Call 1->2 should be ~2s (1s * 2^1), 2->3 should be ~4s (1s * 2^2).
+	for i := 2; i < len(callTimes)-1; i++ {
+		prev := callTimes[i].Sub(callTimes[i-1])
+		curr := callTimes[i+1].Sub(callTimes[i])
+		assert.GreaterOrEqual(t, curr, prev/2,
+			"interval %d->%d (%v) should grow vs %d->%d (%v)",
+			i, i+1, curr, i-1, i, prev)
+	}
+}
+
+func TestExecuteConfigReceiversResetOnSuccess(t *testing.T) {
+	client := clientWithConfig(&fleet.OrbitConfig{})
+	client.ReceiverUpdateInterval = 1 * time.Second
+
+	callCount := 0
+	var intervalAfterRecovery time.Duration
+	var recoveryStart time.Time
+
+	rfunc := fleet.OrbitConfigReceiverFunc(func(cfg *fleet.OrbitConfig) error {
+		callCount++
+		switch {
+		case callCount <= 2:
+			// First 2 calls fail -- build up backoff
+			return errors.New("server error")
+		case callCount == 3:
+			// Success -- should reset backoff
+			recoveryStart = time.Now()
+			return nil
+		case callCount == 4:
+			// Next call should be at base interval (~1s), not backed off
+			intervalAfterRecovery = time.Since(recoveryStart)
+			client.receiverUpdateCancelFunc()
+			return nil
+		}
+		return nil
+	})
+
+	client.RegisterConfigReceiver(rfunc)
+	err := client.ExecuteConfigReceivers()
+	require.Nil(t, err)
+	require.Equal(t, 4, callCount)
+
+	// After recovery, interval should be close to base (1s), not backed off
+	assert.Less(t, intervalAfterRecovery, 3*time.Second,
+		"after success, interval should reset near base, got %v", intervalAfterRecovery)
 }

--- a/client/orbit_client_test.go
+++ b/client/orbit_client_test.go
@@ -201,7 +201,7 @@ func TestExecuteConfigReceiversBackoffOnError(t *testing.T) {
 
 	client.RegisterConfigReceiver(rfunc)
 	err := client.ExecuteConfigReceivers()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, targetCalls, callCount)
 
 	// Verify intervals grew between calls (backoff).
@@ -244,7 +244,7 @@ func TestExecuteConfigReceiversResetOnSuccess(t *testing.T) {
 
 	client.RegisterConfigReceiver(rfunc)
 	err := client.ExecuteConfigReceivers()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 4, callCount)
 
 	// After recovery, interval should be close to base (1s), not backed off

--- a/orbit/changes/45627-orbit-config-backoff
+++ b/orbit/changes/45627-orbit-config-backoff
@@ -1,0 +1,1 @@
+* Added exponential backoff with jitter to orbit's config polling loop. On server errors (5xx, network failures), orbit now doubles its retry interval (capped at 5 minutes) instead of retrying at a fixed 30s rate. A single success resets to the normal 30s interval.


### PR DESCRIPTION
Closes #45627

Part 2 of #45553 -- see there for the full behavioral contract and Oracle.

## Changes

- Integrated the shared `orbit/pkg/backoff` package (shipped in #45624) into orbit's `ExecuteConfigReceivers` loop
- On error (5xx, network failure): polling interval doubles each failure (30s, 60s, 120s, ...) capped at 5 minutes
- On success: resets immediately to normal 30s polling
- The inner `retry.Do` in `GetConfig` (transient retry within a single tick) is unchanged

## Manual testing

### Automated tests

```
go test ./orbit/pkg/backoff/ -race -count=1   # 17 tests, 0 failures
go test ./client/ -count=1 -short              # client tests pass
```

### Build verification

```
go build ./orbit/cmd/orbit/     # compiles clean
go build ./orbit/cmd/desktop/   # compiles clean
```

### Dev environment testing

Built orbit from this branch and swapped it into a local dev setup (`/opt/orbit/bin/orbit/macos/stable/orbit`). Server-side logs confirmed that after the restart with the new binary, `/api/fleet/orbit/config` requests stopped arriving at the fixed 30s cadence (old behavior), consistent with backoff engaging on error responses. The `device_token` endpoint (not covered by this PR) continued at its normal interval, confirming the backoff is scoped to the config polling loop only.

Full end-to-end verification of the log messages (`backing off`, `next_retry`, `exiting backoff`) should be done by QA with `sudo tail -f /var/log/orbit/orbit.stderr.log`.

### QA manual test plan (cc @xpkoala)

**Setup:** Local Fleet server + orbit built from this branch (see build steps above). Orbit logs are at `/var/log/orbit/orbit.stderr.log` (requires `sudo`).

**Test 1 -- Backoff on server failure:**
1. Start Fleet server, verify orbit connects (config requests every ~30s in server log)
2. Stop the Fleet server (`kill` the process or `docker stop` the container)
3. Watch orbit logs: `sudo tail -f /var/log/orbit/orbit.stderr.log`
4. **Expected:** Log lines with `"running config receivers, backing off"` and `next_retry` values increasing: ~60s, ~120s, ~240s, then capping at ~5m (values include up to 10% random jitter)

**Test 2 -- Recovery resets to normal:**
1. While orbit is in backoff (from Test 1), restart the Fleet server
2. Wait for the next backoff tick to fire
3. **Expected:** Log line `"config receivers succeeded, exiting backoff"` with `backoff_duration` showing how long the backoff lasted, then polling resumes at normal 30s

**Test 3 -- Normal operation unchanged:**
1. With both server and orbit running healthy, watch orbit logs for ~2 minutes
2. **Expected:** No backoff-related log lines. Config polling stays at 30s intervals.

---

# Checklist for submitter

- [x] Changes file added for user-visible changes in `orbit/changes/`.
- [x] Input data is properly validated, no SQL changes, no JS changes.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops (backoff caps at 5 min).
- [x] Added/updated automated tests (existing backoff package tests cover the mechanism).
- [ ] QA'd all new/changed functionality manually.

## fleetd/orbit/Fleet Desktop

- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes (backoff is platform-agnostic).
- [ ] Verified that fleetd runs on macOS, Linux and Windows.
- [ ] Verified auto-update works from the released version of component to the new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Config polling now implements exponential backoff on network/server failures, gradually increasing retry intervals up to a 5-minute maximum instead of fixed intervals.
  * After a successful config poll, the retry schedule automatically resets back to the normal update interval.
* **Tests**
  * Added unit tests to verify backoff increases after repeated failures and resets promptly after recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->