### PR TITLE
Update instructions to download VPP token

### DIFF
--- a/articles/apple-mdm-setup.md
+++ b/articles/apple-mdm-setup.md
@@ -149,7 +149,7 @@ Connect Fleet to VPP to deploy [Apple App Store apps](https://fleetdm.com/guides
 1. In Fleet, select your avatar on the far right of the main navigation menu, and then **Settings > Integrations > MDM**.
 2. Under **Apple Business (AB)**, select **Add VPP** next to **Volume Purchasing Program (VPP)**.
 3. Sign in to [Apple Business](https://business.apple.com). If your organization doesn't have an account, select **Sign up now**.
-4. Head to **Settings > Apps & Books** and download the content token for the organization unit you want to use. Each token is based on an organization unit in Apple Business.
+4. Head to **Settings > Payments & Billing** and download the content token for the organization unit you want to use. Each token is based on an organization unit in Apple Business.
 5. Upload the content token (.vpptoken file) to Fleet.
 6. To assign the VPP token to a specific fleet, find the token in the table of VPP tokens. Select the **Actions** dropdown, and then select **Edit fleets**. Use the picker to select which fleet(s) this VPP token should be assigned to.
 
@@ -161,7 +161,7 @@ Connect Fleet to VPP to deploy [Apple App Store apps](https://fleetdm.com/guides
 2. Under **Apple Business (AB)**, select **Edit** next to **Volume Purchasing Program (VPP)** and then find the token that you want to renew.
 3. Select the **Actions > Renew** for the token.
 4. Sign in to [Apple Business](https://business.apple.com).
-5. Head to **Settings > Apps & Books** and download your content token.
+5. Head to **Settings > Payments & Billing** and download your content token.
 6. Upload the content token (.vpptoken file) to Fleet.
 
 ## Best practice


### PR DESCRIPTION
Update the Apple MDM Setup guide to point to "Payments & Billings" in Apple Business. 

It's actually `Settings > Payments & Billings > Apps & Books` but I just wrote `Settings > Payments & Billing` since that's the default tab you land on. Can change if that makes it clearer.