### PR TITLE
Fix preview config 

### DIFF
--- a/changes/fix-preview-historical-data
+++ b/changes/fix-preview-historical-data
@@ -1,0 +1,1 @@
+- Fixed `fleetctl preview` disabling dashboard chart data collection (Hosts online, Vulnerability exposure) on startup.

--- a/cmd/fleetctl/fleetctl/preview.go
+++ b/cmd/fleetctl/fleetctl/preview.go
@@ -406,11 +406,14 @@ func previewCommand() *cli.Command {
 				return fmt.Errorf("failed to apply starter library: %w", err)
 			}
 
-			// disable analytics collection and enable software inventory for preview
-			// TODO(roperzh): replace `host_settings` with `features` once the
-			// Docker image used for preview (fleetdm/fleetctl:latest) is released
+			// disable analytics collection and enable software inventory for preview.
+			// Use `features` (not the deprecated `host_settings` alias): the legacy
+			// alias is unmarshaled by wholesale-replacing the entire Features struct,
+			// which would zero out any field not in this partial patch — including the
+			// historical_data sub-keys that drive the dashboard charts, silently
+			// disabling data collection. `features` merges field-by-field instead.
 			if err := client.ApplyAppConfig(map[string]map[string]bool{
-				"host_settings":   {"enable_software_inventory": true},
+				"features":        {"enable_software_inventory": true},
 				"server_settings": {"enable_analytics": false},
 			}, fleet.ApplySpecOptions{}); err != nil {
 				return fmt.Errorf("failed to apply updated app config: %w", err)

--- a/cmd/fleetctl/fleetctl/preview.go
+++ b/cmd/fleetctl/fleetctl/preview.go
@@ -406,8 +406,8 @@ func previewCommand() *cli.Command {
 				return fmt.Errorf("failed to apply starter library: %w", err)
 			}
 
-			// disable analytics collection and enable software inventory for preview.
-			// otherwise use the defaults for both.
+			// disable analytics collection and enable software inventory for preview,
+			// and preserve all other existing values.
 			if err := client.ApplyAppConfig(map[string]map[string]bool{
 				"features":        {"enable_software_inventory": true},
 				"server_settings": {"enable_analytics": false},

--- a/cmd/fleetctl/fleetctl/preview.go
+++ b/cmd/fleetctl/fleetctl/preview.go
@@ -407,11 +407,7 @@ func previewCommand() *cli.Command {
 			}
 
 			// disable analytics collection and enable software inventory for preview.
-			// Use `features` (not the deprecated `host_settings` alias): the legacy
-			// alias is unmarshaled by wholesale-replacing the entire Features struct,
-			// which would zero out any field not in this partial patch — including the
-			// historical_data sub-keys that drive the dashboard charts, silently
-			// disabling data collection. `features` merges field-by-field instead.
+			// otherwise use the defaults for both.
 			if err := client.ApplyAppConfig(map[string]map[string]bool{
 				"features":        {"enable_software_inventory": true},
 				"server_settings": {"enable_analytics": false},

--- a/cmd/fleetctl/integrationtest/preview/preview_test.go
+++ b/cmd/fleetctl/integrationtest/preview/preview_test.go
@@ -57,6 +57,16 @@ func TestIntegrationsPreview(t *testing.T) {
 	ok = strings.Contains(appConf, `enable_software_inventory: true`)
 	require.True(t, ok, appConf)
 
+	// dashboard chart data collection must remain enabled. Regression guard:
+	// preview used to apply its config patch via the deprecated `host_settings`
+	// key, which wholesale-replaced the Features struct and silently zeroed the
+	// historical_data sub-keys. Applying via `features` merges field-by-field
+	// and preserves them.
+	ok = strings.Contains(appConf, `uptime: true`)
+	require.True(t, ok, appConf)
+	ok = strings.Contains(appConf, `vulnerabilities: true`)
+	require.True(t, ok, appConf)
+
 	// current instance checks must be on
 	ok = strings.Contains(appConf, `current_instance_checks: "yes"`)
 	require.True(t, ok, appConf)

--- a/cmd/fleetctl/integrationtest/preview/preview_test.go
+++ b/cmd/fleetctl/integrationtest/preview/preview_test.go
@@ -57,7 +57,7 @@ func TestIntegrationsPreview(t *testing.T) {
 	ok = strings.Contains(appConf, `enable_software_inventory: true`)
 	require.True(t, ok, appConf)
 
-	// dashboard chart data collection must remain enabled. Regression guard:
+	// Regression guard:
 	// preview used to apply its config patch via the deprecated `host_settings`
 	// key, which wholesale-replaced the Features struct and silently zeroed the
 	// historical_data sub-keys. Applying via `features` merges field-by-field
@@ -65,6 +65,8 @@ func TestIntegrationsPreview(t *testing.T) {
 	ok = strings.Contains(appConf, `uptime: true`)
 	require.True(t, ok, appConf)
 	ok = strings.Contains(appConf, `vulnerabilities: true`)
+	require.True(t, ok, appConf)
+	ok = strings.Contains(appConf, `enable_host_users: true`)
 	require.True(t, ok, appConf)
 
 	// current instance checks must be on


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46560 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
  - updated preview test. This won't run in CI right now b/c we didn't update fleetctl, but I ran it successfully locally
- [X] QA'd all new/changed functionality manually
  - [x] on main, did `fleetctl preview` with the 4.86.0 tag and verified that charts were disabled
  - [x] on this branch, did the same and verified charts were enabled 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard chart data collection (Hosts online and Vulnerability exposure) is no longer disabled when starting preview mode.

* **Chores**
  * Software inventory config moved to the current features flag so historical chart data is preserved.

* **Tests**
  * Added regression checks to ensure uptime, vulnerabilities, and host-users historical data remain enabled in preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->