### PR TITLE
Website: fix link on device management page, update margin of section heading on page

### DIFF
--- a/website/assets/styles/pages/device-management.less
+++ b/website/assets/styles/pages/device-management.less
@@ -478,6 +478,8 @@
     max-width: 1072px;
     padding-left: 64px;
     padding-right: 64px;
+    margin-left: auto;
+    margin-right: auto;
   }
   [parasails-component='scrollable-tweets'] {
     [purpose='tweets'] {

--- a/website/assets/styles/pages/device-management.less
+++ b/website/assets/styles/pages/device-management.less
@@ -53,7 +53,7 @@
     gap: 48px;
   }
   [purpose='hero-content'] {
-    max-width: 769px;
+    max-width: 775px;
     text-align: center;
     display: flex;
     flex-direction: column;

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -290,7 +290,7 @@
               <p>Flexible APIs and open data formats.</p>
               <p>Keep control of your infrastructure and your data.</p>
             </div>
-            <a purpose="section-button" href="/deploy">Deployment options</a>
+            <a purpose="section-button" href="/deployment">Deployment options</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changes:
- Updated a link on the device management page to go to the deployment page (previously, it was going to /deploy, which redirects to the deployment documentation page.)
- Updated the styles for the testimonials section on the device management page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Deployment options" link on the device management page to point to the correct destination.

* **Style**
  * Improved layout by centering the tweets container on the device management page.
  * Slightly increased the hero content max-width to improve page balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->