### PR TITLE
Website: Fix mistake from my last PR, and a change I left out

### DIFF
--- a/website/views/pages/customers.ejs
+++ b/website/views/pages/customers.ejs
@@ -227,11 +227,11 @@
       <div class="text-center" purpose="bottom-cta">
         <div>
         <h4>Open device management</h4>
-        <h2 class="mx-auto">Manage devices your way</h2>
+        <h2 class="mx-auto">Manage all your devices like it's 2026</h2>
         </div>
         <div purpose="button-row" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" class="mr-0" href="/contact">Get a demo</a>
-          <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
+          <!-- <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button> -->
         </div>
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated customers page call-to-action heading to "Manage all your devices like it's 2026"
  * Removed the "Join a workshop" button from the call-to-action section, keeping the "Get a demo" option available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->