### PR TITLE
Add loadtest metrics tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -58,6 +58,10 @@ go run ./tools/snapshot r
 # Run osquery load tests
 ./tools/loadtest/osquery/gnuplot_osqueryd_cpu_memory.sh
 
+# Collect CloudWatch metrics for a load test environment, then compare runs
+./tools/loadtest/metrics/collect-metrics.sh --workspace 486loadtest --category baseline
+./tools/loadtest/metrics/compare-metrics.sh --filter loadtest --depth 4 --unique
+
 # Test webhooks
 go run ./tools/webhook 8082
 
@@ -306,6 +310,7 @@ go run ./tools/run-scripts -scripts-disabled -content 'echo "Test"'
 | `desktop-rate-limit/` | Test Fleet Desktop rate limiting | `go run ./tools/desktop-rate-limit -fleet_url https://localhost:8080` |
 | `kubequery/` | Kubequery + Fleet config | `kubectl apply -f kubequery-fleet.yml` |
 | `loadtest/fleetd_labels/` | Apply manual labels for load testing | `go run ./tools/loadtest/fleetd_labels` |
+| `loadtest/metrics/` | Collect & compare AWS CloudWatch metrics for load test environments | `./tools/loadtest/metrics/collect-metrics.sh --workspace <ws>` — see [loadtest/metrics/README.md](loadtest/metrics/README.md) |
 | `loadtest/osquery/` | Load test osquery on macOS/Windows/Linux | See [loadtest/osquery/README.md](loadtest/osquery/README.md) |
 | `loadtest/scripts_and_profiles/` | Load test scripts and profiles | `go run ./tools/loadtest/scripts_and_profiles` |
 | `loadtest/unified_queue/` | Load test unified queue story | See [loadtest/unified_queue/README.md](loadtest/unified_queue/README.md) |

--- a/tools/loadtest/metrics/README.md
+++ b/tools/loadtest/metrics/README.md
@@ -1,0 +1,85 @@
+# Load test metrics
+
+Collect and compare AWS CloudWatch metrics for Fleet load test environments. Use these
+scripts to capture a point-in-time synopsis of a running load test and to diff runs
+against each other to catch regressions release-over-release.
+
+- `collect-metrics.sh` — discovers a load test environment's AWS resources from its
+  Terraform workspace name, pulls CloudWatch metrics averaged over a lookback interval,
+  and writes a `.json` data file plus a human-readable `.md` synopsis (with threshold alerts).
+- `compare-metrics.sh` — diffs two or more runs side by side and flags deltas as
+  `ok` / `WARN` / `ALERT`.
+
+## Requirements
+
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html),
+  authenticated against the account hosting the load test environment.
+- [`jq`](https://jqlang.github.io/jq/)
+
+## Collecting metrics
+
+```bash
+# 3h lookback (default) for the "486loadtest" workspace
+./collect-metrics.sh --workspace 486loadtest
+
+# 1h lookback, filed under the mdm category
+./collect-metrics.sh --workspace 483applemdm --interval 1h --category mdm
+```
+
+Key flags (`--help` for the full list):
+
+| Flag | Meaning |
+|------|---------|
+| `-w, --workspace` | Terraform workspace name (required). AWS resource names are derived from it. |
+| `-i, --interval`  | Lookback window: `<N>h`, `<N>m`, or a bare integer (hours). Default `3h`. |
+| `-c, --category`  | File the run under a category: `baseline` \| `migration` \| `mdm`. |
+| `-o, --output`    | Override the output file path. |
+| `-r, --region`    | AWS region. Default `us-east-2`. |
+
+Output lands in `runs/[<category>/]<workspace>/<workspace>-<timestamp>-<interval>.json`
+alongside a matching `.md` synopsis.
+
+> The `--workspace` value is not free-form — `collect-metrics.sh` derives AWS resource
+> names from it (`fleet-<ws>-backend`, `fleetdm-<ws>-mysql`, `fleet-<ws>-redis`, …), so it
+> must match the actual Terraform workspace.
+
+## Comparing runs
+
+```bash
+# Compare the 2 most recent runs across all categories
+./compare-metrics.sh
+
+# Last 4 baseline releases, one run per workspace
+./compare-metrics.sh --filter loadtest --depth 4 --unique
+
+# Two specific files
+./compare-metrics.sh runs/baseline/485loadtest/485*.json runs/baseline/486loadtest/486*.json
+```
+
+`compare-metrics.sh` searches `runs/` **recursively**, so category subfolders are included
+automatically. The `--filter` flag matches on the workspace name, which — thanks to the
+naming conventions below — doubles as a category selector (`--filter loadtest`, `--filter mig`).
+
+## Run organization
+
+Historical runs live under `runs/`, grouped by what the load test exercised:
+
+| Category | `runs/` subfolder | Workspace naming convention | Examples |
+|----------|-------------------|-----------------------------|----------|
+| **Baseline** — per-release branch load test | `runs/baseline/`  | `<version>loadtest`            | `486loadtest` |
+| **Migration** — n-1 → n schema migration    | `runs/migration/` | `<n-1>to<n>mig`                | `485to486mig` |
+| **MDM** — platform-specific MDM load test   | `runs/mdm/`       | `<version><platform>` / `<platform>-release` | `483applemdm`, `486-windows` |
+
+The category subfolder is purely for human organization; the scripts don't depend on it.
+Keeping workspace names to these conventions is what makes `--filter` a reliable category
+selector.
+
+## Submitting results
+
+After a load test, commit the run so the history stays useful for future comparisons:
+
+1. Collect with the right category so the files land in the correct folder, e.g.
+   `./collect-metrics.sh --workspace 486loadtest --category baseline`.
+2. Commit both the `.json` (data) and `.md` (synopsis) for the run under `runs/<category>/<workspace>/`.
+   For multi-step tests (e.g. MDM), a short `REPORT.md` summarizing the runs is welcome too.
+3. Open a PR against `main` with the new files. Keep it to the run artifacts — no script changes.

--- a/tools/loadtest/metrics/collect-metrics.sh
+++ b/tools/loadtest/metrics/collect-metrics.sh
@@ -1,0 +1,1494 @@
+#!/usr/bin/env bash
+#
+# collect-metrics.sh - Collect AWS CloudWatch metrics for a Fleet load test environment.
+#
+# Usage:
+#   ./collect-metrics.sh --workspace <name> [options]
+#
+# Options:
+#   -w, --workspace NAME  Terraform workspace name (required)
+#   -i, --interval RANGE  Lookback interval. Accepts <N>h, <N>m, or a bare integer (treated as hours). Default: 3h
+#   -c, --category CAT    Run category for filing output: baseline | migration | mdm.
+#                         Files output under runs/<category>/<workspace>/. Omit to use runs/<workspace>/.
+#   -o, --output FILE     Output file path (default: runs/[<category>/]<workspace>/<workspace>-<date>Z-<interval>.json)
+#   -r, --region REGION   AWS region (default: us-east-2)
+#   -h, --help            Show this help message
+#
+# The script discovers AWS resources by naming convention from the Terraform workspace name,
+# then collects CloudWatch metrics averaged over the specified interval ending at the current time.
+#
+# Required: aws cli v2, jq
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Dependency check
+# ---------------------------------------------------------------------------
+for cmd in aws jq; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' is required but not found in PATH." >&2; exit 1; }
+done
+
+usage() {
+  sed -n '3,15p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+WORKSPACE=""
+OUTPUT=""
+REGION="us-east-2"
+INTERVAL_INPUT="3h"
+CATEGORY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -w|--workspace)  WORKSPACE="$2"; shift 2 ;;
+    -i|--interval)   INTERVAL_INPUT="$2"; shift 2 ;;
+    -c|--category)   CATEGORY="$2"; shift 2 ;;
+    -o|--output)     OUTPUT="$2"; shift 2 ;;
+    -r|--region)     REGION="$2"; shift 2 ;;
+    -h|--help)       usage 0 ;;
+    -*)              echo "Unknown option: $1" >&2; usage 1 ;;
+    *)               echo "Unknown argument: $1. Use --workspace to specify the workspace name." >&2; usage 1 ;;
+  esac
+done
+
+if [[ -z "$WORKSPACE" ]]; then
+  echo "Error: --workspace is required." >&2
+  usage 1
+fi
+
+if [[ -n "$CATEGORY" ]]; then
+  case "$CATEGORY" in
+    baseline|migration|mdm) ;;
+    *) echo "Error: --category must be one of: baseline, migration, mdm. Got: '$CATEGORY'" >&2; exit 1 ;;
+  esac
+fi
+
+# Parse interval: accept "<N>h", "<N>m", or a bare integer (interpreted as hours).
+if [[ "$INTERVAL_INPUT" =~ ^([0-9]+)([hm]?)$ ]]; then
+  INTERVAL_NUM="${BASH_REMATCH[1]}"
+  INTERVAL_UNIT="${BASH_REMATCH[2]:-h}"
+else
+  echo "Error: --interval must be of the form '3h', '30m', or a bare positive integer (hours). Got: '$INTERVAL_INPUT'" >&2
+  exit 1
+fi
+
+if [[ "$INTERVAL_NUM" -lt 1 ]]; then
+  echo "Error: --interval must be a positive integer." >&2
+  exit 1
+fi
+
+case "$INTERVAL_UNIT" in
+  h) INTERVAL_SECONDS=$((INTERVAL_NUM * 3600)) ;;
+  m) INTERVAL_SECONDS=$((INTERVAL_NUM * 60)) ;;
+esac
+INTERVAL_LABEL="${INTERVAL_NUM}${INTERVAL_UNIT}"
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Runs are filed under runs/[<category>/]<workspace>/. compare-metrics.sh discovers
+# them recursively, so the category subfolder is purely for human organization.
+METRICS_DIR="${SCRIPT_DIR}/runs${CATEGORY:+/$CATEGORY}/${WORKSPACE}"
+mkdir -p "$METRICS_DIR"
+OUTPUT="${OUTPUT:-${METRICS_DIR}/${WORKSPACE}-$(date -u +%Y-%m-%d-%H%M%SZ)-${INTERVAL_LABEL}.json}"
+
+# ---------------------------------------------------------------------------
+# Time window: <interval> ending now
+# ---------------------------------------------------------------------------
+END_TIME="$TIMESTAMP"
+if [[ "$(uname)" == "Darwin" ]]; then
+  case "$INTERVAL_UNIT" in
+    h) START_TIME=$(date -u -v-${INTERVAL_NUM}H +"%Y-%m-%dT%H:%M:%SZ") ;;
+    m) START_TIME=$(date -u -v-${INTERVAL_NUM}M +"%Y-%m-%dT%H:%M:%SZ") ;;
+  esac
+else
+  case "$INTERVAL_UNIT" in
+    h) START_TIME=$(date -u -d "${INTERVAL_NUM} hours ago" +"%Y-%m-%dT%H:%M:%SZ") ;;
+    m) START_TIME=$(date -u -d "${INTERVAL_NUM} minutes ago" +"%Y-%m-%dT%H:%M:%SZ") ;;
+  esac
+fi
+
+# Max 5-min data points expected in this window (minimum 1 to avoid div-by-zero
+# on sub-5-minute intervals).
+MAX_POINTS=$(( INTERVAL_SECONDS / 300 ))
+[[ $MAX_POINTS -lt 1 ]] && MAX_POINTS=1
+
+echo "Collecting metrics for workspace: $WORKSPACE"
+echo "Region: $REGION"
+echo "Interval: ${INTERVAL_LABEL}"
+echo "Time range: $START_TIME → $END_TIME"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Resource name derivation
+# ---------------------------------------------------------------------------
+# Two possible naming schemes:
+#   Root config:  cluster = fleet-<ws>-backend, rds = fleetdm-<ws>-mysql, redis = fleet-<ws>-redis
+#   Infra module: cluster = fleet-<ws>,         rds = fleet-<ws>,         redis = fleet-<ws>
+
+PREFIX="fleet-${WORKSPACE}"
+
+# ---------------------------------------------------------------------------
+# Discovery: find actual resource names
+# ---------------------------------------------------------------------------
+echo "Discovering resources..."
+
+# ECS clusters — try both naming patterns
+ECS_CLUSTER=""
+for candidate in "${PREFIX}-backend" "${PREFIX}"; do
+  if aws ecs describe-clusters --clusters "$candidate" --region "$REGION" \
+       --query "clusters[?status=='ACTIVE'].clusterName" --output text 2>/dev/null | grep -q .; then
+    ECS_CLUSTER="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$ECS_CLUSTER" ]]; then
+  echo "Warning: Could not find ECS cluster for workspace '$WORKSPACE'. Trying tag-based discovery..." >&2
+  ECS_CLUSTER=$(aws ecs list-clusters --region "$REGION" --output json \
+    | jq -r ".clusterArns[] | select(contains(\"$WORKSPACE\"))" \
+    | head -1 | xargs -I{} basename {})
+fi
+
+if [[ -z "$ECS_CLUSTER" ]]; then
+  echo "Error: No ECS cluster found for workspace '$WORKSPACE'" >&2
+  exit 1
+fi
+echo "  ECS Cluster: $ECS_CLUSTER"
+
+# ECS services in the cluster
+ECS_SERVICES_JSON=$(aws ecs list-services --cluster "$ECS_CLUSTER" --region "$REGION" --output json 2>/dev/null || echo '{"serviceArns":[]}')
+ECS_SERVICE_ARNS=$(echo "$ECS_SERVICES_JSON" | jq -r '.serviceArns[]')
+
+FLEET_SERVICE=""
+OSQUERY_PERF_SERVICE=""
+LOADTEST_SERVICES=()
+
+for arn in $ECS_SERVICE_ARNS; do
+  svc=$(basename "$arn")
+  case "$svc" in
+    fleet)          FLEET_SERVICE="$svc" ;;
+    osquery_perf)   OSQUERY_PERF_SERVICE="$svc" ;;
+    loadtest-*)     LOADTEST_SERVICES+=("$svc") ;;
+  esac
+done
+
+echo "  Fleet Service: ${FLEET_SERVICE:-<not found>}"
+echo "  osquery-perf Service: ${OSQUERY_PERF_SERVICE:-<not found>}"
+echo "  Loadtest Services: ${#LOADTEST_SERVICES[@]} found"
+
+# RDS — try both naming patterns
+RDS_CLUSTER_ID=""
+for candidate in "fleetdm-${WORKSPACE}-mysql" "${PREFIX}"; do
+  if aws rds describe-db-clusters --db-cluster-identifier "$candidate" --region "$REGION" \
+       --query "DBClusters[0].DBClusterIdentifier" --output text 2>/dev/null | grep -q .; then
+    RDS_CLUSTER_ID="$candidate"
+    break
+  fi
+done
+echo "  RDS Cluster: ${RDS_CLUSTER_ID:-<not found>}"
+
+# Get RDS instance identifiers (writer + readers)
+RDS_WRITER_INSTANCE=""
+RDS_READER_INSTANCES=()
+if [[ -n "$RDS_CLUSTER_ID" ]]; then
+  RDS_MEMBERS_JSON=$(aws rds describe-db-clusters --db-cluster-identifier "$RDS_CLUSTER_ID" --region "$REGION" \
+    --query "DBClusters[0].DBClusterMembers" --output json 2>/dev/null || echo "[]")
+  RDS_WRITER_INSTANCE=$(echo "$RDS_MEMBERS_JSON" | jq -r '.[] | select(.IsClusterWriter==true) | .DBInstanceIdentifier' | head -1)
+  while IFS= read -r inst; do
+    [[ -n "$inst" ]] && RDS_READER_INSTANCES+=("$inst")
+  done < <(echo "$RDS_MEMBERS_JSON" | jq -r '.[] | select(.IsClusterWriter==false) | .DBInstanceIdentifier')
+  echo "  RDS Writer: ${RDS_WRITER_INSTANCE:-<not found>}"
+  echo "  RDS Readers: ${RDS_READER_INSTANCES[*]:-<none>}"
+fi
+
+# RDS instance class (for IOPS utilization calculation)
+RDS_WRITER_INSTANCE_CLASS=""
+if [[ -n "$RDS_WRITER_INSTANCE" ]]; then
+  RDS_WRITER_INSTANCE_CLASS=$(aws rds describe-db-instances --db-instance-identifier "$RDS_WRITER_INSTANCE" --region "$REGION" \
+    --query "DBInstances[0].DBInstanceClass" --output text 2>/dev/null || echo "")
+fi
+
+# RDS DbiResourceId for Performance Insights
+RDS_WRITER_DBI_RESOURCE_ID=""
+if [[ -n "$RDS_WRITER_INSTANCE" ]]; then
+  RDS_WRITER_DBI_RESOURCE_ID=$(aws rds describe-db-instances --db-instance-identifier "$RDS_WRITER_INSTANCE" --region "$REGION" \
+    --query "DBInstances[0].DbiResourceId" --output text 2>/dev/null || echo "")
+fi
+
+RDS_READER_DBI_RESOURCE_IDS=()
+for reader in "${RDS_READER_INSTANCES[@]}"; do
+  rid=$(aws rds describe-db-instances --db-instance-identifier "$reader" --region "$REGION" \
+    --query "DBInstances[0].DbiResourceId" --output text 2>/dev/null || echo "")
+  [[ -n "$rid" ]] && RDS_READER_DBI_RESOURCE_IDS+=("$rid")
+done
+
+# ElastiCache Redis — try both naming patterns
+REDIS_REPLICATION_GROUP=""
+for candidate in "${PREFIX}-redis" "${PREFIX}"; do
+  if aws elasticache describe-replication-groups --replication-group-id "$candidate" --region "$REGION" \
+       --query "ReplicationGroups[0].ReplicationGroupId" --output text 2>/dev/null | grep -q .; then
+    REDIS_REPLICATION_GROUP="$candidate"
+    break
+  fi
+done
+echo "  Redis Replication Group: ${REDIS_REPLICATION_GROUP:-<not found>}"
+
+REDIS_NODE_IDS=()
+if [[ -n "$REDIS_REPLICATION_GROUP" ]]; then
+  while IFS= read -r nid; do
+    [[ -n "$nid" ]] && REDIS_NODE_IDS+=("$nid")
+  done < <(aws elasticache describe-replication-groups --replication-group-id "$REDIS_REPLICATION_GROUP" --region "$REGION" \
+    --query "ReplicationGroups[0].MemberClusters[]" --output json 2>/dev/null | jq -r '.[]')
+  echo "  Redis Nodes: ${REDIS_NODE_IDS[*]:-<none>}"
+fi
+
+# ALB discovery
+ALB_ARN_SUFFIX=""
+ALB_TG_ARN_SUFFIX=""
+ALB_ARN=$(aws elbv2 describe-load-balancers --region "$REGION" --output json 2>/dev/null \
+  | jq -r ".LoadBalancers[] | select(.LoadBalancerName | contains(\"$WORKSPACE\")) | .LoadBalancerArn" \
+  | head -1)
+if [[ -n "$ALB_ARN" ]]; then
+  # Extract the suffix after "app/" for CloudWatch dimensions
+  ALB_ARN_SUFFIX=$(echo "$ALB_ARN" | grep -o 'app/.*')
+  echo "  ALB: $ALB_ARN_SUFFIX"
+
+  # Find the target group for the fleet service
+  ALB_TG_ARN=$(aws elbv2 describe-target-groups --load-balancer-arn "$ALB_ARN" --region "$REGION" \
+    --query "TargetGroups[0].TargetGroupArn" --output text 2>/dev/null || echo "")
+  if [[ -n "$ALB_TG_ARN" ]]; then
+    ALB_TG_ARN_SUFFIX=$(echo "$ALB_TG_ARN" | grep -o 'targetgroup/.*')
+    echo "  ALB Target Group: $ALB_TG_ARN_SUFFIX"
+  fi
+else
+  echo "  ALB: <not found>"
+fi
+
+# Discover CloudWatch log group for Fleet server
+# Try exact name matches first, then fall back to a broad search.
+# Patterns: /ecs/<prefix>-backend/fleet, /ecs/<prefix>/fleet, <prefix> (bare)
+FLEET_LOG_GROUP=""
+for candidate in "/ecs/${PREFIX}-backend/fleet" "/ecs/${PREFIX}/fleet" "${PREFIX}"; do
+  if aws logs describe-log-groups --log-group-name-prefix "$candidate" --region "$REGION" \
+       --query "logGroups[0].logGroupName" --output text 2>/dev/null | grep -q "^${candidate}"; then
+    FLEET_LOG_GROUP="$candidate"
+    break
+  fi
+done
+if [[ -z "$FLEET_LOG_GROUP" ]]; then
+  # Broad search: find log groups containing the workspace name and "fleet",
+  # excluding Container Insights groups (which are metrics, not application logs).
+  FLEET_LOG_GROUP=$(aws logs describe-log-groups --region "$REGION" --output json 2>/dev/null \
+    | jq -r ".logGroups[].logGroupName | select(contains(\"$WORKSPACE\")) | select(contains(\"fleet\")) | select(contains(\"containerinsights\") | not)" \
+    | head -1)
+fi
+echo "  Fleet Log Group: ${FLEET_LOG_GROUP:-<not found>}"
+
+echo ""
+echo "Collecting CloudWatch metrics..."
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# get_metric <namespace> <metric_name> <dimensions> <period> <statistics...>
+# Returns JSON with Datapoints
+get_metric() {
+  local ns="$1" metric="$2" dims="$3" period="$4"
+  shift 4
+  local stats=("$@")
+
+  aws cloudwatch get-metric-statistics \
+    --namespace "$ns" \
+    --metric-name "$metric" \
+    --dimensions $dims \
+    --start-time "$START_TIME" \
+    --end-time "$END_TIME" \
+    --period "$period" \
+    --statistics "${stats[@]}" \
+    --region "$REGION" \
+    --output json 2>/dev/null || echo '{"Datapoints":[]}'
+}
+
+# collect_metric <namespace> <metric_name> <dimensions> <statistics...>
+# Returns JSON object with the metric values and data_coverage info.
+# Uses the full interval as one period for the aggregate, plus 5-min periods
+# to count actual data points for coverage reporting.
+collect_metric() {
+  local ns="$1" metric="$2" dims="$3"
+  shift 3
+  local stats=("$@")
+
+  local result fine
+  result=$(get_metric "$ns" "$metric" "$dims" "$INTERVAL_SECONDS" "${stats[@]}")
+  fine=$(get_metric "$ns" "$metric" "$dims" 300 SampleCount)
+
+  local dp_count
+  dp_count=$(echo "$fine" | jq '[.Datapoints[]] | length')
+
+  # Extract the single datapoint, rounding numbers to 2 decimal places
+  local datapoint
+  datapoint=$(echo "$result" | jq '.Datapoints[0] // null | if . then with_entries(if .value | type == "number" then .value = (.value * 100 | round / 100) else . end) else null end')
+
+  jq -n \
+    --argjson dp "$datapoint" \
+    --argjson dp_count "$dp_count" \
+    --argjson max_points "$MAX_POINTS" \
+    'if $dp then $dp + {"data_points": $dp_count, "max_points": $max_points, "data_coverage": (if $dp_count > 0 then ($dp_count / $max_points * 100 | round / 100) else 0 end)} else null end'
+}
+
+# collect_ecs_utilization <cluster> <service> <utilized_metric> <reserved_metric>
+# Computes utilization as Sum(Utilized) / Sum(Reserved) * 100 using Container Insights.
+# This matches the ECS Performance Dashboard formula and gives accurate service-wide
+# percentages. Returns JSON with Average, Minimum, Maximum as percentages, plus
+# data_coverage info.
+collect_ecs_utilization() {
+  local cluster="$1" service="$2" util_metric="$3" resv_metric="$4"
+  local dims="Name=ClusterName,Value=$cluster Name=ServiceName,Value=$service"
+
+  # Get utilized and reserved at 5-min granularity using Sum stat
+  local util_raw resv_raw
+  util_raw=$(get_metric "ECS/ContainerInsights" "$util_metric" "$dims" 300 Sum)
+  resv_raw=$(get_metric "ECS/ContainerInsights" "$resv_metric" "$dims" 300 Sum)
+
+  # Compute utilization percentage per 5-min period, then derive avg/min/max
+  jq -n \
+    --argjson util "$util_raw" \
+    --argjson resv "$resv_raw" \
+    --argjson max_points "$MAX_POINTS" \
+    '
+    # Build lookup of reserved by timestamp
+    ($resv.Datapoints | map({(.Timestamp): .Sum}) | add // {}) as $resv_map |
+    # Calculate percentage for each utilized datapoint where reserved exists
+    [($util.Datapoints // [])[] |
+      . as $dp |
+      ($resv_map[$dp.Timestamp] // null) as $r |
+      select($r != null and $r > 0) |
+      ($dp.Sum / $r * 100)
+    ] |
+    if length > 0 then
+      {
+        Average: (add / length * 100 | round / 100),
+        Minimum: (min * 100 | round / 100),
+        Maximum: (max * 100 | round / 100),
+        Unit: "Percent",
+        data_points: length,
+        max_points: $max_points,
+        data_coverage: (length / $max_points * 100 | round / 100)
+      }
+    else null end'
+}
+
+# ---------------------------------------------------------------------------
+# Collect ECS Fleet Server metrics
+# max_iops_for_class <instance_class>
+# Returns the max IOPS for a given Aurora instance class. Echoes 0 if unknown.
+# Source: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html
+max_iops_for_class() {
+  case "$1" in
+    db.r6g.large)     echo 10000 ;;
+    db.r6g.xlarge)    echo 15000 ;;
+    db.r6g.2xlarge)   echo 20000 ;;
+    db.r6g.4xlarge)   echo 20000 ;;
+    db.r6g.8xlarge)   echo 40000 ;;
+    db.r6g.12xlarge)  echo 40000 ;;
+    db.r6g.16xlarge)  echo 80000 ;;
+    db.r7g.large)     echo 10000 ;;
+    db.r7g.xlarge)    echo 15000 ;;
+    db.r7g.2xlarge)   echo 20000 ;;
+    db.r7g.4xlarge)   echo 20000 ;;
+    db.r7g.8xlarge)   echo 40000 ;;
+    db.r7g.12xlarge)  echo 40000 ;;
+    db.r7g.16xlarge)  echo 80000 ;;
+    *)                echo 0 ;;
+  esac
+}
+
+# calc_iops_util <riops_json> <wiops_json> <instance_class>
+# Returns a JSON object with IOPS utilization details.
+calc_iops_util() {
+  local riops="$1" wiops="$2" inst_class="$3"
+  local max_iops
+  max_iops=$(max_iops_for_class "$inst_class")
+  jq -n \
+    --argjson riops "$riops" \
+    --argjson wiops "$wiops" \
+    --argjson max_iops "$max_iops" \
+    --arg instance_class "${inst_class:-unknown}" \
+    '{
+      instance_class: $instance_class,
+      max_iops: $max_iops,
+      read_iops_avg: ($riops.Average // null),
+      write_iops_avg: ($wiops.Average // null),
+      total_iops_avg: (if ($riops.Average // null) and ($wiops.Average // null) then (($riops.Average + $wiops.Average) * 100 | round / 100) else null end),
+      utilization_pct: (if $max_iops > 0 and ($riops.Average // null) and ($wiops.Average // null) then ((($riops.Average + $wiops.Average) / $max_iops * 100) * 100 | round / 100) else null end)
+    }'
+}
+
+# vcpus_for_class <instance_class>
+# Returns the vCPU count for a given Aurora instance class. Echoes 0 if unknown.
+# Source: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.html
+vcpus_for_class() {
+  case "$1" in
+    db.r6g.large)     echo 2 ;;
+    db.r6g.xlarge)    echo 4 ;;
+    db.r6g.2xlarge)   echo 8 ;;
+    db.r6g.4xlarge)   echo 16 ;;
+    db.r6g.8xlarge)   echo 32 ;;
+    db.r6g.12xlarge)  echo 48 ;;
+    db.r6g.16xlarge)  echo 64 ;;
+    db.r7g.large)     echo 2 ;;
+    db.r7g.xlarge)    echo 4 ;;
+    db.r7g.2xlarge)   echo 8 ;;
+    db.r7g.4xlarge)   echo 16 ;;
+    db.r7g.8xlarge)   echo 32 ;;
+    db.r7g.12xlarge)  echo 48 ;;
+    db.r7g.16xlarge)  echo 64 ;;
+    *)                echo 0 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+FLEET_SERVER_METRICS="{}"
+if [[ -n "$FLEET_SERVICE" ]]; then
+  echo "  Fleet Server: CPU Utilization (Container Insights)..."
+  fleet_cpu=$(collect_ecs_utilization "$ECS_CLUSTER" "$FLEET_SERVICE" "CpuUtilized" "CpuReserved")
+
+  echo "  Fleet Server: Memory Utilization (Container Insights)..."
+  fleet_mem=$(collect_ecs_utilization "$ECS_CLUSTER" "$FLEET_SERVICE" "MemoryUtilized" "MemoryReserved")
+
+  # Get running task count from describe-services (always available, no Container Insights needed)
+  fleet_tasks=$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$FLEET_SERVICE" --region "$REGION" \
+    --query "services[0].{runningCount:runningCount,desiredCount:desiredCount}" --output json 2>/dev/null || echo '{}')
+
+  FLEET_SERVER_METRICS=$(jq -n \
+    --argjson cpu "$fleet_cpu" \
+    --argjson mem "$fleet_mem" \
+    --argjson tasks "$fleet_tasks" \
+    '{cpu_utilization: $cpu, memory_utilization: $mem, task_counts: $tasks}')
+fi
+
+# ---------------------------------------------------------------------------
+# Collect ECS osquery-perf / loadtest container metrics
+# ---------------------------------------------------------------------------
+LOADTEST_METRICS="{}"
+
+# osquery-perf service (infra module path)
+if [[ -n "$OSQUERY_PERF_SERVICE" ]]; then
+  echo "  osquery-perf: CPU Utilization (Container Insights)..."
+  oqp_cpu=$(collect_ecs_utilization "$ECS_CLUSTER" "$OSQUERY_PERF_SERVICE" "CpuUtilized" "CpuReserved")
+
+  echo "  osquery-perf: Memory Utilization (Container Insights)..."
+  oqp_mem=$(collect_ecs_utilization "$ECS_CLUSTER" "$OSQUERY_PERF_SERVICE" "MemoryUtilized" "MemoryReserved")
+
+  oqp_tasks=$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$OSQUERY_PERF_SERVICE" --region "$REGION" \
+    --query "services[0].{runningCount:runningCount,desiredCount:desiredCount}" --output json 2>/dev/null || echo '{}')
+
+  LOADTEST_METRICS=$(jq -n \
+    --argjson cpu "$oqp_cpu" \
+    --argjson mem "$oqp_mem" \
+    --argjson tasks "$oqp_tasks" \
+    '{cpu_utilization: $cpu, memory_utilization: $mem, task_counts: $tasks}')
+
+# Loadtest services (root config path — services named loadtest-0, loadtest-1, etc.)
+elif [[ ${#LOADTEST_SERVICES[@]} -gt 0 ]]; then
+  first_svc="${LOADTEST_SERVICES[0]}"
+  echo "  loadtest containers: CPU Utilization (${#LOADTEST_SERVICES[@]} services)..."
+
+  lt_running=0
+  lt_desired=0
+  for svc in "${LOADTEST_SERVICES[@]}"; do
+    counts=$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$svc" --region "$REGION" \
+      --query "services[0].{r:runningCount,d:desiredCount}" --output json 2>/dev/null || echo '{"r":0,"d":0}')
+    lt_running=$((lt_running + $(echo "$counts" | jq '.r // 0')))
+    lt_desired=$((lt_desired + $(echo "$counts" | jq '.d // 0')))
+  done
+
+  lt_cpu=$(collect_ecs_utilization "$ECS_CLUSTER" "$first_svc" "CpuUtilized" "CpuReserved")
+
+  lt_mem=$(collect_ecs_utilization "$ECS_CLUSTER" "$first_svc" "MemoryUtilized" "MemoryReserved")
+
+  LOADTEST_METRICS=$(jq -n \
+    --argjson cpu "$lt_cpu" \
+    --argjson mem "$lt_mem" \
+    --arg running "$lt_running" \
+    --arg desired "$lt_desired" \
+    --arg count "${#LOADTEST_SERVICES[@]}" \
+    '{cpu_utilization: $cpu, memory_utilization: $mem, task_counts: {runningCount: ($running|tonumber), desiredCount: ($desired|tonumber), serviceCount: ($count|tonumber)}}')
+fi
+
+# ---------------------------------------------------------------------------
+# Collect RDS Writer metrics
+# ---------------------------------------------------------------------------
+RDS_WRITER_METRICS="{}"
+if [[ -n "$RDS_WRITER_INSTANCE" ]]; then
+  echo "  RDS Writer: CPU Utilization..."
+  rds_w_cpu=$(collect_metric "AWS/RDS" "CPUUtilization" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Maximum Minimum)
+
+  echo "  RDS Writer: Database Connections..."
+  rds_w_conns=$(collect_metric "AWS/RDS" "DatabaseConnections" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Maximum Minimum)
+
+  echo "  RDS Writer: Read IOPS..."
+  rds_w_riops=$(collect_metric "AWS/RDS" "ReadIOPS" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Maximum)
+
+  echo "  RDS Writer: Write IOPS..."
+  rds_w_wiops=$(collect_metric "AWS/RDS" "WriteIOPS" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Maximum)
+
+  echo "  RDS Writer: Deadlocks..."
+  rds_w_deadlocks=$(collect_metric "AWS/RDS" "Deadlocks" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Sum Average Maximum)
+
+  RDS_WRITER_METRICS=$(jq -n \
+    --argjson cpu "$rds_w_cpu" \
+    --argjson conns "$rds_w_conns" \
+    --argjson riops "$rds_w_riops" \
+    --argjson wiops "$rds_w_wiops" \
+    --argjson deadlocks "$rds_w_deadlocks" \
+    '{instance: "writer", cpu_utilization: $cpu, database_connections: $conns, read_iops: $riops, write_iops: $wiops, deadlocks: $deadlocks}')
+fi
+
+# ---------------------------------------------------------------------------
+# Collect RDS Reader metrics (standard + extended in one pass)
+# ---------------------------------------------------------------------------
+RDS_READER_METRICS="[]"
+RDS_READERS_EXT="[]"
+if [[ ${#RDS_READER_INSTANCES[@]} -gt 0 ]]; then
+  reader_arr="[]"
+  readers_ext_arr="[]"
+  reader_idx=1
+  for reader in "${RDS_READER_INSTANCES[@]}"; do
+    reader_label="reader-${reader_idx}"
+    echo "  RDS $reader_label: CPU, Connections, IOPS..."
+
+    rds_r_cpu=$(collect_metric "AWS/RDS" "CPUUtilization" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Maximum Minimum)
+
+    rds_r_conns=$(collect_metric "AWS/RDS" "DatabaseConnections" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Maximum Minimum)
+
+    rds_r_riops=$(collect_metric "AWS/RDS" "ReadIOPS" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Maximum)
+
+    rds_r_wiops=$(collect_metric "AWS/RDS" "WriteIOPS" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Maximum)
+
+    reader_obj=$(jq -n \
+      --arg instance "$reader_label" \
+      --argjson cpu "$rds_r_cpu" \
+      --argjson conns "$rds_r_conns" \
+      --argjson riops "$rds_r_riops" \
+      --argjson wiops "$rds_r_wiops" \
+      '{instance: $instance, cpu_utilization: $cpu, database_connections: $conns, read_iops: $riops, write_iops: $wiops}')
+    reader_arr=$(echo "$reader_arr" | jq --argjson obj "$reader_obj" '. + [$obj]')
+
+    # Extended metrics for this reader
+    echo "  RDS $reader_label: AuroraReplicaLag, FreeableMemory, BufferCacheHitRatio, SelectLatency..."
+
+    # AuroraReplicaLag: Replication delay (milliseconds) between the writer
+    # and this reader. Values above 20-50ms under load may cause stale reads.
+    # A rising trend across releases indicates the reader can't keep up with
+    # write volume.
+    rds_r_lag=$(collect_metric "AWS/RDS" "AuroraReplicaLag" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Maximum)
+
+    # FreeableMemory: Tracks available RAM on the reader.
+    rds_r_freemem=$(collect_metric "AWS/RDS" "FreeableMemory" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Minimum)
+
+    # BufferCacheHitRatio: Readers often have different cache profiles since
+    # they serve read-heavy query patterns. Investigate if below 99%.
+    rds_r_cache=$(collect_metric "AWS/RDS" "BufferCacheHitRatio" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Minimum)
+
+    # SelectLatency: Readers only serve SELECT queries, so this is their
+    # primary latency indicator.
+    rds_r_select_lat=$(collect_metric "AWS/RDS" "SelectLatency" \
+      "Name=DBInstanceIdentifier,Value=$reader" \
+      Average Maximum)
+
+    # IOPS utilization: Combined read+write IOPS as a percentage of the
+    # reader's instance class maximum.
+    echo "  RDS $reader_label: IOPS Utilization..."
+    rds_r_inst_class=$(aws rds describe-db-instances --db-instance-identifier "$reader" --region "$REGION" \
+      --query "DBInstances[0].DBInstanceClass" --output text 2>/dev/null || echo "")
+    rds_r_iops_util=$(calc_iops_util "$rds_r_riops" "$rds_r_wiops" "$rds_r_inst_class")
+
+    # Threads Running (active sessions via PI): Same as writer — average
+    # active sessions on this reader. db.load.avg without GroupBy returns
+    # the total Average Active Sessions (AAS).
+    rds_r_threads="null"
+    reader_dbi_idx=$((reader_idx - 1))
+    if [[ $reader_dbi_idx -lt ${#RDS_READER_DBI_RESOURCE_IDS[@]} ]] && [[ -n "${RDS_READER_DBI_RESOURCE_IDS[$reader_dbi_idx]:-}" ]]; then
+      echo "  RDS $reader_label: Threads Running (active sessions via PI)..."
+      pi_r_threads_raw=$(aws pi get-resource-metrics \
+        --service-type RDS \
+        --identifier "${RDS_READER_DBI_RESOURCE_IDS[$reader_dbi_idx]}" \
+        --start-time "$START_TIME" \
+        --end-time "$END_TIME" \
+        --period-in-seconds 300 \
+        --metric-queries '[{"Metric":"db.load.avg"}]' \
+        --region "$REGION" \
+        --output json 2>/dev/null || echo '{}')
+      rds_r_vcpus=$(vcpus_for_class "$rds_r_inst_class")
+      rds_r_threads=$(echo "$pi_r_threads_raw" | jq --argjson vcpus "$rds_r_vcpus" '
+        (.MetricList // [])[0].DataPoints
+        | if . and length > 0 then
+            [.[].Value | select(. != null)] |
+            if length > 0 then
+              { average: (add / length * 100 | round / 100),
+                maximum: (max * 100 | round / 100),
+                vcpus: $vcpus }
+            else null end
+          else null end')
+    fi
+
+    reader_ext=$(jq -n \
+      --arg instance "$reader_label" \
+      --argjson lag "$rds_r_lag" \
+      --argjson freemem "$rds_r_freemem" \
+      --argjson cache "$rds_r_cache" \
+      --argjson select_lat "$rds_r_select_lat" \
+      --argjson iops_util "$rds_r_iops_util" \
+      --argjson threads "$rds_r_threads" \
+      '{
+        instance: $instance,
+        aurora_replica_lag: $lag,
+        freeable_memory: $freemem,
+        buffer_cache_hit_ratio: $cache,
+        select_latency: $select_lat,
+        iops_utilization: $iops_util,
+        threads_running: $threads
+      }')
+    readers_ext_arr=$(echo "$readers_ext_arr" | jq --argjson obj "$reader_ext" '. + [$obj]')
+
+    reader_idx=$((reader_idx + 1))
+  done
+  RDS_READER_METRICS="$reader_arr"
+  RDS_READERS_EXT="$readers_ext_arr"
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: extract flattened top SQL from a raw PI get-resource-metrics response.
+# Input: raw JSON from aws pi get-resource-metrics
+# Output: array of {rank, sql, load_avg} sorted by load descending
+#
+# PI response structure: MetricList[] where [0] is the aggregate and [1..N]
+# are per-SQL entries. Each entry has .Key.Dimensions["db.sql_tokenized.statement"]
+# and .DataPoints[].Value. We average the DataPoints for the load value.
+# ---------------------------------------------------------------------------
+flatten_top_sql() {
+  local raw="$1"
+  echo "$raw" | jq '
+    [(.MetricList // [])[1:] | .[] |
+      select(.Key.Dimensions["db.sql_tokenized.statement"] | . and (. | length > 0)) |
+      # Filter to only datapoints that have a Value field (PI omits Value when load is zero)
+      (.DataPoints | [.[] | select(.Value)]) as $valid_points |
+      select($valid_points | length > 0) |
+      {
+        sql: .Key.Dimensions["db.sql_tokenized.statement"],
+        load_avg: ([$valid_points[].Value] | add / length * 100 | round / 100)
+      }
+    ] | sort_by(-.load_avg) | to_entries | map({rank: (.key + 1)} + .value)
+  ' 2>/dev/null || echo '[]'
+}
+
+# ---------------------------------------------------------------------------
+# Collect RDS Performance Insights — Top SQL by Load (writer)
+# ---------------------------------------------------------------------------
+RDS_PI_WRITER="[]"
+if [[ -n "$RDS_WRITER_DBI_RESOURCE_ID" ]]; then
+  echo "  RDS Performance Insights: Top SQL (writer)..."
+  pi_raw=$(aws pi get-resource-metrics \
+    --service-type RDS \
+    --identifier "$RDS_WRITER_DBI_RESOURCE_ID" \
+    --start-time "$START_TIME" \
+    --end-time "$END_TIME" \
+    --period-in-seconds 3600 \
+    --metric-queries '[{"Metric":"db.load.avg","GroupBy":{"Group":"db.sql_tokenized","Limit":5}}]' \
+    --region "$REGION" \
+    --output json 2>/dev/null || echo '{}')
+
+  RDS_PI_WRITER=$(flatten_top_sql "$pi_raw")
+fi
+
+# Performance Insights for reader(s)
+RDS_PI_READERS="[]"
+if [[ ${#RDS_READER_DBI_RESOURCE_IDS[@]} -gt 0 ]]; then
+  pi_reader_arr="[]"
+  idx=0
+  for rid in "${RDS_READER_DBI_RESOURCE_IDS[@]}"; do
+    reader_label="reader-$((idx + 1))"
+    echo "  RDS Performance Insights: Top SQL ($reader_label)..."
+
+    pi_raw=$(aws pi get-resource-metrics \
+      --service-type RDS \
+      --identifier "$rid" \
+      --start-time "$START_TIME" \
+      --end-time "$END_TIME" \
+      --period-in-seconds 3600 \
+      --metric-queries '[{"Metric":"db.load.avg","GroupBy":{"Group":"db.sql_tokenized","Limit":5}}]' \
+      --region "$REGION" \
+      --output json 2>/dev/null || echo '{}')
+
+    pi_flat=$(flatten_top_sql "$pi_raw")
+    pi_reader_obj=$(jq -n --arg inst "$reader_label" --argjson sql "$pi_flat" '{instance: $inst, top_sql: $sql}')
+    pi_reader_arr=$(echo "$pi_reader_arr" | jq --argjson obj "$pi_reader_obj" '. + [$obj]')
+    idx=$((idx + 1))
+  done
+  RDS_PI_READERS="$pi_reader_arr"
+fi
+
+# ---------------------------------------------------------------------------
+# Collect ElastiCache Redis metrics (standard + extended in one pass)
+# ---------------------------------------------------------------------------
+REDIS_METRICS="[]"
+REDIS_EXT="[]"
+if [[ ${#REDIS_NODE_IDS[@]} -gt 0 ]]; then
+  redis_arr="[]"
+  redis_ext_arr="[]"
+  redis_idx=1
+  for node_id in "${REDIS_NODE_IDS[@]}"; do
+    redis_label="redis-${redis_idx}"
+    echo "  $redis_label: CPU, Memory, Connections, Evictions, CacheHitRate..."
+
+    redis_cpu=$(collect_metric "AWS/ElastiCache" "EngineCPUUtilization" \
+      "Name=CacheClusterId,Value=$node_id" \
+      Average Maximum Minimum)
+
+    redis_mem=$(collect_metric "AWS/ElastiCache" "DatabaseMemoryUsagePercentage" \
+      "Name=CacheClusterId,Value=$node_id" \
+      Average Maximum Minimum)
+
+    node_obj=$(jq -n \
+      --arg node "$redis_label" \
+      --argjson cpu "$redis_cpu" \
+      --argjson mem "$redis_mem" \
+      '{node: $node, cpu_utilization: $cpu, memory_utilization: $mem}')
+    redis_arr=$(echo "$redis_arr" | jq --argjson obj "$node_obj" '. + [$obj]')
+
+    # Extended metrics for this node
+
+    # CurrConnections: Number of active client connections. A rising trend
+    # across runs with the same container count may indicate connection leaks.
+    redis_conns=$(collect_metric "AWS/ElastiCache" "CurrConnections" \
+      "Name=CacheClusterId,Value=$node_id" \
+      Average Maximum)
+
+    # Evictions: Keys evicted due to memory pressure. Any non-zero value means
+    # Redis is dropping data to stay within its memory limit.
+    redis_evictions=$(collect_metric "AWS/ElastiCache" "Evictions" \
+      "Name=CacheClusterId,Value=$node_id" \
+      Sum Maximum)
+
+    # CacheHitRate: Percentage of key lookups that found data. A declining
+    # trend means more cache misses pushing load to the database.
+    redis_hitrate=$(collect_metric "AWS/ElastiCache" "CacheHitRate" \
+      "Name=CacheClusterId,Value=$node_id" \
+      Average Minimum)
+
+    node_ext=$(jq -n \
+      --arg node "$redis_label" \
+      --argjson conns "$redis_conns" \
+      --argjson evictions "$redis_evictions" \
+      --argjson hitrate "$redis_hitrate" \
+      '{
+        node: $node,
+        curr_connections: $conns,
+        evictions: $evictions,
+        cache_hit_rate: $hitrate
+      }')
+    redis_ext_arr=$(echo "$redis_ext_arr" | jq --argjson obj "$node_ext" '. + [$obj]')
+
+    redis_idx=$((redis_idx + 1))
+  done
+  REDIS_METRICS="$redis_arr"
+  REDIS_EXT="$redis_ext_arr"
+fi
+
+# ---------------------------------------------------------------------------
+# ALB metrics
+# Provides API-level latency and error rates from the load balancer's
+# perspective — the closest proxy to end-user experience.
+# -------------------------------------------------------------------------
+ALB_METRICS="{}"
+if [[ -n "$ALB_ARN_SUFFIX" ]]; then
+  # TargetResponseTime: Average time (seconds) for the target (Fleet server)
+  # to respond to a request. Tracks API latency as seen by the ALB. Rising
+  # values across releases indicate server-side performance degradation.
+  echo "  ALB: TargetResponseTime (API latency)..."
+  alb_latency=$(collect_metric "AWS/ApplicationELB" "TargetResponseTime" \
+    "Name=LoadBalancer,Value=$ALB_ARN_SUFFIX" \
+    Average Maximum Minimum)
+
+  # HTTPCode_Target_5XX_Count: Total number of HTTP 5xx responses from Fleet
+  # server containers. Non-zero values indicate server errors. Track over time
+  # to catch regressions that introduce error-producing code paths.
+  echo "  ALB: HTTPCode_Target_5XX_Count (server errors)..."
+  alb_5xx=$(collect_metric "AWS/ApplicationELB" "HTTPCode_Target_5XX_Count" \
+    "Name=LoadBalancer,Value=$ALB_ARN_SUFFIX" \
+    Sum)
+
+  # RequestCount: Total HTTP requests handled by the ALB during the interval.
+  # Useful for normalizing other metrics (e.g. errors per request) and verifying
+  # the load test is generating expected traffic volume.
+  echo "  ALB: RequestCount (total throughput)..."
+  alb_requests=$(collect_metric "AWS/ApplicationELB" "RequestCount" \
+    "Name=LoadBalancer,Value=$ALB_ARN_SUFFIX" \
+    Sum)
+
+  # ProcessedBytes: Total bytes processed by the ALB (request + response).
+  # Tracks the volume of data flowing through the load balancer. Useful for
+  # detecting unexpected payload size changes across releases (e.g. a new
+  # API response that's much larger than before).
+  echo "  ALB: ProcessedBytes (traffic volume)..."
+  alb_bytes=$(collect_metric "AWS/ApplicationELB" "ProcessedBytes" \
+    "Name=LoadBalancer,Value=$ALB_ARN_SUFFIX" \
+    Sum)
+
+  ALB_METRICS=$(jq -n \
+    --argjson latency "$alb_latency" \
+    --argjson errors_5xx "$alb_5xx" \
+    --argjson requests "$alb_requests" \
+    --argjson bytes "$alb_bytes" \
+    '{
+      target_response_time: $latency,
+      http_5xx_count: $errors_5xx,
+      request_count: $requests,
+      processed_bytes: $bytes
+    }')
+fi
+
+# -------------------------------------------------------------------------
+# CloudWatch Logs Insights — Fleet server error query
+# Queries the Fleet server log group for error-level log entries, filtering
+# out known noise:
+#   - fleet_detail_query_software errors (osquery-perf has a default 50%
+#     failure rate for software queries)
+#   - "context canceled" errors (normal during container deployments)
+#
+# Returns the total error count and up to 10 sample error messages for
+# manual review. The expected value is 0 errors over at least 1 hour.
+# -------------------------------------------------------------------------
+LOGS_ERRORS="{}"
+if [[ -n "$FLEET_LOG_GROUP" ]]; then
+  echo "  CloudWatch Logs: Querying Fleet server errors..."
+  # Start the Logs Insights query (async)
+  LOGS_QUERY_ID=$(aws logs start-query \
+    --log-group-name "$FLEET_LOG_GROUP" \
+    --start-time "$(date -d "$START_TIME" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$START_TIME" +%s)" \
+    --end-time "$(date -d "$END_TIME" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$END_TIME" +%s)" \
+    --query-string 'fields @timestamp, @message
+| filter ispresent(error) or ispresent(err) or level = "error"
+| filter @message not like /fleet_detail_query_software/
+| filter @message not like /context canceled/
+| filter level != "debug"
+| filter level != "info"
+| sort @timestamp desc
+| limit 10000' \
+    --region "$REGION" \
+    --output text --query 'queryId' 2>/dev/null || echo "")
+
+  if [[ -n "$LOGS_QUERY_ID" ]]; then
+    # Poll for query completion (typically takes 5-15 seconds)
+    echo "  CloudWatch Logs: Waiting for query results..."
+    logs_status="Running"
+    logs_attempts=0
+    while [[ "$logs_status" == "Running" || "$logs_status" == "Scheduled" ]] && [[ $logs_attempts -lt 30 ]]; do
+      sleep 2
+      logs_result=$(aws logs get-query-results --query-id "$LOGS_QUERY_ID" --region "$REGION" --output json 2>/dev/null || echo '{"status":"Failed"}')
+      logs_status=$(echo "$logs_result" | jq -r '.status')
+      logs_attempts=$((logs_attempts + 1))
+    done
+
+    if [[ "$logs_status" == "Complete" ]]; then
+      # Count total matched records and extract sample messages
+      logs_total=$(echo "$logs_result" | jq '.statistics.recordsMatched // 0')
+      logs_samples=$(echo "$logs_result" | jq '[.results[:10][] | [.[] | select(.field == "@message") | .value] | first // empty]')
+
+      LOGS_ERRORS=$(jq -n \
+        --argjson total "$logs_total" \
+        --argjson samples "$logs_samples" \
+        '{
+          error_count: $total,
+          sample_messages: $samples
+        }')
+      echo "  CloudWatch Logs: Found $logs_total errors"
+    else
+      echo "  CloudWatch Logs: Query did not complete (status: $logs_status)" >&2
+      LOGS_ERRORS='{"error_count": null, "query_status": "'"$logs_status"'"}'
+    fi
+  else
+    echo "  CloudWatch Logs: Failed to start query" >&2
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Aurora MySQL extended metrics (writer)
+# These track database health indicators that degrade slowly over time
+# and are easy to miss in a single load test run.
+# -------------------------------------------------------------------------
+RDS_WRITER_EXT="{}"
+if [[ -n "$RDS_WRITER_INSTANCE" ]]; then
+  # FreeableMemory: Available RAM (bytes) on the DB instance. A downward
+  # trend across releases can indicate memory leaks in queries, growing
+  # working sets, or the need to upsize the instance class.
+  echo "  RDS Writer: FreeableMemory (available RAM)..."
+  rds_w_freemem=$(collect_metric "AWS/RDS" "FreeableMemory" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Minimum)
+
+  # BufferCacheHitRatio: Percentage of requests served from the Aurora buffer
+  # cache vs reading from disk. Values near 100% are ideal. A decline over
+  # time means more queries are hitting disk, increasing latency. Investigate
+  # if this drops below 99%.
+  echo "  RDS Writer: BufferCacheHitRatio (cache efficiency)..."
+  rds_w_cache=$(collect_metric "AWS/RDS" "BufferCacheHitRatio" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Minimum)
+
+  # VolumeBytesUsed: Total storage consumed by the Aurora cluster (bytes).
+  # Track over time for capacity planning. Sharp increases may indicate
+  # unexpected data growth from new features or logging changes.
+  echo "  RDS Writer: VolumeBytesUsed (disk usage)..."
+  rds_w_disk=$(collect_metric "AWS/RDS" "VolumeBytesUsed" \
+    "Name=DBClusterIdentifier,Value=$RDS_CLUSTER_ID" \
+    Average Maximum)
+
+  # SelectLatency: Average latency (seconds) of SELECT queries on the writer.
+  # Rising values indicate query performance degradation, possibly due to
+  # missing indexes, growing table sizes, or lock contention.
+  echo "  RDS Writer: SelectLatency..."
+  rds_w_select_lat=$(collect_metric "AWS/RDS" "SelectLatency" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Maximum)
+
+  # InsertLatency: Average latency (seconds) of INSERT queries on the writer.
+  # Fleet's workload is insert-heavy (host checkins, software inventory).
+  # Rising values may indicate index bloat or lock contention.
+  echo "  RDS Writer: InsertLatency..."
+  rds_w_insert_lat=$(collect_metric "AWS/RDS" "InsertLatency" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Maximum)
+
+  # DMLLatency: Average latency (seconds) of all DML operations (INSERT,
+  # UPDATE, DELETE). Provides a single overall write-path health indicator.
+  echo "  RDS Writer: DMLLatency..."
+  rds_w_dml_lat=$(collect_metric "AWS/RDS" "DMLLatency" \
+    "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
+    Average Maximum)
+
+  # DatabaseConnections via Performance Insights — "threads running" metric.
+  # This is distinct from CloudWatch DatabaseConnections (which counts all
+  # connections including idle ones). Threads running counts only actively
+  # executing queries. Expected: <= vCPUs on the instance (e.g.
+  # db.r6g.4xlarge has 16 vCPUs). Sustained values above vCPU count indicate
+  # CPU saturation from query concurrency.
+  echo "  RDS Writer: Threads Running (active sessions via PI)..."
+  rds_w_threads="null"
+  if [[ -n "$RDS_WRITER_DBI_RESOURCE_ID" ]]; then
+    pi_threads_raw=$(aws pi get-resource-metrics \
+      --service-type RDS \
+      --identifier "$RDS_WRITER_DBI_RESOURCE_ID" \
+      --start-time "$START_TIME" \
+      --end-time "$END_TIME" \
+      --period-in-seconds 300 \
+      --metric-queries '[{"Metric":"db.load.avg"}]' \
+      --region "$REGION" \
+      --output json 2>/dev/null || echo '{}')
+    # db.load.avg without GroupBy returns the total Average Active Sessions
+    # (AAS), which equals the average number of threads running.
+    # Expected: average <= vCPUs on the instance. Sustained values above
+    # vCPU count indicate CPU saturation from query concurrency.
+    rds_w_vcpus=$(vcpus_for_class "$RDS_WRITER_INSTANCE_CLASS")
+    rds_w_threads=$(echo "$pi_threads_raw" | jq --argjson vcpus "$rds_w_vcpus" '
+      (.MetricList // [])[0].DataPoints
+      | if . and length > 0 then
+          [.[].Value | select(. != null)] |
+          if length > 0 then
+            { average: (add / length * 100 | round / 100),
+              maximum: (max * 100 | round / 100),
+              vcpus: $vcpus }
+          else null end
+        else null end')
+  fi
+
+  # IOPS utilization: Combined read+write IOPS as a percentage of the instance
+  # class maximum. Values above 80% indicate I/O saturation risk.
+  echo "  RDS Writer: IOPS Utilization..."
+  rds_w_iops_util=$(calc_iops_util "$rds_w_riops" "$rds_w_wiops" "$RDS_WRITER_INSTANCE_CLASS")
+
+  RDS_WRITER_EXT=$(jq -n \
+    --argjson freemem "$rds_w_freemem" \
+    --argjson cache "$rds_w_cache" \
+    --argjson disk "$rds_w_disk" \
+    --argjson select_lat "$rds_w_select_lat" \
+    --argjson insert_lat "$rds_w_insert_lat" \
+    --argjson dml_lat "$rds_w_dml_lat" \
+    --argjson threads "$rds_w_threads" \
+    --argjson iops_util "$rds_w_iops_util" \
+    '{
+      freeable_memory: $freemem,
+      buffer_cache_hit_ratio: $cache,
+      volume_bytes_used: $disk,
+      select_latency: $select_lat,
+      insert_latency: $insert_lat,
+      dml_latency: $dml_lat,
+      threads_running: $threads,
+      iops_utilization: $iops_util
+    }')
+fi
+
+
+
+# -------------------------------------------------------------------------
+# ECS Network traffic (Container Insights)
+# NetworkRxBytes / NetworkTxBytes measure the total bytes received/sent by
+# Fleet server containers. Useful for detecting unexpected traffic changes
+# (e.g. a new feature that increases payload sizes). Requires Container
+# Insights to be enabled on the ECS cluster.
+# -------------------------------------------------------------------------
+NETWORK_METRICS="{}"
+if [[ -n "$FLEET_SERVICE" ]]; then
+  echo "  Fleet Server: Network RX (Container Insights)..."
+  net_rx=$(collect_metric "ECS/ContainerInsights" "NetworkRxBytes" \
+    "Name=ClusterName,Value=$ECS_CLUSTER Name=ServiceName,Value=$FLEET_SERVICE" \
+    Sum Average)
+
+  echo "  Fleet Server: Network TX (Container Insights)..."
+  net_tx=$(collect_metric "ECS/ContainerInsights" "NetworkTxBytes" \
+    "Name=ClusterName,Value=$ECS_CLUSTER Name=ServiceName,Value=$FLEET_SERVICE" \
+    Sum Average)
+
+  NETWORK_METRICS=$(jq -n \
+    --argjson rx "$net_rx" \
+    --argjson tx "$net_tx" \
+    '{
+      network_rx_bytes: $rx,
+      network_tx_bytes: $tx
+    }')
+fi
+
+# -------------------------------------------------------------------------
+# osquery-perf / loadtest container health
+#
+# Checks two things:
+#   1. Stopped tasks — any tasks with non-zero exit codes during the interval
+#      indicate crashes or OOM kills. Expected: 0.
+#   2. Running task uptime — queries all running tasks for the loadtest service,
+#      captures each task's startedAt time and calculates uptime. If any
+#      container started significantly later than the others (>10 min spread),
+#      it likely restarted. All containers should start within a few minutes
+#      of each other.
+#
+# Output JSON:
+#   abnormal_stops:    count of tasks that stopped with non-zero exit code
+#   running_tasks:     number of currently running tasks
+#   oldest_start:      ISO timestamp of the earliest startedAt
+#   newest_start:      ISO timestamp of the latest startedAt
+#   start_spread_min:  difference in minutes between oldest and newest start
+#   start_spread_alert: true if spread > 10 minutes (indicates a restart)
+#   tasks:             array of {task_id, started_at, uptime_min} per task
+# -------------------------------------------------------------------------
+CONTAINER_HEALTH="{}"
+LOADTEST_SVC="${OSQUERY_PERF_SERVICE:-${LOADTEST_SERVICES[0]:-}}"
+if [[ -n "$LOADTEST_SVC" ]]; then
+  echo "  Loadtest: Checking for container restarts..."
+  # List stopped tasks in the cluster from the interval and count non-zero exit codes
+  stopped_tasks=$(aws ecs list-tasks --cluster "$ECS_CLUSTER" --desired-status STOPPED \
+    --region "$REGION" --output json 2>/dev/null || echo '{"taskArns":[]}')
+  stopped_arns=$(echo "$stopped_tasks" | jq -r '.taskArns[]' | head -50)
+
+  restart_count=0
+  if [[ -n "$stopped_arns" ]]; then
+    task_details=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" \
+      --tasks $stopped_arns \
+      --region "$REGION" --output json 2>/dev/null || echo '{"tasks":[]}')
+
+    restart_count=$(echo "$task_details" | jq \
+      --arg starttime "$START_TIME" --arg endtime "$END_TIME" \
+      '[.tasks[] | select(.stoppedAt >= $starttime) | select(.stoppedAt <= $endtime) | select([.containers[]? | select(.exitCode > 0)] | length > 0)] | length')
+  fi
+  echo "  Loadtest: $restart_count abnormal container stops detected"
+
+  # Query running tasks for uptime analysis
+  echo "  Loadtest: Checking container uptime..."
+  running_tasks=$(aws ecs list-tasks --cluster "$ECS_CLUSTER" --service-name "$LOADTEST_SVC" \
+    --desired-status RUNNING --region "$REGION" --output json 2>/dev/null || echo '{"taskArns":[]}')
+  running_arns=$(echo "$running_tasks" | jq -r '.taskArns[]')
+  running_count=$(echo "$running_tasks" | jq '.taskArns | length')
+
+  uptime_json="[]"
+  oldest_start=""
+  newest_start=""
+  if [[ -n "$running_arns" ]] && [[ "$running_count" -gt 0 ]]; then
+    running_details=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" \
+      --tasks $running_arns \
+      --region "$REGION" --output json 2>/dev/null || echo '{"tasks":[]}')
+
+    # Extract task start times and compute uptime in minutes
+    uptime_json=$(echo "$running_details" | jq --arg now "$TIMESTAMP" '
+      [.tasks[] | select(.startedAt) | {
+        task_id: (.taskArn | split("/") | last),
+        started_at: .startedAt,
+        uptime_min: (
+          (($now | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) -
+           (.startedAt | strptime("%Y-%m-%dT%H:%M:%S") | mktime)) / 60
+          | . * 100 | round / 100
+        )
+      }] | sort_by(.started_at)
+    ' 2>/dev/null || echo '[]')
+
+    oldest_start=$(echo "$uptime_json" | jq -r 'if length > 0 then first.started_at else null end')
+    newest_start=$(echo "$uptime_json" | jq -r 'if length > 0 then last.started_at else null end')
+  fi
+
+  # Calculate the spread between oldest and newest start time
+  start_spread_min="null"
+  start_spread_alert="false"
+  if [[ -n "$oldest_start" && "$oldest_start" != "null" && -n "$newest_start" && "$newest_start" != "null" ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+      oldest_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${oldest_start%%.*}" +%s 2>/dev/null || echo 0)
+      newest_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${newest_start%%.*}" +%s 2>/dev/null || echo 0)
+    else
+      oldest_epoch=$(date -d "${oldest_start}" +%s 2>/dev/null || echo 0)
+      newest_epoch=$(date -d "${newest_start}" +%s 2>/dev/null || echo 0)
+    fi
+    if [[ "$oldest_epoch" -gt 0 && "$newest_epoch" -gt 0 ]]; then
+      spread_seconds=$(( newest_epoch - oldest_epoch ))
+      start_spread_min=$(awk "BEGIN { printf \"%.1f\", $spread_seconds / 60 }")
+      # Alert if any container started >10 minutes after the first one
+      if (( spread_seconds > 600 )); then
+        start_spread_alert="true"
+      fi
+    fi
+  fi
+
+  echo "  Loadtest: $running_count running tasks, start spread=${start_spread_min}min"
+
+  CONTAINER_HEALTH=$(jq -n \
+    --argjson abnormal_stops "$restart_count" \
+    --argjson running_tasks "$running_count" \
+    --arg oldest_start "${oldest_start:-null}" \
+    --arg newest_start "${newest_start:-null}" \
+    --argjson start_spread_min "${start_spread_min:-null}" \
+    --argjson start_spread_alert "$start_spread_alert" \
+    --argjson tasks "$uptime_json" \
+    '{
+      abnormal_stops: $abnormal_stops,
+      running_tasks: $running_tasks,
+      oldest_start: (if $oldest_start == "null" then null else $oldest_start end),
+      newest_start: (if $newest_start == "null" then null else $newest_start end),
+      start_spread_min: $start_spread_min,
+      start_spread_alert: $start_spread_alert,
+      tasks: $tasks
+    }')
+fi
+
+
+# ---------------------------------------------------------------------------
+# Assemble final JSON output
+# ---------------------------------------------------------------------------
+echo ""
+echo "Assembling results..."
+
+jq -n \
+  --arg workspace "$WORKSPACE" \
+  --arg collected_at "$TIMESTAMP" \
+  --arg region "$REGION" \
+  --arg interval "${INTERVAL_LABEL}" \
+  --arg start_time "$START_TIME" \
+  --arg end_time "$END_TIME" \
+  --argjson fleet_server "$FLEET_SERVER_METRICS" \
+  --argjson loadtest_containers "$LOADTEST_METRICS" \
+  --argjson rds_writer "$RDS_WRITER_METRICS" \
+  --argjson rds_readers "$RDS_READER_METRICS" \
+  --argjson rds_pi_writer "$RDS_PI_WRITER" \
+  --argjson rds_pi_readers "$RDS_PI_READERS" \
+  --argjson redis "$REDIS_METRICS" \
+  --argjson alb "$ALB_METRICS" \
+  --argjson fleet_server_errors "$LOGS_ERRORS" \
+  --argjson rds_writer_ext "$RDS_WRITER_EXT" \
+  --argjson rds_readers_ext "$RDS_READERS_EXT" \
+  --argjson redis_ext "$REDIS_EXT" \
+  --argjson network "$NETWORK_METRICS" \
+  --argjson container_health "$CONTAINER_HEALTH" \
+  '{
+    metadata: {
+      workspace: $workspace,
+      collected_at: $collected_at,
+      region: $region,
+      interval: $interval,
+      time_window: {start: $start_time, end: $end_time}
+    },
+    fleet_server: $fleet_server,
+    loadtest_containers: $loadtest_containers,
+    rds_writer: $rds_writer,
+    rds_readers: $rds_readers,
+    rds_performance_insights: {
+      writer: $rds_pi_writer,
+      readers: $rds_pi_readers
+    },
+    redis: $redis,
+    alb: $alb,
+    fleet_server_errors: $fleet_server_errors,
+    rds_writer_extended: $rds_writer_ext,
+    rds_readers_extended: $rds_readers_ext,
+    redis_extended: $redis_ext,
+    network: $network,
+    container_health: $container_health
+  }' > "$OUTPUT"
+
+echo "Done! Metrics written to: $OUTPUT"
+
+# Markdown synopsis file — same name as JSON but .md extension
+MD_OUTPUT="${OUTPUT%.json}.md"
+
+# Start building synopsis (goes to both stdout and markdown file)
+{
+echo "# Metrics Synopsis: ${WORKSPACE}"
+echo ""
+echo "- **Collected:** ${TIMESTAMP}"
+echo "- **Interval:** ${INTERVAL_LABEL}"
+echo "- **Window:** ${START_TIME} to ${END_TIME}"
+echo ""
+echo "## Summary (${INTERVAL_LABEL} averages)"
+echo ""
+echo '```'
+
+# Print a quick summary table to stdout
+if jq -e '.fleet_server.cpu_utilization' "$OUTPUT" >/dev/null 2>&1; then
+  fleet_cpu_avg=$(jq -r '.fleet_server.cpu_utilization.Average // "N/A"' "$OUTPUT")
+  fleet_mem_avg=$(jq -r '.fleet_server.memory_utilization.Average // "N/A"' "$OUTPUT")
+  fleet_running=$(jq -r '.fleet_server.task_counts.runningCount // "N/A"' "$OUTPUT")
+  printf "Fleet Server:  CPU=%s%%  Mem=%s%%  Containers=%s\n" "$fleet_cpu_avg" "$fleet_mem_avg" "$fleet_running"
+fi
+
+if jq -e '.loadtest_containers.task_counts' "$OUTPUT" >/dev/null 2>&1; then
+  lt_cpu_avg=$(jq -r '.loadtest_containers.cpu_utilization.Average // "N/A"' "$OUTPUT")
+  lt_mem_avg=$(jq -r '.loadtest_containers.memory_utilization.Average // "N/A"' "$OUTPUT")
+  lt_running=$(jq -r '.loadtest_containers.task_counts.runningCount // "N/A"' "$OUTPUT")
+  printf "Loadtest:      CPU=%s%%  Mem=%s%%  Containers=%s\n" "$lt_cpu_avg" "$lt_mem_avg" "$lt_running"
+fi
+
+if jq -e '.rds_writer.cpu_utilization' "$OUTPUT" >/dev/null 2>&1; then
+  rds_w_cpu_avg=$(jq -r '.rds_writer.cpu_utilization.Average // "N/A"' "$OUTPUT")
+  rds_w_conns_avg=$(jq -r '.rds_writer.database_connections.Average // "N/A"' "$OUTPUT")
+  rds_w_deadlocks=$(jq -r '.rds_writer.deadlocks.Sum // "N/A"' "$OUTPUT")
+  printf "RDS Writer:    CPU=%s%%  Connections=%s  Deadlocks=%s\n" "$rds_w_cpu_avg" "$rds_w_conns_avg" "$rds_w_deadlocks"
+fi
+
+for reader_label in $(jq -r '.rds_readers[].instance // empty' "$OUTPUT" 2>/dev/null); do
+  rds_r_cpu_avg=$(jq -r --arg inst "$reader_label" '.rds_readers[] | select(.instance==$inst) | .cpu_utilization.Average // "N/A"' "$OUTPUT")
+  rds_r_conns_avg=$(jq -r --arg inst "$reader_label" '.rds_readers[] | select(.instance==$inst) | .database_connections.Average // "N/A"' "$OUTPUT")
+  rds_r_deadlocks=$(jq -r --arg inst "$reader_label" '.rds_readers[] | select(.instance==$inst) | .deadlocks.Sum // "N/A"' "$OUTPUT" 2>/dev/null || echo "N/A")
+  printf "RDS %s:  CPU=%s%%  Connections=%s\n" "$reader_label" "$rds_r_cpu_avg" "$rds_r_conns_avg"
+done
+
+if jq -e '.redis[0].cpu_utilization' "$OUTPUT" >/dev/null 2>&1; then
+  redis_cpu_avg=$(jq -r '.redis[0].cpu_utilization.Average // "N/A"' "$OUTPUT")
+  redis_mem_avg=$(jq -r '.redis[0].memory_utilization.Average // "N/A"' "$OUTPUT")
+  printf "Redis:         CPU=%s%%  Mem=%s%%\n" "$redis_cpu_avg" "$redis_mem_avg"
+fi
+
+# Print top SQL for writer
+if jq -e '.rds_performance_insights.writer | length > 0' "$OUTPUT" >/dev/null 2>&1; then
+  printf "\nTop SQL (writer):\n"
+  jq -r '.rds_performance_insights.writer[] | "  #\(.rank) load=\(.load_avg)  \(.sql[:80])"' "$OUTPUT"
+fi
+
+# Print top SQL for each reader
+for reader_label in $(jq -r '.rds_performance_insights.readers[].instance // empty' "$OUTPUT" 2>/dev/null); do
+  printf "\nTop SQL (%s):\n" "$reader_label"
+  jq -r --arg inst "$reader_label" '.rds_performance_insights.readers[] | select(.instance==$inst) | .top_sql[] | "  #\(.rank) load=\(.load_avg)  \(.sql[:80])"' "$OUTPUT"
+done
+
+if jq -e '.alb.target_response_time' "$OUTPUT" >/dev/null 2>&1; then
+  alb_lat=$(jq -r '.alb.target_response_time.Average // "N/A"' "$OUTPUT")
+  alb_5xx=$(jq -r '.alb.http_5xx_count.Sum // 0' "$OUTPUT")
+  alb_reqs=$(jq -r '.alb.request_count.Sum // "N/A"' "$OUTPUT")
+  alb_bytes=$(jq -r '.alb.processed_bytes.Sum // "N/A" | if type == "number" then (. / 1048576 * 100 | round / 100 | tostring) + "MB" else . end' "$OUTPUT")
+  printf "ALB:           Latency=%ss  5xx=%s  Requests=%s  Traffic=%s\n" "$alb_lat" "$alb_5xx" "$alb_reqs" "$alb_bytes"
+fi
+
+if jq -e '.fleet_server_errors.error_count' "$OUTPUT" >/dev/null 2>&1; then
+  err_count=$(jq -r '.fleet_server_errors.error_count // "N/A"' "$OUTPUT")
+  printf "Fleet Errors:  Count=%s\n" "$err_count"
+fi
+
+if jq -e '.rds_writer_extended.freeable_memory' "$OUTPUT" >/dev/null 2>&1; then
+  rds_freemem=$(jq -r '.rds_writer_extended.freeable_memory.Average // "N/A" | if type == "number" then (. / 1073741824 * 100 | round / 100 | tostring) + "GB" else . end' "$OUTPUT")
+  rds_cache=$(jq -r '.rds_writer_extended.buffer_cache_hit_ratio.Average // "N/A"' "$OUTPUT")
+  rds_disk=$(jq -r '.rds_writer_extended.volume_bytes_used.Average // "N/A" | if type == "number" then (. / 1073741824 * 100 | round / 100 | tostring) + "GB" else . end' "$OUTPUT")
+  rds_sel_lat=$(jq -r '.rds_writer_extended.select_latency.Average // "N/A"' "$OUTPUT")
+  rds_ins_lat=$(jq -r '.rds_writer_extended.insert_latency.Average // "N/A"' "$OUTPUT")
+  rds_threads=$(jq -r '.rds_writer_extended.threads_running.average // "N/A"' "$OUTPUT")
+  rds_iops_pct=$(jq -r '.rds_writer_extended.iops_utilization.utilization_pct // "N/A"' "$OUTPUT")
+  printf "RDS Writer:    FreeMem=%s  CacheHit=%s%%  Disk=%s  Threads=%s  IOPS=%s%%\n" \
+    "$rds_freemem" "$rds_cache" "$rds_disk" "$rds_threads" "$rds_iops_pct"
+  printf "               SelectLat=%ss  InsertLat=%ss\n" "$rds_sel_lat" "$rds_ins_lat"
+fi
+
+for reader_label in $(jq -r '.rds_readers_extended[].instance // empty' "$OUTPUT" 2>/dev/null); do
+  rlag=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .aurora_replica_lag.Average // "N/A"' "$OUTPUT")
+  rcache=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .buffer_cache_hit_ratio.Average // "N/A"' "$OUTPUT")
+  rfreemem=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .freeable_memory.Average // "N/A" | if type == "number" then (. / 1073741824 * 100 | round / 100 | tostring) + "GB" else . end' "$OUTPUT")
+  rthreads=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .threads_running.average // "N/A"' "$OUTPUT")
+  rsel_lat=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .select_latency.Average // "N/A"' "$OUTPUT")
+  riops_pct=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .iops_utilization.utilization_pct // "N/A"' "$OUTPUT")
+  printf "RDS %s: FreeMem=%s  CacheHit=%s%%  ReplicaLag=%sms  Threads=%s  IOPS=%s%%\n" \
+    "$reader_label" "$rfreemem" "$rcache" "$rlag" "$rthreads" "$riops_pct"
+  printf "               SelectLat=%ss\n" "$rsel_lat"
+done
+
+if jq -e '.redis_extended[0].curr_connections' "$OUTPUT" >/dev/null 2>&1; then
+  r_conns=$(jq -r '.redis_extended[0].curr_connections.Average // "N/A"' "$OUTPUT")
+  r_evict=$(jq -r '.redis_extended[0].evictions.Sum // 0' "$OUTPUT")
+  r_hit=$(jq -r '.redis_extended[0].cache_hit_rate.Average // "N/A"' "$OUTPUT")
+  printf "Redis:         Connections=%s  Evictions=%s  CacheHit=%s%%\n" "$r_conns" "$r_evict" "$r_hit"
+fi
+
+if jq -e '.network.network_rx_bytes' "$OUTPUT" >/dev/null 2>&1; then
+  net_rx_mb=$(jq -r '.network.network_rx_bytes.Sum // "N/A" | if type == "number" then (. / 1048576 * 100 | round / 100 | tostring) + "MB" else . end' "$OUTPUT")
+  net_tx_mb=$(jq -r '.network.network_tx_bytes.Sum // "N/A" | if type == "number" then (. / 1048576 * 100 | round / 100 | tostring) + "MB" else . end' "$OUTPUT")
+  printf "Network:       RX=%s  TX=%s\n" "$net_rx_mb" "$net_tx_mb"
+fi
+
+if jq -e '.container_health' "$OUTPUT" >/dev/null 2>&1; then
+  ch_stops=$(jq -r '.container_health.abnormal_stops // 0' "$OUTPUT")
+  ch_running=$(jq -r '.container_health.running_tasks // 0' "$OUTPUT")
+  ch_spread=$(jq -r '.container_health.start_spread_min // "N/A"' "$OUTPUT")
+  ch_alert=$(jq -r '.container_health.start_spread_alert // false' "$OUTPUT")
+  printf "Containers:    Running=%s  AbnormalStops=%s  StartSpread=%smin" "$ch_running" "$ch_stops" "$ch_spread"
+  if [[ "$ch_alert" == "true" ]]; then
+    printf "  ⚠ STAGGERED STARTS"
+  fi
+  printf "\n"
+fi
+
+echo '```'
+echo ""
+echo "## Threshold Checks"
+echo ""
+echo '```'
+
+# ---------------------------------------------------------------------------
+# Threshold alerts
+#
+# Based on expected values from the load test key metrics document.
+# Thresholds are checked against the collected data and violations are
+# printed as alerts.
+#
+# Thresholds:
+#   Fleet Server CPU          < 80% avg
+#   Fleet Server Memory       < 80% avg
+#   RDS Writer CPU            < 80% avg
+#   RDS Reader CPU            < 90% avg
+#   RDS Writer Deadlocks      == 0
+#   Redis CPU                 < 80% avg
+#   Redis Memory              < 70% avg
+#   Loadtest CPU              < 90% avg
+#   Loadtest Memory           < 90% avg
+#   Fleet Server Errors       == 0
+#   IOPS Utilization          < 80% avg
+#   Container Abnormal Stops   == 0
+#   Container Start Spread    < 10 min
+# ---------------------------------------------------------------------------
+ALERT_COUNT=0
+
+check_threshold() {
+  local label="$1" jq_path="$2" op="$3" threshold="$4"
+  local value
+  value=$(jq -r "$jq_path" "$OUTPUT" 2>/dev/null)
+
+  # Skip if value is null, N/A, or empty
+  if [[ -z "$value" || "$value" == "null" || "$value" == "N/A" ]]; then
+    return
+  fi
+
+  local failed=false
+  case "$op" in
+    lt)  failed=$(echo "$value $threshold" | awk '{print ($1 >= $2) ? "true" : "false"}') ;;
+    eq)  failed=$(echo "$value $threshold" | awk '{print ($1 != $2) ? "true" : "false"}') ;;
+    gt)  failed=$(echo "$value $threshold" | awk '{print ($1 > $2) ? "true" : "false"}') ;;
+  esac
+
+  if [[ "$failed" == "true" ]]; then
+    case "$op" in
+      lt) printf "  🔴 ALERT: %s = %s (expected < %s)\n" "$label" "$value" "$threshold" ;;
+      eq) printf "  🔴 ALERT: %s = %s (expected %s)\n" "$label" "$value" "$threshold" ;;
+      gt) printf "  🔴 ALERT: %s = %s (expected <= %s)\n" "$label" "$value" "$threshold" ;;
+    esac
+    ALERT_COUNT=$((ALERT_COUNT + 1))
+  fi
+}
+
+# Standard thresholds
+check_threshold "Fleet Server CPU avg"     '.fleet_server.cpu_utilization.Average'        lt 80
+check_threshold "Fleet Server Memory avg"  '.fleet_server.memory_utilization.Average'     lt 80
+check_threshold "RDS Writer CPU avg"       '.rds_writer.cpu_utilization.Average'          lt 80
+check_threshold "RDS Writer Deadlocks"     '.rds_writer.deadlocks.Sum'                   eq 0
+check_threshold "Redis CPU avg"            '.redis[0].cpu_utilization.Average'            lt 80
+check_threshold "Redis Memory avg"         '.redis[0].memory_utilization.Average'         lt 70
+check_threshold "Loadtest CPU avg"         '.loadtest_containers.cpu_utilization.Average'  lt 90
+check_threshold "Loadtest Memory avg"      '.loadtest_containers.memory_utilization.Average' lt 90
+
+# Check each reader
+for reader_label in $(jq -r '.rds_readers[].instance // empty' "$OUTPUT" 2>/dev/null); do
+  check_threshold "RDS $reader_label CPU avg" \
+    ".rds_readers[] | select(.instance==\"$reader_label\") | .cpu_utilization.Average" lt 90
+  check_threshold "RDS $reader_label IOPS Utilization" \
+    ".rds_readers_extended[] | select(.instance==\"$reader_label\") | .iops_utilization.utilization_pct" lt 80
+done
+
+check_threshold "Fleet Server Errors"      '.fleet_server_errors.error_count' eq 0
+check_threshold "IOPS Utilization"         '.rds_writer_extended.iops_utilization.utilization_pct' lt 80
+check_threshold "Container Abnormal Stops"  '.container_health.abnormal_stops' eq 0
+check_threshold "Container Start Spread (min)" '.container_health.start_spread_min' lt 10
+
+# Threads running vs vCPU count — dynamic threshold per instance
+# Average active sessions should be <= vCPUs. Above that means CPU saturation.
+writer_vcpus=$(jq -r '.rds_writer_extended.threads_running.vcpus // 0' "$OUTPUT")
+if [[ "$writer_vcpus" -gt 0 ]]; then
+  check_threshold "RDS Writer Threads Running (vCPUs=$writer_vcpus)" \
+    '.rds_writer_extended.threads_running.average' lt "$writer_vcpus"
+fi
+
+for reader_label in $(jq -r '.rds_readers_extended[].instance // empty' "$OUTPUT" 2>/dev/null); do
+  reader_vcpus=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .threads_running.vcpus // 0' "$OUTPUT")
+  if [[ "$reader_vcpus" -gt 0 ]]; then
+    check_threshold "RDS $reader_label Threads Running (vCPUs=$reader_vcpus)" \
+      ".rds_readers_extended[] | select(.instance==\"$reader_label\") | .threads_running.average" lt "$reader_vcpus"
+  fi
+done
+
+if [[ $ALERT_COUNT -eq 0 ]]; then
+  echo "  ✅ All metrics within expected thresholds"
+else
+  echo ""
+  printf "  ⚠ %d alert(s) detected\n" "$ALERT_COUNT"
+fi
+echo '```'
+} | tee "$MD_OUTPUT"
+
+echo ""
+echo "Synopsis written to: $MD_OUTPUT"

--- a/tools/loadtest/metrics/collect-metrics.sh
+++ b/tools/loadtest/metrics/collect-metrics.sh
@@ -94,6 +94,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 METRICS_DIR="${SCRIPT_DIR}/runs${CATEGORY:+/$CATEGORY}/${WORKSPACE}"
 mkdir -p "$METRICS_DIR"
 OUTPUT="${OUTPUT:-${METRICS_DIR}/${WORKSPACE}-$(date -u +%Y-%m-%d-%H%M%SZ)-${INTERVAL_LABEL}.json}"
+# Ensure the parent dir exists even when a custom --output path is given.
+mkdir -p "$(dirname "$OUTPUT")"
 
 # ---------------------------------------------------------------------------
 # Time window: <interval> ending now
@@ -1300,7 +1302,6 @@ fi
 for reader_label in $(jq -r '.rds_readers[].instance // empty' "$OUTPUT" 2>/dev/null); do
   rds_r_cpu_avg=$(jq -r --arg inst "$reader_label" '.rds_readers[] | select(.instance==$inst) | .cpu_utilization.Average // "N/A"' "$OUTPUT")
   rds_r_conns_avg=$(jq -r --arg inst "$reader_label" '.rds_readers[] | select(.instance==$inst) | .database_connections.Average // "N/A"' "$OUTPUT")
-  rds_r_deadlocks=$(jq -r --arg inst "$reader_label" '.rds_readers[] | select(.instance==$inst) | .deadlocks.Sum // "N/A"' "$OUTPUT" 2>/dev/null || echo "N/A")
   printf "RDS %s:  CPU=%s%%  Connections=%s\n" "$reader_label" "$rds_r_cpu_avg" "$rds_r_conns_avg"
 done
 

--- a/tools/loadtest/metrics/collect-metrics.sh
+++ b/tools/loadtest/metrics/collect-metrics.sh
@@ -60,6 +60,14 @@ if [[ -z "$WORKSPACE" ]]; then
   usage 1
 fi
 
+# The workspace name is interpolated into output file paths, so constrain it to a
+# conservative slug. This rejects path separators / "../" (no writes outside runs/)
+# and matches the Terraform workspace naming conventions documented in the README.
+if [[ ! "$WORKSPACE" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
+  echo "Error: --workspace must match ^[A-Za-z0-9][A-Za-z0-9_-]*$ (letters, digits, '-', '_'). Got: '$WORKSPACE'" >&2
+  exit 1
+fi
+
 if [[ -n "$CATEGORY" ]]; then
   case "$CATEGORY" in
     baseline|migration|mdm) ;;
@@ -151,7 +159,7 @@ done
 if [[ -z "$ECS_CLUSTER" ]]; then
   echo "Warning: Could not find ECS cluster for workspace '$WORKSPACE'. Trying tag-based discovery..." >&2
   ECS_CLUSTER=$(aws ecs list-clusters --region "$REGION" --output json \
-    | jq -r ".clusterArns[] | select(contains(\"$WORKSPACE\"))" \
+    | jq -r --arg ws "$WORKSPACE" '.clusterArns[] | select(contains($ws))' \
     | head -1 | xargs -I{} basename {})
 fi
 
@@ -252,7 +260,7 @@ fi
 ALB_ARN_SUFFIX=""
 ALB_TG_ARN_SUFFIX=""
 ALB_ARN=$(aws elbv2 describe-load-balancers --region "$REGION" --output json 2>/dev/null \
-  | jq -r ".LoadBalancers[] | select(.LoadBalancerName | contains(\"$WORKSPACE\")) | .LoadBalancerArn" \
+  | jq -r --arg ws "$WORKSPACE" '.LoadBalancers[] | select(.LoadBalancerName | contains($ws)) | .LoadBalancerArn' \
   | head -1)
 if [[ -n "$ALB_ARN" ]]; then
   # Extract the suffix after "app/" for CloudWatch dimensions
@@ -285,7 +293,7 @@ if [[ -z "$FLEET_LOG_GROUP" ]]; then
   # Broad search: find log groups containing the workspace name and "fleet",
   # excluding Container Insights groups (which are metrics, not application logs).
   FLEET_LOG_GROUP=$(aws logs describe-log-groups --region "$REGION" --output json 2>/dev/null \
-    | jq -r ".logGroups[].logGroupName | select(contains(\"$WORKSPACE\")) | select(contains(\"fleet\")) | select(contains(\"containerinsights\") | not)" \
+    | jq -r --arg ws "$WORKSPACE" '.logGroups[].logGroupName | select(contains($ws)) | select(contains("fleet")) | select(contains("containerinsights") | not)' \
     | head -1)
 fi
 echo "  Fleet Log Group: ${FLEET_LOG_GROUP:-<not found>}"
@@ -320,6 +328,7 @@ get_metric() {
 # Returns JSON object with the metric values and data_coverage info.
 # Uses the full interval as one period for the aggregate, plus 5-min periods
 # to count actual data points for coverage reporting.
+# Note: data_coverage is a 0-1 ratio (1.0 == full coverage), not a percentage.
 collect_metric() {
   local ns="$1" metric="$2" dims="$3"
   shift 3
@@ -357,7 +366,8 @@ collect_ecs_utilization() {
   util_raw=$(get_metric "ECS/ContainerInsights" "$util_metric" "$dims" 300 Sum)
   resv_raw=$(get_metric "ECS/ContainerInsights" "$resv_metric" "$dims" 300 Sum)
 
-  # Compute utilization percentage per 5-min period, then derive avg/min/max
+  # Compute utilization percentage per 5-min period, then derive avg/min/max.
+  # As above, data_coverage is a 0-1 ratio (1.0 == full coverage), not a percentage.
   jq -n \
     --argjson util "$util_raw" \
     --argjson resv "$resv_raw" \
@@ -976,7 +986,7 @@ if [[ -n "$RDS_WRITER_INSTANCE" ]]; then
     "Name=DBClusterIdentifier,Value=$RDS_CLUSTER_ID" \
     Average Maximum)
 
-  # SelectLatency: Average latency (seconds) of SELECT queries on the writer.
+  # SelectLatency: Average latency (milliseconds) of SELECT queries on the writer.
   # Rising values indicate query performance degradation, possibly due to
   # missing indexes, growing table sizes, or lock contention.
   echo "  RDS Writer: SelectLatency..."
@@ -984,7 +994,7 @@ if [[ -n "$RDS_WRITER_INSTANCE" ]]; then
     "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
     Average Maximum)
 
-  # InsertLatency: Average latency (seconds) of INSERT queries on the writer.
+  # InsertLatency: Average latency (milliseconds) of INSERT queries on the writer.
   # Fleet's workload is insert-heavy (host checkins, software inventory).
   # Rising values may indicate index bloat or lock contention.
   echo "  RDS Writer: InsertLatency..."
@@ -992,7 +1002,7 @@ if [[ -n "$RDS_WRITER_INSTANCE" ]]; then
     "Name=DBInstanceIdentifier,Value=$RDS_WRITER_INSTANCE" \
     Average Maximum)
 
-  # DMLLatency: Average latency (seconds) of all DML operations (INSERT,
+  # DMLLatency: Average latency (milliseconds) of all DML operations (INSERT,
   # UPDATE, DELETE). Provides a single overall write-path health indicator.
   echo "  RDS Writer: DMLLatency..."
   rds_w_dml_lat=$(collect_metric "AWS/RDS" "DMLLatency" \
@@ -1346,7 +1356,7 @@ if jq -e '.rds_writer_extended.freeable_memory' "$OUTPUT" >/dev/null 2>&1; then
   rds_iops_pct=$(jq -r '.rds_writer_extended.iops_utilization.utilization_pct // "N/A"' "$OUTPUT")
   printf "RDS Writer:    FreeMem=%s  CacheHit=%s%%  Disk=%s  Threads=%s  IOPS=%s%%\n" \
     "$rds_freemem" "$rds_cache" "$rds_disk" "$rds_threads" "$rds_iops_pct"
-  printf "               SelectLat=%ss  InsertLat=%ss\n" "$rds_sel_lat" "$rds_ins_lat"
+  printf "               SelectLat=%sms  InsertLat=%sms\n" "$rds_sel_lat" "$rds_ins_lat"
 fi
 
 for reader_label in $(jq -r '.rds_readers_extended[].instance // empty' "$OUTPUT" 2>/dev/null); do
@@ -1358,7 +1368,7 @@ for reader_label in $(jq -r '.rds_readers_extended[].instance // empty' "$OUTPUT
   riops_pct=$(jq -r --arg i "$reader_label" '.rds_readers_extended[] | select(.instance==$i) | .iops_utilization.utilization_pct // "N/A"' "$OUTPUT")
   printf "RDS %s: FreeMem=%s  CacheHit=%s%%  ReplicaLag=%sms  Threads=%s  IOPS=%s%%\n" \
     "$reader_label" "$rfreemem" "$rcache" "$rlag" "$rthreads" "$riops_pct"
-  printf "               SelectLat=%ss\n" "$rsel_lat"
+  printf "               SelectLat=%sms\n" "$rsel_lat"
 done
 
 if jq -e '.redis_extended[0].curr_connections' "$OUTPUT" >/dev/null 2>&1; then

--- a/tools/loadtest/metrics/compare-metrics.sh
+++ b/tools/loadtest/metrics/compare-metrics.sh
@@ -1,0 +1,559 @@
+#!/usr/bin/env bash
+#
+# compare-metrics.sh - Compare metrics across Fleet load test runs to detect regressions.
+#
+# Usage:
+#   ./compare-metrics.sh [options]
+#   ./compare-metrics.sh <file1.json> <file2.json>
+#
+# Options:
+#   -f, --filter PATTERN   Only include runs whose workspace name contains PATTERN.
+#                          Run-naming conventions make this a category selector, e.g.
+#                          "loadtest" → baselines, "mig" → migrations.
+#   -d, --depth N          Number of most recent runs to compare (default: 2)
+#   -u, --unique           Deduplicate by workspace — keep only the most recent run
+#                          per workspace. Useful for release-over-release comparison.
+#   -m, --metrics-dir DIR  Path to runs directory (default: runs/ next to this script;
+#                          searched recursively, so category subfolders are included)
+#   -h, --help             Show this help message
+#
+# Examples:
+#   ./compare-metrics.sh                                       # compare 2 most recent runs
+#   ./compare-metrics.sh --filter loadtest --depth 4 --unique  # last 4 baseline releases
+#   ./compare-metrics.sh file-a.json file-b.json               # compare two specific files
+#
+# Required: jq
+
+set -euo pipefail
+
+usage() {
+  sed -n '3,23p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+FILTER=""
+DEPTH=2
+UNIQUE=false
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+METRICS_DIR="${SCRIPT_DIR}/runs"
+EXPLICIT_FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--filter)      FILTER="$2"; shift 2 ;;
+    -d|--depth)       DEPTH="$2"; shift 2 ;;
+    -u|--unique)      UNIQUE=true; shift ;;
+    -m|--metrics-dir) METRICS_DIR="$2"; shift 2 ;;
+    -h|--help)        usage 0 ;;
+    -*)               echo "Unknown option: $1" >&2; usage 1 ;;
+    *.json)           EXPLICIT_FILES+=("$1"); shift ;;
+    *)                echo "Unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+if ! [[ "$DEPTH" =~ ^[0-9]+$ ]] || [[ "$DEPTH" -lt 2 ]]; then
+  echo "Error: --depth must be an integer >= 2." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Discover and select JSON files to compare
+# ---------------------------------------------------------------------------
+
+# Collect all candidate files, sorted by collected_at timestamp (newest first)
+gather_files() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    echo "Error: Metrics directory '$dir' does not exist." >&2
+    exit 1
+  fi
+
+  # Find all .json files, extract collected_at, sort descending by timestamp
+  local tmpfile
+  tmpfile=$(mktemp)
+  trap "rm -f '$tmpfile'" EXIT
+
+  while IFS= read -r f; do
+    # Extract collected_at from metadata; skip files that aren't valid metric files
+    local ts workspace
+    ts=$(jq -r '.metadata.collected_at // empty' "$f" 2>/dev/null) || continue
+    workspace=$(jq -r '.metadata.workspace // empty' "$f" 2>/dev/null) || continue
+    [[ -z "$ts" || -z "$workspace" ]] && continue
+
+    # Apply filter if specified
+    if [[ -n "$FILTER" ]] && [[ "$workspace" != *"$FILTER"* ]]; then
+      continue
+    fi
+
+    echo "${ts}|${workspace}|${f}"
+  done < <(find "$dir" -name '*.json' -type f 2>/dev/null) | sort -t'|' -k1 -r > "$tmpfile"
+
+  if [[ "$UNIQUE" == true ]]; then
+    # Keep only the most recent file per workspace (first occurrence since sorted desc)
+    awk -F'|' '!seen[$2]++' "$tmpfile"
+  else
+    cat "$tmpfile"
+  fi
+}
+
+FILES=()
+EXPLICIT_MODE=false
+if [[ ${#EXPLICIT_FILES[@]} -gt 0 ]]; then
+  EXPLICIT_MODE=true
+  # Explicit files provided — use them directly (in the order given)
+  for f in "${EXPLICIT_FILES[@]}"; do
+    if [[ ! -f "$f" ]]; then
+      echo "Error: File not found: $f" >&2
+      exit 1
+    fi
+    FILES+=("$f")
+  done
+  if [[ ${#FILES[@]} -lt 2 ]]; then
+    echo "Error: Need at least 2 files to compare." >&2
+    exit 1
+  fi
+else
+  # Auto-discover from metrics directory
+  while IFS='|' read -r _ts _ws filepath; do
+    FILES+=("$filepath")
+    [[ ${#FILES[@]} -ge $DEPTH ]] && break
+  done < <(gather_files "$METRICS_DIR")
+
+  if [[ ${#FILES[@]} -lt 2 ]]; then
+    echo "Error: Found ${#FILES[@]} metric file(s) in '$METRICS_DIR' (need at least 2)." >&2
+    [[ -n "$FILTER" ]] && echo "  Filter: '$FILTER'" >&2
+    [[ "$UNIQUE" == true ]] && echo "  Unique: enabled" >&2
+    exit 1
+  fi
+fi
+
+# For auto-discovered files, reverse so oldest is first (they come sorted newest-first).
+# For explicit files, keep the user-provided order (assumed oldest → newest).
+ORDERED_FILES=()
+if [[ "$EXPLICIT_MODE" == true ]]; then
+  ORDERED_FILES=("${FILES[@]}")
+else
+  for (( i=${#FILES[@]}-1; i>=0; i-- )); do
+    ORDERED_FILES+=("${FILES[$i]}")
+  done
+fi
+
+echo "Comparing ${#ORDERED_FILES[@]} runs (oldest → newest):"
+echo ""
+for f in "${ORDERED_FILES[@]}"; do
+  ws=$(jq -r '.metadata.workspace' "$f")
+  ts=$(jq -r '.metadata.collected_at' "$f")
+  interval=$(jq -r '.metadata.interval' "$f")
+  printf "  %s  (%s, %s)\n" "$(basename "$f")" "$ws" "$interval"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Metric definitions: JSON path, display name, format, thresholds
+#
+# Format: path|name|unit|warn_pct|alert_pct|zero_alert|abs_op|abs_threshold
+#   - warn_pct:       percentage change (delta) that triggers a ⚠️  warning
+#   - alert_pct:      percentage change (delta) that triggers a 🔴 alert
+#   - zero_alert:     "true" if going from 0 to non-zero is always an alert
+#   - abs_op:         absolute threshold operator: "lt" (value must be < threshold),
+#                     "eq" (value must equal threshold), or "" for none
+#   - abs_threshold:  the absolute threshold value. Each individual column value
+#                     is checked against this — a 🔴 appears inline next to any
+#                     value that violates. Delta/Status only reflects relative change.
+# ---------------------------------------------------------------------------
+METRIC_DEFS=(
+  # Fleet Server
+  ".fleet_server.cpu_utilization.Average|Fleet CPU|%|15|30|false|lt|80"
+  ".fleet_server.cpu_utilization.Maximum|Fleet CPU (max)|%|20|40|false||"
+  ".fleet_server.memory_utilization.Average|Fleet Memory|%|15|30|false|lt|80"
+
+  # RDS Writer
+  ".rds_writer.cpu_utilization.Average|RDS Writer CPU|%|15|30|false|lt|80"
+  ".rds_writer.database_connections.Average|RDS Writer Conns||50|100|false||"
+  ".rds_writer.read_iops.Average|RDS Writer Read IOPS||50|100|false||"
+  ".rds_writer.write_iops.Average|RDS Writer Write IOPS||50|100|false||"
+  ".rds_writer.deadlocks.Sum|RDS Deadlocks||0|0|true|eq|0"
+
+  # Redis (first node)
+  ".redis[0].cpu_utilization.Average|Redis CPU|%|20|40|false|lt|80"
+  ".redis[0].memory_utilization.Average|Redis Memory|%|15|30|false|lt|70"
+)
+
+# ALB metrics
+ALB_DEFS=(
+  ".alb.target_response_time.Average|ALB Latency|s|50|100|false||"
+  ".alb.target_response_time.Maximum|ALB Latency (max)|s|50|100|false||"
+  ".alb.http_5xx_count.Sum|ALB 5xx Errors||0|0|true|eq|0"
+  ".alb.request_count.Sum|ALB Requests||0|0|false||"
+)
+
+# RDS Writer extended
+RDS_WRITER_EXT_DEFS=(
+  ".rds_writer_extended.buffer_cache_hit_ratio.Average|RDS Cache Hit Ratio|%|1|3|false||"
+  ".rds_writer_extended.freeable_memory.Average|RDS Freeable Memory|bytes|15|30|false||"
+  ".rds_writer_extended.select_latency.Average|RDS Select Latency|s|50|100|false||"
+  ".rds_writer_extended.insert_latency.Average|RDS Insert Latency|s|50|100|false||"
+  ".rds_writer_extended.dml_latency.Average|RDS DML Latency|s|50|100|false||"
+  ".rds_writer_extended.iops_utilization.utilization_pct|IOPS Utilization|%|15|30|false|lt|80"
+)
+
+# RDS Reader extended (first reader)
+RDS_READER_EXT_DEFS=(
+  ".rds_readers_extended[0].aurora_replica_lag.Average|Aurora Replica Lag|ms|50|100|false||"
+  ".rds_readers_extended[0].buffer_cache_hit_ratio.Average|Reader Cache Hit Ratio|%|1|3|false||"
+  ".rds_readers_extended[0].iops_utilization.utilization_pct|Reader IOPS Utilization|%|15|30|false|lt|80"
+)
+
+# Redis extended (first node)
+REDIS_EXT_DEFS=(
+  ".redis_extended[0].curr_connections.Average|Redis Connections||50|100|false||"
+  ".redis_extended[0].evictions.Sum|Redis Evictions||0|0|true|eq|0"
+  ".redis_extended[0].cache_hit_rate.Average|Redis Cache Hit Rate|%|5|15|false||"
+)
+
+# Other
+OTHER_DEFS=(
+  ".fleet_server_errors.error_count|Fleet Server Errors||0|0|true|eq|0"
+  ".container_health.abnormal_stops|Container Stops||0|0|true|eq|0"
+  ".container_health.start_spread_min|Container Start Spread|min|5|10|false|lt|10"
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Portable last/second-to-last element accessors (macOS bash 3 lacks [-1])
+arr_last()  { local arr=("$@"); echo "${arr[$((${#arr[@]}-1))]}"; }
+arr_prev()  { local arr=("$@"); echo "${arr[$((${#arr[@]}-2))]}"; }
+
+# Extract a metric value from a file, returning "null" if not present
+get_val() {
+  local file="$1" path="$2"
+  jq -r "$path // \"null\"" "$file" 2>/dev/null || echo "null"
+}
+
+# Format a number for display
+fmt_val() {
+  local val="$1" unit="$2"
+  if [[ "$val" == "null" || -z "$val" ]]; then
+    echo "N/A"
+    return
+  fi
+  case "$unit" in
+    bytes)
+      # Convert to human-readable
+      echo "$val" | awk '{
+        if ($1 >= 1073741824) printf "%.1fGB", $1/1073741824
+        else if ($1 >= 1048576) printf "%.1fMB", $1/1048576
+        else if ($1 >= 1024) printf "%.1fKB", $1/1024
+        else printf "%d B", $1
+      }'
+      ;;
+    %)  printf "%.1f%%" "$val" ;;
+    s)  printf "%.3fs" "$val" ;;
+    ms) printf "%.1fms" "$val" ;;
+    *)  printf "%.1f" "$val" ;;
+  esac
+}
+
+# Calculate percentage change between two values
+# For "inverse" metrics (cache hit ratio) where lower is worse,
+# the caller handles interpretation.
+pct_change() {
+  local old="$1" new="$2"
+  if [[ "$old" == "null" || "$new" == "null" ]]; then
+    echo "null"
+    return
+  fi
+  awk -v o="$old" -v n="$new" 'BEGIN {
+    if (o == 0 && n == 0) { print 0; exit }
+    if (o == 0) { print 999; exit }
+    printf "%.1f", ((n - o) / (o < 0 ? -o : o)) * 100
+  }'
+}
+
+# Determine status icon based on change and thresholds
+# For metrics where decrease is bad (cache hit ratio), pass "invert"
+status_icon() {
+  local change="$1" warn="$2" alert="$3" zero_alert="$4" old_val="$5" new_val="$6" direction="${7:-normal}"
+
+  if [[ "$change" == "null" ]]; then
+    echo "  —"
+    return
+  fi
+
+  # Zero-alert: value went from 0 to non-zero
+  if [[ "$zero_alert" == "true" && "$old_val" != "null" && "$new_val" != "null" ]]; then
+    local is_old_zero is_new_nonzero
+    is_old_zero=$(awk -v v="$old_val" 'BEGIN { print (v == 0) ? "true" : "false" }')
+    is_new_nonzero=$(awk -v v="$new_val" 'BEGIN { print (v != 0) ? "true" : "false" }')
+    if [[ "$is_old_zero" == "true" && "$is_new_nonzero" == "true" ]]; then
+      echo "  ALERT"
+      return
+    fi
+  fi
+
+  # For inverted metrics (higher is better, like cache hit ratio),
+  # flip the sign for threshold comparison
+  local abs_change
+  if [[ "$direction" == "invert" ]]; then
+    abs_change=$(awk -v c="$change" 'BEGIN { print -c }')
+  else
+    abs_change="$change"
+  fi
+
+  # Only flag increases (or decreases for inverted metrics)
+  local is_regression
+  is_regression=$(awk -v c="$abs_change" 'BEGIN { print (c > 0) ? "true" : "false" }')
+
+  if [[ "$is_regression" == "true" ]]; then
+    local exceeds_alert exceeds_warn
+    exceeds_alert=$(awk -v c="$abs_change" -v t="$alert" 'BEGIN { print (c >= t) ? "true" : "false" }')
+    exceeds_warn=$(awk -v c="$abs_change" -v t="$warn" 'BEGIN { print (c >= t) ? "true" : "false" }')
+
+    if [[ "$exceeds_alert" == "true" ]]; then
+      echo "  ALERT"
+    elif [[ "$exceeds_warn" == "true" ]]; then
+      echo "  WARN"
+    else
+      echo "  ok"
+    fi
+  else
+    echo "  ok"
+  fi
+}
+
+# Check a value against an absolute threshold, return icon suffix or empty string
+# Usage: abs_icon=$(check_abs_threshold "$val" "$abs_op" "$abs_threshold")
+check_abs_threshold() {
+  local val="$1" op="$2" threshold="$3"
+  if [[ -z "$op" || -z "$threshold" || "$val" == "null" ]]; then
+    echo ""
+    return
+  fi
+  local violated=false
+  case "$op" in
+    lt) violated=$(awk -v v="$val" -v t="$threshold" 'BEGIN { print (v >= t) ? "true" : "false" }') ;;
+    eq) violated=$(awk -v v="$val" -v t="$threshold" 'BEGIN { print (v != t) ? "true" : "false" }') ;;
+    gt) violated=$(awk -v v="$val" -v t="$threshold" 'BEGIN { print (v > t) ? "true" : "false" }') ;;
+  esac
+  if [[ "$violated" == "true" ]]; then
+    echo " 🔴"
+  else
+    echo ""
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Compare metrics across all files
+# ---------------------------------------------------------------------------
+
+# Track totals and individual findings for synopsis
+TOTAL_ALERTS=0
+TOTAL_WARNINGS=0
+# Each entry: "severity|metric_name|detail"
+# severity: 1=ALERT, 2=WARN (for sort: 1 sorts first = highest severity)
+ALERT_LOG=()
+
+log_alert() {
+  local severity="$1" name="$2" detail="$3"
+  ALERT_LOG+=("${severity}|${name}|${detail}")
+  if [[ "$severity" == "1" ]]; then
+    TOTAL_ALERTS=$((TOTAL_ALERTS + 1))
+  else
+    TOTAL_WARNINGS=$((TOTAL_WARNINGS + 1))
+  fi
+}
+
+compare_metric_set() {
+  local label="$1"
+  shift
+  local defs=("$@")
+  local has_data=false
+  local section_output=""
+
+  for def in "${defs[@]}"; do
+    IFS='|' read -r path name unit warn alert zero_alert abs_op abs_threshold <<< "$def"
+
+    # Check if this metric exists in at least the last two files
+    local last_file
+    last_file=$(arr_last "${ORDERED_FILES[@]}")
+    local prev_file
+    prev_file=$(arr_prev "${ORDERED_FILES[@]}")
+    local last_val prev_val
+    last_val=$(get_val "$last_file" "$path")
+    prev_val=$(get_val "$prev_file" "$path")
+
+    if [[ "$last_val" == "null" && "$prev_val" == "null" ]]; then
+      continue
+    fi
+    has_data=true
+
+    # Determine if this is an "inverted" metric (where decrease = regression)
+    local direction="normal"
+    case "$name" in
+      *"Cache Hit"*|*"Freeable Memory"*) direction="invert" ;;
+    esac
+
+    # Build the row: name, then value for each file, then delta + status
+    local row
+    row=$(printf "  %-28s" "$name")
+
+    # Values for each file — check each against absolute threshold
+    for f in "${ORDERED_FILES[@]}"; do
+      local val ws_name
+      val=$(get_val "$f" "$path")
+      ws_name=$(jq -r '.metadata.workspace' "$f")
+      local abs_icon
+      abs_icon=$(check_abs_threshold "$val" "$abs_op" "$abs_threshold")
+      if [[ -n "$abs_icon" ]]; then
+        row+=$(printf "  %9s%s" "$(fmt_val "$val" "$unit")" "$abs_icon")
+        log_alert 1 "$name" "$(fmt_val "$val" "$unit") in $ws_name (threshold: ${abs_op} ${abs_threshold})"
+      else
+        row+=$(printf "  %12s" "$(fmt_val "$val" "$unit")")
+      fi
+    done
+
+    # Delta between last two
+    local change
+    change=$(pct_change "$prev_val" "$last_val")
+    if [[ "$change" != "null" ]]; then
+      local sign=""
+      local is_positive
+      is_positive=$(awk -v c="$change" 'BEGIN { print (c > 0) ? "true" : "false" }')
+      [[ "$is_positive" == "true" ]] && sign="+"
+      row+=$(printf "  %8s%%" "${sign}${change}")
+    else
+      row+=$(printf "  %9s" "—")
+    fi
+
+    # Status (relative change)
+    local icon
+    icon=$(status_icon "$change" "$warn" "$alert" "$zero_alert" "$prev_val" "$last_val" "$direction")
+    row+="$icon"
+
+    case "$icon" in
+      *ALERT*) log_alert 1 "$name" "delta ${change}% (threshold: ${alert}%)" ;;
+      *WARN*)  log_alert 2 "$name" "delta ${change}% (threshold: ${warn}%)" ;;
+    esac
+
+    section_output+="${row}"$'\n'
+  done
+
+  if [[ "$has_data" == true ]]; then
+    echo "$label"
+    echo "$section_output"
+  fi
+}
+
+# Print header
+header=$(printf "  %-28s" "Metric")
+for f in "${ORDERED_FILES[@]}"; do
+  ws=$(jq -r '.metadata.workspace' "$f")
+  header+=$(printf "  %12s" "$ws")
+done
+header+=$(printf "  %9s" "Delta")
+header+="  Status"
+echo "$header"
+
+separator=""
+for (( i=0; i < ${#header}; i++ )); do separator+="-"; done
+echo "$separator"
+
+compare_metric_set "Fleet Server" "${METRIC_DEFS[@]:0:3}"
+compare_metric_set "RDS Writer" "${METRIC_DEFS[@]:3:5}"
+compare_metric_set "Redis" "${METRIC_DEFS[@]:8:2}"
+compare_metric_set "ALB" "${ALB_DEFS[@]}"
+compare_metric_set "RDS Writer (extended)" "${RDS_WRITER_EXT_DEFS[@]}"
+compare_metric_set "Aurora Replication" "${RDS_READER_EXT_DEFS[@]}"
+compare_metric_set "Redis (extended)" "${REDIS_EXT_DEFS[@]}"
+compare_metric_set "Errors & Restarts" "${OTHER_DEFS[@]}"
+
+# ---------------------------------------------------------------------------
+# RDS Reader comparison (dynamic — one row per reader across files)
+# ---------------------------------------------------------------------------
+# Readers are trickier since different workspaces may have different reader
+# counts. We compare by position (first reader vs first reader).
+has_readers=false
+for f in "${ORDERED_FILES[@]}"; do
+  if jq -e '.rds_readers | length > 0' "$f" >/dev/null 2>&1; then
+    has_readers=true
+    break
+  fi
+done
+
+if [[ "$has_readers" == true ]]; then
+  echo "RDS Readers"
+  for idx in 0 1 2; do
+    last_file=$(arr_last "${ORDERED_FILES[@]}")
+    if ! jq -e ".rds_readers[$idx]" "$last_file" >/dev/null 2>&1; then
+      continue
+    fi
+
+    for metric_pair in \
+      "cpu_utilization.Average|Reader $((idx+1)) CPU|%|15|30|lt|90" \
+      "database_connections.Average|Reader $((idx+1)) Conns||50|100||" \
+      "read_iops.Average|Reader $((idx+1)) Read IOPS||50|100||"; do
+      IFS='|' read -r mpath mname munit mwarn malert mabs_op mabs_threshold <<< "$metric_pair"
+      full_path=".rds_readers[$idx].$mpath"
+
+      row=$(printf "  %-28s" "$mname")
+      local_vals=()
+      for f in "${ORDERED_FILES[@]}"; do
+        val=$(get_val "$f" "$full_path")
+        local_vals+=("$val")
+        ws_name=$(jq -r '.metadata.workspace' "$f")
+        abs_icon=$(check_abs_threshold "$val" "$mabs_op" "$mabs_threshold")
+        if [[ -n "$abs_icon" ]]; then
+          row+=$(printf "  %9s%s" "$(fmt_val "$val" "$munit")" "$abs_icon")
+          log_alert 1 "$mname" "$(fmt_val "$val" "$munit") in $ws_name (threshold: ${mabs_op} ${mabs_threshold})"
+        else
+          row+=$(printf "  %12s" "$(fmt_val "$val" "$munit")")
+        fi
+      done
+
+      prev_val=$(arr_prev "${local_vals[@]}")
+      last_val=$(arr_last "${local_vals[@]}")
+      change=$(pct_change "$prev_val" "$last_val")
+      if [[ "$change" != "null" ]]; then
+        sign=""
+        is_positive=$(awk -v c="$change" 'BEGIN { print (c > 0) ? "true" : "false" }')
+        [[ "$is_positive" == "true" ]] && sign="+"
+        row+=$(printf "  %8s%%" "${sign}${change}")
+      else
+        row+=$(printf "  %9s" "—")
+      fi
+
+      icon=$(status_icon "$change" "$mwarn" "$malert" "false" "$prev_val" "$last_val")
+      row+="$icon"
+      case "$icon" in
+        *ALERT*) log_alert 1 "$mname" "delta ${change}% (threshold: ${malert}%)" ;;
+        *WARN*)  log_alert 2 "$mname" "delta ${change}% (threshold: ${mwarn}%)" ;;
+      esac
+      echo "$row"
+    done
+  done
+  echo ""
+fi
+
+
+# ---------------------------------------------------------------------------
+# Synopsis — all alerts and warnings sorted by severity (highest first)
+# ---------------------------------------------------------------------------
+echo "==============================="
+if [[ ${#ALERT_LOG[@]} -gt 0 ]]; then
+  printf "Synopsis: %d alert(s), %d warning(s)\n\n" "$TOTAL_ALERTS" "$TOTAL_WARNINGS"
+  # Sort by severity field (1=ALERT before 2=WARN)
+  printf '%s\n' "${ALERT_LOG[@]}" | sort -t'|' -k1,1n | while IFS='|' read -r sev name detail; do
+    if [[ "$sev" == "1" ]]; then
+      printf "  🔴 ALERT: %s — %s\n" "$name" "$detail"
+    else
+      printf "  ⚠️  WARN:  %s — %s\n" "$name" "$detail"
+    fi
+  done
+else
+  echo "✅ All metrics within thresholds"
+fi

--- a/tools/loadtest/metrics/compare-metrics.sh
+++ b/tools/loadtest/metrics/compare-metrics.sh
@@ -26,6 +26,8 @@
 
 set -euo pipefail
 
+command -v jq >/dev/null 2>&1 || { echo "Error: 'jq' is required but not found in PATH." >&2; exit 1; }
+
 usage() {
   sed -n '3,23p' "$0" | sed 's/^# \?//'
   exit "${1:-0}"
@@ -43,10 +45,10 @@ EXPLICIT_FILES=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -f|--filter)      FILTER="$2"; shift 2 ;;
-    -d|--depth)       DEPTH="$2"; shift 2 ;;
+    -f|--filter)      [[ $# -ge 2 ]] || { echo "Error: $1 requires a value." >&2; exit 1; }; FILTER="$2"; shift 2 ;;
+    -d|--depth)       [[ $# -ge 2 ]] || { echo "Error: $1 requires a value." >&2; exit 1; }; DEPTH="$2"; shift 2 ;;
     -u|--unique)      UNIQUE=true; shift ;;
-    -m|--metrics-dir) METRICS_DIR="$2"; shift 2 ;;
+    -m|--metrics-dir) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value." >&2; exit 1; }; METRICS_DIR="$2"; shift 2 ;;
     -h|--help)        usage 0 ;;
     -*)               echo "Unknown option: $1" >&2; usage 1 ;;
     *.json)           EXPLICIT_FILES+=("$1"); shift ;;
@@ -74,7 +76,7 @@ gather_files() {
   # Find all .json files, extract collected_at, sort descending by timestamp
   local tmpfile
   tmpfile=$(mktemp)
-  trap "rm -f '$tmpfile'" EXIT
+  trap 'rm -f "$tmpfile"' EXIT
 
   while IFS= read -r f; do
     # Extract collected_at from metadata; skip files that aren't valid metric files
@@ -89,7 +91,7 @@ gather_files() {
     fi
 
     echo "${ts}|${workspace}|${f}"
-  done < <(find "$dir" -name '*.json' -type f 2>/dev/null) | sort -t'|' -k1 -r > "$tmpfile"
+  done < <(find "$dir" -name '*.json' -type f 2>/dev/null) | sort -t'|' -k1,1 -r > "$tmpfile"
 
   if [[ "$UNIQUE" == true ]]; then
     # Keep only the most recent file per workspace (first occurrence since sorted desc)
@@ -285,6 +287,12 @@ status_icon() {
     return
   fi
 
+  # Informational metrics (e.g. request counts) are reported but never graded.
+  if [[ "$direction" == "info" ]]; then
+    echo "  —"
+    return
+  fi
+
   # Zero-alert: value went from 0 to non-zero
   if [[ "$zero_alert" == "true" && "$old_val" != "null" && "$new_val" != "null" ]]; then
     local is_old_zero is_new_nonzero
@@ -392,10 +400,13 @@ compare_metric_set() {
     fi
     has_data=true
 
-    # Determine if this is an "inverted" metric (where decrease = regression)
+    # Determine grading direction:
+    #   invert — decrease is the regression (higher is better)
+    #   info   — throughput counters that grow run-to-run; show the delta but never grade it
     local direction="normal"
     case "$name" in
       *"Cache Hit"*|*"Freeable Memory"*) direction="invert" ;;
+      *"Requests"*) direction="info" ;;
     esac
 
     # Build the row: name, then value for each file, then delta + status

--- a/tools/loadtest/metrics/compare-metrics.sh
+++ b/tools/loadtest/metrics/compare-metrics.sh
@@ -196,9 +196,9 @@ ALB_DEFS=(
 RDS_WRITER_EXT_DEFS=(
   ".rds_writer_extended.buffer_cache_hit_ratio.Average|RDS Cache Hit Ratio|%|1|3|false||"
   ".rds_writer_extended.freeable_memory.Average|RDS Freeable Memory|bytes|15|30|false||"
-  ".rds_writer_extended.select_latency.Average|RDS Select Latency|s|50|100|false||"
-  ".rds_writer_extended.insert_latency.Average|RDS Insert Latency|s|50|100|false||"
-  ".rds_writer_extended.dml_latency.Average|RDS DML Latency|s|50|100|false||"
+  ".rds_writer_extended.select_latency.Average|RDS Select Latency|ms|50|100|false||"
+  ".rds_writer_extended.insert_latency.Average|RDS Insert Latency|ms|50|100|false||"
+  ".rds_writer_extended.dml_latency.Average|RDS DML Latency|ms|50|100|false||"
   ".rds_writer_extended.iops_utilization.utilization_pct|IOPS Utilization|%|15|30|false|lt|80"
 )
 
@@ -257,6 +257,7 @@ fmt_val() {
     %)  printf "%.1f%%" "$val" ;;
     s)  printf "%.3fs" "$val" ;;
     ms) printf "%.1fms" "$val" ;;
+    min) printf "%.1fmin" "$val" ;;
     *)  printf "%.1f" "$val" ;;
   esac
 }

--- a/tools/loadtest/metrics/runs/baseline/483loadtest/483loadtest-2026-03-27-18h.json
+++ b/tools/loadtest/metrics/runs/baseline/483loadtest/483loadtest-2026-03-27-18h.json
@@ -1,0 +1,525 @@
+{
+  "metadata": {
+    "workspace": "483loadtest",
+    "collected_at": "2026-03-27T20:44:42Z",
+    "region": "us-east-2",
+    "interval": "18h",
+    "time_window": {
+      "start": "2026-03-27T02:44:42Z",
+      "end": "2026-03-27T20:44:42Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 56.67,
+      "Minimum": 20.3,
+      "Maximum": 75.09,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 4.31,
+      "Minimum": 2.82,
+      "Maximum": 5.88,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 16.68,
+      "Minimum": 0,
+      "Maximum": 55.89,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 10,
+      "Minimum": 0,
+      "Maximum": 10.45,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 200,
+      "desiredCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 19.99,
+      "Minimum": 13.1,
+      "Maximum": 39.23,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 239.78,
+      "Minimum": 203,
+      "Maximum": 260,
+      "Unit": "Count",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 0,
+      "Maximum": 0.13,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 2517.72,
+      "Maximum": 3771.34,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 0,
+      "Sum": 0.02,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 44.82,
+        "Minimum": 39.49,
+        "Maximum": 55.54,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 260,
+        "Minimum": 260,
+        "Maximum": 260,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 3.16,
+        "Maximum": 142.69,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.53
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.49
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.19
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.14
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.07
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 2.36
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.64
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( EXISTS ( SELECT ? FROM `query_labels` `ql` JOIN `label_membership` `hl` ON ( `",
+            "load_avg": 0.63
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `hs` . `host_id` , `sc` . `software_id` , `sc` . `cve` , `sc` . `resolved_in_version` FROM `software_cve` AS `sc` INNER JOIN `host_software` AS `hs` ON ( `sc` . `software_id` = `hs` . `software_id` ) WHERE ( ( `hs` . `host_id` IN (...) ) AND ( `sc` . `source` = ? ) )",
+            "load_avg": 0.25
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `bundle_identifier` , `s` . RELEASE , `s` . `arch` , `s` . `vendor` , `s` . `extension_for` , `s` . `extension_id` , `s` . `title_id` , COALESCE ( `sc` . `cpe` , ? ) AS `generated_cpe` FROM `software` `s` LEFT JOIN `software_cpe` `sc` ON ( `s` . `id` = `sc` . `software_id` ) WHERE `s` . SOURCE NOT IN (...) ",
+            "load_avg": 0.08
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0.35,
+        "Minimum": 0.28,
+        "Maximum": 0.43,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0.26,
+        "Minimum": 0.25,
+        "Maximum": 0.27,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0.14,
+        "Minimum": 0.12,
+        "Maximum": 0.17,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0.2,
+        "Minimum": 0.2,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0.14,
+        "Minimum": 0.1,
+        "Maximum": 0.17,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0.2,
+        "Minimum": 0.2,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 7.75,
+      "Unit": "Seconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Sum": 864585300,
+      "Unit": "Count",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Sum": 951222590891,
+      "Unit": "Bytes",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {},
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 29069852353.42,
+      "Minimum": 28295090176,
+      "Unit": "Bytes",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 25508027122.53,
+      "Maximum": 26332872704,
+      "Unit": "Bytes",
+      "data_points": 209,
+      "max_points": 216,
+      "data_coverage": 0.97
+    },
+    "select_latency": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 5.63,
+      "Maximum": 69.89,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 3.72,
+      "Maximum": 8.07,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 1.9,
+      "Maximum": 3.8,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "threads_running": null,
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2517.72,
+      "total_iops_avg": 2517.72,
+      "utilization_pct": 12.59
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 7.31,
+        "Maximum": 41,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 29973538869.1,
+        "Minimum": 29361364992,
+        "Unit": "Bytes",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 100,
+        "Minimum": 99.98,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0.34,
+        "Maximum": 1.78,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 86.14,
+        "Maximum": 105,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 0,
+        "Minimum": 0,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 5.29,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Average": 5.15,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-03-26T21:44:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 1292242.36,
+      "Sum": 34882790217,
+      "Unit": "Bytes/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-03-26T21:44:00-05:00",
+      "Average": 301576.39,
+      "Sum": 8140752938,
+      "Unit": "Bytes/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "container_restarts": {
+    "abnormal_stops": 0
+  }
+}

--- a/tools/loadtest/metrics/runs/baseline/484loadtest/484loadtest-2026-04-21-202817Z-16h.json
+++ b/tools/loadtest/metrics/runs/baseline/484loadtest/484loadtest-2026-04-21-202817Z-16h.json
@@ -1,0 +1,547 @@
+{
+  "metadata": {
+    "workspace": "484loadtest",
+    "collected_at": "2026-04-21T20:28:17Z",
+    "region": "us-east-2",
+    "interval": "16h",
+    "time_window": {
+      "start": "2026-04-21T04:28:17Z",
+      "end": "2026-04-21T20:28:17Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 58.55,
+      "Minimum": 55.26,
+      "Maximum": 61.35,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 4.43,
+      "Minimum": 4.19,
+      "Maximum": 4.61,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.93,
+      "Minimum": 2.85,
+      "Maximum": 3,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.48,
+      "Minimum": 2.45,
+      "Maximum": 2.5,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 29.39,
+      "Minimum": 18.6,
+      "Maximum": 44.78,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 314,
+      "Minimum": 314,
+      "Maximum": 314,
+      "Unit": "Count",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 0,
+      "Maximum": 0.03,
+      "Unit": "Count/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 2414.02,
+      "Maximum": 3611.75,
+      "Unit": "Count/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 0,
+      "Sum": 0.03,
+      "Maximum": 0.03,
+      "Unit": "Count/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 37.79,
+        "Minimum": 33.08,
+        "Maximum": 44.48,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 206,
+        "Minimum": 206,
+        "Maximum": 206,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.78,
+        "Maximum": 74.08,
+        "Unit": "Count/Second",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.59
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.47
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+        "load_avg": 0.36
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `hs` . `host_id` , `sc` . `software_id` , `sc` . `cve` , `sc` . `resolved_in_version` FROM `software_cve` AS `sc` INNER JOIN `host_software` AS `hs` ON ( `sc` . `software_id` = `hs` . `software_id` ) WHERE ( ( `hs` . `host_id` IN (...) ) AND ( `sc` . `source` = ? ) )",
+        "load_avg": 0.25
+      },
+      {
+        "rank": 5,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.16
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 2.07
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.56
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( EXISTS ( SELECT ? FROM `query_labels` `ql` JOIN `label_membership` `hl` ON ( `",
+            "load_avg": 0.55
+          },
+          {
+            "rank": 4,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.11
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `extension_for` , `s` . `bundle_identifier` , `s` . RELEASE , `s` . `vendor` , `s` . `arch` , `s` . `extension_id` , `s` . `upgrade_code` , `hs` . `last_opened_at` FROM `software` `s` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` WHERE `hs` . `host_id` = ? ",
+            "load_avg": 0.05
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.32,
+        "Minimum": 0.23,
+        "Maximum": 0.42,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.26,
+        "Minimum": 0.25,
+        "Maximum": 0.28,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.13,
+        "Minimum": 0.1,
+        "Maximum": 0.17,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.2,
+        "Minimum": 0.2,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.13,
+        "Minimum": 0.1,
+        "Maximum": 0.17,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.21,
+        "Minimum": 0.2,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 8.35,
+      "Unit": "Seconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Sum": 769675802,
+      "Unit": "Count",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Sum": 847702725072,
+      "Unit": "Bytes",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 28955711859.2,
+      "Minimum": 28314972160,
+      "Unit": "Bytes",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 25035543283.13,
+      "Maximum": 25173540864,
+      "Unit": "Bytes",
+      "data_points": 179,
+      "max_points": 192,
+      "data_coverage": 0.93
+    },
+    "select_latency": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 0.73,
+      "Maximum": 5.1,
+      "Unit": "Milliseconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 3.97,
+      "Maximum": 10.34,
+      "Unit": "Milliseconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 2.17,
+      "Maximum": 7.67,
+      "Unit": "Milliseconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.88,
+      "maximum": 6.19,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2414.02,
+      "total_iops_avg": 2414.02,
+      "utilization_pct": 12.07
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 7.6,
+        "Maximum": 26,
+        "Unit": "Milliseconds",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 30082185710.93,
+        "Minimum": 29960839168,
+        "Unit": "Bytes",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 100,
+        "Minimum": 99.99,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0.27,
+        "Maximum": 0.71,
+        "Unit": "Milliseconds",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 0.78,
+        "write_iops_avg": 0,
+        "total_iops_avg": 0.78,
+        "utilization_pct": 0
+      },
+      "threads_running": {
+        "average": 3.43,
+        "maximum": 4.42,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 88.13,
+        "Maximum": 104,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 0,
+        "Minimum": 0,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 5.29,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Average": 5.76,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-20T23:28:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 1298362.53,
+      "Sum": 31151612279,
+      "Unit": "Bytes/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-04-20T23:28:00-05:00",
+      "Average": 302474.96,
+      "Sum": 7257281813,
+      "Unit": "Bytes/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/baseline/484loadtest/484loadtest-2026-04-21-202817Z-16h.md
+++ b/tools/loadtest/metrics/runs/baseline/484loadtest/484loadtest-2026-04-21-202817Z-16h.md
@@ -1,0 +1,46 @@
+# Metrics Synopsis: 484loadtest
+
+- **Collected:** 2026-04-21T20:28:17Z
+- **Interval:** 16h
+- **Window:** 2026-04-21T04:28:17Z to 2026-04-21T20:28:17Z
+
+## Summary (16h averages)
+
+```
+Fleet Server:  CPU=58.55%  Mem=4.43%  Containers=25
+Loadtest:      CPU=2.93%  Mem=2.48%  Containers=50
+RDS Writer:    CPU=29.39%  Connections=314  Deadlocks=0.03
+RDS reader-1:  CPU=37.79%  Connections=206
+Redis:         CPU=0.32%  Mem=0.26%
+
+Top SQL (writer):
+  #1 load=0.59  COMMIT
+  #2 load=0.47  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.36  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #4 load=0.25  SELECT `hs` . `host_id` , `sc` . `software_id` , `sc` . `cve` , `sc` . `resolved
+  #5 load=0.16  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+
+Top SQL (reader-1):
+  #1 load=2.07  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #2 load=0.56  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.55  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.11  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+  #5 load=0.05  SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `extensi
+ALB:           Latency=0s  5xx=0  Requests=769675802  Traffic=808432.32MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=26.97GB  CacheHit=100%  Disk=23.32GB  Threads=2.88  IOPS=12.07%
+               SelectLat=0.73s  InsertLat=3.97s
+RDS reader-1: FreeMem=28.02GB  CacheHit=100%  ReplicaLag=7.6ms  Threads=3.43  IOPS=0%
+               SelectLat=0.27s
+Redis:         Connections=88.13  Evictions=0  CacheHit=0%
+Network:       RX=29708.49MB  TX=6921.08MB
+Containers:    Running=50  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer Deadlocks = 0.03 (expected 0)
+
+  ⚠ 1 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/baseline/485loadtest/485loadtest-2026-05-11-144517Z-16h.json
+++ b/tools/loadtest/metrics/runs/baseline/485loadtest/485loadtest-2026-05-11-144517Z-16h.json
@@ -1,0 +1,670 @@
+{
+  "metadata": {
+    "workspace": "485loadtest",
+    "collected_at": "2026-05-11T14:45:17Z",
+    "region": "us-east-2",
+    "interval": "16h",
+    "time_window": {
+      "start": "2026-05-10T22:45:17Z",
+      "end": "2026-05-11T14:45:17Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 61.11,
+      "Minimum": 59.31,
+      "Maximum": 63.24,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 5.15,
+      "Minimum": 4.25,
+      "Maximum": 6.77,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.6,
+      "Minimum": 2.55,
+      "Maximum": 2.67,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.47,
+      "Minimum": 2.43,
+      "Maximum": 2.5,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 19.6,
+      "Minimum": 14.79,
+      "Maximum": 36.08,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 210.9,
+      "Minimum": 135,
+      "Maximum": 253,
+      "Unit": "Count",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 0,
+      "Maximum": 0.03,
+      "Unit": "Count/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 2405.85,
+      "Maximum": 3558.99,
+      "Unit": "Count/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 31.47,
+        "Minimum": 14.16,
+        "Maximum": 51.35,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 144.4,
+        "Minimum": 112,
+        "Maximum": 175,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 6.43,
+        "Maximum": 446.59,
+        "Unit": "Count/Second",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 23.13,
+        "Minimum": 9.74,
+        "Maximum": 45.79,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 114.84,
+        "Minimum": 79,
+        "Maximum": 140,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 5.31,
+        "Maximum": 422.76,
+        "Unit": "Count/Second",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.64
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.48
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.14
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.13
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.07
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 1.37
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.38
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( EXISTS ( SELECT ? FROM `query_labels` `ql` JOIN `label_membership` `hl` ON ( `",
+            "load_avg": 0.37
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( EXISTS ( SELECT ? FROM `query_labels` `ql` JOIN `label_membership` `hl` ON ( `hl` ",
+            "load_avg": 0.19
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `hs` . `host_id` , `sc` . `software_id` , `sc` . `cve` , `sc` . `resolved_in_version` FROM `software_cve` AS `sc` INNER JOIN `host_software` AS `hs` ON ( `sc` . `software_id` = `hs` . `software_id` ) WHERE ( ( `hs` . `host_id` IN (...) ) AND ( `sc` . `source` = ? ) )",
+            "load_avg": 0.18
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.93
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.26
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( EXISTS ( SELECT ? FROM `query_labels` `ql` JOIN `label_membership` `hl` ON ( `",
+            "load_avg": 0.25
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_software` `hs` ON `hs` . `software_id` = `sc` . `software_id`",
+            "load_avg": 0.24
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( EXISTS ( SELECT ? FROM `query_labels` `ql` JOIN `label_membership` `hl` ON ( `hl` ",
+            "load_avg": 0.13
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.36,
+        "Minimum": 0.32,
+        "Maximum": 0.4,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.24,
+        "Minimum": 0.23,
+        "Maximum": 0.24,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.15,
+        "Minimum": 0.13,
+        "Maximum": 0.18,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.21,
+        "Minimum": 0.21,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.15,
+        "Minimum": 0.13,
+        "Maximum": 0.18,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.21,
+        "Minimum": 0.21,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 8.18,
+      "Unit": "Seconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Sum": 769672223,
+      "Unit": "Count",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Sum": 831139938192,
+      "Unit": "Bytes",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 29754326459.73,
+      "Minimum": 29127344128,
+      "Unit": "Bytes",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 32621069111.78,
+      "Maximum": 35008053248,
+      "Unit": "Bytes",
+      "data_points": 179,
+      "max_points": 192,
+      "data_coverage": 0.93
+    },
+    "select_latency": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 4.85,
+      "Maximum": 55.79,
+      "Unit": "Milliseconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 4.23,
+      "Maximum": 12.35,
+      "Unit": "Milliseconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 2.23,
+      "Maximum": 5.59,
+      "Unit": "Milliseconds",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 1.83,
+      "maximum": 3.49,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2405.85,
+      "total_iops_avg": 2405.85,
+      "utilization_pct": 12.03
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 7.26,
+        "Maximum": 51,
+        "Unit": "Milliseconds",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 30750109111.47,
+        "Minimum": 30590259200,
+        "Unit": "Bytes",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 100,
+        "Minimum": 99.88,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.3,
+        "Maximum": 1.71,
+        "Unit": "Milliseconds",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 6.43,
+        "write_iops_avg": 0,
+        "total_iops_avg": 6.43,
+        "utilization_pct": 0.03
+      },
+      "threads_running": {
+        "average": 2.96,
+        "maximum": 5.36,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 7.75,
+        "Maximum": 78,
+        "Unit": "Milliseconds",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 30760545113.6,
+        "Minimum": 30664433664,
+        "Unit": "Bytes",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 100,
+        "Minimum": 99.85,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0.36,
+        "Maximum": 2.28,
+        "Unit": "Milliseconds",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 5.31,
+        "write_iops_avg": 0,
+        "total_iops_avg": 5.31,
+        "utilization_pct": 0.03
+      },
+      "threads_running": {
+        "average": 2.06,
+        "maximum": 4.21,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 88.98,
+        "Maximum": 106,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 0,
+        "Minimum": 0,
+        "Unit": "Percent",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 5.31,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Average": 5.45,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-10T17:45:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 192,
+        "max_points": 192,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 1416974.25,
+      "Sum": 33998880191,
+      "Unit": "Bytes/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-05-10T17:45:00-05:00",
+      "Average": 339505.92,
+      "Sum": 8146444454,
+      "Unit": "Bytes/Second",
+      "data_points": 192,
+      "max_points": 192,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 1,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/baseline/485loadtest/485loadtest-2026-05-11-144517Z-16h.md
+++ b/tools/loadtest/metrics/runs/baseline/485loadtest/485loadtest-2026-05-11-144517Z-16h.md
@@ -1,0 +1,56 @@
+# Metrics Synopsis: 485loadtest
+
+- **Collected:** 2026-05-11T14:45:17Z
+- **Interval:** 16h
+- **Window:** 2026-05-10T22:45:17Z to 2026-05-11T14:45:17Z
+
+## Summary (16h averages)
+
+```
+Fleet Server:  CPU=61.11%  Mem=5.15%  Containers=25
+Loadtest:      CPU=2.6%  Mem=2.47%  Containers=50
+RDS Writer:    CPU=19.6%  Connections=210.9  Deadlocks=0
+RDS reader-1:  CPU=31.47%  Connections=144.4
+RDS reader-2:  CPU=23.13%  Connections=114.84
+Redis:         CPU=0.36%  Mem=0.24%
+
+Top SQL (writer):
+  #1 load=0.64  COMMIT
+  #2 load=0.48  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.14  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+  #4 load=0.13  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #5 load=0.07  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=1.37  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #2 load=0.38  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.37  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.19  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #5 load=0.18  SELECT `hs` . `host_id` , `sc` . `software_id` , `sc` . `cve` , `sc` . `resolved
+
+Top SQL (reader-2):
+  #1 load=0.93  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #2 load=0.26  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.25  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.24  SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_softw
+  #5 load=0.13  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+ALB:           Latency=0s  5xx=0  Requests=769672223  Traffic=792636.81MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.71GB  CacheHit=100%  Disk=30.38GB  Threads=1.83  IOPS=12.03%
+               SelectLat=4.85s  InsertLat=4.23s
+RDS reader-1: FreeMem=28.64GB  CacheHit=100%  ReplicaLag=7.26ms  Threads=2.96  IOPS=0.03%
+               SelectLat=0.3s
+RDS reader-2: FreeMem=28.65GB  CacheHit=100%  ReplicaLag=7.75ms  Threads=2.06  IOPS=0.03%
+               SelectLat=0.36s
+Redis:         Connections=88.98  Evictions=0  CacheHit=0%
+Network:       RX=32423.86MB  TX=7769.05MB
+Containers:    Running=50  AbnormalStops=1  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: Container Abnormal Stops = 1 (expected 0)
+
+  ⚠ 1 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/baseline/486loadtest/486loadtest-2026-05-27-215735Z-18h.json
+++ b/tools/loadtest/metrics/runs/baseline/486loadtest/486loadtest-2026-05-27-215735Z-18h.json
@@ -1,0 +1,681 @@
+{
+  "metadata": {
+    "workspace": "486loadtest",
+    "collected_at": "2026-05-27T21:57:35Z",
+    "region": "us-east-2",
+    "interval": "18h",
+    "time_window": {
+      "start": "2026-05-27T03:57:35Z",
+      "end": "2026-05-27T21:57:35Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 58.01,
+      "Minimum": 53.94,
+      "Maximum": 60.5,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 4.49,
+      "Minimum": 3.94,
+      "Maximum": 5.18,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.74,
+      "Minimum": 2.65,
+      "Maximum": 2.83,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.48,
+      "Minimum": 2.42,
+      "Maximum": 2.52,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 48,
+      "desiredCount": 48
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 20.03,
+      "Minimum": 8.07,
+      "Maximum": 45.68,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 213.69,
+      "Minimum": 101,
+      "Maximum": 260,
+      "Unit": "Count",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 0,
+      "Maximum": 0.03,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 2313.3,
+      "Maximum": 3633.53,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 0,
+      "Sum": 0.02,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 15.88,
+        "Minimum": 6.78,
+        "Maximum": 32.82,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 119.6,
+        "Minimum": 79,
+        "Maximum": 142,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 1.24,
+        "Maximum": 90.58,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 20.05,
+        "Minimum": 8.15,
+        "Maximum": 35.44,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 133.82,
+        "Minimum": 99,
+        "Maximum": 159,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 1.47,
+        "Maximum": 106.44,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.62
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.4
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.33
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.13
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.05
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.32
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.26
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.19
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.14
+          },
+          {
+            "rank": 5,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.06
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.42
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.34
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.25
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.2
+          },
+          {
+            "rank": 5,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.08
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 39.6,
+        "Minimum": 38.67,
+        "Maximum": 48.14,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 4.55,
+        "Minimum": 4.52,
+        "Maximum": 4.86,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 9.69,
+        "Minimum": 8.97,
+        "Maximum": 9.88,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 4.49,
+        "Minimum": 4.47,
+        "Maximum": 4.51,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 9.67,
+        "Minimum": 8.94,
+        "Maximum": 9.87,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 4.49,
+        "Minimum": 4.47,
+        "Maximum": 4.51,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 10.27,
+      "Unit": "Seconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Sum": 831204572,
+      "Unit": "Count",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Sum": 898720843902,
+      "Unit": "Bytes",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 62377.0,
+    "sample_messages": [
+      "{\"ts\":\"2026-05-27T21:58:37Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":117129196,\"host_id\":13044,\"ip_addr\":\"10.12.3.137\",\"x_for_ip_addr\":\"10.12.3.137\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:36Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":35740186,\"host_id\":75332,\"ip_addr\":\"10.12.2.187\",\"x_for_ip_addr\":\"10.12.2.187\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:34Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":85609731,\"host_id\":15702,\"ip_addr\":\"10.12.1.237\",\"x_for_ip_addr\":\"10.12.1.237\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:33Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":181480279,\"host_id\":29798,\"ip_addr\":\"10.12.3.119\",\"x_for_ip_addr\":\"10.12.3.119\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:33Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":87087850,\"host_id\":63123,\"ip_addr\":\"10.12.2.201\",\"x_for_ip_addr\":\"10.12.2.201\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:33Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":156017328,\"host_id\":86288,\"ip_addr\":\"10.12.2.73\",\"x_for_ip_addr\":\"10.12.2.73\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:32Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":85945707,\"host_id\":92155,\"ip_addr\":\"10.12.1.225\",\"x_for_ip_addr\":\"10.12.1.225\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:32Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":371260011,\"host_id\":80332,\"ip_addr\":\"10.12.1.213\",\"x_for_ip_addr\":\"10.12.1.213\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:32Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":77883646,\"host_id\":47468,\"ip_addr\":\"10.12.3.32\",\"x_for_ip_addr\":\"10.12.3.32\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:31Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":75386812,\"host_id\":86768,\"ip_addr\":\"10.12.2.73\",\"x_for_ip_addr\":\"10.12.2.73\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}"
+    ]
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 29803200792.65,
+      "Minimum": 28958326784,
+      "Unit": "Bytes",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 24955688558.06,
+      "Maximum": 25308495872,
+      "Unit": "Bytes",
+      "data_points": 214,
+      "max_points": 216,
+      "data_coverage": 0.99
+    },
+    "select_latency": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 7.84,
+      "Maximum": 86.12,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 4.08,
+      "Maximum": 22.07,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 1.96,
+      "Maximum": 11.68,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 1.92,
+      "maximum": 4.27,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2313.3,
+      "total_iops_avg": 2313.3,
+      "utilization_pct": 11.57
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 7.12,
+        "Maximum": 52,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 30707426467.08,
+        "Minimum": 30512402432,
+        "Unit": "Bytes",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 100,
+        "Minimum": 99.98,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 0.44,
+        "Maximum": 4,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 1.24,
+        "write_iops_avg": 0,
+        "total_iops_avg": 1.24,
+        "utilization_pct": 0.01
+      },
+      "threads_running": {
+        "average": 1.22,
+        "maximum": 2.88,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 6.87,
+        "Maximum": 25,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 30725667233.19,
+        "Minimum": 30558932992,
+        "Unit": "Bytes",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 100,
+        "Minimum": 99.97,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 0.44,
+        "Maximum": 3.32,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 1.47,
+        "write_iops_avg": 0,
+        "total_iops_avg": 1.47,
+        "utilization_pct": 0.01
+      },
+      "threads_running": {
+        "average": 1.66,
+        "maximum": 3.9,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 217.81,
+        "Maximum": 2848,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 73.98,
+        "Minimum": 72.84,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 5.44,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Average": 5.64,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-26T22:57:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 1016698.31,
+      "Sum": 27465088201,
+      "Unit": "Bytes/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-05-26T22:57:00-05:00",
+      "Average": 460748.17,
+      "Sum": 12446651193,
+      "Unit": "Bytes/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 48,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/baseline/486loadtest/486loadtest-2026-05-27-215735Z-18h.md
+++ b/tools/loadtest/metrics/runs/baseline/486loadtest/486loadtest-2026-05-27-215735Z-18h.md
@@ -1,0 +1,57 @@
+# Metrics Synopsis: 486loadtest
+
+- **Collected:** 2026-05-27T21:57:35Z
+- **Interval:** 18h
+- **Window:** 2026-05-27T03:57:35Z to 2026-05-27T21:57:35Z
+
+## Summary (18h averages)
+
+```
+Fleet Server:  CPU=58.01%  Mem=4.49%  Containers=25
+Loadtest:      CPU=2.74%  Mem=2.48%  Containers=48
+RDS Writer:    CPU=20.03%  Connections=213.69  Deadlocks=0.02
+RDS reader-1:  CPU=15.88%  Connections=119.6
+RDS reader-2:  CPU=20.05%  Connections=133.82
+Redis:         CPU=39.6%  Mem=4.55%
+
+Top SQL (writer):
+  #1 load=0.62  COMMIT
+  #2 load=0.4  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.33  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #4 load=0.13  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+  #5 load=0.05  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.32  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.26  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.19  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.14  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.06  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+
+Top SQL (reader-2):
+  #1 load=0.42  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.34  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.25  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.2  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.08  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+ALB:           Latency=0s  5xx=0  Requests=831204572  Traffic=857086.99MB
+Fleet Errors:  Count=62377.0
+RDS Writer:    FreeMem=27.76GB  CacheHit=100%  Disk=23.24GB  Threads=1.92  IOPS=11.57%
+               SelectLat=7.84s  InsertLat=4.08s
+RDS reader-1: FreeMem=28.6GB  CacheHit=100%  ReplicaLag=7.12ms  Threads=1.22  IOPS=0.01%
+               SelectLat=0.44s
+RDS reader-2: FreeMem=28.62GB  CacheHit=100%  ReplicaLag=6.87ms  Threads=1.66  IOPS=0.01%
+               SelectLat=0.44s
+Redis:         Connections=217.81  Evictions=0  CacheHit=73.98%
+Network:       RX=26192.75MB  TX=11870.05MB
+Containers:    Running=48  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer Deadlocks = 0.02 (expected 0)
+  🔴 ALERT: Fleet Server Errors = 62377.0 (expected 0)
+
+  ⚠ 2 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185210Z-1h.json
+++ b/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185210Z-1h.json
@@ -1,0 +1,547 @@
+{
+  "metadata": {
+    "workspace": "483applemdm",
+    "collected_at": "2026-04-23T18:52:10Z",
+    "region": "us-east-2",
+    "interval": "1h",
+    "time_window": {
+      "start": "2026-04-23T17:52:10Z",
+      "end": "2026-04-23T18:52:10Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 39.39,
+      "Minimum": 38.36,
+      "Maximum": 40.77,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 8.1,
+      "Minimum": 7.98,
+      "Maximum": 8.15,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 10,
+      "desiredCount": 10
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 6.26,
+      "Minimum": 6.05,
+      "Maximum": 6.43,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 8.43,
+      "Minimum": 8.16,
+      "Maximum": 8.64,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 5,
+      "desiredCount": 5
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 92.6,
+      "Minimum": 79.71,
+      "Maximum": 98.85,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 204,
+      "Minimum": 204,
+      "Maximum": 204,
+      "Unit": "Count",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 323.44,
+      "Maximum": 521.44,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 24.07,
+        "Minimum": 17.38,
+        "Maximum": 37.57,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 14,
+        "Minimum": 14,
+        "Maximum": 14,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.65,
+        "Maximum": 2.42,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.76
+      },
+      {
+        "rank": 2,
+        "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+        "load_avg": 0.64
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `subtype` FROM `nano_enrollment_queue` AS `q` INNER JOIN `nano_commands` AS `c` ON `q` . `command_uuid` = `c` . `command_uuid` LEFT JOIN `nano_command_results` `r` ON `r` . `command_uuid` = `q` . `command_uuid` AND `r` . `id` = `q` . `id` AND ( `r` . `status` != ? OR FALSE ) WHERE `q` . `id` = ? AND `q` . `active` = ? AND `r` . `status` IS NULL ORDER BY `q` . `priority` DESC , `q` . `created_at` LIMIT ?",
+        "load_avg": 0.26
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+        "load_avg": 0.25
+      },
+      {
+        "rank": 5,
+        "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+        "load_avg": 0.18
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.04
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.01
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `subtype` FROM `nano_enrollment_queue` AS `q` INNER JOIN `nano_commands` AS `c` ON `q` . `command_uuid` = `c` . `command_uuid` LEFT JOIN `nano_command_results` `r` ON `r` . `command_uuid` = `q` . `command_uuid` AND `r` . `id` = `q` . `id` AND ( `r` . `status` != ? OR FALSE ) WHERE `q` . `id` = ? AND `q` . `active` = ? AND `r` . `status` IS NULL ORDER BY `q` . `priority` DESC , `q` . `created_at` LIMIT ?",
+            "load_avg": 0.01
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.01
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SELECT `ua` . `id` , `ua` . `host_id` , `ua` . `execution_id` , `sua` . `script_id` , `ua` . `priority` , `ua` . `created_at` , IF ( `ua` . `activated_at` IS NULL , ?, ... ) AS `topmost` FROM `upcoming_activities` `ua` LEFT JOIN `script_upcoming_activities` `sua` ON `ua` . `id` = `sua` . `upcoming_activity_id` WHERE `ua` . `host_id` = ? AND `ua` . `activity_type` IN (...) AND `ua` . `activated_at` IS NOT NULL ORDER BY `",
+            "load_avg": 0.01
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.62,
+        "Minimum": 0.53,
+        "Maximum": 0.75,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.23,
+        "Minimum": 0.22,
+        "Maximum": 0.23,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.25,
+        "Minimum": 0.22,
+        "Maximum": 0.3,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.21,
+        "Minimum": 0.21,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.26,
+        "Minimum": 0.22,
+        "Maximum": 0.3,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.21,
+        "Minimum": 0.21,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 0.01,
+      "Minimum": 0,
+      "Maximum": 5.05,
+      "Unit": "Seconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Sum": 10106288,
+      "Unit": "Count",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Sum": 8637432281,
+      "Unit": "Bytes",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 5329753019.73,
+      "Minimum": 5309992960,
+      "Unit": "Bytes",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 20016316416,
+      "Maximum": 20016316416,
+      "Unit": "Bytes",
+      "data_points": 2,
+      "max_points": 12,
+      "data_coverage": 0.17
+    },
+    "select_latency": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 0.73,
+      "Maximum": 1.84,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 12.27,
+      "Maximum": 47.22,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 1.67,
+      "Maximum": 4.47,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 3.03,
+      "maximum": 4.02,
+      "vcpus": 2
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.large",
+      "max_iops": 10000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 323.44,
+      "total_iops_avg": 323.44,
+      "utilization_pct": 3.23
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 15.53,
+        "Maximum": 41,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 5930140603.73,
+        "Minimum": 5918183424,
+        "Unit": "Bytes",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 100,
+        "Minimum": 99.99,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0.35,
+        "Maximum": 0.6,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.large",
+        "max_iops": 10000,
+        "read_iops_avg": 0.65,
+        "write_iops_avg": 0,
+        "total_iops_avg": 0.65,
+        "utilization_pct": 0.01
+      },
+      "threads_running": {
+        "average": 0.13,
+        "maximum": 0.18,
+        "vcpus": 2
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 37.02,
+        "Maximum": 40,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 0,
+        "Minimum": 0,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Average": 6.02,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T12:52:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 513629.06,
+      "Sum": 303041144,
+      "Unit": "Bytes/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-04-23T12:52:00-05:00",
+      "Average": 197609.11,
+      "Sum": 116589376,
+      "Unit": "Bytes/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 5,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185210Z-1h.md
+++ b/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185210Z-1h.md
@@ -1,0 +1,47 @@
+# Metrics Synopsis: 483applemdm
+
+- **Collected:** 2026-04-23T18:52:10Z
+- **Interval:** 1h
+- **Window:** 2026-04-23T17:52:10Z to 2026-04-23T18:52:10Z
+
+## Summary (1h averages)
+
+```
+Fleet Server:  CPU=39.39%  Mem=8.1%  Containers=10
+Loadtest:      CPU=6.26%  Mem=8.43%  Containers=5
+RDS Writer:    CPU=92.6%  Connections=204  Deadlocks=0
+RDS reader-1:  CPU=24.07%  Connections=14
+Redis:         CPU=0.62%  Mem=0.23%
+
+Top SQL (writer):
+  #1 load=0.76  COMMIT
+  #2 load=0.64  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #3 load=0.26  SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `su
+  #4 load=0.25  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.18  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+
+Top SQL (reader-1):
+  #1 load=0.04  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #2 load=0.01  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.01  SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `su
+  #4 load=0.01  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.01  SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SEL
+ALB:           Latency=0.01s  5xx=0  Requests=10106288  Traffic=8237.3MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=4.96GB  CacheHit=100%  Disk=18.64GB  Threads=3.03  IOPS=3.23%
+               SelectLat=0.73s  InsertLat=12.27s
+RDS reader-1: FreeMem=5.52GB  CacheHit=100%  ReplicaLag=15.53ms  Threads=0.13  IOPS=0.01%
+               SelectLat=0.35s
+Redis:         Connections=37.02  Evictions=0  CacheHit=0%
+Network:       RX=289MB  TX=111.19MB
+Containers:    Running=5  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer CPU avg = 92.6 (expected < 80)
+  🔴 ALERT: RDS Writer Threads Running (vCPUs=2) = 3.03 (expected < 2)
+
+  ⚠ 2 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185318Z-3h.json
+++ b/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185318Z-3h.json
@@ -1,0 +1,547 @@
+{
+  "metadata": {
+    "workspace": "483applemdm",
+    "collected_at": "2026-04-23T18:53:18Z",
+    "region": "us-east-2",
+    "interval": "3h",
+    "time_window": {
+      "start": "2026-04-23T15:53:18Z",
+      "end": "2026-04-23T18:53:18Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 39.59,
+      "Minimum": 37.47,
+      "Maximum": 42.1,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 7.22,
+      "Minimum": 5.38,
+      "Maximum": 8.72,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 10,
+      "desiredCount": 10
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 6.36,
+      "Minimum": 6.04,
+      "Maximum": 7.07,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 8.31,
+      "Minimum": 7.76,
+      "Maximum": 8.79,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 5,
+      "desiredCount": 5
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 92.68,
+      "Minimum": 79.71,
+      "Maximum": 99.27,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 204.02,
+      "Minimum": 203,
+      "Maximum": 205,
+      "Unit": "Count",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 342.44,
+      "Maximum": 572.76,
+      "Unit": "Count/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 0,
+      "Sum": 0.12,
+      "Maximum": 0.07,
+      "Unit": "Count/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 24.34,
+        "Minimum": 16,
+        "Maximum": 45.53,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 14,
+        "Minimum": 14,
+        "Maximum": 14,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 1.31,
+        "Maximum": 23.04,
+        "Unit": "Count/Second",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.61
+      },
+      {
+        "rank": 2,
+        "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+        "load_avg": 0.56
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` IN (...) ) AS ",
+        "load_avg": 0.23
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+        "load_avg": 0.21
+      },
+      {
+        "rank": 5,
+        "sql": "SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `subtype` FROM `nano_enrollment_queue` AS `q` INNER JOIN `nano_commands` AS `c` ON `q` . `command_uuid` = `c` . `command_uuid` LEFT JOIN `nano_command_results` `r` ON `r` . `command_uuid` = `q` . `command_uuid` AND `r` . `id` = `q` . `id` AND ( `r` . `status` != ? OR FALSE ) WHERE `q` . `id` = ? AND `q` . `active` = ? AND `r` . `status` IS NULL ORDER BY `q` . `priority` DESC , `q` . `created_at` LIMIT ?",
+        "load_avg": 0.19
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.03
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.01
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.01
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `subtype` FROM `nano_enrollment_queue` AS `q` INNER JOIN `nano_commands` AS `c` ON `q` . `command_uuid` = `c` . `command_uuid` LEFT JOIN `nano_command_results` `r` ON `r` . `command_uuid` = `q` . `command_uuid` AND `r` . `id` = `q` . `id` AND ( `r` . `status` != ? OR FALSE ) WHERE `q` . `id` = ? AND `q` . `active` = ? AND `r` . `status` IS NULL ORDER BY `q` . `priority` DESC , `q` . `created_at` LIMIT ?",
+            "load_avg": 0.01
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `ne` . `id` FROM `nano_enrollments` `ne` JOIN HOSTS `h` ON `h` . `uuid` = `ne` . `id` JOIN `host_mdm` `hm` ON `hm` . `host_id` = `h` . `id` WHERE `h` . `id` = ? AND `ne` . `enabled` = ? AND `ne` . `type` IN (...) AND `hm` . `enrolled` = ? LIMIT ?",
+            "load_avg": 0.01
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0.62,
+        "Minimum": 0.53,
+        "Maximum": 0.75,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0.23,
+        "Minimum": 0.22,
+        "Maximum": 0.23,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0.25,
+        "Minimum": 0.22,
+        "Maximum": 0.3,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0.21,
+        "Minimum": 0.21,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0.25,
+        "Minimum": 0.22,
+        "Maximum": 0.3,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0.21,
+        "Minimum": 0.21,
+        "Maximum": 0.21,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 0.03,
+      "Minimum": 0,
+      "Maximum": 82.77,
+      "Unit": "Seconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Sum": 30364007,
+      "Unit": "Count",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Sum": 26286282403,
+      "Unit": "Bytes",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 5358375799.47,
+      "Minimum": 5303209984,
+      "Unit": "Bytes",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 19971932160,
+      "Maximum": 20016316416,
+      "Unit": "Bytes",
+      "data_points": 26,
+      "max_points": 36,
+      "data_coverage": 0.72
+    },
+    "select_latency": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 0.78,
+      "Maximum": 3.58,
+      "Unit": "Milliseconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 11.53,
+      "Maximum": 87.69,
+      "Unit": "Milliseconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 1.87,
+      "Maximum": 8.08,
+      "Unit": "Milliseconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 3.52,
+      "maximum": 10.54,
+      "vcpus": 2
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.large",
+      "max_iops": 10000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 342.44,
+      "total_iops_avg": 342.44,
+      "utilization_pct": 3.42
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 15.31,
+        "Maximum": 71,
+        "Unit": "Milliseconds",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 5932166166.76,
+        "Minimum": 5915058176,
+        "Unit": "Bytes",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.94,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0.33,
+        "Maximum": 0.6,
+        "Unit": "Milliseconds",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.large",
+        "max_iops": 10000,
+        "read_iops_avg": 1.31,
+        "write_iops_avg": 0,
+        "total_iops_avg": 1.31,
+        "utilization_pct": 0.01
+      },
+      "threads_running": {
+        "average": 0.12,
+        "maximum": 0.23,
+        "vcpus": 2
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 37.52,
+        "Maximum": 44,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 0,
+        "Minimum": 0,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Average": 6.01,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T10:53:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 518483.01,
+      "Sum": 928603071,
+      "Unit": "Bytes/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-04-23T10:53:00-05:00",
+      "Average": 201085.58,
+      "Sum": 360144266,
+      "Unit": "Bytes/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 5,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185318Z-3h.md
+++ b/tools/loadtest/metrics/runs/mdm/483applemdm/483applemdm-2026-04-23-185318Z-3h.md
@@ -1,0 +1,48 @@
+# Metrics Synopsis: 483applemdm
+
+- **Collected:** 2026-04-23T18:53:18Z
+- **Interval:** 3h
+- **Window:** 2026-04-23T15:53:18Z to 2026-04-23T18:53:18Z
+
+## Summary (3h averages)
+
+```
+Fleet Server:  CPU=39.59%  Mem=7.22%  Containers=10
+Loadtest:      CPU=6.36%  Mem=8.31%  Containers=5
+RDS Writer:    CPU=92.68%  Connections=204.02  Deadlocks=0.12
+RDS reader-1:  CPU=24.34%  Connections=14
+Redis:         CPU=0.62%  Mem=0.23%
+
+Top SQL (writer):
+  #1 load=0.61  COMMIT
+  #2 load=0.56  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #3 load=0.23  SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT
+  #4 load=0.21  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.19  SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `su
+
+Top SQL (reader-1):
+  #1 load=0.03  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #2 load=0.01  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #3 load=0.01  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.01  SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `su
+  #5 load=0.01  SELECT `ne` . `id` FROM `nano_enrollments` `ne` JOIN HOSTS `h` ON `h` . `uuid` =
+ALB:           Latency=0.03s  5xx=0  Requests=30364007  Traffic=25068.55MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=4.99GB  CacheHit=100%  Disk=18.6GB  Threads=3.52  IOPS=3.42%
+               SelectLat=0.78s  InsertLat=11.53s
+RDS reader-1: FreeMem=5.52GB  CacheHit=99.99%  ReplicaLag=15.31ms  Threads=0.12  IOPS=0.01%
+               SelectLat=0.33s
+Redis:         Connections=37.52  Evictions=0  CacheHit=0%
+Network:       RX=885.58MB  TX=343.46MB
+Containers:    Running=5  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer CPU avg = 92.68 (expected < 80)
+  🔴 ALERT: RDS Writer Deadlocks = 0.12 (expected 0)
+  🔴 ALERT: RDS Writer Threads Running (vCPUs=2) = 3.52 (expected < 2)
+
+  ⚠ 3 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/mdm/484win-release/484win-release-2026-04-24-140020Z-12h.json
+++ b/tools/loadtest/metrics/runs/mdm/484win-release/484win-release-2026-04-24-140020Z-12h.json
@@ -1,0 +1,547 @@
+{
+  "metadata": {
+    "workspace": "484win-release",
+    "collected_at": "2026-04-24T14:00:20Z",
+    "region": "us-east-2",
+    "interval": "12h",
+    "time_window": {
+      "start": "2026-04-24T02:00:20Z",
+      "end": "2026-04-24T14:00:20Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 22.36,
+      "Minimum": 21.61,
+      "Maximum": 23.61,
+      "Unit": "Percent",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.24,
+      "Minimum": 2.21,
+      "Maximum": 2.28,
+      "Unit": "Percent",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 8,
+      "desiredCount": 8
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 6.08,
+      "Minimum": 5.5,
+      "Maximum": 6.94,
+      "Unit": "Percent",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 9.42,
+      "Minimum": 9.31,
+      "Maximum": 9.53,
+      "Unit": "Percent",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 2,
+      "desiredCount": 2
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 29.41,
+      "Minimum": 23.79,
+      "Maximum": 60.48,
+      "Unit": "Percent",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 70,
+      "Minimum": 47,
+      "Maximum": 90,
+      "Unit": "Count",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 137.63,
+      "Maximum": 817.9,
+      "Unit": "Count/Second",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 50.49,
+        "Minimum": 46.02,
+        "Maximum": 72.43,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 87.97,
+        "Minimum": 87,
+        "Maximum": 90,
+        "Unit": "Count",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 0.1,
+        "Maximum": 9.57,
+        "Unit": "Count/Second",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "SELECT `ds` . `profile_uuid` , `ds` . `host_uuid` , `ds` . NAME AS `profile_name` , `ds` . CHECKSUM , `ds` . `secrets_updated_at` FROM ( SELECT `mwcp` . `profile_uuid` , `mwcp` . NAME , `mwcp` . CHECKSUM , `mwcp` . `secrets_updated_at` , `h` . `uuid` AS `host_uuid` , ? AS `count_profile_labels` , ? AS `count_non_broken_labels` , ? AS `count_host_labels` , ? AS `count_host_updated_after_labels` FROM `mdm_windows_configuration_profiles` `mwcp` JOIN HOSTS `h` ON `h` . `team_id` = `mwcp` . `team_id`",
+        "load_avg": 0.09
+      },
+      {
+        "rank": 2,
+        "sql": "SELECT `hmwp` . `profile_uuid` , `hmwp` . `host_uuid` , `hmwp` . `profile_name` , `hmwp` . `operation_type` , COALESCE ( `hmwp` . `detail` , ? ) AS `detail` , `hmwp` . `status` , `hmwp` . `command_uuid` FROM ( SELECT `mwcp` . `profile_uuid` , `mwcp` . `name` , `mwcp` . `checksum` , `mwcp` . `secrets_updated_at` , `h` . `uuid` AS `host_uuid` , ? AS `count_profile_labels` , ? AS `count_non_broken_labels` , ? AS `count_host_labels` , ? AS `count_host_updated_after_labels` FROM `mdm_windows_configur",
+        "load_avg": 0.08
+      },
+      {
+        "rank": 3,
+        "sql": "COMMIT",
+        "load_avg": 0.03
+      },
+      {
+        "rank": 4,
+        "sql": "UPDATE `software` SET NAME = ? WHERE `bundle_identifier` = ? AND NAME != ? ",
+        "load_avg": 0.01
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.01
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.12
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.05
+          },
+          {
+            "rank": 3,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.04
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` ON `h` . `uuid` = `mwe` . `host_uuid` JOIN `host_mdm` `hm` ON `hm` . `host_id` = `h` . `id` WHERE `h` . `id` = ? AND `mwe` . `device_state` = ? AND `hm` . `enrolled` = ? LIMIT ?",
+            "load_avg": 0.04
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.03
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 1.75,
+        "Minimum": 1.37,
+        "Maximum": 2.73,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 0.49,
+        "Minimum": 0.48,
+        "Maximum": 0.5,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 1.06,
+        "Minimum": 0.98,
+        "Maximum": 1.35,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 0.46,
+        "Minimum": 0.45,
+        "Maximum": 0.46,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 1.06,
+        "Minimum": 0.95,
+        "Maximum": 1.33,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 0.46,
+        "Minimum": 0.45,
+        "Maximum": 0.46,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 1.47,
+      "Unit": "Seconds",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Sum": 51866962,
+      "Unit": "Count",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Sum": 46520691104,
+      "Unit": "Bytes",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 2752787564.09,
+      "Minimum": 2702417920,
+      "Unit": "Bytes",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 20397933040.48,
+      "Maximum": 20404682752,
+      "Unit": "Bytes",
+      "data_points": 132,
+      "max_points": 144,
+      "data_coverage": 0.92
+    },
+    "select_latency": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 21.07,
+      "Maximum": 31.95,
+      "Unit": "Milliseconds",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 2.75,
+      "Maximum": 31.44,
+      "Unit": "Milliseconds",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 1.84,
+      "Maximum": 22.51,
+      "Unit": "Milliseconds",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 0.26,
+      "maximum": 0.55,
+      "vcpus": 0
+    },
+    "iops_utilization": {
+      "instance_class": "db.t4g.large",
+      "max_iops": 0,
+      "read_iops_avg": 0,
+      "write_iops_avg": 137.63,
+      "total_iops_avg": 137.63,
+      "utilization_pct": null
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 15.74,
+        "Maximum": 68,
+        "Unit": "Milliseconds",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 3126640856.18,
+        "Minimum": 3109269504,
+        "Unit": "Bytes",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 100,
+        "Minimum": 99.99,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 0.61,
+        "Maximum": 1.45,
+        "Unit": "Milliseconds",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.t4g.large",
+        "max_iops": 0,
+        "read_iops_avg": 0.1,
+        "write_iops_avg": 0,
+        "total_iops_avg": 0.1,
+        "utilization_pct": null
+      },
+      "threads_running": {
+        "average": 0.47,
+        "maximum": 0.87,
+        "vcpus": 0
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 26.38,
+        "Maximum": 29,
+        "Unit": "Count",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 53.1,
+        "Minimum": 44.64,
+        "Unit": "Percent",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 5.51,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Average": 5.25,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-04-23T21:00:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 144,
+        "max_points": 144,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 276546.91,
+      "Sum": 1592633663,
+      "Unit": "Bytes/Second",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-04-23T21:00:00-05:00",
+      "Average": 107889.37,
+      "Sum": 621334860,
+      "Unit": "Bytes/Second",
+      "data_points": 144,
+      "max_points": 144,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 2,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/484win-release/484win-release-2026-04-24-140020Z-12h.md
+++ b/tools/loadtest/metrics/runs/mdm/484win-release/484win-release-2026-04-24-140020Z-12h.md
@@ -1,0 +1,44 @@
+# Metrics Synopsis: 484win-release
+
+- **Collected:** 2026-04-24T14:00:20Z
+- **Interval:** 12h
+- **Window:** 2026-04-24T02:00:20Z to 2026-04-24T14:00:20Z
+
+## Summary (12h averages)
+
+```
+Fleet Server:  CPU=22.36%  Mem=2.24%  Containers=8
+Loadtest:      CPU=6.08%  Mem=9.42%  Containers=2
+RDS Writer:    CPU=29.41%  Connections=70  Deadlocks=0
+RDS reader-1:  CPU=50.49%  Connections=87.97
+Redis:         CPU=1.75%  Mem=0.49%
+
+Top SQL (writer):
+  #1 load=0.09  SELECT `ds` . `profile_uuid` , `ds` . `host_uuid` , `ds` . NAME AS `profile_name
+  #2 load=0.08  SELECT `hmwp` . `profile_uuid` , `hmwp` . `host_uuid` , `hmwp` . `profile_name` 
+  #3 load=0.03  COMMIT
+  #4 load=0.01  UPDATE `software` SET NAME = ? WHERE `bundle_identifier` = ? AND NAME != ? 
+  #5 load=0.01  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.12  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #2 load=0.05  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #3 load=0.04  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+  #4 load=0.04  SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` O
+  #5 load=0.03  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+ALB:           Latency=0s  5xx=0  Requests=51866962  Traffic=44365.59MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=2.56GB  CacheHit=100%  Disk=19GB  Threads=0.26  IOPS=N/A%
+               SelectLat=21.07s  InsertLat=2.75s
+RDS reader-1: FreeMem=2.91GB  CacheHit=100%  ReplicaLag=15.74ms  Threads=0.47  IOPS=N/A%
+               SelectLat=0.61s
+Redis:         Connections=26.38  Evictions=0  CacheHit=53.1%
+Network:       RX=1518.85MB  TX=592.55MB
+Containers:    Running=2  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-224746Z-35m.json
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-224746Z-35m.json
@@ -1,0 +1,584 @@
+{
+  "metadata": {
+    "workspace": "486-windows",
+    "collected_at": "2026-05-19T22:47:46Z",
+    "region": "us-east-2",
+    "interval": "35m",
+    "time_window": {
+      "start": "2026-05-19T22:12:46Z",
+      "end": "2026-05-19T22:47:46Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 72.29,
+      "Minimum": 69.34,
+      "Maximum": 75.19,
+      "Unit": "Percent",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 3.25,
+      "Minimum": 3.13,
+      "Maximum": 3.39,
+      "Unit": "Percent",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 15,
+      "desiredCount": 15
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 6.39,
+      "Minimum": 6.22,
+      "Maximum": 6.67,
+      "Unit": "Percent",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 9.02,
+      "Minimum": 8.91,
+      "Maximum": 9.15,
+      "Unit": "Percent",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 16,
+      "desiredCount": 16
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 47.62,
+      "Minimum": 26.94,
+      "Maximum": 68.08,
+      "Unit": "Percent",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 160,
+      "Minimum": 160,
+      "Maximum": 160,
+      "Unit": "Count",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 0.01,
+      "Maximum": 0.28,
+      "Unit": "Count/Second",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 1616.35,
+      "Maximum": 2035.83,
+      "Unit": "Count/Second",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 57.9,
+        "Minimum": 48.92,
+        "Maximum": 68.7,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 80,
+        "Minimum": 80,
+        "Maximum": 80,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 8.89,
+        "Maximum": 75.18,
+        "Unit": "Count/Second",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 64.77,
+        "Minimum": 54.26,
+        "Maximum": 74.47,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 79.94,
+        "Minimum": 79,
+        "Maximum": 80,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 10.24,
+        "Maximum": 97.09,
+        "Unit": "Count/Second",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": []
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": []
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 24.13,
+        "Minimum": 22.06,
+        "Maximum": 26.58,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 1.61,
+        "Minimum": 1.59,
+        "Maximum": 1.62,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 7.07,
+        "Minimum": 6.85,
+        "Maximum": 7.3,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 1.59,
+        "Minimum": 1.58,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 7.01,
+        "Minimum": 6.76,
+        "Maximum": 7.23,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 1.59,
+        "Minimum": 1.58,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 0.61,
+      "Unit": "Seconds",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Sum": 20277296,
+      "Unit": "Count",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Sum": 18585388978,
+      "Unit": "Bytes",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 9538081587.2,
+      "Minimum": 9513975808,
+      "Unit": "Bytes",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 0.92,
+      "Maximum": 1.64,
+      "Unit": "Milliseconds",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 0.73,
+      "Maximum": 1.05,
+      "Unit": "Milliseconds",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 0.62,
+      "Maximum": 0.84,
+      "Unit": "Milliseconds",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.66,
+      "maximum": 4.5,
+      "vcpus": 4
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.xlarge",
+      "max_iops": 15000,
+      "read_iops_avg": 0.01,
+      "write_iops_avg": 1616.35,
+      "total_iops_avg": 1616.36,
+      "utilization_pct": 10.78
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 7.94,
+        "Maximum": 23,
+        "Unit": "Milliseconds",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 9625785490.29,
+        "Minimum": 9301372928,
+        "Unit": "Bytes",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.95,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 0.33,
+        "Maximum": 0.44,
+        "Unit": "Milliseconds",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 8.89,
+        "write_iops_avg": 0,
+        "total_iops_avg": 8.89,
+        "utilization_pct": 0.06
+      },
+      "threads_running": {
+        "average": 1.16,
+        "maximum": 1.44,
+        "vcpus": 4
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 8.74,
+        "Maximum": 18,
+        "Unit": "Milliseconds",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 9694541648.46,
+        "Minimum": 9492475904,
+        "Unit": "Bytes",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.94,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 0.32,
+        "Maximum": 0.41,
+        "Unit": "Milliseconds",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 10.24,
+        "write_iops_avg": 0,
+        "total_iops_avg": 10.24,
+        "utilization_pct": 0.07
+      },
+      "threads_running": {
+        "average": 1.27,
+        "maximum": 1.43,
+        "vcpus": 4
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 103.31,
+        "Maximum": 178,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 65.78,
+        "Minimum": 64.52,
+        "Unit": "Percent",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T17:12:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 7,
+        "max_points": 7,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 1147277.87,
+      "Sum": 597731770,
+      "Unit": "Bytes/Second",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-05-19T17:12:00-05:00",
+      "Average": 623766.36,
+      "Sum": 325606040,
+      "Unit": "Bytes/Second",
+      "data_points": 7,
+      "max_points": 7,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 16,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-224746Z-35m.md
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-224746Z-35m.md
@@ -1,0 +1,37 @@
+# Metrics Synopsis: 486-windows
+
+- **Collected:** 2026-05-19T22:47:46Z
+- **Interval:** 35m
+- **Window:** 2026-05-19T22:12:46Z to 2026-05-19T22:47:46Z
+
+## Summary (35m averages)
+
+```
+Fleet Server:  CPU=72.29%  Mem=3.25%  Containers=15
+Loadtest:      CPU=6.39%  Mem=9.02%  Containers=16
+RDS Writer:    CPU=47.62%  Connections=160  Deadlocks=0
+RDS reader-1:  CPU=57.9%  Connections=80
+RDS reader-2:  CPU=64.77%  Connections=79.94
+Redis:         CPU=24.13%  Mem=1.61%
+
+Top SQL (reader-1):
+
+Top SQL (reader-2):
+ALB:           Latency=0s  5xx=0  Requests=20277296  Traffic=17724.41MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=8.88GB  CacheHit=100%  Disk=N/A  Threads=2.66  IOPS=10.78%
+               SelectLat=0.92s  InsertLat=0.73s
+RDS reader-1: FreeMem=8.96GB  CacheHit=99.99%  ReplicaLag=7.94ms  Threads=1.16  IOPS=0.06%
+               SelectLat=0.33s
+RDS reader-2: FreeMem=9.03GB  CacheHit=99.99%  ReplicaLag=8.74ms  Threads=1.27  IOPS=0.07%
+               SelectLat=0.32s
+Redis:         Connections=103.31  Evictions=0  CacheHit=65.78%
+Network:       RX=570.04MB  TX=310.52MB
+Containers:    Running=16  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-230906Z-20m.json
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-230906Z-20m.json
@@ -1,0 +1,662 @@
+{
+  "metadata": {
+    "workspace": "486-windows",
+    "collected_at": "2026-05-19T23:09:06Z",
+    "region": "us-east-2",
+    "interval": "20m",
+    "time_window": {
+      "start": "2026-05-19T22:49:06Z",
+      "end": "2026-05-19T23:09:06Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 71.55,
+      "Minimum": 71.22,
+      "Maximum": 72.31,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 3.29,
+      "Minimum": 3.24,
+      "Maximum": 3.33,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 15,
+      "desiredCount": 15
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 6.33,
+      "Minimum": 6.25,
+      "Maximum": 6.38,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 9.15,
+      "Minimum": 9.15,
+      "Maximum": 9.15,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 16,
+      "desiredCount": 16
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 38.2,
+      "Minimum": 27.8,
+      "Maximum": 51.63,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 120.75,
+      "Minimum": 47,
+      "Maximum": 160,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 1394.86,
+      "Maximum": 2087.59,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 51.44,
+        "Minimum": 41.13,
+        "Maximum": 67.18,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 72.8,
+        "Minimum": 57,
+        "Maximum": 80,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 7.74,
+        "Maximum": 20.98,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 68.7,
+        "Minimum": 56.5,
+        "Maximum": 84.87,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 81.7,
+        "Minimum": 68,
+        "Maximum": 86,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 10.11,
+        "Maximum": 28.21,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 1.9
+      },
+      {
+        "rank": 2,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.18
+      },
+      {
+        "rank": 3,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.07
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `command_uuid` , `raw_command` , `target_loc_uri` FROM `windows_mdm_commands` WHERE `command_uuid` IN (...) ",
+        "load_avg": 0.03
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `windows_mdm_responses` ( `enrollment_id` , `raw_response` ) VALUES (...) ",
+        "load_avg": 0.03
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `host_uuid` FROM ( SELECT `host_uuid` FROM ( SELECT `ds` . `profile_uuid` , `ds` . `host_uuid` , `ds` . NAME AS `profile_name` , `ds` . CHECKSUM , `ds` . `secrets_updated_at` FROM ( SELECT `mwcp` . `profile_uuid` , `mwcp` . NAME , `mwcp` . CHECKSUM , `mwcp` . `secrets_updated_at` , `h` . `uuid` AS `host_uuid` , ? AS `count_profile_labels` , ? AS `count_non_broken_labels` , ? AS `count_host_labels` , ? AS `count_host_updated_after_labels` FROM `mdm_windows_configuration_profiles` `mwcp` JO",
+            "load_avg": 0.11
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.11
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` ON `h` . `uuid` = `mwe` . `host_uuid` JOIN `host_mdm` `hm` ON `hm` . `host_id` = `h` . `id` WHERE `h` . `id` = ? AND `mwe` . `device_state` = ? AND `hm` . `enrolled` = ? LIMIT ?",
+            "load_avg": 0.09
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.09
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SELECT `ua` . `id` , `ua` . `host_id` , `ua` . `execution_id` , `sua` . `script_id` , `ua` . `priority` , `ua` . `created_at` , IF ( `ua` . `activated_at` IS NULL , ?, ... ) AS `topmost` FROM `upcoming_activities` `ua` LEFT JOIN `script_upcoming_activities` `sua` ON `ua` . `id` = `sua` . `upcoming_activity_id` WHERE `ua` . `host_id` = ? AND `ua` . `activity_type` IN (...) AND `ua` . `activated_at` IS NOT NULL ORDER BY `",
+            "load_avg": 0.07
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.12
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` ON `h` . `uuid` = `mwe` . `host_uuid` JOIN `host_mdm` `hm` ON `hm` . `host_id` = `h` . `id` WHERE `h` . `id` = ? AND `mwe` . `device_state` = ? AND `hm` . `enrolled` = ? LIMIT ?",
+            "load_avg": 0.1
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.1
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `id` , `mdm_device_id` , `mdm_hardware_id` , `device_state` , `device_type` , `device_name` , `enroll_type` , `enroll_user_id` , `enroll_proto_version` , `enroll_client_version` , `not_in_oobe` , `awaiting_configuration` , `awaiting_configuration_at` , `credentials_hash` , `credentials_acknowledged` , `created_at` , `updated_at` , `host_uuid` FROM `mdm_windows_enrollments` WHERE `mdm_device_id` = ? ORDER BY `created_at` DESC , `id` DESC LIMIT ? ",
+            "load_avg": 0.08
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.08
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 23.51,
+        "Minimum": 22.13,
+        "Maximum": 28.66,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 1.62,
+        "Minimum": 1.53,
+        "Maximum": 1.63,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 6.8,
+        "Minimum": 5.27,
+        "Maximum": 8.92,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 1.59,
+        "Minimum": 1.31,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 6.75,
+        "Minimum": 5.42,
+        "Maximum": 8.83,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 1.59,
+        "Minimum": 1.32,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 0.64,
+      "Unit": "Seconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Sum": 11511638,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Sum": 9997579225,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 9546538393.6,
+      "Minimum": 9524260864,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 0.19,
+      "Maximum": 0.3,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 1.01,
+      "Maximum": 3.1,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 1.01,
+      "Maximum": 3.02,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.01,
+      "maximum": 2.62,
+      "vcpus": 4
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.xlarge",
+      "max_iops": 15000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 1394.86,
+      "total_iops_avg": 1394.86,
+      "utilization_pct": 9.3
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 10.15,
+        "Maximum": 24,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 9695869952,
+        "Minimum": 9299722240,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.98,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 0.29,
+        "Maximum": 0.4,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 7.74,
+        "write_iops_avg": 0,
+        "total_iops_avg": 7.74,
+        "utilization_pct": 0.05
+      },
+      "threads_running": {
+        "average": 1.01,
+        "maximum": 1.29,
+        "vcpus": 4
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 9.3,
+        "Maximum": 18,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 9699903488,
+        "Minimum": 9665966080,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.99,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 0.38,
+        "Maximum": 0.88,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 10.11,
+        "write_iops_avg": 0,
+        "total_iops_avg": 10.11,
+        "utilization_pct": 0.07
+      },
+      "threads_running": {
+        "average": 1.48,
+        "maximum": 1.75,
+        "vcpus": 4
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 140.75,
+        "Maximum": 350,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 65.99,
+        "Minimum": 56.19,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T17:49:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 1101494.01,
+      "Sum": 316128780,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-05-19T17:49:00-05:00",
+      "Average": 606610.67,
+      "Sum": 174703873,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 16,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-230906Z-20m.md
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-230906Z-20m.md
@@ -1,0 +1,54 @@
+# Metrics Synopsis: 486-windows
+
+- **Collected:** 2026-05-19T23:09:06Z
+- **Interval:** 20m
+- **Window:** 2026-05-19T22:49:06Z to 2026-05-19T23:09:06Z
+
+## Summary (20m averages)
+
+```
+Fleet Server:  CPU=71.55%  Mem=3.29%  Containers=15
+Loadtest:      CPU=6.33%  Mem=9.15%  Containers=16
+RDS Writer:    CPU=38.2%  Connections=120.75  Deadlocks=0
+RDS reader-1:  CPU=51.44%  Connections=72.8
+RDS reader-2:  CPU=68.7%  Connections=81.7
+Redis:         CPU=23.51%  Mem=1.62%
+
+Top SQL (writer):
+  #1 load=1.9  COMMIT
+  #2 load=0.18  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #3 load=0.07  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #4 load=0.03  SELECT `command_uuid` , `raw_command` , `target_loc_uri` FROM `windows_mdm_comma
+  #5 load=0.03  INSERT INTO `windows_mdm_responses` ( `enrollment_id` , `raw_response` ) VALUES 
+
+Top SQL (reader-1):
+  #1 load=0.11  SELECT `host_uuid` FROM ( SELECT `host_uuid` FROM ( SELECT `ds` . `profile_uuid`
+  #2 load=0.11  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #3 load=0.09  SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` O
+  #4 load=0.09  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #5 load=0.07  SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SEL
+
+Top SQL (reader-2):
+  #1 load=0.12  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.1  SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` O
+  #3 load=0.1  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.08  SELECT `id` , `mdm_device_id` , `mdm_hardware_id` , `device_state` , `device_typ
+  #5 load=0.08  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+ALB:           Latency=0s  5xx=0  Requests=11511638  Traffic=9534.43MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=8.89GB  CacheHit=100%  Disk=N/A  Threads=2.01  IOPS=9.3%
+               SelectLat=0.19s  InsertLat=1.01s
+RDS reader-1: FreeMem=9.03GB  CacheHit=99.99%  ReplicaLag=10.15ms  Threads=1.01  IOPS=0.05%
+               SelectLat=0.29s
+RDS reader-2: FreeMem=9.03GB  CacheHit=99.99%  ReplicaLag=9.3ms  Threads=1.48  IOPS=0.07%
+               SelectLat=0.38s
+Redis:         Connections=140.75  Evictions=0  CacheHit=65.99%
+Network:       RX=301.48MB  TX=166.61MB
+Containers:    Running=16  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-233833Z-30m.json
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-233833Z-30m.json
@@ -1,0 +1,584 @@
+{
+  "metadata": {
+    "workspace": "486-windows",
+    "collected_at": "2026-05-19T23:38:33Z",
+    "region": "us-east-2",
+    "interval": "30m",
+    "time_window": {
+      "start": "2026-05-19T23:08:33Z",
+      "end": "2026-05-19T23:38:33Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 73.78,
+      "Minimum": 72.35,
+      "Maximum": 74.84,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 3.29,
+      "Minimum": 3.21,
+      "Maximum": 3.35,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 15,
+      "desiredCount": 15
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 6.42,
+      "Minimum": 6.3,
+      "Maximum": 6.59,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 9.16,
+      "Minimum": 9.15,
+      "Maximum": 9.17,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 16,
+      "desiredCount": 16
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 50.11,
+      "Minimum": 26.95,
+      "Maximum": 61.45,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 155.07,
+      "Minimum": 151,
+      "Maximum": 157,
+      "Unit": "Count",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 1810.55,
+      "Maximum": 2107.28,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 53.16,
+        "Minimum": 42.33,
+        "Maximum": 64.9,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 73.57,
+        "Minimum": 69,
+        "Maximum": 74,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 8.36,
+        "Maximum": 29.68,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 76.17,
+        "Minimum": 65.84,
+        "Maximum": 85.34,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 86.2,
+        "Minimum": 86,
+        "Maximum": 88,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 12,
+        "Maximum": 77.83,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": []
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": []
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 23.35,
+        "Minimum": 22.02,
+        "Maximum": 24.53,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 1.61,
+        "Minimum": 1.59,
+        "Maximum": 1.62,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 6.99,
+        "Minimum": 6.12,
+        "Maximum": 8.47,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 1.59,
+        "Minimum": 1.58,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 6.96,
+        "Minimum": 6.08,
+        "Maximum": 8.39,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 1.59,
+        "Minimum": 1.58,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 0.91,
+      "Unit": "Seconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Sum": 17386530,
+      "Unit": "Count",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Sum": 16078878427,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 9471629448.53,
+      "Minimum": 9455505408,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 0.78,
+      "Maximum": 1.24,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 0.79,
+      "Maximum": 1.23,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 0.67,
+      "Maximum": 1.27,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 3.05,
+      "maximum": 3.94,
+      "vcpus": 4
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.xlarge",
+      "max_iops": 15000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 1810.55,
+      "total_iops_avg": 1810.55,
+      "utilization_pct": 12.07
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 8.33,
+        "Maximum": 24,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 9652659131.73,
+        "Minimum": 9288400896,
+        "Unit": "Bytes",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.98,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 0.31,
+        "Maximum": 0.43,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 8.36,
+        "write_iops_avg": 0,
+        "total_iops_avg": 8.36,
+        "utilization_pct": 0.06
+      },
+      "threads_running": {
+        "average": 0.93,
+        "maximum": 1.18,
+        "vcpus": 4
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 8.17,
+        "Maximum": 18,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 9567063790.93,
+        "Minimum": 9358475264,
+        "Unit": "Bytes",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.97,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 0.4,
+        "Maximum": 0.62,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 12,
+        "write_iops_avg": 0,
+        "total_iops_avg": 12,
+        "utilization_pct": 0.08
+      },
+      "threads_running": {
+        "average": 1.94,
+        "maximum": 2.12,
+        "vcpus": 4
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 92.27,
+        "Maximum": 95,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 65.44,
+        "Minimum": 59.83,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 6.03,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Average": 5.43,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T18:08:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 1164810.64,
+      "Sum": 516011115,
+      "Unit": "Bytes/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-05-19T18:08:00-05:00",
+      "Average": 632354.31,
+      "Sum": 280132958,
+      "Unit": "Bytes/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 16,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-233833Z-30m.md
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-19-233833Z-30m.md
@@ -1,0 +1,37 @@
+# Metrics Synopsis: 486-windows
+
+- **Collected:** 2026-05-19T23:38:33Z
+- **Interval:** 30m
+- **Window:** 2026-05-19T23:08:33Z to 2026-05-19T23:38:33Z
+
+## Summary (30m averages)
+
+```
+Fleet Server:  CPU=73.78%  Mem=3.29%  Containers=15
+Loadtest:      CPU=6.42%  Mem=9.16%  Containers=16
+RDS Writer:    CPU=50.11%  Connections=155.07  Deadlocks=0
+RDS reader-1:  CPU=53.16%  Connections=73.57
+RDS reader-2:  CPU=76.17%  Connections=86.2
+Redis:         CPU=23.35%  Mem=1.61%
+
+Top SQL (reader-1):
+
+Top SQL (reader-2):
+ALB:           Latency=0s  5xx=0  Requests=17386530  Traffic=15334.01MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=8.82GB  CacheHit=100%  Disk=N/A  Threads=3.05  IOPS=12.07%
+               SelectLat=0.78s  InsertLat=0.79s
+RDS reader-1: FreeMem=8.99GB  CacheHit=99.99%  ReplicaLag=8.33ms  Threads=0.93  IOPS=0.06%
+               SelectLat=0.31s
+RDS reader-2: FreeMem=8.91GB  CacheHit=99.99%  ReplicaLag=8.17ms  Threads=1.94  IOPS=0.08%
+               SelectLat=0.4s
+Redis:         Connections=92.27  Evictions=0  CacheHit=65.44%
+Network:       RX=492.11MB  TX=267.16MB
+Containers:    Running=16  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-20-000458Z-25m.json
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-20-000458Z-25m.json
@@ -1,0 +1,662 @@
+{
+  "metadata": {
+    "workspace": "486-windows",
+    "collected_at": "2026-05-20T00:04:58Z",
+    "region": "us-east-2",
+    "interval": "25m",
+    "time_window": {
+      "start": "2026-05-19T23:39:58Z",
+      "end": "2026-05-20T00:04:58Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 71.56,
+      "Minimum": 69.41,
+      "Maximum": 73.34,
+      "Unit": "Percent",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 3.35,
+      "Minimum": 3.31,
+      "Maximum": 3.39,
+      "Unit": "Percent",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 15,
+      "desiredCount": 15
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 6.23,
+      "Minimum": 6.08,
+      "Maximum": 6.42,
+      "Unit": "Percent",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 9.23,
+      "Minimum": 9.17,
+      "Maximum": 9.31,
+      "Unit": "Percent",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 16,
+      "desiredCount": 16
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 50.72,
+      "Minimum": 33.88,
+      "Maximum": 74.93,
+      "Unit": "Percent",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 158.24,
+      "Minimum": 156,
+      "Maximum": 160,
+      "Unit": "Count",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 1400.16,
+      "Maximum": 1938.49,
+      "Unit": "Count/Second",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 53.23,
+        "Minimum": 40.55,
+        "Maximum": 65.89,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 69.28,
+        "Minimum": 68,
+        "Maximum": 70,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 14.36,
+        "Maximum": 89.4,
+        "Unit": "Count/Second",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 74.74,
+        "Minimum": 64.69,
+        "Maximum": 96.11,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 89.68,
+        "Minimum": 88,
+        "Maximum": 91,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 13.32,
+        "Maximum": 43.02,
+        "Unit": "Count/Second",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 2.11
+      },
+      {
+        "rank": 2,
+        "sql": "DELETE `q` FROM `windows_mdm_command_queue` `q` INNER JOIN ( SELECT `q2` . `enrollment_id` , `q2` . `command_uuid` FROM `windows_mdm_command_queue` `q2` INNER JOIN `windows_mdm_command_results` `r` ON `r` . `enrollment_id` = `q2` . `enrollment_id` AND `r` . `command_uuid` = `q2` . `command_uuid` WHERE `r` . `created_at` < NOW ( ) - INTERVAL ? HOUR LIMIT ? ) `batch` ON `batch` . `enrollment_id` = `q` . `enrollment_id` AND `batch` . `command_uuid` = `q` . `command_uuid` ",
+        "load_avg": 0.15
+      },
+      {
+        "rank": 3,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.13
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.1
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `windows_mdm_command_results` ( `enrollment_id` , `command_uuid` , `raw_result` , `response_id` , `status_code` ) VALUES (...) /* , ... */ ON DUPLICATE KEY UPDATE `raw_result` = COALESCE ( VALUES ( `raw_result` ) , `raw_result` ) , `status_code` = COALESCE ( VALUES ( `status_code` ) , `status_code` ) ",
+        "load_avg": 0.07
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT EXISTS ( SELECT ? FROM `windows_mdm_command_queue` `wmcq` WHERE `wmcq` . `enrollment_id` = ? AND NOT EXISTS ( SELECT ? FROM `windows_mdm_command_results` `wmcr` WHERE `wmcr` . `enrollment_id` = `wmcq` . `enrollment_id` AND `wmcr` . `command_uuid` = `wmcq` . `command_uuid` ) ) ",
+            "load_avg": 0.1
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `host_uuid` FROM ( SELECT `host_uuid` FROM ( SELECT `ds` . `profile_uuid` , `ds` . `host_uuid` , `ds` . NAME AS `profile_name` , `ds` . CHECKSUM , `ds` . `secrets_updated_at` FROM ( SELECT `mwcp` . `profile_uuid` , `mwcp` . NAME , `mwcp` . CHECKSUM , `mwcp` . `secrets_updated_at` , `h` . `uuid` AS `host_uuid` , ? AS `count_profile_labels` , ? AS `count_non_broken_labels` , ? AS `count_host_labels` , ? AS `count_host_updated_after_labels` FROM `mdm_windows_configuration_profiles` `mwcp` JO",
+            "load_avg": 0.09
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.09
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` ON `h` . `uuid` = `mwe` . `host_uuid` JOIN `host_mdm` `hm` ON `hm` . `host_id` = `h` . `id` WHERE `h` . `id` = ? AND `mwe` . `device_state` = ? AND `hm` . `enrolled` = ? LIMIT ?",
+            "load_avg": 0.07
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.07
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `host_uuid` FROM ( SELECT `host_uuid` FROM ( SELECT `ds` . `profile_uuid` , `ds` . `host_uuid` , `ds` . NAME AS `profile_name` , `ds` . CHECKSUM , `ds` . `secrets_updated_at` FROM ( SELECT `mwcp` . `profile_uuid` , `mwcp` . NAME , `mwcp` . CHECKSUM , `mwcp` . `secrets_updated_at` , `h` . `uuid` AS `host_uuid` , ? AS `count_profile_labels` , ? AS `count_non_broken_labels` , ? AS `count_host_labels` , ? AS `count_host_updated_after_labels` FROM `mdm_windows_configuration_profiles` `mwcp` JO",
+            "load_avg": 0.26
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT EXISTS ( SELECT ? FROM `windows_mdm_command_queue` `wmcq` WHERE `wmcq` . `enrollment_id` = ? AND NOT EXISTS ( SELECT ? FROM `windows_mdm_command_results` `wmcr` WHERE `wmcr` . `enrollment_id` = `wmcq` . `enrollment_id` AND `wmcr` . `command_uuid` = `wmcq` . `command_uuid` ) ) ",
+            "load_avg": 0.15
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.14
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` ON `h` . `uuid` = `mwe` . `host_uuid` JOIN `host_mdm` `hm` ON `hm` . `host_id` = `h` . `id` WHERE `h` . `id` = ? AND `mwe` . `device_state` = ? AND `hm` . `enrolled` = ? LIMIT ?",
+            "load_avg": 0.14
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.12
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 22.58,
+        "Minimum": 21.7,
+        "Maximum": 25.87,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 1.62,
+        "Minimum": 1.53,
+        "Maximum": 1.63,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 6.8,
+        "Minimum": 5.35,
+        "Maximum": 9.18,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 1.6,
+        "Minimum": 1.31,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 6.77,
+        "Minimum": 5.45,
+        "Maximum": 9.05,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 1.6,
+        "Minimum": 1.32,
+        "Maximum": 1.61,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 2.87,
+      "Unit": "Seconds",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Sum": 14375976,
+      "Unit": "Count",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Sum": 12585260803,
+      "Unit": "Bytes",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 9442645770.24,
+      "Minimum": 9387749376,
+      "Unit": "Bytes",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 0.22,
+      "Maximum": 0.34,
+      "Unit": "Milliseconds",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 1.68,
+      "Maximum": 3.38,
+      "Unit": "Milliseconds",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 3.26,
+      "Maximum": 6.34,
+      "Unit": "Milliseconds",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.93,
+      "maximum": 3.77,
+      "vcpus": 4
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.xlarge",
+      "max_iops": 15000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 1400.16,
+      "total_iops_avg": 1400.16,
+      "utilization_pct": 9.33
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 9.84,
+        "Maximum": 18,
+        "Unit": "Milliseconds",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 9629031956.48,
+        "Minimum": 9299734528,
+        "Unit": "Bytes",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.96,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 0.35,
+        "Maximum": 0.45,
+        "Unit": "Milliseconds",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 14.36,
+        "write_iops_avg": 0,
+        "total_iops_avg": 14.36,
+        "utilization_pct": 0.1
+      },
+      "threads_running": {
+        "average": 1.03,
+        "maximum": 1.27,
+        "vcpus": 4
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 9.32,
+        "Maximum": 22,
+        "Unit": "Milliseconds",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 9567728926.72,
+        "Minimum": 9427439616,
+        "Unit": "Bytes",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.98,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 0.43,
+        "Maximum": 1.28,
+        "Unit": "Milliseconds",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.xlarge",
+        "max_iops": 15000,
+        "read_iops_avg": 13.32,
+        "write_iops_avg": 0,
+        "total_iops_avg": 13.32,
+        "utilization_pct": 0.09
+      },
+      "threads_running": {
+        "average": 2.03,
+        "maximum": 2.99,
+        "vcpus": 4
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 138.96,
+        "Maximum": 314,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 65.99,
+        "Minimum": 57.07,
+        "Unit": "Percent",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Average": 5,
+        "Maximum": 5,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-19T18:39:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 5,
+        "max_points": 5,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 1117497.71,
+      "Sum": 417944142,
+      "Unit": "Bytes/Second",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-05-19T18:39:00-05:00",
+      "Average": 615182.26,
+      "Sum": 230078167,
+      "Unit": "Bytes/Second",
+      "data_points": 5,
+      "max_points": 5,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 16,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-20-000458Z-25m.md
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/486-windows-2026-05-20-000458Z-25m.md
@@ -1,0 +1,54 @@
+# Metrics Synopsis: 486-windows
+
+- **Collected:** 2026-05-20T00:04:58Z
+- **Interval:** 25m
+- **Window:** 2026-05-19T23:39:58Z to 2026-05-20T00:04:58Z
+
+## Summary (25m averages)
+
+```
+Fleet Server:  CPU=71.56%  Mem=3.35%  Containers=15
+Loadtest:      CPU=6.23%  Mem=9.23%  Containers=16
+RDS Writer:    CPU=50.72%  Connections=158.24  Deadlocks=0
+RDS reader-1:  CPU=53.23%  Connections=69.28
+RDS reader-2:  CPU=74.74%  Connections=89.68
+Redis:         CPU=22.58%  Mem=1.62%
+
+Top SQL (writer):
+  #1 load=2.11  COMMIT
+  #2 load=0.15  DELETE `q` FROM `windows_mdm_command_queue` `q` INNER JOIN ( SELECT `q2` . `enro
+  #3 load=0.13  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #4 load=0.1  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #5 load=0.07  INSERT INTO `windows_mdm_command_results` ( `enrollment_id` , `command_uuid` , `
+
+Top SQL (reader-1):
+  #1 load=0.1  SELECT EXISTS ( SELECT ? FROM `windows_mdm_command_queue` `wmcq` WHERE `wmcq` . 
+  #2 load=0.09  SELECT `host_uuid` FROM ( SELECT `host_uuid` FROM ( SELECT `ds` . `profile_uuid`
+  #3 load=0.09  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.07  SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` O
+  #5 load=0.07  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+
+Top SQL (reader-2):
+  #1 load=0.26  SELECT `host_uuid` FROM ( SELECT `host_uuid` FROM ( SELECT `ds` . `profile_uuid`
+  #2 load=0.15  SELECT EXISTS ( SELECT ? FROM `windows_mdm_command_queue` `wmcq` WHERE `wmcq` . 
+  #3 load=0.14  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.14  SELECT `mwe` . `host_uuid` FROM `mdm_windows_enrollments` `mwe` JOIN HOSTS `h` O
+  #5 load=0.12  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+ALB:           Latency=0s  5xx=0  Requests=14375976  Traffic=12002.24MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=8.79GB  CacheHit=100%  Disk=N/A  Threads=2.93  IOPS=9.33%
+               SelectLat=0.22s  InsertLat=1.68s
+RDS reader-1: FreeMem=8.97GB  CacheHit=99.99%  ReplicaLag=9.84ms  Threads=1.03  IOPS=0.1%
+               SelectLat=0.35s
+RDS reader-2: FreeMem=8.91GB  CacheHit=99.99%  ReplicaLag=9.32ms  Threads=2.03  IOPS=0.09%
+               SelectLat=0.43s
+Redis:         Connections=138.96  Evictions=0  CacheHit=65.99%
+Network:       RX=398.58MB  TX=219.42MB
+Containers:    Running=16  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/mdm/486-windows/REPORT.md
+++ b/tools/loadtest/metrics/runs/mdm/486-windows/REPORT.md
@@ -1,0 +1,86 @@
+# 4.86 Windows MDM Load Test — 30k Hosts
+
+**Workspace:** `486-windows`
+**Date:** 2026-05-19
+**Goal:** Confirm 4.86 can sustain 30k Windows hosts with MDM enabled across the profile-interaction operations that previously stressed 4.85.
+**Result:** All four operations sustained without errors, deadlocks, evictions, or 5xx. Fleet server CPU held steady around 72%, RDS writer peaked at ~50%, replica lag stayed under 11ms. Significant headroom remained on every tier.
+
+## Test plan
+
+Four sequential operations on a fleet of 32k Windows hosts (15 Fleet server containers, 16 loadtest containers, Aurora writer + 2 readers, ElastiCache Redis):
+
+| # | Time (local) | Operation | Window covered |
+|---|---|---|---|
+| 1 | 5:10 PM | Add 15 profiles to current team | 22:12 → 22:47 UTC (35 min) |
+| 2 | 5:51 PM | Move 32k hosts → team with 0 profiles (force-delete profiles) | 22:49 → 23:09 UTC (20 min) |
+| 3 | 6:10 PM | Move 32k hosts → team with 15 profiles (transfer + reapply) | 23:08 → 23:38 UTC (30 min) |
+| 4 | 6:40 PM | Move 32k hosts → different team with another set of 15 profiles | 23:39 → 00:04 UTC (25 min) |
+
+## Headline numbers
+
+| Metric | Test 1: add 15 | Test 2: → 0 prof | Test 3: → 15 prof | Test 4: team→team |
+|---|---|---|---|---|
+| **Fleet server CPU (avg)** | 72.29% | 71.55% | 73.78% | 71.56% |
+| **Fleet server mem (avg)** | 3.25% | 3.29% | 3.29% | 3.35% |
+| **RDS writer CPU (avg)** | 47.62% | 38.20% | 50.11% | 50.72% |
+| **RDS writer connections** | 160 | 121 | 155 | 158 |
+| **RDS writer IOPS util** | 10.78% | 9.30% | 12.07% | 9.33% |
+| **RDS writer InsertLat** | 0.73s | 1.01s | 0.79s | 1.68s |
+| **RDS writer SelectLat** | 0.92s | 0.19s | 0.78s | 0.22s |
+| **RDS writer threads (AAS)** | 2.66 | 2.01 | 3.05 | 2.93 |
+| **RDS reader-1 CPU** | 57.90% | 51.44% | 53.16% | 53.23% |
+| **RDS reader-2 CPU** | 64.77% | 68.70% | 76.17% | 74.74% |
+| **Aurora replica lag (max)** | ~9 ms | ~10 ms | ~8 ms | ~10 ms |
+| **Buffer cache hit ratio** | 100% / 99.99% | 100% / 99.99% | 100% / 99.99% | 100% / 99.99% |
+| **ALB 5xx** | 0 | 0 | 0 | 0 |
+| **Fleet server errors** | 0 | 0 | 0 | 0 |
+| **Deadlocks** | 0 | 0 | 0 | 0 |
+| **ALB throughput** | 20.3M req / 17.7 GB | 11.5M req / 9.5 GB | 17.4M req / 15.3 GB | 14.4M req / 12.0 GB |
+
+## Fleet server CPU
+
+CPU stayed within a tight 71.5 – 73.8% band across all four operations — i.e. the server tier behaved identically regardless of which profile operation was running. Memory was negligible at ~3.3%. With 15 containers running steady-state at ~72% and no scale-up triggered, the cluster has ~28% per-container headroom (and could scale out further if needed).
+
+No abnormal container stops, no restarts, no errors in the Fleet log stream over any of the four windows.
+
+## RDS writer
+
+Writer CPU peaked at 50.7% (Test 4) and never came near saturation. The heavier operations — the two "transfer + reapply 15 profiles" cases — are visibly more write-heavy than the "drop profiles to a team with none" case:
+
+- **Test 2 (drop to 0 profiles)** is the lightest: 38% CPU, 121 connections, 2.0 AAS. Profile removal is mostly DELETEs against a single set of MDM tables.
+- **Tests 3 and 4 (transfer + apply 15 profiles)** are the heaviest: ~50% CPU, ~155 connections, ~3.0 AAS, 10–12% IOPS utilization. These do INSERTs into the per-host profile/command tables for 32k × 15 = ~480k rows of profile state per operation.
+
+`COMMIT` dominates writer load in both top-SQL captures (1.9–2.1 AAS), which is expected — high write throughput with small transactions. No single application query came close to saturating the writer; #2 onwards is all under 0.2 AAS.
+
+**InsertLat in Test 4 jumped to 1.68s** (vs 0.73–1.01s elsewhere). This is the team-to-team move, which is the most write-intensive (deletes from old team's profile state + inserts to new team's). Still well within healthy range and not surfacing as user-visible latency — the ALB recorded 0 5xx and the host-side request rate held at ~570k req/min.
+
+0 deadlocks across all four operations.
+
+## RDS readers
+
+Reader-1 stayed in the 51 – 58% CPU band; reader-2 ran consistently hotter at 64 – 76%, peaking at 76.17% during Test 3 (the heaviest profile-reapply operation). The asymmetry is just routing — both readers are healthy.
+
+Replica lag stayed between 7.9 and 10.2 ms across all four tests, which is well inside Aurora's healthy range and well below the threshold (20–50 ms) where stale reads start to matter for Fleet's workflows.
+
+Buffer cache hit ratio was 99.99% on both readers throughout — they're serving their working set entirely from memory.
+
+Top reader queries are the expected MDM read paths: `windows_mdm_enrollments` lookups, profile-status queries, and the live-query scheduler's pack/query resolution. None exceeded 0.26 AAS individually.
+
+## Redis
+
+No notable activity. CPU 22–24%, memory ~1.6%, **0 evictions**, ~93–140 active connections. Cache hit rate sat at ~65% — this is the working baseline for Fleet's Redis usage pattern under load and didn't shift during any operation.
+
+## What this means
+
+- **30k Windows hosts with MDM on is sustainable on 4.86 at the current cluster size.** All four operations completed cleanly with significant headroom on every tier.
+- **No regression signal** in this run: zero 5xx, zero application errors, zero deadlocks, zero evictions, sub-millisecond increases in replica lag.
+- **Reader-2 at 76% CPU during the heaviest operation (Test 3)** is the closest thing to a watchpoint — worth re-checking on the next test if scale increases or the operation pattern changes, but not flagging today.
+- **Writer InsertLat of 1.68s in Test 4** is the other thing to keep an eye on if team-to-team moves become a common operation, but it's not user-facing (ALB target response time was effectively 0s and no 5xx).
+- Compared to the 4.85 results that prompted this validation, the cluster ran well below the saturation behavior that previously appeared at this scale.
+
+## Source files
+
+- [486-windows-2026-05-19-224746Z-35m.md](486-windows-2026-05-19-224746Z-35m.md) — Test 1 (add 15 profiles)
+- [486-windows-2026-05-19-230906Z-20m.md](486-windows-2026-05-19-230906Z-20m.md) — Test 2 (→ 0 profiles)
+- [486-windows-2026-05-19-233833Z-30m.md](486-windows-2026-05-19-233833Z-30m.md) — Test 3 (→ 15 profiles)
+- [486-windows-2026-05-20-000458Z-25m.md](486-windows-2026-05-20-000458Z-25m.md) — Test 4 (team-to-team move)

--- a/tools/loadtest/metrics/runs/migration/485to486mig/485to486mig-2026-05-27-221200Z-6h.json
+++ b/tools/loadtest/metrics/runs/migration/485to486mig/485to486mig-2026-05-27-221200Z-6h.json
@@ -1,0 +1,681 @@
+{
+  "metadata": {
+    "workspace": "485to486mig",
+    "collected_at": "2026-05-27T22:12:00Z",
+    "region": "us-east-2",
+    "interval": "6h",
+    "time_window": {
+      "start": "2026-05-27T16:12:00Z",
+      "end": "2026-05-27T22:12:00Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 59.1,
+      "Minimum": 54.51,
+      "Maximum": 77.47,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 6.01,
+      "Minimum": 5.77,
+      "Maximum": 6.28,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.75,
+      "Minimum": 2.66,
+      "Maximum": 3.15,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.67,
+      "Minimum": 2.62,
+      "Maximum": 2.68,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 48,
+      "desiredCount": 48
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 18.43,
+      "Minimum": 6.69,
+      "Maximum": 74.95,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 211.44,
+      "Minimum": 69,
+      "Maximum": 257,
+      "Unit": "Count",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 1740.58,
+      "Maximum": 3655.2,
+      "Unit": "Count/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 21.66,
+        "Minimum": 13.61,
+        "Maximum": 35.74,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 130.8,
+        "Minimum": 71,
+        "Maximum": 140,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 1.04,
+        "Maximum": 57.03,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 15.42,
+        "Minimum": 7.77,
+        "Maximum": 33.9,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 120.19,
+        "Minimum": 111,
+        "Maximum": 127,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 0.79,
+        "Maximum": 36.19,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 1.24
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.4
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.27
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.06
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.05
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.45
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.37
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.27
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.21
+          },
+          {
+            "rank": 5,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.08
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.29
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.24
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.17
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.13
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.09
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 39.06,
+        "Minimum": 38.16,
+        "Maximum": 46.93,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 4.55,
+        "Minimum": 4.32,
+        "Maximum": 5.08,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 9.46,
+        "Minimum": 8.78,
+        "Maximum": 11.14,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 4.49,
+        "Minimum": 4.23,
+        "Maximum": 4.52,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 9.67,
+        "Minimum": 9,
+        "Maximum": 11.37,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 4.49,
+        "Minimum": 4.22,
+        "Maximum": 4.52,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 8.9,
+      "Unit": "Seconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Sum": 277515745,
+      "Unit": "Count",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Sum": 301134177684,
+      "Unit": "Bytes",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 4852.0,
+    "sample_messages": [
+      "{\"ts\":\"2026-05-27T22:03:39Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":87015491,\"host_id\":71404,\"ip_addr\":\"10.12.1.94\",\"x_for_ip_addr\":\"10.12.1.94\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T22:03:27Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":60220369,\"host_id\":74206,\"ip_addr\":\"10.12.3.236\",\"x_for_ip_addr\":\"10.12.3.236\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T22:01:33Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":85498333,\"host_id\":15219,\"ip_addr\":\"10.12.2.145\",\"x_for_ip_addr\":\"10.12.2.145\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T22:01:16Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":84312007,\"host_id\":47697,\"ip_addr\":\"10.12.3.231\",\"x_for_ip_addr\":\"10.12.3.231\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T22:00:30Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":96919598,\"host_id\":29073,\"ip_addr\":\"10.12.3.240\",\"x_for_ip_addr\":\"10.12.3.240\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:59:01Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":77334816,\"host_id\":89937,\"ip_addr\":\"10.12.1.81\",\"x_for_ip_addr\":\"10.12.1.81\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:59Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":88181136,\"host_id\":68715,\"ip_addr\":\"10.12.1.81\",\"x_for_ip_addr\":\"10.12.1.81\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:15Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":145062222,\"host_id\":11151,\"ip_addr\":\"10.12.2.58\",\"x_for_ip_addr\":\"10.12.2.58\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:58:15Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":86122551,\"host_id\":46006,\"ip_addr\":\"10.12.1.203\",\"x_for_ip_addr\":\"10.12.1.203\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-05-27T21:57:52Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":168835047,\"host_id\":2133,\"ip_addr\":\"10.12.3.46\",\"x_for_ip_addr\":\"10.12.3.46\",\"ingestion-err\":\"ingesting query disk_encryption_windows: parsing bitlocker conversion_status \\\"\\\": strconv.Atoi: parsing \\\"\\\": invalid syntax\",\"err\":\"error in query ingestion\"}"
+    ]
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 29548441873.07,
+      "Minimum": 29017014272,
+      "Unit": "Bytes",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 25093947114.31,
+      "Maximum": 25196363776,
+      "Unit": "Bytes",
+      "data_points": 59,
+      "max_points": 72,
+      "data_coverage": 0.82
+    },
+    "select_latency": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 4.77,
+      "Maximum": 89.98,
+      "Unit": "Milliseconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 29.04,
+      "Maximum": 233.69,
+      "Unit": "Milliseconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 15.06,
+      "Maximum": 124.48,
+      "Unit": "Milliseconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.48,
+      "maximum": 20.99,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 1740.58,
+      "total_iops_avg": 1740.58,
+      "utilization_pct": 8.7
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 10.02,
+        "Maximum": 107,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 30699720396.8,
+        "Minimum": 30525890560,
+        "Unit": "Bytes",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 100,
+        "Minimum": 99.99,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 0.49,
+        "Maximum": 2.68,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 1.04,
+        "write_iops_avg": 0,
+        "total_iops_avg": 1.04,
+        "utilization_pct": 0.01
+      },
+      "threads_running": {
+        "average": 1.72,
+        "maximum": 3.29,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 9.95,
+        "Maximum": 202,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 30682876108.8,
+        "Minimum": 30511104000,
+        "Unit": "Bytes",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 100,
+        "Minimum": 100,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 0.5,
+        "Maximum": 3.47,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 0.79,
+        "write_iops_avg": 0,
+        "total_iops_avg": 0.79,
+        "utilization_pct": 0
+      },
+      "threads_running": {
+        "average": 1.23,
+        "maximum": 2.82,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 236.01,
+        "Maximum": 2692,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 73.92,
+        "Minimum": 70.23,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 5.78,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Average": 5.01,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-05-27T11:12:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 1025708.83,
+      "Sum": 9226250921,
+      "Unit": "Bytes/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-05-27T11:12:00-05:00",
+      "Average": 463844.47,
+      "Sum": 4173208696,
+      "Unit": "Bytes/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 48,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/migration/485to486mig/485to486mig-2026-05-27-221200Z-6h.md
+++ b/tools/loadtest/metrics/runs/migration/485to486mig/485to486mig-2026-05-27-221200Z-6h.md
@@ -1,0 +1,56 @@
+# Metrics Synopsis: 485to486mig
+
+- **Collected:** 2026-05-27T22:12:00Z
+- **Interval:** 6h
+- **Window:** 2026-05-27T16:12:00Z to 2026-05-27T22:12:00Z
+
+## Summary (6h averages)
+
+```
+Fleet Server:  CPU=59.1%  Mem=6.01%  Containers=25
+Loadtest:      CPU=2.75%  Mem=2.67%  Containers=48
+RDS Writer:    CPU=18.43%  Connections=211.44  Deadlocks=0
+RDS reader-1:  CPU=21.66%  Connections=130.8
+RDS reader-2:  CPU=15.42%  Connections=120.19
+Redis:         CPU=39.06%  Mem=4.55%
+
+Top SQL (writer):
+  #1 load=1.24  COMMIT
+  #2 load=0.4  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.27  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #4 load=0.06  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+  #5 load=0.05  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.45  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.37  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.27  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.21  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.08  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+
+Top SQL (reader-2):
+  #1 load=0.29  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.24  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.17  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.13  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.09  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+ALB:           Latency=0s  5xx=0  Requests=277515745  Traffic=287183.93MB
+Fleet Errors:  Count=4852.0
+RDS Writer:    FreeMem=27.52GB  CacheHit=100%  Disk=23.37GB  Threads=2.48  IOPS=8.7%
+               SelectLat=4.77s  InsertLat=29.04s
+RDS reader-1: FreeMem=28.59GB  CacheHit=100%  ReplicaLag=10.02ms  Threads=1.72  IOPS=0.01%
+               SelectLat=0.49s
+RDS reader-2: FreeMem=28.58GB  CacheHit=100%  ReplicaLag=9.95ms  Threads=1.23  IOPS=0%
+               SelectLat=0.5s
+Redis:         Connections=236.01  Evictions=0  CacheHit=73.92%
+Network:       RX=8798.84MB  TX=3979.88MB
+Containers:    Running=48  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: Fleet Server Errors = 4852.0 (expected 0)
+
+  ⚠ 1 alert(s) detected
+```


### PR DESCRIPTION
## Summary

Adds a load test metrics tool under [`tools/loadtest/metrics/`](tools/loadtest/metrics/) for capturing and comparing AWS CloudWatch metrics across Fleet load test runs.

- **`collect-metrics.sh`** — discovers a load test environment's AWS resources from its Terraform workspace name, pulls CloudWatch metrics over a lookback interval, and writes a `.json` data file plus a human-readable `.md` synopsis (with threshold alerts). Supports a `--category` flag (`baseline` | `migration` | `mdm`) that files output under `runs/<category>/<workspace>/`.
- **`compare-metrics.sh`** — diffs two or more runs side by side and flags deltas as `ok` / `WARN` / `ALERT`. Searches `runs/` recursively, and `--filter` doubles as a category selector thanks to the naming conventions.
- **`runs/`** — committed historical runs, organized by category: `baseline/`, `migration/`, `mdm/`.
- New `README.md` documenting usage, run organization, and how to submit results; linked from the root `tools/README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated metrics tooling for AWS load-test environments — collects ECS/RDS/Redis/ALB/network metrics, Performance Insights top-SQL, CloudWatch Logs error samples, produces consolidated JSON + Markdown summaries, and performs threshold checks with alerts.
  * Added a metrics comparison tool to detect regressions across runs with run selection, deduplication, per-metric comparisons, percent-change, and aggregated alert synopsis.

* **Tests**
  * Added numerous baseline and sample load-test metrics reports covering multiple workspaces, intervals, and scenarios for validation and regression analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->