### PR TITLE
Show wipe pending/wiped status badge for Linux hosts

### DIFF
--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
@@ -148,7 +148,7 @@ describe("HostHeader", () => {
     expect(await screen.findByText(/Host is locked/i)).toBeInTheDocument();
   });
 
-  it("does not render wipe status tags for Linux hosts", () => {
+  it("renders wipe status tags for Linux hosts", () => {
     const linuxSummaryData = { ...defaultSummaryData, platform: "ubuntu" };
 
     const { rerender } = render(
@@ -161,7 +161,7 @@ describe("HostHeader", () => {
         hostMdmEnrollmentStatus={null}
       />
     );
-    expect(screen.queryByText("Wipe pending")).not.toBeInTheDocument();
+    expect(screen.getByText("Wipe pending")).toBeInTheDocument();
 
     rerender(
       <HostHeader
@@ -173,7 +173,7 @@ describe("HostHeader", () => {
         hostMdmEnrollmentStatus={null}
       />
     );
-    expect(screen.queryByText("Wiped")).not.toBeInTheDocument();
+    expect(screen.getByText("Wiped")).toBeInTheDocument();
   });
 
   it("renders 'Lock pending' and 'Wiped' badges for Android hosts", () => {

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import classnames from "classnames";
 
-import { isAndroid, isIPadOrIPhone, isLinuxLike } from "interfaces/platform";
+import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
@@ -159,12 +159,6 @@ const HostHeader = ({
 
   const renderDeviceStatusTag = () => {
     if (!hostMdmDeviceStatus || hostMdmDeviceStatus === "unlocked") return null;
-    if (
-      isLinuxLike(platform) &&
-      (hostMdmDeviceStatus === "wiping" || hostMdmDeviceStatus === "wiped")
-    )
-      return null;
-
     const tag = DEVICE_STATUS_TAGS[hostMdmDeviceStatus];
 
     const title = tag.title;


### PR DESCRIPTION
**Related issue:** N/A

Restores the "Wipe pending" and "Wiped" status badges for Linux hosts on the host details page.

These badges were requested to be hidden as part of work on #43116 and later requested to be re instated after review. 

Manually tested by triggering a wipe on a Linux host and confirming the badge appears correctly.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linux hosts now correctly display device wipe status in the host details view. Wipe status indicators such as "Wipe pending" and "Wiped" now appear consistently across all platforms. Previously, this information was not visible for Linux hosts, resulting in incomplete status visibility during device operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->