### PR TITLE
Fix root URL 404 in subpath deployments

### DIFF
--- a/changes/46640-fix-root-url-404-subpath-deployments
+++ b/changes/46640-fix-root-url-404-subpath-deployments
@@ -1,0 +1,1 @@
+* Fixed a bug where navigating to the Fleet root URL returned a 404 in subpath deployments.

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -170,7 +170,7 @@ const routes = (
         <Route path="email/change/:token" component={EmailTokenRedirect} />
         <Route path="logout" component={LogoutPage} />
         <Route component={CoreLayout}>
-          <IndexRedirect to="/dashboard" />
+          <IndexRedirect to="dashboard" />
           <Route path="dashboard" component={DashboardPage}>
             <Route path="linux" component={DashboardPage} />
             <Route path="mac" component={DashboardPage} />


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #46640

The root IndexRedirect used an absolute path ("/dashboard"), causing React Router to push /dashboard to history regardless of the URL prefix. This made the app fall through to the 404 route when Fleet was deployed at a subpath (FLEET_SERVER_URL_PREFIX). Removing the leading slash lets React Router resolve the redirect relative to the mounted route.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where accessing the Fleet root URL returned a 404 error when deployed under a subpath. The application now properly handles redirects in subpath deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fleetdm/fleet/pull/46713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->