### PR TITLE
Fix logout/login redirects in subpath deployments

### DIFF
--- a/changes/46639-login-logout-redirects-ignore-url-prefix
+++ b/changes/46639-login-logout-redirects-ignore-url-prefix
@@ -1,0 +1,1 @@
+* Fixed logout/login redirects to respect the URL prefix in subpath deployments.

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "react-query";
 import { ErrorBoundary } from "react-error-boundary";
 import { isBefore } from "date-fns";
 
+import PATHS from "router/paths";
 import page_titles from "router/page_titles";
 import TableProvider from "context/table";
 import QueryProvider from "context/query";
@@ -210,7 +211,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
       // if this is not the device user page,
       // redirect to login
       if (!location?.pathname.includes("/device/")) {
-        window.location.href = "/login";
+        window.location.href = PATHS.LOGIN;
       }
     }
     return true;

--- a/frontend/pages/LogoutPage/LogoutPage.tsx
+++ b/frontend/pages/LogoutPage/LogoutPage.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from "react";
 import { InjectedRouter } from "react-router";
 
+import PATHS from "router/paths";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import sessionsAPI from "services/entities/sessions";
@@ -22,7 +23,7 @@ const LogoutPage = ({ router }: ILogoutPageProps) => {
         setTimeout(() => {
           window.location.href = isSandboxMode
             ? "https://www.fleetdm.com/logout"
-            : "/";
+            : PATHS.ROOT;
         }, 500);
       } catch (response) {
         console.error(response);

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
@@ -150,7 +150,7 @@ const UsersPage = ({ location, router }: ITeamSubnavProps): JSX.Element => {
         );
         // If user removes self from team, redirect to home
         if (currentUser && currentUser.id === removedUsers.users[0].id) {
-          window.location.href = "/";
+          window.location.href = PATHS.ROOT;
         }
       })
       .catch(() =>
@@ -319,7 +319,7 @@ const UsersPage = ({ location, router }: ITeamSubnavProps): JSX.Element => {
                 (thisTeam) => thisTeam.id === teamIdForApi
               );
               if (selectedTeam && selectedTeam[0].role !== "admin") {
-                window.location.href = "/";
+                window.location.href = PATHS.ROOT;
               }
             } else {
               refetchUsers();

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTable.tsx
@@ -218,7 +218,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
         if (isResettingCurrentUser) {
           authToken.remove();
           setTimeout(() => {
-            window.location.href = "/";
+            window.location.href = PATHS.ROOT;
           }, 500);
           return;
         }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #46639

Hard-coded "/" and "/login" strings bypassed the URL prefix when Fleet is deployed behind a reverse proxy at a subpath. Replaced with PATHS.ROOT / PATHS.LOGIN, which embed URL_PREFIX, so redirects now land at the correct subpath.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login, logout, and user navigation redirects to properly respect the configured URL prefix when the application is deployed under a subpath.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->