### PR TITLE
Linux wipe copy updates

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
@@ -74,7 +74,7 @@ const WipeModal = ({
         {isLinuxHost && (
           <>
             <p>
-              This wil run a script to erase content from this host.{" "}
+              This will run a script to erase content from this host.{" "}
               <CustomLink
                 url="https://fleetdm.com/learn-more-about/linux-wipe"
                 text="Learn more"

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
@@ -53,7 +53,7 @@ const WipeModal = ({
         "error",
         isAndroidHost
           ? errorReason ||
-          "Couldn't send request to wipe this host. Please try again."
+              "Couldn't send request to wipe this host. Please try again."
           : errorReason
       );
     }
@@ -78,11 +78,10 @@ const WipeModal = ({
               <CustomLink
                 url="https://fleetdm.com/learn-more-about/linux-wipe"
                 text="Learn more"
-                newTab />{" "}
+                newTab
+              />{" "}
             </p>
-            <p>
-              To use the host again, you will have to do an OS reinstall.
-            </p>
+            <p>To use the host again, you will have to do an OS reinstall.</p>
           </>
         )}
         <div className={`${baseClass}__confirm-message`}>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
@@ -53,7 +53,7 @@ const WipeModal = ({
         "error",
         isAndroidHost
           ? errorReason ||
-              "Couldn't send request to wipe this host. Please try again."
+          "Couldn't send request to wipe this host. Please try again."
           : errorReason
       );
     }
@@ -72,17 +72,18 @@ const WipeModal = ({
           </p>
         )}
         {isLinuxHost && (
-          <p>
-            <b>Important!</b> Ensure you have read our{" "}
-            <CustomLink
-              url="https://fleetdm.com/guides/lock-wipe-hosts"
-              text="guide"
-              newTab
-            />{" "}
-            on what data is attempted to be erased and consider the consequences
-            of our script for your specific Linux host&apos;s setup before
-            wiping.
-          </p>
+          <>
+            <p>
+              This wil run a script to erase content from this host.{" "}
+              <CustomLink
+                url="https://fleetdm.com/learn-more-about/linux-wipe"
+                text="Learn more"
+                newTab />{" "}
+            </p>
+            <p>
+              To use the host again, you will have to do an OS reinstall.
+            </p>
+          </>
         )}
         <div className={`${baseClass}__confirm-message`}>
           <span>

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/FailedWipeActivityItem/FailedWipeActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/FailedWipeActivityItem/FailedWipeActivityItem.tsx
@@ -18,22 +18,6 @@ const FailedWipeActivityItem = ({
       hideShowDetails
     >
       Wipe failed on this host.
-      {activity.details?.host_platform === "linux" && (
-        <>
-          {" "}
-          <CustomLink
-            url="https://fleetdm.com/guides/lock-wipe-hosts"
-            text="Learn more"
-            newTab
-          />{" "}
-          Expecting it to work differently?{" "}
-          <CustomLink
-            url="https://github.com/fleetdm/fleet/issues/new?assignees=&labels=idea&template=feature-request.md&title="
-            text="File a feature request"
-            newTab
-          />
-        </>
-      )}
     </ActivityItem>
   );
 };

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipeHostActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipeHostActivityItem.tests.tsx
@@ -38,5 +38,4 @@ describe("WipeHostActivityItem", () => {
 
     expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
   });
-
 });

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipeHostActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipeHostActivityItem.tests.tsx
@@ -39,41 +39,4 @@ describe("WipeHostActivityItem", () => {
     expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
   });
 
-  it("renders guide and feature request links for Linux hosts", () => {
-    render(
-      <WipeHostActivityItem
-        activity={createMockHostPastActivity({
-          actor_full_name: "Test User",
-          details: { host_platform: "linux" },
-        })}
-        tab="past"
-      />
-    );
-
-    expect(
-      screen.getByRole("link", { name: /learn more/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /file a feature request/i })
-    ).toBeInTheDocument();
-  });
-
-  it("does not render guide and feature request links for non-Linux hosts", () => {
-    render(
-      <WipeHostActivityItem
-        activity={createMockHostPastActivity({
-          actor_full_name: "Test User",
-          details: { host_platform: "darwin" },
-        })}
-        tab="past"
-      />
-    );
-
-    expect(
-      screen.queryByRole("link", { name: /learn more/i })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: /file a feature request/i })
-    ).not.toBeInTheDocument();
-  });
 });

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipedHostActivityItem.tsx
@@ -18,22 +18,6 @@ const WipedHostActivityItem = ({
       hideShowDetails
     >
       <b>{activity.actor_full_name}</b> wiped this host.
-      {activity.details?.host_platform === "linux" && (
-        <>
-          {" "}
-          <CustomLink
-            url="https://fleetdm.com/guides/lock-wipe-hosts"
-            text="Learn more"
-            newTab
-          />{" "}
-          Expecting it to work differently?{" "}
-          <CustomLink
-            url="https://github.com/fleetdm/fleet/issues/new?assignees=&labels=idea&template=feature-request.md&title="
-            text="File a feature request"
-            newTab
-          />
-        </>
-      )}
     </ActivityItem>
   );
 };

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/WipedHostActivityItem/WipedHostActivityItem.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import ActivityItem from "components/ActivityItem";
-import CustomLink from "components/CustomLink";
 
 import { IHostActivityItemComponentProps } from "../../ActivityConfig";
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1216,7 +1216,7 @@ module.exports.routes = {
   'GET /announcements/consolidate-multiple-tools-with-fleet': '/case-study/stripe',
   'GET /announcements/foursquare-quickly-migrates-to-fleet': '/case-study/foursquare',
 
-  'GET /downloads' : '/download',
+  'GET /downloads': '/download',
   'GET /deals': '/partners#deals',
 
   // Shortlinks for texting friends, radio ads, etc
@@ -1364,6 +1364,7 @@ module.exports.routes = {
   'GET /learn-more-about/fleet-variables': '/guides/fleet-variables',
   'GET /learn-more-about/fleets': '/guides/fleets',
   'GET /learn-more-about/vulnerability-exposure-cves': 'https://github.com/fleetdm/fleet/blob/1ea1fddfd62f66fd14de65cbeceb4f7a9d0167ec/server/chart/internal/mysql/charts.go#L111-L138',
+  'GET /learn-more-about/linux-wipe': '/guides/lock-wipe-hosts#linux-wipe-behavior',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
Follow up PR for the following bug:
- https://github.com/fleetdm/fleet/issues/43116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified Linux wipe messaging: added a “This will run a script…” note with a learn-more link and a warning that the host will require an OS reinstall; simplified activity messages to show only essential wipe status.
* **Documentation**
  * Added a convenience redirect to the Linux wipe guide.
* **Tests**
  * Removed tests asserting now-removed Linux-specific links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->