### PR TITLE
Fleet UI: Script action buttons now keyboard accessible

### DIFF
--- a/changes/46591-script-actions-keyboard
+++ b/changes/46591-script-actions-keyboard
@@ -1,0 +1,1 @@
+- Fixed Scripts library action buttons (edit, download, delete) being unreachable via keyboard navigation, and added accessible labels so screen readers can distinguish them.

--- a/frontend/components/ListItem/_styles.scss
+++ b/frontend/components/ListItem/_styles.scss
@@ -28,5 +28,6 @@
     display: flex;
     justify-content: flex-end;
     gap: $pad-xsmall; // Padding on buttons
+    min-width: max-content; // Prevent wrapping on low screen widths
   }
 }

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.stories.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.stories.tsx
@@ -25,7 +25,35 @@ export default meta;
 
 type Story = StoryObj<typeof TooltipTruncatedText>;
 
-export const Default: Story = {};
+// Drag the `containerWidth` control in the Storybook addons panel to resize the
+// container. The tooltip should only appear when the container is narrow enough
+// that the text actually overflows.
+export const Default: StoryObj<
+  React.ComponentProps<typeof TooltipTruncatedText> & { containerWidth: number }
+> = {
+  args: {
+    containerWidth: 200,
+    value: "Resize the container to show tooltip only shows on truncation",
+  },
+  argTypes: {
+    containerWidth: {
+      control: { type: "range", min: 50, max: 900, step: 10 },
+      description:
+        "Width of the wrapping container in px. Tooltip only shows when the text is truncated.",
+    },
+  },
+  render: ({ containerWidth, ...args }) => (
+    <div
+      style={{
+        width: containerWidth,
+        padding: "8px",
+        border: "1px dashed #c5c7d1",
+      }}
+    >
+      <TooltipTruncatedText {...args} />
+    </div>
+  ),
+};
 
 export const UsedInsideDataSet: Story = {
   decorators: [
@@ -36,24 +64,6 @@ export const UsedInsideDataSet: Story = {
         value={<Story />}
         orientation="horizontal"
       />
-    ),
-  ],
-};
-
-// Demonstrates fixedPositionStrategy: use this when the truncated text lives
-// inside an `overflow: hidden` ancestor. With the default `absolute`
-// positioning, the tooltip can be misplaced or clipped; with
-// `fixedPositionStrategy`, it positions relative to the viewport and renders
-// reliably.
-export const FixedPositioningInsideOverflowHidden: Story = {
-  args: { fixedPositionStrategy: true },
-  decorators: [
-    (Story) => (
-      <div style={{ maxWidth: "300px", overflow: "hidden", padding: "16px" }}>
-        <div style={{ maxWidth: "200px", overflow: "hidden" }}>
-          <Story />
-        </div>
-      </div>
     ),
   ],
 };

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.stories.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.stories.tsx
@@ -39,3 +39,21 @@ export const UsedInsideDataSet: Story = {
     ),
   ],
 };
+
+// Demonstrates fixedPositionStrategy: use this when the truncated text lives
+// inside an `overflow: hidden` ancestor. With the default `absolute`
+// positioning, the tooltip can be misplaced or clipped; with
+// `fixedPositionStrategy`, it positions relative to the viewport and renders
+// reliably.
+export const FixedPositioningInsideOverflowHidden: Story = {
+  args: { fixedPositionStrategy: true },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: "300px", overflow: "hidden", padding: "16px" }}>
+        <div style={{ maxWidth: "200px", overflow: "hidden" }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
+import TooltipWrapper from "components/TooltipWrapper";
+import { useCheckTruncatedElement } from "hooks/useCheckTruncatedElement";
 import TooltipTruncatedText from "./TooltipTruncatedText";
 
 // Mock TooltipWrapper so we can spy on the props TooltipTruncatedText forwards.
 // We don't care about TooltipWrapper's internal behavior here — only that
 // pass-through props (notably fixedPositionStrategy, disableTooltip, and
 // tipContent) reach it correctly.
-jest.mock("components/TooltipWrapper", () => {
-  const mock = jest.fn(({ children }) => <div>{children}</div>);
-  return { __esModule: true, default: mock };
-});
+jest.mock("components/TooltipWrapper", () => ({
+  __esModule: true,
+  default: jest.fn(({ children }) => <div>{children}</div>),
+}));
 
 // Mock useCheckTruncatedElement so we can control isTruncated in tests.
 // In jsdom there's no layout computation, so the real hook always returns
@@ -19,21 +21,19 @@ jest.mock("hooks/useCheckTruncatedElement", () => ({
   useCheckTruncatedElement: jest.fn(),
 }));
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-const TooltipWrapper = require("components/TooltipWrapper").default as jest.Mock;
-const { useCheckTruncatedElement } = require("hooks/useCheckTruncatedElement");
-/* eslint-enable @typescript-eslint/no-var-requires */
+const mockedTooltipWrapper = (TooltipWrapper as unknown) as jest.Mock;
+const mockedUseCheckTruncatedElement = useCheckTruncatedElement as jest.Mock;
 
 describe("TooltipTruncatedText", () => {
   beforeEach(() => {
-    TooltipWrapper.mockClear();
-    (useCheckTruncatedElement as jest.Mock).mockReturnValue(false);
+    mockedTooltipWrapper.mockClear();
+    mockedUseCheckTruncatedElement.mockReturnValue(false);
   });
 
   it("forwards fixedPositionStrategy=true to TooltipWrapper when set", () => {
     render(<TooltipTruncatedText value="example" fixedPositionStrategy />);
 
-    expect(TooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
       expect.objectContaining({ fixedPositionStrategy: true }),
       expect.anything()
     );
@@ -42,29 +42,31 @@ describe("TooltipTruncatedText", () => {
   it("defaults fixedPositionStrategy to false when not provided", () => {
     render(<TooltipTruncatedText value="example" />);
 
-    expect(TooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
       expect.objectContaining({ fixedPositionStrategy: false }),
       expect.anything()
     );
   });
 
   it("disables the tooltip when text is not truncated", () => {
-    (useCheckTruncatedElement as jest.Mock).mockReturnValue(false);
+    mockedUseCheckTruncatedElement.mockReturnValue(false);
 
     render(<TooltipTruncatedText value="short" />);
 
-    expect(TooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
       expect.objectContaining({ disableTooltip: true }),
       expect.anything()
     );
   });
 
   it("enables the tooltip when text is truncated", () => {
-    (useCheckTruncatedElement as jest.Mock).mockReturnValue(true);
+    mockedUseCheckTruncatedElement.mockReturnValue(true);
 
-    render(<TooltipTruncatedText value="a very long value that gets truncated" />);
+    render(
+      <TooltipTruncatedText value="a very long value that gets truncated" />
+    );
 
-    expect(TooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
       expect.objectContaining({ disableTooltip: false }),
       expect.anything()
     );
@@ -73,7 +75,7 @@ describe("TooltipTruncatedText", () => {
   it("uses value as the tip content when tooltip prop is not provided", () => {
     render(<TooltipTruncatedText value="just-the-value" />);
 
-    expect(TooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
       expect.objectContaining({ tipContent: "just-the-value" }),
       expect.anything()
     );
@@ -81,10 +83,13 @@ describe("TooltipTruncatedText", () => {
 
   it("uses tooltip prop as the tip content when provided, overriding value", () => {
     render(
-      <TooltipTruncatedText value="display-value" tooltip="custom-tip-content" />
+      <TooltipTruncatedText
+        value="display-value"
+        tooltip="custom-tip-content"
+      />
     );
 
-    expect(TooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
       expect.objectContaining({ tipContent: "custom-tip-content" }),
       expect.anything()
     );

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
@@ -33,7 +33,7 @@ describe("TooltipTruncatedText", () => {
   it("forwards fixedPositionStrategy=true to TooltipWrapper when set", () => {
     render(<TooltipTruncatedText value="example" fixedPositionStrategy />);
 
-    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper.mock.calls[0][0]).toEqual(
       expect.objectContaining({ fixedPositionStrategy: true })
     );
   });
@@ -41,7 +41,7 @@ describe("TooltipTruncatedText", () => {
   it("defaults fixedPositionStrategy to false when not provided", () => {
     render(<TooltipTruncatedText value="example" />);
 
-    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper.mock.calls[0][0]).toEqual(
       expect.objectContaining({ fixedPositionStrategy: false })
     );
   });
@@ -51,7 +51,7 @@ describe("TooltipTruncatedText", () => {
 
     render(<TooltipTruncatedText value="short" />);
 
-    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper.mock.calls[0][0]).toEqual(
       expect.objectContaining({ disableTooltip: true })
     );
   });
@@ -63,7 +63,7 @@ describe("TooltipTruncatedText", () => {
       <TooltipTruncatedText value="a very long value that gets truncated" />
     );
 
-    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper.mock.calls[0][0]).toEqual(
       expect.objectContaining({ disableTooltip: false })
     );
   });
@@ -71,7 +71,7 @@ describe("TooltipTruncatedText", () => {
   it("uses value as the tip content when tooltip prop is not provided", () => {
     render(<TooltipTruncatedText value="just-the-value" />);
 
-    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper.mock.calls[0][0]).toEqual(
       expect.objectContaining({ tipContent: "just-the-value" })
     );
   });
@@ -84,7 +84,7 @@ describe("TooltipTruncatedText", () => {
       />
     );
 
-    expect(mockedTooltipWrapper).toHaveBeenCalledWith(
+    expect(mockedTooltipWrapper.mock.calls[0][0]).toEqual(
       expect.objectContaining({ tipContent: "custom-tip-content" })
     );
   });

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
@@ -34,8 +34,7 @@ describe("TooltipTruncatedText", () => {
     render(<TooltipTruncatedText value="example" fixedPositionStrategy />);
 
     expect(mockedTooltipWrapper).toHaveBeenCalledWith(
-      expect.objectContaining({ fixedPositionStrategy: true }),
-      expect.anything()
+      expect.objectContaining({ fixedPositionStrategy: true })
     );
   });
 
@@ -43,8 +42,7 @@ describe("TooltipTruncatedText", () => {
     render(<TooltipTruncatedText value="example" />);
 
     expect(mockedTooltipWrapper).toHaveBeenCalledWith(
-      expect.objectContaining({ fixedPositionStrategy: false }),
-      expect.anything()
+      expect.objectContaining({ fixedPositionStrategy: false })
     );
   });
 
@@ -54,8 +52,7 @@ describe("TooltipTruncatedText", () => {
     render(<TooltipTruncatedText value="short" />);
 
     expect(mockedTooltipWrapper).toHaveBeenCalledWith(
-      expect.objectContaining({ disableTooltip: true }),
-      expect.anything()
+      expect.objectContaining({ disableTooltip: true })
     );
   });
 
@@ -67,8 +64,7 @@ describe("TooltipTruncatedText", () => {
     );
 
     expect(mockedTooltipWrapper).toHaveBeenCalledWith(
-      expect.objectContaining({ disableTooltip: false }),
-      expect.anything()
+      expect.objectContaining({ disableTooltip: false })
     );
   });
 
@@ -76,8 +72,7 @@ describe("TooltipTruncatedText", () => {
     render(<TooltipTruncatedText value="just-the-value" />);
 
     expect(mockedTooltipWrapper).toHaveBeenCalledWith(
-      expect.objectContaining({ tipContent: "just-the-value" }),
-      expect.anything()
+      expect.objectContaining({ tipContent: "just-the-value" })
     );
   });
 
@@ -90,8 +85,7 @@ describe("TooltipTruncatedText", () => {
     );
 
     expect(mockedTooltipWrapper).toHaveBeenCalledWith(
-      expect.objectContaining({ tipContent: "custom-tip-content" }),
-      expect.anything()
+      expect.objectContaining({ tipContent: "custom-tip-content" })
     );
   });
 });

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tests.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import TooltipTruncatedText from "./TooltipTruncatedText";
+
+// Mock TooltipWrapper so we can spy on the props TooltipTruncatedText forwards.
+// We don't care about TooltipWrapper's internal behavior here — only that
+// pass-through props (notably fixedPositionStrategy, disableTooltip, and
+// tipContent) reach it correctly.
+jest.mock("components/TooltipWrapper", () => {
+  const mock = jest.fn(({ children }) => <div>{children}</div>);
+  return { __esModule: true, default: mock };
+});
+
+// Mock useCheckTruncatedElement so we can control isTruncated in tests.
+// In jsdom there's no layout computation, so the real hook always returns
+// false — mocking lets us assert the disableTooltip wiring in both states.
+jest.mock("hooks/useCheckTruncatedElement", () => ({
+  useCheckTruncatedElement: jest.fn(),
+}));
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const TooltipWrapper = require("components/TooltipWrapper").default as jest.Mock;
+const { useCheckTruncatedElement } = require("hooks/useCheckTruncatedElement");
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+describe("TooltipTruncatedText", () => {
+  beforeEach(() => {
+    TooltipWrapper.mockClear();
+    (useCheckTruncatedElement as jest.Mock).mockReturnValue(false);
+  });
+
+  it("forwards fixedPositionStrategy=true to TooltipWrapper when set", () => {
+    render(<TooltipTruncatedText value="example" fixedPositionStrategy />);
+
+    expect(TooltipWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({ fixedPositionStrategy: true }),
+      expect.anything()
+    );
+  });
+
+  it("defaults fixedPositionStrategy to false when not provided", () => {
+    render(<TooltipTruncatedText value="example" />);
+
+    expect(TooltipWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({ fixedPositionStrategy: false }),
+      expect.anything()
+    );
+  });
+
+  it("disables the tooltip when text is not truncated", () => {
+    (useCheckTruncatedElement as jest.Mock).mockReturnValue(false);
+
+    render(<TooltipTruncatedText value="short" />);
+
+    expect(TooltipWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({ disableTooltip: true }),
+      expect.anything()
+    );
+  });
+
+  it("enables the tooltip when text is truncated", () => {
+    (useCheckTruncatedElement as jest.Mock).mockReturnValue(true);
+
+    render(<TooltipTruncatedText value="a very long value that gets truncated" />);
+
+    expect(TooltipWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({ disableTooltip: false }),
+      expect.anything()
+    );
+  });
+
+  it("uses value as the tip content when tooltip prop is not provided", () => {
+    render(<TooltipTruncatedText value="just-the-value" />);
+
+    expect(TooltipWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({ tipContent: "just-the-value" }),
+      expect.anything()
+    );
+  });
+
+  it("uses tooltip prop as the tip content when provided, overriding value", () => {
+    render(
+      <TooltipTruncatedText value="display-value" tooltip="custom-tip-content" />
+    );
+
+    expect(TooltipWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({ tipContent: "custom-tip-content" }),
+      expect.anything()
+    );
+  });
+});

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
@@ -12,6 +12,10 @@ interface ITooltipTruncatedTextCellProps {
   className?: string;
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   isMobileView?: boolean;
+  /** Pass-through to TooltipWrapper. Set to `true` when the truncated text
+   * lives inside an `overflow: hidden` ancestor — the default `absolute`
+   * positioning can misplace the tooltip in that case. */
+  fixedPositionStrategy?: boolean;
 }
 
 const baseClass = "tooltip-truncated-text";
@@ -22,6 +26,7 @@ const TooltipTruncatedText = ({
   className,
   tooltipPosition = "top",
   isMobileView = false,
+  fixedPositionStrategy = false,
 }: ITooltipTruncatedTextCellProps): JSX.Element => {
   const classNames = classnames(baseClass, className);
 
@@ -39,6 +44,7 @@ const TooltipTruncatedText = ({
       showArrow
       tipContent={tooltip ?? value}
       isMobileView={isMobileView}
+      fixedPositionStrategy={fixedPositionStrategy}
     >
       <div className={`${baseClass}__text-value`} ref={ref}>
         {value}

--- a/frontend/pages/ManageControlsPage/Scripts/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Scripts/_styles.scss
@@ -8,7 +8,15 @@
 
   .list-item {
     &__actions {
-      display: none;
+      // opacity/pointer-events (not display:none) so action buttons stay in
+      // the tab order in both directions. display:none would remove them from
+      // layout and tab order, breaking Shift+Tab reversal.
+      display: flex;
+      justify-content: flex-end;
+      gap: $pad-medium;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease-in-out;
     }
   }
   .upload-list__list-item {
@@ -16,15 +24,16 @@
     padding: 0;
     .script-list-item {
       padding: 1rem 1.5rem;
-      &:hover {
-        // currently this behavior has only been specified for Script list items
+      &:hover,
+      &:focus-within {
         background-color: $ui-off-white;
-        cursor: pointer;
         .list-item__actions {
-          display: flex;
-          justify-content: flex-end;
-          gap: $pad-medium;
+          opacity: 1;
+          pointer-events: auto;
         }
+      }
+      &:hover {
+        cursor: pointer;
       }
     }
   }

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
@@ -61,6 +61,27 @@ describe("ScriptListItem", () => {
     expect(screen.getByText(/Windows/)).toBeInTheDocument();
   });
 
+  it("labels each action button with the script name for screen readers", () => {
+    render(
+      <ScriptListItem
+        script={MAC_SCRIPT}
+        onDelete={onDelete}
+        onEdit={onEdit}
+        onClickScript={onClickScript}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: `Edit ${MAC_SCRIPT.name}` })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Download ${MAC_SCRIPT.name}` })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Delete ${MAC_SCRIPT.name}` })
+    ).toBeInTheDocument();
+  });
+
   it("calls onClickScript when script name is clicked", async () => {
     const { user } = renderWithSetup(
       <ScriptListItem

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
@@ -107,6 +107,7 @@ const ScriptListItem = ({
             onClick={onClickEdit}
             className={`${baseClass}__action-button`}
             variant="icon"
+            ariaLabel={`Edit ${script.name}`}
           >
             <Icon name="pencil" />
           </Button>
@@ -116,6 +117,7 @@ const ScriptListItem = ({
         className={`${baseClass}__action-button`}
         variant="icon"
         onClick={onClickDownload}
+        ariaLabel={`Download ${script.name}`}
       >
         <Icon name="download" />
       </Button>
@@ -126,6 +128,7 @@ const ScriptListItem = ({
             onClick={onClickDelete}
             className={`${baseClass}__action-button`}
             variant="icon"
+            ariaLabel={`Delete ${script.name}`}
           >
             <Icon name="trash" />
           </Button>

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
@@ -12,6 +12,7 @@ import ListItem from "components/ListItem";
 import { ISupportedGraphicNames } from "components/ListItem/ListItem";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 const baseClass = "script-list-item";
 
@@ -141,7 +142,11 @@ const ScriptListItem = ({
     <ListItem
       className={baseClass}
       graphic={graphicName}
-      title={<Button variant="link">{script.name}</Button>}
+      title={
+        <Button variant="link" className={`${baseClass}__title-button`}>
+          <TooltipTruncatedText value={script.name} fixedPositionStrategy />
+        </Button>
+      }
       details={
         <ScriptListItemDetails
           platform={platform}

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/_styles.scss
@@ -7,6 +7,36 @@
     overflow: hidden;
   }
 
+  // Constrain the title slot so TooltipTruncatedText can engage its ellipsis
+  // when script names are long. min-width: 0 on the flex children is required
+  // because flex items default to min-width: auto, which refuses to shrink
+  // below content width — without it, __info inherits the long name's width
+  // and bleeds past __main-content's max-width.
+  .list-item__info {
+    min-width: 0;
+  }
+  .list-item__title {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  &__title-button {
+    max-width: 100%;
+    // children-wrapper is a flex item of the inline-flex Button and needs
+    // min-width: 0 to actually shrink to the parent's max-width. Without it,
+    // overflow: hidden on children-wrapper just visually clips while the
+    // computed width still tracks the content — meaning TooltipTruncatedText's
+    // ref'd __text-value div sees clientWidth == scrollWidth, so
+    // useCheckTruncatedElement returns false and the tooltip never enables.
+    .children-wrapper {
+      max-width: 100%;
+      min-width: 0;
+      overflow: hidden;
+    }
+  }
+
   &__action-button {
     width: 40px;
     height: 40px;


### PR DESCRIPTION
## Issue
Closes #46591 

## Description
- Script action buttons are now keyboard accessible
- Also fixed long script names from jumping around and followed pattern of truncation with tooltip used in other long fields in the UI
- Kept buttons from wrapping onto multiple lines

> Note: I filed another bug to address the larger awkwardness of the list item UI https://github.com/fleetdm/fleet/issues/46699

## Screenrecording

<img width="551" height="421" alt="Screenshot 2026-06-03 at 10 19 48 AM" src="https://github.com/user-attachments/assets/b27853ea-3d73-494c-8647-e8d27cd626b8" />

- Sorry haven't had my coffee so not greatly communicated

This is the before:

https://github.com/user-attachments/assets/d1152229-003b-4e93-b931-03a84b0f842a


This is the after:

https://fleetdm.zoom.us/clips/share/gFo9zkubRZC27oveZ_z-0Q

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored keyboard focus/navigation for script action buttons and prevented action-area wrapping on narrow screens.

* **Accessibility**
  * Added descriptive screen-reader labels to action buttons and a prop to improve tooltip positioning when needed.

* **UI / Style**
  * Kept action controls keyboard-focusable and enabled proper text truncation with ellipsis.

* **Tests**
  * Added tests for accessible labels, keyboard focus, and tooltip/truncation behaviors.

* **Documentation**
  * Enhanced Storybook story to demo truncation/tooltip with an adjustable container width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->