### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/8x8-work/darwin.json
+++ b/ee/maintained-apps/outputs/8x8-work/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.33.2",
+      "version": "8.34.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.8x8---virtual-office';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.8x8---virtual-office' AND version_compare(bundle_short_version, '8.33.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.8x8---virtual-office' AND version_compare(bundle_short_version, '8.34.1') < 0);"
       },
-      "installer_url": "https://work-desktop-assets.8x8.com/prod-publish/ga/work-arm64-dmg-v8.33.2-2.dmg",
+      "installer_url": "https://work-desktop-assets.8x8.com/prod-publish/ga/work-arm64-dmg-v8.34.1-11.dmg",
       "install_script_ref": "9a372acc",
       "uninstall_script_ref": "6eb42abf",
-      "sha256": "c9eaf3b9017a44864e4ed89d7b4f55e49ffe5b979401d1a425c03fb2d8f414bb",
+      "sha256": "3f26bf3a07e83c0e8e0b303c66f1440dac8d902c78d846c8b7a50073f0485077",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated 8x8 Virtual Office macOS application metadata from version 8.33.2 to 8.34.1, including updated installer package and verification checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->