### PR TITLE
Fleet UI: Wrap element in div to avoid flex gap

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -146,7 +146,12 @@ $shadow-transition-width: 16px;
           min-width: max-content;
           font-weight: $bold;
 
-          span {
+          // Targets only HeaderCell's wrapper span (direct child of
+          // `.header-cell`), not arbitrary descendant spans. Previously
+          // `.column-header span` matched every descendant, leaking
+          // `display: flex` onto nested suffix/decoration spans like
+          // `.resolved-suffix` and turning them block-level.
+          .header-cell > span {
             display: flex;
             align-items: center;
             gap: $gap-icon-text;

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
@@ -64,11 +64,12 @@ const generateColumnConfigs = (
       Header: () => (
         <HeaderCell
           value={
-            // Wrap in a single element to avoid flex gap before "version"
-            // from `.column-header span` in DataTable/_styles.scss
-            <div>
-              Resolved in <div className="resolved-suffix">version</div>
-            </div>
+            // Wrapper span groups "Resolved in" and the suffix into a
+            // single flex item under HeaderCell's wrapper span — keeps
+            // them on one line without a flex gap appearing between them.
+            <span>
+              Resolved in <span className="resolved-suffix">version</span>
+            </span>
           }
           disableSortBy
         />

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
@@ -64,9 +64,11 @@ const generateColumnConfigs = (
       Header: () => (
         <HeaderCell
           value={
-            <>
+            // Wrap in a single element to avoid flex gap before "version"
+            // from `.column-header span` in DataTable/_styles.scss
+            <div>
               Resolved in <div className="resolved-suffix">version</div>
-            </>
+            </div>
           }
           disableSortBy
         />

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
@@ -65,11 +65,12 @@ const generateColumnConfigs = (
       Header: () => (
         <HeaderCell
           value={
-            // Wrap in a single element to avoid flex gap before "version"
-            // from `.column-header span` in DataTable/_styles.scss
-            <div>
-              Resolved in <div className="resolved-suffix">version</div>
-            </div>
+            // Wrapper span groups "Resolved in" and the suffix into a
+            // single flex item under HeaderCell's wrapper span — keeps
+            // them on one line without a flex gap appearing between them.
+            <span>
+              Resolved in <span className="resolved-suffix">version</span>
+            </span>
           }
           disableSortBy
         />

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
@@ -65,9 +65,11 @@ const generateColumnConfigs = (
       Header: () => (
         <HeaderCell
           value={
-            <>
+            // Wrap in a single element to avoid flex gap before "version"
+            // from `.column-header span` in DataTable/_styles.scss
+            <div>
               Resolved in <div className="resolved-suffix">version</div>
-            </>
+            </div>
           }
           disableSortBy
         />


### PR DESCRIPTION
## Issue
Closes #45896

## Description
- Removes flex gap spacing before "version" in two places
- Note: version is not rendered on low widths, hence the double div required that caused this bug

## Screenshot

<img width="908" height="252" alt="Screenshot 2026-06-03 at 10 27 14 AM" src="https://github.com/user-attachments/assets/d69df012-cf41-4b9b-894d-56b85a0d450c" />
<img width="1036" height="330" alt="Screenshot 2026-06-03 at 10 27 34 AM" src="https://github.com/user-attachments/assets/32bbbf5b-0fe9-45bc-b772-a34926e54016" />



## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved table header layout on Software Vulnerability details pages: the "Resolved in" label and its suffix now render as a single unit to prevent unwanted spacing, and header styles were scoped more narrowly to avoid layout leakage into nested decorations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->