### PR TITLE
Decrease lock state cleanup time to 1 minute

### DIFF
--- a/changes/44440-lower-clean-lock-timeout
+++ b/changes/44440-lower-clean-lock-timeout
@@ -1,0 +1,1 @@
+- Reduced the Apple MDM lock state cleanup timeout from 5 minutes to 1 minute, decreasing the time a recently unlocked host may still appear as locked in Fleet.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5206,7 +5206,7 @@ WHERE id = ? AND enabled = 1 AND enrolled_from_migration = 1`
 // since unlock_ref was set before CleanAppleMDMLock will clear the lock state.
 // This prevents the trailing Idle check-in (sent by the device right after
 // acknowledging the lock command) from prematurely clearing the lock state.
-const MDMLockCleanupMinutes = 5
+const MDMLockCleanupMinutes = 1
 
 func (ds *Datastore) CleanAppleMDMLock(ctx context.Context, hostUUID string) error {
 	stmt := fmt.Sprintf(`

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -6183,7 +6183,7 @@ func testLockUnlockWipeMacOS(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	checkLockWipeState(t, status, false, true, false, false, false, false)
 
-	// backdate unlock_ref to simulate the device having been locked for more than 5 minutes
+	// backdate unlock_ref to simulate the device having been locked for more than the MDMLockCleanupMinutes
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE host_mdm_actions hma JOIN hosts h ON hma.host_id = h.id

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2545,7 +2545,7 @@ type Datastore interface {
 
 	// CleanAppleMDMLock cleans the lock status and pin for a macOS device
 	// after it has been unlocked. 	CleanAppleMDMLock will be a no-op when
-	// unlock_ref was set within the last 5 minutes, to prevent the trailing
+	// unlock_ref was set within the value configured for MDMLockCleanupMinutes, to prevent the trailing
 	// Idle (sent right after the device acknowledges the lock command)
 	// from prematurely clearing the lock state.
 	CleanAppleMDMLock(ctx context.Context, hostUUID string) error


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44440

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually
^ I verified if within 1 minute it's still locked, after 1 minute it removes the Locked state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the delay for Apple MDM unlock status updates so recently unlocked hosts are reflected as unlocked much faster (cleanup window shortened from ~5 minutes to ~1 minute), improving Fleet responsiveness and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->