### PR TITLE
Update JSON example for Create Fleet-maintained app endpoint in REST API documentation

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -12293,7 +12293,7 @@ Add the `X-Fleet-Scripts-Encoded: base64` header line to parse `install_script`,
 {
   "fleet_maintained_app_id": 3,
   "team_id": 2,
-  "ensure": "present"
+  "automatic_install": true
 }
 ```
 


### PR DESCRIPTION
Added 'automatic_install' field to JSON example.

The example for the [Create Fleet-maintained app](https://fleetdm.com/docs/rest-api/rest-api#create-fleet-maintained-app) endpoint previously showed `"ensure": "present"`, which is not a parameter listed for this endpoint. `ensure` appears to only be supported in the [Add app store app](https://fleetdm.com/docs/rest-api/rest-api#add-app-store-app) endpoint.