### PR TITLE
Fleet UI: Allow DataSet value to wrap, apply to policy 

### DIFF
--- a/changes/45227-long-policy-res
+++ b/changes/45227-long-policy-res
@@ -1,0 +1,1 @@
+* Long policy resolution text now wraps on the policy details page instead of being truncated.

--- a/frontend/components/DataSet/DataSet.stories.tsx
+++ b/frontend/components/DataSet/DataSet.stories.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import DataSet from "./DataSet";
@@ -21,4 +22,20 @@ export const HorizontalOrientation: Story = {
   args: {
     orientation: "horizontal",
   },
+};
+
+// Multiline values wrap instead of truncating with an ellipsis. Use for
+// free-form prose like "Resolve" or "Description".
+export const Multiline: Story = {
+  args: {
+    title: "Resolve",
+    value:
+      "Re-enable FileVault on the device. Open System Settings, navigate to Privacy & Security, and turn on FileVault. Store the recovery key in a safe place.",
+    multiline: true,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: "320px", padding: "16px" }}>{Story()}</div>
+    ),
+  ],
 };

--- a/frontend/components/DataSet/DataSet.tests.tsx
+++ b/frontend/components/DataSet/DataSet.tests.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import DataSet from "./DataSet";
+
+describe("DataSet", () => {
+  it("renders title and value", () => {
+    render(<DataSet title="Author" value="Alice" />);
+    expect(screen.getByText("Author")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("uses vertical orientation by default (no horizontal class, no colon)", () => {
+    const { container } = render(<DataSet title="Author" value="Alice" />);
+    expect(container.querySelector(".data-set__horizontal")).toBeNull();
+    expect(container.querySelector("dt")?.textContent).toBe("Author");
+  });
+
+  it("applies horizontal orientation class and appends a colon to the title", () => {
+    const { container } = render(
+      <DataSet title="Author" value="Alice" orientation="horizontal" />
+    );
+    expect(
+      container.querySelector(".data-set__horizontal")
+    ).toBeInTheDocument();
+    expect(container.querySelector("dt")?.textContent).toBe("Author:");
+  });
+
+  it("applies the text-only modifier when textOnly is set", () => {
+    const { container } = render(
+      <DataSet title="Author" value="Alice" textOnly />
+    );
+    expect(container.querySelector(".data-set--text-only")).toBeInTheDocument();
+  });
+
+  it("applies the multiline modifier when multiline is set", () => {
+    const { container } = render(
+      <DataSet title="Resolve" value="Long remediation text." multiline />
+    );
+    expect(container.querySelector(".data-set--multiline")).toBeInTheDocument();
+  });
+
+  it("does not apply the multiline modifier by default", () => {
+    const { container } = render(<DataSet title="Author" value="Alice" />);
+    expect(container.querySelector(".data-set--multiline")).toBeNull();
+  });
+
+  it("merges a custom className alongside the base class", () => {
+    const { container } = render(
+      <DataSet title="Author" value="Alice" className="custom-class" />
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass("data-set");
+    expect(root).toHaveClass("custom-class");
+  });
+});

--- a/frontend/components/DataSet/DataSet.tsx
+++ b/frontend/components/DataSet/DataSet.tsx
@@ -13,6 +13,12 @@ interface IDataSetProps {
    * baseline. Do NOT use when the value contains icons, buttons, or status
    * indicators that need vertical centering. */
   textOnly?: boolean;
+  /** When true, the value wraps onto multiple lines instead of truncating
+   * with an ellipsis. Use for free-form prose like "Resolve" or
+   * "Description" where the full text needs to be readable. Default behavior
+   * (single-line truncation with ellipsis) assumes the consumer wraps the
+   * value in a tooltip-on-truncate helper. */
+  multiline?: boolean;
   className?: string;
 }
 
@@ -21,11 +27,13 @@ const DataSet = ({
   value,
   orientation = "vertical",
   textOnly = false,
+  multiline = false,
   className,
 }: IDataSetProps) => {
   const classNames = classnames(baseClass, className, {
     [`${baseClass}__horizontal`]: orientation === "horizontal",
     [`${baseClass}--text-only`]: textOnly,
+    [`${baseClass}--multiline`]: multiline,
   });
 
   return (

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -27,7 +27,7 @@
     white-space: normal;
     overflow: visible;
     text-overflow: clip;
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   &__horizontal {

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -24,7 +24,7 @@
   }
 
   &--multiline dd {
-    white-space: normal;
+    white-space: pre-wrap;
     overflow: visible;
     overflow-wrap: anywhere;
   }

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -23,6 +23,13 @@
     align-items: baseline;
   }
 
+  &--multiline dd {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    word-break: break-word;
+  }
+
   &__horizontal {
     flex-direction: row;
   }

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -26,7 +26,6 @@
   &--multiline dd {
     white-space: normal;
     overflow: visible;
-    text-overflow: clip;
     overflow-wrap: anywhere;
   }
 

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -426,6 +426,7 @@ const PolicyDetailsPage = ({
                 className={`${baseClass}__resolve`}
                 title="Resolve"
                 value={lastEditedQueryResolution}
+                multiline
               />
             )}
             {renderAuthor()}


### PR DESCRIPTION
## Issue
Closes #45227

## Description
- Adds a `multiline` prop to DataSet that switches the value from single-line truncation to natural wrapping. Applies it to the Resolve field on the policy details page so multi-sentence remediation text is fully readable.

## Screenshot of fix
<img width="1409" height="622" alt="Screenshot 2026-06-03 at 10 53 56 AM" src="https://github.com/user-attachments/assets/9c6ac820-e42e-4274-b4b2-639513edbabe" />



<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Policy resolution on the details page now wraps and displays in full instead of being truncated.
* **New Feature**
  * Data display component supports a multiline mode to allow wrapped content instead of single-line truncation.
* **Tests**
  * Added unit tests covering orientation, multiline behavior, and class handling.
* **Documentation**
  * Added a Storybook example demonstrating multiline rendering.
* **Style**
  * CSS updates to enable multiline wrapping and disable truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->