### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '132.0') < 0);"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/132.0.5905.19/mac/Opera_132.0.5905.19_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/132.0.5905.22/mac/Opera_132.0.5905.22_Setup.dmg",
       "install_script_ref": "e9e947a7",
       "uninstall_script_ref": "566d9846",
-      "sha256": "e1fc083948f474efefd7f0c6468207184aeeab9f608b1fe647939efe2445e30a",
+      "sha256": "900e10d2df7f67b62131591132e598d886dd039a03061f9277ced7fb44e40010",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/windows.json
+++ b/ee/maintained-apps/outputs/prisma-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "148.18.4.217",
+      "version": "149.10.3.53",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '148.18.4.217') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '149.10.3.53') < 0);"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_148_18_4_217-148.18.4.217-57dd232e.msi",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_149_10_3_53-149.10.3.53-f52fe377.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "28ec3eda",
-      "sha256": "b31856e4f1e761b29bc5f564e0e2ad3b384514457c971af66d1e87008cfd3ed7",
+      "sha256": "7b315dab1818da0b8e6655477c22eb4716b629460b2319e858c879a53af0a6bc",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.12.15",
+      "version": "2.12.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.16') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.15/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.16/Stats.dmg",
       "install_script_ref": "de9e4d0c",
       "uninstall_script_ref": "7e8d1240",
-      "sha256": "80afcbaef90c68f95a9b9c3520c802e6bccfcded62b99bd84ce32a47177108ce",
+      "sha256": "8beab818b582d057e763c6b5537b8b8515427f942990a1a83906da92e607c29d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tor-browser/darwin.json
+++ b/ee/maintained-apps/outputs/tor-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "15.0.14",
+      "version": "15.0.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser' AND version_compare(bundle_short_version, '15.0.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser' AND version_compare(bundle_short_version, '15.0.15') < 0);"
       },
-      "installer_url": "https://www.torproject.org/dist/torbrowser/15.0.14/tor-browser-macos-15.0.14.dmg",
+      "installer_url": "https://www.torproject.org/dist/torbrowser/15.0.15/tor-browser-macos-15.0.15.dmg",
       "install_script_ref": "26872e10",
       "uninstall_script_ref": "f961039a",
-      "sha256": "78b9a4511e160d6435b1dcf7942bcf4e0696aae2079dabe39b250e7860b852e5",
+      "sha256": "a46ae3494e92795f476dfb57a2d542295408fc2c73be5ba593514b51262e1a18",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.122.1",
+      "version": "1.123.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.122.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.123.0') < 0);"
       },
-      "installer_url": "https://update.code.visualstudio.com/1.122.1/darwin-arm64/stable",
+      "installer_url": "https://update.code.visualstudio.com/1.123.0/darwin-arm64/stable",
       "install_script_ref": "e6d54100",
       "uninstall_script_ref": "c6e93467",
-      "sha256": "a1779965602fa549f9288b44391f325fd890d05a7a1335c6bb1d23bd86d9aad5",
+      "sha256": "018e96783cc6107e735d1a2c3751ffa2cc42ddee63d07b3db3662cdb17b55312",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/windows.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.122.1",
+      "version": "1.123.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation' AND version_compare(version, '1.122.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation' AND version_compare(version, '1.123.0') < 0);"
       },
-      "installer_url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/8761a5560cfd65fdd19ce7e2bd18dab5c0a4d84e/VSCodeSetup-x64-1.122.1.exe",
+      "installer_url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/6a44c352bd24569c417e530095901b649960f9f8/VSCodeSetup-x64-1.123.0.exe",
       "install_script_ref": "49122823",
       "uninstall_script_ref": "e09509e2",
-      "sha256": "0508a23a33f25ec0b3bdb0efbf270147d6a860635bd9216edb80963059c3816b",
+      "sha256": "7d08422f0d793280236460b05016831c6285ee2ec0257797dfa99981180b4bc7",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maintained application versions: Opera to 132.0, Prisma Browser to 149.10.3.53, Stats to 2.12.16, Tor Browser to 15.0.15, and Visual Studio Code to 1.123.0 with corresponding installer URLs and integrity checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->