### PR TITLE
Release fleetd v1.56.0

### DIFF
--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 * Updated orbit to rotate desktop token ("identifier" file) even if Fleet Desktop is disabled.
 
-* Improved validation around file paths in Orbit. 
+* Improved validation around file paths in Orbit.
 
 * Fixed Fleet Desktop tray icon in KDE:
-  * Fixed the tray icon appearing oversized in KDE Plasma on Linux installs when hosts have kde-plasma-desktop installed alongside another windows manager.
+  * Fixed the tray icon appearing oversized in KDE Plasma on Linux installs when hosts have kde-plasma-desktop installed alongside another window manager.
   * Used the color version of the icon on KDE to improve UX on light/dark themes.
 
 * Updated go to 1.26.3.

--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.56.0 (Jun 03, 2026)
 
-* Added the `orbit.debug_logging_on_enroll_duration` agent option to allow enabling orbit debug logging for a specified time period after enrollment
+* Added the `orbit.debug_logging_on_enroll_duration` agent option to allow enabling orbit debug logging for a specified time period after enrollment.
 
 * Fixed Fleet Desktop failing to start on openSUSE Leap 16, by dropping the `-i` (login shell) flag from the sudo invocation used to launch Fleet Desktop and key-escrow dialogs as the logged-in user.
 
@@ -8,13 +8,13 @@
 
 * Improved validation around file paths in Orbit. 
 
-* Fixed Fleet Desktop tray icon appearing oversized in KDE Plasma on Linux installs when hosts have kde-plasma-desktop installed alongside another windows manager.
+* Fixed Fleet Desktop tray icon in KDE:
+  * Fixed the tray icon appearing oversized in KDE Plasma on Linux installs when hosts have kde-plasma-desktop installed alongside another windows manager.
+  * Used the color version of the icon on KDE to improve UX on light/dark themes.
 
-* Updated go to 1.26.3
+* Updated go to 1.26.3.
 
 * Added new `adobe_plugins` osquery extension table to fleetd that detects Adobe CEP, UXP, and native plug-ins on macOS and Windows by scanning well-known directories and parsing plugin manifests for name, version, vendor, host application, and other metadata.
-
-* Use color version of icon on KDE to improve UX on light/dark themes
 
 ## 1.55.0 (May 05, 2026)
 

--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.56.0 (Jun 03, 2026)
+
+* Added the `orbit.debug_logging_on_enroll_duration` agent option to allow enabling orbit debug logging for a specified time period after enrollment
+
+* Fixed Fleet Desktop failing to start on openSUSE Leap 16, by dropping the `-i` (login shell) flag from the sudo invocation used to launch Fleet Desktop and key-escrow dialogs as the logged-in user.
+
+* Updated orbit to rotate desktop token ("identifier" file) even if Fleet Desktop is disabled.
+
+* Improved validation around file paths in Orbit. 
+
+* Fixed Fleet Desktop tray icon appearing oversized in KDE Plasma on Linux installs when hosts have kde-plasma-desktop installed alongside another windows manager.
+
+* Updated go to 1.26.3
+
+* Added new `adobe_plugins` osquery extension table to fleetd that detects Adobe CEP, UXP, and native plug-ins on macOS and Windows by scanning well-known directories and parsing plugin manifests for name, version, vendor, host application, and other metadata.
+
+* Use color version of icon on KDE to improve UX on light/dark themes
+
 ## 1.55.0 (May 05, 2026)
 
 * Updated go to 1.26.2.

--- a/orbit/changes/14263-security-improvement-go-file-handling-issue
+++ b/orbit/changes/14263-security-improvement-go-file-handling-issue
@@ -1,1 +1,0 @@
-* Improved validation around file paths in Orbit. 

--- a/orbit/changes/41108-improve-kde-icon
+++ b/orbit/changes/41108-improve-kde-icon
@@ -1,1 +1,0 @@
-- Use color version of icon on KDE to improve UX on light/dark themes

--- a/orbit/changes/43997-orbit-debug-logging-on-enroll
+++ b/orbit/changes/43997-orbit-debug-logging-on-enroll
@@ -1,1 +1,0 @@
-- Added the `orbit.debug_logging_on_enroll_duration` agent option to allow enabling orbit debug logging for a specified time period after enrollment

--- a/orbit/changes/44681-always-update-identifier
+++ b/orbit/changes/44681-always-update-identifier
@@ -1,1 +1,0 @@
-* Updated orbit to rotate desktop token ("identifier" file) even if Fleet Desktop is disabled.

--- a/orbit/changes/45206-adobe-plugins-table
+++ b/orbit/changes/45206-adobe-plugins-table
@@ -1,1 +1,0 @@
-* Added new `adobe_plugins` osquery extension table to fleetd that detects Adobe CEP, UXP, and native plug-ins on macOS and Windows by scanning well-known directories and parsing plugin manifests for name, version, vendor, host application, and other metadata.

--- a/orbit/changes/45963-use-plasmashell-for-kde-detection
+++ b/orbit/changes/45963-use-plasmashell-for-kde-detection
@@ -1,1 +1,0 @@
-- Fixed Fleet Desktop tray icon appearing oversized in KDE Plasma on Linux installs when hosts have kde-plasma-desktop installed alongside another windows manager.

--- a/orbit/changes/fleet-desktop-linux-no-login-shell
+++ b/orbit/changes/fleet-desktop-linux-no-login-shell
@@ -1,1 +1,0 @@
-* Fixed Fleet Desktop failing to start on openSUSE Leap 16, by dropping the `-i` (login shell) flag from the sudo invocation used to launch Fleet Desktop and key-escrow dialogs as the logged-in user.

--- a/orbit/changes/update-go-1.26.3
+++ b/orbit/changes/update-go-1.26.3
@@ -1,1 +1,0 @@
-* Updated go to 1.26.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file-path validation for improved handling
  * Resolved Fleet Desktop startup issues on openSUSE Leap systems
  * Updated Orbit identifier token rotation behavior

* **New Features**
  * Added Adobe plugins detection table to identify plug-ins on macOS and Windows

* **Chores**
  * Updated Go version to 1.26.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->