### PR TITLE
Fix link color on hover in light mode

### DIFF
--- a/frontend/components/CustomLink/CustomLink.tsx
+++ b/frontend/components/CustomLink/CustomLink.tsx
@@ -38,8 +38,9 @@ const CustomLink = ({
   const getIconColor = (): Colors => {
     switch (variant) {
       case "tooltip-link":
-      case "flash-message-link":
         return "core-fleet-white";
+      case "flash-message-link":
+        return "core-fleet-black";
       case "banner-link":
         return "core-fleet-black";
       default:

--- a/frontend/components/CustomLink/_styles.scss
+++ b/frontend/components/CustomLink/_styles.scss
@@ -60,9 +60,12 @@
 
   &--tooltip-link,
   &--flash-message-link {
-    font-size: inherit; // Overrides link default font size with parent tooltip font size
+    font-size: inherit; // Overrides link default font size with parent tooltip/flash font size
+  }
+
+  &--tooltip-link {
     // Use static (non-themed) colors so the underline and icon stay light on
-    // the always-dark tooltip/flash background regardless of light/dark mode.
+    // the always-dark tooltip background regardless of light/dark mode.
     background-image: linear-gradient($static-white, $static-white),
       linear-gradient(rgba($static-white, 0.4), rgba($static-white, 0.4));
 
@@ -89,9 +92,25 @@
   }
 
   &--flash-message-link {
+    // Flash message backgrounds are themed (light in light mode, dark in dark
+    // mode), so use themed colors instead of static white.
+    .external-link-icon__outline {
+      stroke: $core-fleet-black;
+    }
+
+    .external-link-icon__arrow {
+      stroke: $core-fleet-black;
+    }
+
     &:hover {
+      color: $ui-fleet-black-75-over;
+
+      .external-link-icon__outline {
+        fill: $ui-error-flash-bg;
+      }
+
       .external-link-icon__arrow {
-        stroke: $core-vibrant-red;
+        stroke: $ui-fleet-black-75-over;
       }
     }
   }

--- a/frontend/components/CustomLink/_styles.scss
+++ b/frontend/components/CustomLink/_styles.scss
@@ -92,16 +92,8 @@
   }
 
   &--flash-message-link {
-    // Flash message backgrounds are themed (light in light mode, dark in dark
-    // mode), so use themed colors instead of static white.
-    .external-link-icon__outline {
-      stroke: $core-fleet-black;
-    }
-
-    .external-link-icon__arrow {
-      stroke: $core-fleet-black;
-    }
-
+    // Override the default hover colors (white arrow stroke, dark outline fill)
+    // which assume a dark background — flash messages use a light background.
     &:hover {
       color: $ui-fleet-black-75-over;
 


### PR DESCRIPTION
For the following bug:
- https://github.com/fleetdm/fleet/issues/46739


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined styling for tooltip and flash message links
  * Enhanced visual feedback for link interactions with improved color handling on hover and focus states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->