### PR TITLE
Remove debug log statement

### DIFF
--- a/orbit/cmd/desktop/desktop_linux.go
+++ b/orbit/cmd/desktop/desktop_linux.go
@@ -41,7 +41,6 @@ func isKDE() bool {
 	}
 	uid := strconv.FormatInt(guiUser.ID, 10)
 	if err := exec.Command("pgrep", "-u", uid, "-x", "plasmashell").Run(); err != nil {
-		log.Debug().Err(err).Str("uid", uid).Msg("isKDE: plasmashell not found for user")
 		return false
 	}
 	return true


### PR DESCRIPTION
Debug log statement introced in 45963 breaks Orbit's parse logic of `fleet-desktop --version` output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal logging for desktop environment detection.

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->