### PR TITLE
Navigate back to the report details page after saving a report

### DIFF
--- a/changes/38928-navigate-to-report-after-saving
+++ b/changes/38928-navigate-to-report-after-saving
@@ -1,0 +1,1 @@
+- Navigate back to the report details page after saving changes to a report.

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -315,7 +315,12 @@ const EditQueryPage = ({
     try {
       await queryAPI.update(queryId, updatedQuery);
       renderFlash("success", "Report updated.");
-      router.push(PATHS.REPORT_DETAILS(queryId));
+      router.push(
+        getPathWithQueryParams(PATHS.REPORT_DETAILS(queryId), {
+          host_id: location.query.host_id,
+          fleet_id: location.query.fleet_id,
+        })
+      );
     } catch (updateError) {
       console.error(updateError);
       const reason = getErrorReason(updateError);

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -315,7 +315,7 @@ const EditQueryPage = ({
     try {
       await queryAPI.update(queryId, updatedQuery);
       renderFlash("success", "Report updated.");
-      refetchStoredQuery(); // Required to compare recently saved query to a subsequent save to the query
+      router.push(PATHS.REPORT_DETAILS(queryId));
     } catch (updateError) {
       console.error(updateError);
       const reason = getErrorReason(updateError);


### PR DESCRIPTION
**Related issue:** Resolves #38928

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After saving report edits, the UI now redirects users back to the report details page.
  * URL context (host_id and fleet_id) is preserved during this navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->