### PR TITLE
Display instructions needed for SSO-enabled accounts with `fleetctl`

### DIFF
--- a/changes/21818-fleetctl-sso-warning
+++ b/changes/21818-fleetctl-sso-warning
@@ -1,0 +1,1 @@
+- Improved `fleetctl` to detect when SSO is enabled on the Fleet server and display a helpful message directing users to authenticate using an API token instead of email and password.

--- a/cmd/fleetctl/fleetctl/api.go
+++ b/cmd/fleetctl/fleetctl/api.go
@@ -37,8 +37,9 @@ func unauthenticatedClientFromCLI(c *cli.Context) (*service.Client, error) {
 	return unauthenticatedClientFromConfig(cc, getDebug(c), c.App.Writer, c.App.ErrWriter)
 }
 
-const ssoAuthInstructions = "SSO is enabled for this Fleet instance. Email/password login is not supported.\n\n" +
-	"To authenticate with fleetctl:\n" +
+const ssoAuthInstructions = "SSO is enabled for this Fleet instance. Email/password login is not supported on SSO-enabled accounts.\n" +
+	"If your user account isn't SSO-enabled, you may authenticate with fleetctl login.\n\n" +
+	"To authenticate with fleetctl for SSO-enabled accounts:\n" +
 	"  1. Log in to the Fleet UI in your browser\n" +
 	"  2. Go to My account > Get API token\n" +
 	"  3. Run: fleetctl config set --token <your-api-token>"

--- a/cmd/fleetctl/fleetctl/api.go
+++ b/cmd/fleetctl/fleetctl/api.go
@@ -37,6 +37,23 @@ func unauthenticatedClientFromCLI(c *cli.Context) (*service.Client, error) {
 	return unauthenticatedClientFromConfig(cc, getDebug(c), c.App.Writer, c.App.ErrWriter)
 }
 
+const ssoAuthInstructions = "SSO is enabled for this Fleet instance. Email/password login is not supported.\n\n" +
+	"To authenticate with fleetctl:\n" +
+	"  1. Log in to the Fleet UI in your browser\n" +
+	"  2. Go to My account > Get API token\n" +
+	"  3. Run: fleetctl config set --token <your-api-token>"
+
+// printAuthError prints an authentication error message. If SSO is enabled on the server,
+// it directs the user to authenticate via API token instead of fleetctl login.
+func printAuthError(w io.Writer, client *service.Client, prefix string) {
+	ssoSettings, err := client.SSOSettings()
+	if err == nil && ssoSettings != nil && ssoSettings.SSOEnabled {
+		fmt.Fprintf(w, "%s %s\n", prefix, ssoAuthInstructions)
+		return
+	}
+	fmt.Fprintf(w, "%s Please log in with: fleetctl login\n", prefix)
+}
+
 func clientFromCLI(c *cli.Context) (*service.Client, error) {
 	fleetClient, err := unauthenticatedClientFromCLI(c)
 	if err != nil {
@@ -59,11 +76,11 @@ func clientFromCLI(c *cli.Context) (*service.Client, error) {
 
 	token, ok := t.(string)
 	if !ok {
-		fmt.Fprintln(os.Stderr, "Token invalid. Please log in with: fleetctl login")
+		printAuthError(os.Stderr, fleetClient, "Token invalid.")
 		return nil, fmt.Errorf("token config value expected type %T, got %T: %+v", "", t, t)
 	}
 	if token == "" {
-		fmt.Fprintln(os.Stderr, "Token missing. Please log in with: fleetctl login")
+		printAuthError(os.Stderr, fleetClient, "Token missing.")
 		return nil, errors.New("token config value missing")
 	}
 	fleetClient.SetToken(token)
@@ -74,7 +91,7 @@ func clientFromCLI(c *cli.Context) (*service.Client, error) {
 	serverInfo, err := fleetClient.Version()
 	if err != nil {
 		if errors.Is(err, service.ErrUnauthenticated) {
-			fmt.Fprintln(os.Stderr, "Token invalid or session expired. Please log in with: fleetctl login")
+			printAuthError(os.Stderr, fleetClient, "Token invalid or session expired.")
 		}
 		return nil, err
 	}

--- a/cmd/fleetctl/fleetctl/api.go
+++ b/cmd/fleetctl/fleetctl/api.go
@@ -38,11 +38,9 @@ func unauthenticatedClientFromCLI(c *cli.Context) (*service.Client, error) {
 }
 
 const ssoAuthInstructions = "SSO is enabled for this Fleet instance. Email/password login is not supported on SSO-enabled accounts.\n" +
-	"If your user account isn't SSO-enabled, you may authenticate with fleetctl login.\n\n" +
-	"To authenticate with fleetctl for SSO-enabled accounts:\n" +
-	"  1. Log in to the Fleet UI in your browser\n" +
-	"  2. Go to My account > Get API token\n" +
-	"  3. Run: fleetctl config set --token <your-api-token>"
+	"If your account isn't SSO-enabled, use fleetctl login.\n\n" +
+	"Learn how to authenticate with fleetctl for SSO-enabled accounts:\n" +
+	"https://fleetdm.com/guides/fleetctl#users-with-single-sign-on-sso-or-email-two-factor-authentication-2-fa"
 
 // printAuthError prints an authentication error message. If SSO is enabled on the server,
 // it directs the user to authenticate via API token instead of fleetctl login.

--- a/cmd/fleetctl/fleetctl/login.go
+++ b/cmd/fleetctl/fleetctl/login.go
@@ -23,14 +23,11 @@ fleetctl login [options]
 
 Interactively prompts for email and password if not specified in the flags or environment variables.
 
-If SSO is enabled on the Fleet server, a warning will be displayed with instructions for
-authenticating via API token. You may still attempt to log in with email and password, but it
-will only succeed if your account is not SSO-enabled.
+If SSO is enabled on the Fleet server, a warning will be displayed. You may still attempt to
+log in with email and password, but it will only succeed if your account is not SSO-enabled.
 
-To authenticate with fleetctl for SSO-enabled accounts:
-  1. Log in to the Fleet UI in your browser
-  2. Go to My account > Get API token
-  3. Run: fleetctl config set --token <your-api-token>
+Learn how to authenticate with fleetctl for SSO-enabled accounts:
+https://fleetdm.com/guides/fleetctl#users-with-single-sign-on-sso-or-email-two-factor-authentication-2-fa
 `,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/fleetctl/fleetctl/login.go
+++ b/cmd/fleetctl/fleetctl/login.go
@@ -1,7 +1,6 @@
 package fleetctl
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -24,7 +23,14 @@ fleetctl login [options]
 
 Interactively prompts for email and password if not specified in the flags or environment variables.
 
-Trying to login with SSO or MFA? First, login to the Fleet UI and retrieve your API token from the "My account" page. Then set your API token with the fleetctl config set --token <your-api-token-here> command. You're now logged in to fleetctl.
+If SSO is enabled on the Fleet server, a warning will be displayed with instructions for
+authenticating via API token. You may still attempt to log in with email and password, but it
+will only succeed if your account is not SSO-enabled.
+
+To authenticate with fleetctl for SSO-enabled accounts:
+  1. Log in to the Fleet UI in your browser
+  2. Go to My account > Get API token
+  3. Run: fleetctl config set --token <your-api-token>
 `,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -51,9 +57,8 @@ Trying to login with SSO or MFA? First, login to the Fleet UI and retrieve your 
 				return err
 			}
 
-			ssoSettings, err := fleet.SSOSettings()
-			if err == nil && ssoSettings != nil && ssoSettings.SSOEnabled {
-				return errors.New(ssoAuthInstructions)
+			if ssoSettings, ssoErr := fleet.SSOSettings(); ssoErr == nil && ssoSettings != nil && ssoSettings.SSOEnabled {
+				fmt.Fprintf(os.Stderr, "Warning: %s\n\n", ssoAuthInstructions)
 			}
 
 			definedAsEnvOnly := func(flagName, envName string) bool {

--- a/cmd/fleetctl/fleetctl/login.go
+++ b/cmd/fleetctl/fleetctl/login.go
@@ -1,6 +1,7 @@
 package fleetctl
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -48,6 +49,11 @@ Trying to login with SSO or MFA? First, login to the Fleet UI and retrieve your 
 			fleet, err := unauthenticatedClientFromCLI(c)
 			if err != nil {
 				return err
+			}
+
+			ssoSettings, err := fleet.SSOSettings()
+			if err == nil && ssoSettings != nil && ssoSettings.SSOEnabled {
+				return errors.New(ssoAuthInstructions)
 			}
 
 			definedAsEnvOnly := func(flagName, envName string) bool {

--- a/cmd/fleetctl/fleetctl/sso_warning_test.go
+++ b/cmd/fleetctl/fleetctl/sso_warning_test.go
@@ -1,0 +1,61 @@
+package fleetctl
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl/testing_utils"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/service"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrintAuthError verifies that the authentication-error message adapts to
+// whether SSO is enabled on the server. The SSO-enabled case also guards the
+// response contract relied on by the warning (the "settings" wrapper and the
+// "sso_enabled" field): a server-side rename of either would drop the
+// instructions and fail here.
+func TestPrintAuthError(t *testing.T) {
+	cfg := config.TestConfig()
+	server, ds := testing_utils.RunServerWithMockedDS(t, &service.TestServerOpts{
+		License:     &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)},
+		FleetConfig: &cfg,
+		// Bypass the app config cache so each sub-test sees its own SSO setting.
+		NoCacheDatastore: true,
+	})
+
+	client, err := service.NewClient(server.URL, true, "", "")
+	require.NoError(t, err)
+
+	setSSO := func(enabled bool) {
+		ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{SSOSettings: &fleet.SSOSettings{EnableSSO: enabled}}, nil
+		}
+	}
+
+	t.Run("SSO enabled shows SSO instructions", func(t *testing.T) {
+		setSSO(true)
+
+		var buf bytes.Buffer
+		printAuthError(&buf, client, "Token missing.")
+
+		out := buf.String()
+		require.Contains(t, out, "Token missing.")
+		require.Contains(t, out, ssoAuthInstructions)
+	})
+
+	t.Run("SSO disabled shows default login message", func(t *testing.T) {
+		setSSO(false)
+
+		var buf bytes.Buffer
+		printAuthError(&buf, client, "Token missing.")
+
+		out := buf.String()
+		require.Contains(t, out, "Token missing.")
+		require.Contains(t, out, "Please log in with: fleetctl login")
+		require.NotContains(t, out, ssoAuthInstructions)
+	})
+}

--- a/server/service/client_sessions.go
+++ b/server/service/client_sessions.go
@@ -46,6 +46,29 @@ func (c *Client) Login(email, password string) (string, error) {
 	return responseBody.Token, nil
 }
 
+// SSOSettings returns the SSO settings for the current Fleet instance.
+// This endpoint is unauthenticated and can be called before login.
+func (c *Client) SSOSettings() (*fleet.SessionSSOSettings, error) {
+	response, err := c.Do("GET", "/api/v1/fleet/sso", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("GET /api/v1/fleet/sso: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get SSO settings received status %d %s", response.StatusCode, extractServerErrorText(response.Body))
+	}
+
+	var responseBody struct {
+		Settings *fleet.SessionSSOSettings `json:"settings"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&responseBody); err != nil {
+		return nil, fmt.Errorf("decode SSO settings response: %w", err)
+	}
+
+	return responseBody.Settings, nil
+}
+
 // Logout attempts to logout to the current Fleet instance.
 func (c *Client) Logout() error {
 	verb, path := "POST", "/api/latest/fleet/logout"


### PR DESCRIPTION
**Related issue:** Resolves #21818

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI now detects when SSO is enabled on the server and shows a warning directing users to authenticate with an API token (with guidance link) instead of email/password.

* **Bug Fixes**
  * Authentication error messaging is now SSO-aware, improving guidance when credential login fails.

* **Tests**
  * Added coverage to verify the authentication guidance changes correctly based on whether SSO is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->