### PR TITLE
Drop Trivy misconfig scanner to restore prior scope

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -123,9 +123,10 @@ jobs:
           scan-type: "fs"
           ignore-unfixed: false
           # PR/push: only scan for secrets (block leaked credentials before merge).
-          # Schedule/manual: full scan (vuln + secret + misconfig) with SARIF upload
-          # to the Security tab for triage. CVEs are tracked nightly, not per-PR.
-          scanners: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'vuln,secret,misconfig' || 'secret' }}
+          # Schedule/manual: vuln + secret with SARIF upload to the Security tab
+          # for triage. CVEs are tracked nightly, not per-PR. Misconfig is
+          # intentionally excluded; revisit after the SOC 2 audit.
+          scanners: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'vuln,secret' || 'secret' }}
           format: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'sarif' || 'table' }}
           output: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'trivy-results.sarif' || '' }}
           exit-code: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '0' || '1' }}


### PR DESCRIPTION
## Summary

- #46194 inadvertently enabled the `misconfig` scanner on scheduled Trivy runs, producing 237 new IaC findings (AWS/KSV/DS/GCP rules) on the next nightly upload.
- These findings represent a scanning category that wasn't part of our defined posture program.
- Revert to `vuln,secret` on scheduled/manual runs; PR/push behavior (secret-only) is unchanged.
- Misconfig coverage will be revisited as a planned program addition after the SOC 2 audit.

## Test plan

- [ ] Confirm the next scheduled run uploads SARIF without `misconfig` findings.
- [ ] Confirm previously-open misconfig alerts are dismissed (handled separately, not auto-closed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to optimize scan coverage during scheduled and manual runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->