### PR TITLE
Document public VDP and scope in SECURITY.md and handbook

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,10 +29,6 @@ Reports that are typically not eligible:
 - Self-XSS requiring significant user interaction
 - Issues solely affecting outdated browsers
 
-### Rewards
-
-The VDP recognizes valid, in-scope reports with swag and platform credits across Critical/High/Medium/Low tiers. Researchers are credited in security advisories at their request.
-
 ### PGP Key
 
 To encrypt vulnerability reports before sending them, please use this [PGP key](https://keys.openpgp.org/vks/v1/by-fingerprint/82F2AF19547E462A4605D53801B2575E46766EBE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Fleet endeavors to acknowledge and fix any reported vulnerabilities ASAP. Acknow
 
 In scope:
 - Fleet product source code: [github.com/fleetdm/fleet](https://github.com/fleetdm/fleet)
-- Fleet REST API: [fleetdm.com/docs/rest-api](https://fleetdm.com/docs/rest-api/rest-api)
+- Fleet REST API documentation: [fleetdm.com/docs/rest-api/rest-api](https://fleetdm.com/docs/rest-api/rest-api)
 
 Out of scope:
 - Marketing pages, blogs, and landing pages on fleetdm.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,36 @@
 
 ## Reporting a Vulnerability
 
-Please report any vulnerabilities discovered in Fleet products to security **at** fleetdm.com.
+Fleet runs a Vulnerability Disclosure Program (VDP) on Bugbop:
+
+**[https://bugbop.com/programs/b5f2f20e-fe4d-466b-a474-6db65b4d2bb3](https://bugbop.com/programs/b5f2f20e-fe4d-466b-a474-6db65b4d2bb3)**
+
+Please review the program scope and rules of engagement on Bugbop before submitting. Researchers can also report vulnerabilities directly to security **at** fleetdm.com (PGP key below) for coordinated, non-public disclosure.
 
 Fleet endeavors to acknowledge and fix any reported vulnerabilities ASAP. Acknowledgement is typically within 1 business day, and patches usually go out within 5 business days (depending on severity and timing).
+
+### Scope
+
+In scope:
+- Fleet product source code: [github.com/fleetdm/fleet](https://github.com/fleetdm/fleet)
+- Fleet REST API: [fleetdm.com/docs/rest-api](https://fleetdm.com/docs/rest-api/rest-api)
+
+Out of scope:
+- Marketing pages, blogs, and landing pages on fleetdm.com
+- Third-party hosted services (unless they directly impact a primary in-scope asset)
+- Physical offices and infrastructure
+- Employee social media accounts
+
+Reports that are typically not eligible:
+- Missing HTTP security headers (unless they lead to a proven, demonstrated vulnerability)
+- Theoretical vulnerabilities without proof of exploitation
+- Automated tool output without clear impact evidence
+- Self-XSS requiring significant user interaction
+- Issues solely affecting outdated browsers
+
+### Rewards
+
+The VDP recognizes valid, in-scope reports with swag and platform credits across Critical/High/Medium/Low tiers. Researchers are credited in security advisories at their request.
 
 ### PGP Key
 

--- a/handbook/it/security.md
+++ b/handbook/it/security.md
@@ -1858,7 +1858,9 @@ When using externally provided CVSSv4 scores, Fleet maps them like this:
 
 ### Disclosure
 
-Researchers who discover vulnerabilities in Fleet can disclose them as per the [Fleet repository security policy](https://github.com/fleetdm/fleet/security/policy).
+Researchers who discover vulnerabilities in Fleet can disclose them through Fleet's [Vulnerability Disclosure Program on Bugbop](https://bugbop.com/programs/b5f2f20e-fe4d-466b-a474-6db65b4d2bb3) or by following the [Fleet repository security policy](https://github.com/fleetdm/fleet/security/policy). Coordinated, non-public disclosures can also be sent to security@fleetdm.com (PGP key on the repository security policy).
+
+The VDP scope covers the Fleet product source ([github.com/fleetdm/fleet](https://github.com/fleetdm/fleet)) and the [REST API](https://fleetdm.com/docs/rest-api/rest-api). Marketing pages on fleetdm.com, third-party hosted services, and theoretical findings without a demonstrated exploit are out of scope. Valid in-scope reports submitted through the VDP are recognized with swag and platform credits.
 
 If Fleet confirms the vulnerability:
 

--- a/handbook/it/security.md
+++ b/handbook/it/security.md
@@ -1858,7 +1858,7 @@ When using externally provided CVSSv4 scores, Fleet maps them like this:
 
 ### Disclosure
 
-Researchers who discover vulnerabilities in Fleet can disclose them through Fleet's [Vulnerability Disclosure Program on Bugbop](https://bugbop.com/programs/b5f2f20e-fe4d-466b-a474-6db65b4d2bb3) or by following the [Fleet repository security policy](https://github.com/fleetdm/fleet/security/policy). Coordinated, non-public disclosures can also be sent to security@fleetdm.com (PGP key on the repository security policy).
+Researchers who discover vulnerabilities in Fleet can disclose them through Fleet's [Vulnerability Disclosure Program on Bugbop](https://bugbop.com/programs/b5f2f20e-fe4d-466b-a474-6db65b4d2bb3) or by following the [Fleet repository security policy](https://github.com/fleetdm/fleet/security/policy). Coordinated, non-public disclosures can also be sent to security@ (fleetdm.com) (PGP key on the repository security policy).
 
 The VDP scope covers the Fleet product source ([github.com/fleetdm/fleet](https://github.com/fleetdm/fleet)) and the [REST API](https://fleetdm.com/docs/rest-api/rest-api). Marketing pages on fleetdm.com, third-party hosted services, and theoretical findings without a demonstrated exploit are out of scope.
 

--- a/handbook/it/security.md
+++ b/handbook/it/security.md
@@ -1860,7 +1860,7 @@ When using externally provided CVSSv4 scores, Fleet maps them like this:
 
 Researchers who discover vulnerabilities in Fleet can disclose them through Fleet's [Vulnerability Disclosure Program on Bugbop](https://bugbop.com/programs/b5f2f20e-fe4d-466b-a474-6db65b4d2bb3) or by following the [Fleet repository security policy](https://github.com/fleetdm/fleet/security/policy). Coordinated, non-public disclosures can also be sent to security@fleetdm.com (PGP key on the repository security policy).
 
-The VDP scope covers the Fleet product source ([github.com/fleetdm/fleet](https://github.com/fleetdm/fleet)) and the [REST API](https://fleetdm.com/docs/rest-api/rest-api). Marketing pages on fleetdm.com, third-party hosted services, and theoretical findings without a demonstrated exploit are out of scope. Valid in-scope reports submitted through the VDP are recognized with swag and platform credits.
+The VDP scope covers the Fleet product source ([github.com/fleetdm/fleet](https://github.com/fleetdm/fleet)) and the [REST API](https://fleetdm.com/docs/rest-api/rest-api). Marketing pages on fleetdm.com, third-party hosted services, and theoretical findings without a demonstrated exploit are out of scope.
 
 If Fleet confirms the vulnerability:
 


### PR DESCRIPTION
@allenhouchins Documenting our VDP

## Summary

- Adds a pointer to Fleet's public Bugbop Vulnerability Disclosure Program from `SECURITY.md` and `handbook/it/security.md`.
- Documents the program's in-scope, out-of-scope, and typically-not-eligible categories so researchers can self-triage before submitting.
- Keeps `security@fleetdm.com` as the channel for coordinated, non-public disclosure.

Motivation: two recent informal disclosures (missing CAA, missing MTA-STS) revealed that our published policy made no mention of the VDP or its scope, which left the boundary ambiguous when declining out-of-scope submissions.

## Test plan

- [ ] Verify rendered `SECURITY.md` on the repo's Security tab links to the Bugbop program.
- [ ] Verify the handbook page renders the new VDP paragraph in the "Disclosure" section without breaking surrounding structure.
- [ ] Confirm no internal/private program details are referenced.