### PR TITLE
Add OCI source labels to Docker Hub images

### DIFF
--- a/tools/bomutils-docker/Dockerfile
+++ b/tools/bomutils-docker/Dockerfile
@@ -22,6 +22,13 @@ RUN cd xar-xar-1.6.1/xar && patch < ../../patch.txt && autoconf && ./configure &
 
 FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba
 
+LABEL maintainer="Fleet Developers"
+LABEL org.opencontainers.image.vendor="Fleet Device Management Inc."
+LABEL org.opencontainers.image.title="bomutils"
+LABEL org.opencontainers.image.source="https://github.com/fleetdm/fleet"
+LABEL org.opencontainers.image.url="https://fleetdm.com"
+LABEL org.opencontainers.image.documentation="https://fleetdm.com/docs"
+
 RUN apt-get update && dpkg --add-architecture i386 && apt-get upgrade -y && apt-get install -y --no-install-recommends libxml2 ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/bin /usr/bin/
 COPY --from=builder /usr/local/bin /usr/local/bin/

--- a/tools/fleet-docker/Dockerfile
+++ b/tools/fleet-docker/Dockerfile
@@ -5,6 +5,8 @@ LABEL org.opencontainers.image.version="${FLEET_VERSION}"
 LABEL org.opencontainers.image.vendor="Fleet Device Management Inc."
 LABEL org.opencontainers.image.title="fleet"
 LABEL org.opencontainers.image.source="https://github.com/fleetdm/fleet"
+LABEL org.opencontainers.image.url="https://fleetdm.com"
+LABEL org.opencontainers.image.documentation="https://fleetdm.com/docs"
 
 RUN apk --update add ca-certificates
 RUN apk --no-cache add jq

--- a/tools/fleetctl-docker/Dockerfile
+++ b/tools/fleetctl-docker/Dockerfile
@@ -8,6 +8,13 @@ RUN cargo install --locked --version 0.28.0 apple-codesign \
 
 FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba
 
+LABEL maintainer="Fleet Developers"
+LABEL org.opencontainers.image.vendor="Fleet Device Management Inc."
+LABEL org.opencontainers.image.title="fleetctl"
+LABEL org.opencontainers.image.source="https://github.com/fleetdm/fleet"
+LABEL org.opencontainers.image.url="https://fleetdm.com"
+LABEL org.opencontainers.image.documentation="https://fleetdm.com/docs"
+
 ARG binpath=build/binary-bundle/linux/fleetctl
 
 RUN apt-get update \

--- a/tools/wix-docker/Dockerfile
+++ b/tools/wix-docker/Dockerfile
@@ -1,5 +1,12 @@
 FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba
 
+LABEL maintainer="Fleet Developers"
+LABEL org.opencontainers.image.vendor="Fleet Device Management Inc."
+LABEL org.opencontainers.image.title="wix"
+LABEL org.opencontainers.image.source="https://github.com/fleetdm/fleet"
+LABEL org.opencontainers.image.url="https://fleetdm.com"
+LABEL org.opencontainers.image.documentation="https://fleetdm.com/docs"
+
 RUN true \
     && dpkg --add-architecture i386 \
     && apt update \


### PR DESCRIPTION
## Summary

For #39902. Adds `org.opencontainers.image.source` (and `url`, `documentation`, `vendor`, `title`) labels to the Dockerfiles for `fleetdm/fleetctl`, `fleetdm/bomutils`, and `fleetdm/wix` so Docker Hub renders a "Source repository" link back to this repo, which helps with troubleshooting and security audits. Also extends the labels on `fleetdm/fleet` for consistency (it already had `source`).

The labels apply on the next publish:
- `fleetdm/fleet` and `fleetdm/fleetctl` ship via `.goreleaser.yml` on the next release.
- `fleetdm/bomutils` and `fleetdm/wix` ship via the manual `release-fleetctl-docker-deps.yaml` workflow.

## Test plan
- [ ] After next release, confirm `fleetdm/fleet` and `fleetdm/fleetctl` images on Docker Hub show "Source repository" linking to https://github.com/fleetdm/fleet.
- [ ] After next manual run of `release-fleetctl-docker-deps.yaml`, confirm `fleetdm/bomutils` and `fleetdm/wix` show the same.
- [ ] Spot-check with `docker inspect fleetdm/fleet:<tag> --format '{{json .Config.Labels}}'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker image metadata labels (maintainer, vendor, title, source, and documentation) across container images to improve discoverability and image organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->