### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.34.60",
+      "version": "2.34.61",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.34.60') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.34.61') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.34.60.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.34.61.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "08be0723",
-      "sha256": "86e51310b35ec9ce6be281db9e9d27e38abb24b6087dde9f0c1f7bec176c926d",
+      "sha256": "133e43318435a71b2518938a3164d75c62bb38c4bd301f068b4f73f9acafeb8a",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.10628.0",
+      "version": "1.10628.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.10628.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.10628.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.10628.0/Claude-b4f860bb5e61a4289cf2a8bca78f006ebde1bb3f.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.10628.2/Claude-deee0a79e9070caed69480a2c8d2e09f895512c4.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "57f5409528e095e5920231eea7fa55bc25d5f532e12a781c3abe3682c972b9d2",
+      "sha256": "aed0ee22d42010a19fb53e4c287271e4fd8d4fa94ea958ecfd32efa2d3d4e16c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/google-drive/windows.json
+++ b/ee/maintained-apps/outputs/google-drive/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "125.0.0.0",
+      "version": "126.0.5.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Google Drive' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Google Drive' AND publisher = 'Google LLC' AND version_compare(version, '125.0.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Google Drive' AND publisher = 'Google LLC' AND version_compare(version, '126.0.5.0') < 0);"
       },
-      "installer_url": "https://dl.google.com/release2/drive-file-stream/jdnygtxjhspl3nvfi5zi6oumli_125.0.0.0/setup.exe",
+      "installer_url": "https://dl.google.com/release2/drive-file-stream/bojq6y2g3cpbbgm6smuw7zmwby_126.0.5.0/setup.exe",
       "install_script_ref": "fa36b892",
       "uninstall_script_ref": "785a96b9",
-      "sha256": "b8fffc8035f4a6abf8d7650da0cf9f73ed474c161f3b577464d8dd87a86482a6",
+      "sha256": "a3c045ab377bd70da0d9eed15614d50635467d2b30e3333fb32a5919d9300ae2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.30.2",
+      "version": "0.30.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.3') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.2/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.3/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "bf40e2d5",
-      "sha256": "b65b02408b1c539215bf4689f1cfc1e3924396c7b5780ce090e2efd26ea601b4",
+      "sha256": "b21b2c55874eb34ade3fc5e872cb21e00f2d8f7d352ccb8d99a822e2ed695e50",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.12.0",
+      "version": "8.13.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.12.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.13.0') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.12.0.zip",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.13.0.zip",
       "install_script_ref": "fac7f399",
       "uninstall_script_ref": "c0c94e32",
-      "sha256": "086c12eb39cea7c4b8ca28825b2f74d17d954a74ac4a30c8b2a4a78dab80c8b7",
+      "sha256": "0625d97bc564f39f6aab6f7a3bfaf40fb0c807efed7321b31d392212922bd1c7",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/signal/windows.json
+++ b/ee/maintained-apps/outputs/signal/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.12.0",
+      "version": "8.13.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Signal' AND publisher = 'Signal Messenger, LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Signal' AND publisher = 'Signal Messenger, LLC' AND version_compare(version, '8.12.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Signal' AND publisher = 'Signal Messenger, LLC' AND version_compare(version, '8.13.0') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-win-8.12.0.exe",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-win-8.13.0.exe",
       "install_script_ref": "06366bfb",
       "uninstall_script_ref": "8c3c10d6",
-      "sha256": "ef3e3bc288c8b44b3fba0d045c7176651455991ccb574545f04f25fda08153af",
+      "sha256": "fe4f49f43caca580154ec29e8d391337de88359c4c83816715c2bfdd332cd032",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/snagit/windows.json
+++ b/ee/maintained-apps/outputs/snagit/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.2.1",
+      "version": "26.2.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Snagit 2026' AND publisher = 'TechSmith Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Snagit 2026' AND publisher = 'TechSmith Corporation' AND version_compare(version, '26.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Snagit 2026' AND publisher = 'TechSmith Corporation' AND version_compare(version, '26.2.2') < 0);"
       },
-      "installer_url": "https://download.techsmith.com/snagit/releases/2621/snagit.msi",
+      "installer_url": "https://download.techsmith.com/snagit/releases/2622/snagit.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "6de12ca9",
-      "sha256": "c815b0315c6e16bdded87395859445b8ff23f094e9b518f9ea15d51e7e931cc0",
+      "sha256": "5121847ac6766983416578856adfe41abd84aa2b7d8e246f2d1e93fcac2cf44e",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.4",
+      "version": "1.5.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.4.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.5.3') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.4.4/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.5.3/Zed-aarch64.dmg",
       "install_script_ref": "ad597b79",
       "uninstall_script_ref": "2a2c7eb8",
-      "sha256": "238e077674cf73858621a64a1a7fa0bafe02a8bcc4af6c8c0edc22810276cb46",
+      "sha256": "71f4fefacbce0032336f5d1a916abb2388d40ebc59a8c27d638ca679eaafee8b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.4",
+      "version": "1.5.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.4.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.5.3') < 0);"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.4.4/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.5.3/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "b0638b0fae222046ef336ba635d861dc64e8125b1c62e3c9d324a0ffe7be35c6",
+      "sha256": "23f2d56e58bac639cae7f88290195830113e28bb9d24db1a395f613be92fe634",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application metadata for AWS CLI, Claude, Google Drive, Ollama, Signal, Snagit, and Zed with latest release information and checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->