### PR TITLE
add sub headers to local account section

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/LocalAccountSection/LocalAccountSection.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/LocalAccountSection/LocalAccountSection.tests.tsx
@@ -31,7 +31,7 @@ describe("LocalAccountSection", () => {
 
   it("renders the section title and subtitle", () => {
     render(<LocalAccountSection {...defaultProps} />);
-    expect(screen.getByText("Local account")).toBeInTheDocument();
+    expect(screen.getByText("Local accounts")).toBeInTheDocument();
     expect(
       screen.getByText(/Currently supported for macOS hosts/)
     ).toBeInTheDocument();

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/LocalAccountSection/LocalAccountSection.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/LocalAccountSection/LocalAccountSection.tsx
@@ -40,7 +40,7 @@ const LocalAccountSection = ({
     localAccountType !== EndUserLocalAccountType.ADMIN;
   return (
     <SettingsSection
-      title="Local account"
+      title="Local accounts"
       subTitle={
         <span>
           Currently supported for macOS hosts. End users get the default role
@@ -79,6 +79,7 @@ const LocalAccountSection = ({
           renderChildren={(gitopsEnabled) => {
             return (
               <div className={`${baseClass}__field-group`}>
+                <h3 className={`${baseClass}__sub-header`}>End user</h3>
                 <fieldset className="form-field">
                   <Radio
                     name="localAccountType"
@@ -125,6 +126,8 @@ const LocalAccountSection = ({
                     }
                   />
                 </fieldset>
+
+                <h3 className={`${baseClass}__sub-header`}>Managed</h3>
                 <Checkbox
                   className={`${baseClass}__managed-local-account`}
                   disabled={

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/LocalAccountSection/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/LocalAccountSection/_styles.scss
@@ -10,4 +10,8 @@
     flex-direction: column;
     gap: $gap-page-component;
   }
+
+  &__sub-header {
+    font-size: $x-small;
+  }
 }


### PR DESCRIPTION
Follow up work for the macOS local admin account

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected section title text from singular to plural form.

* **UI/UX Improvements**
  * Added visual sub-headers to clearly separate and organize input groups within the local account management section.
  * Improved visual hierarchy with styling for section organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->