### PR TITLE
Fix resizable read-only installer command in Add host modal

### DIFF
--- a/changes/44901-ui-add-host-modal-read-only-resize
+++ b/changes/44901-ui-add-host-modal-read-only-resize
@@ -1,0 +1,1 @@
+- Fixed the Add host modal so its read-only installer command fields can no longer be resized.

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -20,6 +20,7 @@
       line-height: $line-height;
       line-break: anywhere;
       padding: 12px $pad-xlarge 12px $pad-medium;
+      resize: none;
     }
   }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44901

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<img width="826" height="427" alt="Screenshot 2026-06-04 at 9 00 40 AM" src="https://github.com/user-attachments/assets/a0b1d2fb-3077-4883-a69a-c37e6e81d3d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Add host modal so read-only installer command fields can no longer be resized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->