### PR TITLE
Fix TestTranslateCPEToCVE: replace deferred Docker CVE

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -677,11 +677,11 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:docker:desktop:4.43.2:*:*:*:*:macos:*:*": {
-			includedCVEs:      []cve{{ID: "CVE-2025-9074", resolvedInVersion: "4.44.3"}},
+			includedCVEs:      []cve{{ID: "CVE-2026-2664", resolvedInVersion: "4.62.0"}},
 			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:docker:desktop:4.39.0:*:*:*:*:windows:*:*": {
-			includedCVEs:      []cve{{ID: "CVE-2025-9074", resolvedInVersion: "4.44.3"}},
+			includedCVEs:      []cve{{ID: "CVE-2026-2664", resolvedInVersion: "4.62.0"}},
 			continuesToUpdate: true,
 		},
 		// #41586 - Admin By Request false positives on macOS/Linux


### PR DESCRIPTION
**Related issue:** NA

## Problem

`TestTranslateCPEToCVE/find_vulns_on_cpes` fails in CI: Docker Desktop no longer matches the asserted `CVE-2025-9074`.

NVD changed that CVE to `vulnStatus: Deferred` and removed its CPE `configurations` entirely, so the matcher has nothing to associate with `docker:desktop`. This is upstream NVD data drift, not a Fleet regression — matching still works for other Docker CVEs.

## Fix

Swap `CVE-2025-9074` for `CVE-2026-2664` (status Analyzed), which NVD currently lists for `docker:desktop` on macOS/Windows/Linux, resolved in `4.62.0` — covering both the macOS 4.43.2 and Windows 4.39.0 test entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This pull request contains only internal test updates with no end-user impact. The changes update test fixture data for vulnerability mapping validation and do not affect functionality, features, or user experience.

* **Tests**
  * Updated test data for vulnerability mapping validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->