### PR TITLE
Stop 1Password autofill icon from interfering with Fleet UI form fields

### DIFF
--- a/changes/44854-1password-autofill-icon-interferes-with
+++ b/changes/44854-1password-autofill-icon-interferes-with
@@ -1,0 +1,1 @@
+* Stopped the 1Password autofill icon from appearing on Fleet UI inputs that are not credential fields.

--- a/frontend/components/forms/ChangeEmailForm/ChangeEmailForm.jsx
+++ b/frontend/components/forms/ChangeEmailForm/ChangeEmailForm.jsx
@@ -28,6 +28,7 @@ class ChangeEmailForm extends Component {
           autofocus
           label="Password"
           type="password"
+          ignore1password={false}
         />
         <div className="modal-cta-wrap">
           <Button type="submit">Submit</Button>

--- a/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.jsx
+++ b/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.jsx
@@ -35,17 +35,20 @@ class ChangePasswordForm extends Component {
           autofocus
           label="Original password"
           type="password"
+          ignore1password={false}
         />
         <InputField
           {...fields.new_password}
           label="New password"
           type="password"
           helpText="Must include 12 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)"
+          ignore1password={false}
         />
         <InputField
           {...fields.new_password_confirmation}
           label="New password confirmation"
           type="password"
+          ignore1password={false}
         />
         <div className="modal-cta-wrap">
           <Button type="submit">Change password</Button>

--- a/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.tsx
+++ b/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.tsx
@@ -111,6 +111,7 @@ const ConfirmInviteForm = ({
         error={formErrors.name}
         parseTarget
         inputOptions={{ maxLength: 80 }}
+        ignore1password={false}
       />
       <InputField
         label="Password"
@@ -122,6 +123,7 @@ const ConfirmInviteForm = ({
         value={password}
         error={formErrors.password}
         parseTarget
+        ignore1password={false}
       />
       <InputField
         label="Confirm password"
@@ -132,6 +134,7 @@ const ConfirmInviteForm = ({
         value={password_confirmation}
         error={formErrors.password_confirmation}
         parseTarget
+        ignore1password={false}
       />
       <div className="button-wrap--center">
         <Button

--- a/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
+++ b/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
@@ -41,6 +41,7 @@ class ForgotPasswordForm extends Component {
           label="Email"
           placeholder="Email"
           type="email"
+          ignore1Password={false}
         />
         <div className="button-wrap--center">
           <Button

--- a/frontend/components/forms/LoginForm/LoginForm.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tsx
@@ -167,6 +167,7 @@ const LoginForm = ({
           placeholder="Email"
           value={formData.email}
           onChange={onInputChange("email")}
+          ignore1Password={false}
         />
         <InputFieldWithIcon
           error={errors.password}
@@ -175,6 +176,7 @@ const LoginForm = ({
           type="password"
           value={formData.password}
           onChange={onInputChange("password")}
+          ignore1Password={false}
         />
       </div>
       {/* Actions displayed using CSS column-reverse to preserve tab order */}

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -60,12 +60,14 @@ class AdminDetails extends Component {
           inputOptions={{
             maxLength: "80",
           }}
+          ignore1password={false}
         />
         <InputField
           {...fields.email}
           label="Email"
           tabIndex={tabIndex}
           type="email"
+          ignore1password={false}
         />
         <InputField
           {...fields.password}
@@ -73,12 +75,14 @@ class AdminDetails extends Component {
           type="password"
           tabIndex={tabIndex}
           helpText="12-48 characters, with at least 1 number (e.g. 0 - 9) and 1 symbol (e.g. &*#)."
+          ignore1password={false}
         />
         <InputField
           {...fields.password_confirmation}
           type="password"
           tabIndex={tabIndex}
           label="Confirm password"
+          ignore1password={false}
         />
         <div className="button-wrap--center">
           <Button

--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tsx
@@ -107,6 +107,7 @@ const ResetPasswordForm = ({
         className={`${baseClass}__input`}
         type="password"
         helpText="12-48 characters, with at least 1 number (e.g. 0 - 9) and 1 symbol (e.g. &*#)."
+        ignore1Password={false}
       />
       <InputFieldWithIcon
         error={errors.new_password_confirmation}
@@ -116,6 +117,7 @@ const ResetPasswordForm = ({
         value={formData.new_password_confirmation || ""}
         className={`${baseClass}__input`}
         type="password"
+        ignore1Password={false}
       />
       <div className="button-wrap--center">
         <Button type="submit" onClick={onFormSubmit} size="wide">

--- a/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
+++ b/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
@@ -56,6 +56,7 @@ class UserSettingsForm extends Component {
             label="Email (required)"
             helpText={renderEmailHelpText()}
             readOnly={!smtpConfigured}
+            ignore1password={false}
             tooltip={
               <>
                 Editing your email address requires that SMTP or SES is

--- a/frontend/components/forms/fields/InputField/InputField.tests.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tests.tsx
@@ -231,7 +231,7 @@ describe("InputField Component", () => {
     );
   });
 
-  test("sets data-1p-ignore when ignore1password is true", () => {
+  test("sets data-1p-ignore by default (1Password ignored)", () => {
     render(
       <InputField
         value=""
@@ -239,13 +239,29 @@ describe("InputField Component", () => {
         label="Test Input"
         placeholder="Enter text"
         name="test-input"
-        ignore1password
       />
     );
 
     expect(screen.getByPlaceholderText(/enter text/i)).toHaveAttribute(
       "data-1p-ignore",
       "true"
+    );
+  });
+
+  test("does not set data-1p-ignore when ignore1password is false", () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        ignore1password={false}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/enter text/i)).not.toHaveAttribute(
+      "data-1p-ignore"
     );
   });
 

--- a/frontend/components/forms/fields/InputField/InputField.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tsx
@@ -48,6 +48,10 @@ export interface IInputFieldProps {
   /** Use in conjunction with type "password" and enableCopy to see eye icon to view */
   enableShowSecret?: boolean;
   enableCopy?: boolean;
+  /**
+   * Whether 1Password should skip this field.
+   * Defaults to `true` because most Fleet inputs are not credential fields.
+   */
   ignore1password?: boolean;
   /** Only effective on input type number */
   step?: string | number;
@@ -82,7 +86,7 @@ const InputField = ({
   helpText = "",
   enableShowSecret = false,
   enableCopy = false,
-  ignore1password = false,
+  ignore1password = true,
   step,
   min,
   max,
@@ -236,6 +240,7 @@ const InputField = ({
             }}
             {...(inputOptions as React.TextareaHTMLAttributes<HTMLTextAreaElement>)}
             value={value as string | number}
+            data-1p-ignore={ignore1password || undefined}
           />
           {enableCopy && renderTextareaCopyButton()}
         </div>
@@ -267,7 +272,10 @@ const InputField = ({
           {...inputOptions}
           value={value as string | number}
           autoComplete={blockAutoComplete ? "new-password" : ""}
-          data-1p-ignore={ignore1password}
+          // 1Password only checks for the presence (not the value) of `data-1p-ignore`,
+          // so we omit the attribute entirely when the field is not meant to be ignored.
+          // See https://developer.1password.com/docs/web/compatible-website-design/
+          data-1p-ignore={ignore1password || undefined}
           step={step}
           min={min}
           max={max}

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.tests.tsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.tests.tsx
@@ -241,7 +241,7 @@ describe("InputFieldWithIcon Component", () => {
     expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 
-  test("sets data-1p-ignore attribute when ignore1Password is true", () => {
+  test("sets data-1p-ignore attribute by default (1Password ignored)", () => {
     render(
       <InputFieldWithIcon
         value=""
@@ -249,13 +249,29 @@ describe("InputFieldWithIcon Component", () => {
         label="Test Input"
         placeholder="Enter text"
         name="test-input"
-        ignore1Password
       />
     );
 
     expect(screen.getByPlaceholderText(/enter text/i)).toHaveAttribute(
       "data-1p-ignore",
       "true"
+    );
+  });
+
+  test("does not set data-1p-ignore when ignore1Password is false", () => {
+    render(
+      <InputFieldWithIcon
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        ignore1Password={false}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/enter text/i)).not.toHaveAttribute(
+      "data-1p-ignore"
     );
   });
 

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.tsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.tsx
@@ -27,6 +27,10 @@ export interface IInputFieldWithIconProps {
   disabled?: boolean;
   inputOptions?: React.InputHTMLAttributes<HTMLInputElement>;
   tooltip?: string;
+  /**
+   * Whether 1Password should skip this field.
+   * Defaults to `true` because most Fleet inputs are not credential fields.
+   */
   ignore1Password?: boolean;
   value?: string;
 }
@@ -48,7 +52,7 @@ const InputFieldWithIcon = ({
   disabled,
   inputOptions,
   tooltip,
-  ignore1Password,
+  ignore1Password = true,
   value,
 }: IInputFieldWithIconProps): JSX.Element => {
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -144,7 +148,10 @@ const InputFieldWithIcon = ({
           value={value}
           disabled={disabled}
           {...inputOptions}
-          data-1p-ignore={ignore1Password}
+          // 1Password only checks for the presence (not the value) of `data-1p-ignore`,
+          // so we omit the attribute entirely when the field is not meant to be ignored.
+          // See https://developer.1password.com/docs/web/compatible-website-design/
+          data-1p-ignore={ignore1Password || undefined}
         />
         {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
         {clearButton && !!value && (

--- a/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
+++ b/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
@@ -111,7 +111,6 @@ const EditPackForm = ({
         name="name"
         error={errors.name}
         inputWrapperClass={`${baseClass}__pack-title`}
-        ignore1password
       />
       <InputField
         onChange={onChangePackDescription}

--- a/frontend/components/forms/packs/NewPackForm/NewPackForm.tsx
+++ b/frontend/components/forms/packs/NewPackForm/NewPackForm.tsx
@@ -93,7 +93,6 @@ const NewPackForm = ({
           error={errors.name}
           inputWrapperClass={`${baseClass}__pack-title`}
           autofocus
-          ignore1password
         />
         <InputField
           onChange={onChangePackDescription}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
@@ -185,7 +185,6 @@ const AddCertModal = ({
           parseTarget
           placeholder="VPN certificate"
           autofocus
-          ignore1password
         />
         <DropdownWrapper
           label="Certificate authority (CA)"

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -313,7 +313,6 @@ const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
                         parseTarget
                         type="textarea"
                         placeholder={API_KEY_JSON_PLACEHOLDER}
-                        ignore1password
                         inputClassName={`${baseClass}__api-key-json`}
                         error={formErrors.apiKeyJson}
                         disabled={gomEnabled}

--- a/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
@@ -67,7 +67,6 @@ const CreateFleetModal = ({
           placeholder="Workstations"
           value={name}
           error={errors.name}
-          ignore1password
         />
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tsx
@@ -63,7 +63,6 @@ const RenameFleetModal = ({
           placeholder="Fleet name"
           value={name}
           error={errors.name}
-          ignore1password
         />
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tsx
@@ -505,7 +505,6 @@ const UserForm = ({
         inputOptions={{
           maxLength: 80,
         }}
-        ignore1password
         parseTarget
       />
       <InputField

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
@@ -195,6 +195,7 @@ const Smtp = ({
           onBlur={onInputBlur}
           error={formErrors.user_name}
           blockAutoComplete
+          ignore1password={false}
         />
         <InputField
           label="SMTP password"
@@ -206,6 +207,7 @@ const Smtp = ({
           onBlur={onInputBlur}
           error={formErrors.password}
           blockAutoComplete
+          ignore1password={false}
         />
         <Dropdown
           label="Auth method"

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -373,7 +373,6 @@ const SaveNewPolicyModal = ({
           inputClassName={`${baseClass}__policy-save-modal-name`}
           label="Name"
           autofocus
-          ignore1password
           disabled={disableForm}
         />
         <InputField

--- a/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
@@ -197,7 +197,6 @@ const SaveAsNewQueryModal = ({
           inputClassName={`${baseClass}__name`}
           label="Name"
           autofocus
-          ignore1password
           parseTarget
         />
         {isPremiumTier && (userTeams?.length || 0) > 1 && (

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
@@ -238,7 +238,6 @@ const SaveNewQueryModal = ({
           inputClassName={`${baseClass}__name`}
           label="Name"
           autofocus
-          ignore1password
         />
         <InputField
           name="description"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44854

This PR explicitly enables the 1Password autofill icon for credential fields, such as the ones in the login form.
Made the decision to have `ignore1password=true` by default (less LOC changed since the vast majority of inputs aren't credential fields).

Note: even though the Certificate Authority input fields contain some kind of secret or credentials, I feel like these differ enough from one another (+ these are usually admin-pasted values) that it didn't make sense to have the 1PW autofill on them.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/c8539d8f-e0e3-4499-ae67-16cfd0f59e3a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the 1Password autofill icon from appearing on non-credential inputs.
  * Ensured explicit 1Password autofill handling for email/password fields across login, registration, password reset, and account forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->