### PR TITLE
Fix restoration of DEP hosts when a duplicate exists

### DIFF
--- a/changes/45192-duplicate-dep-host-delete
+++ b/changes/45192-duplicate-dep-host-delete
@@ -1,1 +1,1 @@
-- Fixed a bug where deleting one duplicate DEP host not resolving the duplicate. Fleet no longer recreates a pending host record when another host with the same serial and platform still exists
+- Fixed a bug where deleting one of multiple duplicate DEP hosts did not resolve the duplicate. Fleet no longer recreates a pending host record when another host with the same serial and platform still exists.

--- a/changes/45192-duplicate-dep-host-delete
+++ b/changes/45192-duplicate-dep-host-delete
@@ -1,0 +1,1 @@
+- Fixed a bug where deleting one duplicate DEP host not resolving the duplicate. Fleet no longer recreates a pending host record when another host with the same serial and platform still exists

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2156,6 +2156,59 @@ func (ds *Datastore) GetHostDEPAssignmentsBySerial(ctx context.Context, serial s
 	return res, nil
 }
 
+func (ds *Datastore) ReconcileDuplicateDEPHostOnDelete(ctx context.Context, serial, platform string, deletedHostID uint) (duplicateExists bool, err error) {
+	type candidate struct {
+		HostID              uint `db:"host_id"`
+		HasActiveAssignment bool `db:"has_active_assignment"`
+		HasAnyAssignment    bool `db:"has_any_assignment"`
+	}
+	var candidates []candidate
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &candidates, `
+		SELECT
+			h.id AS host_id,
+			EXISTS (
+				SELECT 1 FROM host_dep_assignments a
+				WHERE a.host_id = h.id AND a.hardware_serial = h.hardware_serial AND a.deleted_at IS NULL
+			) AS has_active_assignment,
+			EXISTS (
+				SELECT 1 FROM host_dep_assignments a WHERE a.host_id = h.id
+			) AS has_any_assignment
+		FROM hosts h
+		WHERE h.hardware_serial = ? AND h.platform = ? AND h.id != ?`, serial, platform, deletedHostID); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "find surviving dep hosts")
+	}
+
+	if len(candidates) == 0 {
+		return false, nil
+	}
+
+	// If any survivor already owns an active assignment for this serial, the ABM
+	// relationship is already preserved and there's nothing to do.
+	for _, c := range candidates {
+		if c.HasActiveAssignment {
+			return true, nil
+		}
+	}
+
+	// Otherwise transfer the deleted host's assignment to a survivor that has no
+	// assignment row of its own. host_id is the primary key, so a survivor that
+	// already has a (soft-deleted) row can't be a transfer target.
+	for _, c := range candidates {
+		if !c.HasAnyAssignment {
+			if _, err := ds.writer(ctx).ExecContext(ctx,
+				`UPDATE host_dep_assignments SET host_id = ? WHERE host_id = ?`,
+				c.HostID, deletedHostID,
+			); err != nil {
+				return true, ctxerr.Wrap(ctx, err, "transfer dep assignment to surviving host")
+			}
+			return true, nil
+		}
+	}
+
+	// No survivor can take the assignment; leave the deleted host's row in place.
+	return true, nil
+}
+
 func (ds *Datastore) SetHostMDMMigrationCompleted(ctx context.Context, hostID uint) error {
 	_, err := ds.writer(ctx).ExecContext(ctx, `
 		UPDATE host_dep_assignments

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2157,6 +2157,9 @@ func (ds *Datastore) GetHostDEPAssignmentsBySerial(ctx context.Context, serial s
 }
 
 func (ds *Datastore) ReconcileDuplicateDEPHostOnDelete(ctx context.Context, serial, platform string, deletedHostID uint) (duplicateExists bool, err error) {
+	if serial == "" || platform == "" {
+		return false, nil
+	}
 	type candidate struct {
 		HostID              uint `db:"host_id"`
 		HasActiveAssignment bool `db:"has_active_assignment"`
@@ -2196,8 +2199,8 @@ func (ds *Datastore) ReconcileDuplicateDEPHostOnDelete(ctx context.Context, seri
 	for _, c := range candidates {
 		if !c.HasAnyAssignment {
 			if _, err := ds.writer(ctx).ExecContext(ctx,
-				`UPDATE host_dep_assignments SET host_id = ? WHERE host_id = ?`,
-				c.HostID, deletedHostID,
+				`UPDATE host_dep_assignments SET host_id = ? WHERE host_id = ? AND hardware_serial = ? AND deleted_at IS NULL`,
+				c.HostID, deletedHostID, serial,
 			); err != nil {
 				return true, ctxerr.Wrap(ctx, err, "transfer dep assignment to surviving host")
 			}

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -81,6 +81,7 @@ func TestMDMApple(t *testing.T) {
 		{"TestMDMAppleSetupAssistant", testMDMAppleSetupAssistant},
 		{"TestMDMAppleEnrollmentProfile", testMDMAppleEnrollmentProfile},
 		{"TestListMDMAppleSerials", testListMDMAppleSerials},
+		{"TestReconcileDuplicateDEPHostOnDelete", testReconcileDuplicateDEPHostOnDelete},
 		{"TestMDMAppleDefaultSetupAssistant", testMDMAppleDefaultSetupAssistant},
 		{"TestSetVerifiedMacOSProfiles", testSetVerifiedMacOSProfiles},
 		{"TestMDMAppleConfigProfileHash", testMDMAppleConfigProfileHash},
@@ -4633,6 +4634,140 @@ func testMDMAppleEnrollmentProfile(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	getProf.UpdateCreateTimestamps = fleet.UpdateCreateTimestamps{}
 	require.Equal(t, profMan, getProf)
+}
+
+func testReconcileDuplicateDEPHostOnDelete(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	encTok := uuid.NewString()
+	abmToken, err := ds.InsertABMToken(ctx, &fleet.ABMToken{OrganizationName: "unused", EncryptedToken: []byte(encTok), RenewAt: time.Now().Add(365 * 24 * time.Hour)})
+	require.NoError(t, err)
+
+	newHostPlatform := func(name, serial, platform string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:       name,
+			OsqueryHostID:  ptr.String("osquery-" + name),
+			NodeKey:        ptr.String("nodekey-" + name),
+			UUID:           "uuid-" + name,
+			Platform:       platform,
+			HardwareSerial: serial,
+		})
+		require.NoError(t, err)
+		return h
+	}
+	newHost := func(name, serial string) *fleet.Host {
+		return newHostPlatform(name, serial, "darwin")
+	}
+	assignDEP := func(h *fleet.Host) {
+		require.NoError(t, ds.UpsertMDMAppleHostDEPAssignments(ctx, []fleet.Host{*h}, abmToken.ID, make(map[uint]time.Time)))
+	}
+	hasAssignment := func(hostID uint) bool {
+		_, err := ds.GetHostDEPAssignment(ctx, hostID)
+		if err != nil {
+			require.True(t, fleet.IsNotFound(err))
+			return false
+		}
+		return true
+	}
+
+	t.Run("no duplicate, assignment untouched", func(t *testing.T) {
+		serial := "solo-serial"
+		deleted := newHost("solo-deleted", serial)
+		assignDEP(deleted)
+
+		dup, err := ds.ReconcileDuplicateDEPHostOnDelete(ctx, serial, "darwin", deleted.ID)
+		require.NoError(t, err)
+		require.False(t, dup)
+		require.True(t, hasAssignment(deleted.ID))
+	})
+
+	t.Run("survivor already assigned, no transfer", func(t *testing.T) {
+		serial := "dup-serial"
+		deleted := newHost("dup-deleted", serial)
+		survivor := newHost("dup-survivor", serial)
+		assignDEP(deleted)
+		assignDEP(survivor)
+
+		dup, err := ds.ReconcileDuplicateDEPHostOnDelete(ctx, serial, "darwin", deleted.ID)
+		require.NoError(t, err)
+		require.True(t, dup)
+		// Both rows remain in place; the deleted host's row becomes a phantom.
+		require.True(t, hasAssignment(deleted.ID))
+		require.True(t, hasAssignment(survivor.ID))
+	})
+
+	t.Run("survivor unassigned, assignment transferred", func(t *testing.T) {
+		serial := "xfer-serial"
+		deleted := newHost("xfer-deleted", serial)
+		survivor := newHost("xfer-survivor", serial)
+		assignDEP(deleted)
+
+		dup, err := ds.ReconcileDuplicateDEPHostOnDelete(ctx, serial, "darwin", deleted.ID)
+		require.NoError(t, err)
+		require.True(t, dup)
+		// The deleted host's assignment moved to the surviving host.
+		require.False(t, hasAssignment(deleted.ID))
+		require.True(t, hasAssignment(survivor.ID))
+
+		transferred, err := ds.GetHostDEPAssignment(ctx, survivor.ID)
+		require.NoError(t, err)
+		require.Equal(t, survivor.ID, transferred.HostID)
+	})
+
+	t.Run("survivor has soft-deleted assignment, no transfer", func(t *testing.T) {
+		serial := "softdel-serial"
+		deleted := newHost("softdel-deleted", serial)
+		survivor := newHost("softdel-survivor", serial)
+		assignDEP(deleted)
+		assignDEP(survivor)
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `UPDATE host_dep_assignments SET deleted_at = NOW() WHERE host_id = ?`, survivor.ID)
+			return err
+		})
+
+		dup, err := ds.ReconcileDuplicateDEPHostOnDelete(ctx, serial, "darwin", deleted.ID)
+		require.NoError(t, err)
+		require.True(t, dup)
+		// No transfer: the survivor already has a (soft-deleted) row, so moving
+		// the deleted host's row would collide on the primary key.
+		require.True(t, hasAssignment(deleted.ID))
+		require.True(t, hasAssignment(survivor.ID))
+	})
+
+	t.Run("survivor assignment serial mismatch, no transfer", func(t *testing.T) {
+		serial := "mismatch-serial"
+		deleted := newHost("mm-deleted", serial)
+		assignDEP(deleted)
+		// Survivor's host row has the serial, but its assignment row carries a
+		// stale serial, so it is neither an active match nor a transfer target.
+		survivor := newHost("mm-survivor", "mm-temp-serial")
+		assignDEP(survivor)
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `UPDATE hosts SET hardware_serial = ? WHERE id = ?`, serial, survivor.ID)
+			return err
+		})
+
+		dup, err := ds.ReconcileDuplicateDEPHostOnDelete(ctx, serial, "darwin", deleted.ID)
+		require.NoError(t, err)
+		require.True(t, dup)
+		require.True(t, hasAssignment(deleted.ID))
+	})
+
+	t.Run("same serial different platform is not a duplicate", func(t *testing.T) {
+		serial := "platform-serial"
+		deleted := newHost("plat-deleted", serial)
+		assignDEP(deleted)
+		// Same serial but a different platform (e.g. a stale iOS record) must not
+		// be treated as a duplicate of the darwin host being deleted.
+		other := newHostPlatform("plat-other", serial, "ios")
+		assignDEP(other)
+
+		dup, err := ds.ReconcileDuplicateDEPHostOnDelete(ctx, serial, "darwin", deleted.ID)
+		require.NoError(t, err)
+		require.False(t, dup)
+		require.True(t, hasAssignment(deleted.ID))
+		require.True(t, hasAssignment(other.ID))
+	})
 }
 
 func testListMDMAppleSerials(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1527,6 +1527,15 @@ type Datastore interface {
 	// GetHostDEPAssignmentsBySerial returns the DEP assignment for the host with the specified serial number.
 	GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*HostDEPAssignment, error)
 
+	// ReconcileDuplicateDEPHostOnDelete handles the DEP assignment of a host
+	// being deleted when one or more duplicate hosts (same serial and platform,
+	// excluding deletedHostID) still exist. It returns true if such a duplicate
+	// exists, in which case the caller must NOT restore a pending "ghost" host.
+	// When a surviving duplicate has no DEP assignment of its own, the deleted
+	// host's assignment is transferred to it so the ABM relationship is
+	// preserved.
+	ReconcileDuplicateDEPHostOnDelete(ctx context.Context, serial, platform string, deletedHostID uint) (duplicateExists bool, err error)
+
 	// GetNanoMDMEnrollment returns the nano enrollment information for the device id.
 	GetNanoMDMEnrollment(ctx context.Context, id string) (*NanoEnrollment, error)
 

--- a/server/mdm/lifecycle/lifecycle.go
+++ b/server/mdm/lifecycle/lifecycle.go
@@ -304,6 +304,21 @@ func (t *HostLifecycle) deleteApple(ctx context.Context, opts HostOptions) error
 	}
 
 	if dep != nil && dep.DeletedAt == nil {
+		// Don't recreate a pending "ghost" host if a duplicate host for the same
+		// serial still exists. This happens when an operator deletes one of a set
+		// of duplicate hosts (e.g. from a Migration Assistant flow) to resolve the
+		// duplicate — restoring a ghost here would just recreate the duplicate they
+		// removed. If the surviving duplicate has no DEP assignment of its own, the
+		// deleted host's assignment is transferred to it to preserve the ABM
+		// relationship.
+		dupExists, err := t.ds.ReconcileDuplicateDEPHostOnDelete(ctx, opts.Host.HardwareSerial, opts.Host.Platform, opts.Host.ID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "reconcile duplicate dep host")
+		}
+		if dupExists {
+			return nil
+		}
+
 		return t.restorePendingDEPHost(ctx, opts.Host, dep.ABMTokenID)
 	}
 

--- a/server/mdm/lifecycle/lifecycle_test.go
+++ b/server/mdm/lifecycle/lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/require"
@@ -63,4 +64,67 @@ func TestDoParamValidation(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
+}
+
+// TestDeleteAppleDuplicateDEPHost verifies that deleting one of a set of
+// duplicate DEP hosts (same serial) does not recreate a pending "ghost" host
+// when another DEP-assigned host with that serial still exists, while a host
+// with no duplicate is still restored as before.
+func TestDeleteAppleDuplicateDEPHost(t *testing.T) {
+	ctx := license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+
+	const serial = "ABC123XYZ"
+	host := &fleet.Host{ID: 1, HardwareSerial: serial, Platform: "darwin"}
+
+	newDS := func(dupExists bool) *mock.Store {
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			ac := &fleet.AppConfig{}
+			ac.MDM.AppleBMEnabledAndConfigured = true
+			return ac, nil
+		}
+		abmTokenID := uint(7)
+		ds.GetHostDEPAssignmentFunc = func(ctx context.Context, hostID uint) (*fleet.HostDEPAssignment, error) {
+			return &fleet.HostDEPAssignment{HostID: hostID, ABMTokenID: &abmTokenID}, nil
+		}
+		ds.ReconcileDuplicateDEPHostOnDeleteFunc = func(ctx context.Context, s, platform string, deletedHostID uint) (bool, error) {
+			require.Equal(t, serial, s)
+			require.Equal(t, host.Platform, platform)
+			require.Equal(t, host.ID, deletedHostID)
+			return dupExists, nil
+		}
+		ds.RestoreMDMApplePendingDEPHostFunc = func(ctx context.Context, h *fleet.Host) error {
+			return nil
+		}
+		return ds
+	}
+
+	t.Run("duplicate exists, ghost host not restored", func(t *testing.T) {
+		ds := newDS(true)
+
+		lc := New(ds, slog.New(slog.DiscardHandler), nopNewActivity)
+		err := lc.Do(ctx, HostOptions{Action: HostActionDelete, Platform: "darwin", Host: host})
+		require.NoError(t, err)
+
+		require.True(t, ds.ReconcileDuplicateDEPHostOnDeleteFuncInvoked)
+		require.False(t, ds.RestoreMDMApplePendingDEPHostFuncInvoked)
+	})
+
+	t.Run("no duplicate, ghost host restored", func(t *testing.T) {
+		ds := newDS(false)
+		// "No team" default keeps getDefaultTeamForABMToken from needing TeamExists.
+		ds.GetABMTokenByIDFunc = func(ctx context.Context, tokenID uint) (*fleet.ABMToken, error) {
+			return &fleet.ABMToken{ID: tokenID}, nil
+		}
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+			return job, nil
+		}
+
+		lc := New(ds, slog.New(slog.DiscardHandler), nopNewActivity)
+		err := lc.Do(ctx, HostOptions{Action: HostActionDelete, Platform: "darwin", Host: host})
+		require.NoError(t, err)
+
+		require.True(t, ds.ReconcileDuplicateDEPHostOnDeleteFuncInvoked)
+		require.True(t, ds.RestoreMDMApplePendingDEPHostFuncInvoked)
+	})
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1032,6 +1032,8 @@ type GetHostDEPAssignmentFunc func(ctx context.Context, hostID uint) (*fleet.Hos
 
 type GetHostDEPAssignmentsBySerialFunc func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error)
 
+type ReconcileDuplicateDEPHostOnDeleteFunc func(ctx context.Context, serial string, platform string, deletedHostID uint) (duplicateExists bool, err error)
+
 type GetNanoMDMEnrollmentFunc func(ctx context.Context, id string) (*fleet.NanoEnrollment, error)
 
 type GetNanoMDMUserEnrollmentFunc func(ctx context.Context, id string) (*fleet.NanoEnrollment, error)
@@ -3568,6 +3570,9 @@ type DataStore struct {
 
 	GetHostDEPAssignmentsBySerialFunc        GetHostDEPAssignmentsBySerialFunc
 	GetHostDEPAssignmentsBySerialFuncInvoked bool
+
+	ReconcileDuplicateDEPHostOnDeleteFunc        ReconcileDuplicateDEPHostOnDeleteFunc
+	ReconcileDuplicateDEPHostOnDeleteFuncInvoked bool
 
 	GetNanoMDMEnrollmentFunc        GetNanoMDMEnrollmentFunc
 	GetNanoMDMEnrollmentFuncInvoked bool
@@ -8634,6 +8639,13 @@ func (s *DataStore) GetHostDEPAssignmentsBySerial(ctx context.Context, serial st
 	s.GetHostDEPAssignmentsBySerialFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetHostDEPAssignmentsBySerialFunc(ctx, serial)
+}
+
+func (s *DataStore) ReconcileDuplicateDEPHostOnDelete(ctx context.Context, serial string, platform string, deletedHostID uint) (duplicateExists bool, err error) {
+	s.mu.Lock()
+	s.ReconcileDuplicateDEPHostOnDeleteFuncInvoked = true
+	s.mu.Unlock()
+	return s.ReconcileDuplicateDEPHostOnDeleteFunc(ctx, serial, platform, deletedHostID)
 }
 
 func (s *DataStore) GetNanoMDMEnrollment(ctx context.Context, id string) (*fleet.NanoEnrollment, error) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45192 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting one of multiple duplicate Apple DEP hosts now properly resolves the duplicate and prevents recreation of a pending host when another host with the same serial and platform still exists.

* **Tests**
  * Added unit tests covering deletion behavior for duplicate DEP hosts to ensure correct resolution and no unintended pending-host restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->