### PR TITLE
Display tooltips for fleets and roles on Settings > Users and My account pages

### DIFF
--- a/changes/46920-tooltips-for-fleets-and-roles
+++ b/changes/46920-tooltips-for-fleets-and-roles
@@ -1,0 +1,1 @@
+- Added tooltips on the Settings > Users and My account pages to show assigned fleets and roles when a user has multiple.

--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -14,7 +14,14 @@ import CustomLink from "components/CustomLink";
 import Radio from "components/forms/fields/Radio";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
-import { generateRole, generateTeam, readableDate } from "utilities/helpers";
+import {
+  generateRole,
+  generateTeam,
+  readableDate,
+  tooltipTextWithLineBreaks,
+} from "utilities/helpers";
+import stringUtils from "utilities/strings";
+import TooltipWrapper from "components/TooltipWrapper";
 import { getThemeMode, setThemeMode, ThemeMode } from "utilities/theme";
 
 interface IAccountSidePanelProps {
@@ -65,6 +72,33 @@ const AccountSidePanel = ({
   const roleText = generateRole(teams, globalRole);
   const teamsText = generateTeam(teams, globalRole);
 
+  const teamNames = (() => {
+    const names = teams.map((t) => t.name);
+    return globalRole !== null && teams.length > 0
+      ? ["Global", ...names]
+      : names;
+  })();
+
+  const roleGroups = (() => {
+    const groups: { role: string; names: string[] }[] = [];
+    if (globalRole !== null && teams.length > 0) {
+      groups.push({
+        role: stringUtils.capitalizeRole(globalRole),
+        names: ["Global"],
+      });
+    }
+    teams.forEach((team) => {
+      const role = stringUtils.capitalizeRole(team.role || "Unassigned");
+      const existing = groups.find((g) => g.role === role);
+      if (existing) {
+        existing.names.push(team.name);
+      } else {
+        groups.push({ role, names: [team.name] });
+      }
+    });
+    return groups;
+  })();
+
   const lastUpdatedAt = updatedAt && (
     <HumanTimeDiffWithDateTip timeString={updatedAt} />
   );
@@ -110,8 +144,51 @@ const AccountSidePanel = ({
           onChange={onThemeSelect}
         />
       </div>
-      {isPremiumTier && <DataSet title="Fleets" value={teamsText} />}
-      <DataSet title="Role" value={roleText} />
+      {isPremiumTier && (
+        <DataSet
+          title="Fleets"
+          value={
+            teamNames.length > 1 ? (
+              <TooltipWrapper
+                tipContent={tooltipTextWithLineBreaks(teamNames)}
+                underline={false}
+                showArrow
+                position="top"
+                tipOffset={10}
+                fixedPositionStrategy
+              >
+                {teamsText}
+              </TooltipWrapper>
+            ) : (
+              teamsText
+            )
+          }
+        />
+      )}
+      <DataSet
+        title="Role"
+        value={
+          roleText === "Various" ? (
+            <TooltipWrapper
+              tipContent={roleGroups.map(({ role, names }) => (
+                <span key={role}>
+                  <b>{role}:</b> {names.join(", ")}
+                  <br />
+                </span>
+              ))}
+              underline={false}
+              showArrow
+              position="top"
+              tipOffset={10}
+              fixedPositionStrategy
+            >
+              {roleText}
+            </TooltipWrapper>
+          ) : (
+            roleText
+          )
+        }
+      />
       {isPremiumTier && config && (
         <DataSet
           title="License expiration date"

--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -16,11 +16,12 @@ import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
 import {
   generateRole,
+  generateRoleGroups,
   generateTeam,
+  generateTeamNames,
   readableDate,
   tooltipTextWithLineBreaks,
 } from "utilities/helpers";
-import stringUtils from "utilities/strings";
 import TooltipWrapper from "components/TooltipWrapper";
 import { getThemeMode, setThemeMode, ThemeMode } from "utilities/theme";
 
@@ -72,21 +73,8 @@ const AccountSidePanel = ({
   const roleText = generateRole(teams, globalRole);
   const teamsText = generateTeam(teams, globalRole);
 
-  const teamNames = teams.map((t) => t.name);
-
-  const roleGroups = (() => {
-    const groups: { role: string; names: string[] }[] = [];
-    teams.forEach((team) => {
-      const role = stringUtils.capitalizeRole(team.role || "Unassigned");
-      const existing = groups.find((g) => g.role === role);
-      if (existing) {
-        existing.names.push(team.name);
-      } else {
-        groups.push({ role, names: [team.name] });
-      }
-    });
-    return groups;
-  })();
+  const teamNames = generateTeamNames(teams);
+  const roleGroups = generateRoleGroups(teams);
 
   const lastUpdatedAt = updatedAt && (
     <HumanTimeDiffWithDateTip timeString={updatedAt} />

--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -72,21 +72,10 @@ const AccountSidePanel = ({
   const roleText = generateRole(teams, globalRole);
   const teamsText = generateTeam(teams, globalRole);
 
-  const teamNames = (() => {
-    const names = teams.map((t) => t.name);
-    return globalRole !== null && teams.length > 0
-      ? ["Global", ...names]
-      : names;
-  })();
+  const teamNames = teams.map((t) => t.name);
 
   const roleGroups = (() => {
     const groups: { role: string; names: string[] }[] = [];
-    if (globalRole !== null && teams.length > 0) {
-      groups.push({
-        role: stringUtils.capitalizeRole(globalRole),
-        names: ["Global"],
-      });
-    }
     teams.forEach((team) => {
       const role = stringUtils.capitalizeRole(team.role || "Unassigned");
       const existing = groups.find((g) => g.role === role);

--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -20,6 +20,7 @@ import {
   generateTeam,
   generateTeamNames,
   readableDate,
+  ROLE_VARIOUS,
   tooltipTextWithLineBreaks,
 } from "utilities/helpers";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -145,7 +146,7 @@ const AccountSidePanel = ({
       <DataSet
         title="Role"
         value={
-          roleText === "Various" ? (
+          roleText === ROLE_VARIOUS ? (
             <TooltipWrapper
               tipContent={roleGroups.map(({ role, names }) => (
                 <span key={role}>

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -7,9 +7,10 @@ import TooltipTruncatedTextCell from "components/TableContainer/DataTable/Toolti
 import TooltipWrapper from "components/TooltipWrapper";
 import PillBadge from "components/PillBadge";
 import { IInvite } from "interfaces/invite";
+import { ITeam } from "interfaces/team";
 import { IUser, UserRole } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";
-import { generateRole, generateTeam, greyCell } from "utilities/helpers";
+import { generateRole, generateTeam, greyCell, tooltipTextWithLineBreaks } from "utilities/helpers";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import ActionsDropdown from "../../../../../components/ActionsDropdown";
 
@@ -58,6 +59,7 @@ export interface IUserTableData {
   status: string;
   email: string;
   teams: string;
+  teamNames: string[];
   role: UserRole;
   actions: IDropdownOption[];
   /** Prefixed ID used as a unique react-table row key (e.g. "user-3", "invite-1") */
@@ -200,9 +202,31 @@ const generateTableHeaders = (
       Header: "Fleets",
       accessor: "teams",
       disableSortBy: true,
-      Cell: (cellProps: ICellProps) => (
-        <TextCell value={cellProps.cell.value} />
-      ),
+      Cell: (cellProps: ICellProps) => {
+        const { teamNames } = cellProps.row.original;
+        if (teamNames.length > 1) {
+          return (
+            <TooltipWrapper
+              tipContent={tooltipTextWithLineBreaks(teamNames)}
+              underline={false}
+              showArrow
+              position="top"
+              tipOffset={10}
+              fixedPositionStrategy
+            >
+              <TextCell value={cellProps.cell.value} grey italic />
+            </TooltipWrapper>
+          );
+        }
+        const isGrey = greyCell(cellProps.cell.value);
+        return (
+          <TextCell
+            value={cellProps.cell.value}
+            grey={isGrey}
+            italic={isGrey && cellProps.cell.value !== "Global"}
+          />
+        );
+      },
     });
   }
 
@@ -276,6 +300,17 @@ const generateActionDropdownOptions = (
   return dropdownOptions;
 };
 
+const generateTeamNames = (
+  teams: ITeam[],
+  globalRole: UserRole | null
+): string[] => {
+  const names = teams.map((t) => t.name);
+  if (globalRole !== null && teams.length > 0) {
+    return ["Global", ...names];
+  }
+  return names;
+};
+
 const enhanceUserData = (
   users: IUser[],
   currentUserId: number
@@ -286,6 +321,7 @@ const enhanceUserData = (
       status: generateStatus("user", user),
       email: user.email,
       teams: generateTeam(user.teams, user.global_role),
+      teamNames: generateTeamNames(user.teams, user.global_role),
       role: generateRole(user.teams, user.global_role),
       actions: generateActionDropdownOptions(
         user.id === currentUserId,
@@ -308,6 +344,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       status: generateStatus("invite", invite),
       email: invite.email,
       teams: generateTeam(invite.teams, invite.global_role),
+      teamNames: generateTeamNames(invite.teams, invite.global_role),
       role: generateRole(invite.teams, invite.global_role),
       actions: generateActionDropdownOptions(
         false,

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -7,16 +7,16 @@ import TooltipTruncatedTextCell from "components/TableContainer/DataTable/Toolti
 import TooltipWrapper from "components/TooltipWrapper";
 import PillBadge from "components/PillBadge";
 import { IInvite } from "interfaces/invite";
-import { ITeam } from "interfaces/team";
 import { IUser, UserRole } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import {
   generateRole,
+  generateRoleGroups,
   generateTeam,
+  generateTeamNames,
   greyCell,
   tooltipTextWithLineBreaks,
 } from "utilities/helpers";
-import stringUtils from "utilities/strings";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import ActionsDropdown from "../../../../../components/ActionsDropdown";
 
@@ -327,26 +327,6 @@ const generateActionDropdownOptions = (
   return dropdownOptions;
 };
 
-const generateTeamNames = (teams: ITeam[]): string[] => {
-  return teams.map((t) => t.name);
-};
-
-const generateRoleGroups = (
-  teams: ITeam[]
-): { role: string; names: string[] }[] => {
-  const groups: { role: string; names: string[] }[] = [];
-  teams.forEach((team) => {
-    const role = stringUtils.capitalizeRole(team.role || "Unassigned");
-    const existing = groups.find((g) => g.role === role);
-    if (existing) {
-      existing.names.push(team.name);
-    } else {
-      groups.push({ role, names: [team.name] });
-    }
-  });
-  return groups;
-};
-
 const enhanceUserData = (
   users: IUser[],
   currentUserId: number
@@ -381,7 +361,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       status: generateStatus("invite", invite),
       email: invite.email,
       teams: generateTeam(invite.teams, invite.global_role),
-      teamNames: generateTeamNames(invite.teams, invite.global_role),
+      teamNames: generateTeamNames(invite.teams),
       roleGroups: generateRoleGroups(invite.teams),
       role: generateRole(invite.teams, invite.global_role),
       actions: generateActionDropdownOptions(

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -327,28 +327,14 @@ const generateActionDropdownOptions = (
   return dropdownOptions;
 };
 
-const generateTeamNames = (
-  teams: ITeam[],
-  globalRole: UserRole | null
-): string[] => {
-  const names = teams.map((t) => t.name);
-  if (globalRole !== null && teams.length > 0) {
-    return ["Global", ...names];
-  }
-  return names;
+const generateTeamNames = (teams: ITeam[]): string[] => {
+  return teams.map((t) => t.name);
 };
 
 const generateRoleGroups = (
-  teams: ITeam[],
-  globalRole: UserRole | null
+  teams: ITeam[]
 ): { role: string; names: string[] }[] => {
   const groups: { role: string; names: string[] }[] = [];
-  if (globalRole !== null && teams.length > 0) {
-    groups.push({
-      role: stringUtils.capitalizeRole(globalRole),
-      names: ["Global"],
-    });
-  }
   teams.forEach((team) => {
     const role = stringUtils.capitalizeRole(team.role || "Unassigned");
     const existing = groups.find((g) => g.role === role);
@@ -371,8 +357,8 @@ const enhanceUserData = (
       status: generateStatus("user", user),
       email: user.email,
       teams: generateTeam(user.teams, user.global_role),
-      teamNames: generateTeamNames(user.teams, user.global_role),
-      roleGroups: generateRoleGroups(user.teams, user.global_role),
+      teamNames: generateTeamNames(user.teams),
+      roleGroups: generateRoleGroups(user.teams),
       role: generateRole(user.teams, user.global_role),
       actions: generateActionDropdownOptions(
         user.id === currentUserId,
@@ -396,7 +382,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       email: invite.email,
       teams: generateTeam(invite.teams, invite.global_role),
       teamNames: generateTeamNames(invite.teams, invite.global_role),
-      roleGroups: generateRoleGroups(invite.teams, invite.global_role),
+      roleGroups: generateRoleGroups(invite.teams),
       role: generateRole(invite.teams, invite.global_role),
       actions: generateActionDropdownOptions(
         false,

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -11,6 +11,7 @@ import { ITeam } from "interfaces/team";
 import { IUser, UserRole } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import { generateRole, generateTeam, greyCell, tooltipTextWithLineBreaks } from "utilities/helpers";
+import stringUtils from "utilities/strings";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import ActionsDropdown from "../../../../../components/ActionsDropdown";
 
@@ -60,6 +61,7 @@ export interface IUserTableData {
   email: string;
   teams: string;
   teamNames: string[];
+  roleGroups: { role: string; names: string[] }[];
   role: UserRole;
   actions: IDropdownOption[];
   /** Prefixed ID used as a unique react-table row key (e.g. "user-3", "invite-1") */
@@ -131,6 +133,26 @@ const generateTableHeaders = (
               }
             >
               {cellProps.cell.value}
+            </TooltipWrapper>
+          );
+        }
+        if (cellProps.cell.value === "Various") {
+          const { roleGroups } = cellProps.row.original;
+          return (
+            <TooltipWrapper
+              tipContent={roleGroups.map(({ role, names }) => (
+                <span key={role}>
+                  <b>{role}:</b> {names.join(", ")}
+                  <br />
+                </span>
+              ))}
+              underline={false}
+              showArrow
+              position="top"
+              tipOffset={10}
+              fixedPositionStrategy
+            >
+              <TextCell value="Various" grey italic />
             </TooltipWrapper>
           );
         }
@@ -311,6 +333,26 @@ const generateTeamNames = (
   return names;
 };
 
+const generateRoleGroups = (
+  teams: ITeam[],
+  globalRole: UserRole | null
+): { role: string; names: string[] }[] => {
+  const groups: { role: string; names: string[] }[] = [];
+  if (globalRole !== null && teams.length > 0) {
+    groups.push({ role: stringUtils.capitalizeRole(globalRole), names: ["Global"] });
+  }
+  teams.forEach((team) => {
+    const role = stringUtils.capitalizeRole(team.role || "Unassigned");
+    const existing = groups.find((g) => g.role === role);
+    if (existing) {
+      existing.names.push(team.name);
+    } else {
+      groups.push({ role, names: [team.name] });
+    }
+  });
+  return groups;
+};
+
 const enhanceUserData = (
   users: IUser[],
   currentUserId: number
@@ -322,6 +364,7 @@ const enhanceUserData = (
       email: user.email,
       teams: generateTeam(user.teams, user.global_role),
       teamNames: generateTeamNames(user.teams, user.global_role),
+      roleGroups: generateRoleGroups(user.teams, user.global_role),
       role: generateRole(user.teams, user.global_role),
       actions: generateActionDropdownOptions(
         user.id === currentUserId,
@@ -345,6 +388,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       email: invite.email,
       teams: generateTeam(invite.teams, invite.global_role),
       teamNames: generateTeamNames(invite.teams, invite.global_role),
+      roleGroups: generateRoleGroups(invite.teams, invite.global_role),
       role: generateRole(invite.teams, invite.global_role),
       actions: generateActionDropdownOptions(
         false,

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -10,7 +10,12 @@ import { IInvite } from "interfaces/invite";
 import { ITeam } from "interfaces/team";
 import { IUser, UserRole } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";
-import { generateRole, generateTeam, greyCell, tooltipTextWithLineBreaks } from "utilities/helpers";
+import {
+  generateRole,
+  generateTeam,
+  greyCell,
+  tooltipTextWithLineBreaks,
+} from "utilities/helpers";
 import stringUtils from "utilities/strings";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import ActionsDropdown from "../../../../../components/ActionsDropdown";
@@ -339,7 +344,10 @@ const generateRoleGroups = (
 ): { role: string; names: string[] }[] => {
   const groups: { role: string; names: string[] }[] = [];
   if (globalRole !== null && teams.length > 0) {
-    groups.push({ role: stringUtils.capitalizeRole(globalRole), names: ["Global"] });
+    groups.push({
+      role: stringUtils.capitalizeRole(globalRole),
+      names: ["Global"],
+    });
   }
   teams.forEach((team) => {
     const role = stringUtils.capitalizeRole(team.role || "Unassigned");

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -15,6 +15,8 @@ import {
   generateTeam,
   generateTeamNames,
   greyCell,
+  ROLE_VARIOUS,
+  ROLE_GLOBAL,
   tooltipTextWithLineBreaks,
 } from "utilities/helpers";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
@@ -141,7 +143,7 @@ const generateTableHeaders = (
             </TooltipWrapper>
           );
         }
-        if (cellProps.cell.value === "Various") {
+        if (cellProps.cell.value === ROLE_VARIOUS) {
           const { roleGroups } = cellProps.row.original;
           return (
             <TooltipWrapper
@@ -157,7 +159,7 @@ const generateTableHeaders = (
               tipOffset={10}
               fixedPositionStrategy
             >
-              <TextCell value="Various" grey italic />
+              <TextCell value={ROLE_VARIOUS} grey italic />
             </TooltipWrapper>
           );
         }
@@ -250,7 +252,7 @@ const generateTableHeaders = (
           <TextCell
             value={cellProps.cell.value}
             grey={isGrey}
-            italic={isGrey && cellProps.cell.value !== "Global"}
+            italic={isGrey && cellProps.cell.value !== ROLE_GLOBAL}
           />
         );
       },

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -450,6 +450,9 @@ export const formatScriptNameForActivityItem = (name: string | undefined) => {
   );
 };
 
+export const ROLE_VARIOUS = "Various";
+export const ROLE_GLOBAL = "Global";
+
 export const generateRole = (
   teams: ITeam[],
   globalRole: UserRole | null
@@ -477,14 +480,14 @@ export const generateRole = (
       return "Technician";
     }
 
-    return "Various"; // no global role and multiple teams
+    return ROLE_VARIOUS; // no global role and multiple teams
   }
 
   if (teams.length === 0) {
     // global role and no teams
     return stringUtils.capitalizeRole(globalRole);
   }
-  return "Various"; // global role and one or more teams
+  return ROLE_VARIOUS; // global role and one or more teams
 };
 
 export const generateTeam = (
@@ -504,7 +507,7 @@ export const generateTeam = (
 
   if (teams.length === 0) {
     // global role and no teams
-    return "Global";
+    return ROLE_GLOBAL;
   }
   return `${teams.length + 1} fleets`; // global role and one or more teams
 };
@@ -530,7 +533,13 @@ export const generateRoleGroups = (
 };
 
 export const greyCell = (roleOrTeamText: string): boolean => {
-  const GREYED_TEXT = ["Global", "Unassigned", "Various", "No team", "Unknown"];
+  const GREYED_TEXT = [
+    ROLE_GLOBAL,
+    "Unassigned",
+    ROLE_VARIOUS,
+    "No team",
+    "Unknown",
+  ];
 
   return (
     GREYED_TEXT.includes(roleOrTeamText) || roleOrTeamText.includes(" fleets")
@@ -1013,6 +1022,8 @@ export default {
   generateRoleGroups,
   generateTeam,
   generateTeamNames,
+  ROLE_VARIOUS,
+  ROLE_GLOBAL,
   getUniqueColsAreNumTypeFromRows,
   getCustomDropdownOptions,
   greyCell,

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -509,6 +509,26 @@ export const generateTeam = (
   return `${teams.length + 1} fleets`; // global role and one or more teams
 };
 
+export const generateTeamNames = (teams: ITeam[]): string[] => {
+  return teams.map((t) => t.name);
+};
+
+export const generateRoleGroups = (
+  teams: ITeam[]
+): { role: string; names: string[] }[] => {
+  const groups: { role: string; names: string[] }[] = [];
+  teams.forEach((team) => {
+    const role = stringUtils.capitalizeRole(team.role || "Unassigned");
+    const existing = groups.find((g) => g.role === role);
+    if (existing) {
+      existing.names.push(team.name);
+    } else {
+      groups.push({ role, names: [team.name] });
+    }
+  });
+  return groups;
+};
+
 export const greyCell = (roleOrTeamText: string): boolean => {
   const GREYED_TEXT = ["Global", "Unassigned", "Various", "No team", "Unknown"];
 
@@ -990,7 +1010,9 @@ export default {
   formatSelectedTargetsForApi,
   formatPackTargetsForApi,
   generateRole,
+  generateRoleGroups,
   generateTeam,
+  generateTeamNames,
   getUniqueColsAreNumTypeFromRows,
   getCustomDropdownOptions,
   greyCell,


### PR DESCRIPTION
Resolves #46920.

When a user is assigned to multiple fleets, show a tooltip with those fleets (similar to the User email column on the Hosts page).

<img width="317" height="201" alt="Screenshot 2026-06-04 at 10 23 32" src="https://github.com/user-attachments/assets/7a579bc7-30fc-47cf-b3d7-3042b5348698" />

When a user has more than one role type, show a tooltip with the roles/fleets for Various:

<img width="414" height="213" alt="Screenshot 2026-06-04 at 10 23 36" src="https://github.com/user-attachments/assets/2e1e2cb1-9265-462a-a51e-a9a0b9930b8a" />

My account:

<img width="244" height="278" alt="Screenshot 2026-06-11 at 09 13 02" src="https://github.com/user-attachments/assets/5a7f2621-8809-4c94-a02c-599f8137a562" />
<img width="323" height="293" alt="Screenshot 2026-06-11 at 09 13 06" src="https://github.com/user-attachments/assets/2e3befd2-dc97-49ea-a02d-42a888b140b2" />


# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Updates

* **New Features**
  * Added tooltip details for **Settings > Users** and **My account** to show all fleets and role groupings when a user has multiple assignments.

* **Improvements**
  * Updated admin user/invite tables to enrich displayed data for **Fleets** and **Role**.
  * “Role” now supports a special **Various** view with tooltip breakdown by associated teams.
  * **Fleets** cells now show expanded, multi-line tooltips for multi-team users and improved grey/italic styling for special cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->