### PR TITLE
Fix tight install loop on continous automations feature

### DIFF
--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2040,7 +2040,7 @@ func (ds *Datastore) getLatestUpcomingInstall(ctx context.Context, hostID, insta
 SELECT
 	execution_id,
 	'pending_install' AS status,
-	created_at
+	updated_at
 FROM
 	upcoming_activities
 WHERE
@@ -2067,7 +2067,7 @@ func (ds *Datastore) getLatestPastInstall(ctx context.Context, hostID, installer
 SELECT
 	execution_id,
 	status,
-	created_at
+	updated_at
 FROM
 	host_software_installs
 WHERE

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2039,7 +2039,8 @@ func (ds *Datastore) getLatestUpcomingInstall(ctx context.Context, hostID, insta
 	stmt := `
 SELECT
 	execution_id,
-	'pending_install' AS status
+	'pending_install' AS status,
+	created_at
 FROM
 	upcoming_activities
 WHERE
@@ -2065,7 +2066,8 @@ func (ds *Datastore) getLatestPastInstall(ctx context.Context, hostID, installer
 	stmt := `
 SELECT
 	execution_id,
-	status
+	status,
+	created_at
 FROM
 	host_software_installs
 WHERE

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -1285,10 +1285,14 @@ func (ds *Datastore) MapAdamIDsRecentInstalls(ctx context.Context, hostID uint, 
 
 func (ds *Datastore) MapAdamIDsRecentlyVerifiedInstalls(ctx context.Context, hostID uint, seconds int) (adamIDs map[string]struct{}, err error) {
 	var adamIDsList []string
+	// The window is keyed on verification_at (when the install became successful and
+	// triggered the host refetch), not created_at, so a long-running install verified
+	// recently still counts and the cooldown isn't bypassed. removed=1 rows are software
+	// no longer on the host, which should be reinstalled rather than throttled.
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &adamIDsList,
 		`SELECT DISTINCT(adam_id) FROM host_vpp_software_installs
-		WHERE host_id = ? AND canceled = 0 AND verification_at IS NOT NULL
-			AND created_at >= NOW() - INTERVAL ? SECOND`,
+		WHERE host_id = ? AND canceled = 0 AND removed = 0
+			AND verification_at >= NOW() - INTERVAL ? SECOND`,
 		hostID, seconds); err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "list host recently verified VPP installs")
 	}

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -1283,6 +1283,22 @@ func (ds *Datastore) MapAdamIDsRecentInstalls(ctx context.Context, hostID uint, 
 	return adamIDs, nil
 }
 
+func (ds *Datastore) MapAdamIDsRecentlyVerifiedInstalls(ctx context.Context, hostID uint, seconds int) (adamIDs map[string]struct{}, err error) {
+	var adamIDsList []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &adamIDsList,
+		`SELECT DISTINCT(adam_id) FROM host_vpp_software_installs
+		WHERE host_id = ? AND canceled = 0 AND verification_at IS NOT NULL
+			AND created_at >= NOW() - INTERVAL ? SECOND`,
+		hostID, seconds); err != nil && err != sql.ErrNoRows {
+		return nil, ctxerr.Wrap(ctx, err, "list host recently verified VPP installs")
+	}
+	adamIDs = make(map[string]struct{}, len(adamIDsList))
+	for _, id := range adamIDsList {
+		adamIDs[id] = struct{}{}
+	}
+	return adamIDs, nil
+}
+
 func (ds *Datastore) GetPastActivityDataForAndroidVPPAppInstall(ctx context.Context, cmdUUID string, status fleet.SoftwareInstallerStatus) (*fleet.User, *fleet.ActivityInstalledAppStoreApp, error) {
 	return ds.getPastActivityDataForAndroidVPPAppInstallDB(ctx, ds.reader(ctx), cmdUUID, status)
 }
@@ -3005,7 +3021,8 @@ func (ds *Datastore) checkSoftwareConflictsForVPPApp(ctx context.Context, tx sql
 		if exists {
 			return ctxerr.Wrap(ctx, fleet.ConflictError{
 				Message: fmt.Sprintf(fleet.CantAddSoftwareConflictMessage,
-					conflictingTitle, teamName)}, "vpp app conflicts with existing software installer")
+					conflictingTitle, teamName),
+			}, "vpp app conflicts with existing software installer")
 		}
 	}
 

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -52,6 +52,7 @@ func TestVPP(t *testing.T) {
 		{"VPPInstallOmitsConfigurationOnMacOS", testVPPInstallOmitsConfigurationOnMacOS},
 		{"MapAdamIDsPendingInstallVerification", testMapAdamIDsPendingInstallVerification},
 		{"MapAdamIDsRecentInstalls", testMapAdamIDsRecentInstalls},
+		{"MapAdamIDsRecentlyVerifiedInstalls", testMapAdamIDsRecentlyVerifiedInstalls},
 		{"GetHostVPPInstallByCommandUUID", testGetHostVPPInstallByCommandUUID},
 		{"RetryVPPInstallForHost", testRetryVPPAppInstallForHost},
 		{"VPPClientUsers", testVPPClientUsers},
@@ -2989,6 +2990,76 @@ func testMapAdamIDsRecentInstalls(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Empty(t, adamIDs)
 	})
+}
+
+func testMapAdamIDsRecentlyVerifiedInstalls(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+
+	dataToken, err := test.CreateVPPTokenData(time.Now().Add(24*time.Hour), "Test org"+t.Name(), "Test location"+t.Name())
+	require.NoError(t, err)
+	tok1, err := ds.InsertVPPToken(ctx, dataToken)
+	require.NoError(t, err)
+	_, err = ds.UpdateVPPTokenTeams(ctx, tok1.ID, []uint{tm.ID})
+	require.NoError(t, err)
+
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	iOSHost, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:       "ios-test-1",
+		UUID:           uuid.NewString(),
+		Platform:       string(fleet.IOSPlatform),
+		HardwareSerial: uuid.NewString(),
+		TeamID:         &tm.ID,
+	})
+	require.NoError(t, err)
+	nanoEnroll(t, ds, iOSHost, false)
+
+	iOSVPPApp := &fleet.VPPApp{
+		VPPAppTeam: fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{
+			AdamID:   "adam_vpp_1",
+			Platform: fleet.IOSPlatform,
+		}},
+		Name:             "vpp1",
+		BundleIdentifier: "com.app.vpp1",
+		LatestVersion:    "1.0.0",
+	}
+	va1, err := ds.InsertVPPAppWithTeam(ctx, iOSVPPApp, &tm.ID)
+	require.NoError(t, err)
+	adamID := va1.AdamID
+
+	// No installs yet.
+	adamIDs, err := ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, iOSHost.ID, 3600)
+	require.NoError(t, err)
+	require.Empty(t, adamIDs)
+
+	// Issue and acknowledge an install: not yet verified, so it must not be returned
+	// (only successful/verified installs request the refetch that drives the loop).
+	cmdUUID := createVPPAppInstallRequest(t, ds, iOSHost, adamID, user)
+	_, err = ds.activateNextUpcomingActivity(ctx, ds.writer(ctx), iOSHost.ID, "")
+	require.NoError(t, err)
+	createVPPAppInstallResult(t, ds, iOSHost, cmdUUID, fleet.MDMAppleStatusAcknowledged)
+
+	adamIDs, err = ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, iOSHost.ID, 3600)
+	require.NoError(t, err)
+	require.Empty(t, adamIDs, "an acknowledged-but-not-verified install must not count")
+
+	// Mark the install as verified: now it must be returned.
+	err = ds.SetVPPInstallAsVerified(ctx, iOSHost.ID, cmdUUID, uuid.NewString())
+	require.NoError(t, err)
+
+	adamIDs, err = ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, iOSHost.ID, 3600)
+	require.NoError(t, err)
+	require.Len(t, adamIDs, 1)
+	require.Contains(t, adamIDs, adamID)
+
+	// Outside the lookback window: not returned.
+	time.Sleep(2 * time.Second)
+	adamIDs, err = ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, iOSHost.ID, 1)
+	require.NoError(t, err)
+	require.Empty(t, adamIDs)
 }
 
 func testGetHostVPPInstallByCommandUUID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -3055,11 +3055,23 @@ func testMapAdamIDsRecentlyVerifiedInstalls(t *testing.T, ds *Datastore) {
 	require.Len(t, adamIDs, 1)
 	require.Contains(t, adamIDs, adamID)
 
-	// Outside the lookback window: not returned.
-	time.Sleep(2 * time.Second)
-	adamIDs, err = ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, iOSHost.ID, 1)
+	// Verified before the lookback window: not returned. Move verification_at into the
+	// past deterministically rather than sleeping.
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`UPDATE host_vpp_software_installs SET verification_at = NOW() - INTERVAL 2 HOUR WHERE command_uuid = ?`, cmdUUID)
 	require.NoError(t, err)
-	require.Empty(t, adamIDs)
+	adamIDs, err = ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, iOSHost.ID, 3600)
+	require.NoError(t, err)
+	require.Empty(t, adamIDs, "an install verified before the lookback window must not count")
+
+	// Recently verified but removed: not returned. Removed software is no longer on the
+	// host and should be reinstalled rather than throttled.
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`UPDATE host_vpp_software_installs SET verification_at = NOW(), removed = 1 WHERE command_uuid = ?`, cmdUUID)
+	require.NoError(t, err)
+	adamIDs, err = ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, iOSHost.ID, 3600)
+	require.NoError(t, err)
+	require.Empty(t, adamIDs, "a removed install must not count")
 }
 
 func testGetHostVPPInstallByCommandUUID(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2686,6 +2686,14 @@ type Datastore interface {
 	// MapAdamIDsPendingInstall gets App Store IDs of VPP apps pending install for a host
 	MapAdamIDsPendingInstall(ctx context.Context, hostID uint) (map[string]struct{}, error)
 
+	// MapAdamIDsRecentlyVerifiedInstalls gets App Store IDs of VPP apps that were
+	// successfully installed (verified) on the host within the provided number of
+	// seconds. It is used to throttle continuous policy automation re-installs (see
+	// the continuousAutomationOnCooldown service helper): only a successful install
+	// requests a host refetch, so only successful installs can drive the loop the
+	// throttle prevents.
+	MapAdamIDsRecentlyVerifiedInstalls(ctx context.Context, hostID uint, seconds int) (adamIDs map[string]struct{}, err error)
+
 	// MapAdamIDsPendingInstallVerification gets Apps Store IDs of VPP apps pending verifications
 	// on VPP installations for a host
 	//

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -401,9 +401,11 @@ type HostLastInstallData struct {
 	ExecutionID string `db:"execution_id"`
 	// Status is the status of the installation on the host.
 	Status *SoftwareInstallerStatus `db:"status"`
-	// CreatedAt is when the install request was created. It is used to throttle
-	// continuous policy automation re-installs (see continuousAutomationOnCooldown).
-	CreatedAt time.Time `db:"created_at"`
+	// UpdatedAt is when the install record was last updated. For a completed install
+	// this reflects when it reached its terminal status (e.g. installed), which is what
+	// requests the host refetch; it is used to throttle continuous policy automation
+	// re-installs (see continuousAutomationOnCooldown).
+	UpdatedAt time.Time `db:"updated_at"`
 }
 
 // HostSoftwareInstaller represents a software installer package that has been installed on a host.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -401,6 +401,9 @@ type HostLastInstallData struct {
 	ExecutionID string `db:"execution_id"`
 	// Status is the status of the installation on the host.
 	Status *SoftwareInstallerStatus `db:"status"`
+	// CreatedAt is when the install request was created. It is used to throttle
+	// continuous policy automation re-installs (see continuousAutomationOnCooldown).
+	CreatedAt time.Time `db:"created_at"`
 }
 
 // HostSoftwareInstaller represents a software installer package that has been installed on a host.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1570,6 +1570,8 @@ type GetVPPAppMetadataByTeamAndTitleIDFunc func(ctx context.Context, teamID *uin
 
 type MapAdamIDsPendingInstallFunc func(ctx context.Context, hostID uint) (map[string]struct{}, error)
 
+type MapAdamIDsRecentlyVerifiedInstallsFunc func(ctx context.Context, hostID uint, seconds int) (adamIDs map[string]struct{}, err error)
+
 type MapAdamIDsPendingInstallVerificationFunc func(ctx context.Context, hostID uint) (adamIDs map[string]struct{}, err error)
 
 type MapAdamIDsRecentInstallsFunc func(ctx context.Context, hostID uint, seconds int) (adamIDs map[string]struct{}, err error)
@@ -4375,6 +4377,9 @@ type DataStore struct {
 
 	MapAdamIDsPendingInstallFunc        MapAdamIDsPendingInstallFunc
 	MapAdamIDsPendingInstallFuncInvoked bool
+
+	MapAdamIDsRecentlyVerifiedInstallsFunc        MapAdamIDsRecentlyVerifiedInstallsFunc
+	MapAdamIDsRecentlyVerifiedInstallsFuncInvoked bool
 
 	MapAdamIDsPendingInstallVerificationFunc        MapAdamIDsPendingInstallVerificationFunc
 	MapAdamIDsPendingInstallVerificationFuncInvoked bool
@@ -10517,6 +10522,13 @@ func (s *DataStore) MapAdamIDsPendingInstall(ctx context.Context, hostID uint) (
 	s.MapAdamIDsPendingInstallFuncInvoked = true
 	s.mu.Unlock()
 	return s.MapAdamIDsPendingInstallFunc(ctx, hostID)
+}
+
+func (s *DataStore) MapAdamIDsRecentlyVerifiedInstalls(ctx context.Context, hostID uint, seconds int) (adamIDs map[string]struct{}, err error) {
+	s.mu.Lock()
+	s.MapAdamIDsRecentlyVerifiedInstallsFuncInvoked = true
+	s.mu.Unlock()
+	return s.MapAdamIDsRecentlyVerifiedInstallsFunc(ctx, hostID, seconds)
 }
 
 func (s *DataStore) MapAdamIDsPendingInstallVerification(ctx context.Context, hostID uint) (adamIDs map[string]struct{}, err error) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -31206,12 +31206,35 @@ func (s *integrationEnterpriseTestSuite) TestPolicyAutomationsContinuousSoftware
 	}, 5*time.Second, 100*time.Millisecond)
 	completePendingInstall()
 
-	// Second fail (fail→fail): continuous policy re-queues, default does not.
+	// Second fail (fail→fail) within the policy update interval: the continuous policy
+	// is throttled. A successful install requests a host refetch that re-runs policies
+	// immediately, so without throttling this would be a tight install→refetch→re-run
+	// loop. It must NOT re-queue until the interval elapses.
+	submitPolicyResult(continuousPolicy.ID, false)
+	require.Never(t, func() bool {
+		return countInstallsFor(continuousPolicy.ID) != 1
+	}, 2*time.Second, 100*time.Millisecond, "continuous policy must be throttled within the policy update interval")
+
+	// Age the last successful install past the policy update interval; the next failing
+	// result must re-queue (the retry happens on the next interval). The cooldown is
+	// keyed per host+installer (GetHostLastInstallData), and both policies share this
+	// installer, so age every install for it rather than only the continuous policy's.
+	ageInstaller := func() {
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `
+				UPDATE host_software_installs SET updated_at = NOW() - INTERVAL 2 HOUR
+				WHERE host_id = ? AND software_installer_id = ?
+			`, host.ID, installerID)
+			return err
+		})
+	}
+	ageInstaller()
 	submitPolicyResult(continuousPolicy.ID, false)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.Equal(t, 2, countInstallsFor(continuousPolicy.ID), "continuous policy must fire on every failing result")
+		assert.Equal(t, 2, countInstallsFor(continuousPolicy.ID), "continuous policy must re-fire after the cooldown elapses")
 	}, 5*time.Second, 100*time.Millisecond)
 	completePendingInstall()
+
 	submitPolicyResult(transitionPolicy.ID, false)
 	// Poll for a window so a delayed enqueue doesn't slip past a one-shot check.
 	require.Never(t, func() bool {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -19366,23 +19366,39 @@ func (s *integrationMDMTestSuite) TestPolicyAutomationsContinuousVPPApp() {
 	continuousCount := func() int { return countInstallsFor(continuousPolicy.ID) }
 	transitionCount := func() int { return countInstallsFor(transitionPolicy.ID) }
 
+	// Age a policy's verified VPP install so it sits outside the policy update interval.
+	// The continuous cooldown is keyed on verification_at.
+	ageVPPInstall := func(policyID uint) {
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `
+				UPDATE host_vpp_software_installs SET verification_at = NOW() - INTERVAL 2 HOUR
+				WHERE host_id = ? AND policy_id = ?
+			`, mdmHost.ID, policyID)
+			return err
+		})
+	}
+
 	// First failing result: pass→fail transition queues an install on both.
 	step(continuousPolicy.ID, 1, continuousCount, "first install for continuous policy")
 	step(transitionPolicy.ID, 1, transitionCount, "first install for transition policy")
 
-	// Second failing result (fail→fail): only the continuous policy re-queues.
-	step(continuousPolicy.ID, 2, continuousCount, "continuous policy must fire on every failing result")
+	// Second failing result (fail→fail) within the interval: the continuous policy is
+	// throttled. A successful VPP install requests a host refetch that re-runs policies
+	// immediately, so without throttling this would be a tight loop. It must NOT re-queue.
+	submitPolicyResult(continuousPolicy.ID, false)
+	require.Never(t, func() bool {
+		return continuousCount() != 1
+	}, 2*time.Second, 100*time.Millisecond, "continuous policy must be throttled within the policy update interval")
+
+	// After the interval elapses, the continuous policy re-fires.
+	ageVPPInstall(continuousPolicy.ID)
+	step(continuousPolicy.ID, 2, continuousCount, "continuous policy must re-fire after the cooldown elapses")
+
+	// The default (transition-only) policy never re-fires on fail→fail.
 	submitPolicyResult(transitionPolicy.ID, false)
 	require.Never(t, func() bool {
 		return transitionCount() != 1
 	}, 2*time.Second, 100*time.Millisecond, "default policy must not re-trigger on fail→fail")
-
-	// Third failing result: continuous still re-triggers, default still does not.
-	step(continuousPolicy.ID, 3, continuousCount, "continuous policy must fire on every failing result")
-	submitPolicyResult(transitionPolicy.ID, false)
-	require.Never(t, func() bool {
-		return transitionCount() != 1
-	}, 2*time.Second, 100*time.Millisecond)
 
 	// Final: passing results never trigger an install, regardless of mode.
 	continuousBefore := continuousCount()

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2058,12 +2058,16 @@ func (svc *Service) processSoftwareForNewlyFailingPolicies(
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "get software installer metadata by id")
 		}
+		softwareInstallerTitleID_ := uint(0)
+		if installerMetadata.TitleID != nil {
+			softwareInstallerTitleID_ = *installerMetadata.TitleID
+		}
 		logger := svc.logger.With(
 			"host_id", hostID,
 			"host_platform", hostPlatform,
 			"policy_id", failingPolicyWithInstaller.ID,
 			"software_installer_id", failingPolicyWithInstaller.InstallerID,
-			"software_title_id", installerMetadata.TitleID,
+			"software_title_id", softwareInstallerTitleID_,
 			"software_installer_platform", installerMetadata.Platform,
 		)
 		if fleet.PlatformFromHost(hostPlatform) != installerMetadata.Platform {
@@ -2109,8 +2113,6 @@ func (svc *Service) processSoftwareForNewlyFailingPolicies(
 			*hostLastInstall.Status == fleet.SoftwareInstalled &&
 			svc.continuousAutomationOnCooldown(hostLastInstall.CreatedAt) {
 			logger.InfoContext(ctx, "skipping continuous policy automation install; within policy update interval cooldown",
-				"host_id", hostID,
-				"policy_id", policyID,
 				"last_install_execution_id", hostLastInstall.ExecutionID,
 				"last_install_at", hostLastInstall.CreatedAt,
 			)
@@ -2230,8 +2232,8 @@ func (svc *Service) processVPPForNewlyFailingPolicies(
 			"host_platform", hostPlatform,
 			"policy_id", policyID,
 			"vpp_adam_id", failingPolicyWithVPP.AdamID,
-			"vpp_platform", failingPolicyWithVPP.AdamID,
-			"software_title_id", failingPolicyWithVPP.Platform,
+			"vpp_platform", failingPolicyWithVPP.Platform,
+			"continuous_automations_enabled", failingPolicyWithVPP.ContinuousAutomationsEnabled,
 		)
 
 		if _, hasPendingInstall := pendingAppInstalls[failingPolicyWithVPP.AdamID]; hasPendingInstall {
@@ -2266,11 +2268,7 @@ func (svc *Service) processVPPForNewlyFailingPolicies(
 		// A successful VPP install requests a host refetch, which re-runs policies
 		// immediately; without this a perpetually-failing policy would loop tightly.
 		if _, recentlyInstalled := recentAppInstalls[failingPolicyWithVPP.AdamID]; !newlyFailing && failingPolicyWithVPP.ContinuousAutomationsEnabled && recentlyInstalled {
-			logger.InfoContext(ctx, "skipping continuous policy automation vpp install; within policy update interval cooldown",
-				"host_id", hostID,
-				"policy_id", policyID,
-				"adam_id", failingPolicyWithVPP.AdamID,
-			)
+			logger.InfoContext(ctx, "skipping continuous policy automation vpp install; within policy update interval cooldown")
 			continue
 		}
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1979,6 +1979,23 @@ func (svc *Service) registerFlippedPolicies(ctx context.Context, hostID uint, ho
 	return nil
 }
 
+// continuousAutomationOnCooldown reports whether a continuous policy automation that
+// last fired (queued an install) at lastFiredAt should be skipped on this run.
+//
+// Continuous automations re-fire on every failing policy result, not just on
+// pass→fail transitions. A successful install requests a host vitals refetch, and a
+// refetch makes policies re-run immediately (bypassing the policy update interval).
+// If the policy keeps failing, that creates a tight install→refetch→re-run→install
+// loop. We throttle continuous re-fires to at most once per policy update interval so
+// a perpetually-failing policy retries on the next interval (~1h) instead of
+// continuously. A zero lastFiredAt (no prior automation install) is never on cooldown.
+func (svc *Service) continuousAutomationOnCooldown(lastFiredAt time.Time) bool {
+	if lastFiredAt.IsZero() {
+		return false
+	}
+	return svc.clock.Now().Sub(lastFiredAt) < svc.config.Osquery.PolicyUpdateInterval
+}
+
 func (svc *Service) processSoftwareForNewlyFailingPolicies(
 	ctx context.Context,
 	hostID uint,
@@ -2036,6 +2053,7 @@ func (svc *Service) processSoftwareForNewlyFailingPolicies(
 
 	for _, failingPolicyWithInstaller := range failingPoliciesWithInstaller {
 		policyID := failingPolicyWithInstaller.ID
+		_, newlyFailing := newFailingSet[policyID]
 		installerMetadata, err := svc.ds.GetSoftwareInstallerMetadataByID(ctx, failingPolicyWithInstaller.InstallerID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "get software installer metadata by id")
@@ -2074,6 +2092,27 @@ func (svc *Service) processSoftwareForNewlyFailingPolicies(
 			// thus we do not queue another install request.
 			logger.DebugContext(ctx, "found pending install request for this host and installer",
 				"pending_execution_id", hostLastInstall.ExecutionID,
+			)
+			continue
+		}
+
+		// Throttle continuous policy automation re-installs: if this policy fired only
+		// because continuous_automations_enabled is set (not a pass→fail transition)
+		// and we already queued a successful install within the policy update interval,
+		// skip it. This prevents a tight install→refetch→re-run loop when the install
+		// succeeds but never makes the policy pass. We only throttle on a successful
+		// install because only success requests the refetch that drives the loop; failed
+		// installs are retried via the dedicated retry path (see
+		// shouldRetryPolicyAutomationSoftwareInstall). See continuousAutomationOnCooldown.
+		if !newlyFailing && failingPolicyWithInstaller.ContinuousAutomationsEnabled &&
+			hostLastInstall != nil && hostLastInstall.Status != nil &&
+			*hostLastInstall.Status == fleet.SoftwareInstalled &&
+			svc.continuousAutomationOnCooldown(hostLastInstall.CreatedAt) {
+			logger.InfoContext(ctx, "skipping continuous policy automation install; within policy update interval cooldown",
+				"host_id", hostID,
+				"policy_id", policyID,
+				"last_install_execution_id", hostLastInstall.ExecutionID,
+				"last_install_at", hostLastInstall.CreatedAt,
 			)
 			continue
 		}
@@ -2176,8 +2215,16 @@ func (svc *Service) processVPPForNewlyFailingPolicies(
 		return ctxerr.Wrapf(ctx, err, "failed to check pending VPP installs")
 	}
 
+	// Apps successfully installed within the policy update interval are used to throttle
+	// continuous policy automation re-installs (see continuousAutomationOnCooldown).
+	recentAppInstalls, err := svc.ds.MapAdamIDsRecentlyVerifiedInstalls(ctx, hostID, int(svc.config.Osquery.PolicyUpdateInterval.Seconds()))
+	if err != nil {
+		return ctxerr.Wrapf(ctx, err, "failed to check recent VPP installs")
+	}
+
 	for _, failingPolicyWithVPP := range failingPoliciesWithVPP {
 		policyID := failingPolicyWithVPP.ID
+		_, newlyFailing := newFailingSet[policyID]
 		logger := svc.logger.With(
 			"host_id", hostID,
 			"host_platform", hostPlatform,
@@ -2210,6 +2257,20 @@ func (svc *Service) processVPPForNewlyFailingPolicies(
 			// host details.
 			incomingPolicyResults[failingPolicyWithVPP.ID] = nil
 			logger.DebugContext(ctx, "not marking policy as failed since vpp app is out of scope for host")
+			continue
+		}
+
+		// Throttle continuous policy automation re-installs: if this policy fired only
+		// because continuous_automations_enabled is set (not a pass→fail transition)
+		// and we already queued a VPP install within the policy update interval, skip it.
+		// A successful VPP install requests a host refetch, which re-runs policies
+		// immediately; without this a perpetually-failing policy would loop tightly.
+		if _, recentlyInstalled := recentAppInstalls[failingPolicyWithVPP.AdamID]; !newlyFailing && failingPolicyWithVPP.ContinuousAutomationsEnabled && recentlyInstalled {
+			logger.InfoContext(ctx, "skipping continuous policy automation vpp install; within policy update interval cooldown",
+				"host_id", hostID,
+				"policy_id", policyID,
+				"adam_id", failingPolicyWithVPP.AdamID,
+			)
 			continue
 		}
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2111,10 +2111,10 @@ func (svc *Service) processSoftwareForNewlyFailingPolicies(
 		if !newlyFailing && failingPolicyWithInstaller.ContinuousAutomationsEnabled &&
 			hostLastInstall != nil && hostLastInstall.Status != nil &&
 			*hostLastInstall.Status == fleet.SoftwareInstalled &&
-			svc.continuousAutomationOnCooldown(hostLastInstall.CreatedAt) {
+			svc.continuousAutomationOnCooldown(hostLastInstall.UpdatedAt) {
 			logger.InfoContext(ctx, "skipping continuous policy automation install; within policy update interval cooldown",
 				"last_install_execution_id", hostLastInstall.ExecutionID,
-				"last_install_at", hostLastInstall.CreatedAt,
+				"last_install_at", hostLastInstall.UpdatedAt,
 			)
 			continue
 		}
@@ -2264,9 +2264,10 @@ func (svc *Service) processVPPForNewlyFailingPolicies(
 
 		// Throttle continuous policy automation re-installs: if this policy fired only
 		// because continuous_automations_enabled is set (not a pass→fail transition)
-		// and we already queued a VPP install within the policy update interval, skip it.
-		// A successful VPP install requests a host refetch, which re-runs policies
-		// immediately; without this a perpetually-failing policy would loop tightly.
+		// and the VPP app was successfully installed (verified) within the policy update
+		// interval, skip it. A successful VPP install requests a host refetch, which
+		// re-runs policies immediately; without this a perpetually-failing policy would
+		// loop tightly.
 		if _, recentlyInstalled := recentAppInstalls[failingPolicyWithVPP.AdamID]; !newlyFailing && failingPolicyWithVPP.ContinuousAutomationsEnabled && recentlyInstalled {
 			logger.InfoContext(ctx, "skipping continuous policy automation vpp install; within policy update interval cooldown")
 			continue

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -4795,3 +4795,107 @@ func makeLiveQueryStore(t *testing.T, countToReturn int) *live_query_mock.MockLi
 	}
 	return lq
 }
+
+func TestContinuousAutomationOnCooldown(t *testing.T) {
+	ds := new(mock.Store)
+	mockClock := clock.NewMockClock()
+	svc, _ := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{Clock: mockClock})
+	svcImpl := svc.(validationMiddleware).Service.(*Service)
+
+	now := mockClock.Now()
+	// No prior automation install (zero time) is never on cooldown.
+	require.False(t, svcImpl.continuousAutomationOnCooldown(time.Time{}))
+	// Fired within the policy update interval (1h in TestConfig) => on cooldown.
+	require.True(t, svcImpl.continuousAutomationOnCooldown(now.Add(-30*time.Minute)))
+	// Fired before the policy update interval => not on cooldown.
+	require.False(t, svcImpl.continuousAutomationOnCooldown(now.Add(-2*time.Hour)))
+}
+
+// TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown verifies that a
+// continuous policy automation (continuous_automations_enabled) does not re-queue a
+// software install more than once per policy update interval. This prevents the tight
+// install→refetch→re-run→install loop that happens when the install succeeds but the
+// policy keeps failing. Newly-failing (pass→fail) policies still fire immediately.
+func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) {
+	ds := new(mock.Store)
+	mockClock := clock.NewMockClock()
+	svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{Clock: mockClock})
+	svcImpl := svc.(validationMiddleware).Service.(*Service)
+
+	const (
+		policyID    = uint(1)
+		installerID = uint(100)
+		hostID      = uint(42)
+	)
+	titleID := uint(7)
+
+	ds.GetPoliciesWithAssociatedInstallerFunc = func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicySoftwareInstallerData, error) {
+		return []fleet.PolicySoftwareInstallerData{{ID: policyID, InstallerID: installerID, ContinuousAutomationsEnabled: true}}, nil
+	}
+	ds.GetSoftwareInstallerMetadataByIDFunc = func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{InstallerID: installerID, TitleID: &titleID, Platform: "darwin"}, nil
+	}
+	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
+		return true, nil
+	}
+	ds.ResetPolicyAutomationRetryAttemptsForHostFunc = func(ctx context.Context, hostID uint, policyIDs []uint) error {
+		return nil
+	}
+	var insertCalled bool
+	ds.InsertSoftwareInstallRequestFunc = func(ctx context.Context, hostID, swInstallerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
+		insertCalled = true
+		return "exec-uuid", nil
+	}
+
+	orbitKey := "orbit-key"
+	failing := map[uint]*bool{policyID: new(false)}
+	noNewlyFailing := map[uint]struct{}{}
+	now := mockClock.Now()
+	installed := fleet.SoftwareInstalled
+	failedInstall := fleet.SoftwareInstallFailed
+
+	setLastInstall := func(status *fleet.SoftwareInstallerStatus, createdAt time.Time) {
+		ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
+			return &fleet.HostLastInstallData{ExecutionID: "prev-exec", Status: status, CreatedAt: createdAt}, nil
+		}
+	}
+
+	// Continuous re-fire with a recent successful install => throttled.
+	insertCalled = false
+	setLastInstall(&installed, now.Add(-10*time.Minute))
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, failing, noNewlyFailing))
+	require.False(t, insertCalled, "continuous install should be throttled within the policy update interval")
+
+	// Continuous re-fire after the interval elapsed => fires.
+	insertCalled = false
+	setLastInstall(&installed, now.Add(-2*time.Hour))
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, failing, noNewlyFailing))
+	require.True(t, insertCalled, "continuous install should fire once the cooldown elapses")
+
+	// Newly failing (pass→fail) bypasses the cooldown even with a recent install.
+	insertCalled = false
+	setLastInstall(&installed, now.Add(-1*time.Minute))
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, failing, map[uint]struct{}{policyID: {}}))
+	require.True(t, insertCalled, "newly-failing install should fire regardless of cooldown")
+
+	// A recent FAILED install does not throttle: only successful installs request the
+	// refetch that drives the loop, and failures are retried via the dedicated path.
+	insertCalled = false
+	setLastInstall(&failedInstall, now.Add(-1*time.Minute))
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, failing, noNewlyFailing))
+	require.True(t, insertCalled, "continuous install should fire when the recent install failed")
+
+	// A recent install with nil status (installed then removed) does not throttle.
+	insertCalled = false
+	setLastInstall(nil, now.Add(-1*time.Minute))
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, failing, noNewlyFailing))
+	require.True(t, insertCalled, "continuous install should fire when the recent install has no resolved status")
+
+	// No prior install => fires.
+	insertCalled = false
+	ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
+		return nil, nil
+	}
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, failing, noNewlyFailing))
+	require.True(t, insertCalled, "install should fire when there is no prior install")
+}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -4899,3 +4899,79 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, failing, noNewlyFailing))
 	require.True(t, insertCalled, "install should fire when there is no prior install")
 }
+
+// TestProcessVPPForNewlyFailingPoliciesContinuousCooldown is the VPP analog of
+// TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown: a continuous
+// policy automation must not re-install a VPP app more than once per policy update
+// interval. The cooldown is keyed on apps verified-installed within the interval
+// (MapAdamIDsRecentlyVerifiedInstalls). Newly-failing (pass→fail) policies still
+// fire immediately.
+func TestProcessVPPForNewlyFailingPoliciesContinuousCooldown(t *testing.T) {
+	ds := new(mock.Store)
+	mockClock := clock.NewMockClock()
+	svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{Clock: mockClock})
+	svcImpl := svc.(validationMiddleware).Service.(*Service)
+
+	const (
+		policyID = uint(1)
+		hostID   = uint(42)
+		adamID   = "adam-vpp-1"
+	)
+
+	ds.GetPoliciesWithAssociatedVPPFunc = func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyVPPData, error) {
+		return []fleet.PolicyVPPData{{ID: policyID, AdamID: adamID, Platform: fleet.MacOSPlatform, ContinuousAutomationsEnabled: true}}, nil
+	}
+	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return &fleet.Host{ID: hostID, Platform: "darwin"}, nil
+	}
+	ds.MapAdamIDsPendingInstallFunc = func(ctx context.Context, hostID uint) (map[string]struct{}, error) {
+		return map[string]struct{}{}, nil
+	}
+	ds.GetVPPAppMetadataByAdamIDPlatformTeamIDFunc = func(ctx context.Context, adamID string, platform fleet.InstallableDevicePlatform, teamID *uint) (*fleet.VPPApp, error) {
+		return &fleet.VPPApp{VPPAppTeam: fleet.VPPAppTeam{AppTeamID: 1, VPPAppID: fleet.VPPAppID{AdamID: adamID, Platform: platform}}}, nil
+	}
+	ds.IsVPPAppLabelScopedFunc = func(ctx context.Context, vppAppTeamID, hostID uint) (bool, error) {
+		return true, nil
+	}
+
+	var installCalled bool
+	svcImpl.SetEnterpriseOverrides(fleet.EnterpriseOverrides{
+		GetVPPTokenIfCanInstallVPPApps: func(ctx context.Context, appleDevice bool, host *fleet.Host) (string, error) {
+			return "vpp-token", nil
+		},
+		InstallVPPAppPostValidation: func(ctx context.Context, host *fleet.Host, vppApp *fleet.VPPApp, token string, opts fleet.HostSoftwareInstallOptions) (string, error) {
+			installCalled = true
+			return "command-uuid", nil
+		},
+	})
+
+	failing := map[uint]*bool{policyID: new(false)}
+	noNewlyFailing := map[uint]struct{}{}
+
+	setRecentlyVerified := func(recent bool) {
+		ds.MapAdamIDsRecentlyVerifiedInstallsFunc = func(ctx context.Context, hostID uint, seconds int) (map[string]struct{}, error) {
+			if recent {
+				return map[string]struct{}{adamID: {}}, nil
+			}
+			return map[string]struct{}{}, nil
+		}
+	}
+
+	// Continuous re-fire with the app verified-installed within the interval => throttled.
+	installCalled = false
+	setRecentlyVerified(true)
+	require.NoError(t, svcImpl.processVPPForNewlyFailingPolicies(ctx, hostID, nil, "darwin", failing, noNewlyFailing))
+	require.False(t, installCalled, "continuous VPP install should be throttled within the policy update interval")
+
+	// Continuous re-fire with no recent verified install (cooldown elapsed) => fires.
+	installCalled = false
+	setRecentlyVerified(false)
+	require.NoError(t, svcImpl.processVPPForNewlyFailingPolicies(ctx, hostID, nil, "darwin", failing, noNewlyFailing))
+	require.True(t, installCalled, "continuous VPP install should fire once the cooldown elapses")
+
+	// Newly failing (pass→fail) bypasses the cooldown even with a recent verified install.
+	installCalled = false
+	setRecentlyVerified(true)
+	require.NoError(t, svcImpl.processVPPForNewlyFailingPolicies(ctx, hostID, nil, "darwin", failing, map[uint]struct{}{policyID: {}}))
+	require.True(t, installCalled, "newly-failing VPP install should fire regardless of cooldown")
+}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -4854,9 +4854,9 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	installed := fleet.SoftwareInstalled
 	failedInstall := fleet.SoftwareInstallFailed
 
-	setLastInstall := func(status *fleet.SoftwareInstallerStatus, createdAt time.Time) {
+	setLastInstall := func(status *fleet.SoftwareInstallerStatus, updatedAt time.Time) {
 		ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
-			return &fleet.HostLastInstallData{ExecutionID: "prev-exec", Status: status, CreatedAt: createdAt}, nil
+			return &fleet.HostLastInstallData{ExecutionID: "prev-exec", Status: status, UpdatedAt: updatedAt}, nil
 		}
 	}
 


### PR DESCRIPTION
**Related issue:** Resolves #45149 (adds to)

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Throttle continuous policy automations to avoid repeated install attempts within the policy update interval.

* **New Features**
  * Install records now include an updated timestamp for accurate cooldown decisions.
  * Added tracking of recently verified VPP app installs to avoid redundant re-installs.

* **Tests**
  * New and updated unit and integration tests covering cooldown behavior and VPP verification lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->