### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "148.1.90.128",
+      "version": "149.1.91.168",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '148.1.90.128') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '149.1.91.168') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/190.128/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/191.168/Brave-Browser-arm64.dmg",
       "install_script_ref": "013e53e8",
       "uninstall_script_ref": "9a376609",
-      "sha256": "08321ab43021a670536ec1ea74ce6bc0b7bfa1a85db38172ae62342b07bc7b37",
+      "sha256": "7b85fd3d16837c205f7e26631e0f8c5cd921bcbd0f9a2632fd90c6b52b14648c",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/figma/darwin.json
+++ b/ee/maintained-apps/outputs/figma/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "126.4.11",
+      "version": "126.4.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.4.11') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.4.12') < 0);"
       },
-      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.4.11.zip",
+      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.4.12.zip",
       "install_script_ref": "f0952230",
       "uninstall_script_ref": "7dcd0304",
-      "sha256": "f5191c182bc74e3d0f5b9f887e3c1a636f850513b38bfc3ac4cd5d0601726e02",
+      "sha256": "c4d258885be902a869f18e28c201b898ec79f40af5ffe2e447a7059e2aaccde0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.290.0",
+      "version": "7.303.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.290.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.303.0') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.290.0/Granola-7.290.0-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.303.0/Granola-7.303.0-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "9e3ffddf70ebdb545d00e628bda5c35e69d3503c9b1be00b21d76ab4c868f457",
+      "sha256": "038c7dd6b1a8013f0bf956f31d0d8dee1b9b641b756a8ff2fb11d41421b698b7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.351.2",
+      "version": "0.352.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.351.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.352.4') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.351.2-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.352.4-arm64.dmg",
       "install_script_ref": "bd0f7905",
       "uninstall_script_ref": "f408ec47",
-      "sha256": "1586756635c622a2e3e1532387e6de7800507e5a780eddea30121749e71e6544",
+      "sha256": "23474358c65b1ca9176b68d115c22820ad29ae055aa32e443bf145ed719bad3f",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS application maintenance metadata: Brave Browser (149.1.91.168), Figma (126.4.12), Granola (7.303.0), and Loom (0.352.4). Each version update includes new installer download URLs and refreshed SHA256 checksums for integrity verification. Updates ensure accurate deployment, proper version detection, and integrity checking across all applications while maintaining existing deployment script configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->