### PR TITLE
Restore software platform/version subtitle in policy install-software automation

### DIFF
--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -23,6 +23,7 @@ import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import TooltipWrapper from "components/TooltipWrapper";
 
 import {
+  generateSoftwareOptionHelpText,
   getTicketOrWebhookInfo,
   getTicketOrWebhookLabel,
 } from "pages/policies/helpers";
@@ -205,6 +206,7 @@ const PolicyAutomationsFields = forwardRef<
         (softwareTitlesData?.software_titles ?? []).map((t) => ({
           label: t.name,
           value: String(t.id),
+          helpText: generateSoftwareOptionHelpText(t),
         })),
       [softwareTitlesData]
     );

--- a/frontend/pages/policies/helpers.tests.tsx
+++ b/frontend/pages/policies/helpers.tests.tsx
@@ -69,6 +69,20 @@ describe("generateSoftwareOptionHelpText", () => {
     expect(generateSoftwareOptionHelpText(title)).toBe("Windows (.exe)");
   });
 
+  it("omits the leading separator when there is a version but no platform string", () => {
+    const title = createMockSoftwareTitle({
+      // null-platform source -> empty platform string, but the package has a version
+      source: "go_binaries",
+      app_store_app: null,
+      software_package: createMockSoftwarePackage({
+        name: "mytool",
+        version: "1.2.3",
+      }),
+    });
+
+    expect(generateSoftwareOptionHelpText(title)).toBe("1.2.3");
+  });
+
   it("returns an empty string when neither platform nor version is available", () => {
     const title = createMockSoftwareTitle({
       source: "programs",

--- a/frontend/pages/policies/helpers.tests.tsx
+++ b/frontend/pages/policies/helpers.tests.tsx
@@ -1,0 +1,81 @@
+import {
+  createMockSoftwareTitle,
+  createMockSoftwarePackage,
+  createMockAppStoreApp,
+} from "__mocks__/softwareMock";
+
+import { generateSoftwareOptionHelpText } from "./helpers";
+
+describe("generateSoftwareOptionHelpText", () => {
+  it("builds the platform/extension and version subtitle for a package", () => {
+    const title = createMockSoftwareTitle({
+      source: "programs",
+      app_store_app: null,
+      software_package: createMockSoftwarePackage({
+        name: "Notepad++.exe",
+        version: "8.9.6.4",
+      }),
+    });
+
+    expect(generateSoftwareOptionHelpText(title)).toBe(
+      "Windows (.exe) • 8.9.6.4"
+    );
+  });
+
+  it("maps the source to its platform display name (macOS package)", () => {
+    const title = createMockSoftwareTitle({
+      source: "apps",
+      app_store_app: null,
+      software_package: createMockSoftwarePackage({
+        name: "TestPackage-1.2.3.pkg",
+        version: "1.2.3",
+      }),
+    });
+
+    expect(generateSoftwareOptionHelpText(title)).toBe("macOS (.pkg) • 1.2.3");
+  });
+
+  it("labels App Store (VPP) apps and uses the app_store_app version", () => {
+    const title = createMockSoftwareTitle({
+      source: "apps",
+      app_store_app: createMockAppStoreApp({ version: "5.0.0" }),
+    });
+
+    expect(generateSoftwareOptionHelpText(title)).toBe(
+      "macOS (App Store) • 5.0.0"
+    );
+  });
+
+  it("omits the version for a VPP app that has none", () => {
+    const title = createMockSoftwareTitle({
+      source: "apps",
+      // default app_store_app mock has no `version`
+      app_store_app: createMockAppStoreApp(),
+    });
+
+    expect(generateSoftwareOptionHelpText(title)).toBe("macOS (App Store)");
+  });
+
+  it("omits the version when the package has none", () => {
+    const title = createMockSoftwareTitle({
+      source: "programs",
+      app_store_app: null,
+      software_package: createMockSoftwarePackage({
+        name: "MyApp.exe",
+        version: "",
+      }),
+    });
+
+    expect(generateSoftwareOptionHelpText(title)).toBe("Windows (.exe)");
+  });
+
+  it("returns an empty string when neither platform nor version is available", () => {
+    const title = createMockSoftwareTitle({
+      source: "programs",
+      app_store_app: null,
+      software_package: null,
+    });
+
+    expect(generateSoftwareOptionHelpText(title)).toBe("");
+  });
+});

--- a/frontend/pages/policies/helpers.ts
+++ b/frontend/pages/policies/helpers.ts
@@ -1,6 +1,12 @@
 import { IConfig } from "interfaces/config";
+import { Platform, PLATFORM_DISPLAY_NAMES } from "interfaces/platform";
 import { TicketOrWebhookState } from "interfaces/policy";
+import {
+  INSTALLABLE_SOURCE_PLATFORM_CONVERSION,
+  ISoftwareTitle,
+} from "interfaces/software";
 import { ITeamConfig } from "interfaces/team";
+import { getExtensionFromFileName } from "utilities/file/fileUtils";
 
 export interface ITicketOrWebhookInfo {
   /** "webhook" or "ticket" when an "other workflow" automation is configured
@@ -46,4 +52,33 @@ export const getTicketOrWebhookLabel = (
   if (state === "webhook") return "Send webhook";
   if (state === "ticket") return "Create ticket";
   return "Send webhook or create ticket";
+};
+
+export const generateSoftwareOptionHelpText = (
+  title: ISoftwareTitle
+): string => {
+  const isVppApp = title.source === "apps" && !!title.app_store_app;
+
+  if (isVppApp) {
+    const version = title.app_store_app?.version
+      ? ` • ${title.app_store_app.version}`
+      : "";
+    return `macOS (App Store)${version}`;
+  }
+
+  const platform: Platform | null =
+    INSTALLABLE_SOURCE_PLATFORM_CONVERSION[title.source] || null;
+  const extension =
+    (title.software_package &&
+      getExtensionFromFileName(title.software_package.name)) ||
+    undefined;
+  const platformString =
+    platform && extension
+      ? `${PLATFORM_DISPLAY_NAMES[platform]} (.${extension})`
+      : "";
+  const version = title.software_package?.version
+    ? ` • ${title.software_package.version}`
+    : "";
+
+  return `${platformString}${version}`;
 };

--- a/frontend/pages/policies/helpers.ts
+++ b/frontend/pages/policies/helpers.ts
@@ -76,9 +76,8 @@ export const generateSoftwareOptionHelpText = (
     platform && extension
       ? `${PLATFORM_DISPLAY_NAMES[platform]} (.${extension})`
       : "";
-  const version = title.software_package?.version
-    ? ` • ${title.software_package.version}`
-    : "";
+  const version = title.software_package?.version ?? "";
+  const separator = platformString && version ? " • " : "";
 
-  return `${platformString}${version}`;
+  return `${platformString}${separator}${version}`;
 };

--- a/frontend/pages/policies/helpers.ts
+++ b/frontend/pages/policies/helpers.ts
@@ -68,10 +68,9 @@ export const generateSoftwareOptionHelpText = (
 
   const platform: Platform | null =
     INSTALLABLE_SOURCE_PLATFORM_CONVERSION[title.source] || null;
-  const extension =
-    (title.software_package &&
-      getExtensionFromFileName(title.software_package.name)) ||
-    undefined;
+  const extension = getExtensionFromFileName(
+    title.software_package?.name ?? ""
+  );
   const platformString =
     platform && extension
       ? `${PLATFORM_DISPLAY_NAMES[platform]} (.${extension})`


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45148 (it's part of the Manage Automations Modal, didn't want to create a new issue just for this small regression).

<img width="927" height="331" alt="Screenshot 2026-06-04 at 3 35 27 PM" src="https://github.com/user-attachments/assets/400406fa-a99c-4f29-a8a2-571f5acb63eb" />


The platform/version subtitle logic (e.g. `Windows (.exe) • 8.9.6.4`) was extracted from `InstallSoftwareModal` into the shared `pages/policies/helpers.ts` so the new `PolicyAutomationsFields` software dropdown can reuse it. `InstallSoftwareModal` is no longer rendered anywhere and will be removed in a follow-up cleanup PR, at which point its now-duplicate copy of this helper goes away with it.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

#### Before

<img width="405" height="222" alt="main" src="https://github.com/user-attachments/assets/8be30833-1066-428d-baf2-4209c099c95f" />

#### After

<img width="839" height="724" alt="Screenshot 2026-06-04 at 3 26 26 PM" src="https://github.com/user-attachments/assets/274fb185-c770-4445-89d9-35ece891f46f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Software dropdown options now display platform and version details, include App Store labeling, and show file-extension hints when available.

* **Tests**
  * Added tests for generation of dropdown descriptive text, covering platform mapping, App Store/version handling, file-extension extraction, and cases with missing platform or version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->