### PR TITLE
Website: Add script tag to layout to strip query parameters once pages fully load

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -1120,13 +1120,13 @@
       vgo('process');
     </script>      
    <% } %>
-    <% /* Remove query params from the URL after analytics have ingested them. */ %>
+    <% /* Remove query params from the page URLs after the page is fully loaded. */ %>
     <script>
       window.addEventListener('load', function() {
         setTimeout(function() {
           try {
             if (window.location.search) {
-              history.replaceState({}, document.title, window.location.pathname + window.location.hash);
+              history.replaceState(window.history.state, document.title, window.location.pathname + window.location.hash);
             }
           } catch (unusedErr) {
             // No-op: never let URL cleanup break the page.

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -1123,7 +1123,7 @@
     <% /* Remove query params from the page URLs after the page is fully loaded. */ %>
     <script>
       window.addEventListener('load', function() {
-        setTimeout(function() {
+        setTimeout(function() {// Note: we're using setTimeout here to run this code after other load event handlers have run.
           try {
             if (window.location.search) {
               history.replaceState(window.history.state, document.title, window.location.pathname + window.location.hash);

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -1120,5 +1120,19 @@
       vgo('process');
     </script>      
    <% } %>
+    <% /* Remove query params from the URL after analytics have ingested them. */ %>
+    <script>
+      window.addEventListener('load', function() {
+        setTimeout(function() {
+          try {
+            if (window.location.search) {
+              history.replaceState({}, document.title, window.location.pathname + window.location.hash);
+            }
+          } catch (unusedErr) {
+            // No-op: never let URL cleanup break the page.
+          }
+        }, 0);
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/45848

Changes:
- Added a script tag to the website layout that removes query parameters from URLs after pages load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address bar cleanup: URL query parameters are now automatically removed on page load when present, providing a cleaner browsing experience while keeping you on the same page.
  * Safe preservation: The update preserves the current page path, hash fragment, document title and navigation state, and is applied safely to avoid impacting page behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->