### PR TITLE
Expand security considerations in frontend patterns doc

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -73,8 +73,11 @@ Use react-router, not `window.location` / `window.history`. Direct window mutati
 - Use `renderMultiFlash()` for batch operations
 
 ## XSS Prevention
-- ALWAYS sanitize user-generated HTML with `DOMPurify.sanitize(html, options)` before `dangerouslySetInnerHTML`
-- Configure allowed tags/attributes explicitly: `{ ADD_ATTR: ["target"] }`
+- ALWAYS sanitize user-generated HTML before `dangerouslySetInnerHTML`. Approved helpers:
+  - `DOMPurify.sanitize(html, options)` — arbitrary HTML. Configure allowed tags/attributes explicitly: `{ ADD_ATTR: ["target"] }`
+  - `syntaxHighlight(value)` from `frontend/utilities/helpers.tsx` — JSON/code previews. Input must be a value to JSON-serialize (object/array/primitive), not a pre-built string of user content
+  - `ClickableUrls` from `frontend/components/ClickableUrls/` — plain text that may contain URLs, rendered as clickable links
+- See `frontend/docs/patterns.md#security-considerations` for full guidance, including frontend pitfalls common in AI-assisted code
 
 ## String Utilities
 Use helpers from `frontend/utilities/strings/stringUtils.ts`:

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -590,9 +590,10 @@ helpers below.
   string defeats the purpose of using it. See `ExampleWebhookUrlPayloadModal`
   or `HostStatusWebhookPreviewModal` for representative call sites.
 - [`ClickableUrls`](../components/ClickableUrls/ClickableUrls.tsx) — for
-  rendering plain text that may contain URLs as clickable links. It detects
-  URLs in the input, builds anchors with `target="_blank"` and
-  `rel="noreferrer"`, and passes the result through `DOMPurify.sanitize` before
+  rendering user-provided text that may contain URLs as clickable links. It
+  replaces URL-looking substrings with anchors (`target="_blank"` and
+  `rel="noreferrer"`), then sanitizes the resulting HTML with
+  `DOMPurify.sanitize` (assumes the input is text, not pre-built HTML) before
   rendering. Use it instead of constructing anchor HTML by hand when the source
   is user-provided text.
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -635,10 +635,10 @@ You own the code you submit, AI-assisted or otherwise. The handbook covers the
 general principle; this section lists frontend pitfalls that AI tools produce
 often enough to warrant a deliberate check on every diff:
 
-- `dangerouslySetInnerHTML` introduced without an in-diff sanitizer. If the prop
-  is added and the same change does not also pass the input through
-  `DOMPurify.sanitize`, `syntaxHighlight`, or `ClickableUrls`, request the
-  sanitizer before approving.
+- `dangerouslySetInnerHTML` introduced for user-controlled content without an in-diff
+  sanitizer. If the prop is added and the same change does not also pass the
+  input through `DOMPurify.sanitize`, `syntaxHighlight`, or `ClickableUrls`,
+  request a sanitizer before approving.
 - Dynamic code execution: `eval`, `new Function`, and `setTimeout` or
   `setInterval` invoked with string arguments have no legitimate place in
   product code.

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -571,8 +571,85 @@ At a bare minimum, critical bugs released involving the UI will have automated t
 
 ## Security considerations
 
-We make every effort to avoid using the `dangerouslySetInnerHTML` prop. When absolutely necessary to
-use this prop, we make sure to sanitize any user-defined input to it with `DOMPurify.sanitize`
+### Sanitization for `dangerouslySetInnerHTML`
+
+We make every effort to avoid using the `dangerouslySetInnerHTML` prop. When the
+prop is necessary, sanitize any user-defined input with one of the approved
+helpers below.
+
+- `DOMPurify.sanitize(html, options)` — for rendering arbitrary HTML. Configure
+  allowed tags and attributes explicitly at the call site, for example
+  `{ ADD_ATTR: ["target"] }`.
+- [`syntaxHighlight(value)`](../utilities/helpers.tsx) — for rendering JSON or
+  code previews. The function HTML-escapes `&`, `<`, and `>` in the
+  JSON-stringified output before wrapping tokens in `<span class="…">`, so the
+  only markup it emits is a span with a fixed set of class names: `key`,
+  `string`, `number`, `boolean`, `null`. Pass a value to JSON-serialize (object,
+  array, or primitive), not a pre-built string of user content. The function
+  calls `JSON.stringify` on its input before highlighting, so a pre-built
+  string defeats the purpose of using it. See `ExampleWebhookUrlPayloadModal`
+  or `HostStatusWebhookPreviewModal` for representative call sites.
+- [`ClickableUrls`](../components/ClickableUrls/ClickableUrls.tsx) — for
+  rendering plain text that may contain URLs as clickable links. It detects
+  URLs in the input, builds anchors with `target="_blank"` and
+  `rel="noreferrer"`, and passes the result through `DOMPurify.sanitize` before
+  rendering. Use it instead of constructing anchor HTML by hand when the source
+  is user-provided text.
+
+### Other frontend security considerations
+
+Beyond the sanitization rules above, the following considerations apply across
+the frontend.
+
+Today:
+
+- URL handling: treat any user-controlled value used in `href`, `window.open`,
+  or `router.push`/`router.replace` as untrusted. Route to a known internal path
+  and pass user data as URL params rather than building a full URL from a user
+  value.
+- Logging: `no-console` is disabled to support local debugging, but clean up
+  `console.log` statements before merging. Do not log access tokens, session
+  identifiers, or full response bodies that may contain user PII.
+- Dependency review: when a pull request adds an entry to `package.json`,
+  confirm the package is well-maintained, that the name is not a typosquat of a
+  more popular package, and that the version pinned is consistent with the
+  surrounding ecosystem.
+
+Candidates for future work:
+
+- Add an ESLint rule or `CODEOWNERS` gate on new uses of
+  `dangerouslySetInnerHTML` so a reviewer must consciously opt into each new
+  occurrence.
+- Inventory existing uses of `dangerouslySetInnerHTML` and migrate any that can
+  render through React directly.
+- Reduce direct `localStorage` writes for values with a security implication.
+  Prefer in-memory state for short-lived sensitive values.
+
+### Frontend pitfalls in AI-assisted code
+
+Fleet engineers are expected to use AI coding tools as part of their daily
+workflow (see [AI tooling](https://fleetdm.com/handbook/engineering#ai-tooling)
+and [AI usage guidelines](https://fleetdm.com/handbook/company/communications#ai-usage-guidelines)).
+You own the code you submit, AI-assisted or otherwise. The handbook covers the
+general principle; this section lists frontend pitfalls that AI tools produce
+often enough to warrant a deliberate check on every diff:
+
+- `dangerouslySetInnerHTML` introduced without an in-diff sanitizer. If the prop
+  is added and the same change does not also pass the input through
+  `DOMPurify.sanitize`, `syntaxHighlight`, or `ClickableUrls`, request the
+  sanitizer before approving.
+- Dynamic code execution: `eval`, `new Function`, and `setTimeout` or
+  `setInterval` invoked with string arguments have no legitimate place in
+  product code.
+- New runtime dependencies. Flag any added entry in `package.json` for the
+  dependency-review pass above, even when the surrounding change appears
+  unrelated.
+- Permissive URL construction in anchors, `window.open` calls, or router pushes
+  that interpolate user-controlled values without going through the approved
+  helpers above.
+
+See [`.claude/rules/fleet-frontend.md`](../../.claude/rules/fleet-frontend.md)
+for the LLM-targeted summary of these rules.
 
 ## Other
 


### PR DESCRIPTION
Per the TODO items from our 5/21 FE sync ([doc](https://docs.google.com/document/d/1cuAP-HWcu0KoK5bMmNsax-0-H819OW2y50DUVYoICX4/edit?tab=t.0)), this expands the security considerations section in `frontend/docs/patterns.md`:

- Documents `syntaxHighlight()` as an approved sanitization helper alongside `DOMPurify` for JSON/code previews (P1 item), with the constraint that input must be a value to JSON-serialize, not a pre-built string of user content.
- Adds `ClickableUrls` as a third approved sanitization helper, for rendering plain text that may contain URLs as clickable links.
- Documents classic frontend security risks (URL handling, logging hygiene, dependency review) split into "Today" and "Candidates for future work."
- Adds a "Frontend pitfalls in AI-assisted code" subsection that points to the handbook's [AI tooling](https://fleetdm.com/handbook/engineering#ai-tooling) and [AI usage guidelines](https://fleetdm.com/handbook/company/communications#ai-usage-guidelines), then lists frontend-specific gotchas worth a deliberate check on every diff.

Also updates `.claude/rules/fleet-frontend.md` so the XSS prevention rule mirrors the helper list and cross-links back to the patterns doc.

Drafting for your review before flipping to ready — flagging the "Candidates for future work" list and the AI-pitfalls framing as the most opinionated parts.