### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.34.61",
+      "version": "2.34.62",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.34.61') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.34.62') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.34.61.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.34.62.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "08be0723",
-      "sha256": "133e43318435a71b2518938a3164d75c62bb38c4bd301f068b4f73f9acafeb8a",
+      "sha256": "a30cf34896888e1ce5b1d86aa5d1a93599e7e6345f57c6a0663fb6bde5fc7a39",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "148.1.90.128",
+      "version": "149.1.91.168",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '148.1.90.128') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '149.1.91.168') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.90.128/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.91.168/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "0e0bde3759ed648e28b6e9fdec9ca30c0391d7733566a789381254f35348665b",
+      "sha256": "7905a5351d5c52d03fbe21423c443f00c60260f573e74ec3375b364da7367cbb",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.10628.2",
+      "version": "1.11187.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.10628.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.11187.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.10628.2/Claude-deee0a79e9070caed69480a2c8d2e09f895512c4.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.11187.1/Claude-370d3bd8e2159025901b720ad479c9ae36f180fa.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "aed0ee22d42010a19fb53e4c287271e4fd8d4fa94ea958ecfd32efa2d3d4e16c",
+      "sha256": "8a6e2009633fb8eeca74cb4acf3a118eb723c3a106e73111af5c0b9cfe29b16a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.290.0",
+      "version": "7.303.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.290.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.303.0') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.290.0/Granola-7.290.0-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.303.0/Granola-7.303.0-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "1ea982b793b2a255cb83cafde4f7f450dea949feb692113812a721fd48b2936e",
+      "sha256": "5381b059899caf0a6b6f7b7d6506db4b7d7b408afe8eec05ea42535dc3628da8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/windows.json
+++ b/ee/maintained-apps/outputs/loom/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.351.2",
+      "version": "0.352.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.351.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.352.4') < 0);"
       },
-      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.351.2.exe",
+      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.352.4.exe",
       "install_script_ref": "77327cbf",
       "uninstall_script_ref": "b012f1e7",
-      "sha256": "cea75d3df8ce7f8ba7205683cbe3ccbb9287016582ac5fb38b352b80fdd879e7",
+      "sha256": "24ad5a943ea509eeb51cb3e55f430899e032c4b67ab2f1024a0e2c871cad830c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "148.0.3967.96",
+      "version": "149.0.4022.52",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '148.0.3967.96') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.52') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/207765a9-3991-4576-80dd-92c5dd9daac0/MicrosoftEdge-148.0.3967.96.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/175d61fb-7a6d-4b2c-87c3-2b8cfcf3247e/MicrosoftEdge-149.0.4022.52.dmg",
       "install_script_ref": "caf6f785",
       "uninstall_script_ref": "3b06f51c",
-      "sha256": "9556628a00160bb48693198e50c9f03551a83070d5e9ce56c359e0dd388a5a90",
+      "sha256": "a08d2b67e5b655f46d1aaba13fd60c2db48bd5a12391809ed47135bf2be6a601",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/nordvpn/windows.json
+++ b/ee/maintained-apps/outputs/nordvpn/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.3.6.0",
+      "version": "8.4.3.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'NordVPN %' AND publisher = 'Nord Security';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'NordVPN %' AND publisher = 'Nord Security' AND version_compare(version, '8.3.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'NordVPN %' AND publisher = 'Nord Security' AND version_compare(version, '8.4.3.0') < 0);"
       },
-      "installer_url": "https://downloads.nordcdn.com/apps/windows/NordVPN/8.3.6.0/NordVPNInstall.exe",
+      "installer_url": "https://downloads.nordcdn.com/apps/windows/NordVPN/8.4.3.0/NordVPNInstall.exe",
       "install_script_ref": "61026ed8",
       "uninstall_script_ref": "b5dba69c",
-      "sha256": "299706a4e144784b48ecd4f3d24fb470c1cad9a32e08fa9acabe9bd4d4a54d0b",
+      "sha256": "aab8c8eacab4a71762ade6b49e646b6888d74c536c1d7b95d6b74b16bc0721f8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.30.4",
+      "version": "0.30.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.5') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.4/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.5/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "bf40e2d5",
-      "sha256": "4ec5297bd4642b4caed7c4dcf6f630f22f2977684464bf7a438f7a2cfb762274",
+      "sha256": "d1679f85014e5f59409e41ec0e9c864bbbd3f9784dc6d58d505439d9e1648ab5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/orbstack/darwin.json
+++ b/ee/maintained-apps/outputs/orbstack/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.2.1') < 0);"
       },
-      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.2.0_20607_arm64.dmg",
+      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.2.1_20628_arm64.dmg",
       "install_script_ref": "ffffa6a2",
       "uninstall_script_ref": "a77f3f59",
-      "sha256": "43b77bc05af716676e774f40e58ce540c2a91d467dbe51e18facad7f4c0f3ea3",
+      "sha256": "5bc1719c3c987c4c60c65be9fdd65b4730990e1697ec1cb1c33e6bba31bf92b5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/phpstorm/darwin.json
+++ b/ee/maintained-apps/outputs/phpstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.2",
+      "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1.2-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1.3-aarch64.dmg",
       "install_script_ref": "a85d5737",
       "uninstall_script_ref": "bdde2409",
-      "sha256": "7493aa758f83e45b2c0c0be870c39793d3b6daa93e40bc700e6d8c1cad968208",
+      "sha256": "628e741215500e0edcfc2dc967dbad671a6c398d03b997e063362d04df4d9b09",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rubymine/windows.json
+++ b/ee/maintained-apps/outputs/rubymine/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.2",
+      "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'RubyMine %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'RubyMine %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'RubyMine %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1.2.exe",
+      "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1.3.exe",
       "install_script_ref": "a737b660",
       "uninstall_script_ref": "1bc953e9",
-      "sha256": "3f9c000d513818182548cc7e600323e22b3d47c9bc080a50de86d73d21f8a4bb",
+      "sha256": "f04bceaa3af5a289c1a5714c8ceb773fc70238c8899f3fe00ef728cd81892d70",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/webstorm/windows.json
+++ b/ee/maintained-apps/outputs/webstorm/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.2",
+      "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'WebStorm %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'WebStorm %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'WebStorm %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.2.exe",
+      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3.exe",
       "install_script_ref": "68119c0c",
       "uninstall_script_ref": "c2646a7f",
-      "sha256": "ff2a17927caa426e0cc5743319c371ec791639c3a67c18fd8470920d62982b1f",
+      "sha256": "21331dbb0d64ace77e3eee223db1ac4ced2629484cab563dab73f45b439366e6",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer metadata for 12 applications across Windows and macOS: AWS CLI v2, Brave Browser, Claude, Granola, Loom, Microsoft Edge, NordVPN, Ollama, OrbStack, PhpStorm, RubyMine, and WebStorm.
  * Updated version numbers, installer URLs, and checksums for each application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->