### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.13.5",
+      "version": "12.13.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.13.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.13.6') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.13.5/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.13.6/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "ab842cde2c05adb312fdf6cc9b44ac62011d4ce999fb3983b8b7905c7b3f111e",
+      "sha256": "5a7343c72ecea23f99886304669b1c507de7e5129742f78aac5d0911a379a7f1",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.13.5",
+      "version": "12.13.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.13.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.13.6') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.13.5/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.13.6/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "96d5edf6cb603fd02fe1ce87974bd72323046190ef290019a9d3776405d3453c",
+      "sha256": "be873b49868ba2e47401a46e3526788fbc662c74a13f0460120ba1464cf34308",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/teleport-connect/darwin.json
+++ b/ee/maintained-apps/outputs/teleport-connect/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "18.8.2",
+      "version": "18.8.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect' AND version_compare(bundle_short_version, '18.8.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect' AND version_compare(bundle_short_version, '18.8.3') < 0);"
       },
-      "installer_url": "https://cdn.teleport.dev/Teleport%20Connect-18.8.2.dmg",
+      "installer_url": "https://cdn.teleport.dev/Teleport%20Connect-18.8.3.dmg",
       "install_script_ref": "671bf444",
       "uninstall_script_ref": "e96ff37d",
-      "sha256": "9afbeafb3db0c5dee7710178757f27d5ee6fa514e3282e46205eba228cb2ac37",
+      "sha256": "a80afc2093ccea13e6e35bc2bb53731e282a43c815b72af02b91d6df6fc6a54b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.05.27.15.44.01",
+      "version": "0.2026.06.03.09.49.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.05.27.15.44.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.03.09.49.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.05.27.15.44.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.03.09.49.stable_01/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata for Postman (macOS and Windows) to version 12.13.6
  * Updated metadata for Teleport Connect (macOS) to version 18.8.3
  * Updated metadata for Warp (Darwin) to version 0.2026.06.03.09.49.01

<!-- end of auto-generated comment: release notes by coderabbit.ai -->