### PR TITLE
Command palette: highlight search matches in picker subpages

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -498,9 +498,13 @@ const CommandPalette = (): JSX.Element | null => {
       <React.Fragment key={item.id}>
         <Command.Item
           value={getUniqueItemValue(item)}
-          onSelect={() =>
-            item.onAction ? item.onAction() : navigate(item.path!)
-          }
+          onSelect={() => {
+            if (item.onAction) {
+              item.onAction();
+              return;
+            }
+            if (item.path) navigate(item.path);
+          }}
           className={`${baseClass}__item`}
         >
           <div className={`${baseClass}__item-left`}>
@@ -597,7 +601,7 @@ const CommandPalette = (): JSX.Element | null => {
                       item.onAction();
                       return;
                     }
-                    navigate(item.path!);
+                    if (item.path) navigate(item.path);
                   }}
                   className={itemClass}
                 >

--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -23,13 +23,13 @@ import {
   buildPaletteItems,
   buildFleetSwitchUrl,
   computeBestMatch,
-  highlightMatches,
 } from "./helpers";
 import FleetPicker from "./components/FleetPicker";
 import HostPicker from "./components/HostPicker";
 import SoftwarePicker from "./components/SoftwarePicker";
 import ReportPicker from "./components/ReportPicker";
 import PolicyPicker from "./components/PolicyPicker";
+import HighlightedLabel from "./components/HighlightedLabel";
 import { isPreFilteredResult } from "./components/constants";
 
 const baseClass = "command-palette";
@@ -603,23 +603,7 @@ const CommandPalette = (): JSX.Element | null => {
                 >
                   <div className={`${baseClass}__item-left`}>
                     <span className={`${baseClass}__item-label`}>
-                      {highlightMatches(target.label, search).map((seg, i) =>
-                        seg.matched ? (
-                          <mark
-                            // Index keys are safe here — segments are
-                            // derived synchronously from the same label
-                            // + query each render, so order is stable.
-                            // eslint-disable-next-line react/no-array-index-key
-                            key={i}
-                            className={`${baseClass}__item-label-match`}
-                          >
-                            {seg.text}
-                          </mark>
-                        ) : (
-                          // eslint-disable-next-line react/no-array-index-key
-                          <React.Fragment key={i}>{seg.text}</React.Fragment>
-                        )
-                      )}
+                      <HighlightedLabel text={target.label} query={search} />
                     </span>
                     {/* Render the sub-page chevron for items that open a
                         picker (View host, View software, etc.). The
@@ -844,6 +828,7 @@ const CommandPalette = (): JSX.Element | null => {
           <FleetPicker
             availableTeams={availableTeams}
             currentTeam={currentTeam}
+            search={search}
             onSelect={handleSwitchFleet}
           />
         )}

--- a/frontend/components/CommandPalette/components/FleetPicker.tests.tsx
+++ b/frontend/components/CommandPalette/components/FleetPicker.tests.tsx
@@ -27,6 +27,7 @@ describe("FleetPicker", () => {
       <FleetPicker
         availableTeams={availableTeams}
         currentTeam={availableTeams[2]}
+        search=""
         onSelect={jest.fn()}
       />
     );
@@ -42,6 +43,7 @@ describe("FleetPicker", () => {
       <FleetPicker
         availableTeams={availableTeams}
         currentTeam={availableTeams[2]}
+        search=""
         onSelect={jest.fn()}
       />
     );
@@ -59,6 +61,7 @@ describe("FleetPicker", () => {
       <FleetPicker
         availableTeams={availableTeams}
         currentTeam={availableTeams[2]}
+        search=""
         onSelect={onSelect}
       />
     );
@@ -68,7 +71,7 @@ describe("FleetPicker", () => {
   });
 
   it("renders empty (no items) when availableTeams is undefined", () => {
-    renderPicker(<FleetPicker onSelect={jest.fn()} />);
+    renderPicker(<FleetPicker search="" onSelect={jest.fn()} />);
     expect(screen.queryByText("Engineering")).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/CommandPalette/components/FleetPicker.tsx
+++ b/frontend/components/CommandPalette/components/FleetPicker.tsx
@@ -3,17 +3,21 @@ import { Command } from "cmdk";
 
 import { ITeamSummary } from "interfaces/team";
 
+import HighlightedLabel from "./HighlightedLabel";
+
 const baseClass = "command-palette";
 
 interface IFleetPickerProps {
   availableTeams?: ITeamSummary[];
   currentTeam?: ITeamSummary;
+  search: string;
   onSelect: (fleetId: number) => void;
 }
 
 const FleetPicker = ({
   availableTeams,
   currentTeam,
+  search,
   onSelect,
 }: IFleetPickerProps): JSX.Element => {
   return (
@@ -32,7 +36,7 @@ const FleetPicker = ({
                 isSelected ? ` ${baseClass}__item-label--selected` : ""
               }`}
             >
-              {fleet.name}
+              <HighlightedLabel text={fleet.name} query={search} />
             </span>
           </Command.Item>
         );

--- a/frontend/components/CommandPalette/components/HighlightedLabel.tests.tsx
+++ b/frontend/components/CommandPalette/components/HighlightedLabel.tests.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import HighlightedLabel from "./HighlightedLabel";
+
+describe("HighlightedLabel", () => {
+  it("renders the text plainly when query is empty", () => {
+    const { container } = render(
+      <HighlightedLabel text="Engineering" query="" />
+    );
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+    expect(container.querySelectorAll("mark")).toHaveLength(0);
+  });
+
+  it("wraps the matched substring in a <mark>", () => {
+    const { container } = render(
+      <HighlightedLabel text="Engineering" query="gin" />
+    );
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(1);
+    expect(marks[0].textContent).toBe("gin");
+    expect(marks[0]).toHaveClass("command-palette__item-label-match");
+  });
+
+  it("matches case-insensitively while preserving original case", () => {
+    const { container } = render(
+      <HighlightedLabel text="Engineering" query="ENG" />
+    );
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(1);
+    expect(marks[0].textContent).toBe("Eng");
+  });
+
+  it("highlights each token of a multi-token query", () => {
+    const { container } = render(
+      <HighlightedLabel text="View host details" query="view det" />
+    );
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(2);
+    expect(marks[0].textContent).toBe("View");
+    expect(marks[1].textContent).toBe("det");
+  });
+
+  it("renders plain text when the query has no match", () => {
+    const { container } = render(
+      <HighlightedLabel text="Engineering" query="zzz" />
+    );
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+    expect(container.querySelectorAll("mark")).toHaveLength(0);
+  });
+});

--- a/frontend/components/CommandPalette/components/HighlightedLabel.tsx
+++ b/frontend/components/CommandPalette/components/HighlightedLabel.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import { highlightMatches } from "../helpers";
+
+const baseClass = "command-palette";
+
+interface IHighlightedLabelProps {
+  text: string;
+  query: string;
+}
+
+/**
+ * Wraps matched ranges of `query` within `text` in <mark> elements so the
+ * user can see which part of a result matched their search. Renders a
+ * Fragment — callers control the surrounding element/class.
+ */
+const HighlightedLabel = ({
+  text,
+  query,
+}: IHighlightedLabelProps): JSX.Element => {
+  return (
+    <>
+      {highlightMatches(text, query).map((seg, i) =>
+        seg.matched ? (
+          // Index keys are safe — segments are derived synchronously from
+          // the same text + query each render, so order is stable.
+          // eslint-disable-next-line react/no-array-index-key
+          <mark key={i} className={`${baseClass}__item-label-match`}>
+            {seg.text}
+          </mark>
+        ) : (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={i}>{seg.text}</React.Fragment>
+        )
+      )}
+    </>
+  );
+};
+
+export default HighlightedLabel;

--- a/frontend/components/CommandPalette/components/HostPicker.tests.tsx
+++ b/frontend/components/CommandPalette/components/HostPicker.tests.tsx
@@ -149,5 +149,22 @@ describe("HostPicker", () => {
       expect(await findByText("Rachel's MacBook")).toBeInTheDocument();
       expect(queryByText("Engineering")).not.toBeInTheDocument();
     });
+
+    it("highlights the matched substring of the host name", async () => {
+      mockedHosts.loadHosts.mockResolvedValue(hosts);
+
+      const { findByText, container } = renderPicker(
+        <HostPicker search="Rachel" onSelect={jest.fn()} />
+      );
+      // Wait for the row to render. With "Rachel" matched, the label
+      // text is split across <mark> + plain segments, so we look for the
+      // mark by its class instead of getByText("Rachel's MacBook").
+      await findByText(/MacBook/);
+      const mark = container.querySelector(
+        "mark.command-palette__item-label-match"
+      );
+      expect(mark).toBeInTheDocument();
+      expect(mark?.textContent).toBe("Rachel");
+    });
   });
 });

--- a/frontend/components/CommandPalette/components/HostPicker.tsx
+++ b/frontend/components/CommandPalette/components/HostPicker.tsx
@@ -78,7 +78,9 @@ const HostPicker = ({
                 aria-label={`status: ${host.status}`}
               />
               <span className={`${baseClass}__item-label`}>
-                <HighlightedLabel text={label} query={search} />
+                {/* debouncedQuery, not live search — stays in sync
+                    with the debounced row list. */}
+                <HighlightedLabel text={label} query={debouncedQuery} />
               </span>
             </span>
             {showTeamColumn && (

--- a/frontend/components/CommandPalette/components/HostPicker.tsx
+++ b/frontend/components/CommandPalette/components/HostPicker.tsx
@@ -5,6 +5,7 @@ import hostsAPI, { ILoadHostsResponse } from "services/entities/hosts";
 
 import usePickerSearch from "./usePickerSearch";
 import { RESULT_PREFIXES } from "./constants";
+import HighlightedLabel from "./HighlightedLabel";
 
 const baseClass = "command-palette";
 
@@ -76,7 +77,9 @@ const HostPicker = ({
                 className={dotClass}
                 aria-label={`status: ${host.status}`}
               />
-              <span className={`${baseClass}__item-label`}>{label}</span>
+              <span className={`${baseClass}__item-label`}>
+                <HighlightedLabel text={label} query={search} />
+              </span>
             </span>
             {showTeamColumn && (
               <span className={`${baseClass}__host-team`}>

--- a/frontend/components/CommandPalette/components/PolicyPicker.tsx
+++ b/frontend/components/CommandPalette/components/PolicyPicker.tsx
@@ -106,7 +106,7 @@ const PolicyPicker = ({
           >
             <div className={`${baseClass}__item-left`}>
               <span className={`${baseClass}__item-label`}>
-                <HighlightedLabel text={policy.name} query={search} />
+                <HighlightedLabel text={policy.name} query={debouncedQuery} />
               </span>
               {showCriticalBadge && <CriticalPolicyBadge />}
               {showPatchBadge && (

--- a/frontend/components/CommandPalette/components/PolicyPicker.tsx
+++ b/frontend/components/CommandPalette/components/PolicyPicker.tsx
@@ -16,6 +16,7 @@ import { PATCH_TOOLTIP_CONTENT } from "components/SoftwareInstallPolicyBadges/So
 import usePickerSearch from "./usePickerSearch";
 import { RESULT_PREFIXES } from "./constants";
 import getFleetSuffix from "./pickerCopy";
+import HighlightedLabel from "./HighlightedLabel";
 
 const baseClass = "command-palette";
 
@@ -104,7 +105,9 @@ const PolicyPicker = ({
             className={`${baseClass}__item`}
           >
             <div className={`${baseClass}__item-left`}>
-              <span className={`${baseClass}__item-label`}>{policy.name}</span>
+              <span className={`${baseClass}__item-label`}>
+                <HighlightedLabel text={policy.name} query={search} />
+              </span>
               {showCriticalBadge && <CriticalPolicyBadge />}
               {showPatchBadge && (
                 <PillBadge tipContent={PATCH_TOOLTIP_CONTENT}>Patch</PillBadge>

--- a/frontend/components/CommandPalette/components/ReportPicker.tsx
+++ b/frontend/components/CommandPalette/components/ReportPicker.tsx
@@ -96,7 +96,7 @@ const ReportPicker = ({
           >
             <div className={`${baseClass}__item-left`}>
               <span className={`${baseClass}__item-label`}>
-                <HighlightedLabel text={report.name} query={search} />
+                <HighlightedLabel text={report.name} query={debouncedQuery} />
               </span>
               {showObserverIcon && (
                 <TooltipWrapper

--- a/frontend/components/CommandPalette/components/ReportPicker.tsx
+++ b/frontend/components/CommandPalette/components/ReportPicker.tsx
@@ -11,6 +11,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import usePickerSearch from "./usePickerSearch";
 import { RESULT_PREFIXES } from "./constants";
 import getFleetSuffix from "./pickerCopy";
+import HighlightedLabel from "./HighlightedLabel";
 
 const baseClass = "command-palette";
 
@@ -94,7 +95,9 @@ const ReportPicker = ({
             className={`${baseClass}__item`}
           >
             <div className={`${baseClass}__item-left`}>
-              <span className={`${baseClass}__item-label`}>{report.name}</span>
+              <span className={`${baseClass}__item-label`}>
+                <HighlightedLabel text={report.name} query={search} />
+              </span>
               {showObserverIcon && (
                 <TooltipWrapper
                   tipContent="Observers can run this report."

--- a/frontend/components/CommandPalette/components/SoftwarePicker.tsx
+++ b/frontend/components/CommandPalette/components/SoftwarePicker.tsx
@@ -130,7 +130,7 @@ const SoftwarePicker = ({
           >
             <div className={`${baseClass}__item-left`}>
               <span className={`${baseClass}__item-label`}>
-                <HighlightedLabel text={label} query={search} />
+                <HighlightedLabel text={label} query={debouncedQuery} />
               </span>
               {installerProps && <InstallIconWithTooltip {...installerProps} />}
             </div>

--- a/frontend/components/CommandPalette/components/SoftwarePicker.tsx
+++ b/frontend/components/CommandPalette/components/SoftwarePicker.tsx
@@ -20,6 +20,7 @@ import { InstallIconWithTooltip } from "components/TableContainer/DataTable/Soft
 import getFleetSuffix from "./pickerCopy";
 import usePickerSearch from "./usePickerSearch";
 import { RESULT_PREFIXES } from "./constants";
+import HighlightedLabel from "./HighlightedLabel";
 
 const baseClass = "command-palette";
 
@@ -128,7 +129,9 @@ const SoftwarePicker = ({
             className={`${baseClass}__item`}
           >
             <div className={`${baseClass}__item-left`}>
-              <span className={`${baseClass}__item-label`}>{label}</span>
+              <span className={`${baseClass}__item-label`}>
+                <HighlightedLabel text={label} query={search} />
+              </span>
               {installerProps && <InstallIconWithTooltip {...installerProps} />}
             </div>
             {typeLabel && (

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -1229,5 +1229,38 @@ describe("CommandPalette helpers", () => {
         { text: "tup", matched: false },
       ]);
     });
+
+    it("slices the original text correctly when a match follows a length-changing case fold", () => {
+      // "İ" (U+0130) lowercases to "i̇" (U+0069 + U+0307), expanding
+      // 1 char into 2. A naive textLower.indexOf + text.slice would find
+      // "stan" at lower-index 2 (the i + combining dot pushed it
+      // forward), then slice the original at [2, 6] — producing "tanb"
+      // instead of "stan". The offset map translates the lower-coord
+      // range back to the original-text range.
+      const result = highlightMatches("İstanbul", "stan");
+      expect(result.map((s) => s.text).join("")).toBe("İstanbul");
+      const matched = result.filter((s) => s.matched).map((s) => s.text);
+      expect(matched).toEqual(["stan"]);
+    });
+
+    it("matches an ASCII query against a source char whose lowercase expands (İ → i̇)", () => {
+      // utf8mb4_unicode_ci treats İ and i as equivalent, so the backend
+      // returns "İstanbul" for query "i". The frontend must do the same
+      // or rows render with zero highlights. The match in textLower
+      // ("i̇stanbul") ends mid-folded-char; the offset map expands it
+      // to cover the whole "İ".
+      const result = highlightMatches("İstanbul", "i");
+      expect(result.map((s) => s.text).join("")).toBe("İstanbul");
+      expect(result[0]).toEqual({ text: "İ", matched: true });
+    });
+
+    it("matches a multi-char-lowercased query against the source char that produced it", () => {
+      // Query "İ" lowercases to "i̇" (2 chars); source "İ" also lowercases
+      // to "i̇". The whole source char should highlight in its original
+      // form.
+      const result = highlightMatches("İstanbul", "İ");
+      expect(result.map((s) => s.text).join("")).toBe("İstanbul");
+      expect(result[0]).toEqual({ text: "İ", matched: true });
+    });
   });
 });

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -1262,5 +1262,38 @@ describe("CommandPalette helpers", () => {
       expect(result.map((s) => s.text).join("")).toBe("İstanbul");
       expect(result[0]).toEqual({ text: "İ", matched: true });
     });
+
+    it("folds supplementary-plane characters (Adlam)", () => {
+      // U+1E900 (Adlam capital A) lowercases to U+1E922 (Adlam small a).
+      // Per-code-unit folding would leave the lone surrogates unchanged
+      // and silently drop the match.
+      const result = highlightMatches("\u{1E900}stanbul", "\u{1E922}stanbul");
+      expect(result).toEqual([{ text: "\u{1E900}stanbul", matched: true }]);
+    });
+
+    it("matches a multi-char ASCII query across a length-changing fold", () => {
+      // 'İ' → 'i' + combining dot splits the run; without combining-mark
+      // stripping, indexOf('istanbul') in the folded text returns -1.
+      const result = highlightMatches("İstanbul", "istanbul");
+      expect(result).toEqual([{ text: "İstanbul", matched: true }]);
+    });
+
+    it("matches accent-insensitively to mirror utf8mb4_unicode_ci", () => {
+      // Backend returns 'Café Server' for query 'cafe'; highlighter must
+      // do the same or the row renders with zero <mark> tags.
+      const result = highlightMatches("Café Server", "cafe");
+      expect(result).toEqual([
+        { text: "Café", matched: true },
+        { text: " Server", matched: false },
+      ]);
+    });
+
+    it("matches when the query itself carries an accent", () => {
+      const result = highlightMatches("Cafe Server", "café");
+      expect(result).toEqual([
+        { text: "Cafe", matched: true },
+        { text: " Server", matched: false },
+      ]);
+    });
   });
 });

--- a/frontend/components/CommandPalette/helpers.ts
+++ b/frontend/components/CommandPalette/helpers.ts
@@ -323,7 +323,6 @@ export const highlightMatches = (
   const queryLower = query.toLowerCase().trim();
   if (!queryLower) return [{ text, matched: false }];
 
-  const textLower = text.toLowerCase();
   // Always include the full query as one needle so phrase matches get
   // a contiguous highlight, plus each individual token for multi-token
   // queries.
@@ -332,12 +331,41 @@ export const highlightMatches = (
     if (tok) needles.add(tok);
   });
 
+  // Build textLower in lockstep with an offset map back to the original.
+  // Some Unicode case folds change length (Turkish "İ" → "i̇"), so a
+  // naive textLower.indexOf + slice(original) misaligns and highlights
+  // the wrong characters. lowerToOrigStart[i] holds the original-text
+  // index of the source char that contributed textLower[i]. The
+  // collation Fleet's MySQL uses (utf8mb4_unicode_ci) returns "İstanbul"
+  // for query "i", so this needs to match leniently against any source
+  // char whose lowered form contains the needle — not just exact
+  // source-char-vs-needle alignment.
+  let textLower = "";
+  const lowerToOrigStart: number[] = [];
+  for (let i = 0; i < text.length; i += 1) {
+    const lowered = text[i].toLowerCase();
+    for (let j = 0; j < lowered.length; j += 1) {
+      lowerToOrigStart.push(i);
+    }
+    textLower += lowered;
+  }
+  // Sentinel for end-of-text — lets lowerEnd === textLower.length resolve
+  // without a bounds check.
+  lowerToOrigStart.push(text.length);
+
   const ranges: Array<[number, number]> = [];
   needles.forEach((needle) => {
     let idx = textLower.indexOf(needle);
     while (idx !== -1) {
-      ranges.push([idx, idx + needle.length]);
-      idx = textLower.indexOf(needle, idx + needle.length);
+      const lowerEnd = idx + needle.length;
+      // Translate to original-text coords. For origEnd:
+      // lowerToOrigStart[lowerEnd-1] is the source-char index whose
+      // contribution includes the last matched lower char; +1 covers
+      // the full source char, even when the match ends mid-folded-char.
+      const origStart = lowerToOrigStart[idx];
+      const origEnd = lowerToOrigStart[lowerEnd - 1] + 1;
+      ranges.push([origStart, origEnd]);
+      idx = textLower.indexOf(needle, lowerEnd);
     }
   });
 

--- a/frontend/components/CommandPalette/helpers.ts
+++ b/frontend/components/CommandPalette/helpers.ts
@@ -320,7 +320,13 @@ export const highlightMatches = (
   query: string
 ): IHighlightSegment[] => {
   if (!text) return [{ text: "", matched: false }];
-  const queryLower = query.toLowerCase().trim();
+  // NFD-decompose, drop combining marks, lowercase. Mirrors
+  // utf8mb4_unicode_ci's accent-insensitive folding so the highlighter
+  // never undershoots a row the backend surfaced.
+  const foldChar = (cp: string): string =>
+    cp.normalize("NFD").replace(/\p{M}/gu, "").toLowerCase();
+  const fold = (s: string): string => Array.from(s, foldChar).join("");
+  const queryLower = fold(query).trim();
   if (!queryLower) return [{ text, matched: false }];
 
   // Always include the full query as one needle so phrase matches get
@@ -331,39 +337,38 @@ export const highlightMatches = (
     if (tok) needles.add(tok);
   });
 
-  // Build textLower in lockstep with an offset map back to the original.
-  // Some Unicode case folds change length (Turkish "İ" → "i̇"), so a
-  // naive textLower.indexOf + slice(original) misaligns and highlights
-  // the wrong characters. lowerToOrigStart[i] holds the original-text
-  // index of the source char that contributed textLower[i]. The
-  // collation Fleet's MySQL uses (utf8mb4_unicode_ci) returns "İstanbul"
-  // for query "i", so this needs to match leniently against any source
-  // char whose lowered form contains the needle — not just exact
-  // source-char-vs-needle alignment.
+  // Build textLower in lockstep with offset maps back to the original.
+  // Iterate by codepoint (not code unit) so supplementary-plane chars
+  // fold correctly — text[i].toLowerCase() on a lone surrogate is a
+  // no-op. Some folds change length (Turkish "İ" → "i", combining marks
+  // stripped from "Café" → "Cafe"); lowerToOrigStart/End translate
+  // matches back to original-text ranges.
   let textLower = "";
   const lowerToOrigStart: number[] = [];
-  for (let i = 0; i < text.length; i += 1) {
-    const lowered = text[i].toLowerCase();
-    for (let j = 0; j < lowered.length; j += 1) {
-      lowerToOrigStart.push(i);
+  const lowerToOrigEnd: number[] = [];
+  let origIdx = 0;
+  Array.from(text).forEach((cp) => {
+    const folded = foldChar(cp);
+    for (let j = 0; j < folded.length; j += 1) {
+      lowerToOrigStart.push(origIdx);
+      lowerToOrigEnd.push(origIdx + cp.length);
     }
-    textLower += lowered;
-  }
-  // Sentinel for end-of-text — lets lowerEnd === textLower.length resolve
-  // without a bounds check.
+    textLower += folded;
+    origIdx += cp.length;
+  });
+  // Sentinels for end-of-text alignment.
   lowerToOrigStart.push(text.length);
+  lowerToOrigEnd.push(text.length);
 
   const ranges: Array<[number, number]> = [];
   needles.forEach((needle) => {
     let idx = textLower.indexOf(needle);
     while (idx !== -1) {
       const lowerEnd = idx + needle.length;
-      // Translate to original-text coords. For origEnd:
-      // lowerToOrigStart[lowerEnd-1] is the source-char index whose
-      // contribution includes the last matched lower char; +1 covers
-      // the full source char, even when the match ends mid-folded-char.
+      // Translate to original-text coords. lowerToOrigEnd already
+      // accounts for surrogate-pair widths and length-changing folds.
       const origStart = lowerToOrigStart[idx];
-      const origEnd = lowerToOrigStart[lowerEnd - 1] + 1;
+      const origEnd = lowerToOrigEnd[lowerEnd - 1];
       ranges.push([origStart, origEnd]);
       idx = textLower.indexOf(needle, lowerEnd);
     }


### PR DESCRIPTION
## Issue
Closes #43757 

## Description
- The main palette already highlighted matched ranges of the search query in best-match results, but the host / software / report / policy / fleet pickers rendered their labels as plain text. Extract the inline highlighting into a small shared HighlightedLabel component (wrapping matched ranges in <mark class="command-palette__item-label-match">) and use it across all five pickers and the main best-match list.

## Screenrecording of fix


https://github.com/user-attachments/assets/0cd36c43-2c9d-46f6-8aff-09c39a4ddc64



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared HighlightedLabel and applied query highlighting across fleets, hosts, policies, reports, software, and best-match items in the Command Palette.
  * Command Palette selection now prioritizes item actions before navigation.

* **Bug Fixes**
  * Matching/highlighting now handles Unicode, accent-insensitive folding, and case-folding edge cases for more accurate highlights.

* **Tests**
  * Added/updated tests for highlighting, multi-token queries, Unicode/case-fold scenarios, and picker rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->