### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.11187.1",
+      "version": "1.11187.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.11187.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.11187.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.11187.1/Claude-370d3bd8e2159025901b720ad479c9ae36f180fa.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.11187.2/Claude-8cc3afa7b40409eb06b0c048fad852f0c0df3d12.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "8a6e2009633fb8eeca74cb4acf3a118eb723c3a106e73111af5c0b9cfe29b16a",
+      "sha256": "67fda7a005111e4c3e7fc9cb418efa9681878bf0683b491491eef471bcf1ac94",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cleanmymac/darwin.json
+++ b/ee/maintained-apps/outputs/cleanmymac/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5' AND version_compare(bundle_short_version, '5.5.4') < 0);"
       },
-      "installer_url": "https://updates.cleanmymac.com/com.macpaw.cleanmymac5/releases/CleanMyMac5_50504.0.2605191427.zip",
+      "installer_url": "https://updates.cleanmymac.com/com.macpaw.cleanmymac5/releases/CleanMyMac5_50504.0.2605291449.zip",
       "install_script_ref": "fff893a1",
       "uninstall_script_ref": "6b7419ac",
-      "sha256": "4581b2e6d0a7c1203ea68aecf4c6e0e57fa2c224ebe6653b50afae19afe2c464",
+      "sha256": "b66d2f26ce4d1dc6819f1b4dd7e9f020f9f3b3527beaeb6406b9a41cac5b5020",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.13.5",
+      "version": "12.13.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.13.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.13.6') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.13.5/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.13.6/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "ab842cde2c05adb312fdf6cc9b44ac62011d4ce999fb3983b8b7905c7b3f111e",
+      "sha256": "5a7343c72ecea23f99886304669b1c507de7e5129742f78aac5d0911a379a7f1",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.13.5",
+      "version": "12.13.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.13.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.13.6') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.13.5/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.13.6/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "96d5edf6cb603fd02fe1ce87974bd72323046190ef290019a9d3776405d3453c",
+      "sha256": "be873b49868ba2e47401a46e3526788fbc662c74a13f0460120ba1464cf34308",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/sourcetree/windows.json
+++ b/ee/maintained-apps/outputs/sourcetree/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.30",
+      "version": "3.4.31",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Sourcetree Enterprise' AND publisher = 'Atlassian';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Sourcetree Enterprise' AND publisher = 'Atlassian' AND version_compare(version, '3.4.30') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Sourcetree Enterprise' AND publisher = 'Atlassian' AND version_compare(version, '3.4.31') < 0);"
       },
-      "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourcetreeEnterpriseSetup_3.4.30.msi",
+      "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourcetreeEnterpriseSetup_3.4.31.msi",
       "install_script_ref": "17f62246",
       "uninstall_script_ref": "7389fcbc",
-      "sha256": "137bd80ac026e6eca635a85fdc66cea5ff66b4ec0b7ffa86ef49be8e359a5fb0",
+      "sha256": "d7c9845869072f9c0d10dc703fbf4ab25b21e4b1b01bd7c422920e99c2e2fcd2",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/teleport-connect/darwin.json
+++ b/ee/maintained-apps/outputs/teleport-connect/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "18.8.2",
+      "version": "18.8.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect' AND version_compare(bundle_short_version, '18.8.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'gravitational.teleport.connect' AND version_compare(bundle_short_version, '18.8.3') < 0);"
       },
-      "installer_url": "https://cdn.teleport.dev/Teleport%20Connect-18.8.2.dmg",
+      "installer_url": "https://cdn.teleport.dev/Teleport%20Connect-18.8.3.dmg",
       "install_script_ref": "671bf444",
       "uninstall_script_ref": "e96ff37d",
-      "sha256": "9afbeafb3db0c5dee7710178757f27d5ee6fa514e3282e46205eba228cb2ac37",
+      "sha256": "a80afc2093ccea13e6e35bc2bb53731e282a43c815b72af02b91d6df6fc6a54b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.05.27.15.44.01",
+      "version": "0.2026.06.03.09.49.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.05.27.15.44.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.03.09.49.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.05.27.15.44.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.03.09.49.stable_01/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Claude to version 1.11187.2
  * Updated Postman to version 12.13.6 (macOS and Windows)
  * Updated Sourcetree to version 3.4.31
  * Updated Teleport Connect to version 18.8.3
  * Refreshed installer resources for CleanMyMac and Warp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->