### PR TITLE
Optimize ListLabels host-count query

### DIFF
--- a/changes/4890-optimize-label-query
+++ b/changes/4890-optimize-label-query
@@ -1,0 +1,1 @@
+- Improved the performance of listing labels with host counts by aggregating membership counts in a single pass instead of a per-label subquery, and skipping the unnecessary join to the hosts table when the requesting user can see all hosts.

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -830,14 +830,25 @@ func (ds *Datastore) ListLabels(ctx context.Context, filter fleet.TeamFilter, op
 	query := "SELECT l.* FROM labels l "
 	// When applicable, filter host membership by team and return counts with the labels.
 	if filter.User != nil && includeHostCounts {
+		countFrom := "label_membership lm JOIN hosts h ON (lm.host_id = h.id)"
+		// When the team filter allows all hosts ("TRUE"),
+		// skip the join to the hosts table and count straight off the
+		// label_membership index.
+		teamFilter := ds.whereFilterHostsByTeams(filter, "h")
+		if teamFilter == "TRUE" {
+			countFrom = "label_membership lm"
+		}
 		query = fmt.Sprintf(`
-				SELECT l.*,
-					(SELECT COUNT(1)
-					 FROM label_membership lm
-					     JOIN hosts h ON (lm.host_id = h.id) WHERE label_id = l.id AND %s
-					 ) AS host_count
+				WITH label_host_counts AS (
+					SELECT lm.label_id, COUNT(1) AS host_count
+					FROM %s
+					WHERE %s
+					GROUP BY lm.label_id
+				)
+				SELECT l.*, COALESCE(lhc.host_count, 0) AS host_count
 				FROM labels l
-			`, ds.whereFilterHostsByTeams(filter, "h"),
+				LEFT JOIN label_host_counts lhc ON lhc.label_id = l.id
+			`, countFrom, teamFilter,
 		)
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #4890

* Optimized listing labels query by refactoring correlated subquery.
* Optimized aggregate that counts host's labels to executed once, and skip the join to hosts entirely when the team filter allows all hosts.

```
Results @ 100k hosts, 68 labels
  ┌──────────────────┬──────┬────────────────┬────────────────┬─────────────────────────┐
  │ Scenario         │ Plan │ Per-label cost │ Total (approx) │ hosts-table row lookups │
  ├──────────────────┼──────┼────────────────┼────────────────┼─────────────────────────┤
  │ Global           │ OLD  │ 6.47 ms × 68   │ ~440 ms        │ 451,886                 │
  ├──────────────────┼──────┼────────────────┼────────────────┼─────────────────────────┤
  │                  │ NEW  │ —              │ ~57 ms         │ 0                       │
  ├──────────────────┼──────┼────────────────┼────────────────┼─────────────────────────┤
  │ Team-scoped      │ OLD  │ 11.8 ms × 68   │ ~800 ms        │ 680,000                 │
  ├──────────────────┼──────┼────────────────┼────────────────┼─────────────────────────┤
  │                  │ NEW  │ —              │ ~26 ms         │ 56,130 (one pass)       │
  └──────────────────┴──────┴────────────────┴────────────────┴─────────────────────────┘

```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] QA'd all new/changed functionality manually