### PR TITLE
Extract osquery logging initialization out of runServeCmd

### DIFF
--- a/cmd/fleet/logging.go
+++ b/cmd/fleet/logging.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/logging"
+)
+
+// buildLoggingConfig maps the Fleet config into the common logging.Config
+// shared by the osquery status, result, and audit JSON loggers. The
+// topic/stream/plugin fields specific to each logger are applied by the
+// caller before constructing it.
+func buildLoggingConfig(cfg config.FleetConfig) logging.Config {
+	return logging.Config{
+		Filesystem: logging.FilesystemConfig{
+			EnableLogRotation:    cfg.Filesystem.EnableLogRotation,
+			EnableLogCompression: cfg.Filesystem.EnableLogCompression,
+			MaxSize:              cfg.Filesystem.MaxSize,
+			MaxAge:               cfg.Filesystem.MaxAge,
+			MaxBackups:           cfg.Filesystem.MaxBackups,
+		},
+		Webhook: logging.WebhookConfig{},
+		Firehose: logging.FirehoseConfig{
+			Region:           cfg.Firehose.Region,
+			EndpointURL:      cfg.Firehose.EndpointURL,
+			AccessKeyID:      cfg.Firehose.AccessKeyID,
+			SecretAccessKey:  cfg.Firehose.SecretAccessKey,
+			StsAssumeRoleArn: cfg.Firehose.StsAssumeRoleArn,
+			StsExternalID:    cfg.Firehose.StsExternalID,
+		},
+		Kinesis: logging.KinesisConfig{
+			Region:           cfg.Kinesis.Region,
+			EndpointURL:      cfg.Kinesis.EndpointURL,
+			AccessKeyID:      cfg.Kinesis.AccessKeyID,
+			SecretAccessKey:  cfg.Kinesis.SecretAccessKey,
+			StsAssumeRoleArn: cfg.Kinesis.StsAssumeRoleArn,
+			StsExternalID:    cfg.Kinesis.StsExternalID,
+		},
+		Lambda: logging.LambdaConfig{
+			Region:           cfg.Lambda.Region,
+			AccessKeyID:      cfg.Lambda.AccessKeyID,
+			SecretAccessKey:  cfg.Lambda.SecretAccessKey,
+			StsAssumeRoleArn: cfg.Lambda.StsAssumeRoleArn,
+			StsExternalID:    cfg.Lambda.StsExternalID,
+		},
+		PubSub: logging.PubSubConfig{
+			Project: cfg.PubSub.Project,
+		},
+		KafkaREST: logging.KafkaRESTConfig{
+			ProxyHost:        cfg.KafkaREST.ProxyHost,
+			ContentTypeValue: cfg.KafkaREST.ContentTypeValue,
+			Timeout:          cfg.KafkaREST.Timeout,
+		},
+		Nats: logging.NatsConfig{
+			Server:            cfg.Nats.Server,
+			CredFile:          cfg.Nats.CredFile,
+			NKeyFile:          cfg.Nats.NKeyFile,
+			TLSClientCertFile: cfg.Nats.TLSClientCrtFile,
+			TLSClientKeyFile:  cfg.Nats.TLSClientKeyFile,
+			CACertFile:        cfg.Nats.CACrtFile,
+			Compression:       cfg.Nats.Compression,
+			JetStream:         cfg.Nats.JetStream,
+			Timeout:           cfg.Nats.Timeout,
+		},
+	}
+}
+
+// shouldEnableAuditLog reports whether the audit JSON logger should be
+// constructed: audit logging is a Fleet Premium feature and must also be
+// explicitly enabled in config.
+func shouldEnableAuditLog(license *fleet.LicenseInfo, cfg config.FleetConfig) bool {
+	return license.IsPremium() && cfg.Activity.EnableAuditLog
+}
+
+// initOsqueryLogging constructs the osquery status and result JSON loggers
+// and, when enabled for a premium license, the audit logger. Failures go
+// through initFatal. Returns nil values on the failure path so the function
+// is safe when initFatal does not terminate (e.g., tests using a recorder).
+func initOsqueryLogging(
+	ctx context.Context,
+	cfg config.FleetConfig,
+	license *fleet.LicenseInfo,
+	logger *slog.Logger,
+	initFatal func(err error, msg string),
+) (status fleet.JSONLogger, result fleet.JSONLogger, audit fleet.JSONLogger) {
+	if license == nil {
+		initFatal(errors.New("license was nil"), "initializing osqueryd logging")
+		return nil, nil, nil
+	}
+
+	loggingConfig := buildLoggingConfig(cfg)
+
+	// Set specific configuration to osqueryd status logs.
+	loggingConfig.Plugin = cfg.Osquery.StatusLogPlugin
+	loggingConfig.Filesystem.LogFile = cfg.Filesystem.StatusLogFile
+	loggingConfig.Webhook.URL = cfg.Webhook.StatusURL
+	loggingConfig.Firehose.StreamName = cfg.Firehose.StatusStream
+	loggingConfig.Kinesis.StreamName = cfg.Kinesis.StatusStream
+	loggingConfig.Lambda.Function = cfg.Lambda.StatusFunction
+	loggingConfig.PubSub.Topic = cfg.PubSub.StatusTopic
+	loggingConfig.PubSub.AddAttributes = false // only used by result logs
+	loggingConfig.KafkaREST.Topic = cfg.KafkaREST.StatusTopic
+	loggingConfig.Nats.Subject = cfg.Nats.StatusSubject
+
+	statusLogger, err := logging.NewJSONLogger(ctx, "status", loggingConfig, logger)
+	if err != nil {
+		initFatal(err, "initializing osqueryd status logging")
+		return nil, nil, nil
+	}
+
+	// Set specific configuration to osqueryd result logs.
+	loggingConfig.Plugin = cfg.Osquery.ResultLogPlugin
+	loggingConfig.Filesystem.LogFile = cfg.Filesystem.ResultLogFile
+	loggingConfig.Webhook.URL = cfg.Webhook.ResultURL
+	loggingConfig.Firehose.StreamName = cfg.Firehose.ResultStream
+	loggingConfig.Kinesis.StreamName = cfg.Kinesis.ResultStream
+	loggingConfig.Lambda.Function = cfg.Lambda.ResultFunction
+	loggingConfig.PubSub.Topic = cfg.PubSub.ResultTopic
+	loggingConfig.PubSub.AddAttributes = cfg.PubSub.AddAttributes
+	loggingConfig.KafkaREST.Topic = cfg.KafkaREST.ResultTopic
+	loggingConfig.Nats.Subject = cfg.Nats.ResultSubject
+
+	resultLogger, err := logging.NewJSONLogger(ctx, "result", loggingConfig, logger)
+	if err != nil {
+		initFatal(err, "initializing osqueryd result logging")
+		return nil, nil, nil
+	}
+
+	var auditLogger fleet.JSONLogger
+	if shouldEnableAuditLog(license, cfg) {
+		// Set specific configuration to audit logs.
+		loggingConfig.Plugin = cfg.Activity.AuditLogPlugin
+		loggingConfig.Filesystem.LogFile = cfg.Filesystem.AuditLogFile
+		loggingConfig.Firehose.StreamName = cfg.Firehose.AuditStream
+		loggingConfig.Kinesis.StreamName = cfg.Kinesis.AuditStream
+		loggingConfig.Lambda.Function = cfg.Lambda.AuditFunction
+		loggingConfig.PubSub.Topic = cfg.PubSub.AuditTopic
+		loggingConfig.PubSub.AddAttributes = false // only used by result logs
+		loggingConfig.KafkaREST.Topic = cfg.KafkaREST.AuditTopic
+		loggingConfig.Nats.Subject = cfg.Nats.AuditSubject
+
+		auditLogger, err = logging.NewJSONLogger(ctx, "audit", loggingConfig, logger)
+		if err != nil {
+			initFatal(err, "initializing audit logging")
+			return nil, nil, nil
+		}
+	}
+
+	return statusLogger, resultLogger, auditLogger
+}

--- a/cmd/fleet/logging_test.go
+++ b/cmd/fleet/logging_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldEnableAuditLog(t *testing.T) {
+	premium := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+	free := &fleet.LicenseInfo{Tier: fleet.TierFree}
+
+	for _, tc := range []struct {
+		name      string
+		license   *fleet.LicenseInfo
+		enabled   bool
+		wantAudit bool
+	}{
+		{name: "premium and enabled", license: premium, enabled: true, wantAudit: true},
+		{name: "premium but disabled", license: premium, enabled: false, wantAudit: false},
+		{name: "free but enabled is not allowed", license: free, enabled: true, wantAudit: false},
+		{name: "free and disabled", license: free, enabled: false, wantAudit: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.FleetConfig{}
+			cfg.Activity.EnableAuditLog = tc.enabled
+			assert.Equal(t, tc.wantAudit, shouldEnableAuditLog(tc.license, cfg))
+		})
+	}
+}
+
+func TestBuildLoggingConfigMapsConfig(t *testing.T) {
+	cfg := config.FleetConfig{}
+	cfg.Firehose.Region = "us-east-1"
+	cfg.PubSub.Project = "fleet-project"
+	cfg.Nats.Server = "nats://localhost:4222"
+
+	got := buildLoggingConfig(cfg)
+
+	assert.Equal(t, "us-east-1", got.Firehose.Region)
+	assert.Equal(t, "fleet-project", got.PubSub.Project)
+	assert.Equal(t, "nats://localhost:4222", got.Nats.Server)
+}

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -64,7 +64,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/health"
 	"github.com/fleetdm/fleet/v4/server/launcher"
 	"github.com/fleetdm/fleet/v4/server/live_query"
-	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mail"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	acme_api "github.com/fleetdm/fleet/v4/server/mdm/acme/api"
@@ -289,111 +288,10 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	liveQueryStore := live_query.NewRedisLiveQuery(redisPool, logger, liveQueryMemCacheDuration)
 	ssoSessionStore := sso.NewSessionStore(redisPool)
 
-	// Set common configuration for all logging.
-	loggingConfig := logging.Config{
-		Filesystem: logging.FilesystemConfig{
-			EnableLogRotation:    config.Filesystem.EnableLogRotation,
-			EnableLogCompression: config.Filesystem.EnableLogCompression,
-			MaxSize:              config.Filesystem.MaxSize,
-			MaxAge:               config.Filesystem.MaxAge,
-			MaxBackups:           config.Filesystem.MaxBackups,
-		},
-		Webhook: logging.WebhookConfig{},
-		Firehose: logging.FirehoseConfig{
-			Region:           config.Firehose.Region,
-			EndpointURL:      config.Firehose.EndpointURL,
-			AccessKeyID:      config.Firehose.AccessKeyID,
-			SecretAccessKey:  config.Firehose.SecretAccessKey,
-			StsAssumeRoleArn: config.Firehose.StsAssumeRoleArn,
-			StsExternalID:    config.Firehose.StsExternalID,
-		},
-		Kinesis: logging.KinesisConfig{
-			Region:           config.Kinesis.Region,
-			EndpointURL:      config.Kinesis.EndpointURL,
-			AccessKeyID:      config.Kinesis.AccessKeyID,
-			SecretAccessKey:  config.Kinesis.SecretAccessKey,
-			StsAssumeRoleArn: config.Kinesis.StsAssumeRoleArn,
-			StsExternalID:    config.Kinesis.StsExternalID,
-		},
-		Lambda: logging.LambdaConfig{
-			Region:           config.Lambda.Region,
-			AccessKeyID:      config.Lambda.AccessKeyID,
-			SecretAccessKey:  config.Lambda.SecretAccessKey,
-			StsAssumeRoleArn: config.Lambda.StsAssumeRoleArn,
-			StsExternalID:    config.Lambda.StsExternalID,
-		},
-		PubSub: logging.PubSubConfig{
-			Project: config.PubSub.Project,
-		},
-		KafkaREST: logging.KafkaRESTConfig{
-			ProxyHost:        config.KafkaREST.ProxyHost,
-			ContentTypeValue: config.KafkaREST.ContentTypeValue,
-			Timeout:          config.KafkaREST.Timeout,
-		},
-		Nats: logging.NatsConfig{
-			Server:            config.Nats.Server,
-			CredFile:          config.Nats.CredFile,
-			NKeyFile:          config.Nats.NKeyFile,
-			TLSClientCertFile: config.Nats.TLSClientCrtFile,
-			TLSClientKeyFile:  config.Nats.TLSClientKeyFile,
-			CACertFile:        config.Nats.CACrtFile,
-			Compression:       config.Nats.Compression,
-			JetStream:         config.Nats.JetStream,
-			Timeout:           config.Nats.Timeout,
-		},
-	}
-
-	// Set specific configuration to osqueryd status logs.
-	loggingConfig.Plugin = config.Osquery.StatusLogPlugin
-	loggingConfig.Filesystem.LogFile = config.Filesystem.StatusLogFile
-	loggingConfig.Webhook.URL = config.Webhook.StatusURL
-	loggingConfig.Firehose.StreamName = config.Firehose.StatusStream
-	loggingConfig.Kinesis.StreamName = config.Kinesis.StatusStream
-	loggingConfig.Lambda.Function = config.Lambda.StatusFunction
-	loggingConfig.PubSub.Topic = config.PubSub.StatusTopic
-	loggingConfig.PubSub.AddAttributes = false // only used by result logs
-	loggingConfig.KafkaREST.Topic = config.KafkaREST.StatusTopic
-	loggingConfig.Nats.Subject = config.Nats.StatusSubject
-
-	osquerydStatusLogger, err := logging.NewJSONLogger(cmd.Context(), "status", loggingConfig, logger)
-	if err != nil {
-		initFatal(err, "initializing osqueryd status logging")
-	}
-
-	// Set specific configuration to osqueryd result logs.
-	loggingConfig.Plugin = config.Osquery.ResultLogPlugin
-	loggingConfig.Filesystem.LogFile = config.Filesystem.ResultLogFile
-	loggingConfig.Webhook.URL = config.Webhook.ResultURL
-	loggingConfig.Firehose.StreamName = config.Firehose.ResultStream
-	loggingConfig.Kinesis.StreamName = config.Kinesis.ResultStream
-	loggingConfig.Lambda.Function = config.Lambda.ResultFunction
-	loggingConfig.PubSub.Topic = config.PubSub.ResultTopic
-	loggingConfig.PubSub.AddAttributes = config.PubSub.AddAttributes
-	loggingConfig.KafkaREST.Topic = config.KafkaREST.ResultTopic
-	loggingConfig.Nats.Subject = config.Nats.ResultSubject
-
-	osquerydResultLogger, err := logging.NewJSONLogger(cmd.Context(), "result", loggingConfig, logger)
-	if err != nil {
-		initFatal(err, "initializing osqueryd result logging")
-	}
-
-	var auditLogger fleet.JSONLogger
-	if license.IsPremium() && config.Activity.EnableAuditLog {
-		// Set specific configuration to audit logs.
-		loggingConfig.Plugin = config.Activity.AuditLogPlugin
-		loggingConfig.Filesystem.LogFile = config.Filesystem.AuditLogFile
-		loggingConfig.Firehose.StreamName = config.Firehose.AuditStream
-		loggingConfig.Kinesis.StreamName = config.Kinesis.AuditStream
-		loggingConfig.Lambda.Function = config.Lambda.AuditFunction
-		loggingConfig.PubSub.Topic = config.PubSub.AuditTopic
-		loggingConfig.PubSub.AddAttributes = false // only used by result logs
-		loggingConfig.KafkaREST.Topic = config.KafkaREST.AuditTopic
-		loggingConfig.Nats.Subject = config.Nats.AuditSubject
-
-		auditLogger, err = logging.NewJSONLogger(cmd.Context(), "audit", loggingConfig, logger)
-		if err != nil {
-			initFatal(err, "initializing audit logging")
-		}
+	osquerydStatusLogger, osquerydResultLogger, auditLogger := initOsqueryLogging(cmd.Context(), config, license, logger, initFatal)
+	if osquerydStatusLogger == nil || osquerydResultLogger == nil {
+		initFatal(errors.New("osquery loggers were nil after initialization"), "initializing osqueryd logging")
+		return
 	}
 
 	failingPolicySet := redis_policy_set.NewFailing(redisPool)


### PR DESCRIPTION
Extracts the osquery status, result, and audit JSON logger setup out of `runServeCmd` and into a new `cmd/fleet/logging.go`. Same pattern as the prior extractions on this issue (#44929, #45343, #45583, #46166, #46421, #46517, #46742, #46830). Continues trimming `runServeCmd` toward the `serve.go` coverage goal on #33370 — this is the largest single slice so far (~100 lines out).

Three functions come out of the inline block:

- `initOsqueryLogging` — builds the status and result loggers, plus the audit logger when enabled. Mutates the shared `logging.Config` per logger in the same sequence as before, so the constructed loggers are identical.
- `buildLoggingConfig` — maps `config.FleetConfig` into the common `logging.Config` shared by all three loggers.
- `shouldEnableAuditLog` — the premium-and-enabled gate for the audit logger, pulled out so the decision is its own testable unit.

Behavior is preserved — `runServeCmd` calls this in the same place with the same arguments, the per-logger config mutation order is unchanged, and the full `cmd/fleet` suite passes against MySQL + Redis. `initOsqueryLogging` returns early after `initFatal` so it's safe when the caller's `initFatal` doesn't terminate (the case in tests), and it guards a nil license up front since the audit gate dereferences it (matching the nil-guard precedent from #46742/#46830).

On test scope: `TestShouldEnableAuditLog` covers all four combinations of license tier and the config flag — audit logging is a premium feature, so the gate is the meaningful decision here. `TestBuildLoggingConfigMapsConfig` is a light check that the config mapping is wired through. I didn't add a full `initOsqueryLogging` happy-path unit test: `logging.NewJSONLogger` constructs real log sinks, so that path is exercised by booting the server rather than by standing up logger backends in a unit test.

**Related issue:** Refs #33370

# Checklist for submitter

- [x] Added/updated automated tests
- Changes file: not applicable — internal refactor with no user-visible behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit logging support is now available for premium license holders.

* **Refactor**
  * Improved logging initialization and configuration management.

* **Tests**
  * Added test coverage for audit logging enablement and configuration mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->