### PR TITLE
Fix custom variable modal clearing when switching browser focus

### DIFF
--- a/changes/44805-fix-custom-variable-modal-clears-on-focus-switch
+++ b/changes/44805-fix-custom-variable-modal-clears-on-focus-switch
@@ -1,0 +1,1 @@
+* Fixed a bug where the "Add custom variable" modal would clear entered values when switching focus to another browser tab or application window.

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -154,6 +154,28 @@ describe("Modal", () => {
     expect(onExit).toHaveBeenCalledTimes(1);
   });
 
+  it("does not call onExit when a backdrop mousedown is interrupted by the window losing focus", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit}>
+        <div>content</div>
+      </Modal>
+    );
+
+    const background = container.querySelector(".modal__background");
+    if (!background) throw new Error("Background element not found");
+
+    // User presses down on the backdrop then the window loses focus (tab switch /
+    // app switch) before releasing — mouseup never fires on the page.
+    fireEvent.mouseDown(background);
+    fireEvent.blur(window);
+    // On return, the stale mousedown state must not close the modal.
+    fireEvent.mouseUp(background);
+    act(() => jest.runAllTimers());
+
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
   it("does not call onExit when clicking the background if disableClosingModal is true", async () => {
     const onExit = jest.fn();
     const { container } = render(

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -105,6 +105,16 @@ const Modal = ({
     return undefined;
   }, [onEnter]);
 
+  useEffect(() => {
+    const onWindowBlur = () => {
+      isDownOnBackgroundRef.current = false;
+    };
+    window.addEventListener("blur", onWindowBlur);
+    return () => {
+      window.removeEventListener("blur", onWindowBlur);
+    };
+  }, []);
+
   const backgroundClasses = classnames(`${baseClass}__background`, {
     [`${baseClass}__hidden`]: isHidden,
     [`${baseClass}__closing`]: isClosing,

--- a/frontend/pages/ManageControlsPage/Variables/Variables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tsx
@@ -11,7 +11,10 @@ import { IVariable } from "interfaces/variables";
 import { AppContext } from "context/app";
 
 import { stringToClipboard } from "utilities/copy_text";
-import { DEFAULT_USE_QUERY_OPTIONS, FLEET_WEBSITE_URL } from "utilities/constants";
+import {
+  DEFAULT_USE_QUERY_OPTIONS,
+  FLEET_WEBSITE_URL,
+} from "utilities/constants";
 import CustomLink from "components/CustomLink";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import ListItem from "components/ListItem/ListItem";

--- a/frontend/pages/ManageControlsPage/Variables/Variables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tsx
@@ -11,7 +11,7 @@ import { IVariable } from "interfaces/variables";
 import { AppContext } from "context/app";
 
 import { stringToClipboard } from "utilities/copy_text";
-import { FLEET_WEBSITE_URL } from "utilities/constants";
+import { DEFAULT_USE_QUERY_OPTIONS, FLEET_WEBSITE_URL } from "utilities/constants";
 import CustomLink from "components/CustomLink";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import ListItem from "components/ListItem/ListItem";
@@ -58,11 +58,13 @@ const Variables = ({ router, location }: IVariablesProps) => {
   const canEdit = isGlobalAdmin || isGlobalMaintainer;
 
   const apiParams = { page: pageNumber, per_page: VARIABLES_PAGE_SIZE };
-  const { data, isFetching: isLoading, refetch } = useQuery<
+  const { data, isLoading, refetch } = useQuery<
     IListVariablesResponse,
     Error,
     IListVariablesResponse
-  >(["variables", apiParams], () => variablesAPI.getVariables(apiParams));
+  >(["variables", apiParams], () => variablesAPI.getVariables(apiParams), {
+    ...DEFAULT_USE_QUERY_OPTIONS,
+  });
 
   // Open the Add variable modal via deep-link (e.g. from the command
   // palette). Gate on the same predicate the in-page button uses — the

--- a/frontend/pages/ManageControlsPage/Variables/Variables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tsx
@@ -61,7 +61,7 @@ const Variables = ({ router, location }: IVariablesProps) => {
   const canEdit = isGlobalAdmin || isGlobalMaintainer;
 
   const apiParams = { page: pageNumber, per_page: VARIABLES_PAGE_SIZE };
-  const { data, isLoading, refetch } = useQuery<
+  const { data, isFetching: isLoading, refetch } = useQuery<
     IListVariablesResponse,
     Error,
     IListVariablesResponse


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #44805

Fixed a bug where the "Add custom variable" modal would clear entered values when switching focus to another browser tab or application window due to network refetches.

### Before

https://github.com/user-attachments/assets/5f58b2fc-3103-4184-aa89-d835976d4361

### After

https://github.com/user-attachments/assets/c4ff0736-bcf9-4409-a9c3-23403e241469

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Add custom variable" modal clearing form inputs when browser focus switched tabs/windows; entered values are now preserved.

* **Improvements**
  * Made variable loading behavior more consistent for loading/empty/content states.

* **Tests**
  * Added a modal test ensuring interrupted backdrop interactions caused by window blur do not close the modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->