### PR TITLE
Fix policy automations role restrictions in UI

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -385,7 +385,7 @@ const ManagePolicyPage = ({
       return configAPI.loadAll();
     },
     {
-      enabled: isRouteOk && canAddOrDeletePolicies,
+      enabled: isRouteOk,
       onSuccess: (data) => {
         setConfig(data);
       },
@@ -398,7 +398,7 @@ const ManagePolicyPage = ({
     Error
   >(["teams", teamIdForApi], () => teamsAPI.load(teamIdForApi), {
     // Enable for all teams including "No team" (teamIdForApi === 0)
-    enabled: isRouteOk && teamIdForApi !== undefined && canAddOrDeletePolicies,
+    enabled: isRouteOk && teamIdForApi !== undefined,
     staleTime: 5000,
   });
   const teamConfig = teamData?.team;

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -136,28 +136,11 @@ const AutomationsCell = ({
   onOpenManageAutomationsModal,
 }: IAutomationsCellProps): JSX.Element => {
   const automations = getAutomationsForPolicy(policy, otherAutomationType);
+  // Without an edit callback the user's role can't open the automations modal,
+  // so the cell is read-only: no pencil icon, no pointer cursor, not focusable.
+  const canEdit = !!onOpenManageAutomationsModal;
 
   const handleEdit = () => onOpenManageAutomationsModal?.(policy);
-
-  if (automations.length === 0) {
-    // Read-only users (no edit callback) keep the plain, non-interactive "---".
-    if (!onOpenManageAutomationsModal) {
-      return (
-        <span className="automations__cell-content automations__cell-content--none">
-          {DEFAULT_EMPTY_CELL_VALUE}
-        </span>
-      );
-    }
-    return (
-      <EditableAutomationsCell
-        ariaLabel="Add automation"
-        onEdit={handleEdit}
-        className="automations__cell-content--none"
-      >
-        <span className="automations__name">{DEFAULT_EMPTY_CELL_VALUE}</span>
-      </EditableAutomationsCell>
-    );
-  }
 
   const renderAutomationIcon = ({ type, name, iconUrl }: IAutomationData) => {
     return AUTOMATION_ICON_RENDERERS[type]({
@@ -166,24 +149,28 @@ const AutomationsCell = ({
     });
   };
 
-  if (automations.length === 1) {
-    const automation = automations[0];
-    return (
-      <EditableAutomationsCell
-        ariaLabel={`Edit automation: ${automation.name}`}
-        onEdit={handleEdit}
-      >
-        <TooltipTruncatedTextCell
-          prefix={renderAutomationIcon(automation)}
-          value={automation.name}
-          className="automations__name"
-        />
-      </EditableAutomationsCell>
-    );
-  }
+  const isEmpty = automations.length === 0;
 
-  return (
-    <EditableAutomationsCell ariaLabel="Edit automations" onEdit={handleEdit}>
+  let ariaLabel: string;
+  let content: React.ReactNode;
+  if (isEmpty) {
+    ariaLabel = "Add automation";
+    content = (
+      <span className="automations__name">{DEFAULT_EMPTY_CELL_VALUE}</span>
+    );
+  } else if (automations.length === 1) {
+    const automation = automations[0];
+    ariaLabel = `Edit automation: ${automation.name}`;
+    content = (
+      <TooltipTruncatedTextCell
+        prefix={renderAutomationIcon(automation)}
+        value={automation.name}
+        className="automations__name"
+      />
+    );
+  } else {
+    ariaLabel = "Edit automations";
+    content = (
       <TooltipWrapper
         className="automations__count"
         position="top"
@@ -194,6 +181,30 @@ const AutomationsCell = ({
       >
         {automations.length} automations
       </TooltipWrapper>
+    );
+  }
+
+  if (!canEdit) {
+    return (
+      <span
+        className={classnames(
+          "automations__cell-content",
+          "automations__cell-content--readonly",
+          { "automations__cell-content--none": isEmpty }
+        )}
+      >
+        {content}
+      </span>
+    );
+  }
+
+  return (
+    <EditableAutomationsCell
+      ariaLabel={ariaLabel}
+      onEdit={handleEdit}
+      className={classnames({ "automations__cell-content--none": isEmpty })}
+    >
+      {content}
     </EditableAutomationsCell>
   );
 };

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/_styles.scss
@@ -42,12 +42,13 @@
   &--none {
     color: $ui-fleet-black-50;
   }
-}
 
-// The read-only empty cell is a plain <span> (no role="button"); keep it
-// non-interactive. The editable empty cell is a <div role="button">.
-span.automations__cell-content--none {
-  cursor: default;
+  // Read-only cells (rendered for roles that can't open the automations modal)
+  // are plain, non-interactive <span>s with no pencil icon — keep the default
+  // cursor so they don't appear clickable.
+  &--readonly {
+    cursor: default;
+  }
 }
 
 .automations__name {

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -2,16 +2,19 @@
 
 import React, {
   forwardRef,
+  useContext,
   useImperativeHandle,
   useMemo,
   useState,
 } from "react";
 import { SingleValue } from "react-select-5";
 
+import { AppContext } from "context/app";
 import { IConfig } from "interfaces/config";
 import { IPolicy } from "interfaces/policy";
 import { ITeamConfig, API_NO_TEAM_ID } from "interfaces/team";
 
+import permissions from "utilities/permissions";
 import useGitOpsMode from "hooks/useGitOpsMode";
 
 import Checkbox from "components/forms/fields/Checkbox";
@@ -96,12 +99,23 @@ const PolicyAutomationsFields = forwardRef<
     ref
   ) => {
     const { gitOpsModeEnabled } = useGitOpsMode();
+    const { currentUser, isGlobalAdmin } = useContext(AppContext);
 
     const {
       state: ticketOrWebhookState,
       policyIds: webhookOrTicketPolicyIds,
     } = getTicketOrWebhookInfo(automationsConfig);
     const isTicketWebhookEnabled = ticketOrWebhookState !== "disabled";
+
+    // Only admins (global, or fleet-level admin of this policy's fleet) may
+    // manage the webhook/ticket automation. For "All fleets" and "Unassigned"
+    // policies there is no team-level admin, so it's global-admin only.
+    const canEditWebhookOrTicket =
+      !!isGlobalAdmin ||
+      (teamIdForApi !== undefined &&
+        teamIdForApi !== API_NO_TEAM_ID &&
+        !!currentUser &&
+        permissions.isTeamAdmin(currentUser, teamIdForApi));
 
     // Calendar events are a team/fleet-only feature: they're never available for
     // global ("All fleets") or "No team"/"Unassigned" policies.
@@ -275,6 +289,9 @@ const PolicyAutomationsFields = forwardRef<
         checked: webhookOrTicketEnabled && isTicketWebhookEnabled,
         onToggle: setWebhookOrTicketEnabled,
         isDisabled: !isTicketWebhookEnabled,
+        // Webhook/ticket config requires admin (it writes app/team config, not
+        // the policy itself). Lock for non-admins with no explanation.
+        isLocked: !canEditWebhookOrTicket,
       },
     ];
     if (!isGlobalPolicy) {
@@ -389,7 +406,9 @@ const PolicyAutomationsFields = forwardRef<
                 <tr
                   key={row.key}
                   className={`${baseClass}__row${
-                    row.isDisabled ? ` ${baseClass}__row--disabled` : ""
+                    row.isDisabled || row.isLocked
+                      ? ` ${baseClass}__row--disabled`
+                      : ""
                   }`}
                 >
                   <td className={`${baseClass}__row-label`}>
@@ -398,7 +417,9 @@ const PolicyAutomationsFields = forwardRef<
                         <Checkbox
                           name={row.key}
                           value={row.checked}
-                          disabled={row.isDisabled || disableChildren}
+                          disabled={
+                            row.isDisabled || row.isLocked || disableChildren
+                          }
                           onChange={row.onToggle}
                         >
                           {row.tooltip ? (

--- a/frontend/pages/policies/components/PolicyAutomationsFields/types.ts
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/types.ts
@@ -11,6 +11,11 @@ export interface IAutomationCheckboxRow {
   tooltip?: React.ReactNode;
   checked: boolean;
   onToggle: (next: boolean) => void;
+  /** Feature isn't enabled for the fleet: greys the row, disables the checkbox,
+   *  and shows the "Not enabled for <fleet>" hint. */
   isDisabled: boolean;
+  /** Disables the checkbox (and greys the row) without showing any hint — used
+   *  when the current user's role can't manage this automation. */
+  isLocked?: boolean;
   picker?: React.ReactNode;
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46912

<!-- Summary of what was resolved -->
- Webhook/ticket checkbox is now disabled (locked, no explanation) for **Maintainers** in `PolicyAutomationsFields` — covers the create modal, edit form, and manage automations modal since all three share the component. (Any role below maintainer can't edit automations.)
- Automations cell pencil icon and `cursor: pointer` are now hidden for roles that can't open the automations modal (technician and below).
- Config and team data are now fetched for all authenticated roles so the webhook automation shows correctly in the table for technicians (previously gated on `canAddOrDeletePolicies`, which excluded them).

## Testing

- [x] QA'd all new/changed functionality manually


#### Before

With a global/fleet technician user, Automations cell on Policies page showed "2 automations" when there were actually 3 automations configured.
Also, the pencil (edit) icon and cursor pointer are shown even though technicians can't access the Manage automations modal.

https://github.com/user-attachments/assets/276f11f2-4d5c-46ed-80c8-cc5172fab62b

Maintainers can manage automations but they can't configure webhooks or tickets (product requirement + also forbidden by BE). This silently failed when checking the "Send webhook" checkbox when creating or editing.

https://github.com/user-attachments/assets/482e546a-5cd6-4c7d-a74a-362e54b7ee09

#### After

Technicians see all available automations on the Policies page (and this matches the Details page).
Also, the edit icon is no longer shown, and the Automations cell is no longer clickable.

https://github.com/user-attachments/assets/21848ad8-42aa-4fe1-87f3-9c0d873c9d10

Locked "Send webhook" / "Create ticket" for Maintainers.
https://github.com/user-attachments/assets/f0c0b058-db02-4174-bb8e-33165014806f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features / Improvements**
  * Users without policy modification permissions can now access and view the policies page.
  * Automations column displays read-only state for users without edit permissions.
  * Non-global admin users can view webhook/ticket automations but see them as locked and uneditable.
  * Enhanced visual feedback distinguishing read-only elements from interactive ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->