### PR TITLE
Fix for hosts macos application filter not maintaining state

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -132,11 +132,14 @@ const HostSoftwareTable = ({
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
         fleet_id: teamId,
+        ...(macosApplicationsFilter !== undefined && {
+          macos_applications: macosApplicationsFilter,
+        }),
         ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
       };
       return newQueryParam;
     },
-    [vulnFilters]
+    [vulnFilters, teamId, macosApplicationsFilter]
   );
 
   // TODO: Look into useDebounceCallback with dependencies


### PR DESCRIPTION
**Related issue:** Resolves #39017

Fix for #46223

Missed the case of filtering after switching, easy fix

## Testing

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the macOS Applications filter in the host software table to ensure filter selections are properly maintained and synchronized when updating views and navigating the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->