### PR TITLE
Remove unused packages: write from goreleaser-orbit jobs

### DIFF
--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -20,7 +20,6 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -87,7 +86,6 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -136,7 +134,6 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -182,7 +179,6 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -240,7 +236,6 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
## Summary

- The `goreleaser-orbit.yaml` workflow has 5 build jobs (macOS, Linux x64/arm64, Windows x64/arm64), each granted `packages: write` at the job level. None of them use it: goreleaser runs with `--skip=publish` and artifacts are surfaced via `actions/upload-artifact` (artifact API, not the packages/GHCR API).
- Removes the unused permission to follow least privilege.
- Closes 5 open Scorecard code-scanning alerts on this file (#2097, #2098, #2099, #2100, #2101 — all "jobLevel 'packages' permission set to 'write'").

`attestations: write` and `id-token: write` are retained — both are required for `actions/attest-build-provenance`. `contents: write` is left in place for now; it may also be removable since `--skip=publish` is used, but I scoped this PR to the specific alerts and didn't audit it further.

## Test plan

- [ ] Push a pre-release `orbit-*` tag (e.g. `orbit-1.49.0-rc1`) and confirm the workflow still builds, attests, and uploads binaries on all 5 platforms.
- [ ] Verify the 5 code-scanning alerts auto-close after the next Scorecard run on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow permissions for improved security and artifact verification capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->