### PR TITLE
Modify healthcheck for TLS support in docker-compose

### DIFF
--- a/docs/solutions/docker-compose/docker-compose.yml
+++ b/docs/solutions/docker-compose/docker-compose.yml
@@ -112,7 +112,10 @@ services:
       - ./certs/fleet.key:/fleet/fleet.key:ro
     healthcheck:
       test:
-        ["CMD", "wget", "-qO-", "http://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
+        # If FLEET_SERVER_TLS=true
+        ["CMD", "wget", "--no-check-certificate", "-qO-", "https://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
+        # If FLEET_SERVER_TLS=false
+        # ["CMD", "wget", "-qO-", "http://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docs/solutions/docker-compose/docker-compose.yml
+++ b/docs/solutions/docker-compose/docker-compose.yml
@@ -112,10 +112,10 @@ services:
       - ./certs/fleet.key:/fleet/fleet.key:ro
     healthcheck:
       test:
-        # If FLEET_SERVER_TLS=true
-        ["CMD", "wget", "--no-check-certificate", "-qO-", "https://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
-        # If FLEET_SERVER_TLS=false
-        # ["CMD", "wget", "-qO-", "http://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
+        [
+          "CMD-SHELL",
+          "if [ \"$$FLEET_SERVER_TLS\" = \"true\" ]; then wget --no-check-certificate -qO- https://127.0.0.1:$$FLEET_SERVER_PORT/healthz; else wget -qO- http://127.0.0.1:$$FLEET_SERVER_PORT/healthz; fi"
+        ]        
       interval: 10s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
Updated healthcheck command to support TLS configuration. accompanying env.example sets FLEET_SERVER_TLS=true by default but our default test in docker-compose.yml tests to http. Causes test to fail.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Closes https://github.com/fleetdm/fleet/issues/46927


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated service health monitoring to correctly probe the health endpoint over HTTPS when TLS is enabled, and over HTTP when it is not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->