### PR TITLE
Update encryption passphrase instructions for clarity

### DIFF
--- a/articles/linux-disk-encryption-end-user.md
+++ b/articles/linux-disk-encryption-end-user.md
@@ -44,10 +44,10 @@ Follow the steps below to get set up.
 > LUKS allows multiple passphrases for decrypting the volume. The original passphrase remains active along with the escrowed passphrase created by Fleet.
 
   - Open Fleet Desktop. If your device is encrypted, you'll see a banner prompting you to escrow the key.
-  - Click **Create key**. Enter your existing encryption passphrase when prompted. 
+  - Click **Create key**. Enter your existing encryption passphrase when prompted. Your passphrase is only used for authentication purposes during the next step and is not stored.
   - Fleet will generate and securely store a new passphrase for recovery. This may take several minutes. A popup will appear when Fleet is done.
 
-Now, your encryption status will update to "verified" in Fleet Desktop, meaning that your recovery key has been successfully stored.
+Now, your encryption status will update to "verified" in Fleet Desktop, meaning that the newly created recovery key has been successfully stored.
 
 
 

--- a/articles/linux-disk-encryption-end-user.md
+++ b/articles/linux-disk-encryption-end-user.md
@@ -44,7 +44,7 @@ Follow the steps below to get set up.
 > LUKS allows multiple passphrases for decrypting the volume. The original passphrase remains active along with the escrowed passphrase created by Fleet.
 
   - Open Fleet Desktop. If your device is encrypted, you'll see a banner prompting you to escrow the key.
-  - Click **Create key**. Enter your existing encryption passphrase when prompted. Your passphrase is only used for authentication purposes during the next step and is not stored.
+  - Click **Create key**. Enter your existing encryption passphrase when prompted. Your passphrase is only used locally for authentication purposes during the next step and is not stored or sent to Fleet. 
   - Fleet will generate and securely store a new passphrase for recovery. This may take several minutes. A popup will appear when Fleet is done.
 
 Now, your encryption status will update to "verified" in Fleet Desktop, meaning that the newly created recovery key has been successfully stored.


### PR DESCRIPTION
Clarify that the existing passphrase is only used for authentication and not stored.