### PR TITLE
Website: update testimonial order

### DIFF
--- a/handbook/company/testimonials.yml
+++ b/handbook/company/testimonials.yml
@@ -293,7 +293,7 @@
   quoteAuthorProfileImageFilename: testimonial-author-adam-pippert-48x48@2x.png
   quoteLinkUrl: https://www.linkedin.com/feed/update/urn:li:activity:7462273958181093376/?dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287462579370302390272%2Curn%3Ali%3Aactivity%3A7462273958181093376%29
   quoteAuthorJobTitle: Principal Solutions Architect @ Red Hat
-  productCategories: [Device management]
+  productCategories: [Device management, Software management]
 # -
 #   quote: Thank you for enabling SCIM for the admin interface! You have solved de-provisioning for us because if an admin leaves their identity gets turned off automatically by Okta. We also can quickly check user roles in Okta without needing to login to FleetDM or monitoring user_role.yaml with GitOps.
 #   quoteAuthorName: Nick Borgers

--- a/website/api/controllers/view-device-management.js
+++ b/website/api/controllers/view-device-management.js
@@ -39,7 +39,7 @@ module.exports = {
         'Eric Tan',
         'matt carr',
         'Nico Waisman',
-        'Dan Grzelak',
+        'Adam Pippert',
         'Philip Chotipradit',
         'Roger Cantrell',
         'Chayce O\'Neal',

--- a/website/api/controllers/view-homepage-or-redirect.js
+++ b/website/api/controllers/view-homepage-or-redirect.js
@@ -51,6 +51,7 @@ module.exports = {
         'Eric Tan',
         'Matt Carr',
         'Nico Waisman',
+        'Adam Pippert',
         'Dan Grzelak',
         'Philip Chotipradit',
         'Roger Cantrell',

--- a/website/api/controllers/view-homepage-or-redirect.js
+++ b/website/api/controllers/view-homepage-or-redirect.js
@@ -52,7 +52,6 @@ module.exports = {
         'Matt Carr',
         'Nico Waisman',
         'Adam Pippert',
-        'Dan Grzelak',
         'Philip Chotipradit',
         'Roger Cantrell',
         'Chayce O\'Neal',

--- a/website/api/controllers/view-linux-management.js
+++ b/website/api/controllers/view-linux-management.js
@@ -30,6 +30,7 @@ module.exports = {
       let testimonialOrderForThisPage = [
         'Erik Gomez',
         'Nick Fohs',
+        'Adam Pippert',
         'Dan Grzelak',
         'matt carr',
         'Justin LaBo',

--- a/website/api/controllers/view-software-management.js
+++ b/website/api/controllers/view-software-management.js
@@ -38,7 +38,7 @@ module.exports = {
         'Kenny Botelho',
         'Erik Gomez',
         'Eric Tan',
-        'Dan Grzelak',
+        'Adam Pippert',
         'Justin LaBo',
         'Brian LaShomb',
       ];


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/46872

Changes:
- Updated the `productCategories` value of the testimonial from Adam Pippert to show it on the /software-management page.
- Updated the order of testimonials on the homepage, /software-management, /device-management, and /linux-management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * A testimonial was updated to include an additional product category.
  * Testimonial ordering was adjusted on the Device management, Software management, Linux management, and homepage views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->