### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.11187.2",
+      "version": "1.11187.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.11187.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.11187.4') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.11187.2/Claude-8cc3afa7b40409eb06b0c048fad852f0c0df3d12.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.11187.4/Claude-58400536f3ccde1cff9a129de6c3112dc8cb489a.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "67fda7a005111e4c3e7fc9cb418efa9681878bf0683b491491eef471bcf1ac94",
+      "sha256": "ab256a225373d58d4f80163de3438e076fa2d04d75e30eccbee6d9d4b4b1fc5b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.6.31",
+      "version": "3.7.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.6.31') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.12') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/81fcf2931d7687b4ff3f3017858d0c6dee7e2a68/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/b887a26c4f70bd8136bfffeda812b24194ec9ce0/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "a48877c1c1b33921d71b335e703693c4a4e9c1c78620ce628cd994cc42e7f8a1",
+      "sha256": "62c7fd7bed3e1705e9aeb3e13a6193600cdea281a31769dcb5dbaf2bbd613139",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/figma/darwin.json
+++ b/ee/maintained-apps/outputs/figma/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "126.4.12",
+      "version": "126.4.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.4.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.4.13') < 0);"
       },
-      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.4.12.zip",
+      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.4.13.zip",
       "install_script_ref": "f0952230",
       "uninstall_script_ref": "7dcd0304",
-      "sha256": "c4d258885be902a869f18e28c201b898ec79f40af5ffe2e447a7059e2aaccde0",
+      "sha256": "36dbf69cb4b3148b95f9708cdf01270c865fd279d91cf284c51d93bfdb511652",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/fork/windows.json
+++ b/ee/maintained-apps/outputs/fork/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.19.0",
+      "version": "2.20.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Fork' AND publisher = 'Fork';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Fork' AND publisher = 'Fork' AND version_compare(version, '2.19.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Fork' AND publisher = 'Fork' AND version_compare(version, '2.20.0') < 0);"
       },
-      "installer_url": "https://cdn.fork.dev/win/Fork-2.19.0.exe",
+      "installer_url": "https://cdn.fork.dev/win/Fork-2.20.0.exe",
       "install_script_ref": "51b8d74f",
       "uninstall_script_ref": "44d976af",
-      "sha256": "a6a0455962d26a5b8ab39bb16185d6eb5534af11f3d8dbde350289ca487c196f",
+      "sha256": "b9d48f27dacc066d2524c4f987c309cbf3272ac3a556d8bcead10322d0b85c67",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.30.5",
+      "version": "0.30.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.6') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.5/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.6/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "bf40e2d5",
-      "sha256": "d1679f85014e5f59409e41ec0e9c864bbbd3f9784dc6d58d505439d9e1648ab5",
+      "sha256": "5b95c6c35595f668309a0c10de3cb059ddbf8fa06b548e4c4c4b3c7733dfbdec",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Desktop (macOS) to version 1.11187.4
  * Updated Cursor (macOS) to version 3.7.12
  * Updated Figma Desktop (macOS) to version 126.4.13
  * Updated Fork (Windows) to version 2.20.0
  * Updated Ollama (macOS) to version 0.30.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->