### PR TITLE
Grayw guides update managinggooglechrome

### DIFF
--- a/articles/managing-chrome-with-fleet.md
+++ b/articles/managing-chrome-with-fleet.md
@@ -145,7 +145,7 @@ However, if you would like to manage your Chrome configuration by code, you can 
 - Explore additional Chrome policies in the [Chrome Enterprise Policy List](https://chromeenterprise.google/policies/).
 - Test policies in a staging environment before fleet-wide deployment.
 
-<meta name="articleTitle" value="Managing Google Chrome with Fleet">
+<meta name="articleTitle" value="Managing Google Chrome on Windows with Fleet">
 <meta name="authorFullName" value="Gray Williams">
 <meta name="authorGitHubUsername" value="GrayW">
 <meta name="category" value="guides">

--- a/articles/managing-chrome-with-fleet.md
+++ b/articles/managing-chrome-with-fleet.md
@@ -1,4 +1,4 @@
-# Managing Google Chrome with Fleet
+# Managing Google Chrome on Windows with Fleet
 
 Use configuration profiles to enforce consistent Chrome browser settings across your Windows devices. Before configuring Chrome policies, you must first deploy the Google Chrome ADMX file to your devices — skipping this step will cause errors during verification or prevent policies from applying.
 
@@ -7,6 +7,11 @@ Use configuration profiles to enforce consistent Chrome browser settings across 
 - Administrative access to Fleet.
 - Windows devices enrolled in Fleet.
 - Basic familiarity with XML syntax and Group Policy concepts.
+
+
+** Resources**
+- An example Google Chrome ADMX configuration profile is available in our [GitHub solutions folder](https://github.com/fleetdm/fleet/blob/docs/solutions/windows/configuration-profiles/admx%20Google%20Chrome.xml) (May not be the latest version available)
+- An example configuration profile for enrolling your browsers into Chrome Enterprise Core for a Cloud-managed Chrome browser is available in our [GitHub solutions folder](https://github.com/fleetdm/fleet/blob/docs/solutions/windows/configuration-profiles/enroll%20Google%20Chrome%20to%20enterprise%20console.xml)
 
 ---
 
@@ -19,12 +24,11 @@ Use configuration profiles to enforce consistent Chrome browser settings across 
 
 ## Step 2: Deploy the ADMX file to the device
 
-To apply Chrome policies, Windows needs the ADMX file to understand what settings are being configured. Do this by creating a configuration profile that deploys the file to your devices. For more information, see [Creating Windows CSPs: Ingesting custom ADMX templates](https://fleetdm.com/guides/creating-windows-csps#ingesting-custom-admx-templates-admxinstall).
+To apply Chrome policies, Windows needs the ADMX file to understand what settings are being configured. Do this by creating a configuration profile that deploys the ADMX content to your devices. For more information, see [Creating Windows CSPs: Ingesting custom ADMX templates](https://fleetdm.com/guides/creating-windows-csps#ingesting-custom-admx-templates-admxinstall).
 
 ### Create a configuration profile for ADMX ingestion
 
-1. In Fleet, navigate to **Configuration profiles** and create a new profile.
-2. Use the following XML to upload the `chrome.admx` file to the device's policy store:
+1. Create a new file in your editor of choice, and use the following template:
 
 ```xml
 <Add>
@@ -45,18 +49,37 @@ To apply Chrome policies, Windows needs the ADMX file to understand what setting
 
 **Note:**
 
-- Replace `<![CDATA[ ... ]]>` with the entire contents of the `chrome.admx` file.
+- Add the entire contents of the `chrome.admx` file into `<![CDATA[ ... ]]>`
 - This ensures the ADMX file is available for policy configuration on target devices.
+
+2. In Fleet, navigate to **Controls > OS settings > Configuration profiles** and add a profile.
+3. Select the .xml file you have just created.
 
 ---
 
-## Step 3: Configure Chrome policies
+## Step 3: Configure Chrome policies or enroll into Chrome Enterprise cloud management 
 
-Once the ADMX file is deployed, configure Chrome policies using the `<Replace>` block in a new or existing configuration profile.
+Once the ADMX file is deployed, you can configure Chrome policies using the `<Replace>` block in a new or existing configuration profile.
+
+### Example: enrolling devices in to Chrome Enterprise cloud management
+
+If you would like to enroll your Chrome browsers to control the settings from the [Google cloud management portal](https://chromeenterprise.google/products/chrome-enterprise-core/), you can deploy a profile with the relevant enrollment key. Replace the the x's with your key.
+
+```xml
+<Replace>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/chrome~Policy~googlechrome/CloudManagementEnrollmentToken</LocURI>
+    </Target>
+    <Meta><Format xmlns="syncml:metinf">chr</Format></Meta>
+    <Data>&lt;enabled/&gt;&lt;data id=&quot;CloudManagementEnrollmentToken&quot; value=&quot;xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&quot;/&gt;</Data>
+  </Item>
+</Replace>
+```
 
 ### Example: configuring `RelaunchNotification` and `RelaunchNotificationPeriod`
 
-Use the following XML to enforce Chrome policies. Note the use of `int` for REG_DWORD values (e.g., `RelaunchNotificationPeriod`):
+If you would like to manage your Chrome configuration by code, you can use profiles to configure any settings available from the ADMX file.
 
 ```xml
 <Replace>
@@ -88,8 +111,8 @@ Use the following XML to enforce Chrome policies. Note the use of `int` for REG_
 
 ## Step 4: Deploy and verify
 
-1. Assign the profile to the desired devices or groups in Fleet.
-2. **Refetch** the devices to apply the configuration.
+1. In Fleet, navigate to **Controls > OS settings > Configuration profiles** and add your new configuration profile.
+2. You can **Refetch** the devices to apply the configuration sooner.
 3. Verify the policies:
   - Open `regedit` on a target device and navigate to: `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome`
   - Confirm that the policies (e.g., `RelaunchNotification`, `RelaunchNotificationPeriod`) appear with the correct values.

--- a/articles/managing-chrome-with-fleet.md
+++ b/articles/managing-chrome-with-fleet.md
@@ -9,7 +9,7 @@ Use configuration profiles to enforce consistent Chrome browser settings across 
 - Basic familiarity with XML syntax and Group Policy concepts.
 
 
-** Resources**
+**Resources:**
 - An example Google Chrome ADMX configuration profile is available in our [GitHub solutions folder](https://github.com/fleetdm/fleet/blob/docs/solutions/windows/configuration-profiles/admx%20Google%20Chrome.xml) (May not be the latest version available)
 - An example configuration profile for enrolling your browsers into Chrome Enterprise Core for a Cloud-managed Chrome browser is available in our [GitHub solutions folder](https://github.com/fleetdm/fleet/blob/docs/solutions/windows/configuration-profiles/enroll%20Google%20Chrome%20to%20enterprise%20console.xml)
 
@@ -79,7 +79,7 @@ If you would like to enroll your Chrome browsers to control the settings from th
 
 ### Example: configuring `RelaunchNotification` and `RelaunchNotificationPeriod`
 
-If you would like to manage your Chrome configuration by code, you can use profiles to configure any settings available from the ADMX file.
+However, if you would like to manage your Chrome configuration by code, you can use profiles to configure any settings available from the ADMX file.
 
 ```xml
 <Replace>

--- a/docs/solutions/windows/configuration-profiles/admx Google Chrome.xml
+++ b/docs/solutions/windows/configuration-profiles/admx Google Chrome.xml
@@ -1,0 +1,7657 @@
+<Add>
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">chr</Format>
+      <Type>text/plain</Type>
+    </Meta>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/ConfigOperations/ADMXInstall/Chrome/Policy/ChromeAdmxFile</LocURI>
+    </Target>
+    <Data><![CDATA[
+      <?xml version="1.0" ?>
+<policyDefinitions revision="1.0" schemaVersion="1.0">
+  <!--chrome version: 149.0.7827.54-->
+  <policyNamespaces>
+    <target namespace="Google.Policies.Chrome" prefix="chrome"/>
+    <using namespace="Google.Policies" prefix="Google"/>
+    <using namespace="Microsoft.Policies.Windows" prefix="windows"/>
+  </policyNamespaces>
+  <resources minRequiredRevision="1.0"/>
+  <supportedOn>
+    <definitions>
+      <definition displayName="$(string.SUPPORTED_WIN7)" name="SUPPORTED_WIN7"/>
+      <definition displayName="$(string.SUPPORTED_WIN7_ONLY)" name="SUPPORTED_WIN7_ONLY"/>
+    </definitions>
+  </supportedOn>
+  <categories>
+    <category displayName="$(string.googlechrome)" name="googlechrome">
+      <parentCategory ref="Google:Cat_Google"/>
+    </category>
+    <category displayName="$(string.googlechrome_recommended)" name="googlechrome_recommended">
+      <parentCategory ref="Google:Cat_Google"/>
+    </category>
+    <category displayName="$(string.Accessibility_group)" name="Accessibility">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.Accessibility_group)" name="Accessibility_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.ScreenCapture_group)" name="ScreenCapture">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.CertificateManagement_group)" name="CertificateManagement">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.ContentSettings_group)" name="ContentSettings">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.ContentSettings_group)" name="ContentSettings_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.CryptographyCompliance_group)" name="CryptographyCompliance">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.DefaultSearchProvider_group)" name="DefaultSearchProvider">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.DefaultSearchProvider_group)" name="DefaultSearchProvider_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.DeprecatedPolicies_group)" name="DeprecatedPolicies">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.DeprecatedPolicies_group)" name="DeprecatedPolicies_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.Extensions_group)" name="Extensions">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.GenerativeAI_group)" name="GenerativeAI">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.GoogleCast_group)" name="GoogleCast">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.HTTPAuthentication_group)" name="HTTPAuthentication">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.BrowserIdle_group)" name="BrowserIdle">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.BrowserSwitcher_group)" name="BrowserSwitcher">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.LocalNetworkAccessSettings_group)" name="LocalNetworkAccessSettings">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.ActiveDirectoryManagement_group)" name="ActiveDirectoryManagement">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.NativeMessaging_group)" name="NativeMessaging">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.Network_group)" name="Network">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.PasswordManager_group)" name="PasswordManager">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.PasswordManager_group)" name="PasswordManager_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.Printing_group)" name="Printing">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.Printing_group)" name="Printing_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.ProtectedContent_group)" name="ProtectedContent">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.Proxy_group)" name="Proxy">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.RemoteAccess_group)" name="RemoteAccess">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.RemovedPolicies_group)" name="RemovedPolicies">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.RemovedPolicies_group)" name="RemovedPolicies_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.SafeBrowsing_group)" name="SafeBrowsing">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.SafeBrowsing_group)" name="SafeBrowsing_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.Signin_group)" name="Signin">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.Startup_group)" name="Startup">
+      <parentCategory ref="googlechrome"/>
+    </category>
+    <category displayName="$(string.Startup_group)" name="Startup_recommended">
+      <parentCategory ref="googlechrome_recommended"/>
+    </category>
+    <category displayName="$(string.WebRtc_group)" name="WebRtc">
+      <parentCategory ref="googlechrome"/>
+    </category>
+  </categories>
+  <policies>
+    <policy class="Both" displayName="$(string.LiveCaptionEnabled)" explainText="$(string.LiveCaptionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LiveCaptionEnabled" presentation="$(presentation.LiveCaptionEnabled)" valueName="LiveCaptionEnabled">
+      <parentCategory ref="Accessibility"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LiveTranslateEnabled)" explainText="$(string.LiveTranslateEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LiveTranslateEnabled" presentation="$(presentation.LiveTranslateEnabled)" valueName="LiveTranslateEnabled">
+      <parentCategory ref="Accessibility"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LiveCaptionEnabled)" explainText="$(string.LiveCaptionEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="LiveCaptionEnabled_recommended" presentation="$(presentation.LiveCaptionEnabled)" valueName="LiveCaptionEnabled">
+      <parentCategory ref="Accessibility_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LiveTranslateEnabled)" explainText="$(string.LiveTranslateEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="LiveTranslateEnabled_recommended" presentation="$(presentation.LiveTranslateEnabled)" valueName="LiveTranslateEnabled">
+      <parentCategory ref="Accessibility_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SameOriginTabCaptureAllowedByOrigins)" explainText="$(string.SameOriginTabCaptureAllowedByOrigins_Explain)" key="Software\Policies\Google\Chrome" name="SameOriginTabCaptureAllowedByOrigins" presentation="$(presentation.SameOriginTabCaptureAllowedByOrigins)">
+      <parentCategory ref="ScreenCapture"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SameOriginTabCaptureAllowedByOriginsDesc" key="Software\Policies\Google\Chrome\SameOriginTabCaptureAllowedByOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ScreenCaptureAllowed)" explainText="$(string.ScreenCaptureAllowed_Explain)" key="Software\Policies\Google\Chrome" name="ScreenCaptureAllowed" presentation="$(presentation.ScreenCaptureAllowed)" valueName="ScreenCaptureAllowed">
+      <parentCategory ref="ScreenCapture"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ScreenCaptureAllowedByOrigins)" explainText="$(string.ScreenCaptureAllowedByOrigins_Explain)" key="Software\Policies\Google\Chrome" name="ScreenCaptureAllowedByOrigins" presentation="$(presentation.ScreenCaptureAllowedByOrigins)">
+      <parentCategory ref="ScreenCapture"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ScreenCaptureAllowedByOriginsDesc" key="Software\Policies\Google\Chrome\ScreenCaptureAllowedByOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.TabCaptureAllowedByOrigins)" explainText="$(string.TabCaptureAllowedByOrigins_Explain)" key="Software\Policies\Google\Chrome" name="TabCaptureAllowedByOrigins" presentation="$(presentation.TabCaptureAllowedByOrigins)">
+      <parentCategory ref="ScreenCapture"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="TabCaptureAllowedByOriginsDesc" key="Software\Policies\Google\Chrome\TabCaptureAllowedByOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WindowCaptureAllowedByOrigins)" explainText="$(string.WindowCaptureAllowedByOrigins_Explain)" key="Software\Policies\Google\Chrome" name="WindowCaptureAllowedByOrigins" presentation="$(presentation.WindowCaptureAllowedByOrigins)">
+      <parentCategory ref="ScreenCapture"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WindowCaptureAllowedByOriginsDesc" key="Software\Policies\Google\Chrome\WindowCaptureAllowedByOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CACertificateManagementAllowed)" explainText="$(string.CACertificateManagementAllowed_Explain)" key="Software\Policies\Google\Chrome" name="CACertificateManagementAllowed" presentation="$(presentation.CACertificateManagementAllowed)">
+      <parentCategory ref="CertificateManagement"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="CACertificateManagementAllowed" valueName="CACertificateManagementAllowed">
+          <item displayName="$(string.CACertificateManagementAllowed_All)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.CACertificateManagementAllowed_UserOnly)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.CACertificateManagementAllowed_None)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CACertificates)" explainText="$(string.CACertificates_Explain)" key="Software\Policies\Google\Chrome" name="CACertificates" presentation="$(presentation.CACertificates)">
+      <parentCategory ref="CertificateManagement"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CACertificatesDesc" key="Software\Policies\Google\Chrome\CACertificates" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CACertificatesWithConstraints)" explainText="$(string.CACertificatesWithConstraints_Explain)" key="Software\Policies\Google\Chrome" name="CACertificatesWithConstraints" presentation="$(presentation.CACertificatesWithConstraints)">
+      <parentCategory ref="CertificateManagement"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="CACertificatesWithConstraints" maxLength="1000000" valueName="CACertificatesWithConstraints"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CADistrustedCertificates)" explainText="$(string.CADistrustedCertificates_Explain)" key="Software\Policies\Google\Chrome" name="CADistrustedCertificates" presentation="$(presentation.CADistrustedCertificates)">
+      <parentCategory ref="CertificateManagement"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CADistrustedCertificatesDesc" key="Software\Policies\Google\Chrome\CADistrustedCertificates" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CAHintCertificates)" explainText="$(string.CAHintCertificates_Explain)" key="Software\Policies\Google\Chrome" name="CAHintCertificates" presentation="$(presentation.CAHintCertificates)">
+      <parentCategory ref="CertificateManagement"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CAHintCertificatesDesc" key="Software\Policies\Google\Chrome\CAHintCertificates" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CAPlatformIntegrationEnabled)" explainText="$(string.CAPlatformIntegrationEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CAPlatformIntegrationEnabled" presentation="$(presentation.CAPlatformIntegrationEnabled)" valueName="CAPlatformIntegrationEnabled">
+      <parentCategory ref="CertificateManagement"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoSelectCertificateForUrls)" explainText="$(string.AutoSelectCertificateForUrls_Explain)" key="Software\Policies\Google\Chrome" name="AutoSelectCertificateForUrls" presentation="$(presentation.AutoSelectCertificateForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AutoSelectCertificateForUrlsDesc" key="Software\Policies\Google\Chrome\AutoSelectCertificateForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutomaticFullscreenAllowedForUrls)" explainText="$(string.AutomaticFullscreenAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="AutomaticFullscreenAllowedForUrls" presentation="$(presentation.AutomaticFullscreenAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AutomaticFullscreenAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\AutomaticFullscreenAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutomaticFullscreenBlockedForUrls)" explainText="$(string.AutomaticFullscreenBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="AutomaticFullscreenBlockedForUrls" presentation="$(presentation.AutomaticFullscreenBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AutomaticFullscreenBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\AutomaticFullscreenBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ClipboardAllowedForUrls)" explainText="$(string.ClipboardAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="ClipboardAllowedForUrls" presentation="$(presentation.ClipboardAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ClipboardAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\ClipboardAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ClipboardBlockedForUrls)" explainText="$(string.ClipboardBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="ClipboardBlockedForUrls" presentation="$(presentation.ClipboardBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ClipboardBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\ClipboardBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CookiesAllowedForUrls)" explainText="$(string.CookiesAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="CookiesAllowedForUrls" presentation="$(presentation.CookiesAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CookiesAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\CookiesAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CookiesBlockedForUrls)" explainText="$(string.CookiesBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="CookiesBlockedForUrls" presentation="$(presentation.CookiesBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CookiesBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\CookiesBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CookiesSessionOnlyForUrls)" explainText="$(string.CookiesSessionOnlyForUrls_Explain)" key="Software\Policies\Google\Chrome" name="CookiesSessionOnlyForUrls" presentation="$(presentation.CookiesSessionOnlyForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CookiesSessionOnlyForUrlsDesc" key="Software\Policies\Google\Chrome\CookiesSessionOnlyForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DataUrlInSvgUseEnabled)" explainText="$(string.DataUrlInSvgUseEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DataUrlInSvgUseEnabled" presentation="$(presentation.DataUrlInSvgUseEnabled)" valueName="DataUrlInSvgUseEnabled">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultClipboardSetting)" explainText="$(string.DefaultClipboardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultClipboardSetting" presentation="$(presentation.DefaultClipboardSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultClipboardSetting" valueName="DefaultClipboardSetting">
+          <item displayName="$(string.DefaultClipboardSetting_BlockClipboard)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultClipboardSetting_AskClipboard)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultCookiesSetting)" explainText="$(string.DefaultCookiesSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultCookiesSetting" presentation="$(presentation.DefaultCookiesSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultCookiesSetting" valueName="DefaultCookiesSetting">
+          <item displayName="$(string.DefaultCookiesSetting_AllowCookies)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultCookiesSetting_BlockCookies)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultCookiesSetting_SessionOnly)">
+            <value>
+              <decimal value="4"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultFileSystemReadGuardSetting)" explainText="$(string.DefaultFileSystemReadGuardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultFileSystemReadGuardSetting" presentation="$(presentation.DefaultFileSystemReadGuardSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultFileSystemReadGuardSetting" valueName="DefaultFileSystemReadGuardSetting">
+          <item displayName="$(string.DefaultFileSystemReadGuardSetting_BlockFileSystemRead)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultFileSystemReadGuardSetting_AskFileSystemRead)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultFileSystemWriteGuardSetting)" explainText="$(string.DefaultFileSystemWriteGuardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultFileSystemWriteGuardSetting" presentation="$(presentation.DefaultFileSystemWriteGuardSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultFileSystemWriteGuardSetting" valueName="DefaultFileSystemWriteGuardSetting">
+          <item displayName="$(string.DefaultFileSystemWriteGuardSetting_BlockFileSystemWrite)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultFileSystemWriteGuardSetting_AskFileSystemWrite)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultGeolocationSetting)" explainText="$(string.DefaultGeolocationSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultGeolocationSetting" presentation="$(presentation.DefaultGeolocationSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultGeolocationSetting" valueName="DefaultGeolocationSetting">
+          <item displayName="$(string.DefaultGeolocationSetting_AllowGeolocation)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultGeolocationSetting_BlockGeolocation)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultGeolocationSetting_AskGeolocation)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultIdleDetectionSetting)" explainText="$(string.DefaultIdleDetectionSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultIdleDetectionSetting" presentation="$(presentation.DefaultIdleDetectionSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultIdleDetectionSetting" valueName="DefaultIdleDetectionSetting">
+          <item displayName="$(string.DefaultIdleDetectionSetting_AllowIdleDetection)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultIdleDetectionSetting_BlockIdleDetection)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultIdleDetectionSetting_AskIdleDetection)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultImagesSetting)" explainText="$(string.DefaultImagesSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultImagesSetting" presentation="$(presentation.DefaultImagesSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultImagesSetting" valueName="DefaultImagesSetting">
+          <item displayName="$(string.DefaultImagesSetting_AllowImages)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultImagesSetting_BlockImages)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultInsecureContentSetting)" explainText="$(string.DefaultInsecureContentSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultInsecureContentSetting" presentation="$(presentation.DefaultInsecureContentSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultInsecureContentSetting" valueName="DefaultInsecureContentSetting">
+          <item displayName="$(string.DefaultInsecureContentSetting_BlockInsecureContent)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultInsecureContentSetting_AllowExceptionsInsecureContent)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultJavaScriptJitSetting)" explainText="$(string.DefaultJavaScriptJitSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultJavaScriptJitSetting" presentation="$(presentation.DefaultJavaScriptJitSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultJavaScriptJitSetting" valueName="DefaultJavaScriptJitSetting">
+          <item displayName="$(string.DefaultJavaScriptJitSetting_AllowJavaScriptJit)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultJavaScriptJitSetting_BlockJavaScriptJit)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultJavaScriptOptimizerSetting)" explainText="$(string.DefaultJavaScriptOptimizerSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultJavaScriptOptimizerSetting" presentation="$(presentation.DefaultJavaScriptOptimizerSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultJavaScriptOptimizerSetting" valueName="DefaultJavaScriptOptimizerSetting">
+          <item displayName="$(string.DefaultJavaScriptOptimizerSetting_AllowJavaScriptOptimizer)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultJavaScriptOptimizerSetting_BlockJavaScriptOptimizer)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultJavaScriptSetting)" explainText="$(string.DefaultJavaScriptSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultJavaScriptSetting" presentation="$(presentation.DefaultJavaScriptSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultJavaScriptSetting" valueName="DefaultJavaScriptSetting">
+          <item displayName="$(string.DefaultJavaScriptSetting_AllowJavaScript)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultJavaScriptSetting_BlockJavaScript)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultLocalFontsSetting)" explainText="$(string.DefaultLocalFontsSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultLocalFontsSetting" presentation="$(presentation.DefaultLocalFontsSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultLocalFontsSetting" valueName="DefaultLocalFontsSetting">
+          <item displayName="$(string.DefaultLocalFontsSetting_BlockLocalFonts)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultLocalFontsSetting_AskLocalFonts)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultNotificationsSetting)" explainText="$(string.DefaultNotificationsSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultNotificationsSetting" presentation="$(presentation.DefaultNotificationsSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultNotificationsSetting" valueName="DefaultNotificationsSetting">
+          <item displayName="$(string.DefaultNotificationsSetting_AllowNotifications)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultNotificationsSetting_BlockNotifications)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultNotificationsSetting_AskNotifications)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultPopupsSetting)" explainText="$(string.DefaultPopupsSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultPopupsSetting" presentation="$(presentation.DefaultPopupsSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultPopupsSetting" valueName="DefaultPopupsSetting">
+          <item displayName="$(string.DefaultPopupsSetting_AllowPopups)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultPopupsSetting_BlockPopups)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSensorsSetting)" explainText="$(string.DefaultSensorsSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSensorsSetting" presentation="$(presentation.DefaultSensorsSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultSensorsSetting" valueName="DefaultSensorsSetting">
+          <item displayName="$(string.DefaultSensorsSetting_AllowSensors)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultSensorsSetting_BlockSensors)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSerialGuardSetting)" explainText="$(string.DefaultSerialGuardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSerialGuardSetting" presentation="$(presentation.DefaultSerialGuardSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultSerialGuardSetting" valueName="DefaultSerialGuardSetting">
+          <item displayName="$(string.DefaultSerialGuardSetting_BlockSerial)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultSerialGuardSetting_AskSerial)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultWebBluetoothGuardSetting)" explainText="$(string.DefaultWebBluetoothGuardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultWebBluetoothGuardSetting" presentation="$(presentation.DefaultWebBluetoothGuardSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultWebBluetoothGuardSetting" valueName="DefaultWebBluetoothGuardSetting">
+          <item displayName="$(string.DefaultWebBluetoothGuardSetting_BlockWebBluetooth)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultWebBluetoothGuardSetting_AskWebBluetooth)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultWebHidGuardSetting)" explainText="$(string.DefaultWebHidGuardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultWebHidGuardSetting" presentation="$(presentation.DefaultWebHidGuardSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultWebHidGuardSetting" valueName="DefaultWebHidGuardSetting">
+          <item displayName="$(string.DefaultWebHidGuardSetting_BlockWebHid)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultWebHidGuardSetting_AskWebHid)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultWebUsbGuardSetting)" explainText="$(string.DefaultWebUsbGuardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultWebUsbGuardSetting" presentation="$(presentation.DefaultWebUsbGuardSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultWebUsbGuardSetting" valueName="DefaultWebUsbGuardSetting">
+          <item displayName="$(string.DefaultWebUsbGuardSetting_BlockWebUsb)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultWebUsbGuardSetting_AskWebUsb)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultWindowManagementSetting)" explainText="$(string.DefaultWindowManagementSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultWindowManagementSetting" presentation="$(presentation.DefaultWindowManagementSetting)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultWindowManagementSetting" valueName="DefaultWindowManagementSetting">
+          <item displayName="$(string.DefaultWindowManagementSetting_BlockWindowManagement)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultWindowManagementSetting_AskWindowManagement)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileSystemReadAskForUrls)" explainText="$(string.FileSystemReadAskForUrls_Explain)" key="Software\Policies\Google\Chrome" name="FileSystemReadAskForUrls" presentation="$(presentation.FileSystemReadAskForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="FileSystemReadAskForUrlsDesc" key="Software\Policies\Google\Chrome\FileSystemReadAskForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileSystemReadBlockedForUrls)" explainText="$(string.FileSystemReadBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="FileSystemReadBlockedForUrls" presentation="$(presentation.FileSystemReadBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="FileSystemReadBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\FileSystemReadBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileSystemWriteAskForUrls)" explainText="$(string.FileSystemWriteAskForUrls_Explain)" key="Software\Policies\Google\Chrome" name="FileSystemWriteAskForUrls" presentation="$(presentation.FileSystemWriteAskForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="FileSystemWriteAskForUrlsDesc" key="Software\Policies\Google\Chrome\FileSystemWriteAskForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileSystemWriteBlockedForUrls)" explainText="$(string.FileSystemWriteBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="FileSystemWriteBlockedForUrls" presentation="$(presentation.FileSystemWriteBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="FileSystemWriteBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\FileSystemWriteBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.GeolocationBlockedForUrls)" explainText="$(string.GeolocationBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="GeolocationBlockedForUrls" presentation="$(presentation.GeolocationBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="GeolocationBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\GeolocationBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.IdleDetectionAllowedForUrls)" explainText="$(string.IdleDetectionAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="IdleDetectionAllowedForUrls" presentation="$(presentation.IdleDetectionAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="IdleDetectionAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\IdleDetectionAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.IdleDetectionBlockedForUrls)" explainText="$(string.IdleDetectionBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="IdleDetectionBlockedForUrls" presentation="$(presentation.IdleDetectionBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="IdleDetectionBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\IdleDetectionBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ImagesAllowedForUrls)" explainText="$(string.ImagesAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="ImagesAllowedForUrls" presentation="$(presentation.ImagesAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ImagesAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\ImagesAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ImagesBlockedForUrls)" explainText="$(string.ImagesBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="ImagesBlockedForUrls" presentation="$(presentation.ImagesBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ImagesBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\ImagesBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.InsecureContentAllowedForUrls)" explainText="$(string.InsecureContentAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="InsecureContentAllowedForUrls" presentation="$(presentation.InsecureContentAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="InsecureContentAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\InsecureContentAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.InsecureContentBlockedForUrls)" explainText="$(string.InsecureContentBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="InsecureContentBlockedForUrls" presentation="$(presentation.InsecureContentBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="InsecureContentBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\InsecureContentBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.JavaScriptAllowedForUrls)" explainText="$(string.JavaScriptAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="JavaScriptAllowedForUrls" presentation="$(presentation.JavaScriptAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="JavaScriptAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\JavaScriptAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.JavaScriptBlockedForUrls)" explainText="$(string.JavaScriptBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="JavaScriptBlockedForUrls" presentation="$(presentation.JavaScriptBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="JavaScriptBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\JavaScriptBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.JavaScriptJitAllowedForSites)" explainText="$(string.JavaScriptJitAllowedForSites_Explain)" key="Software\Policies\Google\Chrome" name="JavaScriptJitAllowedForSites" presentation="$(presentation.JavaScriptJitAllowedForSites)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="JavaScriptJitAllowedForSitesDesc" key="Software\Policies\Google\Chrome\JavaScriptJitAllowedForSites" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.JavaScriptJitBlockedForSites)" explainText="$(string.JavaScriptJitBlockedForSites_Explain)" key="Software\Policies\Google\Chrome" name="JavaScriptJitBlockedForSites" presentation="$(presentation.JavaScriptJitBlockedForSites)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="JavaScriptJitBlockedForSitesDesc" key="Software\Policies\Google\Chrome\JavaScriptJitBlockedForSites" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.JavaScriptOptimizerAllowedForSites)" explainText="$(string.JavaScriptOptimizerAllowedForSites_Explain)" key="Software\Policies\Google\Chrome" name="JavaScriptOptimizerAllowedForSites" presentation="$(presentation.JavaScriptOptimizerAllowedForSites)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="JavaScriptOptimizerAllowedForSitesDesc" key="Software\Policies\Google\Chrome\JavaScriptOptimizerAllowedForSites" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.JavaScriptOptimizerBlockedForSites)" explainText="$(string.JavaScriptOptimizerBlockedForSites_Explain)" key="Software\Policies\Google\Chrome" name="JavaScriptOptimizerBlockedForSites" presentation="$(presentation.JavaScriptOptimizerBlockedForSites)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="JavaScriptOptimizerBlockedForSitesDesc" key="Software\Policies\Google\Chrome\JavaScriptOptimizerBlockedForSites" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalFontsAllowedForUrls)" explainText="$(string.LocalFontsAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LocalFontsAllowedForUrls" presentation="$(presentation.LocalFontsAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LocalFontsAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\LocalFontsAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalFontsBlockedForUrls)" explainText="$(string.LocalFontsBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LocalFontsBlockedForUrls" presentation="$(presentation.LocalFontsBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LocalFontsBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\LocalFontsBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NotificationsAllowedForUrls)" explainText="$(string.NotificationsAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="NotificationsAllowedForUrls" presentation="$(presentation.NotificationsAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="NotificationsAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\NotificationsAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NotificationsBlockedForUrls)" explainText="$(string.NotificationsBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="NotificationsBlockedForUrls" presentation="$(presentation.NotificationsBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="NotificationsBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\NotificationsBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PartitionedBlobUrlUsage)" explainText="$(string.PartitionedBlobUrlUsage_Explain)" key="Software\Policies\Google\Chrome" name="PartitionedBlobUrlUsage" presentation="$(presentation.PartitionedBlobUrlUsage)" valueName="PartitionedBlobUrlUsage">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PdfLocalFileAccessAllowedForDomains)" explainText="$(string.PdfLocalFileAccessAllowedForDomains_Explain)" key="Software\Policies\Google\Chrome" name="PdfLocalFileAccessAllowedForDomains" presentation="$(presentation.PdfLocalFileAccessAllowedForDomains)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PdfLocalFileAccessAllowedForDomainsDesc" key="Software\Policies\Google\Chrome\PdfLocalFileAccessAllowedForDomains" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PopupsAllowedForUrls)" explainText="$(string.PopupsAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="PopupsAllowedForUrls" presentation="$(presentation.PopupsAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PopupsAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\PopupsAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PopupsBlockedForUrls)" explainText="$(string.PopupsBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="PopupsBlockedForUrls" presentation="$(presentation.PopupsBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PopupsBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\PopupsBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PreciseGeolocationAllowedForUrls)" explainText="$(string.PreciseGeolocationAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="PreciseGeolocationAllowedForUrls" presentation="$(presentation.PreciseGeolocationAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PreciseGeolocationAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\PreciseGeolocationAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SensorsAllowedForUrls)" explainText="$(string.SensorsAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="SensorsAllowedForUrls" presentation="$(presentation.SensorsAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SensorsAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\SensorsAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SensorsBlockedForUrls)" explainText="$(string.SensorsBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="SensorsBlockedForUrls" presentation="$(presentation.SensorsBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SensorsBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\SensorsBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SerialAllowAllPortsForUrls)" explainText="$(string.SerialAllowAllPortsForUrls_Explain)" key="Software\Policies\Google\Chrome" name="SerialAllowAllPortsForUrls" presentation="$(presentation.SerialAllowAllPortsForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SerialAllowAllPortsForUrlsDesc" key="Software\Policies\Google\Chrome\SerialAllowAllPortsForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SerialAllowUsbDevicesForUrls)" explainText="$(string.SerialAllowUsbDevicesForUrls_Explain)" key="Software\Policies\Google\Chrome" name="SerialAllowUsbDevicesForUrls" presentation="$(presentation.SerialAllowUsbDevicesForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="SerialAllowUsbDevicesForUrls" maxLength="1000000" valueName="SerialAllowUsbDevicesForUrls"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SerialAskForUrls)" explainText="$(string.SerialAskForUrls_Explain)" key="Software\Policies\Google\Chrome" name="SerialAskForUrls" presentation="$(presentation.SerialAskForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SerialAskForUrlsDesc" key="Software\Policies\Google\Chrome\SerialAskForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SerialBlockedForUrls)" explainText="$(string.SerialBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="SerialBlockedForUrls" presentation="$(presentation.SerialBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SerialBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\SerialBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebHidAllowAllDevicesForUrls)" explainText="$(string.WebHidAllowAllDevicesForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebHidAllowAllDevicesForUrls" presentation="$(presentation.WebHidAllowAllDevicesForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebHidAllowAllDevicesForUrlsDesc" key="Software\Policies\Google\Chrome\WebHidAllowAllDevicesForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebHidAllowDevicesForUrls)" explainText="$(string.WebHidAllowDevicesForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebHidAllowDevicesForUrls" presentation="$(presentation.WebHidAllowDevicesForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="WebHidAllowDevicesForUrls" maxLength="1000000" valueName="WebHidAllowDevicesForUrls"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebHidAllowDevicesWithHidUsagesForUrls)" explainText="$(string.WebHidAllowDevicesWithHidUsagesForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebHidAllowDevicesWithHidUsagesForUrls" presentation="$(presentation.WebHidAllowDevicesWithHidUsagesForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="WebHidAllowDevicesWithHidUsagesForUrls" maxLength="1000000" valueName="WebHidAllowDevicesWithHidUsagesForUrls"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebHidAskForUrls)" explainText="$(string.WebHidAskForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebHidAskForUrls" presentation="$(presentation.WebHidAskForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebHidAskForUrlsDesc" key="Software\Policies\Google\Chrome\WebHidAskForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebHidBlockedForUrls)" explainText="$(string.WebHidBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebHidBlockedForUrls" presentation="$(presentation.WebHidBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebHidBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\WebHidBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebUsbAllowDevicesForUrls)" explainText="$(string.WebUsbAllowDevicesForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebUsbAllowDevicesForUrls" presentation="$(presentation.WebUsbAllowDevicesForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="WebUsbAllowDevicesForUrls" maxLength="1000000" valueName="WebUsbAllowDevicesForUrls"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebUsbAskForUrls)" explainText="$(string.WebUsbAskForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebUsbAskForUrls" presentation="$(presentation.WebUsbAskForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebUsbAskForUrlsDesc" key="Software\Policies\Google\Chrome\WebUsbAskForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebUsbBlockedForUrls)" explainText="$(string.WebUsbBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebUsbBlockedForUrls" presentation="$(presentation.WebUsbBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebUsbBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\WebUsbBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WindowManagementAllowedForUrls)" explainText="$(string.WindowManagementAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WindowManagementAllowedForUrls" presentation="$(presentation.WindowManagementAllowedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WindowManagementAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\WindowManagementAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WindowManagementBlockedForUrls)" explainText="$(string.WindowManagementBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WindowManagementBlockedForUrls" presentation="$(presentation.WindowManagementBlockedForUrls)">
+      <parentCategory ref="ContentSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WindowManagementBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\WindowManagementBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RegisteredProtocolHandlers)" explainText="$(string.RegisteredProtocolHandlers_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="RegisteredProtocolHandlers_recommended" presentation="$(presentation.RegisteredProtocolHandlers)">
+      <parentCategory ref="ContentSettings_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RegisteredProtocolHandlers" maxLength="1000000" valueName="RegisteredProtocolHandlers"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PreferSlowCiphers)" explainText="$(string.PreferSlowCiphers_Explain)" key="Software\Policies\Google\Chrome" name="PreferSlowCiphers" presentation="$(presentation.PreferSlowCiphers)">
+      <parentCategory ref="CryptographyCompliance"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PreferSlowCiphers" valueName="PreferSlowCiphers">
+          <item displayName="$(string.PreferSlowCiphers_CNSA)">
+            <value>
+              <string>cnsa</string>
+            </value>
+          </item>
+          <item displayName="$(string.PreferSlowCiphers_Default)">
+            <value>
+              <string>default</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PreferSlowKexAlgorithms)" explainText="$(string.PreferSlowKexAlgorithms_Explain)" key="Software\Policies\Google\Chrome" name="PreferSlowKexAlgorithms" presentation="$(presentation.PreferSlowKexAlgorithms)">
+      <parentCategory ref="CryptographyCompliance"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PreferSlowKexAlgorithms" valueName="PreferSlowKexAlgorithms">
+          <item displayName="$(string.PreferSlowKexAlgorithms_CNSA2_0)">
+            <value>
+              <string>cnsa2</string>
+            </value>
+          </item>
+          <item displayName="$(string.PreferSlowKexAlgorithms_Default)">
+            <value>
+              <string>default</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderAlternateURLs)" explainText="$(string.DefaultSearchProviderAlternateURLs_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderAlternateURLs" presentation="$(presentation.DefaultSearchProviderAlternateURLs)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DefaultSearchProviderAlternateURLsDesc" key="Software\Policies\Google\Chrome\DefaultSearchProviderAlternateURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderEnabled)" explainText="$(string.DefaultSearchProviderEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderEnabled" presentation="$(presentation.DefaultSearchProviderEnabled)" valueName="DefaultSearchProviderEnabled">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderEncodings)" explainText="$(string.DefaultSearchProviderEncodings_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderEncodings" presentation="$(presentation.DefaultSearchProviderEncodings)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DefaultSearchProviderEncodingsDesc" key="Software\Policies\Google\Chrome\DefaultSearchProviderEncodings" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderImageURL)" explainText="$(string.DefaultSearchProviderImageURL_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderImageURL" presentation="$(presentation.DefaultSearchProviderImageURL)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderImageURL" maxLength="1000000" valueName="DefaultSearchProviderImageURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderImageURLPostParams)" explainText="$(string.DefaultSearchProviderImageURLPostParams_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderImageURLPostParams" presentation="$(presentation.DefaultSearchProviderImageURLPostParams)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderImageURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderImageURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderKeyword)" explainText="$(string.DefaultSearchProviderKeyword_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderKeyword" presentation="$(presentation.DefaultSearchProviderKeyword)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderKeyword" maxLength="1000000" valueName="DefaultSearchProviderKeyword"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderName)" explainText="$(string.DefaultSearchProviderName_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderName" presentation="$(presentation.DefaultSearchProviderName)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderName" maxLength="1000000" valueName="DefaultSearchProviderName"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderNewTabURL)" explainText="$(string.DefaultSearchProviderNewTabURL_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderNewTabURL" presentation="$(presentation.DefaultSearchProviderNewTabURL)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderNewTabURL" maxLength="1000000" valueName="DefaultSearchProviderNewTabURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSearchURL)" explainText="$(string.DefaultSearchProviderSearchURL_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderSearchURL" presentation="$(presentation.DefaultSearchProviderSearchURL)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSearchURL" maxLength="1000000" valueName="DefaultSearchProviderSearchURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSearchURLPostParams)" explainText="$(string.DefaultSearchProviderSearchURLPostParams_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderSearchURLPostParams" presentation="$(presentation.DefaultSearchProviderSearchURLPostParams)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSearchURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderSearchURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSuggestURL)" explainText="$(string.DefaultSearchProviderSuggestURL_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderSuggestURL" presentation="$(presentation.DefaultSearchProviderSuggestURL)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSuggestURL" maxLength="1000000" valueName="DefaultSearchProviderSuggestURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSuggestURLPostParams)" explainText="$(string.DefaultSearchProviderSuggestURLPostParams_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderSuggestURLPostParams" presentation="$(presentation.DefaultSearchProviderSuggestURLPostParams)">
+      <parentCategory ref="DefaultSearchProvider"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSuggestURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderSuggestURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderAlternateURLs)" explainText="$(string.DefaultSearchProviderAlternateURLs_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderAlternateURLs_recommended" presentation="$(presentation.DefaultSearchProviderAlternateURLs)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DefaultSearchProviderAlternateURLsDesc" key="Software\Policies\Google\Chrome\Recommended\DefaultSearchProviderAlternateURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderEnabled)" explainText="$(string.DefaultSearchProviderEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderEnabled_recommended" presentation="$(presentation.DefaultSearchProviderEnabled)" valueName="DefaultSearchProviderEnabled">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderEncodings)" explainText="$(string.DefaultSearchProviderEncodings_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderEncodings_recommended" presentation="$(presentation.DefaultSearchProviderEncodings)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DefaultSearchProviderEncodingsDesc" key="Software\Policies\Google\Chrome\Recommended\DefaultSearchProviderEncodings" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderImageURL)" explainText="$(string.DefaultSearchProviderImageURL_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderImageURL_recommended" presentation="$(presentation.DefaultSearchProviderImageURL)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderImageURL" maxLength="1000000" valueName="DefaultSearchProviderImageURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderImageURLPostParams)" explainText="$(string.DefaultSearchProviderImageURLPostParams_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderImageURLPostParams_recommended" presentation="$(presentation.DefaultSearchProviderImageURLPostParams)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderImageURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderImageURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderKeyword)" explainText="$(string.DefaultSearchProviderKeyword_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderKeyword_recommended" presentation="$(presentation.DefaultSearchProviderKeyword)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderKeyword" maxLength="1000000" valueName="DefaultSearchProviderKeyword"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderName)" explainText="$(string.DefaultSearchProviderName_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderName_recommended" presentation="$(presentation.DefaultSearchProviderName)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderName" maxLength="1000000" valueName="DefaultSearchProviderName"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderNewTabURL)" explainText="$(string.DefaultSearchProviderNewTabURL_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderNewTabURL_recommended" presentation="$(presentation.DefaultSearchProviderNewTabURL)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderNewTabURL" maxLength="1000000" valueName="DefaultSearchProviderNewTabURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSearchURL)" explainText="$(string.DefaultSearchProviderSearchURL_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderSearchURL_recommended" presentation="$(presentation.DefaultSearchProviderSearchURL)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSearchURL" maxLength="1000000" valueName="DefaultSearchProviderSearchURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSearchURLPostParams)" explainText="$(string.DefaultSearchProviderSearchURLPostParams_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderSearchURLPostParams_recommended" presentation="$(presentation.DefaultSearchProviderSearchURLPostParams)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSearchURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderSearchURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSuggestURL)" explainText="$(string.DefaultSearchProviderSuggestURL_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderSuggestURL_recommended" presentation="$(presentation.DefaultSearchProviderSuggestURL)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSuggestURL" maxLength="1000000" valueName="DefaultSearchProviderSuggestURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSuggestURLPostParams)" explainText="$(string.DefaultSearchProviderSuggestURLPostParams_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderSuggestURLPostParams_recommended" presentation="$(presentation.DefaultSearchProviderSuggestURLPostParams)">
+      <parentCategory ref="DefaultSearchProvider_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSuggestURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderSuggestURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultMediaStreamSetting)" explainText="$(string.DefaultMediaStreamSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultMediaStreamSetting" presentation="$(presentation.DefaultMediaStreamSetting)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultMediaStreamSetting" valueName="DefaultMediaStreamSetting">
+          <item displayName="$(string.DefaultMediaStreamSetting_BlockAccess)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultMediaStreamSetting_PromptOnAccess)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultWindowPlacementSetting)" explainText="$(string.DefaultWindowPlacementSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultWindowPlacementSetting" presentation="$(presentation.DefaultWindowPlacementSetting)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultWindowPlacementSetting" valueName="DefaultWindowPlacementSetting">
+          <item displayName="$(string.DefaultWindowPlacementSetting_BlockWindowPlacement)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultWindowPlacementSetting_AskWindowPlacement)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WindowPlacementAllowedForUrls)" explainText="$(string.WindowPlacementAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WindowPlacementAllowedForUrls" presentation="$(presentation.WindowPlacementAllowedForUrls)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WindowPlacementAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\WindowPlacementAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WindowPlacementBlockedForUrls)" explainText="$(string.WindowPlacementBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="WindowPlacementBlockedForUrls" presentation="$(presentation.WindowPlacementBlockedForUrls)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WindowPlacementBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\WindowPlacementBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FirstPartySetsEnabled)" explainText="$(string.FirstPartySetsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="FirstPartySetsEnabled" presentation="$(presentation.FirstPartySetsEnabled)" valueName="FirstPartySetsEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.FirstPartySetsOverrides)" explainText="$(string.FirstPartySetsOverrides_Explain)" key="Software\Policies\Google\Chrome" name="FirstPartySetsOverrides" presentation="$(presentation.FirstPartySetsOverrides)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="FirstPartySetsOverrides" maxLength="1000000" valueName="FirstPartySetsOverrides"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoFillEnabled)" explainText="$(string.AutoFillEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AutoFillEnabled" presentation="$(presentation.AutoFillEnabled)" valueName="AutoFillEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DeveloperToolsDisabled)" explainText="$(string.DeveloperToolsDisabled_Explain)" key="Software\Policies\Google\Chrome" name="DeveloperToolsDisabled" presentation="$(presentation.DeveloperToolsDisabled)" valueName="DeveloperToolsDisabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisabledSchemes)" explainText="$(string.DisabledSchemes_Explain)" key="Software\Policies\Google\Chrome" name="DisabledSchemes" presentation="$(presentation.DisabledSchemes)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DisabledSchemesDesc" key="Software\Policies\Google\Chrome\DisabledSchemes" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceBrowserSignin)" explainText="$(string.ForceBrowserSignin_Explain)" key="Software\Policies\Google\Chrome" name="ForceBrowserSignin" presentation="$(presentation.ForceBrowserSignin)" valueName="ForceBrowserSignin">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceSafeSearch)" explainText="$(string.ForceSafeSearch_Explain)" key="Software\Policies\Google\Chrome" name="ForceSafeSearch" presentation="$(presentation.ForceSafeSearch)" valueName="ForceSafeSearch">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceYouTubeSafetyMode)" explainText="$(string.ForceYouTubeSafetyMode_Explain)" key="Software\Policies\Google\Chrome" name="ForceYouTubeSafetyMode" presentation="$(presentation.ForceYouTubeSafetyMode)" valueName="ForceYouTubeSafetyMode">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.IncognitoEnabled)" explainText="$(string.IncognitoEnabled_Explain)" key="Software\Policies\Google\Chrome" name="IncognitoEnabled" presentation="$(presentation.IncognitoEnabled)" valueName="IncognitoEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.InsecureFormsWarningsEnabled)" explainText="$(string.InsecureFormsWarningsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="InsecureFormsWarningsEnabled" presentation="$(presentation.InsecureFormsWarningsEnabled)" valueName="InsecureFormsWarningsEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.JavascriptEnabled)" explainText="$(string.JavascriptEnabled_Explain)" key="Software\Policies\Google\Chrome" name="JavascriptEnabled" presentation="$(presentation.JavascriptEnabled)" valueName="JavascriptEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LensDesktopNTPSearchEnabled)" explainText="$(string.LensDesktopNTPSearchEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LensDesktopNTPSearchEnabled" presentation="$(presentation.LensDesktopNTPSearchEnabled)" valueName="LensDesktopNTPSearchEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LensOverlaySettings)" explainText="$(string.LensOverlaySettings_Explain)" key="Software\Policies\Google\Chrome" name="LensOverlaySettings" presentation="$(presentation.LensOverlaySettings)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="LensOverlaySettings" valueName="LensOverlaySettings">
+          <item displayName="$(string.LensOverlaySettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.LensOverlaySettings_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LensRegionSearchEnabled)" explainText="$(string.LensRegionSearchEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LensRegionSearchEnabled" presentation="$(presentation.LensRegionSearchEnabled)" valueName="LensRegionSearchEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ManagedAccountsSigninRestriction)" explainText="$(string.ManagedAccountsSigninRestriction_Explain)" key="Software\Policies\Google\Chrome" name="ManagedAccountsSigninRestriction" presentation="$(presentation.ManagedAccountsSigninRestriction)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ManagedAccountsSigninRestriction" valueName="ManagedAccountsSigninRestriction">
+          <item displayName="$(string.ManagedAccountsSigninRestriction_PrimaryAccount)">
+            <value>
+              <string>primary_account</string>
+            </value>
+          </item>
+          <item displayName="$(string.ManagedAccountsSigninRestriction_PrimaryAccountStrict)">
+            <value>
+              <string>primary_account_strict</string>
+            </value>
+          </item>
+          <item displayName="$(string.ManagedAccountsSigninRestriction_None)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+          <item displayName="$(string.ManagedAccountsSigninRestriction_PrimaryAccountKeepExistingData)">
+            <value>
+              <string>primary_account_keep_existing_data</string>
+            </value>
+          </item>
+          <item displayName="$(string.ManagedAccountsSigninRestriction_PrimaryAccountStrictKeepExistingData)">
+            <value>
+              <string>primary_account_strict_keep_existing_data</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PromotionalTabsEnabled)" explainText="$(string.PromotionalTabsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PromotionalTabsEnabled" presentation="$(presentation.PromotionalTabsEnabled)" valueName="PromotionalTabsEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SigninAllowed)" explainText="$(string.SigninAllowed_Explain)" key="Software\Policies\Google\Chrome" name="SigninAllowed" presentation="$(presentation.SigninAllowed)" valueName="SigninAllowed">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UnsafelyTreatInsecureOriginAsSecure)" explainText="$(string.UnsafelyTreatInsecureOriginAsSecure_Explain)" key="Software\Policies\Google\Chrome" name="UnsafelyTreatInsecureOriginAsSecure" presentation="$(presentation.UnsafelyTreatInsecureOriginAsSecure)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="UnsafelyTreatInsecureOriginAsSecureDesc" key="Software\Policies\Google\Chrome\UnsafelyTreatInsecureOriginAsSecure" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrivacySandboxAdMeasurementEnabled)" explainText="$(string.PrivacySandboxAdMeasurementEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrivacySandboxAdMeasurementEnabled" presentation="$(presentation.PrivacySandboxAdMeasurementEnabled)" valueName="PrivacySandboxAdMeasurementEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrivacySandboxAdTopicsEnabled)" explainText="$(string.PrivacySandboxAdTopicsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrivacySandboxAdTopicsEnabled" presentation="$(presentation.PrivacySandboxAdTopicsEnabled)" valueName="PrivacySandboxAdTopicsEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrivacySandboxPromptEnabled)" explainText="$(string.PrivacySandboxPromptEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrivacySandboxPromptEnabled" presentation="$(presentation.PrivacySandboxPromptEnabled)" valueName="PrivacySandboxPromptEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrivacySandboxSiteEnabledAdsEnabled)" explainText="$(string.PrivacySandboxSiteEnabledAdsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrivacySandboxSiteEnabledAdsEnabled" presentation="$(presentation.PrivacySandboxSiteEnabledAdsEnabled)" valueName="PrivacySandboxSiteEnabledAdsEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ProxyBypassList)" explainText="$(string.ProxyBypassList_Explain)" key="Software\Policies\Google\Chrome" name="ProxyBypassList" presentation="$(presentation.ProxyBypassList)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ProxyBypassList" maxLength="1000000" valueName="ProxyBypassList"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ProxyMode)" explainText="$(string.ProxyMode_Explain)" key="Software\Policies\Google\Chrome" name="ProxyMode" presentation="$(presentation.ProxyMode)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ProxyMode" valueName="ProxyMode">
+          <item displayName="$(string.ProxyMode_ProxyDisabled)">
+            <value>
+              <string>direct</string>
+            </value>
+          </item>
+          <item displayName="$(string.ProxyMode_ProxyAutoDetect)">
+            <value>
+              <string>auto_detect</string>
+            </value>
+          </item>
+          <item displayName="$(string.ProxyMode_ProxyPacScript)">
+            <value>
+              <string>pac_script</string>
+            </value>
+          </item>
+          <item displayName="$(string.ProxyMode_ProxyFixedServers)">
+            <value>
+              <string>fixed_servers</string>
+            </value>
+          </item>
+          <item displayName="$(string.ProxyMode_ProxyUseSystem)">
+            <value>
+              <string>system</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ProxyPacUrl)" explainText="$(string.ProxyPacUrl_Explain)" key="Software\Policies\Google\Chrome" name="ProxyPacUrl" presentation="$(presentation.ProxyPacUrl)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ProxyPacUrl" maxLength="1000000" valueName="ProxyPacUrl"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ProxyServer)" explainText="$(string.ProxyServer_Explain)" key="Software\Policies\Google\Chrome" name="ProxyServer" presentation="$(presentation.ProxyServer)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ProxyServer" maxLength="1000000" valueName="ProxyServer"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ProxyServerMode)" explainText="$(string.ProxyServerMode_Explain)" key="Software\Policies\Google\Chrome" name="ProxyServerMode" presentation="$(presentation.ProxyServerMode)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ProxyServerMode" valueName="ProxyServerMode">
+          <item displayName="$(string.ProxyServerMode_ProxyServerDisabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ProxyServerMode_ProxyServerAutoDetect)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.ProxyServerMode_ProxyServerManual)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.ProxyServerMode_ProxyServerUseSystem)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RelatedWebsiteSetsEnabled)" explainText="$(string.RelatedWebsiteSetsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="RelatedWebsiteSetsEnabled" presentation="$(presentation.RelatedWebsiteSetsEnabled)" valueName="RelatedWebsiteSetsEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RelatedWebsiteSetsOverrides)" explainText="$(string.RelatedWebsiteSetsOverrides_Explain)" key="Software\Policies\Google\Chrome" name="RelatedWebsiteSetsOverrides" presentation="$(presentation.RelatedWebsiteSetsOverrides)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RelatedWebsiteSetsOverrides" maxLength="1000000" valueName="RelatedWebsiteSetsOverrides"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostClientDomain)" explainText="$(string.RemoteAccessHostClientDomain_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostClientDomain" presentation="$(presentation.RemoteAccessHostClientDomain)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RemoteAccessHostClientDomain" maxLength="1000000" valueName="RemoteAccessHostClientDomain"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostDomain)" explainText="$(string.RemoteAccessHostDomain_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostDomain" presentation="$(presentation.RemoteAccessHostDomain)">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RemoteAccessHostDomain" maxLength="1000000" valueName="RemoteAccessHostDomain"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingEnabled)" explainText="$(string.SafeBrowsingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingEnabled" presentation="$(presentation.SafeBrowsingEnabled)" valueName="SafeBrowsingEnabled">
+      <parentCategory ref="DeprecatedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoFillEnabled)" explainText="$(string.AutoFillEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="AutoFillEnabled_recommended" presentation="$(presentation.AutoFillEnabled)" valueName="AutoFillEnabled">
+      <parentCategory ref="DeprecatedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingEnabled)" explainText="$(string.SafeBrowsingEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="SafeBrowsingEnabled_recommended" presentation="$(presentation.SafeBrowsingEnabled)" valueName="SafeBrowsingEnabled">
+      <parentCategory ref="DeprecatedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BlockExternalExtensions)" explainText="$(string.BlockExternalExtensions_Explain)" key="Software\Policies\Google\Chrome" name="BlockExternalExtensions" presentation="$(presentation.BlockExternalExtensions)" valueName="BlockExternalExtensions">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionAllowedTypes)" explainText="$(string.ExtensionAllowedTypes_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionAllowedTypes" presentation="$(presentation.ExtensionAllowedTypes)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionAllowedTypesDesc" key="Software\Policies\Google\Chrome\ExtensionAllowedTypes" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionDeveloperModeSettings)" explainText="$(string.ExtensionDeveloperModeSettings_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionDeveloperModeSettings" presentation="$(presentation.ExtensionDeveloperModeSettings)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ExtensionDeveloperModeSettings" valueName="ExtensionDeveloperModeSettings">
+          <item displayName="$(string.ExtensionDeveloperModeSettings_Allow)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ExtensionDeveloperModeSettings_Disallow)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionExtendedBackgroundLifetimeForPortConnectionsToUrls)" explainText="$(string.ExtensionExtendedBackgroundLifetimeForPortConnectionsToUrls_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionExtendedBackgroundLifetimeForPortConnectionsToUrls" presentation="$(presentation.ExtensionExtendedBackgroundLifetimeForPortConnectionsToUrls)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionExtendedBackgroundLifetimeForPortConnectionsToUrlsDesc" key="Software\Policies\Google\Chrome\ExtensionExtendedBackgroundLifetimeForPortConnectionsToUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionInstallAllowlist)" explainText="$(string.ExtensionInstallAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionInstallAllowlist" presentation="$(presentation.ExtensionInstallAllowlist)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionInstallAllowlistDesc" key="Software\Policies\Google\Chrome\ExtensionInstallAllowlist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionInstallBlocklist)" explainText="$(string.ExtensionInstallBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionInstallBlocklist" presentation="$(presentation.ExtensionInstallBlocklist)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionInstallBlocklistDesc" key="Software\Policies\Google\Chrome\ExtensionInstallBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionInstallForcelist)" explainText="$(string.ExtensionInstallForcelist_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionInstallForcelist" presentation="$(presentation.ExtensionInstallForcelist)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionInstallForcelistDesc" key="Software\Policies\Google\Chrome\ExtensionInstallForcelist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionInstallSources)" explainText="$(string.ExtensionInstallSources_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionInstallSources" presentation="$(presentation.ExtensionInstallSources)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionInstallSourcesDesc" key="Software\Policies\Google\Chrome\ExtensionInstallSources" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionInstallTypeBlocklist)" explainText="$(string.ExtensionInstallTypeBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionInstallTypeBlocklist" presentation="$(presentation.ExtensionInstallTypeBlocklist)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionInstallTypeBlocklistDesc" key="Software\Policies\Google\Chrome\ExtensionInstallTypeBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionSettings)" explainText="$(string.ExtensionSettings_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionSettings" presentation="$(presentation.ExtensionSettings)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ExtensionSettings" maxLength="1000000" valueName="ExtensionSettings"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionUnpublishedAvailability)" explainText="$(string.ExtensionUnpublishedAvailability_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionUnpublishedAvailability" presentation="$(presentation.ExtensionUnpublishedAvailability)">
+      <parentCategory ref="Extensions"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ExtensionUnpublishedAvailability" valueName="ExtensionUnpublishedAvailability">
+          <item displayName="$(string.ExtensionUnpublishedAvailability_AllowUnpublished)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ExtensionUnpublishedAvailability_DisableUnpublished)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AIModeSettings)" explainText="$(string.AIModeSettings_Explain)" key="Software\Policies\Google\Chrome" name="AIModeSettings" presentation="$(presentation.AIModeSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="AIModeSettings" valueName="AIModeSettings">
+          <item displayName="$(string.AIModeSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.AIModeSettings_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutofillPredictionSettings)" explainText="$(string.AutofillPredictionSettings_Explain)" key="Software\Policies\Google\Chrome" name="AutofillPredictionSettings" presentation="$(presentation.AutofillPredictionSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="AutofillPredictionSettings" valueName="AutofillPredictionSettings">
+          <item displayName="$(string.AutofillPredictionSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.AutofillPredictionSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.AutofillPredictionSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CreateThemesSettings)" explainText="$(string.CreateThemesSettings_Explain)" key="Software\Policies\Google\Chrome" name="CreateThemesSettings" presentation="$(presentation.CreateThemesSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="CreateThemesSettings" valueName="CreateThemesSettings">
+          <item displayName="$(string.CreateThemesSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.CreateThemesSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.CreateThemesSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DevToolsGenAiSettings)" explainText="$(string.DevToolsGenAiSettings_Explain)" key="Software\Policies\Google\Chrome" name="DevToolsGenAiSettings" presentation="$(presentation.DevToolsGenAiSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DevToolsGenAiSettings" valueName="DevToolsGenAiSettings">
+          <item displayName="$(string.DevToolsGenAiSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.DevToolsGenAiSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DevToolsGenAiSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.GeminiActOnWebAllowedForURLs)" explainText="$(string.GeminiActOnWebAllowedForURLs_Explain)" key="Software\Policies\Google\Chrome" name="GeminiActOnWebAllowedForURLs" presentation="$(presentation.GeminiActOnWebAllowedForURLs)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="GeminiActOnWebAllowedForURLsDesc" key="Software\Policies\Google\Chrome\GeminiActOnWebAllowedForURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.GeminiActOnWebBlockedForURLs)" explainText="$(string.GeminiActOnWebBlockedForURLs_Explain)" key="Software\Policies\Google\Chrome" name="GeminiActOnWebBlockedForURLs" presentation="$(presentation.GeminiActOnWebBlockedForURLs)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="GeminiActOnWebBlockedForURLsDesc" key="Software\Policies\Google\Chrome\GeminiActOnWebBlockedForURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.GeminiActOnWebSettings)" explainText="$(string.GeminiActOnWebSettings_Explain)" key="Software\Policies\Google\Chrome" name="GeminiActOnWebSettings" presentation="$(presentation.GeminiActOnWebSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="GeminiActOnWebSettings" valueName="GeminiActOnWebSettings">
+          <item displayName="$(string.GeminiActOnWebSettings_Enabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.GeminiActOnWebSettings_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.GeminiSettings)" explainText="$(string.GeminiSettings_Explain)" key="Software\Policies\Google\Chrome" name="GeminiSettings" presentation="$(presentation.GeminiSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="GeminiSettings" valueName="GeminiSettings">
+          <item displayName="$(string.GeminiSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.GeminiSettings_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.GenAILocalFoundationalModelSettings)" explainText="$(string.GenAILocalFoundationalModelSettings_Explain)" key="Software\Policies\Google\Chrome" name="GenAILocalFoundationalModelSettings" presentation="$(presentation.GenAILocalFoundationalModelSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="GenAILocalFoundationalModelSettings" valueName="GenAILocalFoundationalModelSettings">
+          <item displayName="$(string.GenAILocalFoundationalModelSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.GenAILocalFoundationalModelSettings_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.HelpMeWriteSettings)" explainText="$(string.HelpMeWriteSettings_Explain)" key="Software\Policies\Google\Chrome" name="HelpMeWriteSettings" presentation="$(presentation.HelpMeWriteSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="HelpMeWriteSettings" valueName="HelpMeWriteSettings">
+          <item displayName="$(string.HelpMeWriteSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.HelpMeWriteSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.HelpMeWriteSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.HistorySearchSettings)" explainText="$(string.HistorySearchSettings_Explain)" key="Software\Policies\Google\Chrome" name="HistorySearchSettings" presentation="$(presentation.HistorySearchSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="HistorySearchSettings" valueName="HistorySearchSettings">
+          <item displayName="$(string.HistorySearchSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.HistorySearchSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.HistorySearchSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SearchContentSharingSettings)" explainText="$(string.SearchContentSharingSettings_Explain)" key="Software\Policies\Google\Chrome" name="SearchContentSharingSettings" presentation="$(presentation.SearchContentSharingSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="SearchContentSharingSettings" valueName="SearchContentSharingSettings">
+          <item displayName="$(string.SearchContentSharingSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.SearchContentSharingSettings_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.TabCompareSettings)" explainText="$(string.TabCompareSettings_Explain)" key="Software\Policies\Google\Chrome" name="TabCompareSettings" presentation="$(presentation.TabCompareSettings)">
+      <parentCategory ref="GenerativeAI"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="TabCompareSettings" valueName="TabCompareSettings">
+          <item displayName="$(string.TabCompareSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.TabCompareSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.TabCompareSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AccessCodeCastDeviceDuration)" explainText="$(string.AccessCodeCastDeviceDuration_Explain)" key="Software\Policies\Google\Chrome" name="AccessCodeCastDeviceDuration" presentation="$(presentation.AccessCodeCastDeviceDuration)">
+      <parentCategory ref="GoogleCast"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="AccessCodeCastDeviceDuration" maxValue="2000000000" minValue="0" valueName="AccessCodeCastDeviceDuration"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AccessCodeCastEnabled)" explainText="$(string.AccessCodeCastEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AccessCodeCastEnabled" presentation="$(presentation.AccessCodeCastEnabled)" valueName="AccessCodeCastEnabled">
+      <parentCategory ref="GoogleCast"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableMediaRouter)" explainText="$(string.EnableMediaRouter_Explain)" key="Software\Policies\Google\Chrome" name="EnableMediaRouter" presentation="$(presentation.EnableMediaRouter)" valueName="EnableMediaRouter">
+      <parentCategory ref="GoogleCast"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.MediaRouterCastAllowAllIPs)" explainText="$(string.MediaRouterCastAllowAllIPs_Explain)" key="Software\Policies\Google\Chrome" name="MediaRouterCastAllowAllIPs" presentation="$(presentation.MediaRouterCastAllowAllIPs)" valueName="MediaRouterCastAllowAllIPs">
+      <parentCategory ref="GoogleCast"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ShowCastIconInToolbar)" explainText="$(string.ShowCastIconInToolbar_Explain)" key="Software\Policies\Google\Chrome" name="ShowCastIconInToolbar" presentation="$(presentation.ShowCastIconInToolbar)" valueName="ShowCastIconInToolbar">
+      <parentCategory ref="GoogleCast"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ShowCastSessionsStartedByOtherDevices)" explainText="$(string.ShowCastSessionsStartedByOtherDevices_Explain)" key="Software\Policies\Google\Chrome" name="ShowCastSessionsStartedByOtherDevices" presentation="$(presentation.ShowCastSessionsStartedByOtherDevices)" valueName="ShowCastSessionsStartedByOtherDevices">
+      <parentCategory ref="GoogleCast"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllHttpAuthSchemesAllowedForOrigins)" explainText="$(string.AllHttpAuthSchemesAllowedForOrigins_Explain)" key="Software\Policies\Google\Chrome" name="AllHttpAuthSchemesAllowedForOrigins" presentation="$(presentation.AllHttpAuthSchemesAllowedForOrigins)">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AllHttpAuthSchemesAllowedForOriginsDesc" key="Software\Policies\Google\Chrome\AllHttpAuthSchemesAllowedForOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowCrossOriginAuthPrompt)" explainText="$(string.AllowCrossOriginAuthPrompt_Explain)" key="Software\Policies\Google\Chrome" name="AllowCrossOriginAuthPrompt" presentation="$(presentation.AllowCrossOriginAuthPrompt)" valueName="AllowCrossOriginAuthPrompt">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AuthNegotiateDelegateAllowlist)" explainText="$(string.AuthNegotiateDelegateAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="AuthNegotiateDelegateAllowlist" presentation="$(presentation.AuthNegotiateDelegateAllowlist)">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AuthNegotiateDelegateAllowlist" maxLength="1000000" valueName="AuthNegotiateDelegateAllowlist"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AuthSchemes)" explainText="$(string.AuthSchemes_Explain)" key="Software\Policies\Google\Chrome" name="AuthSchemes" presentation="$(presentation.AuthSchemes)">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AuthSchemes" maxLength="1000000" valueName="AuthSchemes"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AuthServerAllowlist)" explainText="$(string.AuthServerAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="AuthServerAllowlist" presentation="$(presentation.AuthServerAllowlist)">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AuthServerAllowlist" maxLength="1000000" valueName="AuthServerAllowlist"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BasicAuthOverHttpEnabled)" explainText="$(string.BasicAuthOverHttpEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BasicAuthOverHttpEnabled" presentation="$(presentation.BasicAuthOverHttpEnabled)" valueName="BasicAuthOverHttpEnabled">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisableAuthNegotiateCnameLookup)" explainText="$(string.DisableAuthNegotiateCnameLookup_Explain)" key="Software\Policies\Google\Chrome" name="DisableAuthNegotiateCnameLookup" presentation="$(presentation.DisableAuthNegotiateCnameLookup)" valueName="DisableAuthNegotiateCnameLookup">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableAuthNegotiatePort)" explainText="$(string.EnableAuthNegotiatePort_Explain)" key="Software\Policies\Google\Chrome" name="EnableAuthNegotiatePort" presentation="$(presentation.EnableAuthNegotiatePort)" valueName="EnableAuthNegotiatePort">
+      <parentCategory ref="HTTPAuthentication"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.IdleTimeout)" explainText="$(string.IdleTimeout_Explain)" key="Software\Policies\Google\Chrome" name="IdleTimeout" presentation="$(presentation.IdleTimeout)">
+      <parentCategory ref="BrowserIdle"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="IdleTimeout" maxValue="2000000000" minValue="1" valueName="IdleTimeout"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.IdleTimeoutActions)" explainText="$(string.IdleTimeoutActions_Explain)" key="Software\Policies\Google\Chrome" name="IdleTimeoutActions" presentation="$(presentation.IdleTimeoutActions)">
+      <parentCategory ref="BrowserIdle"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="IdleTimeoutActionsDesc" key="Software\Policies\Google\Chrome\IdleTimeoutActions" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AlternativeBrowserParameters)" explainText="$(string.AlternativeBrowserParameters_Explain)" key="Software\Policies\Google\Chrome" name="AlternativeBrowserParameters" presentation="$(presentation.AlternativeBrowserParameters)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AlternativeBrowserParametersDesc" key="Software\Policies\Google\Chrome\AlternativeBrowserParameters" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AlternativeBrowserPath)" explainText="$(string.AlternativeBrowserPath_Explain)" key="Software\Policies\Google\Chrome" name="AlternativeBrowserPath" presentation="$(presentation.AlternativeBrowserPath)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AlternativeBrowserPath" maxLength="1000000" valueName="AlternativeBrowserPath"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherChromeParameters)" explainText="$(string.BrowserSwitcherChromeParameters_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherChromeParameters" presentation="$(presentation.BrowserSwitcherChromeParameters)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="BrowserSwitcherChromeParametersDesc" key="Software\Policies\Google\Chrome\BrowserSwitcherChromeParameters" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherChromePath)" explainText="$(string.BrowserSwitcherChromePath_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherChromePath" presentation="$(presentation.BrowserSwitcherChromePath)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="BrowserSwitcherChromePath" maxLength="1000000" valueName="BrowserSwitcherChromePath"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherDelay)" explainText="$(string.BrowserSwitcherDelay_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherDelay" presentation="$(presentation.BrowserSwitcherDelay)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="BrowserSwitcherDelay" maxValue="2000000000" minValue="0" valueName="BrowserSwitcherDelay"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherEnabled)" explainText="$(string.BrowserSwitcherEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherEnabled" presentation="$(presentation.BrowserSwitcherEnabled)" valueName="BrowserSwitcherEnabled">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherExternalGreylistUrl)" explainText="$(string.BrowserSwitcherExternalGreylistUrl_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherExternalGreylistUrl" presentation="$(presentation.BrowserSwitcherExternalGreylistUrl)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="BrowserSwitcherExternalGreylistUrl" maxLength="1000000" valueName="BrowserSwitcherExternalGreylistUrl"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherExternalSitelistUrl)" explainText="$(string.BrowserSwitcherExternalSitelistUrl_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherExternalSitelistUrl" presentation="$(presentation.BrowserSwitcherExternalSitelistUrl)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="BrowserSwitcherExternalSitelistUrl" maxLength="1000000" valueName="BrowserSwitcherExternalSitelistUrl"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherKeepLastChromeTab)" explainText="$(string.BrowserSwitcherKeepLastChromeTab_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherKeepLastChromeTab" presentation="$(presentation.BrowserSwitcherKeepLastChromeTab)" valueName="BrowserSwitcherKeepLastChromeTab">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherParsingMode)" explainText="$(string.BrowserSwitcherParsingMode_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherParsingMode" presentation="$(presentation.BrowserSwitcherParsingMode)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="BrowserSwitcherParsingMode" valueName="BrowserSwitcherParsingMode">
+          <item displayName="$(string.BrowserSwitcherParsingMode_Default)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.BrowserSwitcherParsingMode_IESiteListMode)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherUrlGreylist)" explainText="$(string.BrowserSwitcherUrlGreylist_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherUrlGreylist" presentation="$(presentation.BrowserSwitcherUrlGreylist)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="BrowserSwitcherUrlGreylistDesc" key="Software\Policies\Google\Chrome\BrowserSwitcherUrlGreylist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherUrlList)" explainText="$(string.BrowserSwitcherUrlList_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherUrlList" presentation="$(presentation.BrowserSwitcherUrlList)">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="BrowserSwitcherUrlListDesc" key="Software\Policies\Google\Chrome\BrowserSwitcherUrlList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSwitcherUseIeSitelist)" explainText="$(string.BrowserSwitcherUseIeSitelist_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSwitcherUseIeSitelist" presentation="$(presentation.BrowserSwitcherUseIeSitelist)" valueName="BrowserSwitcherUseIeSitelist">
+      <parentCategory ref="BrowserSwitcher"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkAccessAllowedForUrls)" explainText="$(string.LocalNetworkAccessAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkAccessAllowedForUrls" presentation="$(presentation.LocalNetworkAccessAllowedForUrls)">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LocalNetworkAccessAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\LocalNetworkAccessAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkAccessBlockedForUrls)" explainText="$(string.LocalNetworkAccessBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkAccessBlockedForUrls" presentation="$(presentation.LocalNetworkAccessBlockedForUrls)">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LocalNetworkAccessBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\LocalNetworkAccessBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkAccessIpAddressSpaceOverrides)" explainText="$(string.LocalNetworkAccessIpAddressSpaceOverrides_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkAccessIpAddressSpaceOverrides" presentation="$(presentation.LocalNetworkAccessIpAddressSpaceOverrides)">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LocalNetworkAccessIpAddressSpaceOverridesDesc" key="Software\Policies\Google\Chrome\LocalNetworkAccessIpAddressSpaceOverrides" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkAccessPermissionsPolicyDefaultEnabled)" explainText="$(string.LocalNetworkAccessPermissionsPolicyDefaultEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkAccessPermissionsPolicyDefaultEnabled" presentation="$(presentation.LocalNetworkAccessPermissionsPolicyDefaultEnabled)" valueName="LocalNetworkAccessPermissionsPolicyDefaultEnabled">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkAccessRestrictionsTemporaryOptOut)" explainText="$(string.LocalNetworkAccessRestrictionsTemporaryOptOut_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkAccessRestrictionsTemporaryOptOut" presentation="$(presentation.LocalNetworkAccessRestrictionsTemporaryOptOut)" valueName="LocalNetworkAccessRestrictionsTemporaryOptOut">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkAllowedForUrls)" explainText="$(string.LocalNetworkAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkAllowedForUrls" presentation="$(presentation.LocalNetworkAllowedForUrls)">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LocalNetworkAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\LocalNetworkAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkBlockedForUrls)" explainText="$(string.LocalNetworkBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkBlockedForUrls" presentation="$(presentation.LocalNetworkBlockedForUrls)">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LocalNetworkBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\LocalNetworkBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LoopbackNetworkAllowedForUrls)" explainText="$(string.LoopbackNetworkAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LoopbackNetworkAllowedForUrls" presentation="$(presentation.LoopbackNetworkAllowedForUrls)">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LoopbackNetworkAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\LoopbackNetworkAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LoopbackNetworkBlockedForUrls)" explainText="$(string.LoopbackNetworkBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="LoopbackNetworkBlockedForUrls" presentation="$(presentation.LoopbackNetworkBlockedForUrls)">
+      <parentCategory ref="LocalNetworkAccessSettings"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LoopbackNetworkBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\LoopbackNetworkBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudAPAuthEnabled)" explainText="$(string.CloudAPAuthEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CloudAPAuthEnabled" presentation="$(presentation.CloudAPAuthEnabled)">
+      <parentCategory ref="ActiveDirectoryManagement"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="CloudAPAuthEnabled" valueName="CloudAPAuthEnabled">
+          <item displayName="$(string.CloudAPAuthEnabled_Disabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.CloudAPAuthEnabled_Enabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AbusiveExperienceInterventionEnforce)" explainText="$(string.AbusiveExperienceInterventionEnforce_Explain)" key="Software\Policies\Google\Chrome" name="AbusiveExperienceInterventionEnforce" presentation="$(presentation.AbusiveExperienceInterventionEnforce)" valueName="AbusiveExperienceInterventionEnforce">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AccessibilityImageLabelsEnabled)" explainText="$(string.AccessibilityImageLabelsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AccessibilityImageLabelsEnabled" presentation="$(presentation.AccessibilityImageLabelsEnabled)" valueName="AccessibilityImageLabelsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AdditionalDnsQueryTypesEnabled)" explainText="$(string.AdditionalDnsQueryTypesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AdditionalDnsQueryTypesEnabled" presentation="$(presentation.AdditionalDnsQueryTypesEnabled)" valueName="AdditionalDnsQueryTypesEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AdsSettingForIntrusiveAdsSites)" explainText="$(string.AdsSettingForIntrusiveAdsSites_Explain)" key="Software\Policies\Google\Chrome" name="AdsSettingForIntrusiveAdsSites" presentation="$(presentation.AdsSettingForIntrusiveAdsSites)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="AdsSettingForIntrusiveAdsSites" valueName="AdsSettingForIntrusiveAdsSites">
+          <item displayName="$(string.AdsSettingForIntrusiveAdsSites_AllowAds)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.AdsSettingForIntrusiveAdsSites_BlockAds)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AdvancedProtectionAllowed)" explainText="$(string.AdvancedProtectionAllowed_Explain)" key="Software\Policies\Google\Chrome" name="AdvancedProtectionAllowed" presentation="$(presentation.AdvancedProtectionAllowed)" valueName="AdvancedProtectionAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowBackForwardCacheForCacheControlNoStorePageEnabled)" explainText="$(string.AllowBackForwardCacheForCacheControlNoStorePageEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AllowBackForwardCacheForCacheControlNoStorePageEnabled" presentation="$(presentation.AllowBackForwardCacheForCacheControlNoStorePageEnabled)" valueName="AllowBackForwardCacheForCacheControlNoStorePageEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowDeletingBrowserHistory)" explainText="$(string.AllowDeletingBrowserHistory_Explain)" key="Software\Policies\Google\Chrome" name="AllowDeletingBrowserHistory" presentation="$(presentation.AllowDeletingBrowserHistory)" valueName="AllowDeletingBrowserHistory">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowDinosaurEasterEgg)" explainText="$(string.AllowDinosaurEasterEgg_Explain)" key="Software\Policies\Google\Chrome" name="AllowDinosaurEasterEgg" presentation="$(presentation.AllowDinosaurEasterEgg)" valueName="AllowDinosaurEasterEgg">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowFileSelectionDialogs)" explainText="$(string.AllowFileSelectionDialogs_Explain)" key="Software\Policies\Google\Chrome" name="AllowFileSelectionDialogs" presentation="$(presentation.AllowFileSelectionDialogs)" valueName="AllowFileSelectionDialogs">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowWebAuthnWithBrokenTlsCerts)" explainText="$(string.AllowWebAuthnWithBrokenTlsCerts_Explain)" key="Software\Policies\Google\Chrome" name="AllowWebAuthnWithBrokenTlsCerts" presentation="$(presentation.AllowWebAuthnWithBrokenTlsCerts)" valueName="AllowWebAuthnWithBrokenTlsCerts">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowedDomainsForApps)" explainText="$(string.AllowedDomainsForApps_Explain)" key="Software\Policies\Google\Chrome" name="AllowedDomainsForApps" presentation="$(presentation.AllowedDomainsForApps)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AllowedDomainsForApps" maxLength="1000000" valueName="AllowedDomainsForApps"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AlternateErrorPagesEnabled)" explainText="$(string.AlternateErrorPagesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AlternateErrorPagesEnabled" presentation="$(presentation.AlternateErrorPagesEnabled)" valueName="AlternateErrorPagesEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AlwaysOpenPdfExternally)" explainText="$(string.AlwaysOpenPdfExternally_Explain)" key="Software\Policies\Google\Chrome" name="AlwaysOpenPdfExternally" presentation="$(presentation.AlwaysOpenPdfExternally)" valueName="AlwaysOpenPdfExternally">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AmbientAuthenticationInPrivateModesEnabled)" explainText="$(string.AmbientAuthenticationInPrivateModesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AmbientAuthenticationInPrivateModesEnabled" presentation="$(presentation.AmbientAuthenticationInPrivateModesEnabled)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="AmbientAuthenticationInPrivateModesEnabled" valueName="AmbientAuthenticationInPrivateModesEnabled">
+          <item displayName="$(string.AmbientAuthenticationInPrivateModesEnabled_RegularOnly)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.AmbientAuthenticationInPrivateModesEnabled_IncognitoAndRegular)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.AmbientAuthenticationInPrivateModesEnabled_GuestAndRegular)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.AmbientAuthenticationInPrivateModesEnabled_All)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ApplicationBoundEncryptionEnabled)" explainText="$(string.ApplicationBoundEncryptionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ApplicationBoundEncryptionEnabled" presentation="$(presentation.ApplicationBoundEncryptionEnabled)" valueName="ApplicationBoundEncryptionEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ApplicationLocaleValue)" explainText="$(string.ApplicationLocaleValue_Explain)" key="Software\Policies\Google\Chrome" name="ApplicationLocaleValue" presentation="$(presentation.ApplicationLocaleValue)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ApplicationLocaleValue" maxLength="1000000" valueName="ApplicationLocaleValue"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AudioCaptureAllowed)" explainText="$(string.AudioCaptureAllowed_Explain)" key="Software\Policies\Google\Chrome" name="AudioCaptureAllowed" presentation="$(presentation.AudioCaptureAllowed)" valueName="AudioCaptureAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AudioCaptureAllowedUrls)" explainText="$(string.AudioCaptureAllowedUrls_Explain)" key="Software\Policies\Google\Chrome" name="AudioCaptureAllowedUrls" presentation="$(presentation.AudioCaptureAllowedUrls)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AudioCaptureAllowedUrlsDesc" key="Software\Policies\Google\Chrome\AudioCaptureAllowedUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AudioProcessHighPriorityEnabled)" explainText="$(string.AudioProcessHighPriorityEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AudioProcessHighPriorityEnabled" presentation="$(presentation.AudioProcessHighPriorityEnabled)" valueName="AudioProcessHighPriorityEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AudioSandboxEnabled)" explainText="$(string.AudioSandboxEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AudioSandboxEnabled" presentation="$(presentation.AudioSandboxEnabled)" valueName="AudioSandboxEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoLaunchProtocolsFromOrigins)" explainText="$(string.AutoLaunchProtocolsFromOrigins_Explain)" key="Software\Policies\Google\Chrome" name="AutoLaunchProtocolsFromOrigins" presentation="$(presentation.AutoLaunchProtocolsFromOrigins)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AutoLaunchProtocolsFromOrigins" maxLength="1000000" valueName="AutoLaunchProtocolsFromOrigins"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoOpenAllowedForURLs)" explainText="$(string.AutoOpenAllowedForURLs_Explain)" key="Software\Policies\Google\Chrome" name="AutoOpenAllowedForURLs" presentation="$(presentation.AutoOpenAllowedForURLs)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AutoOpenAllowedForURLsDesc" key="Software\Policies\Google\Chrome\AutoOpenAllowedForURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoOpenFileTypes)" explainText="$(string.AutoOpenFileTypes_Explain)" key="Software\Policies\Google\Chrome" name="AutoOpenFileTypes" presentation="$(presentation.AutoOpenFileTypes)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AutoOpenFileTypesDesc" key="Software\Policies\Google\Chrome\AutoOpenFileTypes" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutofillAddressEnabled)" explainText="$(string.AutofillAddressEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AutofillAddressEnabled" presentation="$(presentation.AutofillAddressEnabled)" valueName="AutofillAddressEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutofillCreditCardEnabled)" explainText="$(string.AutofillCreditCardEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AutofillCreditCardEnabled" presentation="$(presentation.AutofillCreditCardEnabled)" valueName="AutofillCreditCardEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoplayAllowed)" explainText="$(string.AutoplayAllowed_Explain)" key="Software\Policies\Google\Chrome" name="AutoplayAllowed" presentation="$(presentation.AutoplayAllowed)" valueName="AutoplayAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoplayAllowlist)" explainText="$(string.AutoplayAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="AutoplayAllowlist" presentation="$(presentation.AutoplayAllowlist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AutoplayAllowlistDesc" key="Software\Policies\Google\Chrome\AutoplayAllowlist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BackgroundModeEnabled)" explainText="$(string.BackgroundModeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BackgroundModeEnabled" presentation="$(presentation.BackgroundModeEnabled)" valueName="BackgroundModeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BatterySaverModeAvailability)" explainText="$(string.BatterySaverModeAvailability_Explain)" key="Software\Policies\Google\Chrome" name="BatterySaverModeAvailability" presentation="$(presentation.BatterySaverModeAvailability)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="BatterySaverModeAvailability" valueName="BatterySaverModeAvailability">
+          <item displayName="$(string.BatterySaverModeAvailability_Disabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.BatterySaverModeAvailability_EnabledBelowThreshold)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.BatterySaverModeAvailability_EnabledOnBattery)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BlockThirdPartyCookies)" explainText="$(string.BlockThirdPartyCookies_Explain)" key="Software\Policies\Google\Chrome" name="BlockThirdPartyCookies" presentation="$(presentation.BlockThirdPartyCookies)" valueName="BlockThirdPartyCookies">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BookmarkBarEnabled)" explainText="$(string.BookmarkBarEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BookmarkBarEnabled" presentation="$(presentation.BookmarkBarEnabled)" valueName="BookmarkBarEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserAddPersonEnabled)" explainText="$(string.BrowserAddPersonEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BrowserAddPersonEnabled" presentation="$(presentation.BrowserAddPersonEnabled)" valueName="BrowserAddPersonEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserGuestModeEnabled)" explainText="$(string.BrowserGuestModeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BrowserGuestModeEnabled" presentation="$(presentation.BrowserGuestModeEnabled)" valueName="BrowserGuestModeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserGuestModeEnforced)" explainText="$(string.BrowserGuestModeEnforced_Explain)" key="Software\Policies\Google\Chrome" name="BrowserGuestModeEnforced" presentation="$(presentation.BrowserGuestModeEnforced)" valueName="BrowserGuestModeEnforced">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserLabsEnabled)" explainText="$(string.BrowserLabsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BrowserLabsEnabled" presentation="$(presentation.BrowserLabsEnabled)" valueName="BrowserLabsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserLegacyExtensionPointsBlocked)" explainText="$(string.BrowserLegacyExtensionPointsBlocked_Explain)" key="Software\Policies\Google\Chrome" name="BrowserLegacyExtensionPointsBlocked" presentation="$(presentation.BrowserLegacyExtensionPointsBlocked)" valueName="BrowserLegacyExtensionPointsBlocked">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserNetworkTimeQueriesEnabled)" explainText="$(string.BrowserNetworkTimeQueriesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BrowserNetworkTimeQueriesEnabled" presentation="$(presentation.BrowserNetworkTimeQueriesEnabled)" valueName="BrowserNetworkTimeQueriesEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserSignin)" explainText="$(string.BrowserSignin_Explain)" key="Software\Policies\Google\Chrome" name="BrowserSignin" presentation="$(presentation.BrowserSignin)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="BrowserSignin" valueName="BrowserSignin">
+          <item displayName="$(string.BrowserSignin_Disable)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.BrowserSignin_Enable)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.BrowserSignin_Force)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowserThemeColor)" explainText="$(string.BrowserThemeColor_Explain)" key="Software\Policies\Google\Chrome" name="BrowserThemeColor" presentation="$(presentation.BrowserThemeColor)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="BrowserThemeColor" maxLength="1000000" valueName="BrowserThemeColor"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BrowsingDataLifetime)" explainText="$(string.BrowsingDataLifetime_Explain)" key="Software\Policies\Google\Chrome" name="BrowsingDataLifetime" presentation="$(presentation.BrowsingDataLifetime)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="BrowsingDataLifetime" maxLength="1000000" valueName="BrowsingDataLifetime"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BuiltInAIAPIsEnabled)" explainText="$(string.BuiltInAIAPIsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BuiltInAIAPIsEnabled" presentation="$(presentation.BuiltInAIAPIsEnabled)" valueName="BuiltInAIAPIsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BuiltInDnsClientEnabled)" explainText="$(string.BuiltInDnsClientEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BuiltInDnsClientEnabled" presentation="$(presentation.BuiltInDnsClientEnabled)" valueName="BuiltInDnsClientEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CORSNonWildcardRequestHeadersSupport)" explainText="$(string.CORSNonWildcardRequestHeadersSupport_Explain)" key="Software\Policies\Google\Chrome" name="CORSNonWildcardRequestHeadersSupport" presentation="$(presentation.CORSNonWildcardRequestHeadersSupport)" valueName="CORSNonWildcardRequestHeadersSupport">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CacheEncryptionEnabled)" explainText="$(string.CacheEncryptionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CacheEncryptionEnabled" presentation="$(presentation.CacheEncryptionEnabled)" valueName="CacheEncryptionEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CertificateTransparencyEnforcementDisabledForCas)" explainText="$(string.CertificateTransparencyEnforcementDisabledForCas_Explain)" key="Software\Policies\Google\Chrome" name="CertificateTransparencyEnforcementDisabledForCas" presentation="$(presentation.CertificateTransparencyEnforcementDisabledForCas)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CertificateTransparencyEnforcementDisabledForCasDesc" key="Software\Policies\Google\Chrome\CertificateTransparencyEnforcementDisabledForCas" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CertificateTransparencyEnforcementDisabledForUrls)" explainText="$(string.CertificateTransparencyEnforcementDisabledForUrls_Explain)" key="Software\Policies\Google\Chrome" name="CertificateTransparencyEnforcementDisabledForUrls" presentation="$(presentation.CertificateTransparencyEnforcementDisabledForUrls)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CertificateTransparencyEnforcementDisabledForUrlsDesc" key="Software\Policies\Google\Chrome\CertificateTransparencyEnforcementDisabledForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ChromeForTestingAllowed)" explainText="$(string.ChromeForTestingAllowed_Explain)" key="Software\Policies\Google\Chrome" name="ChromeForTestingAllowed" presentation="$(presentation.ChromeForTestingAllowed)" valueName="ChromeForTestingAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ChromeVariations)" explainText="$(string.ChromeVariations_Explain)" key="Software\Policies\Google\Chrome" name="ChromeVariations" presentation="$(presentation.ChromeVariations)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ChromeVariations" valueName="ChromeVariations">
+          <item displayName="$(string.ChromeVariations_VariationsEnabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ChromeVariations_CriticalFixesOnly)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.ChromeVariations_VariationsDisabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ClearBrowsingDataOnExitList)" explainText="$(string.ClearBrowsingDataOnExitList_Explain)" key="Software\Policies\Google\Chrome" name="ClearBrowsingDataOnExitList" presentation="$(presentation.ClearBrowsingDataOnExitList)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ClearBrowsingDataOnExitListDesc" key="Software\Policies\Google\Chrome\ClearBrowsingDataOnExitList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ClickToCallEnabled)" explainText="$(string.ClickToCallEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ClickToCallEnabled" presentation="$(presentation.ClickToCallEnabled)" valueName="ClickToCallEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudManagementEnrollmentMandatory)" explainText="$(string.CloudManagementEnrollmentMandatory_Explain)" key="Software\Policies\Google\Chrome" name="CloudManagementEnrollmentMandatory" presentation="$(presentation.CloudManagementEnrollmentMandatory)" valueName="CloudManagementEnrollmentMandatory">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudManagementEnrollmentToken)" explainText="$(string.CloudManagementEnrollmentToken_Explain)" key="Software\Policies\Google\Chrome" name="CloudManagementEnrollmentToken" presentation="$(presentation.CloudManagementEnrollmentToken)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="CloudManagementEnrollmentToken" maxLength="1000000" valueName="CloudManagementEnrollmentToken"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudPolicyOverridesPlatformPolicy)" explainText="$(string.CloudPolicyOverridesPlatformPolicy_Explain)" key="Software\Policies\Google\Chrome" name="CloudPolicyOverridesPlatformPolicy" presentation="$(presentation.CloudPolicyOverridesPlatformPolicy)" valueName="CloudPolicyOverridesPlatformPolicy">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudUserPolicyMerge)" explainText="$(string.CloudUserPolicyMerge_Explain)" key="Software\Policies\Google\Chrome" name="CloudUserPolicyMerge" presentation="$(presentation.CloudUserPolicyMerge)" valueName="CloudUserPolicyMerge">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudUserPolicyOverridesCloudMachinePolicy)" explainText="$(string.CloudUserPolicyOverridesCloudMachinePolicy_Explain)" key="Software\Policies\Google\Chrome" name="CloudUserPolicyOverridesCloudMachinePolicy" presentation="$(presentation.CloudUserPolicyOverridesCloudMachinePolicy)" valueName="CloudUserPolicyOverridesCloudMachinePolicy">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CommandLineFlagSecurityWarningsEnabled)" explainText="$(string.CommandLineFlagSecurityWarningsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CommandLineFlagSecurityWarningsEnabled" presentation="$(presentation.CommandLineFlagSecurityWarningsEnabled)" valueName="CommandLineFlagSecurityWarningsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ComponentUpdatesEnabled)" explainText="$(string.ComponentUpdatesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ComponentUpdatesEnabled" presentation="$(presentation.ComponentUpdatesEnabled)" valueName="ComponentUpdatesEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CpuPerformanceTierOverride)" explainText="$(string.CpuPerformanceTierOverride_Explain)" key="Software\Policies\Google\Chrome" name="CpuPerformanceTierOverride" presentation="$(presentation.CpuPerformanceTierOverride)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="CpuPerformanceTierOverride" maxValue="4" minValue="0" valueName="CpuPerformanceTierOverride"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DNSInterceptionChecksEnabled)" explainText="$(string.DNSInterceptionChecksEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DNSInterceptionChecksEnabled" presentation="$(presentation.DNSInterceptionChecksEnabled)" valueName="DNSInterceptionChecksEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DataUrlInWebWorkerOpaqueOriginEnabled)" explainText="$(string.DataUrlInWebWorkerOpaqueOriginEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DataUrlInWebWorkerOpaqueOriginEnabled" presentation="$(presentation.DataUrlInWebWorkerOpaqueOriginEnabled)" valueName="DataUrlInWebWorkerOpaqueOriginEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultBrowserSettingEnabled)" explainText="$(string.DefaultBrowserSettingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DefaultBrowserSettingEnabled" presentation="$(presentation.DefaultBrowserSettingEnabled)" valueName="DefaultBrowserSettingEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7_ONLY"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderContextMenuAccessAllowed)" explainText="$(string.DefaultSearchProviderContextMenuAccessAllowed_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderContextMenuAccessAllowed" presentation="$(presentation.DefaultSearchProviderContextMenuAccessAllowed)" valueName="DefaultSearchProviderContextMenuAccessAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DesktopSharingHubEnabled)" explainText="$(string.DesktopSharingHubEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DesktopSharingHubEnabled" presentation="$(presentation.DesktopSharingHubEnabled)" valueName="DesktopSharingHubEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DevToolsGoogleDeveloperProgramProfileAvailability)" explainText="$(string.DevToolsGoogleDeveloperProgramProfileAvailability_Explain)" key="Software\Policies\Google\Chrome" name="DevToolsGoogleDeveloperProgramProfileAvailability" presentation="$(presentation.DevToolsGoogleDeveloperProgramProfileAvailability)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DevToolsGoogleDeveloperProgramProfileAvailability" valueName="DevToolsGoogleDeveloperProgramProfileAvailability">
+          <item displayName="$(string.DevToolsGoogleDeveloperProgramProfileAvailability_Enabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.DevToolsGoogleDeveloperProgramProfileAvailability_EnabledWithoutBadges)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DevToolsGoogleDeveloperProgramProfileAvailability_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DeveloperToolsAvailability)" explainText="$(string.DeveloperToolsAvailability_Explain)" key="Software\Policies\Google\Chrome" name="DeveloperToolsAvailability" presentation="$(presentation.DeveloperToolsAvailability)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DeveloperToolsAvailability" valueName="DeveloperToolsAvailability">
+          <item displayName="$(string.DeveloperToolsAvailability_DeveloperToolsDisallowedForForceInstalledExtensions)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.DeveloperToolsAvailability_DeveloperToolsAllowed)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DeveloperToolsAvailability_DeveloperToolsDisallowed)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DeveloperToolsAvailabilityAllowlist)" explainText="$(string.DeveloperToolsAvailabilityAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="DeveloperToolsAvailabilityAllowlist" presentation="$(presentation.DeveloperToolsAvailabilityAllowlist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DeveloperToolsAvailabilityAllowlistDesc" key="Software\Policies\Google\Chrome\DeveloperToolsAvailabilityAllowlist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DeveloperToolsAvailabilityBlocklist)" explainText="$(string.DeveloperToolsAvailabilityBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="DeveloperToolsAvailabilityBlocklist" presentation="$(presentation.DeveloperToolsAvailabilityBlocklist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DeveloperToolsAvailabilityBlocklistDesc" key="Software\Policies\Google\Chrome\DeveloperToolsAvailabilityBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.Disable3DAPIs)" explainText="$(string.Disable3DAPIs_Explain)" key="Software\Policies\Google\Chrome" name="Disable3DAPIs" presentation="$(presentation.Disable3DAPIs)" valueName="Disable3DAPIs">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisableScreenshots)" explainText="$(string.DisableScreenshots_Explain)" key="Software\Policies\Google\Chrome" name="DisableScreenshots" presentation="$(presentation.DisableScreenshots)" valueName="DisableScreenshots">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DiskCacheDir)" explainText="$(string.DiskCacheDir_Explain)" key="Software\Policies\Google\Chrome" name="DiskCacheDir" presentation="$(presentation.DiskCacheDir)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DiskCacheDir" maxLength="1000000" valueName="DiskCacheDir"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DiskCacheSize)" explainText="$(string.DiskCacheSize_Explain)" key="Software\Policies\Google\Chrome" name="DiskCacheSize" presentation="$(presentation.DiskCacheSize)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="DiskCacheSize" maxValue="2000000000" minValue="0" valueName="DiskCacheSize"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DnsOverHttpsMode)" explainText="$(string.DnsOverHttpsMode_Explain)" key="Software\Policies\Google\Chrome" name="DnsOverHttpsMode" presentation="$(presentation.DnsOverHttpsMode)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DnsOverHttpsMode" valueName="DnsOverHttpsMode">
+          <item displayName="$(string.DnsOverHttpsMode_off)">
+            <value>
+              <string>off</string>
+            </value>
+          </item>
+          <item displayName="$(string.DnsOverHttpsMode_automatic)">
+            <value>
+              <string>automatic</string>
+            </value>
+          </item>
+          <item displayName="$(string.DnsOverHttpsMode_secure)">
+            <value>
+              <string>secure</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DnsOverHttpsTemplates)" explainText="$(string.DnsOverHttpsTemplates_Explain)" key="Software\Policies\Google\Chrome" name="DnsOverHttpsTemplates" presentation="$(presentation.DnsOverHttpsTemplates)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DnsOverHttpsTemplates" maxLength="1000000" valueName="DnsOverHttpsTemplates"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DomainReliabilityAllowed)" explainText="$(string.DomainReliabilityAllowed_Explain)" key="Software\Policies\Google\Chrome" name="DomainReliabilityAllowed" presentation="$(presentation.DomainReliabilityAllowed)" valueName="DomainReliabilityAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DownloadDirectory)" explainText="$(string.DownloadDirectory_Explain)" key="Software\Policies\Google\Chrome" name="DownloadDirectory" presentation="$(presentation.DownloadDirectory)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DownloadDirectory" maxLength="1000000" valueName="DownloadDirectory"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DownloadRestrictions)" explainText="$(string.DownloadRestrictions_Explain)" key="Software\Policies\Google\Chrome" name="DownloadRestrictions" presentation="$(presentation.DownloadRestrictions)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DownloadRestrictions" valueName="DownloadRestrictions">
+          <item displayName="$(string.DownloadRestrictions_DefaultDownloadSecurity)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockDangerousDownloads)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockPotentiallyDangerousDownloads)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockAllDownloads)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockMaliciousDownloads)">
+            <value>
+              <decimal value="4"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DynamicCodeSettings)" explainText="$(string.DynamicCodeSettings_Explain)" key="Software\Policies\Google\Chrome" name="DynamicCodeSettings" presentation="$(presentation.DynamicCodeSettings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DynamicCodeSettings" valueName="DynamicCodeSettings">
+          <item displayName="$(string.DynamicCodeSettings_Default)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.DynamicCodeSettings_DisabledForBrowser)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EditBookmarksEnabled)" explainText="$(string.EditBookmarksEnabled_Explain)" key="Software\Policies\Google\Chrome" name="EditBookmarksEnabled" presentation="$(presentation.EditBookmarksEnabled)" valueName="EditBookmarksEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableExperimentalPolicies)" explainText="$(string.EnableExperimentalPolicies_Explain)" key="Software\Policies\Google\Chrome" name="EnableExperimentalPolicies" presentation="$(presentation.EnableExperimentalPolicies)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="EnableExperimentalPoliciesDesc" key="Software\Policies\Google\Chrome\EnableExperimentalPolicies" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableOnlineRevocationChecks)" explainText="$(string.EnableOnlineRevocationChecks_Explain)" key="Software\Policies\Google\Chrome" name="EnableOnlineRevocationChecks" presentation="$(presentation.EnableOnlineRevocationChecks)" valueName="EnableOnlineRevocationChecks">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableUnsafeSwiftShader)" explainText="$(string.EnableUnsafeSwiftShader_Explain)" key="Software\Policies\Google\Chrome" name="EnableUnsafeSwiftShader" presentation="$(presentation.EnableUnsafeSwiftShader)" valueName="EnableUnsafeSwiftShader">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EncryptedClientHelloEnabled)" explainText="$(string.EncryptedClientHelloEnabled_Explain)" key="Software\Policies\Google\Chrome" name="EncryptedClientHelloEnabled" presentation="$(presentation.EncryptedClientHelloEnabled)" valueName="EncryptedClientHelloEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseCustomLabel)" explainText="$(string.EnterpriseCustomLabel_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseCustomLabel" presentation="$(presentation.EnterpriseCustomLabel)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="EnterpriseCustomLabel" maxLength="1000000" valueName="EnterpriseCustomLabel"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseCustomLabelForBrowser)" explainText="$(string.EnterpriseCustomLabelForBrowser_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseCustomLabelForBrowser" presentation="$(presentation.EnterpriseCustomLabelForBrowser)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="EnterpriseCustomLabelForBrowser" maxLength="1000000" valueName="EnterpriseCustomLabelForBrowser"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseHardwarePlatformAPIEnabled)" explainText="$(string.EnterpriseHardwarePlatformAPIEnabled_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseHardwarePlatformAPIEnabled" presentation="$(presentation.EnterpriseHardwarePlatformAPIEnabled)" valueName="EnterpriseHardwarePlatformAPIEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseLogoUrl)" explainText="$(string.EnterpriseLogoUrl_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseLogoUrl" presentation="$(presentation.EnterpriseLogoUrl)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="EnterpriseLogoUrl" maxLength="1000000" valueName="EnterpriseLogoUrl"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseLogoUrlForBrowser)" explainText="$(string.EnterpriseLogoUrlForBrowser_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseLogoUrlForBrowser" presentation="$(presentation.EnterpriseLogoUrlForBrowser)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="EnterpriseLogoUrlForBrowser" maxLength="1000000" valueName="EnterpriseLogoUrlForBrowser"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseProfileBadgeToolbarSettings)" explainText="$(string.EnterpriseProfileBadgeToolbarSettings_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseProfileBadgeToolbarSettings" presentation="$(presentation.EnterpriseProfileBadgeToolbarSettings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="EnterpriseProfileBadgeToolbarSettings" valueName="EnterpriseProfileBadgeToolbarSettings">
+          <item displayName="$(string.EnterpriseProfileBadgeToolbarSettings_show_enterprise_toolbar_badge)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.EnterpriseProfileBadgeToolbarSettings_hide_enterprise_toolbar_badge)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseProfileCreationKeepBrowsingData)" explainText="$(string.EnterpriseProfileCreationKeepBrowsingData_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseProfileCreationKeepBrowsingData" presentation="$(presentation.EnterpriseProfileCreationKeepBrowsingData)" valueName="EnterpriseProfileCreationKeepBrowsingData">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseSearchAggregatorSettings)" explainText="$(string.EnterpriseSearchAggregatorSettings_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseSearchAggregatorSettings" presentation="$(presentation.EnterpriseSearchAggregatorSettings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="EnterpriseSearchAggregatorSettings" maxLength="1000000" valueName="EnterpriseSearchAggregatorSettings"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExemptDomainFileTypePairsFromFileTypeDownloadWarnings)" explainText="$(string.ExemptDomainFileTypePairsFromFileTypeDownloadWarnings_Explain)" key="Software\Policies\Google\Chrome" name="ExemptDomainFileTypePairsFromFileTypeDownloadWarnings" presentation="$(presentation.ExemptDomainFileTypePairsFromFileTypeDownloadWarnings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ExemptDomainFileTypePairsFromFileTypeDownloadWarnings" maxLength="1000000" valueName="ExemptDomainFileTypePairsFromFileTypeDownloadWarnings"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExplicitlyAllowedNetworkPorts)" explainText="$(string.ExplicitlyAllowedNetworkPorts_Explain)" key="Software\Policies\Google\Chrome" name="ExplicitlyAllowedNetworkPorts" presentation="$(presentation.ExplicitlyAllowedNetworkPorts)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExplicitlyAllowedNetworkPortsDesc" key="Software\Policies\Google\Chrome\ExplicitlyAllowedNetworkPorts" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExternalProtocolDialogShowAlwaysOpenCheckbox)" explainText="$(string.ExternalProtocolDialogShowAlwaysOpenCheckbox_Explain)" key="Software\Policies\Google\Chrome" name="ExternalProtocolDialogShowAlwaysOpenCheckbox" presentation="$(presentation.ExternalProtocolDialogShowAlwaysOpenCheckbox)" valueName="ExternalProtocolDialogShowAlwaysOpenCheckbox">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.FeedbackSurveysEnabled)" explainText="$(string.FeedbackSurveysEnabled_Explain)" key="Software\Policies\Google\Chrome" name="FeedbackSurveysEnabled" presentation="$(presentation.FeedbackSurveysEnabled)" valueName="FeedbackSurveysEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.FetchKeepaliveDurationSecondsOnShutdown)" explainText="$(string.FetchKeepaliveDurationSecondsOnShutdown_Explain)" key="Software\Policies\Google\Chrome" name="FetchKeepaliveDurationSecondsOnShutdown" presentation="$(presentation.FetchKeepaliveDurationSecondsOnShutdown)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="FetchKeepaliveDurationSecondsOnShutdown" maxValue="5" minValue="0" valueName="FetchKeepaliveDurationSecondsOnShutdown"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileOrDirectoryPickerWithoutGestureAllowedForOrigins)" explainText="$(string.FileOrDirectoryPickerWithoutGestureAllowedForOrigins_Explain)" key="Software\Policies\Google\Chrome" name="FileOrDirectoryPickerWithoutGestureAllowedForOrigins" presentation="$(presentation.FileOrDirectoryPickerWithoutGestureAllowedForOrigins)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="FileOrDirectoryPickerWithoutGestureAllowedForOriginsDesc" key="Software\Policies\Google\Chrome\FileOrDirectoryPickerWithoutGestureAllowedForOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceEphemeralProfiles)" explainText="$(string.ForceEphemeralProfiles_Explain)" key="Software\Policies\Google\Chrome" name="ForceEphemeralProfiles" presentation="$(presentation.ForceEphemeralProfiles)" valueName="ForceEphemeralProfiles">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceForegroundPriorityForAllTabs)" explainText="$(string.ForceForegroundPriorityForAllTabs_Explain)" key="Software\Policies\Google\Chrome" name="ForceForegroundPriorityForAllTabs" presentation="$(presentation.ForceForegroundPriorityForAllTabs)" valueName="ForceForegroundPriorityForAllTabs">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceForegroundPriorityForUrls)" explainText="$(string.ForceForegroundPriorityForUrls_Explain)" key="Software\Policies\Google\Chrome" name="ForceForegroundPriorityForUrls" presentation="$(presentation.ForceForegroundPriorityForUrls)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ForceForegroundPriorityForUrlsDesc" key="Software\Policies\Google\Chrome\ForceForegroundPriorityForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceGoogleSafeSearch)" explainText="$(string.ForceGoogleSafeSearch_Explain)" key="Software\Policies\Google\Chrome" name="ForceGoogleSafeSearch" presentation="$(presentation.ForceGoogleSafeSearch)" valueName="ForceGoogleSafeSearch">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForcePermissionPolicyUnloadDefaultEnabled)" explainText="$(string.ForcePermissionPolicyUnloadDefaultEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ForcePermissionPolicyUnloadDefaultEnabled" presentation="$(presentation.ForcePermissionPolicyUnloadDefaultEnabled)" valueName="ForcePermissionPolicyUnloadDefaultEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceYouTubeRestrict)" explainText="$(string.ForceYouTubeRestrict_Explain)" key="Software\Policies\Google\Chrome" name="ForceYouTubeRestrict" presentation="$(presentation.ForceYouTubeRestrict)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ForceYouTubeRestrict" valueName="ForceYouTubeRestrict">
+          <item displayName="$(string.ForceYouTubeRestrict_Off)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ForceYouTubeRestrict_Moderate)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.ForceYouTubeRestrict_Strict)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ForcedLanguages)" explainText="$(string.ForcedLanguages_Explain)" key="Software\Policies\Google\Chrome" name="ForcedLanguages" presentation="$(presentation.ForcedLanguages)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ForcedLanguagesDesc" key="Software\Policies\Google\Chrome\ForcedLanguages" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FullscreenAllowed)" explainText="$(string.FullscreenAllowed_Explain)" key="Software\Policies\Google\Chrome" name="FullscreenAllowed" presentation="$(presentation.FullscreenAllowed)" valueName="FullscreenAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.GloballyScopeHTTPAuthCacheEnabled)" explainText="$(string.GloballyScopeHTTPAuthCacheEnabled_Explain)" key="Software\Policies\Google\Chrome" name="GloballyScopeHTTPAuthCacheEnabled" presentation="$(presentation.GloballyScopeHTTPAuthCacheEnabled)" valueName="GloballyScopeHTTPAuthCacheEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.GoogleSearchSidePanelEnabled)" explainText="$(string.GoogleSearchSidePanelEnabled_Explain)" key="Software\Policies\Google\Chrome" name="GoogleSearchSidePanelEnabled" presentation="$(presentation.GoogleSearchSidePanelEnabled)" valueName="GoogleSearchSidePanelEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HSTSPolicyBypassList)" explainText="$(string.HSTSPolicyBypassList_Explain)" key="Software\Policies\Google\Chrome" name="HSTSPolicyBypassList" presentation="$(presentation.HSTSPolicyBypassList)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="HSTSPolicyBypassListDesc" key="Software\Policies\Google\Chrome\HSTSPolicyBypassList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.HardwareAccelerationModeEnabled)" explainText="$(string.HardwareAccelerationModeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="HardwareAccelerationModeEnabled" presentation="$(presentation.HardwareAccelerationModeEnabled)" valueName="HardwareAccelerationModeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HeadlessMode)" explainText="$(string.HeadlessMode_Explain)" key="Software\Policies\Google\Chrome" name="HeadlessMode" presentation="$(presentation.HeadlessMode)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="HeadlessMode" valueName="HeadlessMode">
+          <item displayName="$(string.HeadlessMode_Enabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.HeadlessMode_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.HideWebStoreIcon)" explainText="$(string.HideWebStoreIcon_Explain)" key="Software\Policies\Google\Chrome" name="HideWebStoreIcon" presentation="$(presentation.HideWebStoreIcon)" valueName="HideWebStoreIcon">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HighEfficiencyModeEnabled)" explainText="$(string.HighEfficiencyModeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="HighEfficiencyModeEnabled" presentation="$(presentation.HighEfficiencyModeEnabled)" valueName="HighEfficiencyModeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HistoryClustersVisible)" explainText="$(string.HistoryClustersVisible_Explain)" key="Software\Policies\Google\Chrome" name="HistoryClustersVisible" presentation="$(presentation.HistoryClustersVisible)" valueName="HistoryClustersVisible">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HttpAllowlist)" explainText="$(string.HttpAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="HttpAllowlist" presentation="$(presentation.HttpAllowlist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="HttpAllowlistDesc" key="Software\Policies\Google\Chrome\HttpAllowlist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.HttpsOnlyMode)" explainText="$(string.HttpsOnlyMode_Explain)" key="Software\Policies\Google\Chrome" name="HttpsOnlyMode" presentation="$(presentation.HttpsOnlyMode)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="HttpsOnlyMode" valueName="HttpsOnlyMode">
+          <item displayName="$(string.HttpsOnlyMode_allowed)">
+            <value>
+              <string>allowed</string>
+            </value>
+          </item>
+          <item displayName="$(string.HttpsOnlyMode_disallowed)">
+            <value>
+              <string>disallowed</string>
+            </value>
+          </item>
+          <item displayName="$(string.HttpsOnlyMode_force_enabled)">
+            <value>
+              <string>force_enabled</string>
+            </value>
+          </item>
+          <item displayName="$(string.HttpsOnlyMode_force_balanced_enabled)">
+            <value>
+              <string>force_balanced_enabled</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.HttpsUpgradesEnabled)" explainText="$(string.HttpsUpgradesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="HttpsUpgradesEnabled" presentation="$(presentation.HttpsUpgradesEnabled)" valueName="HttpsUpgradesEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportAutofillFormData)" explainText="$(string.ImportAutofillFormData_Explain)" key="Software\Policies\Google\Chrome" name="ImportAutofillFormData" presentation="$(presentation.ImportAutofillFormData)" valueName="ImportAutofillFormData">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportBookmarks)" explainText="$(string.ImportBookmarks_Explain)" key="Software\Policies\Google\Chrome" name="ImportBookmarks" presentation="$(presentation.ImportBookmarks)" valueName="ImportBookmarks">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportHistory)" explainText="$(string.ImportHistory_Explain)" key="Software\Policies\Google\Chrome" name="ImportHistory" presentation="$(presentation.ImportHistory)" valueName="ImportHistory">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportHomepage)" explainText="$(string.ImportHomepage_Explain)" key="Software\Policies\Google\Chrome" name="ImportHomepage" presentation="$(presentation.ImportHomepage)" valueName="ImportHomepage">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportSavedPasswords)" explainText="$(string.ImportSavedPasswords_Explain)" key="Software\Policies\Google\Chrome" name="ImportSavedPasswords" presentation="$(presentation.ImportSavedPasswords)" valueName="ImportSavedPasswords">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportSearchEngine)" explainText="$(string.ImportSearchEngine_Explain)" key="Software\Policies\Google\Chrome" name="ImportSearchEngine" presentation="$(presentation.ImportSearchEngine)" valueName="ImportSearchEngine">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.IncognitoModeAvailability)" explainText="$(string.IncognitoModeAvailability_Explain)" key="Software\Policies\Google\Chrome" name="IncognitoModeAvailability" presentation="$(presentation.IncognitoModeAvailability)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="IncognitoModeAvailability" valueName="IncognitoModeAvailability">
+          <item displayName="$(string.IncognitoModeAvailability_Enabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.IncognitoModeAvailability_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.IncognitoModeAvailability_Forced)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.IncognitoModeUrlAllowlist)" explainText="$(string.IncognitoModeUrlAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="IncognitoModeUrlAllowlist" presentation="$(presentation.IncognitoModeUrlAllowlist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="IncognitoModeUrlAllowlistDesc" key="Software\Policies\Google\Chrome\IncognitoModeUrlAllowlist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.IncognitoModeUrlBlocklist)" explainText="$(string.IncognitoModeUrlBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="IncognitoModeUrlBlocklist" presentation="$(presentation.IncognitoModeUrlBlocklist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="IncognitoModeUrlBlocklistDesc" key="Software\Policies\Google\Chrome\IncognitoModeUrlBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.IntensiveWakeUpThrottlingEnabled)" explainText="$(string.IntensiveWakeUpThrottlingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="IntensiveWakeUpThrottlingEnabled" presentation="$(presentation.IntensiveWakeUpThrottlingEnabled)" valueName="IntensiveWakeUpThrottlingEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.IntranetRedirectBehavior)" explainText="$(string.IntranetRedirectBehavior_Explain)" key="Software\Policies\Google\Chrome" name="IntranetRedirectBehavior" presentation="$(presentation.IntranetRedirectBehavior)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="IntranetRedirectBehavior" valueName="IntranetRedirectBehavior">
+          <item displayName="$(string.IntranetRedirectBehavior_Default)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.IntranetRedirectBehavior_DisableInterceptionChecksDisableInfobar)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.IntranetRedirectBehavior_DisableInterceptionChecksEnableInfobar)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.IntranetRedirectBehavior_EnableInterceptionChecksEnableInfobar)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.IsolateOrigins)" explainText="$(string.IsolateOrigins_Explain)" key="Software\Policies\Google\Chrome" name="IsolateOrigins" presentation="$(presentation.IsolateOrigins)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="IsolateOrigins" maxLength="1000000" valueName="IsolateOrigins"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LookalikeWarningAllowlistDomains)" explainText="$(string.LookalikeWarningAllowlistDomains_Explain)" key="Software\Policies\Google\Chrome" name="LookalikeWarningAllowlistDomains" presentation="$(presentation.LookalikeWarningAllowlistDomains)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LookalikeWarningAllowlistDomainsDesc" key="Software\Policies\Google\Chrome\LookalikeWarningAllowlistDomains" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ManagedBookmarks)" explainText="$(string.ManagedBookmarks_Explain)" key="Software\Policies\Google\Chrome" name="ManagedBookmarks" presentation="$(presentation.ManagedBookmarks)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ManagedBookmarks" maxLength="1000000" valueName="ManagedBookmarks"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ManagedConfigurationPerOrigin)" explainText="$(string.ManagedConfigurationPerOrigin_Explain)" key="Software\Policies\Google\Chrome" name="ManagedConfigurationPerOrigin" presentation="$(presentation.ManagedConfigurationPerOrigin)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ManagedConfigurationPerOrigin" maxLength="1000000" valueName="ManagedConfigurationPerOrigin"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.MaxConnectionsPerProxy)" explainText="$(string.MaxConnectionsPerProxy_Explain)" key="Software\Policies\Google\Chrome" name="MaxConnectionsPerProxy" presentation="$(presentation.MaxConnectionsPerProxy)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="MaxConnectionsPerProxy" maxValue="256" minValue="6" valueName="MaxConnectionsPerProxy"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.MaxConnectionsPerProxyForWebSocket)" explainText="$(string.MaxConnectionsPerProxyForWebSocket_Explain)" key="Software\Policies\Google\Chrome" name="MaxConnectionsPerProxyForWebSocket" presentation="$(presentation.MaxConnectionsPerProxyForWebSocket)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="MaxConnectionsPerProxyForWebSocket" maxValue="256" minValue="6" valueName="MaxConnectionsPerProxyForWebSocket"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.MaxInvalidationFetchDelay)" explainText="$(string.MaxInvalidationFetchDelay_Explain)" key="Software\Policies\Google\Chrome" name="MaxInvalidationFetchDelay" presentation="$(presentation.MaxInvalidationFetchDelay)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="MaxInvalidationFetchDelay" maxValue="300000" minValue="1000" valueName="MaxInvalidationFetchDelay"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.MediaRecommendationsEnabled)" explainText="$(string.MediaRecommendationsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="MediaRecommendationsEnabled" presentation="$(presentation.MediaRecommendationsEnabled)" valueName="MediaRecommendationsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.MemorySaverModeSavings)" explainText="$(string.MemorySaverModeSavings_Explain)" key="Software\Policies\Google\Chrome" name="MemorySaverModeSavings" presentation="$(presentation.MemorySaverModeSavings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="MemorySaverModeSavings" valueName="MemorySaverModeSavings">
+          <item displayName="$(string.MemorySaverModeSavings_Moderate)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.MemorySaverModeSavings_Balanced)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.MemorySaverModeSavings_Maximum)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.MetricsReportingEnabled)" explainText="$(string.MetricsReportingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="MetricsReportingEnabled" presentation="$(presentation.MetricsReportingEnabled)" valueName="MetricsReportingEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPCardsVisible)" explainText="$(string.NTPCardsVisible_Explain)" key="Software\Policies\Google\Chrome" name="NTPCardsVisible" presentation="$(presentation.NTPCardsVisible)" valueName="NTPCardsVisible">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPCustomBackgroundEnabled)" explainText="$(string.NTPCustomBackgroundEnabled_Explain)" key="Software\Policies\Google\Chrome" name="NTPCustomBackgroundEnabled" presentation="$(presentation.NTPCustomBackgroundEnabled)" valueName="NTPCustomBackgroundEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPFooterExtensionAttributionEnabled)" explainText="$(string.NTPFooterExtensionAttributionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="NTPFooterExtensionAttributionEnabled" presentation="$(presentation.NTPFooterExtensionAttributionEnabled)" valueName="NTPFooterExtensionAttributionEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPFooterManagementNoticeEnabled)" explainText="$(string.NTPFooterManagementNoticeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="NTPFooterManagementNoticeEnabled" presentation="$(presentation.NTPFooterManagementNoticeEnabled)" valueName="NTPFooterManagementNoticeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPMiddleSlotAnnouncementVisible)" explainText="$(string.NTPMiddleSlotAnnouncementVisible_Explain)" key="Software\Policies\Google\Chrome" name="NTPMiddleSlotAnnouncementVisible" presentation="$(presentation.NTPMiddleSlotAnnouncementVisible)" valueName="NTPMiddleSlotAnnouncementVisible">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPOutlookCardVisible)" explainText="$(string.NTPOutlookCardVisible_Explain)" key="Software\Policies\Google\Chrome" name="NTPOutlookCardVisible" presentation="$(presentation.NTPOutlookCardVisible)" valueName="NTPOutlookCardVisible">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPSharepointCardVisible)" explainText="$(string.NTPSharepointCardVisible_Explain)" key="Software\Policies\Google\Chrome" name="NTPSharepointCardVisible" presentation="$(presentation.NTPSharepointCardVisible)" valueName="NTPSharepointCardVisible">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NTPShortcuts)" explainText="$(string.NTPShortcuts_Explain)" key="Software\Policies\Google\Chrome" name="NTPShortcuts" presentation="$(presentation.NTPShortcuts)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="NTPShortcuts" maxLength="1000000" valueName="NTPShortcuts"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeHostsExecutablesLaunchDirectly)" explainText="$(string.NativeHostsExecutablesLaunchDirectly_Explain)" key="Software\Policies\Google\Chrome" name="NativeHostsExecutablesLaunchDirectly" presentation="$(presentation.NativeHostsExecutablesLaunchDirectly)" valueName="NativeHostsExecutablesLaunchDirectly">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NetworkPredictionOptions)" explainText="$(string.NetworkPredictionOptions_Explain)" key="Software\Policies\Google\Chrome" name="NetworkPredictionOptions" presentation="$(presentation.NetworkPredictionOptions)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="NetworkPredictionOptions" valueName="NetworkPredictionOptions">
+          <item displayName="$(string.NetworkPredictionOptions_NetworkPredictionAlways)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.NetworkPredictionOptions_NetworkPredictionWifiOnly)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.NetworkPredictionOptions_NetworkPredictionNever)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NetworkServiceSandboxEnabled)" explainText="$(string.NetworkServiceSandboxEnabled_Explain)" key="Software\Policies\Google\Chrome" name="NetworkServiceSandboxEnabled" presentation="$(presentation.NetworkServiceSandboxEnabled)" valueName="NetworkServiceSandboxEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.OriginAgentClusterDefaultEnabled)" explainText="$(string.OriginAgentClusterDefaultEnabled_Explain)" key="Software\Policies\Google\Chrome" name="OriginAgentClusterDefaultEnabled" presentation="$(presentation.OriginAgentClusterDefaultEnabled)" valueName="OriginAgentClusterDefaultEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.OverrideSecurityRestrictionsOnInsecureOrigin)" explainText="$(string.OverrideSecurityRestrictionsOnInsecureOrigin_Explain)" key="Software\Policies\Google\Chrome" name="OverrideSecurityRestrictionsOnInsecureOrigin" presentation="$(presentation.OverrideSecurityRestrictionsOnInsecureOrigin)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="OverrideSecurityRestrictionsOnInsecureOriginDesc" key="Software\Policies\Google\Chrome\OverrideSecurityRestrictionsOnInsecureOrigin" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PaymentMethodQueryEnabled)" explainText="$(string.PaymentMethodQueryEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PaymentMethodQueryEnabled" presentation="$(presentation.PaymentMethodQueryEnabled)" valueName="PaymentMethodQueryEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PdfAnnotationsEnabled)" explainText="$(string.PdfAnnotationsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PdfAnnotationsEnabled" presentation="$(presentation.PdfAnnotationsEnabled)" valueName="PdfAnnotationsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PdfUseSkiaRendererEnabled)" explainText="$(string.PdfUseSkiaRendererEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PdfUseSkiaRendererEnabled" presentation="$(presentation.PdfUseSkiaRendererEnabled)" valueName="PdfUseSkiaRendererEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PdfViewerOutOfProcessIframeEnabled)" explainText="$(string.PdfViewerOutOfProcessIframeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PdfViewerOutOfProcessIframeEnabled" presentation="$(presentation.PdfViewerOutOfProcessIframeEnabled)" valueName="PdfViewerOutOfProcessIframeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PolicyAtomicGroupsEnabled)" explainText="$(string.PolicyAtomicGroupsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PolicyAtomicGroupsEnabled" presentation="$(presentation.PolicyAtomicGroupsEnabled)" valueName="PolicyAtomicGroupsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PolicyDictionaryMultipleSourceMergeList)" explainText="$(string.PolicyDictionaryMultipleSourceMergeList_Explain)" key="Software\Policies\Google\Chrome" name="PolicyDictionaryMultipleSourceMergeList" presentation="$(presentation.PolicyDictionaryMultipleSourceMergeList)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PolicyDictionaryMultipleSourceMergeListDesc" key="Software\Policies\Google\Chrome\PolicyDictionaryMultipleSourceMergeList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PolicyListMultipleSourceMergeList)" explainText="$(string.PolicyListMultipleSourceMergeList_Explain)" key="Software\Policies\Google\Chrome" name="PolicyListMultipleSourceMergeList" presentation="$(presentation.PolicyListMultipleSourceMergeList)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PolicyListMultipleSourceMergeListDesc" key="Software\Policies\Google\Chrome\PolicyListMultipleSourceMergeList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PolicyRefreshRate)" explainText="$(string.PolicyRefreshRate_Explain)" key="Software\Policies\Google\Chrome" name="PolicyRefreshRate" presentation="$(presentation.PolicyRefreshRate)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="PolicyRefreshRate" maxValue="86400000" minValue="1800000" valueName="PolicyRefreshRate"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrefetchWithServiceWorkerEnabled)" explainText="$(string.PrefetchWithServiceWorkerEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrefetchWithServiceWorkerEnabled" presentation="$(presentation.PrefetchWithServiceWorkerEnabled)" valueName="PrefetchWithServiceWorkerEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ProfilePickerOnStartupAvailability)" explainText="$(string.ProfilePickerOnStartupAvailability_Explain)" key="Software\Policies\Google\Chrome" name="ProfilePickerOnStartupAvailability" presentation="$(presentation.ProfilePickerOnStartupAvailability)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ProfilePickerOnStartupAvailability" valueName="ProfilePickerOnStartupAvailability">
+          <item displayName="$(string.ProfilePickerOnStartupAvailability_Enabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ProfilePickerOnStartupAvailability_Disabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.ProfilePickerOnStartupAvailability_Forced)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ProfileReauthPrompt)" explainText="$(string.ProfileReauthPrompt_Explain)" key="Software\Policies\Google\Chrome" name="ProfileReauthPrompt" presentation="$(presentation.ProfileReauthPrompt)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ProfileReauthPrompt" valueName="ProfileReauthPrompt">
+          <item displayName="$(string.ProfileReauthPrompt_DoNotPrompt)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ProfileReauthPrompt_PromptInTab)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PromotionsEnabled)" explainText="$(string.PromotionsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PromotionsEnabled" presentation="$(presentation.PromotionsEnabled)" valueName="PromotionsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PromptForDownloadLocation)" explainText="$(string.PromptForDownloadLocation_Explain)" key="Software\Policies\Google\Chrome" name="PromptForDownloadLocation" presentation="$(presentation.PromptForDownloadLocation)" valueName="PromptForDownloadLocation">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PromptOnMultipleMatchingCertificates)" explainText="$(string.PromptOnMultipleMatchingCertificates_Explain)" key="Software\Policies\Google\Chrome" name="PromptOnMultipleMatchingCertificates" presentation="$(presentation.PromptOnMultipleMatchingCertificates)" valueName="PromptOnMultipleMatchingCertificates">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ProxySettings)" explainText="$(string.ProxySettings_Explain)" key="Software\Policies\Google\Chrome" name="ProxySettings" presentation="$(presentation.ProxySettings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ProxySettings" maxLength="1000000" valueName="ProxySettings"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.QRCodeGeneratorEnabled)" explainText="$(string.QRCodeGeneratorEnabled_Explain)" key="Software\Policies\Google\Chrome" name="QRCodeGeneratorEnabled" presentation="$(presentation.QRCodeGeneratorEnabled)" valueName="QRCodeGeneratorEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.QuicAllowed)" explainText="$(string.QuicAllowed_Explain)" key="Software\Policies\Google\Chrome" name="QuicAllowed" presentation="$(presentation.QuicAllowed)" valueName="QuicAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ReduceAcceptLanguageEnabled)" explainText="$(string.ReduceAcceptLanguageEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ReduceAcceptLanguageEnabled" presentation="$(presentation.ReduceAcceptLanguageEnabled)" valueName="ReduceAcceptLanguageEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RelaunchFastIfOutdated)" explainText="$(string.RelaunchFastIfOutdated_Explain)" key="Software\Policies\Google\Chrome" name="RelaunchFastIfOutdated" presentation="$(presentation.RelaunchFastIfOutdated)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="RelaunchFastIfOutdated" maxValue="2000000000" minValue="7" valueName="RelaunchFastIfOutdated"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RelaunchNotification)" explainText="$(string.RelaunchNotification_Explain)" key="Software\Policies\Google\Chrome" name="RelaunchNotification" presentation="$(presentation.RelaunchNotification)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="RelaunchNotification" valueName="RelaunchNotification">
+          <item displayName="$(string.RelaunchNotification_Recommended)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.RelaunchNotification_Required)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RelaunchNotificationPeriod)" explainText="$(string.RelaunchNotificationPeriod_Explain)" key="Software\Policies\Google\Chrome" name="RelaunchNotificationPeriod" presentation="$(presentation.RelaunchNotificationPeriod)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="RelaunchNotificationPeriod" maxValue="2000000000" minValue="3600000" valueName="RelaunchNotificationPeriod"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RelaunchWindow)" explainText="$(string.RelaunchWindow_Explain)" key="Software\Policies\Google\Chrome" name="RelaunchWindow" presentation="$(presentation.RelaunchWindow)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RelaunchWindow" maxLength="1000000" valueName="RelaunchWindow"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteDebuggingAllowed)" explainText="$(string.RemoteDebuggingAllowed_Explain)" key="Software\Policies\Google\Chrome" name="RemoteDebuggingAllowed" presentation="$(presentation.RemoteDebuggingAllowed)" valueName="RemoteDebuggingAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RendererAppContainerEnabled)" explainText="$(string.RendererAppContainerEnabled_Explain)" key="Software\Policies\Google\Chrome" name="RendererAppContainerEnabled" presentation="$(presentation.RendererAppContainerEnabled)" valueName="RendererAppContainerEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RequireOnlineRevocationChecksForLocalAnchors)" explainText="$(string.RequireOnlineRevocationChecksForLocalAnchors_Explain)" key="Software\Policies\Google\Chrome" name="RequireOnlineRevocationChecksForLocalAnchors" presentation="$(presentation.RequireOnlineRevocationChecksForLocalAnchors)" valueName="RequireOnlineRevocationChecksForLocalAnchors">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RestrictBackgroundFetchFromServiceWorkerEnabled)" explainText="$(string.RestrictBackgroundFetchFromServiceWorkerEnabled_Explain)" key="Software\Policies\Google\Chrome" name="RestrictBackgroundFetchFromServiceWorkerEnabled" presentation="$(presentation.RestrictBackgroundFetchFromServiceWorkerEnabled)" valueName="RestrictBackgroundFetchFromServiceWorkerEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RestrictCoreSharingOnRenderer)" explainText="$(string.RestrictCoreSharingOnRenderer_Explain)" key="Software\Policies\Google\Chrome" name="RestrictCoreSharingOnRenderer" presentation="$(presentation.RestrictCoreSharingOnRenderer)" valueName="RestrictCoreSharingOnRenderer">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RestrictPdfSaveToGoogleDriveAccountsToPattern)" explainText="$(string.RestrictPdfSaveToGoogleDriveAccountsToPattern_Explain)" key="Software\Policies\Google\Chrome" name="RestrictPdfSaveToGoogleDriveAccountsToPattern" presentation="$(presentation.RestrictPdfSaveToGoogleDriveAccountsToPattern)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RestrictPdfSaveToGoogleDriveAccountsToPattern" maxLength="1000000" valueName="RestrictPdfSaveToGoogleDriveAccountsToPattern"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RestrictSigninToPattern)" explainText="$(string.RestrictSigninToPattern_Explain)" key="Software\Policies\Google\Chrome" name="RestrictSigninToPattern" presentation="$(presentation.RestrictSigninToPattern)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RestrictSigninToPattern" maxLength="1000000" valueName="RestrictSigninToPattern"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RoamingProfileLocation)" explainText="$(string.RoamingProfileLocation_Explain)" key="Software\Policies\Google\Chrome" name="RoamingProfileLocation" presentation="$(presentation.RoamingProfileLocation)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RoamingProfileLocation" maxLength="1000000" valueName="RoamingProfileLocation"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RoamingProfileSupportEnabled)" explainText="$(string.RoamingProfileSupportEnabled_Explain)" key="Software\Policies\Google\Chrome" name="RoamingProfileSupportEnabled" presentation="$(presentation.RoamingProfileSupportEnabled)" valueName="RoamingProfileSupportEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SSLErrorOverrideAllowed)" explainText="$(string.SSLErrorOverrideAllowed_Explain)" key="Software\Policies\Google\Chrome" name="SSLErrorOverrideAllowed" presentation="$(presentation.SSLErrorOverrideAllowed)" valueName="SSLErrorOverrideAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SSLErrorOverrideAllowedForOrigins)" explainText="$(string.SSLErrorOverrideAllowedForOrigins_Explain)" key="Software\Policies\Google\Chrome" name="SSLErrorOverrideAllowedForOrigins" presentation="$(presentation.SSLErrorOverrideAllowedForOrigins)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SSLErrorOverrideAllowedForOriginsDesc" key="Software\Policies\Google\Chrome\SSLErrorOverrideAllowedForOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingForTrustedSourcesEnabled)" explainText="$(string.SafeBrowsingForTrustedSourcesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingForTrustedSourcesEnabled" presentation="$(presentation.SafeBrowsingForTrustedSourcesEnabled)" valueName="SafeBrowsingForTrustedSourcesEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeSitesFilterBehavior)" explainText="$(string.SafeSitesFilterBehavior_Explain)" key="Software\Policies\Google\Chrome" name="SafeSitesFilterBehavior" presentation="$(presentation.SafeSitesFilterBehavior)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="SafeSitesFilterBehavior" valueName="SafeSitesFilterBehavior">
+          <item displayName="$(string.SafeSitesFilterBehavior_SafeSitesFilterDisabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.SafeSitesFilterBehavior_SafeSitesFilterEnabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SandboxExternalProtocolBlocked)" explainText="$(string.SandboxExternalProtocolBlocked_Explain)" key="Software\Policies\Google\Chrome" name="SandboxExternalProtocolBlocked" presentation="$(presentation.SandboxExternalProtocolBlocked)" valueName="SandboxExternalProtocolBlocked">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SavingBrowserHistoryDisabled)" explainText="$(string.SavingBrowserHistoryDisabled_Explain)" key="Software\Policies\Google\Chrome" name="SavingBrowserHistoryDisabled" presentation="$(presentation.SavingBrowserHistoryDisabled)" valueName="SavingBrowserHistoryDisabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ScreenCaptureWithoutGestureAllowedForOrigins)" explainText="$(string.ScreenCaptureWithoutGestureAllowedForOrigins_Explain)" key="Software\Policies\Google\Chrome" name="ScreenCaptureWithoutGestureAllowedForOrigins" presentation="$(presentation.ScreenCaptureWithoutGestureAllowedForOrigins)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ScreenCaptureWithoutGestureAllowedForOriginsDesc" key="Software\Policies\Google\Chrome\ScreenCaptureWithoutGestureAllowedForOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ScrollToTextFragmentEnabled)" explainText="$(string.ScrollToTextFragmentEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ScrollToTextFragmentEnabled" presentation="$(presentation.ScrollToTextFragmentEnabled)" valueName="ScrollToTextFragmentEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SearchSuggestEnabled)" explainText="$(string.SearchSuggestEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SearchSuggestEnabled" presentation="$(presentation.SearchSuggestEnabled)" valueName="SearchSuggestEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SecurityKeyPermitAttestation)" explainText="$(string.SecurityKeyPermitAttestation_Explain)" key="Software\Policies\Google\Chrome" name="SecurityKeyPermitAttestation" presentation="$(presentation.SecurityKeyPermitAttestation)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SecurityKeyPermitAttestationDesc" key="Software\Policies\Google\Chrome\SecurityKeyPermitAttestation" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ServiceWorkerAutoPreloadEnabled)" explainText="$(string.ServiceWorkerAutoPreloadEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ServiceWorkerAutoPreloadEnabled" presentation="$(presentation.ServiceWorkerAutoPreloadEnabled)" valueName="ServiceWorkerAutoPreloadEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ServiceWorkerToControlSrcdocIframeEnabled)" explainText="$(string.ServiceWorkerToControlSrcdocIframeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ServiceWorkerToControlSrcdocIframeEnabled" presentation="$(presentation.ServiceWorkerToControlSrcdocIframeEnabled)" valueName="ServiceWorkerToControlSrcdocIframeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SharedArrayBufferUnrestrictedAccessAllowed)" explainText="$(string.SharedArrayBufferUnrestrictedAccessAllowed_Explain)" key="Software\Policies\Google\Chrome" name="SharedArrayBufferUnrestrictedAccessAllowed" presentation="$(presentation.SharedArrayBufferUnrestrictedAccessAllowed)" valueName="SharedArrayBufferUnrestrictedAccessAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SharedClipboardEnabled)" explainText="$(string.SharedClipboardEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SharedClipboardEnabled" presentation="$(presentation.SharedClipboardEnabled)" valueName="SharedClipboardEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SharedWorkerBlobURLFixEnabled)" explainText="$(string.SharedWorkerBlobURLFixEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SharedWorkerBlobURLFixEnabled" presentation="$(presentation.SharedWorkerBlobURLFixEnabled)" valueName="SharedWorkerBlobURLFixEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SharedWorkerExtendedLifetimeEnabled)" explainText="$(string.SharedWorkerExtendedLifetimeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SharedWorkerExtendedLifetimeEnabled" presentation="$(presentation.SharedWorkerExtendedLifetimeEnabled)" valueName="SharedWorkerExtendedLifetimeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ShoppingListEnabled)" explainText="$(string.ShoppingListEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ShoppingListEnabled" presentation="$(presentation.ShoppingListEnabled)" valueName="ShoppingListEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ShowAppsShortcutInBookmarkBar)" explainText="$(string.ShowAppsShortcutInBookmarkBar_Explain)" key="Software\Policies\Google\Chrome" name="ShowAppsShortcutInBookmarkBar" presentation="$(presentation.ShowAppsShortcutInBookmarkBar)" valueName="ShowAppsShortcutInBookmarkBar">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ShowFullUrlsInAddressBar)" explainText="$(string.ShowFullUrlsInAddressBar_Explain)" key="Software\Policies\Google\Chrome" name="ShowFullUrlsInAddressBar" presentation="$(presentation.ShowFullUrlsInAddressBar)" valueName="ShowFullUrlsInAddressBar">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SideSearchEnabled)" explainText="$(string.SideSearchEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SideSearchEnabled" presentation="$(presentation.SideSearchEnabled)" valueName="SideSearchEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SignedHTTPExchangeEnabled)" explainText="$(string.SignedHTTPExchangeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SignedHTTPExchangeEnabled" presentation="$(presentation.SignedHTTPExchangeEnabled)" valueName="SignedHTTPExchangeEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SigninInterceptionEnabled)" explainText="$(string.SigninInterceptionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SigninInterceptionEnabled" presentation="$(presentation.SigninInterceptionEnabled)" valueName="SigninInterceptionEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SilentPrintingEnabled)" explainText="$(string.SilentPrintingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SilentPrintingEnabled" presentation="$(presentation.SilentPrintingEnabled)" valueName="SilentPrintingEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SitePerProcess)" explainText="$(string.SitePerProcess_Explain)" key="Software\Policies\Google\Chrome" name="SitePerProcess" presentation="$(presentation.SitePerProcess)" valueName="SitePerProcess">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SiteSearchSettings)" explainText="$(string.SiteSearchSettings_Explain)" key="Software\Policies\Google\Chrome" name="SiteSearchSettings" presentation="$(presentation.SiteSearchSettings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="SiteSearchSettings" maxLength="1000000" valueName="SiteSearchSettings"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SpellCheckServiceEnabled)" explainText="$(string.SpellCheckServiceEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SpellCheckServiceEnabled" presentation="$(presentation.SpellCheckServiceEnabled)" valueName="SpellCheckServiceEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SpellcheckEnabled)" explainText="$(string.SpellcheckEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SpellcheckEnabled" presentation="$(presentation.SpellcheckEnabled)" valueName="SpellcheckEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SpellcheckLanguage)" explainText="$(string.SpellcheckLanguage_Explain)" key="Software\Policies\Google\Chrome" name="SpellcheckLanguage" presentation="$(presentation.SpellcheckLanguage)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SpellcheckLanguageDesc" key="Software\Policies\Google\Chrome\SpellcheckLanguage" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SpellcheckLanguageBlocklist)" explainText="$(string.SpellcheckLanguageBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="SpellcheckLanguageBlocklist" presentation="$(presentation.SpellcheckLanguageBlocklist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SpellcheckLanguageBlocklistDesc" key="Software\Policies\Google\Chrome\SpellcheckLanguageBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.StandardizedBrowserZoomEnabled)" explainText="$(string.StandardizedBrowserZoomEnabled_Explain)" key="Software\Policies\Google\Chrome" name="StandardizedBrowserZoomEnabled" presentation="$(presentation.StandardizedBrowserZoomEnabled)" valueName="StandardizedBrowserZoomEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.StaticStorageQuotaEnabled)" explainText="$(string.StaticStorageQuotaEnabled_Explain)" key="Software\Policies\Google\Chrome" name="StaticStorageQuotaEnabled" presentation="$(presentation.StaticStorageQuotaEnabled)" valueName="StaticStorageQuotaEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.StrictMimetypeCheckForWorkerScriptsEnabled)" explainText="$(string.StrictMimetypeCheckForWorkerScriptsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="StrictMimetypeCheckForWorkerScriptsEnabled" presentation="$(presentation.StrictMimetypeCheckForWorkerScriptsEnabled)" valueName="StrictMimetypeCheckForWorkerScriptsEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SuppressDifferentOriginSubframeDialogs)" explainText="$(string.SuppressDifferentOriginSubframeDialogs_Explain)" key="Software\Policies\Google\Chrome" name="SuppressDifferentOriginSubframeDialogs" presentation="$(presentation.SuppressDifferentOriginSubframeDialogs)" valueName="SuppressDifferentOriginSubframeDialogs">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SuppressUnsupportedOSWarning)" explainText="$(string.SuppressUnsupportedOSWarning_Explain)" key="Software\Policies\Google\Chrome" name="SuppressUnsupportedOSWarning" presentation="$(presentation.SuppressUnsupportedOSWarning)" valueName="SuppressUnsupportedOSWarning">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SyncDisabled)" explainText="$(string.SyncDisabled_Explain)" key="Software\Policies\Google\Chrome" name="SyncDisabled" presentation="$(presentation.SyncDisabled)" valueName="SyncDisabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SyncTypesListDisabled)" explainText="$(string.SyncTypesListDisabled_Explain)" key="Software\Policies\Google\Chrome" name="SyncTypesListDisabled" presentation="$(presentation.SyncTypesListDisabled)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SyncTypesListDisabledDesc" key="Software\Policies\Google\Chrome\SyncTypesListDisabled" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.TLS13EarlyDataEnabled)" explainText="$(string.TLS13EarlyDataEnabled_Explain)" key="Software\Policies\Google\Chrome" name="TLS13EarlyDataEnabled" presentation="$(presentation.TLS13EarlyDataEnabled)" valueName="TLS13EarlyDataEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TabDiscardingExceptions)" explainText="$(string.TabDiscardingExceptions_Explain)" key="Software\Policies\Google\Chrome" name="TabDiscardingExceptions" presentation="$(presentation.TabDiscardingExceptions)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="TabDiscardingExceptionsDesc" key="Software\Policies\Google\Chrome\TabDiscardingExceptions" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.TaskManagerEndProcessEnabled)" explainText="$(string.TaskManagerEndProcessEnabled_Explain)" key="Software\Policies\Google\Chrome" name="TaskManagerEndProcessEnabled" presentation="$(presentation.TaskManagerEndProcessEnabled)" valueName="TaskManagerEndProcessEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TotalMemoryLimitMb)" explainText="$(string.TotalMemoryLimitMb_Explain)" key="Software\Policies\Google\Chrome" name="TotalMemoryLimitMb" presentation="$(presentation.TotalMemoryLimitMb)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="TotalMemoryLimitMb" maxValue="2000000000" minValue="1024" valueName="TotalMemoryLimitMb"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.TranslateEnabled)" explainText="$(string.TranslateEnabled_Explain)" key="Software\Policies\Google\Chrome" name="TranslateEnabled" presentation="$(presentation.TranslateEnabled)" valueName="TranslateEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TranslatorAPIAllowed)" explainText="$(string.TranslatorAPIAllowed_Explain)" key="Software\Policies\Google\Chrome" name="TranslatorAPIAllowed" presentation="$(presentation.TranslatorAPIAllowed)" valueName="TranslatorAPIAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.URLAllowlist)" explainText="$(string.URLAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="URLAllowlist" presentation="$(presentation.URLAllowlist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="URLAllowlistDesc" key="Software\Policies\Google\Chrome\URLAllowlist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.URLBlocklist)" explainText="$(string.URLBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="URLBlocklist" presentation="$(presentation.URLBlocklist)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="URLBlocklistDesc" key="Software\Policies\Google\Chrome\URLBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.UrlKeyedAnonymizedDataCollectionEnabled)" explainText="$(string.UrlKeyedAnonymizedDataCollectionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="UrlKeyedAnonymizedDataCollectionEnabled" presentation="$(presentation.UrlKeyedAnonymizedDataCollectionEnabled)" valueName="UrlKeyedAnonymizedDataCollectionEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UserDataDir)" explainText="$(string.UserDataDir_Explain)" key="Software\Policies\Google\Chrome" name="UserDataDir" presentation="$(presentation.UserDataDir)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="UserDataDir" maxLength="1000000" valueName="UserDataDir"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.UserDataSnapshotRetentionLimit)" explainText="$(string.UserDataSnapshotRetentionLimit_Explain)" key="Software\Policies\Google\Chrome" name="UserDataSnapshotRetentionLimit" presentation="$(presentation.UserDataSnapshotRetentionLimit)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="UserDataSnapshotRetentionLimit" maxValue="2000000000" minValue="0" valueName="UserDataSnapshotRetentionLimit"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.UserFeedbackAllowed)" explainText="$(string.UserFeedbackAllowed_Explain)" key="Software\Policies\Google\Chrome" name="UserFeedbackAllowed" presentation="$(presentation.UserFeedbackAllowed)" valueName="UserFeedbackAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.VideoCaptureAllowed)" explainText="$(string.VideoCaptureAllowed_Explain)" key="Software\Policies\Google\Chrome" name="VideoCaptureAllowed" presentation="$(presentation.VideoCaptureAllowed)" valueName="VideoCaptureAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.VideoCaptureAllowedUrls)" explainText="$(string.VideoCaptureAllowedUrls_Explain)" key="Software\Policies\Google\Chrome" name="VideoCaptureAllowedUrls" presentation="$(presentation.VideoCaptureAllowedUrls)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="VideoCaptureAllowedUrlsDesc" key="Software\Policies\Google\Chrome\VideoCaptureAllowedUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WPADQuickCheckEnabled)" explainText="$(string.WPADQuickCheckEnabled_Explain)" key="Software\Policies\Google\Chrome" name="WPADQuickCheckEnabled" presentation="$(presentation.WPADQuickCheckEnabled)" valueName="WPADQuickCheckEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebAppInstallByUserEnabled)" explainText="$(string.WebAppInstallByUserEnabled_Explain)" key="Software\Policies\Google\Chrome" name="WebAppInstallByUserEnabled" presentation="$(presentation.WebAppInstallByUserEnabled)" valueName="WebAppInstallByUserEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebAppInstallForceList)" explainText="$(string.WebAppInstallForceList_Explain)" key="Software\Policies\Google\Chrome" name="WebAppInstallForceList" presentation="$(presentation.WebAppInstallForceList)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="WebAppInstallForceList" maxLength="1000000" valueName="WebAppInstallForceList"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebAppSettings)" explainText="$(string.WebAppSettings_Explain)" key="Software\Policies\Google\Chrome" name="WebAppSettings" presentation="$(presentation.WebAppSettings)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="WebAppSettings" maxLength="1000000" valueName="WebAppSettings"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebAudioOutputBufferingEnabled)" explainText="$(string.WebAudioOutputBufferingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="WebAudioOutputBufferingEnabled" presentation="$(presentation.WebAudioOutputBufferingEnabled)" valueName="WebAudioOutputBufferingEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebAuthenticationRemoteDesktopAllowedOrigins)" explainText="$(string.WebAuthenticationRemoteDesktopAllowedOrigins_Explain)" key="Software\Policies\Google\Chrome" name="WebAuthenticationRemoteDesktopAllowedOrigins" presentation="$(presentation.WebAuthenticationRemoteDesktopAllowedOrigins)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebAuthenticationRemoteDesktopAllowedOriginsDesc" key="Software\Policies\Google\Chrome\WebAuthenticationRemoteDesktopAllowedOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcEventLogCollectionAllowed)" explainText="$(string.WebRtcEventLogCollectionAllowed_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcEventLogCollectionAllowed" presentation="$(presentation.WebRtcEventLogCollectionAllowed)" valueName="WebRtcEventLogCollectionAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcLocalIpsAllowedUrls)" explainText="$(string.WebRtcLocalIpsAllowedUrls_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcLocalIpsAllowedUrls" presentation="$(presentation.WebRtcLocalIpsAllowedUrls)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebRtcLocalIpsAllowedUrlsDesc" key="Software\Policies\Google\Chrome\WebRtcLocalIpsAllowedUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcTextLogCollectionAllowed)" explainText="$(string.WebRtcTextLogCollectionAllowed_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcTextLogCollectionAllowed" presentation="$(presentation.WebRtcTextLogCollectionAllowed)" valueName="WebRtcTextLogCollectionAllowed">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcUdpPortRange)" explainText="$(string.WebRtcUdpPortRange_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcUdpPortRange" presentation="$(presentation.WebRtcUdpPortRange)">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="WebRtcUdpPortRange" maxLength="1000000" valueName="WebRtcUdpPortRange"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WindowOcclusionEnabled)" explainText="$(string.WindowOcclusionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="WindowOcclusionEnabled" presentation="$(presentation.WindowOcclusionEnabled)" valueName="WindowOcclusionEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.XSLTEnabled)" explainText="$(string.XSLTEnabled_Explain)" key="Software\Policies\Google\Chrome" name="XSLTEnabled" presentation="$(presentation.XSLTEnabled)" valueName="XSLTEnabled">
+      <parentCategory ref="googlechrome"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AlwaysOpenPdfExternally)" explainText="$(string.AlwaysOpenPdfExternally_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="AlwaysOpenPdfExternally_recommended" presentation="$(presentation.AlwaysOpenPdfExternally)" valueName="AlwaysOpenPdfExternally">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ApplicationLocaleValue)" explainText="$(string.ApplicationLocaleValue_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ApplicationLocaleValue_recommended" presentation="$(presentation.ApplicationLocaleValue)">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="ApplicationLocaleValue" maxLength="1000000" valueName="ApplicationLocaleValue"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutofillAddressEnabled)" explainText="$(string.AutofillAddressEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="AutofillAddressEnabled_recommended" presentation="$(presentation.AutofillAddressEnabled)" valueName="AutofillAddressEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutofillCreditCardEnabled)" explainText="$(string.AutofillCreditCardEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="AutofillCreditCardEnabled_recommended" presentation="$(presentation.AutofillCreditCardEnabled)" valueName="AutofillCreditCardEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BackgroundModeEnabled)" explainText="$(string.BackgroundModeEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="BackgroundModeEnabled_recommended" presentation="$(presentation.BackgroundModeEnabled)" valueName="BackgroundModeEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BatterySaverModeAvailability)" explainText="$(string.BatterySaverModeAvailability_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="BatterySaverModeAvailability_recommended" presentation="$(presentation.BatterySaverModeAvailability)">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="BatterySaverModeAvailability" valueName="BatterySaverModeAvailability">
+          <item displayName="$(string.BatterySaverModeAvailability_Disabled)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.BatterySaverModeAvailability_EnabledBelowThreshold)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.BatterySaverModeAvailability_EnabledOnBattery)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BlockThirdPartyCookies)" explainText="$(string.BlockThirdPartyCookies_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="BlockThirdPartyCookies_recommended" presentation="$(presentation.BlockThirdPartyCookies)" valueName="BlockThirdPartyCookies">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BookmarkBarEnabled)" explainText="$(string.BookmarkBarEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="BookmarkBarEnabled_recommended" presentation="$(presentation.BookmarkBarEnabled)" valueName="BookmarkBarEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultDownloadDirectory)" explainText="$(string.DefaultDownloadDirectory_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultDownloadDirectory_recommended" presentation="$(presentation.DefaultDownloadDirectory)">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultDownloadDirectory" maxLength="1000000" valueName="DefaultDownloadDirectory"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderContextMenuAccessAllowed)" explainText="$(string.DefaultSearchProviderContextMenuAccessAllowed_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderContextMenuAccessAllowed_recommended" presentation="$(presentation.DefaultSearchProviderContextMenuAccessAllowed)" valueName="DefaultSearchProviderContextMenuAccessAllowed">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DomainReliabilityAllowed)" explainText="$(string.DomainReliabilityAllowed_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DomainReliabilityAllowed_recommended" presentation="$(presentation.DomainReliabilityAllowed)" valueName="DomainReliabilityAllowed">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DownloadDirectory)" explainText="$(string.DownloadDirectory_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DownloadDirectory_recommended" presentation="$(presentation.DownloadDirectory)">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DownloadDirectory" maxLength="1000000" valueName="DownloadDirectory"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DownloadRestrictions)" explainText="$(string.DownloadRestrictions_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DownloadRestrictions_recommended" presentation="$(presentation.DownloadRestrictions)">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DownloadRestrictions" valueName="DownloadRestrictions">
+          <item displayName="$(string.DownloadRestrictions_DefaultDownloadSecurity)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockDangerousDownloads)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockPotentiallyDangerousDownloads)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockAllDownloads)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+          <item displayName="$(string.DownloadRestrictions_BlockMaliciousDownloads)">
+            <value>
+              <decimal value="4"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseProfileCreationKeepBrowsingData)" explainText="$(string.EnterpriseProfileCreationKeepBrowsingData_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="EnterpriseProfileCreationKeepBrowsingData_recommended" presentation="$(presentation.EnterpriseProfileCreationKeepBrowsingData)" valueName="EnterpriseProfileCreationKeepBrowsingData">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HttpsOnlyMode)" explainText="$(string.HttpsOnlyMode_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="HttpsOnlyMode_recommended" presentation="$(presentation.HttpsOnlyMode)">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="HttpsOnlyMode" valueName="HttpsOnlyMode">
+          <item displayName="$(string.HttpsOnlyMode_allowed)">
+            <value>
+              <string>allowed</string>
+            </value>
+          </item>
+          <item displayName="$(string.HttpsOnlyMode_disallowed)">
+            <value>
+              <string>disallowed</string>
+            </value>
+          </item>
+          <item displayName="$(string.HttpsOnlyMode_force_enabled)">
+            <value>
+              <string>force_enabled</string>
+            </value>
+          </item>
+          <item displayName="$(string.HttpsOnlyMode_force_balanced_enabled)">
+            <value>
+              <string>force_balanced_enabled</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportAutofillFormData)" explainText="$(string.ImportAutofillFormData_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ImportAutofillFormData_recommended" presentation="$(presentation.ImportAutofillFormData)" valueName="ImportAutofillFormData">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportBookmarks)" explainText="$(string.ImportBookmarks_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ImportBookmarks_recommended" presentation="$(presentation.ImportBookmarks)" valueName="ImportBookmarks">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportHistory)" explainText="$(string.ImportHistory_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ImportHistory_recommended" presentation="$(presentation.ImportHistory)" valueName="ImportHistory">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportSavedPasswords)" explainText="$(string.ImportSavedPasswords_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ImportSavedPasswords_recommended" presentation="$(presentation.ImportSavedPasswords)" valueName="ImportSavedPasswords">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ImportSearchEngine)" explainText="$(string.ImportSearchEngine_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ImportSearchEngine_recommended" presentation="$(presentation.ImportSearchEngine)" valueName="ImportSearchEngine">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.MetricsReportingEnabled)" explainText="$(string.MetricsReportingEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="MetricsReportingEnabled_recommended" presentation="$(presentation.MetricsReportingEnabled)" valueName="MetricsReportingEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NetworkPredictionOptions)" explainText="$(string.NetworkPredictionOptions_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="NetworkPredictionOptions_recommended" presentation="$(presentation.NetworkPredictionOptions)">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="NetworkPredictionOptions" valueName="NetworkPredictionOptions">
+          <item displayName="$(string.NetworkPredictionOptions_NetworkPredictionAlways)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.NetworkPredictionOptions_NetworkPredictionWifiOnly)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.NetworkPredictionOptions_NetworkPredictionNever)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.OriginKeyedProcessesEnabled)" explainText="$(string.OriginKeyedProcessesEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="OriginKeyedProcessesEnabled_recommended" presentation="$(presentation.OriginKeyedProcessesEnabled)" valueName="OriginKeyedProcessesEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SearchSuggestEnabled)" explainText="$(string.SearchSuggestEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="SearchSuggestEnabled_recommended" presentation="$(presentation.SearchSuggestEnabled)" valueName="SearchSuggestEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ShowFullUrlsInAddressBar)" explainText="$(string.ShowFullUrlsInAddressBar_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ShowFullUrlsInAddressBar_recommended" presentation="$(presentation.ShowFullUrlsInAddressBar)" valueName="ShowFullUrlsInAddressBar">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SpellCheckServiceEnabled)" explainText="$(string.SpellCheckServiceEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="SpellCheckServiceEnabled_recommended" presentation="$(presentation.SpellCheckServiceEnabled)" valueName="SpellCheckServiceEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TranslateEnabled)" explainText="$(string.TranslateEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="TranslateEnabled_recommended" presentation="$(presentation.TranslateEnabled)" valueName="TranslateEnabled">
+      <parentCategory ref="googlechrome_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeMessagingAllowlist)" explainText="$(string.NativeMessagingAllowlist_Explain)" key="Software\Policies\Google\Chrome" name="NativeMessagingAllowlist" presentation="$(presentation.NativeMessagingAllowlist)">
+      <parentCategory ref="NativeMessaging"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="NativeMessagingAllowlistDesc" key="Software\Policies\Google\Chrome\NativeMessagingAllowlist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeMessagingBlocklist)" explainText="$(string.NativeMessagingBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="NativeMessagingBlocklist" presentation="$(presentation.NativeMessagingBlocklist)">
+      <parentCategory ref="NativeMessaging"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="NativeMessagingBlocklistDesc" key="Software\Policies\Google\Chrome\NativeMessagingBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeMessagingUserLevelHosts)" explainText="$(string.NativeMessagingUserLevelHosts_Explain)" key="Software\Policies\Google\Chrome" name="NativeMessagingUserLevelHosts" presentation="$(presentation.NativeMessagingUserLevelHosts)" valueName="NativeMessagingUserLevelHosts">
+      <parentCategory ref="NativeMessaging"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AccessControlAllowMethodsInCORSPreflightSpecConformant)" explainText="$(string.AccessControlAllowMethodsInCORSPreflightSpecConformant_Explain)" key="Software\Policies\Google\Chrome" name="AccessControlAllowMethodsInCORSPreflightSpecConformant" presentation="$(presentation.AccessControlAllowMethodsInCORSPreflightSpecConformant)" valueName="AccessControlAllowMethodsInCORSPreflightSpecConformant">
+      <parentCategory ref="Network"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CompressionDictionaryTransportEnabled)" explainText="$(string.CompressionDictionaryTransportEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CompressionDictionaryTransportEnabled" presentation="$(presentation.CompressionDictionaryTransportEnabled)" valueName="CompressionDictionaryTransportEnabled">
+      <parentCategory ref="Network"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DataURLWhitespacePreservationEnabled)" explainText="$(string.DataURLWhitespacePreservationEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DataURLWhitespacePreservationEnabled" presentation="$(presentation.DataURLWhitespacePreservationEnabled)" valueName="DataURLWhitespacePreservationEnabled">
+      <parentCategory ref="Network"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HappyEyeballsV3Enabled)" explainText="$(string.HappyEyeballsV3Enabled_Explain)" key="Software\Policies\Google\Chrome" name="HappyEyeballsV3Enabled" presentation="$(presentation.HappyEyeballsV3Enabled)" valueName="HappyEyeballsV3Enabled">
+      <parentCategory ref="Network"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.IPv6ReachabilityOverrideEnabled)" explainText="$(string.IPv6ReachabilityOverrideEnabled_Explain)" key="Software\Policies\Google\Chrome" name="IPv6ReachabilityOverrideEnabled" presentation="$(presentation.IPv6ReachabilityOverrideEnabled)" valueName="IPv6ReachabilityOverrideEnabled">
+      <parentCategory ref="Network"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AutomatedPasswordChangeSettings)" explainText="$(string.AutomatedPasswordChangeSettings_Explain)" key="Software\Policies\Google\Chrome" name="AutomatedPasswordChangeSettings" presentation="$(presentation.AutomatedPasswordChangeSettings)">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="AutomatedPasswordChangeSettings" valueName="AutomatedPasswordChangeSettings">
+          <item displayName="$(string.AutomatedPasswordChangeSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.AutomatedPasswordChangeSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.AutomatedPasswordChangeSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DeletingUndecryptablePasswordsEnabled)" explainText="$(string.DeletingUndecryptablePasswordsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DeletingUndecryptablePasswordsEnabled" presentation="$(presentation.DeletingUndecryptablePasswordsEnabled)" valueName="DeletingUndecryptablePasswordsEnabled">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordDismissCompromisedAlertEnabled)" explainText="$(string.PasswordDismissCompromisedAlertEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PasswordDismissCompromisedAlertEnabled" presentation="$(presentation.PasswordDismissCompromisedAlertEnabled)" valueName="PasswordDismissCompromisedAlertEnabled">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordLeakDetectionEnabled)" explainText="$(string.PasswordLeakDetectionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PasswordLeakDetectionEnabled" presentation="$(presentation.PasswordLeakDetectionEnabled)" valueName="PasswordLeakDetectionEnabled">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordManagerBlocklist)" explainText="$(string.PasswordManagerBlocklist_Explain)" key="Software\Policies\Google\Chrome" name="PasswordManagerBlocklist" presentation="$(presentation.PasswordManagerBlocklist)">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PasswordManagerBlocklistDesc" key="Software\Policies\Google\Chrome\PasswordManagerBlocklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordManagerEnabled)" explainText="$(string.PasswordManagerEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PasswordManagerEnabled" presentation="$(presentation.PasswordManagerEnabled)" valueName="PasswordManagerEnabled">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordManagerPasskeysEnabled)" explainText="$(string.PasswordManagerPasskeysEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PasswordManagerPasskeysEnabled" presentation="$(presentation.PasswordManagerPasskeysEnabled)" valueName="PasswordManagerPasskeysEnabled">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordSharingEnabled)" explainText="$(string.PasswordSharingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PasswordSharingEnabled" presentation="$(presentation.PasswordSharingEnabled)" valueName="PasswordSharingEnabled">
+      <parentCategory ref="PasswordManager"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordManagerEnabled)" explainText="$(string.PasswordManagerEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="PasswordManagerEnabled_recommended" presentation="$(presentation.PasswordManagerEnabled)" valueName="PasswordManagerEnabled">
+      <parentCategory ref="PasswordManager_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultPrinterSelection)" explainText="$(string.DefaultPrinterSelection_Explain)" key="Software\Policies\Google\Chrome" name="DefaultPrinterSelection" presentation="$(presentation.DefaultPrinterSelection)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultPrinterSelection" maxLength="1000000" valueName="DefaultPrinterSelection"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DisablePrintPreview)" explainText="$(string.DisablePrintPreview_Explain)" key="Software\Policies\Google\Chrome" name="DisablePrintPreview" presentation="$(presentation.DisablePrintPreview)" valueName="DisablePrintPreview">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.OopPrintDriversAllowed)" explainText="$(string.OopPrintDriversAllowed_Explain)" key="Software\Policies\Google\Chrome" name="OopPrintDriversAllowed" presentation="$(presentation.OopPrintDriversAllowed)" valueName="OopPrintDriversAllowed">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintHeaderFooter)" explainText="$(string.PrintHeaderFooter_Explain)" key="Software\Policies\Google\Chrome" name="PrintHeaderFooter" presentation="$(presentation.PrintHeaderFooter)" valueName="PrintHeaderFooter">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintPdfAsImageAvailability)" explainText="$(string.PrintPdfAsImageAvailability_Explain)" key="Software\Policies\Google\Chrome" name="PrintPdfAsImageAvailability" presentation="$(presentation.PrintPdfAsImageAvailability)" valueName="PrintPdfAsImageAvailability">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintPdfAsImageDefault)" explainText="$(string.PrintPdfAsImageDefault_Explain)" key="Software\Policies\Google\Chrome" name="PrintPdfAsImageDefault" presentation="$(presentation.PrintPdfAsImageDefault)" valueName="PrintPdfAsImageDefault">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintPostScriptMode)" explainText="$(string.PrintPostScriptMode_Explain)" key="Software\Policies\Google\Chrome" name="PrintPostScriptMode" presentation="$(presentation.PrintPostScriptMode)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PrintPostScriptMode" valueName="PrintPostScriptMode">
+          <item displayName="$(string.PrintPostScriptMode_Default)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.PrintPostScriptMode_Type42)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintPreviewUseSystemDefaultPrinter)" explainText="$(string.PrintPreviewUseSystemDefaultPrinter_Explain)" key="Software\Policies\Google\Chrome" name="PrintPreviewUseSystemDefaultPrinter" presentation="$(presentation.PrintPreviewUseSystemDefaultPrinter)" valueName="PrintPreviewUseSystemDefaultPrinter">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintRasterizationMode)" explainText="$(string.PrintRasterizationMode_Explain)" key="Software\Policies\Google\Chrome" name="PrintRasterizationMode" presentation="$(presentation.PrintRasterizationMode)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PrintRasterizationMode" valueName="PrintRasterizationMode">
+          <item displayName="$(string.PrintRasterizationMode_Full)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.PrintRasterizationMode_Fast)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintRasterizePdfDpi)" explainText="$(string.PrintRasterizePdfDpi_Explain)" key="Software\Policies\Google\Chrome" name="PrintRasterizePdfDpi" presentation="$(presentation.PrintRasterizePdfDpi)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="PrintRasterizePdfDpi" maxValue="2000000000" minValue="0" valueName="PrintRasterizePdfDpi"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrinterTypeDenyList)" explainText="$(string.PrinterTypeDenyList_Explain)" key="Software\Policies\Google\Chrome" name="PrinterTypeDenyList" presentation="$(presentation.PrinterTypeDenyList)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PrinterTypeDenyListDesc" key="Software\Policies\Google\Chrome\PrinterTypeDenyList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintingAllowedBackgroundGraphicsModes)" explainText="$(string.PrintingAllowedBackgroundGraphicsModes_Explain)" key="Software\Policies\Google\Chrome" name="PrintingAllowedBackgroundGraphicsModes" presentation="$(presentation.PrintingAllowedBackgroundGraphicsModes)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PrintingAllowedBackgroundGraphicsModes" valueName="PrintingAllowedBackgroundGraphicsModes">
+          <item displayName="$(string.PrintingAllowedBackgroundGraphicsModes_any)">
+            <value>
+              <string>any</string>
+            </value>
+          </item>
+          <item displayName="$(string.PrintingAllowedBackgroundGraphicsModes_enabled)">
+            <value>
+              <string>enabled</string>
+            </value>
+          </item>
+          <item displayName="$(string.PrintingAllowedBackgroundGraphicsModes_disabled)">
+            <value>
+              <string>disabled</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintingBackgroundGraphicsDefault)" explainText="$(string.PrintingBackgroundGraphicsDefault_Explain)" key="Software\Policies\Google\Chrome" name="PrintingBackgroundGraphicsDefault" presentation="$(presentation.PrintingBackgroundGraphicsDefault)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PrintingBackgroundGraphicsDefault" valueName="PrintingBackgroundGraphicsDefault">
+          <item displayName="$(string.PrintingBackgroundGraphicsDefault_enabled)">
+            <value>
+              <string>enabled</string>
+            </value>
+          </item>
+          <item displayName="$(string.PrintingBackgroundGraphicsDefault_disabled)">
+            <value>
+              <string>disabled</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintingEnabled)" explainText="$(string.PrintingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrintingEnabled" presentation="$(presentation.PrintingEnabled)" valueName="PrintingEnabled">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintingLPACSandboxEnabled)" explainText="$(string.PrintingLPACSandboxEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrintingLPACSandboxEnabled" presentation="$(presentation.PrintingLPACSandboxEnabled)" valueName="PrintingLPACSandboxEnabled">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintingPaperSizeDefault)" explainText="$(string.PrintingPaperSizeDefault_Explain)" key="Software\Policies\Google\Chrome" name="PrintingPaperSizeDefault" presentation="$(presentation.PrintingPaperSizeDefault)">
+      <parentCategory ref="Printing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="PrintingPaperSizeDefault" maxLength="1000000" valueName="PrintingPaperSizeDefault"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintHeaderFooter)" explainText="$(string.PrintHeaderFooter_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="PrintHeaderFooter_recommended" presentation="$(presentation.PrintHeaderFooter)" valueName="PrintHeaderFooter">
+      <parentCategory ref="Printing_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrintPreviewUseSystemDefaultPrinter)" explainText="$(string.PrintPreviewUseSystemDefaultPrinter_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="PrintPreviewUseSystemDefaultPrinter_recommended" presentation="$(presentation.PrintPreviewUseSystemDefaultPrinter)" valueName="PrintPreviewUseSystemDefaultPrinter">
+      <parentCategory ref="Printing_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ProtectedContentIdentifiersAllowed)" explainText="$(string.ProtectedContentIdentifiersAllowed_Explain)" key="Software\Policies\Google\Chrome" name="ProtectedContentIdentifiersAllowed" presentation="$(presentation.ProtectedContentIdentifiersAllowed)" valueName="ProtectedContentIdentifiersAllowed">
+      <parentCategory ref="ProtectedContent"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableProxyOverrideRulesForAllUsers)" explainText="$(string.EnableProxyOverrideRulesForAllUsers_Explain)" key="Software\Policies\Google\Chrome" name="EnableProxyOverrideRulesForAllUsers" presentation="$(presentation.EnableProxyOverrideRulesForAllUsers)">
+      <parentCategory ref="Proxy"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="EnableProxyOverrideRulesForAllUsers" maxValue="2000000000" minValue="0" valueName="EnableProxyOverrideRulesForAllUsers"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowClientPairing)" explainText="$(string.RemoteAccessHostAllowClientPairing_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowClientPairing" presentation="$(presentation.RemoteAccessHostAllowClientPairing)" valueName="RemoteAccessHostAllowClientPairing">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowFileTransfer)" explainText="$(string.RemoteAccessHostAllowFileTransfer_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowFileTransfer" presentation="$(presentation.RemoteAccessHostAllowFileTransfer)" valueName="RemoteAccessHostAllowFileTransfer">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowPinAuthentication)" explainText="$(string.RemoteAccessHostAllowPinAuthentication_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowPinAuthentication" presentation="$(presentation.RemoteAccessHostAllowPinAuthentication)" valueName="RemoteAccessHostAllowPinAuthentication">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowRelayedConnection)" explainText="$(string.RemoteAccessHostAllowRelayedConnection_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowRelayedConnection" presentation="$(presentation.RemoteAccessHostAllowRelayedConnection)" valueName="RemoteAccessHostAllowRelayedConnection">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowRemoteAccessConnections)" explainText="$(string.RemoteAccessHostAllowRemoteAccessConnections_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowRemoteAccessConnections" presentation="$(presentation.RemoteAccessHostAllowRemoteAccessConnections)" valueName="RemoteAccessHostAllowRemoteAccessConnections">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowRemoteSupportConnections)" explainText="$(string.RemoteAccessHostAllowRemoteSupportConnections_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowRemoteSupportConnections" presentation="$(presentation.RemoteAccessHostAllowRemoteSupportConnections)" valueName="RemoteAccessHostAllowRemoteSupportConnections">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowUiAccessForRemoteAssistance)" explainText="$(string.RemoteAccessHostAllowUiAccessForRemoteAssistance_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowUiAccessForRemoteAssistance" presentation="$(presentation.RemoteAccessHostAllowUiAccessForRemoteAssistance)" valueName="RemoteAccessHostAllowUiAccessForRemoteAssistance">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostAllowUrlForwarding)" explainText="$(string.RemoteAccessHostAllowUrlForwarding_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostAllowUrlForwarding" presentation="$(presentation.RemoteAccessHostAllowUrlForwarding)" valueName="RemoteAccessHostAllowUrlForwarding">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostClientDomainList)" explainText="$(string.RemoteAccessHostClientDomainList_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostClientDomainList" presentation="$(presentation.RemoteAccessHostClientDomainList)">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="RemoteAccessHostClientDomainListDesc" key="Software\Policies\Google\Chrome\RemoteAccessHostClientDomainList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostClipboardSizeBytes)" explainText="$(string.RemoteAccessHostClipboardSizeBytes_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostClipboardSizeBytes" presentation="$(presentation.RemoteAccessHostClipboardSizeBytes)">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="RemoteAccessHostClipboardSizeBytes" maxValue="2147483647" minValue="0" valueName="RemoteAccessHostClipboardSizeBytes"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostDomainList)" explainText="$(string.RemoteAccessHostDomainList_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostDomainList" presentation="$(presentation.RemoteAccessHostDomainList)">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="RemoteAccessHostDomainListDesc" key="Software\Policies\Google\Chrome\RemoteAccessHostDomainList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostFirewallTraversal)" explainText="$(string.RemoteAccessHostFirewallTraversal_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostFirewallTraversal" presentation="$(presentation.RemoteAccessHostFirewallTraversal)" valueName="RemoteAccessHostFirewallTraversal">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostMaximumSessionDurationMinutes)" explainText="$(string.RemoteAccessHostMaximumSessionDurationMinutes_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostMaximumSessionDurationMinutes" presentation="$(presentation.RemoteAccessHostMaximumSessionDurationMinutes)">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="RemoteAccessHostMaximumSessionDurationMinutes" maxValue="10080" minValue="30" valueName="RemoteAccessHostMaximumSessionDurationMinutes"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostRequireCurtain)" explainText="$(string.RemoteAccessHostRequireCurtain_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostRequireCurtain" presentation="$(presentation.RemoteAccessHostRequireCurtain)" valueName="RemoteAccessHostRequireCurtain">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostUdpPortRange)" explainText="$(string.RemoteAccessHostUdpPortRange_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostUdpPortRange" presentation="$(presentation.RemoteAccessHostUdpPortRange)">
+      <parentCategory ref="RemoteAccess"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RemoteAccessHostUdpPortRange" maxLength="1000000" valueName="RemoteAccessHostUdpPortRange"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.UiAutomationProviderEnabled)" explainText="$(string.UiAutomationProviderEnabled_Explain)" key="Software\Policies\Google\Chrome" name="UiAutomationProviderEnabled" presentation="$(presentation.UiAutomationProviderEnabled)" valueName="UiAutomationProviderEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultFileHandlingGuardSetting)" explainText="$(string.DefaultFileHandlingGuardSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultFileHandlingGuardSetting" presentation="$(presentation.DefaultFileHandlingGuardSetting)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultFileHandlingGuardSetting" valueName="DefaultFileHandlingGuardSetting">
+          <item displayName="$(string.DefaultFileHandlingGuardSetting_BlockFileHandling)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultFileHandlingGuardSetting_AskFileHandling)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultKeygenSetting)" explainText="$(string.DefaultKeygenSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultKeygenSetting" presentation="$(presentation.DefaultKeygenSetting)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultKeygenSetting" valueName="DefaultKeygenSetting">
+          <item displayName="$(string.DefaultKeygenSetting_AllowKeygen)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultKeygenSetting_BlockKeygen)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultPluginsSetting)" explainText="$(string.DefaultPluginsSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultPluginsSetting" presentation="$(presentation.DefaultPluginsSetting)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultPluginsSetting" valueName="DefaultPluginsSetting">
+          <item displayName="$(string.DefaultPluginsSetting_AllowPlugins)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultPluginsSetting_BlockPlugins)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultPluginsSetting_ClickToPlay)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultThirdPartyStoragePartitioningSetting)" explainText="$(string.DefaultThirdPartyStoragePartitioningSetting_Explain)" key="Software\Policies\Google\Chrome" name="DefaultThirdPartyStoragePartitioningSetting" presentation="$(presentation.DefaultThirdPartyStoragePartitioningSetting)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="DefaultThirdPartyStoragePartitioningSetting" valueName="DefaultThirdPartyStoragePartitioningSetting">
+          <item displayName="$(string.DefaultThirdPartyStoragePartitioningSetting_AllowPartitioning)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.DefaultThirdPartyStoragePartitioningSetting_BlockPartitioning)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileHandlingAllowedForUrls)" explainText="$(string.FileHandlingAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="FileHandlingAllowedForUrls" presentation="$(presentation.FileHandlingAllowedForUrls)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="FileHandlingAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\FileHandlingAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileHandlingBlockedForUrls)" explainText="$(string.FileHandlingBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="FileHandlingBlockedForUrls" presentation="$(presentation.FileHandlingBlockedForUrls)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="FileHandlingBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\FileHandlingBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.FileSystemSyncAccessHandleAsyncInterfaceEnabled)" explainText="$(string.FileSystemSyncAccessHandleAsyncInterfaceEnabled_Explain)" key="Software\Policies\Google\Chrome" name="FileSystemSyncAccessHandleAsyncInterfaceEnabled" presentation="$(presentation.FileSystemSyncAccessHandleAsyncInterfaceEnabled)" valueName="FileSystemSyncAccessHandleAsyncInterfaceEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.KeygenAllowedForUrls)" explainText="$(string.KeygenAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="KeygenAllowedForUrls" presentation="$(presentation.KeygenAllowedForUrls)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="KeygenAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\KeygenAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.KeygenBlockedForUrls)" explainText="$(string.KeygenBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="KeygenBlockedForUrls" presentation="$(presentation.KeygenBlockedForUrls)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="KeygenBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\KeygenBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LegacySameSiteCookieBehaviorEnabled)" explainText="$(string.LegacySameSiteCookieBehaviorEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LegacySameSiteCookieBehaviorEnabled" presentation="$(presentation.LegacySameSiteCookieBehaviorEnabled)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="LegacySameSiteCookieBehaviorEnabled" valueName="LegacySameSiteCookieBehaviorEnabled">
+          <item displayName="$(string.LegacySameSiteCookieBehaviorEnabled_DefaultToLegacySameSiteCookieBehavior)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.LegacySameSiteCookieBehaviorEnabled_DefaultToSameSiteByDefaultCookieBehavior)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.LegacySameSiteCookieBehaviorEnabledForDomainList)" explainText="$(string.LegacySameSiteCookieBehaviorEnabledForDomainList_Explain)" key="Software\Policies\Google\Chrome" name="LegacySameSiteCookieBehaviorEnabledForDomainList" presentation="$(presentation.LegacySameSiteCookieBehaviorEnabledForDomainList)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="LegacySameSiteCookieBehaviorEnabledForDomainListDesc" key="Software\Policies\Google\Chrome\LegacySameSiteCookieBehaviorEnabledForDomainList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PluginsAllowedForUrls)" explainText="$(string.PluginsAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="PluginsAllowedForUrls" presentation="$(presentation.PluginsAllowedForUrls)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PluginsAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\PluginsAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PluginsBlockedForUrls)" explainText="$(string.PluginsBlockedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="PluginsBlockedForUrls" presentation="$(presentation.PluginsBlockedForUrls)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PluginsBlockedForUrlsDesc" key="Software\Policies\Google\Chrome\PluginsBlockedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ThirdPartyStoragePartitioningBlockedForOrigins)" explainText="$(string.ThirdPartyStoragePartitioningBlockedForOrigins_Explain)" key="Software\Policies\Google\Chrome" name="ThirdPartyStoragePartitioningBlockedForOrigins" presentation="$(presentation.ThirdPartyStoragePartitioningBlockedForOrigins)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ThirdPartyStoragePartitioningBlockedForOriginsDesc" key="Software\Policies\Google\Chrome\ThirdPartyStoragePartitioningBlockedForOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderIconURL)" explainText="$(string.DefaultSearchProviderIconURL_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderIconURL" presentation="$(presentation.DefaultSearchProviderIconURL)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderIconURL" maxLength="1000000" valueName="DefaultSearchProviderIconURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderInstantURL)" explainText="$(string.DefaultSearchProviderInstantURL_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderInstantURL" presentation="$(presentation.DefaultSearchProviderInstantURL)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderInstantURL" maxLength="1000000" valueName="DefaultSearchProviderInstantURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderInstantURLPostParams)" explainText="$(string.DefaultSearchProviderInstantURLPostParams_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderInstantURLPostParams" presentation="$(presentation.DefaultSearchProviderInstantURLPostParams)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderInstantURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderInstantURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSearchTermsReplacementKey)" explainText="$(string.DefaultSearchProviderSearchTermsReplacementKey_Explain)" key="Software\Policies\Google\Chrome" name="DefaultSearchProviderSearchTermsReplacementKey" presentation="$(presentation.DefaultSearchProviderSearchTermsReplacementKey)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSearchTermsReplacementKey" maxLength="1000000" valueName="DefaultSearchProviderSearchTermsReplacementKey"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ChromeAppsWebViewPermissiveBehaviorAllowed)" explainText="$(string.ChromeAppsWebViewPermissiveBehaviorAllowed_Explain)" key="Software\Policies\Google\Chrome" name="ChromeAppsWebViewPermissiveBehaviorAllowed" presentation="$(presentation.ChromeAppsWebViewPermissiveBehaviorAllowed)" valueName="ChromeAppsWebViewPermissiveBehaviorAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionAllowInsecureUpdates)" explainText="$(string.ExtensionAllowInsecureUpdates_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionAllowInsecureUpdates" presentation="$(presentation.ExtensionAllowInsecureUpdates)" valueName="ExtensionAllowInsecureUpdates">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionForceInstallWithNonMalwareViolationsEnabled)" explainText="$(string.ExtensionForceInstallWithNonMalwareViolationsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionForceInstallWithNonMalwareViolationsEnabled" presentation="$(presentation.ExtensionForceInstallWithNonMalwareViolationsEnabled)" valueName="ExtensionForceInstallWithNonMalwareViolationsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionManifestV2Availability)" explainText="$(string.ExtensionManifestV2Availability_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionManifestV2Availability" presentation="$(presentation.ExtensionManifestV2Availability)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ExtensionManifestV2Availability" valueName="ExtensionManifestV2Availability">
+          <item displayName="$(string.ExtensionManifestV2Availability_Default)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ExtensionManifestV2Availability_Disable)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.ExtensionManifestV2Availability_Enable)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+          <item displayName="$(string.ExtensionManifestV2Availability_EnableForForcedExtensions)">
+            <value>
+              <decimal value="3"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.TabOrganizerSettings)" explainText="$(string.TabOrganizerSettings_Explain)" key="Software\Policies\Google\Chrome" name="TabOrganizerSettings" presentation="$(presentation.TabOrganizerSettings)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="TabOrganizerSettings" valueName="TabOrganizerSettings">
+          <item displayName="$(string.TabOrganizerSettings_Allowed)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.TabOrganizerSettings_AllowedWithoutLogging)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.TabOrganizerSettings_Disabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AssistantWebEnabled)" explainText="$(string.AssistantWebEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AssistantWebEnabled" presentation="$(presentation.AssistantWebEnabled)" valueName="AssistantWebEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalNetworkAccessRestrictionsEnabled)" explainText="$(string.LocalNetworkAccessRestrictionsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LocalNetworkAccessRestrictionsEnabled" presentation="$(presentation.LocalNetworkAccessRestrictionsEnabled)" valueName="LocalNetworkAccessRestrictionsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SupervisedUserCreationEnabled)" explainText="$(string.SupervisedUserCreationEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SupervisedUserCreationEnabled" presentation="$(presentation.SupervisedUserCreationEnabled)" valueName="SupervisedUserCreationEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AdvancedProtectionDeepScanningEnabled)" explainText="$(string.AdvancedProtectionDeepScanningEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AdvancedProtectionDeepScanningEnabled" presentation="$(presentation.AdvancedProtectionDeepScanningEnabled)" valueName="AdvancedProtectionDeepScanningEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowOutdatedPlugins)" explainText="$(string.AllowOutdatedPlugins_Explain)" key="Software\Policies\Google\Chrome" name="AllowOutdatedPlugins" presentation="$(presentation.AllowOutdatedPlugins)" valueName="AllowOutdatedPlugins">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowPopupsDuringPageUnload)" explainText="$(string.AllowPopupsDuringPageUnload_Explain)" key="Software\Policies\Google\Chrome" name="AllowPopupsDuringPageUnload" presentation="$(presentation.AllowPopupsDuringPageUnload)" valueName="AllowPopupsDuringPageUnload">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AllowSyncXHRInPageDismissal)" explainText="$(string.AllowSyncXHRInPageDismissal_Explain)" key="Software\Policies\Google\Chrome" name="AllowSyncXHRInPageDismissal" presentation="$(presentation.AllowSyncXHRInPageDismissal)" valueName="AllowSyncXHRInPageDismissal">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AlwaysAuthorizePlugins)" explainText="$(string.AlwaysAuthorizePlugins_Explain)" key="Software\Policies\Google\Chrome" name="AlwaysAuthorizePlugins" presentation="$(presentation.AlwaysAuthorizePlugins)" valueName="AlwaysAuthorizePlugins">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AppCacheForceEnabled)" explainText="$(string.AppCacheForceEnabled_Explain)" key="Software\Policies\Google\Chrome" name="AppCacheForceEnabled" presentation="$(presentation.AppCacheForceEnabled)" valueName="AppCacheForceEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.AuthNegotiateDelegateWhitelist)" explainText="$(string.AuthNegotiateDelegateWhitelist_Explain)" key="Software\Policies\Google\Chrome" name="AuthNegotiateDelegateWhitelist" presentation="$(presentation.AuthNegotiateDelegateWhitelist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AuthNegotiateDelegateWhitelist" maxLength="1000000" valueName="AuthNegotiateDelegateWhitelist"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AuthServerWhitelist)" explainText="$(string.AuthServerWhitelist_Explain)" key="Software\Policies\Google\Chrome" name="AuthServerWhitelist" presentation="$(presentation.AuthServerWhitelist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="AuthServerWhitelist" maxLength="1000000" valueName="AuthServerWhitelist"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.AutoplayWhitelist)" explainText="$(string.AutoplayWhitelist_Explain)" key="Software\Policies\Google\Chrome" name="AutoplayWhitelist" presentation="$(presentation.AutoplayWhitelist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="AutoplayWhitelistDesc" key="Software\Policies\Google\Chrome\AutoplayWhitelist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BeforeunloadEventCancelByPreventDefaultEnabled)" explainText="$(string.BeforeunloadEventCancelByPreventDefaultEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BeforeunloadEventCancelByPreventDefaultEnabled" presentation="$(presentation.BeforeunloadEventCancelByPreventDefaultEnabled)" valueName="BeforeunloadEventCancelByPreventDefaultEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CECPQ2Enabled)" explainText="$(string.CECPQ2Enabled_Explain)" key="Software\Policies\Google\Chrome" name="CECPQ2Enabled" presentation="$(presentation.CECPQ2Enabled)" valueName="CECPQ2Enabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CSSCustomStateDeprecatedSyntaxEnabled)" explainText="$(string.CSSCustomStateDeprecatedSyntaxEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CSSCustomStateDeprecatedSyntaxEnabled" presentation="$(presentation.CSSCustomStateDeprecatedSyntaxEnabled)" valueName="CSSCustomStateDeprecatedSyntaxEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CertificateTransparencyEnforcementDisabledForLegacyCas)" explainText="$(string.CertificateTransparencyEnforcementDisabledForLegacyCas_Explain)" key="Software\Policies\Google\Chrome" name="CertificateTransparencyEnforcementDisabledForLegacyCas" presentation="$(presentation.CertificateTransparencyEnforcementDisabledForLegacyCas)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CertificateTransparencyEnforcementDisabledForLegacyCasDesc" key="Software\Policies\Google\Chrome\CertificateTransparencyEnforcementDisabledForLegacyCas" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ChromeAppsEnabled)" explainText="$(string.ChromeAppsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ChromeAppsEnabled" presentation="$(presentation.ChromeAppsEnabled)" valueName="ChromeAppsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ChromeCleanupEnabled)" explainText="$(string.ChromeCleanupEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ChromeCleanupEnabled" presentation="$(presentation.ChromeCleanupEnabled)" valueName="ChromeCleanupEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ChromeCleanupReportingEnabled)" explainText="$(string.ChromeCleanupReportingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ChromeCleanupReportingEnabled" presentation="$(presentation.ChromeCleanupReportingEnabled)" valueName="ChromeCleanupReportingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ChromeRootStoreEnabled)" explainText="$(string.ChromeRootStoreEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ChromeRootStoreEnabled" presentation="$(presentation.ChromeRootStoreEnabled)" valueName="ChromeRootStoreEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ClearSiteDataOnExit)" explainText="$(string.ClearSiteDataOnExit_Explain)" key="Software\Policies\Google\Chrome" name="ClearSiteDataOnExit" presentation="$(presentation.ClearSiteDataOnExit)" valueName="ClearSiteDataOnExit">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CorsLegacyModeEnabled)" explainText="$(string.CorsLegacyModeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CorsLegacyModeEnabled" presentation="$(presentation.CorsLegacyModeEnabled)" valueName="CorsLegacyModeEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CorsMitigationList)" explainText="$(string.CorsMitigationList_Explain)" key="Software\Policies\Google\Chrome" name="CorsMitigationList" presentation="$(presentation.CorsMitigationList)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="CorsMitigationListDesc" key="Software\Policies\Google\Chrome\CorsMitigationList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.CrossOriginWebAssemblyModuleSharingEnabled)" explainText="$(string.CrossOriginWebAssemblyModuleSharingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CrossOriginWebAssemblyModuleSharingEnabled" presentation="$(presentation.CrossOriginWebAssemblyModuleSharingEnabled)" valueName="CrossOriginWebAssemblyModuleSharingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DHEEnabled)" explainText="$(string.DHEEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DHEEnabled" presentation="$(presentation.DHEEnabled)" valueName="DHEEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisablePluginFinder)" explainText="$(string.DisablePluginFinder_Explain)" key="Software\Policies\Google\Chrome" name="DisablePluginFinder" presentation="$(presentation.DisablePluginFinder)" valueName="DisablePluginFinder">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisableSSLRecordSplitting)" explainText="$(string.DisableSSLRecordSplitting_Explain)" key="Software\Policies\Google\Chrome" name="DisableSSLRecordSplitting" presentation="$(presentation.DisableSSLRecordSplitting)" valueName="DisableSSLRecordSplitting">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisableSpdy)" explainText="$(string.DisableSpdy_Explain)" key="Software\Policies\Google\Chrome" name="DisableSpdy" presentation="$(presentation.DisableSpdy)" valueName="DisableSpdy">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisabledPlugins)" explainText="$(string.DisabledPlugins_Explain)" key="Software\Policies\Google\Chrome" name="DisabledPlugins" presentation="$(presentation.DisabledPlugins)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DisabledPluginsDesc" key="Software\Policies\Google\Chrome\DisabledPlugins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DisabledPluginsExceptions)" explainText="$(string.DisabledPluginsExceptions_Explain)" key="Software\Policies\Google\Chrome" name="DisabledPluginsExceptions" presentation="$(presentation.DisabledPluginsExceptions)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="DisabledPluginsExceptionsDesc" key="Software\Policies\Google\Chrome\DisabledPluginsExceptions" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DisplayCapturePermissionsPolicyEnabled)" explainText="$(string.DisplayCapturePermissionsPolicyEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DisplayCapturePermissionsPolicyEnabled" presentation="$(presentation.DisplayCapturePermissionsPolicyEnabled)" valueName="DisplayCapturePermissionsPolicyEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DnsPrefetchingEnabled)" explainText="$(string.DnsPrefetchingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DnsPrefetchingEnabled" presentation="$(presentation.DnsPrefetchingEnabled)" valueName="DnsPrefetchingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DownloadBubbleEnabled)" explainText="$(string.DownloadBubbleEnabled_Explain)" key="Software\Policies\Google\Chrome" name="DownloadBubbleEnabled" presentation="$(presentation.DownloadBubbleEnabled)" valueName="DownloadBubbleEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableCommonNameFallbackForLocalAnchors)" explainText="$(string.EnableCommonNameFallbackForLocalAnchors_Explain)" key="Software\Policies\Google\Chrome" name="EnableCommonNameFallbackForLocalAnchors" presentation="$(presentation.EnableCommonNameFallbackForLocalAnchors)" valueName="EnableCommonNameFallbackForLocalAnchors">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableDeprecatedPrivetPrinting)" explainText="$(string.EnableDeprecatedPrivetPrinting_Explain)" key="Software\Policies\Google\Chrome" name="EnableDeprecatedPrivetPrinting" presentation="$(presentation.EnableDeprecatedPrivetPrinting)" valueName="EnableDeprecatedPrivetPrinting">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableDeprecatedWebBasedSignin)" explainText="$(string.EnableDeprecatedWebBasedSignin_Explain)" key="Software\Policies\Google\Chrome" name="EnableDeprecatedWebBasedSignin" presentation="$(presentation.EnableDeprecatedWebBasedSignin)" valueName="EnableDeprecatedWebBasedSignin">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableDeprecatedWebPlatformFeatures)" explainText="$(string.EnableDeprecatedWebPlatformFeatures_Explain)" key="Software\Policies\Google\Chrome" name="EnableDeprecatedWebPlatformFeatures" presentation="$(presentation.EnableDeprecatedWebPlatformFeatures)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="EnableDeprecatedWebPlatformFeaturesDesc" key="Software\Policies\Google\Chrome\EnableDeprecatedWebPlatformFeatures" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableSha1ForLocalAnchors)" explainText="$(string.EnableSha1ForLocalAnchors_Explain)" key="Software\Policies\Google\Chrome" name="EnableSha1ForLocalAnchors" presentation="$(presentation.EnableSha1ForLocalAnchors)" valueName="EnableSha1ForLocalAnchors">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnableSymantecLegacyInfrastructure)" explainText="$(string.EnableSymantecLegacyInfrastructure_Explain)" key="Software\Policies\Google\Chrome" name="EnableSymantecLegacyInfrastructure" presentation="$(presentation.EnableSymantecLegacyInfrastructure)" valueName="EnableSymantecLegacyInfrastructure">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnabledPlugins)" explainText="$(string.EnabledPlugins_Explain)" key="Software\Policies\Google\Chrome" name="EnabledPlugins" presentation="$(presentation.EnabledPlugins)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="EnabledPluginsDesc" key="Software\Policies\Google\Chrome\EnabledPlugins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnforceLocalAnchorConstraintsEnabled)" explainText="$(string.EnforceLocalAnchorConstraintsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="EnforceLocalAnchorConstraintsEnabled" presentation="$(presentation.EnforceLocalAnchorConstraintsEnabled)" valueName="EnforceLocalAnchorConstraintsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseWebStoreName)" explainText="$(string.EnterpriseWebStoreName_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseWebStoreName" presentation="$(presentation.EnterpriseWebStoreName)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="EnterpriseWebStoreName" maxLength="1000000" valueName="EnterpriseWebStoreName"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EnterpriseWebStoreURL)" explainText="$(string.EnterpriseWebStoreURL_Explain)" key="Software\Policies\Google\Chrome" name="EnterpriseWebStoreURL" presentation="$(presentation.EnterpriseWebStoreURL)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="EnterpriseWebStoreURL" maxLength="1000000" valueName="EnterpriseWebStoreURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.EventPathEnabled)" explainText="$(string.EventPathEnabled_Explain)" key="Software\Policies\Google\Chrome" name="EventPathEnabled" presentation="$(presentation.EventPathEnabled)" valueName="EventPathEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionInstallBlacklist)" explainText="$(string.ExtensionInstallBlacklist_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionInstallBlacklist" presentation="$(presentation.ExtensionInstallBlacklist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionInstallBlacklistDesc" key="Software\Policies\Google\Chrome\ExtensionInstallBlacklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ExtensionInstallWhitelist)" explainText="$(string.ExtensionInstallWhitelist_Explain)" key="Software\Policies\Google\Chrome" name="ExtensionInstallWhitelist" presentation="$(presentation.ExtensionInstallWhitelist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ExtensionInstallWhitelistDesc" key="Software\Policies\Google\Chrome\ExtensionInstallWhitelist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceEnablePepperVideoDecoderDevAPI)" explainText="$(string.ForceEnablePepperVideoDecoderDevAPI_Explain)" key="Software\Policies\Google\Chrome" name="ForceEnablePepperVideoDecoderDevAPI" presentation="$(presentation.ForceEnablePepperVideoDecoderDevAPI)" valueName="ForceEnablePepperVideoDecoderDevAPI">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceLegacyDefaultReferrerPolicy)" explainText="$(string.ForceLegacyDefaultReferrerPolicy_Explain)" key="Software\Policies\Google\Chrome" name="ForceLegacyDefaultReferrerPolicy" presentation="$(presentation.ForceLegacyDefaultReferrerPolicy)" valueName="ForceLegacyDefaultReferrerPolicy">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceMajorVersionToMinorPositionInUserAgent)" explainText="$(string.ForceMajorVersionToMinorPositionInUserAgent_Explain)" key="Software\Policies\Google\Chrome" name="ForceMajorVersionToMinorPositionInUserAgent" presentation="$(presentation.ForceMajorVersionToMinorPositionInUserAgent)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ForceMajorVersionToMinorPositionInUserAgent" valueName="ForceMajorVersionToMinorPositionInUserAgent">
+          <item displayName="$(string.ForceMajorVersionToMinorPositionInUserAgent_Default)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ForceMajorVersionToMinorPositionInUserAgent_ForceDisabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.ForceMajorVersionToMinorPositionInUserAgent_ForceEnabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ForceNetworkInProcess)" explainText="$(string.ForceNetworkInProcess_Explain)" key="Software\Policies\Google\Chrome" name="ForceNetworkInProcess" presentation="$(presentation.ForceNetworkInProcess)" valueName="ForceNetworkInProcess">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HideWebStorePromo)" explainText="$(string.HideWebStorePromo_Explain)" key="Software\Policies\Google\Chrome" name="HideWebStorePromo" presentation="$(presentation.HideWebStorePromo)" valueName="HideWebStorePromo">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.Http09OnNonDefaultPortsEnabled)" explainText="$(string.Http09OnNonDefaultPortsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="Http09OnNonDefaultPortsEnabled" presentation="$(presentation.Http09OnNonDefaultPortsEnabled)" valueName="Http09OnNonDefaultPortsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.InsecureHashesInTLSHandshakesEnabled)" explainText="$(string.InsecureHashesInTLSHandshakesEnabled_Explain)" key="Software\Policies\Google\Chrome" name="InsecureHashesInTLSHandshakesEnabled" presentation="$(presentation.InsecureHashesInTLSHandshakesEnabled)" valueName="InsecureHashesInTLSHandshakesEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.InstantEnabled)" explainText="$(string.InstantEnabled_Explain)" key="Software\Policies\Google\Chrome" name="InstantEnabled" presentation="$(presentation.InstantEnabled)" valueName="InstantEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.KeyboardFocusableScrollersEnabled)" explainText="$(string.KeyboardFocusableScrollersEnabled_Explain)" key="Software\Policies\Google\Chrome" name="KeyboardFocusableScrollersEnabled" presentation="$(presentation.KeyboardFocusableScrollersEnabled)" valueName="KeyboardFocusableScrollersEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LoadCryptoTokenExtension)" explainText="$(string.LoadCryptoTokenExtension_Explain)" key="Software\Policies\Google\Chrome" name="LoadCryptoTokenExtension" presentation="$(presentation.LoadCryptoTokenExtension)" valueName="LoadCryptoTokenExtension">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LocalDiscoveryEnabled)" explainText="$(string.LocalDiscoveryEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LocalDiscoveryEnabled" presentation="$(presentation.LocalDiscoveryEnabled)" valueName="LocalDiscoveryEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.LockIconInAddressBarEnabled)" explainText="$(string.LockIconInAddressBarEnabled_Explain)" key="Software\Policies\Google\Chrome" name="LockIconInAddressBarEnabled" presentation="$(presentation.LockIconInAddressBarEnabled)" valueName="LockIconInAddressBarEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.MachineLevelUserCloudPolicyEnrollmentToken)" explainText="$(string.MachineLevelUserCloudPolicyEnrollmentToken_Explain)" key="Software\Policies\Google\Chrome" name="MachineLevelUserCloudPolicyEnrollmentToken" presentation="$(presentation.MachineLevelUserCloudPolicyEnrollmentToken)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="MachineLevelUserCloudPolicyEnrollmentToken" maxLength="1000000" valueName="MachineLevelUserCloudPolicyEnrollmentToken"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.MediaCacheSize)" explainText="$(string.MediaCacheSize_Explain)" key="Software\Policies\Google\Chrome" name="MediaCacheSize" presentation="$(presentation.MediaCacheSize)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <decimal id="MediaCacheSize" maxValue="2000000000" minValue="0" valueName="MediaCacheSize"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.MutationEventsEnabled)" explainText="$(string.MutationEventsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="MutationEventsEnabled" presentation="$(presentation.MutationEventsEnabled)" valueName="MutationEventsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeClientForceAllowed)" explainText="$(string.NativeClientForceAllowed_Explain)" key="Software\Policies\Google\Chrome" name="NativeClientForceAllowed" presentation="$(presentation.NativeClientForceAllowed)" valueName="NativeClientForceAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeMessagingBlacklist)" explainText="$(string.NativeMessagingBlacklist_Explain)" key="Software\Policies\Google\Chrome" name="NativeMessagingBlacklist" presentation="$(presentation.NativeMessagingBlacklist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="NativeMessagingBlacklistDesc" key="Software\Policies\Google\Chrome\NativeMessagingBlacklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeMessagingWhitelist)" explainText="$(string.NativeMessagingWhitelist_Explain)" key="Software\Policies\Google\Chrome" name="NativeMessagingWhitelist" presentation="$(presentation.NativeMessagingWhitelist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="NativeMessagingWhitelistDesc" key="Software\Policies\Google\Chrome\NativeMessagingWhitelist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NativeWindowOcclusionEnabled)" explainText="$(string.NativeWindowOcclusionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="NativeWindowOcclusionEnabled" presentation="$(presentation.NativeWindowOcclusionEnabled)" valueName="NativeWindowOcclusionEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.NewBaseUrlInheritanceBehaviorAllowed)" explainText="$(string.NewBaseUrlInheritanceBehaviorAllowed_Explain)" key="Software\Policies\Google\Chrome" name="NewBaseUrlInheritanceBehaviorAllowed" presentation="$(presentation.NewBaseUrlInheritanceBehaviorAllowed)" valueName="NewBaseUrlInheritanceBehaviorAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.OffsetParentNewSpecBehaviorEnabled)" explainText="$(string.OffsetParentNewSpecBehaviorEnabled_Explain)" key="Software\Policies\Google\Chrome" name="OffsetParentNewSpecBehaviorEnabled" presentation="$(presentation.OffsetParentNewSpecBehaviorEnabled)" valueName="OffsetParentNewSpecBehaviorEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.OptimizationGuideFetchingEnabled)" explainText="$(string.OptimizationGuideFetchingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="OptimizationGuideFetchingEnabled" presentation="$(presentation.OptimizationGuideFetchingEnabled)" valueName="OptimizationGuideFetchingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PPAPISharedImagesSwapChainAllowed)" explainText="$(string.PPAPISharedImagesSwapChainAllowed_Explain)" key="Software\Policies\Google\Chrome" name="PPAPISharedImagesSwapChainAllowed" presentation="$(presentation.PPAPISharedImagesSwapChainAllowed)" valueName="PPAPISharedImagesSwapChainAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PacHttpsUrlStrippingEnabled)" explainText="$(string.PacHttpsUrlStrippingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PacHttpsUrlStrippingEnabled" presentation="$(presentation.PacHttpsUrlStrippingEnabled)" valueName="PacHttpsUrlStrippingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PersistentQuotaEnabled)" explainText="$(string.PersistentQuotaEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PersistentQuotaEnabled" presentation="$(presentation.PersistentQuotaEnabled)" valueName="PersistentQuotaEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PostQuantumKeyAgreementEnabled)" explainText="$(string.PostQuantumKeyAgreementEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PostQuantumKeyAgreementEnabled" presentation="$(presentation.PostQuantumKeyAgreementEnabled)" valueName="PostQuantumKeyAgreementEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrefixedStorageInfoEnabled)" explainText="$(string.PrefixedStorageInfoEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrefixedStorageInfoEnabled" presentation="$(presentation.PrefixedStorageInfoEnabled)" valueName="PrefixedStorageInfoEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrefixedVideoFullscreenApiAvailability)" explainText="$(string.PrefixedVideoFullscreenApiAvailability_Explain)" key="Software\Policies\Google\Chrome" name="PrefixedVideoFullscreenApiAvailability" presentation="$(presentation.PrefixedVideoFullscreenApiAvailability)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PrefixedVideoFullscreenApiAvailability" valueName="PrefixedVideoFullscreenApiAvailability">
+          <item displayName="$(string.PrefixedVideoFullscreenApiAvailability_RuntimeEnabled)">
+            <value>
+              <string>runtime-enabled</string>
+            </value>
+          </item>
+          <item displayName="$(string.PrefixedVideoFullscreenApiAvailability_Disabled)">
+            <value>
+              <string>disabled</string>
+            </value>
+          </item>
+          <item displayName="$(string.PrefixedVideoFullscreenApiAvailability_Enabled)">
+            <value>
+              <string>enabled</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RC4Enabled)" explainText="$(string.RC4Enabled_Explain)" key="Software\Policies\Google\Chrome" name="RC4Enabled" presentation="$(presentation.RC4Enabled)" valueName="RC4Enabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RSAKeyUsageForLocalAnchorsEnabled)" explainText="$(string.RSAKeyUsageForLocalAnchorsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="RSAKeyUsageForLocalAnchorsEnabled" presentation="$(presentation.RSAKeyUsageForLocalAnchorsEnabled)" valueName="RSAKeyUsageForLocalAnchorsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RendererCodeIntegrityEnabled)" explainText="$(string.RendererCodeIntegrityEnabled_Explain)" key="Software\Policies\Google\Chrome" name="RendererCodeIntegrityEnabled" presentation="$(presentation.RendererCodeIntegrityEnabled)" valueName="RendererCodeIntegrityEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RunAllFlashInAllowMode)" explainText="$(string.RunAllFlashInAllowMode_Explain)" key="Software\Policies\Google\Chrome" name="RunAllFlashInAllowMode" presentation="$(presentation.RunAllFlashInAllowMode)" valueName="RunAllFlashInAllowMode">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SSLVersionFallbackMin)" explainText="$(string.SSLVersionFallbackMin_Explain)" key="Software\Policies\Google\Chrome" name="SSLVersionFallbackMin" presentation="$(presentation.SSLVersionFallbackMin)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="SSLVersionFallbackMin" valueName="SSLVersionFallbackMin">
+          <item displayName="$(string.SSLVersionFallbackMin_TLSv1_1)">
+            <value>
+              <string>tls1.1</string>
+            </value>
+          </item>
+          <item displayName="$(string.SSLVersionFallbackMin_TLSv1_2)">
+            <value>
+              <string>tls1.2</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SSLVersionMax)" explainText="$(string.SSLVersionMax_Explain)" key="Software\Policies\Google\Chrome" name="SSLVersionMax" presentation="$(presentation.SSLVersionMax)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="SSLVersionMax" valueName="SSLVersionMax">
+          <item displayName="$(string.SSLVersionMax_TLSv1_2)">
+            <value>
+              <string>tls1.2</string>
+            </value>
+          </item>
+          <item displayName="$(string.SSLVersionMax_TLSv1_3)">
+            <value>
+              <string>tls1.3</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SSLVersionMin)" explainText="$(string.SSLVersionMin_Explain)" key="Software\Policies\Google\Chrome" name="SSLVersionMin" presentation="$(presentation.SSLVersionMin)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="SSLVersionMin" valueName="SSLVersionMin">
+          <item displayName="$(string.SSLVersionMin_TLSv1)">
+            <value>
+              <string>tls1</string>
+            </value>
+          </item>
+          <item displayName="$(string.SSLVersionMin_TLSv1_1)">
+            <value>
+              <string>tls1.1</string>
+            </value>
+          </item>
+          <item displayName="$(string.SSLVersionMin_TLSv1_2)">
+            <value>
+              <string>tls1.2</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingExtendedReportingOptInAllowed)" explainText="$(string.SafeBrowsingExtendedReportingOptInAllowed_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingExtendedReportingOptInAllowed" presentation="$(presentation.SafeBrowsingExtendedReportingOptInAllowed)" valueName="SafeBrowsingExtendedReportingOptInAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingWhitelistDomains)" explainText="$(string.SafeBrowsingWhitelistDomains_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingWhitelistDomains" presentation="$(presentation.SafeBrowsingWhitelistDomains)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SafeBrowsingWhitelistDomainsDesc" key="Software\Policies\Google\Chrome\SafeBrowsingWhitelistDomains" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SelectParserRelaxationEnabled)" explainText="$(string.SelectParserRelaxationEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SelectParserRelaxationEnabled" presentation="$(presentation.SelectParserRelaxationEnabled)" valueName="SelectParserRelaxationEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SendMouseEventsDisabledFormControlsEnabled)" explainText="$(string.SendMouseEventsDisabledFormControlsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SendMouseEventsDisabledFormControlsEnabled" presentation="$(presentation.SendMouseEventsDisabledFormControlsEnabled)" valueName="SendMouseEventsDisabledFormControlsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SetTimeoutWithout1MsClampEnabled)" explainText="$(string.SetTimeoutWithout1MsClampEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SetTimeoutWithout1MsClampEnabled" presentation="$(presentation.SetTimeoutWithout1MsClampEnabled)" valueName="SetTimeoutWithout1MsClampEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SpellcheckLanguageBlacklist)" explainText="$(string.SpellcheckLanguageBlacklist_Explain)" key="Software\Policies\Google\Chrome" name="SpellcheckLanguageBlacklist" presentation="$(presentation.SpellcheckLanguageBlacklist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SpellcheckLanguageBlacklistDesc" key="Software\Policies\Google\Chrome\SpellcheckLanguageBlacklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.StricterMixedContentTreatmentEnabled)" explainText="$(string.StricterMixedContentTreatmentEnabled_Explain)" key="Software\Policies\Google\Chrome" name="StricterMixedContentTreatmentEnabled" presentation="$(presentation.StricterMixedContentTreatmentEnabled)" valueName="StricterMixedContentTreatmentEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TLS13HardeningForLocalAnchorsEnabled)" explainText="$(string.TLS13HardeningForLocalAnchorsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="TLS13HardeningForLocalAnchorsEnabled" presentation="$(presentation.TLS13HardeningForLocalAnchorsEnabled)" valueName="TLS13HardeningForLocalAnchorsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TabFreezingEnabled)" explainText="$(string.TabFreezingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="TabFreezingEnabled" presentation="$(presentation.TabFreezingEnabled)" valueName="TabFreezingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TabUnderAllowed)" explainText="$(string.TabUnderAllowed_Explain)" key="Software\Policies\Google\Chrome" name="TabUnderAllowed" presentation="$(presentation.TabUnderAllowed)" valueName="TabUnderAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.TargetBlankImpliesNoOpener)" explainText="$(string.TargetBlankImpliesNoOpener_Explain)" key="Software\Policies\Google\Chrome" name="TargetBlankImpliesNoOpener" presentation="$(presentation.TargetBlankImpliesNoOpener)" valueName="TargetBlankImpliesNoOpener">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ThirdPartyBlockingEnabled)" explainText="$(string.ThirdPartyBlockingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ThirdPartyBlockingEnabled" presentation="$(presentation.ThirdPartyBlockingEnabled)" valueName="ThirdPartyBlockingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ThrottleNonVisibleCrossOriginIframesAllowed)" explainText="$(string.ThrottleNonVisibleCrossOriginIframesAllowed_Explain)" key="Software\Policies\Google\Chrome" name="ThrottleNonVisibleCrossOriginIframesAllowed" presentation="$(presentation.ThrottleNonVisibleCrossOriginIframesAllowed)" valueName="ThrottleNonVisibleCrossOriginIframesAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ToolbarAvatarLabelSettings)" explainText="$(string.ToolbarAvatarLabelSettings_Explain)" key="Software\Policies\Google\Chrome" name="ToolbarAvatarLabelSettings" presentation="$(presentation.ToolbarAvatarLabelSettings)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="ToolbarAvatarLabelSettings" valueName="ToolbarAvatarLabelSettings">
+          <item displayName="$(string.ToolbarAvatarLabelSettings_display_management_label_permanent)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.ToolbarAvatarLabelSettings_display_management_label_transient)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.TripleDESEnabled)" explainText="$(string.TripleDESEnabled_Explain)" key="Software\Policies\Google\Chrome" name="TripleDESEnabled" presentation="$(presentation.TripleDESEnabled)" valueName="TripleDESEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.U2fSecurityKeyApiEnabled)" explainText="$(string.U2fSecurityKeyApiEnabled_Explain)" key="Software\Policies\Google\Chrome" name="U2fSecurityKeyApiEnabled" presentation="$(presentation.U2fSecurityKeyApiEnabled)" valueName="U2fSecurityKeyApiEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.URLBlacklist)" explainText="$(string.URLBlacklist_Explain)" key="Software\Policies\Google\Chrome" name="URLBlacklist" presentation="$(presentation.URLBlacklist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="URLBlacklistDesc" key="Software\Policies\Google\Chrome\URLBlacklist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.URLWhitelist)" explainText="$(string.URLWhitelist_Explain)" key="Software\Policies\Google\Chrome" name="URLWhitelist" presentation="$(presentation.URLWhitelist)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="URLWhitelistDesc" key="Software\Policies\Google\Chrome\URLWhitelist" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.UnthrottledNestedTimeoutEnabled)" explainText="$(string.UnthrottledNestedTimeoutEnabled_Explain)" key="Software\Policies\Google\Chrome" name="UnthrottledNestedTimeoutEnabled" presentation="$(presentation.UnthrottledNestedTimeoutEnabled)" valueName="UnthrottledNestedTimeoutEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UrlParamFilterEnabled)" explainText="$(string.UrlParamFilterEnabled_Explain)" key="Software\Policies\Google\Chrome" name="UrlParamFilterEnabled" presentation="$(presentation.UrlParamFilterEnabled)" valueName="UrlParamFilterEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UseLegacyFormControls)" explainText="$(string.UseLegacyFormControls_Explain)" key="Software\Policies\Google\Chrome" name="UseLegacyFormControls" presentation="$(presentation.UseLegacyFormControls)" valueName="UseLegacyFormControls">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UseMojoVideoDecoderForPepperAllowed)" explainText="$(string.UseMojoVideoDecoderForPepperAllowed_Explain)" key="Software\Policies\Google\Chrome" name="UseMojoVideoDecoderForPepperAllowed" presentation="$(presentation.UseMojoVideoDecoderForPepperAllowed)" valueName="UseMojoVideoDecoderForPepperAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UserAgentClientHintsEnabled)" explainText="$(string.UserAgentClientHintsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="UserAgentClientHintsEnabled" presentation="$(presentation.UserAgentClientHintsEnabled)" valueName="UserAgentClientHintsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UserAgentClientHintsGREASEUpdateEnabled)" explainText="$(string.UserAgentClientHintsGREASEUpdateEnabled_Explain)" key="Software\Policies\Google\Chrome" name="UserAgentClientHintsGREASEUpdateEnabled" presentation="$(presentation.UserAgentClientHintsGREASEUpdateEnabled)" valueName="UserAgentClientHintsGREASEUpdateEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.UserAgentReduction)" explainText="$(string.UserAgentReduction_Explain)" key="Software\Policies\Google\Chrome" name="UserAgentReduction" presentation="$(presentation.UserAgentReduction)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="UserAgentReduction" valueName="UserAgentReduction">
+          <item displayName="$(string.UserAgentReduction_Default)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.UserAgentReduction_ForceDisabled)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.UserAgentReduction_ForceEnabled)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebComponentsV0Enabled)" explainText="$(string.WebComponentsV0Enabled_Explain)" key="Software\Policies\Google\Chrome" name="WebComponentsV0Enabled" presentation="$(presentation.WebComponentsV0Enabled)" valueName="WebComponentsV0Enabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebDriverOverridesIncompatiblePolicies)" explainText="$(string.WebDriverOverridesIncompatiblePolicies_Explain)" key="Software\Policies\Google\Chrome" name="WebDriverOverridesIncompatiblePolicies" presentation="$(presentation.WebDriverOverridesIncompatiblePolicies)" valueName="WebDriverOverridesIncompatiblePolicies">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcAllowLegacyTLSProtocols)" explainText="$(string.WebRtcAllowLegacyTLSProtocols_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcAllowLegacyTLSProtocols" presentation="$(presentation.WebRtcAllowLegacyTLSProtocols)" valueName="WebRtcAllowLegacyTLSProtocols">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebSQLAccess)" explainText="$(string.WebSQLAccess_Explain)" key="Software\Policies\Google\Chrome" name="WebSQLAccess" presentation="$(presentation.WebSQLAccess)" valueName="WebSQLAccess">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebSQLInThirdPartyContextEnabled)" explainText="$(string.WebSQLInThirdPartyContextEnabled_Explain)" key="Software\Policies\Google\Chrome" name="WebSQLInThirdPartyContextEnabled" presentation="$(presentation.WebSQLInThirdPartyContextEnabled)" valueName="WebSQLInThirdPartyContextEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebSQLNonSecureContextEnabled)" explainText="$(string.WebSQLNonSecureContextEnabled_Explain)" key="Software\Policies\Google\Chrome" name="WebSQLNonSecureContextEnabled" presentation="$(presentation.WebSQLNonSecureContextEnabled)" valueName="WebSQLNonSecureContextEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WelcomePageOnOSUpgradeEnabled)" explainText="$(string.WelcomePageOnOSUpgradeEnabled_Explain)" key="Software\Policies\Google\Chrome" name="WelcomePageOnOSUpgradeEnabled" presentation="$(presentation.WelcomePageOnOSUpgradeEnabled)" valueName="WelcomePageOnOSUpgradeEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.BlockTruncatedCookies)" explainText="$(string.BlockTruncatedCookies_Explain)" key="Software\Policies\Google\Chrome" name="BlockTruncatedCookies" presentation="$(presentation.BlockTruncatedCookies)" valueName="BlockTruncatedCookies">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ZstdContentEncodingEnabled)" explainText="$(string.ZstdContentEncodingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="ZstdContentEncodingEnabled" presentation="$(presentation.ZstdContentEncodingEnabled)" valueName="ZstdContentEncodingEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordManagerAllowShowPasswords)" explainText="$(string.PasswordManagerAllowShowPasswords_Explain)" key="Software\Policies\Google\Chrome" name="PasswordManagerAllowShowPasswords" presentation="$(presentation.PasswordManagerAllowShowPasswords)" valueName="PasswordManagerAllowShowPasswords">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudPrintProxyEnabled)" explainText="$(string.CloudPrintProxyEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CloudPrintProxyEnabled" presentation="$(presentation.CloudPrintProxyEnabled)" valueName="CloudPrintProxyEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudPrintSubmitEnabled)" explainText="$(string.CloudPrintSubmitEnabled_Explain)" key="Software\Policies\Google\Chrome" name="CloudPrintSubmitEnabled" presentation="$(presentation.CloudPrintSubmitEnabled)" valueName="CloudPrintSubmitEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.CloudPrintWarningsSuppressed)" explainText="$(string.CloudPrintWarningsSuppressed_Explain)" key="Software\Policies\Google\Chrome" name="CloudPrintWarningsSuppressed" presentation="$(presentation.CloudPrintWarningsSuppressed)" valueName="CloudPrintWarningsSuppressed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrivacySandboxFingerprintingProtectionEnabled)" explainText="$(string.PrivacySandboxFingerprintingProtectionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrivacySandboxFingerprintingProtectionEnabled" presentation="$(presentation.PrivacySandboxFingerprintingProtectionEnabled)" valueName="PrivacySandboxFingerprintingProtectionEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PrivacySandboxIpProtectionEnabled)" explainText="$(string.PrivacySandboxIpProtectionEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrivacySandboxIpProtectionEnabled" presentation="$(presentation.PrivacySandboxIpProtectionEnabled)" valueName="PrivacySandboxIpProtectionEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.InsecurePrivateNetworkRequestsAllowed)" explainText="$(string.InsecurePrivateNetworkRequestsAllowed_Explain)" key="Software\Policies\Google\Chrome" name="InsecurePrivateNetworkRequestsAllowed" presentation="$(presentation.InsecurePrivateNetworkRequestsAllowed)" valueName="InsecurePrivateNetworkRequestsAllowed">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.InsecurePrivateNetworkRequestsAllowedForUrls)" explainText="$(string.InsecurePrivateNetworkRequestsAllowedForUrls_Explain)" key="Software\Policies\Google\Chrome" name="InsecurePrivateNetworkRequestsAllowedForUrls" presentation="$(presentation.InsecurePrivateNetworkRequestsAllowedForUrls)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="InsecurePrivateNetworkRequestsAllowedForUrlsDesc" key="Software\Policies\Google\Chrome\InsecurePrivateNetworkRequestsAllowedForUrls" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PrivateNetworkAccessRestrictionsEnabled)" explainText="$(string.PrivateNetworkAccessRestrictionsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="PrivateNetworkAccessRestrictionsEnabled" presentation="$(presentation.PrivateNetworkAccessRestrictionsEnabled)" valueName="PrivateNetworkAccessRestrictionsEnabled">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessClientFirewallTraversal)" explainText="$(string.RemoteAccessClientFirewallTraversal_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessClientFirewallTraversal" presentation="$(presentation.RemoteAccessClientFirewallTraversal)" valueName="RemoteAccessClientFirewallTraversal">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostDebugOverridePolicies)" explainText="$(string.RemoteAccessHostDebugOverridePolicies_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostDebugOverridePolicies" presentation="$(presentation.RemoteAccessHostDebugOverridePolicies)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RemoteAccessHostDebugOverridePolicies" maxLength="1000000" valueName="RemoteAccessHostDebugOverridePolicies"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostRequireTwoFactor)" explainText="$(string.RemoteAccessHostRequireTwoFactor_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostRequireTwoFactor" presentation="$(presentation.RemoteAccessHostRequireTwoFactor)" valueName="RemoteAccessHostRequireTwoFactor">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.RemoteAccessHostTalkGadgetPrefix)" explainText="$(string.RemoteAccessHostTalkGadgetPrefix_Explain)" key="Software\Policies\Google\Chrome" name="RemoteAccessHostTalkGadgetPrefix" presentation="$(presentation.RemoteAccessHostTalkGadgetPrefix)">
+      <parentCategory ref="RemovedPolicies"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="RemoteAccessHostTalkGadgetPrefix" maxLength="1000000" valueName="RemoteAccessHostTalkGadgetPrefix"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderIconURL)" explainText="$(string.DefaultSearchProviderIconURL_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderIconURL_recommended" presentation="$(presentation.DefaultSearchProviderIconURL)">
+      <parentCategory ref="RemovedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderIconURL" maxLength="1000000" valueName="DefaultSearchProviderIconURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderInstantURL)" explainText="$(string.DefaultSearchProviderInstantURL_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderInstantURL_recommended" presentation="$(presentation.DefaultSearchProviderInstantURL)">
+      <parentCategory ref="RemovedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderInstantURL" maxLength="1000000" valueName="DefaultSearchProviderInstantURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderInstantURLPostParams)" explainText="$(string.DefaultSearchProviderInstantURLPostParams_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderInstantURLPostParams_recommended" presentation="$(presentation.DefaultSearchProviderInstantURLPostParams)">
+      <parentCategory ref="RemovedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderInstantURLPostParams" maxLength="1000000" valueName="DefaultSearchProviderInstantURLPostParams"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.DefaultSearchProviderSearchTermsReplacementKey)" explainText="$(string.DefaultSearchProviderSearchTermsReplacementKey_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DefaultSearchProviderSearchTermsReplacementKey_recommended" presentation="$(presentation.DefaultSearchProviderSearchTermsReplacementKey)">
+      <parentCategory ref="RemovedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="DefaultSearchProviderSearchTermsReplacementKey" maxLength="1000000" valueName="DefaultSearchProviderSearchTermsReplacementKey"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ClearSiteDataOnExit)" explainText="$(string.ClearSiteDataOnExit_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ClearSiteDataOnExit_recommended" presentation="$(presentation.ClearSiteDataOnExit)" valueName="ClearSiteDataOnExit">
+      <parentCategory ref="RemovedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DnsPrefetchingEnabled)" explainText="$(string.DnsPrefetchingEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="DnsPrefetchingEnabled_recommended" presentation="$(presentation.DnsPrefetchingEnabled)" valueName="DnsPrefetchingEnabled">
+      <parentCategory ref="RemovedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.InstantEnabled)" explainText="$(string.InstantEnabled_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="InstantEnabled_recommended" presentation="$(presentation.InstantEnabled)" valueName="InstantEnabled">
+      <parentCategory ref="RemovedPolicies_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.DisableSafeBrowsingProceedAnyway)" explainText="$(string.DisableSafeBrowsingProceedAnyway_Explain)" key="Software\Policies\Google\Chrome" name="DisableSafeBrowsingProceedAnyway" presentation="$(presentation.DisableSafeBrowsingProceedAnyway)" valueName="DisableSafeBrowsingProceedAnyway">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordProtectionChangePasswordURL)" explainText="$(string.PasswordProtectionChangePasswordURL_Explain)" key="Software\Policies\Google\Chrome" name="PasswordProtectionChangePasswordURL" presentation="$(presentation.PasswordProtectionChangePasswordURL)">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="PasswordProtectionChangePasswordURL" maxLength="1000000" valueName="PasswordProtectionChangePasswordURL"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordProtectionLoginURLs)" explainText="$(string.PasswordProtectionLoginURLs_Explain)" key="Software\Policies\Google\Chrome" name="PasswordProtectionLoginURLs" presentation="$(presentation.PasswordProtectionLoginURLs)">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="PasswordProtectionLoginURLsDesc" key="Software\Policies\Google\Chrome\PasswordProtectionLoginURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.PasswordProtectionWarningTrigger)" explainText="$(string.PasswordProtectionWarningTrigger_Explain)" key="Software\Policies\Google\Chrome" name="PasswordProtectionWarningTrigger" presentation="$(presentation.PasswordProtectionWarningTrigger)">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="PasswordProtectionWarningTrigger" valueName="PasswordProtectionWarningTrigger">
+          <item displayName="$(string.PasswordProtectionWarningTrigger_PasswordProtectionWarningOff)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.PasswordProtectionWarningTrigger_PasswordProtectionWarningOnPasswordReuse)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.PasswordProtectionWarningTrigger_PasswordProtectionWarningOnPhishingReuse)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingAllowlistDomains)" explainText="$(string.SafeBrowsingAllowlistDomains_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingAllowlistDomains" presentation="$(presentation.SafeBrowsingAllowlistDomains)">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="SafeBrowsingAllowlistDomainsDesc" key="Software\Policies\Google\Chrome\SafeBrowsingAllowlistDomains" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingDeepScanningEnabled)" explainText="$(string.SafeBrowsingDeepScanningEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingDeepScanningEnabled" presentation="$(presentation.SafeBrowsingDeepScanningEnabled)" valueName="SafeBrowsingDeepScanningEnabled">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingExtendedReportingEnabled)" explainText="$(string.SafeBrowsingExtendedReportingEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingExtendedReportingEnabled" presentation="$(presentation.SafeBrowsingExtendedReportingEnabled)" valueName="SafeBrowsingExtendedReportingEnabled">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingProtectionLevel)" explainText="$(string.SafeBrowsingProtectionLevel_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingProtectionLevel" presentation="$(presentation.SafeBrowsingProtectionLevel)">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="SafeBrowsingProtectionLevel" valueName="SafeBrowsingProtectionLevel">
+          <item displayName="$(string.SafeBrowsingProtectionLevel_NoProtection)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.SafeBrowsingProtectionLevel_StandardProtection)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.SafeBrowsingProtectionLevel_EnhancedProtection)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingProxiedRealTimeChecksAllowed)" explainText="$(string.SafeBrowsingProxiedRealTimeChecksAllowed_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingProxiedRealTimeChecksAllowed" presentation="$(presentation.SafeBrowsingProxiedRealTimeChecksAllowed)" valueName="SafeBrowsingProxiedRealTimeChecksAllowed">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingSurveysEnabled)" explainText="$(string.SafeBrowsingSurveysEnabled_Explain)" key="Software\Policies\Google\Chrome" name="SafeBrowsingSurveysEnabled" presentation="$(presentation.SafeBrowsingSurveysEnabled)" valueName="SafeBrowsingSurveysEnabled">
+      <parentCategory ref="SafeBrowsing"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.SafeBrowsingProtectionLevel)" explainText="$(string.SafeBrowsingProtectionLevel_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="SafeBrowsingProtectionLevel_recommended" presentation="$(presentation.SafeBrowsingProtectionLevel)">
+      <parentCategory ref="SafeBrowsing_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="SafeBrowsingProtectionLevel" valueName="SafeBrowsingProtectionLevel">
+          <item displayName="$(string.SafeBrowsingProtectionLevel_NoProtection)">
+            <value>
+              <decimal value="0"/>
+            </value>
+          </item>
+          <item displayName="$(string.SafeBrowsingProtectionLevel_StandardProtection)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.SafeBrowsingProtectionLevel_EnhancedProtection)">
+            <value>
+              <decimal value="2"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.BoundSessionCredentialsEnabled)" explainText="$(string.BoundSessionCredentialsEnabled_Explain)" key="Software\Policies\Google\Chrome" name="BoundSessionCredentialsEnabled" presentation="$(presentation.BoundSessionCredentialsEnabled)" valueName="BoundSessionCredentialsEnabled">
+      <parentCategory ref="Signin"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.ProfileSeparationDomainExceptionList)" explainText="$(string.ProfileSeparationDomainExceptionList_Explain)" key="Software\Policies\Google\Chrome" name="ProfileSeparationDomainExceptionList" presentation="$(presentation.ProfileSeparationDomainExceptionList)">
+      <parentCategory ref="Signin"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="ProfileSeparationDomainExceptionListDesc" key="Software\Policies\Google\Chrome\ProfileSeparationDomainExceptionList" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.HomepageIsNewTabPage)" explainText="$(string.HomepageIsNewTabPage_Explain)" key="Software\Policies\Google\Chrome" name="HomepageIsNewTabPage" presentation="$(presentation.HomepageIsNewTabPage)" valueName="HomepageIsNewTabPage">
+      <parentCategory ref="Startup"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HomepageLocation)" explainText="$(string.HomepageLocation_Explain)" key="Software\Policies\Google\Chrome" name="HomepageLocation" presentation="$(presentation.HomepageLocation)">
+      <parentCategory ref="Startup"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="HomepageLocation" maxLength="1000000" valueName="HomepageLocation"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.NewTabPageLocation)" explainText="$(string.NewTabPageLocation_Explain)" key="Software\Policies\Google\Chrome" name="NewTabPageLocation" presentation="$(presentation.NewTabPageLocation)">
+      <parentCategory ref="Startup"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="NewTabPageLocation" maxLength="1000000" valueName="NewTabPageLocation"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RestoreOnStartup)" explainText="$(string.RestoreOnStartup_Explain)" key="Software\Policies\Google\Chrome" name="RestoreOnStartup" presentation="$(presentation.RestoreOnStartup)">
+      <parentCategory ref="Startup"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="RestoreOnStartup" valueName="RestoreOnStartup">
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsNewTabPage)">
+            <value>
+              <decimal value="5"/>
+            </value>
+          </item>
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsLastSession)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsURLs)">
+            <value>
+              <decimal value="4"/>
+            </value>
+          </item>
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsLastSessionAndURLs)">
+            <value>
+              <decimal value="6"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RestoreOnStartupURLs)" explainText="$(string.RestoreOnStartupURLs_Explain)" key="Software\Policies\Google\Chrome" name="RestoreOnStartupURLs" presentation="$(presentation.RestoreOnStartupURLs)">
+      <parentCategory ref="Startup"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="RestoreOnStartupURLsDesc" key="Software\Policies\Google\Chrome\RestoreOnStartupURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ShowHomeButton)" explainText="$(string.ShowHomeButton_Explain)" key="Software\Policies\Google\Chrome" name="ShowHomeButton" presentation="$(presentation.ShowHomeButton)" valueName="ShowHomeButton">
+      <parentCategory ref="Startup"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HomepageIsNewTabPage)" explainText="$(string.HomepageIsNewTabPage_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="HomepageIsNewTabPage_recommended" presentation="$(presentation.HomepageIsNewTabPage)" valueName="HomepageIsNewTabPage">
+      <parentCategory ref="Startup_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.HomepageLocation)" explainText="$(string.HomepageLocation_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="HomepageLocation_recommended" presentation="$(presentation.HomepageLocation)">
+      <parentCategory ref="Startup_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="HomepageLocation" maxLength="1000000" valueName="HomepageLocation"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RestoreOnStartup)" explainText="$(string.RestoreOnStartup_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="RestoreOnStartup_recommended" presentation="$(presentation.RestoreOnStartup)">
+      <parentCategory ref="Startup_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="RestoreOnStartup" valueName="RestoreOnStartup">
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsNewTabPage)">
+            <value>
+              <decimal value="5"/>
+            </value>
+          </item>
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsLastSession)">
+            <value>
+              <decimal value="1"/>
+            </value>
+          </item>
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsURLs)">
+            <value>
+              <decimal value="4"/>
+            </value>
+          </item>
+          <item displayName="$(string.RestoreOnStartup_RestoreOnStartupIsLastSessionAndURLs)">
+            <value>
+              <decimal value="6"/>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.RestoreOnStartupURLs)" explainText="$(string.RestoreOnStartupURLs_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="RestoreOnStartupURLs_recommended" presentation="$(presentation.RestoreOnStartupURLs)">
+      <parentCategory ref="Startup_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="RestoreOnStartupURLsDesc" key="Software\Policies\Google\Chrome\Recommended\RestoreOnStartupURLs" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.ShowHomeButton)" explainText="$(string.ShowHomeButton_Explain)" key="Software\Policies\Google\Chrome\Recommended" name="ShowHomeButton_recommended" presentation="$(presentation.ShowHomeButton)" valueName="ShowHomeButton">
+      <parentCategory ref="Startup_recommended"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcDiagnosticLogCollectionAllowedForOrigins)" explainText="$(string.WebRtcDiagnosticLogCollectionAllowedForOrigins_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcDiagnosticLogCollectionAllowedForOrigins" presentation="$(presentation.WebRtcDiagnosticLogCollectionAllowedForOrigins)">
+      <parentCategory ref="WebRtc"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <list id="WebRtcDiagnosticLogCollectionAllowedForOriginsDesc" key="Software\Policies\Google\Chrome\WebRtcDiagnosticLogCollectionAllowedForOrigins" valuePrefix=""/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcIPHandling)" explainText="$(string.WebRtcIPHandling_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcIPHandling" presentation="$(presentation.WebRtcIPHandling)">
+      <parentCategory ref="WebRtc"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <enum id="WebRtcIPHandling" valueName="WebRtcIPHandling">
+          <item displayName="$(string.WebRtcIPHandling_default)">
+            <value>
+              <string>default</string>
+            </value>
+          </item>
+          <item displayName="$(string.WebRtcIPHandling_default_public_and_private_interfaces)">
+            <value>
+              <string>default_public_and_private_interfaces</string>
+            </value>
+          </item>
+          <item displayName="$(string.WebRtcIPHandling_default_public_interface_only)">
+            <value>
+              <string>default_public_interface_only</string>
+            </value>
+          </item>
+          <item displayName="$(string.WebRtcIPHandling_disable_non_proxied_udp)">
+            <value>
+              <string>disable_non_proxied_udp</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcIPHandlingUrl)" explainText="$(string.WebRtcIPHandlingUrl_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcIPHandlingUrl" presentation="$(presentation.WebRtcIPHandlingUrl)">
+      <parentCategory ref="WebRtc"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <elements>
+        <text id="WebRtcIPHandlingUrl" maxLength="1000000" valueName="WebRtcIPHandlingUrl"/>
+      </elements>
+    </policy>
+    <policy class="Both" displayName="$(string.WebRtcPostQuantumKeyAgreement)" explainText="$(string.WebRtcPostQuantumKeyAgreement_Explain)" key="Software\Policies\Google\Chrome" name="WebRtcPostQuantumKeyAgreement" presentation="$(presentation.WebRtcPostQuantumKeyAgreement)" valueName="WebRtcPostQuantumKeyAgreement">
+      <parentCategory ref="WebRtc"/>
+      <supportedOn ref="SUPPORTED_WIN7"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+  </policies>
+</policyDefinitions>
+    ]]></Data>
+  </Item>
+</Add>

--- a/docs/solutions/windows/configuration-profiles/enroll Google Chrome to enterprise console.xml
+++ b/docs/solutions/windows/configuration-profiles/enroll Google Chrome to enterprise console.xml
@@ -1,0 +1,9 @@
+<Replace>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/chrome~Policy~googlechrome/CloudManagementEnrollmentToken</LocURI>
+    </Target>
+    <Meta><Format xmlns="syncml:metinf">chr</Format></Meta>
+    <Data>&lt;enabled/&gt;&lt;data id=&quot;CloudManagementEnrollmentToken&quot; value=&quot;xxxxxxx-xxxx-43d3-b227-689c148ec054&quot;/&gt;</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/enroll Google Chrome to enterprise console.xml
+++ b/docs/solutions/windows/configuration-profiles/enroll Google Chrome to enterprise console.xml
@@ -4,6 +4,6 @@
       <LocURI>./Device/Vendor/MSFT/Policy/Config/chrome~Policy~googlechrome/CloudManagementEnrollmentToken</LocURI>
     </Target>
     <Meta><Format xmlns="syncml:metinf">chr</Format></Meta>
-    <Data>&lt;enabled/&gt;&lt;data id=&quot;CloudManagementEnrollmentToken&quot; value=&quot;xxxxxxx-xxxx-43d3-b227-689c148ec054&quot;/&gt;</Data>
+    <Data>&lt;enabled/&gt;&lt;data id=&quot;CloudManagementEnrollmentToken&quot; value=&quot;YOUR_CLOUD_MANAGEMENT_ENROLLMENT_TOKEN_UUID&quot;/&gt;</Data>
   </Item>
 </Replace>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46637 

- Updated the wording and flow of the guide
- Included links to new configuration profiles in the solutions folder
- Added alternative option for enrolling in to cloud management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Windows configuration profile to enable enrolling Google Chrome into enterprise management.
  * Included a template with a placeholder enrollment token for administrators to replace when configuring device management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->