### PR TITLE
Fixes several loadtest issues

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -2,7 +2,9 @@ FROM golang:1.26.3-alpine3.23@sha256:f44b851aa23dfa219d18db6eab743203245429d355c
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git
-RUN go install github.com/fleetdm/fleet/v4/cmd/osquery-perf@${TAG}
+# Build from the clone instead of `go install ...@${TAG}`: installing by module path fetches the module zip,
+# and the Fleet monorepo exceeds Go's hardcoded 500 MB module-zip limit.
+RUN cd /go/fleet && go build -o /go/bin/osquery-perf ./cmd/osquery-perf
 
 # Generate software database from SQL file
 RUN cd /go/fleet/cmd/osquery-perf/software-library && \

--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -39,8 +39,10 @@ locals {
       FLEET_FILESYSTEM_RESULT_LOG_FILE               = "/dev/null"
       FLEET_MYSQL_MAX_OPEN_CONNS                     = "10"
       FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS        = "10"
-      FLEET_MYSQL_CONN_MAX_LIFETIME                  = "14400"
-      FLEET_MYSQL_READ_REPLICA_CONN_MAX_LIFETIME     = "14400"
+      # 30 min: recycle connections often enough that pooled reader connections re-spread across replicas after a
+      # replica reboot/failover, and proactively drop bad idles.
+      FLEET_MYSQL_CONN_MAX_LIFETIME                  = "1800"
+      FLEET_MYSQL_READ_REPLICA_CONN_MAX_LIFETIME     = "1800"
       FLEET_OSQUERY_ASYNC_HOST_REDIS_SCAN_KEYS_COUNT = "10000"
       FLEET_REDIS_MAX_OPEN_CONNS                     = "500"
       FLEET_REDIS_MAX_IDLE_CONNS                     = "500"

--- a/infrastructure/loadtesting/terraform/pmm/README.md
+++ b/infrastructure/loadtesting/terraform/pmm/README.md
@@ -1,0 +1,54 @@
+# PMM for Fleet loadtesting
+
+Deploys [Percona Monitoring and Management (PMM)](https://docs.percona.com/percona-monitoring-and-management/) as an optional
+add-on for a loadtest environment. PMM runs on ECS Fargate behind the internal ALB and automatically registers the loadtest's
+Aurora MySQL for metrics dashboards. Adapted from the local dev setup in `tools/percona/pmm/`.
+
+## What PMM is for (and not for)
+
+Use PMM when chasing a MySQL-internal bottleneck. Its dashboards expose `SHOW GLOBAL STATUS` counters that neither CloudWatch
+nor Performance Insights surface. These include InnoDB buffer pool hit rate and evictions, redo log and checkpoint pressure,
+row lock waits and deadlocks, handler rates, temp tables on disk, thread and table cache churn, and connection errors.
+
+Do NOT use PMM's Query Analytics (QAN) for per-query analysis. Fleet runs its parametrized DML as binary-protocol prepared
+statements. MySQL never aggregates those into the `performance_schema` digest table that QAN reads, so QAN misses most of the
+write path (verified on MySQL 8.0.44 and 8.4.9). For per-query analysis use one of these instead:
+
+- **AWS Performance Insights** (enabled on loadtest instances). Server-side and protocol-agnostic. Group by `db.sql_tokenized`.
+- **SigNoz**. Client-side otelsql spans with full query text and the Fleet endpoint or cron context that issued them.
+
+## Prerequisites
+
+- A running loadtest environment (`../infra`), deployed in the same Terraform workspace
+- VPN connection (the PMM UI is internal-only)
+
+## Usage
+
+```sh
+cd infrastructure/loadtesting/terraform/pmm
+terraform init
+terraform workspace select <workspace_name>   # must match your infra workspace
+terraform apply
+```
+
+Outputs:
+
+- `pmm_url` is the UI at `https://pmm-<workspace>.loadtest.fleetdm.com` (VPN required).
+- `pmm_admin_password_secret` is the Secrets Manager secret holding the `admin` user's password:
+
+```sh
+aws secretsmanager get-secret-value \
+  --secret-id fleet-<workspace>-pmm-admin-password \
+  --query SecretString --output text
+```
+
+The MySQL metrics dashboards work out of the box and do not need `performance_schema`. That setting is OFF by default on the
+loadtest Aurora cluster, and enabling it requires a parameter group change plus instance reboots.
+
+## Teardown
+
+```sh
+terraform destroy
+```
+
+Destroy PMM before destroying the infra environment it monitors.

--- a/infrastructure/loadtesting/terraform/signoz/main.tf
+++ b/infrastructure/loadtesting/terraform/signoz/main.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 
   backend "s3" {
@@ -360,7 +364,13 @@ resource "null_resource" "signoz_predestroy_cleanup" {
       # loses the race.
       kubectl delete deployment -n signoz signoz-clickhouse-operator --ignore-not-found --timeout=60s || true
       kubectl delete deployment -n signoz -l app.kubernetes.io/name=clickhouse-operator --ignore-not-found --timeout=60s || true
-      sleep 5
+      # Wait until the operator pods are actually gone (deployment deletion returns before pod termination). Match by
+      # pod name rather than labels so this works regardless of chart label conventions. Bounded at 120s.
+      kubectl wait -n signoz --for=delete pod -l app.kubernetes.io/name=clickhouse-operator --timeout=120s || true
+      for _ in $(seq 1 24); do
+        kubectl get pods -n signoz --no-headers 2>/dev/null | grep -q clickhouse-operator || break
+        sleep 5
+      done
       # With the operator gone the patch sticks; without it, helm uninstall hangs on CHI deletion (#35405).
       kubectl patch clickhouseinstallations.clickhouse.altinity.com signoz-clickhouse -n signoz --type merge -p '{"metadata":{"finalizers":[]}}' || true
       # Release the AWS load balancers before the EKS/VPC teardown.

--- a/infrastructure/loadtesting/terraform/signoz/main.tf
+++ b/infrastructure/loadtesting/terraform/signoz/main.tf
@@ -328,3 +328,47 @@ resource "helm_release" "signoz" {
     kubernetes_storage_class_v1.gp3
   ]
 }
+
+# Pre-destroy cleanup for the known signoz destroy hang (fleetdm/fleet#35405).
+#
+# Root cause: the signoz chart installs the Altinity clickhouse-operator, which puts a finalizer on its
+# ClickHouseInstallation custom resource. During `helm uninstall` the operator is removed, so nothing processes that
+# finalizer; CHI deletion wedges, which wedges PVC and namespace deletion, which wedges the helm_release destroy
+# (wait = true) for its full timeout.
+#
+# This resource depends_on the helm_release, so on destroy Terraform runs this provisioner FIRST (dependents are
+# destroyed before dependencies). It: (1) strips the CHI finalizer, (2) deletes the LoadBalancer services so the AWS
+# ELBs release before the EKS/VPC teardown, and (3) queues PVC deletion so the EBS CSI driver releases the volumes
+# (600Gi ClickHouse included) while the cluster is still alive. Otherwise the volumes orphan when the cluster dies.
+# Every step is idempotent and failure-tolerant (a fresh or partially-created stack simply has nothing to clean).
+resource "null_resource" "signoz_predestroy_cleanup" {
+  triggers = {
+    cluster_name = local.cluster_name
+    region       = var.aws_region
+  }
+
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+    command    = <<-EOT
+      set -x
+      KUBECONFIG_TMP=$(mktemp)
+      trap 'rm -f "$KUBECONFIG_TMP"' EXIT
+      aws eks update-kubeconfig --region ${self.triggers.region} --name ${self.triggers.cluster_name} --kubeconfig "$KUBECONFIG_TMP" || exit 0
+      export KUBECONFIG="$KUBECONFIG_TMP"
+      # Delete the clickhouse-operator FIRST: while it runs it immediately re-adds the CHI finalizer, so a patch alone
+      # loses the race.
+      kubectl delete deployment -n signoz signoz-clickhouse-operator --ignore-not-found --timeout=60s || true
+      kubectl delete deployment -n signoz -l app.kubernetes.io/name=clickhouse-operator --ignore-not-found --timeout=60s || true
+      sleep 5
+      # With the operator gone the patch sticks; without it, helm uninstall hangs on CHI deletion (#35405).
+      kubectl patch clickhouseinstallations.clickhouse.altinity.com signoz-clickhouse -n signoz --type merge -p '{"metadata":{"finalizers":[]}}' || true
+      # Release the AWS load balancers before the EKS/VPC teardown.
+      kubectl delete svc -n signoz signoz signoz-otel-collector --ignore-not-found --timeout=120s || true
+      # Queue PVC deletion so the CSI driver releases the EBS volumes while the cluster still exists.
+      kubectl delete pvc -n signoz --all --wait=false || true
+    EOT
+  }
+
+  depends_on = [helm_release.signoz]
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35405

- fixes broken osquery_perf
- lower max connection lifetime so that loadtest can spread load across readers faster (we often cause issues and need to recover)
- fixed broken signoz `terraform destroy`
- added README.md for pmm

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved load-testing image build process for more reliable binary creation.
  * Reduced MySQL connection pool timeouts to recycle connections more frequently.
  * Added robust, idempotent infrastructure cleanup steps during teardown to avoid resource finalizer hangs and release cloud load balancers and volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->