### PR TITLE
Treat MSI reboot exit codes as success

### DIFF
--- a/pkg/file/scripts/uninstall_msi.ps1
+++ b/pkg/file/scripts/uninstall_msi.ps1
@@ -12,8 +12,12 @@ if (-not $completed) {
     Exit 1603  # ERROR_UNINSTALL_FAILURE
 }
 
+# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,
+# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.
+$successCodes = @(0, 3010, 1641)
+
 # Check exit code and output result
-if ($process.ExitCode -eq 0) {
+if ($successCodes -contains $process.ExitCode) {
     Write-Output "Exit 0"
     Exit 0
 } else {

--- a/pkg/file/scripts/uninstall_msi_with_upgrade_code.ps1
+++ b/pkg/file/scripts/uninstall_msi_with_upgrade_code.ps1
@@ -2,19 +2,23 @@
 $inst = New-Object -ComObject "WindowsInstaller.Installer"
 $timeoutSeconds = 300  # 5 minute timeout per product
 
+# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,
+# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.
+$successCodes = @(0, 3010, 1641)
+
 foreach ($product_code in $inst.RelatedProducts("$UPGRADE_CODE")) {
     $process = Start-Process msiexec -ArgumentList @("/quiet", "/x", $product_code, "/norestart") -PassThru
-    
+
     # Wait for process with timeout
     $completed = $process.WaitForExit($timeoutSeconds * 1000)
-    
+
     if (-not $completed) {
         Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
         Exit 1603  # ERROR_UNINSTALL_FAILURE
     }
-    
+
     # If the uninstall failed, bail
-    if ($process.ExitCode -ne 0) {
+    if ($successCodes -notcontains $process.ExitCode) {
         Write-Output "Uninstall for $($product_code) exited $($process.ExitCode)"
         Exit $process.ExitCode
     }

--- a/pkg/file/testdata/scripts/uninstall_msi.ps1.golden
+++ b/pkg/file/testdata/scripts/uninstall_msi.ps1.golden
@@ -12,8 +12,12 @@ if (-not $completed) {
     Exit 1603  # ERROR_UNINSTALL_FAILURE
 }
 
+# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,
+# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.
+$successCodes = @(0, 3010, 1641)
+
 # Check exit code and output result
-if ($process.ExitCode -eq 0) {
+if ($successCodes -contains $process.ExitCode) {
     Write-Output "Exit 0"
     Exit 0
 } else {


### PR DESCRIPTION
This pull request updates the uninstall scripts to treat additional MSI exit codes that indicate a successful uninstall (but may require a reboot) as success, rather than failure. This improves the robustness of the uninstall process by not incorrectly flagging these scenarios as errors.

**Improvements to exit code handling in uninstall scripts:**

* Added support for treating MSI exit codes `3010` (ERROR_SUCCESS_REBOOT_REQUIRED) and `1641` (ERROR_SUCCESS_REBOOT_INITIATED) as success, in addition to `0`, in both `uninstall_msi.ps1` and `uninstall_msi_with_upgrade_code.ps1`. This is achieved by introducing a `$successCodes` array and updating the exit code checks to use it. [[1]](diffhunk://#diff-09e225a2a28fbf997ddf571274119a20d9210539e5bdd49749beb2226e6de5aaR15-R20) [[2]](diffhunk://#diff-c24faec992d742fed7d16c8621f140f7048ecb2cc88bd135fcf02cbd8653f77bR5-R8) [[3]](diffhunk://#diff-c24faec992d742fed7d16c8621f140f7048ecb2cc88bd135fcf02cbd8653f77bL17-R21)

**Test updates:**

* Updated the golden test data for `uninstall_msi.ps1` to reflect the new logic for handling successful exit codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSI uninstall handling to recognize additional success conditions, including scenarios requiring system restart, enhancing the reliability of software removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->