### PR TITLE
Add TablePlus as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/scripts/tableplus_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/tableplus_install.ps1
@@ -1,0 +1,32 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+#
+# TablePlus ships as an Inno Setup installer.
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+    if (-not (Test-Path $exeFilePath)) {
+        Write-Host "Error: Installer file not found at: $exeFilePath"
+        Exit 1
+    }
+
+    # /ALLUSERS forces a machine-wide install so the app is visible when Fleet
+    # runs the installer in the SYSTEM context.
+    $processOptions = @{
+        FilePath = "$exeFilePath"
+        ArgumentList = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS"
+        PassThru = $true
+        Wait = $true
+        NoNewWindow = $true
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    Write-Host "Install exit code: $exitCode"
+    Exit $exitCode
+
+} catch {
+    Write-Host "Error: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/tableplus_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/tableplus_uninstall.ps1
@@ -1,0 +1,62 @@
+# Attempts to locate TablePlus's Inno Setup uninstaller from the registry and run it silently.
+
+$displayNameLike = "TablePlus*"
+$publisher = "TablePlus, Inc"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -like $displayNameLike -and $_.Publisher -like "$publisher*"
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or -not $uninstall.UninstallString) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+Stop-Process -Name "TablePlus" -Force -ErrorAction SilentlyContinue
+
+$uninstallCommand = $uninstall.UninstallString
+$uninstallArgs = "/VERYSILENT /NORESTART"
+
+$splitArgs = $uninstallCommand.Split('"')
+if ($splitArgs.Length -gt 1) {
+    if ($splitArgs.Length -eq 3) {
+        $existingArgs = $splitArgs[2].Trim()
+        if ($existingArgs -ne '') {
+            $uninstallArgs = "$existingArgs $uninstallArgs"
+        }
+    } elseif ($splitArgs.Length -gt 3) {
+        Write-Host "Error: Uninstall command contains multiple quoted strings"
+        Exit 1
+    }
+    $uninstallCommand = $splitArgs[1]
+}
+
+Write-Host "Uninstall command: $uninstallCommand"
+Write-Host "Uninstall args: $uninstallArgs"
+
+try {
+    $processOptions = @{
+        FilePath = $uninstallCommand
+        ArgumentList = $uninstallArgs
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/tableplus.json
+++ b/ee/maintained-apps/inputs/winget/tableplus.json
@@ -1,0 +1,13 @@
+{
+  "name": "TablePlus",
+  "slug": "tableplus/windows",
+  "package_identifier": "TablePlus.TablePlus",
+  "unique_identifier": "TablePlus",
+  "fuzzy_match_name": "TablePlus%",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"],
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/tableplus_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/tableplus_uninstall.ps1"
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -2459,6 +2459,13 @@
       "description": "TablePlus is a native GUI tool for relational databases."
     },
     {
+      "name": "TablePlus",
+      "slug": "tableplus/windows",
+      "platform": "windows",
+      "unique_identifier": "TablePlus",
+      "description": "TablePlus is a native GUI tool for relational databases."
+    },
+    {
       "name": "Tailscale",
       "slug": "tailscale-app/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/tableplus/windows.json
+++ b/ee/maintained-apps/outputs/tableplus/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "7.1.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name LIKE 'TablePlus%' AND publisher = 'TablePlus, Inc';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'TablePlus%' AND publisher = 'TablePlus, Inc' AND version_compare(version, '7.1.2') < 0);"
+      },
+      "installer_url": "https://files.tableplus.com/windows/7.1.2/TablePlusSetup.exe",
+      "install_script_ref": "052dc935",
+      "uninstall_script_ref": "8bfcecd6",
+      "sha256": "967c04e331a274768518d886651ef04af72d2850039a2b2e3013e83994ab55a2",
+      "default_categories": [
+        "Developer tools"
+      ]
+    }
+  ],
+  "refs": {
+    "052dc935": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n#\n# TablePlus ships as an Inno Setup installer.\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n    if (-not (Test-Path $exeFilePath)) {\n        Write-Host \"Error: Installer file not found at: $exeFilePath\"\n        Exit 1\n    }\n\n    # /ALLUSERS forces a machine-wide install so the app is visible when Fleet\n    # runs the installer in the SYSTEM context.\n    $processOptions = @{\n        FilePath = \"$exeFilePath\"\n        ArgumentList = \"/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS\"\n        PassThru = $true\n        Wait = $true\n        NoNewWindow = $true\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    Write-Host \"Install exit code: $exitCode\"\n    Exit $exitCode\n\n} catch {\n    Write-Host \"Error: $_\"\n    Exit 1\n}\n",
+    "8bfcecd6": "# Attempts to locate TablePlus's Inno Setup uninstaller from the registry and run it silently.\n\n$displayNameLike = \"TablePlus*\"\n$publisher = \"TablePlus, Inc\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -like $displayNameLike -and $_.Publisher -like \"$publisher*\"\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or -not $uninstall.UninstallString) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\nStop-Process -Name \"TablePlus\" -Force -ErrorAction SilentlyContinue\n\n$uninstallCommand = $uninstall.UninstallString\n$uninstallArgs = \"/VERYSILENT /NORESTART\"\n\n$splitArgs = $uninstallCommand.Split('\"')\nif ($splitArgs.Length -gt 1) {\n    if ($splitArgs.Length -eq 3) {\n        $existingArgs = $splitArgs[2].Trim()\n        if ($existingArgs -ne '') {\n            $uninstallArgs = \"$existingArgs $uninstallArgs\"\n        }\n    } elseif ($splitArgs.Length -gt 3) {\n        Write-Host \"Error: Uninstall command contains multiple quoted strings\"\n        Exit 1\n    }\n    $uninstallCommand = $splitArgs[1]\n}\n\nWrite-Host \"Uninstall command: $uninstallCommand\"\nWrite-Host \"Uninstall args: $uninstallArgs\"\n\ntry {\n    $processOptions = @{\n        FilePath = $uninstallCommand\n        ArgumentList = $uninstallArgs\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
Add TablePlus Windows packaging: input manifest, PowerShell install/uninstall scripts, and outputs. The install script runs the Inno Setup installer silently with /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS; the uninstall script locates the Inno Setup uninstaller via registry and runs it with silent args. apps.json was updated to include TablePlus and a new outputs/tableplus/windows.json was added with version 7.1.2, installer URL, sha256, and script references.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TablePlus on Windows platform
  * Enables automated installation, uninstallation, and update management for TablePlus version 7.1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->