### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/comet/darwin.json
+++ b/ee/maintained-apps/outputs/comet/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "148.0.7778.1016",
+      "version": "145.2.7632.4581",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.perplexity.comet';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.perplexity.comet' AND version_compare(bundle_short_version, '148.0.7778.1016') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.perplexity.comet' AND version_compare(bundle_short_version, '145.2.7632.4581') < 0);"
       },
       "installer_url": "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64",
       "install_script_ref": "af8d196c",

--- a/ee/maintained-apps/outputs/kitty/darwin.json
+++ b/ee/maintained-apps/outputs/kitty/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.47.1",
+      "version": "0.47.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty' AND version_compare(bundle_short_version, '0.47.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty' AND version_compare(bundle_short_version, '0.47.2') < 0);"
       },
-      "installer_url": "https://github.com/kovidgoyal/kitty/releases/download/v0.47.1/kitty-0.47.1.dmg",
+      "installer_url": "https://github.com/kovidgoyal/kitty/releases/download/v0.47.2/kitty-0.47.2.dmg",
       "install_script_ref": "113bbbcb",
       "uninstall_script_ref": "610c592a",
-      "sha256": "a0174030d5d5a42727a44b5a1527e4d4e81da30b6d0b24d7491e078dfda3221b",
+      "sha256": "61a603cf8db68de7f18ee8ad088ac427b0e90b711aab4734963af53895a85b24",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.12.16",
+      "version": "3.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.0') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.16/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.0/Stats.dmg",
       "install_script_ref": "de9e4d0c",
       "uninstall_script_ref": "7e8d1240",
-      "sha256": "8beab818b582d057e763c6b5537b8b8515427f942990a1a83906da92e607c29d",
+      "sha256": "2add1bef54707c0734259ead89117de98eec7b12f31f4022dcdd75ca426227aa",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated metadata for maintained macOS applications to reference newer versions:
  * Comet: Browser version reference updated
  * Kitty: Application version updated to 0.47.2
  * Stats: Application version updated to 3.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->