### PR TITLE
Add Beekeeper Studio as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/beekeeper-studio.json
+++ b/ee/maintained-apps/inputs/winget/beekeeper-studio.json
@@ -1,0 +1,12 @@
+{
+  "name": "Beekeeper Studio",
+  "slug": "beekeeper-studio/windows",
+  "package_identifier": "beekeeper-studio.beekeeper-studio",
+  "unique_identifier": "Beekeeper Studio",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"],
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/beekeeper-studio_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/beekeeper-studio_uninstall.ps1"
+}

--- a/ee/maintained-apps/inputs/winget/scripts/beekeeper-studio_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/beekeeper-studio_install.ps1
@@ -1,0 +1,24 @@
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+# Beekeeper Studio ships an electron-builder NSIS installer. /S runs it
+# silently; /allusers forces a per-machine install so the app is reachable
+# from Fleet's SYSTEM context (matches the winget machine-scope switch).
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/S", "/allusers"
+  PassThru = $true
+  Wait = $true
+}
+
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/beekeeper-studio_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/beekeeper-studio_uninstall.ps1
@@ -1,0 +1,75 @@
+$displayNameLike = "Beekeeper Studio*"
+$publisher = "Beekeeper Studio Team"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -like $displayNameLike -and $_.Publisher -like "$publisher*"
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or (-not $uninstall.UninstallString -and -not $uninstall.QuietUninstallString)) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+Stop-Process -Name "Beekeeper Studio" -Force -ErrorAction SilentlyContinue
+
+$uninstallCommand = if ($uninstall.QuietUninstallString) {
+    $uninstall.QuietUninstallString
+} else {
+    $uninstall.UninstallString
+}
+
+$exePath = ""
+$existingArgs = ""
+if ($uninstallCommand -match '^\s*"([^"]+)"\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} elseif ($uninstallCommand -match '(?i)^\s*(.+?\.exe)\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} elseif ($uninstallCommand -match '^\s*(\S+)\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} else {
+    Throw "Could not parse uninstall string: $uninstallCommand"
+}
+
+if ($existingArgs -notmatch '\b/S\b') {
+    $existingArgs = ("$existingArgs /S").Trim()
+}
+# Mirror the install: ensure all-users uninstall so the machine-scope ARP
+# entry under HKLM is removed (not just the calling user's HKCU view).
+if ($existingArgs -notmatch '(?i)/allusers') {
+    $existingArgs = ("$existingArgs /allusers").Trim()
+}
+
+Write-Host "Uninstall command: $exePath"
+Write-Host "Uninstall args: $existingArgs"
+
+try {
+    $processOptions = @{
+        FilePath = $exePath
+        ArgumentList = $existingArgs
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -443,6 +443,13 @@
       "description": "Beekeeper Studio is a cross platform SQL editor and database management app."
     },
     {
+      "name": "Beekeeper Studio",
+      "slug": "beekeeper-studio/windows",
+      "platform": "windows",
+      "unique_identifier": "Beekeeper Studio",
+      "description": "Beekeeper Studio is a cross platform SQL editor and database management app."
+    },
+    {
       "name": "BetterDisplay",
       "slug": "betterdisplay/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/beekeeper-studio/windows.json
+++ b/ee/maintained-apps/outputs/beekeeper-studio/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "5.8.1",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team' AND version_compare(version, '5.8.1') < 0);"
+      },
+      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.8.1/Beekeeper-Studio-Setup-5.8.1.exe",
+      "install_script_ref": "13334753",
+      "uninstall_script_ref": "44e6f772",
+      "sha256": "2e0cc5893e5ce813dbd43bf7d80753dccb7d514ae523947139540f1f45966621",
+      "default_categories": [
+        "Developer tools"
+      ]
+    }
+  ],
+  "refs": {
+    "13334753": "$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n# Beekeeper Studio ships an electron-builder NSIS installer. /S runs it\n# silently; /allusers forces a per-machine install so the app is reachable\n# from Fleet's SYSTEM context (matches the winget machine-scope switch).\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/S\", \"/allusers\"\n  PassThru = $true\n  Wait = $true\n}\n\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "44e6f772": "$displayNameLike = \"Beekeeper Studio*\"\n$publisher = \"Beekeeper Studio Team\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -like $displayNameLike -and $_.Publisher -like \"$publisher*\"\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or (-not $uninstall.UninstallString -and -not $uninstall.QuietUninstallString)) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\nStop-Process -Name \"Beekeeper Studio\" -Force -ErrorAction SilentlyContinue\n\n$uninstallCommand = if ($uninstall.QuietUninstallString) {\n    $uninstall.QuietUninstallString\n} else {\n    $uninstall.UninstallString\n}\n\n$exePath = \"\"\n$existingArgs = \"\"\nif ($uninstallCommand -match '^\\s*\"([^\"]+)\"\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} elseif ($uninstallCommand -match '(?i)^\\s*(.+?\\.exe)\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} elseif ($uninstallCommand -match '^\\s*(\\S+)\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} else {\n    Throw \"Could not parse uninstall string: $uninstallCommand\"\n}\n\nif ($existingArgs -notmatch '\\b/S\\b') {\n    $existingArgs = (\"$existingArgs /S\").Trim()\n}\n# Mirror the install: ensure all-users uninstall so the machine-scope ARP\n# entry under HKLM is removed (not just the calling user's HKCU view).\nif ($existingArgs -notmatch '(?i)/allusers') {\n    $existingArgs = (\"$existingArgs /allusers\").Trim()\n}\n\nWrite-Host \"Uninstall command: $exePath\"\nWrite-Host \"Uninstall args: $existingArgs\"\n\ntry {\n    $processOptions = @{\n        FilePath = $exePath\n        ArgumentList = $existingArgs\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
Add Winget input manifest and PowerShell install/uninstall scripts for Beekeeper Studio, and register the app in outputs. Files added: ee/maintained-apps/inputs/winget/beekeeper-studio.json, install and uninstall scripts under inputs/winget/scripts, and ee/maintained-apps/outputs/beekeeper-studio/windows.json (version 5.8.1 with installer URL and SHA256). Also update ee/maintained-apps/outputs/apps.json to include the Windows entry. Installer script runs the NSIS installer silently with /S and /allusers for machine-scope installs; the uninstaller searches ARP registry entries, parses the uninstall string, and enforces /S and /allusers to ensure a machine-scoped uninstall.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beekeeper Studio is now available for Windows users through the Windows Package Manager (WinGet), enabling streamlined installation and uninstallation directly from the command line or package manager interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->