### PR TITLE
Add 3 more Windows FMAs

### DIFF
--- a/ee/maintained-apps/inputs/winget/adobe-dng-converter.json
+++ b/ee/maintained-apps/inputs/winget/adobe-dng-converter.json
@@ -1,0 +1,12 @@
+{
+  "name": "Adobe DNG Converter",
+  "slug": "adobe-dng-converter/windows",
+  "package_identifier": "Adobe.DNGConverter",
+  "unique_identifier": "Adobe DNG Converter",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"],
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/adobe-dng-converter_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/adobe-dng-converter_uninstall.ps1"
+}

--- a/ee/maintained-apps/inputs/winget/clockify.json
+++ b/ee/maintained-apps/inputs/winget/clockify.json
@@ -1,0 +1,11 @@
+{
+  "name": "Clockify Desktop",
+  "slug": "clockify/windows",
+  "package_identifier": "Clockify.Clockify",
+  "unique_identifier": "Clockify",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"],
+  "program_publisher": "CAKE.com Inc."
+}

--- a/ee/maintained-apps/inputs/winget/podman-desktop.json
+++ b/ee/maintained-apps/inputs/winget/podman-desktop.json
@@ -1,0 +1,13 @@
+{
+  "name": "Podman Desktop",
+  "slug": "podman-desktop/windows",
+  "package_identifier": "RedHat.Podman-Desktop",
+  "unique_identifier": "Podman Desktop",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"],
+  "program_publisher": "Red Hat, Inc.",
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/podman-desktop_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/podman-desktop_uninstall.ps1"
+}

--- a/ee/maintained-apps/inputs/winget/scripts/adobe-dng-converter_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/adobe-dng-converter_install.ps1
@@ -1,0 +1,30 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+#
+# Adobe DNG Converter ships as an Inno Setup installer.
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+    if (-not (Test-Path $exeFilePath)) {
+        Write-Host "Error: Installer file not found at: $exeFilePath"
+        Exit 1
+    }
+
+    $processOptions = @{
+        FilePath = "$exeFilePath"
+        ArgumentList = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS"
+        PassThru = $true
+        Wait = $true
+        NoNewWindow = $true
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    Write-Host "Install exit code: $exitCode"
+    Exit $exitCode
+
+} catch {
+    Write-Host "Error: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/adobe-dng-converter_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/adobe-dng-converter_uninstall.ps1
@@ -1,0 +1,62 @@
+# Attempts to locate Adobe DNG Converter's Inno Setup uninstaller from the registry and run it silently.
+
+$displayNameLike = "Adobe DNG Converter*"
+$publisher = "Adobe"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -like $displayNameLike -and $_.Publisher -like "$publisher*"
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or -not $uninstall.UninstallString) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+Stop-Process -Name "Adobe DNG Converter" -Force -ErrorAction SilentlyContinue
+
+$uninstallCommand = $uninstall.UninstallString
+$uninstallArgs = "/VERYSILENT /NORESTART"
+
+$splitArgs = $uninstallCommand.Split('"')
+if ($splitArgs.Length -gt 1) {
+    if ($splitArgs.Length -eq 3) {
+        $existingArgs = $splitArgs[2].Trim()
+        if ($existingArgs -ne '') {
+            $uninstallArgs = "$existingArgs $uninstallArgs"
+        }
+    } elseif ($splitArgs.Length -gt 3) {
+        Write-Host "Error: Uninstall command contains multiple quoted strings"
+        Exit 1
+    }
+    $uninstallCommand = $splitArgs[1]
+}
+
+Write-Host "Uninstall command: $uninstallCommand"
+Write-Host "Uninstall args: $uninstallArgs"
+
+try {
+    $processOptions = @{
+        FilePath = $uninstallCommand
+        ArgumentList = $uninstallArgs
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/podman-desktop_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/podman-desktop_install.ps1
@@ -1,0 +1,24 @@
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+# Podman Desktop ships an electron-builder NSIS installer. /S runs it
+# silently; /allusers forces a per-machine install so the app is reachable
+# from Fleet's SYSTEM context (matches the winget machine-scope switch).
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/S", "/allusers"
+  PassThru = $true
+  Wait = $true
+}
+
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/podman-desktop_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/podman-desktop_uninstall.ps1
@@ -1,0 +1,75 @@
+$displayNameLike = "Podman Desktop*"
+$publisher = "Red Hat"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -like $displayNameLike -and $_.Publisher -like "$publisher*"
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or (-not $uninstall.UninstallString -and -not $uninstall.QuietUninstallString)) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue
+
+$uninstallCommand = if ($uninstall.QuietUninstallString) {
+    $uninstall.QuietUninstallString
+} else {
+    $uninstall.UninstallString
+}
+
+$exePath = ""
+$existingArgs = ""
+if ($uninstallCommand -match '^\s*"([^"]+)"\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} elseif ($uninstallCommand -match '(?i)^\s*(.+?\.exe)\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} elseif ($uninstallCommand -match '^\s*(\S+)\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} else {
+    Throw "Could not parse uninstall string: $uninstallCommand"
+}
+
+if ($existingArgs -notmatch '\b/S\b') {
+    $existingArgs = ("$existingArgs /S").Trim()
+}
+# Mirror the install: ensure all-users uninstall so the machine-scope ARP
+# entry under HKLM is removed (not just the calling user's HKCU view).
+if ($existingArgs -notmatch '(?i)/allusers') {
+    $existingArgs = ("$existingArgs /allusers").Trim()
+}
+
+Write-Host "Uninstall command: $exePath"
+Write-Host "Uninstall args: $existingArgs"
+
+try {
+    $processOptions = @{
+        FilePath = $exePath
+        ArgumentList = $existingArgs
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/outputs/adobe-dng-converter/windows.json
+++ b/ee/maintained-apps/outputs/adobe-dng-converter/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "18.3.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Adobe DNG Converter' AND publisher = 'Adobe Systems, Inc.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe DNG Converter' AND publisher = 'Adobe Systems, Inc.' AND version_compare(version, '18.3.2') < 0);"
+      },
+      "installer_url": "https://download.adobe.com/pub/adobe/dng/win/AdobeDNGConverter_x64_18_3_2.exe",
+      "install_script_ref": "f32ae4fd",
+      "uninstall_script_ref": "e80de829",
+      "sha256": "78e068c7cbaef60afeee513228e875ed4e8f4ff68712078bf1d91b7ade12af73",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "e80de829": "# Attempts to locate Adobe DNG Converter's Inno Setup uninstaller from the registry and run it silently.\n\n$displayNameLike = \"Adobe DNG Converter*\"\n$publisher = \"Adobe\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -like $displayNameLike -and $_.Publisher -like \"$publisher*\"\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or -not $uninstall.UninstallString) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\nStop-Process -Name \"Adobe DNG Converter\" -Force -ErrorAction SilentlyContinue\n\n$uninstallCommand = $uninstall.UninstallString\n$uninstallArgs = \"/VERYSILENT /NORESTART\"\n\n$splitArgs = $uninstallCommand.Split('\"')\nif ($splitArgs.Length -gt 1) {\n    if ($splitArgs.Length -eq 3) {\n        $existingArgs = $splitArgs[2].Trim()\n        if ($existingArgs -ne '') {\n            $uninstallArgs = \"$existingArgs $uninstallArgs\"\n        }\n    } elseif ($splitArgs.Length -gt 3) {\n        Write-Host \"Error: Uninstall command contains multiple quoted strings\"\n        Exit 1\n    }\n    $uninstallCommand = $splitArgs[1]\n}\n\nWrite-Host \"Uninstall command: $uninstallCommand\"\nWrite-Host \"Uninstall args: $uninstallArgs\"\n\ntry {\n    $processOptions = @{\n        FilePath = $uninstallCommand\n        ArgumentList = $uninstallArgs\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n",
+    "f32ae4fd": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n#\n# Adobe DNG Converter ships as an Inno Setup installer.\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n    if (-not (Test-Path $exeFilePath)) {\n        Write-Host \"Error: Installer file not found at: $exeFilePath\"\n        Exit 1\n    }\n\n    $processOptions = @{\n        FilePath = \"$exeFilePath\"\n        ArgumentList = \"/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS\"\n        PassThru = $true\n        Wait = $true\n        NoNewWindow = $true\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    Write-Host \"Install exit code: $exitCode\"\n    Exit $exitCode\n\n} catch {\n    Write-Host \"Error: $_\"\n    Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -111,7 +111,14 @@
       "slug": "adobe-dng-converter/darwin",
       "platform": "darwin",
       "unique_identifier": "com.adobe.DNGConverter",
-      "description": "Adobe DNG Conver is a DNG file converter."
+      "description": "Adobe DNG Converter is a utility that converts camera raw files into the DNG raw image format."
+    },
+    {
+      "name": "Adobe DNG Converter",
+      "slug": "adobe-dng-converter/windows",
+      "platform": "windows",
+      "unique_identifier": "Adobe DNG Converter",
+      "description": "Adobe DNG Converter is a utility that converts camera raw files into the DNG raw image format."
     },
     {
       "name": "Affinity",
@@ -734,6 +741,13 @@
       "slug": "clockify/darwin",
       "platform": "darwin",
       "unique_identifier": "coing.ClockifyDesktop",
+      "description": "Clockify Desktop is a time tracking tool for agencies and freelancers."
+    },
+    {
+      "name": "Clockify Desktop",
+      "slug": "clockify/windows",
+      "platform": "windows",
+      "unique_identifier": "Clockify",
       "description": "Clockify Desktop is a time tracking tool for agencies and freelancers."
     },
     {
@@ -2177,6 +2191,13 @@
       "platform": "darwin",
       "unique_identifier": "io.podmandesktop.PodmanDesktop",
       "description": "Open source tool for developers to work with containers and Kubernetes."
+    },
+    {
+      "name": "Podman Desktop",
+      "slug": "podman-desktop/windows",
+      "platform": "windows",
+      "unique_identifier": "Podman Desktop",
+      "description": "Podman Desktop is an open-source tool for working with containers and Kubernetes."
     },
     {
       "name": "PostgreSQL 15",

--- a/ee/maintained-apps/outputs/clockify/windows.json
+++ b/ee/maintained-apps/outputs/clockify/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "2.1.8",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.' AND version_compare(version, '2.1.8') < 0);"
+      },
+      "installer_url": "https://clockify.me/downloads/clockify-setup.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "f7f14087",
+      "sha256": "6a5b6b0e591d6262e4c29014afaed83e7df0f1ebf4ed118dddda3e2e5ed9117c",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{A17CEE88-470D-49D0-A58D-40D503A0BEBF}"
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "f7f14087": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{A17CEE88-470D-49D0-A58D-40D503A0BEBF}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+  }
+}

--- a/ee/maintained-apps/outputs/podman-desktop/windows.json
+++ b/ee/maintained-apps/outputs/podman-desktop/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "1.27.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Podman Desktop' AND publisher = 'Red Hat, Inc.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Podman Desktop' AND publisher = 'Red Hat, Inc.' AND version_compare(version, '1.27.2') < 0);"
+      },
+      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.27.2/podman-desktop-1.27.2-setup-x64.exe",
+      "install_script_ref": "1be66459",
+      "uninstall_script_ref": "7dd8497d",
+      "sha256": "e41b9b33a6b2f988e7e3277de7e9b56479cd397a7defe7830a9a0416bc054e1f",
+      "default_categories": [
+        "Developer tools"
+      ]
+    }
+  ],
+  "refs": {
+    "1be66459": "$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n# Podman Desktop ships an electron-builder NSIS installer. /S runs it\n# silently; /allusers forces a per-machine install so the app is reachable\n# from Fleet's SYSTEM context (matches the winget machine-scope switch).\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/S\", \"/allusers\"\n  PassThru = $true\n  Wait = $true\n}\n\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "7dd8497d": "$displayNameLike = \"Podman Desktop*\"\n$publisher = \"Red Hat\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -like $displayNameLike -and $_.Publisher -like \"$publisher*\"\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or (-not $uninstall.UninstallString -and -not $uninstall.QuietUninstallString)) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\nStop-Process -Name \"Podman Desktop\" -Force -ErrorAction SilentlyContinue\n\n$uninstallCommand = if ($uninstall.QuietUninstallString) {\n    $uninstall.QuietUninstallString\n} else {\n    $uninstall.UninstallString\n}\n\n$exePath = \"\"\n$existingArgs = \"\"\nif ($uninstallCommand -match '^\\s*\"([^\"]+)\"\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} elseif ($uninstallCommand -match '(?i)^\\s*(.+?\\.exe)\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} elseif ($uninstallCommand -match '^\\s*(\\S+)\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} else {\n    Throw \"Could not parse uninstall string: $uninstallCommand\"\n}\n\nif ($existingArgs -notmatch '\\b/S\\b') {\n    $existingArgs = (\"$existingArgs /S\").Trim()\n}\n# Mirror the install: ensure all-users uninstall so the machine-scope ARP\n# entry under HKLM is removed (not just the calling user's HKCU view).\nif ($existingArgs -notmatch '(?i)/allusers') {\n    $existingArgs = (\"$existingArgs /allusers\").Trim()\n}\n\nWrite-Host \"Uninstall command: $exePath\"\nWrite-Host \"Uninstall args: $existingArgs\"\n\ntry {\n    $processOptions = @{\n        FilePath = $exePath\n        ArgumentList = $existingArgs\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
Add Windows packaging metadata, installer/uninstaller scripts, and output manifests for Adobe DNG Converter, Clockify Desktop, and Podman Desktop.

- Added winget input JSONs (ee/maintained-apps/inputs/winget/) for Adobe DNG Converter, Clockify, and Podman Desktop with installer metadata and scope.
- Added PowerShell install/uninstall scripts (ee/maintained-apps/inputs/winget/scripts/) for the new apps, handling silent install/uninstall and registry lookup logic.
- Added per-app Windows output manifests (ee/maintained-apps/outputs/*/windows.json) with versions, installer URLs, SHA256, and script refs.
- Updated ee/maintained-apps/outputs/apps.json to include Windows entries for the three apps and clarified the Adobe DNG Converter description.

These changes enable machine-scoped winget/MSI/EXE deployment and uninstallation for the three applications.


