### PR TITLE
Move tooltip for vulnerability support to "Not supported"

### DIFF
--- a/changes/44109-vulns-not-supported
+++ b/changes/44109-vulns-not-supported
@@ -1,0 +1,1 @@
+- Moved and updated tooltip from the Vulnerabilities column on the **Software > OS** page to "Not supported", explaining which platforms support vulnerability detection.

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
@@ -23,6 +23,7 @@ import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import LinkCell from "components/TableContainer/DataTable/LinkCell";
 import TooltipWrapper from "components/TooltipWrapper";
+import CustomLink from "components/CustomLink";
 
 import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/VulnerabilitiesCell";
 import OSIcon from "pages/SoftwarePage/components/icons/OSIcon";
@@ -113,25 +114,7 @@ const generateDefaultTableHeaders = (
     },
   },
   {
-    Header: (): JSX.Element => {
-      const titleWithTooltip = (
-        <TooltipWrapper
-          tipContent={
-            <>
-              Vulnerabilities on Linux are currently supported <br />
-              for Ubuntu, Debian, and RHEL based systems.
-            </>
-          }
-        >
-          Vulnerabilities
-        </TooltipWrapper>
-      );
-      return (
-        <>
-          <HeaderCell value={titleWithTooltip} disableSortBy />
-        </>
-      );
-    },
+    Header: "Vulnerabilities",
     disableSortBy: true,
     accessor: "vulnerabilities",
     Cell: (cellProps: IVulnCellProps) => {
@@ -141,7 +124,29 @@ const generateDefaultTableHeaders = (
         platform !== "windows" &&
         !isLinuxLike(platform)
       ) {
-        return <TextCell value="Not supported" grey />;
+        return (
+          <TooltipWrapper
+            tipContent={
+              <>
+                Vulnerabilities are currently supported on
+                <br />
+                macOS, Windows, and Linux.{" "}
+                <CustomLink
+                  url="https://fleetdm.com/guides/vulnerability-processing#coverage"
+                  variant="tooltip-link"
+                  text="Learn more"
+                  newTab
+                />
+              </>
+            }
+            position="top"
+            underline={false}
+            showArrow
+            fixedPositionStrategy
+          >
+            <TextCell value="Not supported" grey />
+          </TooltipWrapper>
+        );
       }
       return (
         <VulnerabilitiesCell

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
@@ -31,7 +31,7 @@ import {
   INumberCellProps,
   IStringCellProps,
 } from "interfaces/datatable_config";
-import { isLinuxLike } from "interfaces/platform";
+import { isVulnUnsupportedPlatform } from "interfaces/platform";
 import TooltipWrapperArchLinuxRolling from "components/TooltipWrapperArchLinuxRolling";
 
 type ITableColumnConfig = Column<IOperatingSystemVersion>;
@@ -119,11 +119,7 @@ const generateDefaultTableHeaders = (
     accessor: "vulnerabilities",
     Cell: (cellProps: IVulnCellProps) => {
       const platform = cellProps.row.original.platform;
-      if (
-        platform !== "darwin" &&
-        platform !== "windows" &&
-        !isLinuxLike(platform)
-      ) {
+      if (isVulnUnsupportedPlatform(platform)) {
         return (
           <TooltipWrapper
             tipContent={


### PR DESCRIPTION
**Related issue:** Resolves #44109

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the Vulnerabilities column on the Software > OS page: "Not supported" cells now include a tooltip relocated to the unsupported indicator that explains which platforms support vulnerability detection, and a "Learn more" link to Fleet documentation. Copy clarified to make platform support and next steps more visible to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->