### PR TITLE
Bring product design sprint retro into product design sprint kickoff

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Product design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "1. Pull up all contributors' calendars to review time off and, if needed, update design review calendar events. 2. Create reference docs release branches for any milestones newly added to the drafting board 3. For feature requests prioritized during feature fest, add user stories to the drafing and release planning boards, add milestones to the stories, confirm available capacity in targeted release, and align on priorities."
+  description: "1. Pull up all contributors' calendars to review time off and, if needed, update design review calendar events. 2. Create reference docs release branches for any milestones newly added to the drafting board 3. For feature requests prioritized during feature fest, add user stories to the drafing and release planning boards, add milestones to the stories, confirm available capacity in targeted release, and align on priorities. Retro last sprint: What went well? What could go better? What to remember for next time? Pick one improvement to implement next sprint."
   moreInfoUrl: 
   dri: "noahtalerman"
 -
@@ -101,13 +101,6 @@
   description: "Check all brand fronts for consistancy and update as needed with the current product pitch and graphics."
   moreInfoUrl: "https://fleetdm.com/handbook/product-design#update-a-company-brand-front"
   dri: "mike-j-thomas"
--
-  task: "🦢⏮️ Product design sprint retro"
-  startedOn: "2025-10-17" 
-  frequency: "Triweekly" 
-  description: "Retro: What went well? What could go better? What to remember for next time? Pick one improvement to implement next sprint." 
-  moreInfoUrl:  
-  dri: "noahtalerman"
 -
   task: "✅ 🎉 Confirm and celebrate"
   startedOn: "2026-01-20" 


### PR DESCRIPTION
- Remove separate sprint retro ritual and call


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product design sprint kickoff ritual to include retrospective instructions, consolidating sprint review guidance into a single ritual entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->