### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.7.12",
+      "version": "3.7.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.19') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/b887a26c4f70bd8136bfffeda812b24194ec9ce0/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/80c653c2c3528e65016a0d304b54486084b470bb/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "62c7fd7bed3e1705e9aeb3e13a6193600cdea281a31769dcb5dbaf2bbd613139",
+      "sha256": "6afb577260c9ede66c0ad7e1a023cabc5eae86b9b53691b52e2bbf5ee16c82c2",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/microsoft-teams/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-teams/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26120.3106.4725.800",
+      "version": "26134.1610.4759.7759",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2' AND version_compare(bundle_short_version, '26120.3106.4725.800') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2' AND version_compare(bundle_short_version, '26134.1610.4759.7759') < 0);"
       },
-      "installer_url": "https://statics.teams.cdn.office.net/production-osx/26120.3106.4725.800/MicrosoftTeams.pkg",
+      "installer_url": "https://statics.teams.cdn.office.net/production-osx/26134.1610.4759.7759/MicrosoftTeams.pkg",
       "install_script_ref": "9842434b",
       "uninstall_script_ref": "1fbcf592",
-      "sha256": "cdb17499b42e04dfeccb25eb5440f733e968320cb4d80e055518893353d5bef6",
+      "sha256": "1008e86cd19ec1d20ca246e18a9cf810f09d0b375c4338c4c042d602e4b0849f",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.13.6",
+      "version": "12.14.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.13.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.14.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.13.6/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.14.0/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "5a7343c72ecea23f99886304669b1c507de7e5129742f78aac5d0911a379a7f1",
+      "sha256": "0435aa4b9479b923a0ff32eb7c1bfac921be3eb4803f8120967c6cb844a81bfc",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated macOS application versions: Cursor to 3.7.19, Microsoft Teams to build 26134.1610.4759.7759, and Postman to 12.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->