### PR TITLE
Fix live policy page to use full width

### DIFF
--- a/changes/fix-live-policy-page-width
+++ b/changes/fix-live-policy-page-width
@@ -1,0 +1,1 @@
+- Fixed the live policy page not using the full page width like the live query page does.

--- a/frontend/components/MainContent/_styles.scss
+++ b/frontend/components/MainContent/_styles.scss
@@ -21,7 +21,8 @@
 
   &.manage-hosts,
   &.query-details-page,
-  &.run-query-page {
+  &.run-query-page,
+  &.live-policy-page {
     max-width: 100%;
   }
 }


### PR DESCRIPTION
**Related issue:** Resolves #47092.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

`main`:
<img width="2550" height="1286" alt="Screenshot 2026-06-08 at 12 27 01 PM" src="https://github.com/user-attachments/assets/b866201d-aff7-44db-913f-1987322405d5" />
<img width="2550" height="1286" alt="Screenshot 2026-06-08 at 12 27 11 PM" src="https://github.com/user-attachments/assets/da56683e-b0e3-4d6d-b38e-3d94d761c5a0" />

With changes in this PR:
<img width="2550" height="1162" alt="Screenshot 2026-06-08 at 12 25 30 PM" src="https://github.com/user-attachments/assets/73694cb3-e8ae-42c4-9834-372feadb6e81" />
<img width="2550" height="1286" alt="Screenshot 2026-06-08 at 12 25 54 PM" src="https://github.com/user-attachments/assets/71db9c15-cb32-4650-be77-28559b4ac70c" />

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The live policy page now correctly uses the full page width, consistent with the live query page display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->