### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/dbeaver-enterprise/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-enterprise/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.0.0",
+      "version": "26.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.enterprise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.enterprise' AND version_compare(bundle_short_version, '26.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.enterprise' AND version_compare(bundle_short_version, '26.1.0') < 0);"
       },
-      "installer_url": "https://downloads.dbeaver.net/enterprise/26.0.0/dbeaver-ee-26.0.0-macos-aarch64.dmg",
+      "installer_url": "https://downloads.dbeaver.net/enterprise/26.1.0/dbeaver-ee-26.1.0-macos-aarch64.dmg",
       "install_script_ref": "5a0440c4",
       "uninstall_script_ref": "d32399ce",
-      "sha256": "f1b5aef7d32ed1536871dd4270455dff3a665249db2f1fbbeba5cd75b3c27969",
+      "sha256": "b6a9b6c17d136330c357f8f7de49653639304ab57e4f77199f7f96a0e00c9699",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dbeaverlite/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverlite/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.0.0",
+      "version": "26.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite' AND version_compare(bundle_short_version, '26.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite' AND version_compare(bundle_short_version, '26.1.0') < 0);"
       },
-      "installer_url": "https://downloads.dbeaver.net/lite/26.0.0/dbeaver-le-26.0.0-macos-aarch64.dmg",
+      "installer_url": "https://downloads.dbeaver.net/lite/26.1.0/dbeaver-le-26.1.0-macos-aarch64.dmg",
       "install_script_ref": "c72c1bb0",
       "uninstall_script_ref": "4e5f63ae",
-      "sha256": "bad4d7121af716f27594674361663de1b392f7ef7861b900845deef5e134084e",
+      "sha256": "ddad856da3e39ef3ad33286fb27ff3782ff7e8892103d128d70494aa56f813cf",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.0.0",
+      "version": "26.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate' AND version_compare(bundle_short_version, '26.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate' AND version_compare(bundle_short_version, '26.1.0') < 0);"
       },
-      "installer_url": "https://downloads.dbeaver.net/ultimate/26.0.0/dbeaver-ue-26.0.0-macos-aarch64.dmg",
+      "installer_url": "https://downloads.dbeaver.net/ultimate/26.1.0/dbeaver-ue-26.1.0-macos-aarch64.dmg",
       "install_script_ref": "52243cd3",
       "uninstall_script_ref": "23b82863",
-      "sha256": "0d633329c98a84c339b0e94b84cea77e3de953659354547bb333ed4321e4b449",
+      "sha256": "20aacb0db1f818989cb4cb4a4e982c88a3ff6756ce4e0753d25c40920d8b76bb",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DBeaver Enterprise, Lite, and Ultimate macOS distributions from version 26.0.0 to 26.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->