### PR TITLE
Fleet UI: Fix labels actions dropdown and responsive column widths

### DIFF
--- a/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
@@ -3,10 +3,7 @@ import PATHS from "router/paths";
 import { browserHistory } from "react-router";
 import classnames from "classnames";
 
-import { IDropdownOption } from "interfaces/dropdownOption";
-
 import Button from "components/buttons/Button";
-import ActionsDropdown from "components/ActionsDropdown";
 import Icon from "components/Icon";
 import { getPathWithQueryParams, QueryParams } from "utilities/url";
 
@@ -19,14 +16,12 @@ interface IHostLinkProps {
   condensed?: boolean;
   excludeChevron?: boolean;
   responsive?: boolean;
-  /** Custom text replaces "View all hosts" in button or "Actions" in dropdown */
+  /** Custom text replaces "View all hosts" */
   customText?: string;
   /** Table links shows on row hover and tab focus only */
   rowHover?: boolean;
   /** Don't actually create a button, useful when click is handled by an ancestor */
   noLink?: boolean;
-  /** When provided, replaces View all hosts button with ActionDropdown */
-  dropdown?: { options: IDropdownOption[]; onChange: (value: string) => void };
 }
 
 const baseClass = "view-all-hosts-button";
@@ -41,7 +36,6 @@ const ViewAllHostsButton = ({
   customText,
   rowHover = false,
   noLink = false,
-  dropdown,
 }: IHostLinkProps): JSX.Element => {
   const viewAllHostsButtonClass = classnames(baseClass, className, {
     [`${baseClass}__condensed`]: condensed,
@@ -63,19 +57,6 @@ const ViewAllHostsButton = ({
       }
     }
   };
-
-  if (dropdown) {
-    return (
-      <ActionsDropdown
-        className={viewAllHostsButtonClass}
-        options={dropdown.options}
-        onChange={dropdown.onChange}
-        placeholder={customText || "Actions"}
-        variant="small-button"
-        menuAlign="right"
-      />
-    );
-  }
 
   return (
     <Button

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
@@ -15,8 +15,8 @@ import {
   isTeamTechnician,
 } from "utilities/permissions/permissions";
 import { IUser } from "interfaces/user";
+import ActionsDropdown from "components/ActionsDropdown";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
-import ViewAllHostsLink from "components/ViewAllHostsLink";
 import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
 
 interface IHeaderProps {
@@ -175,14 +175,12 @@ const generateTableHeaders = (
           repoURL
         );
         return (
-          <ViewAllHostsLink
-            rowHover
-            noLink
-            excludeChevron
-            dropdown={{
-              options: dropdownOptions,
-              onChange: (value: string) => onClickAction(value, label),
-            }}
+          <ActionsDropdown
+            options={dropdownOptions}
+            onChange={(value: string) => onClickAction(value, label)}
+            placeholder="Actions"
+            menuAlign="right"
+            variant="small-button"
           />
         );
       },

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
@@ -1,18 +1,33 @@
+// Selectors nest under .data-table-block to outrank the global rule
+// `.data-table-block .data-table tbody td { max-width: 500px }`, which
+// otherwise wins on a class-vs-element specificity tie. `width: 100%;
+// max-width: 0` is the table idiom for "absorb the remaining row width
+// and let TooltipTruncatedTextCell truncate the overflow."
 .labels-table {
-  .view-all-hosts-link,
-  .view-all-hosts-link * {
-    text-decoration: none;
-    color: initial;
-    font-weight: initial;
-    font-size: $x-small;
+  .data-table-block .name__cell {
+    width: $col-lg;
+    max-width: $col-lg;
   }
 
-  .data-table-block .data-table__wrapper {
-    overflow-x: auto;
+  // Description flexes so it can't push the table past the viewport; name
+  // stays at $col-lg.
+  .data-table-block .description__cell {
+    width: 100%;
+    max-width: 0;
   }
 
-  .name__cell,
-  .description__cell {
-    min-width: $col-md;
+  // Roles swap at the narrowest viewport: description locks small so it
+  // stays readable, name takes whatever's left.
+  @media (max-width: $break-sm) {
+    .data-table-block .description__cell {
+      width: 185px;
+      min-width: 185px;
+      max-width: 185px;
+    }
+
+    .data-table-block .name__cell {
+      width: 100%;
+      max-width: 0;
+    }
   }
 }


### PR DESCRIPTION
## Issue
Closes #46812 

## Description
- Swap ViewAllHostsLink (whose dropdown prop is being retired) for a direct ActionsDropdown on the labels table row.
- Drop the now-unused dropdown imports + stale comment from ViewAllHostsButton.
- Responsive widths for the labels table: name caps at \$col-lg by default; under \$break-lg description flexes via the "width: 100%; max-width: 0" idiom so it can't push the table past the viewport; under \$break-sm the roles swap so description locks at 185px and name takes whatever's left. Selectors nest under .data-table-block to outrank the global td max-width.

## Screenrecording of fix

https://fleetdm.zoom.us/clips/share/6eE0oi1yQ5SufCVkvqUMTw


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved actions menu implementation in the Labels management table
  * Enhanced responsive table layout with optimized cell sizing and spacing for better use of available space
  * Updated responsive breakpoints and styling for improved display on mobile and smaller viewports
  * Refined table styling for more consistent visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->