### PR TITLE
Record per-host failure activities for policy automations

### DIFF
--- a/changes/38670-policy-status-page
+++ b/changes/38670-policy-status-page
@@ -1,0 +1,1 @@
+- Added per-host activity log entries when policy automations fail to reach their remote provider (webhook, Jira, Zendesk, Google Calendar, and Microsoft conditional access).

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -891,6 +891,7 @@ func newAutomationsSchedule(
 	logger *slog.Logger,
 	intervalReload time.Duration,
 	failingPoliciesSet fleet.FailingPolicySet,
+	newActivitySvc activity_api.NewActivityService,
 ) (*schedule.Schedule, error) {
 	const (
 		name            = string(fleet.CronAutomations)
@@ -929,7 +930,7 @@ func newAutomationsSchedule(
 		schedule.WithJob(
 			"failing_policies_automation",
 			func(ctx context.Context) error {
-				return triggerFailingPoliciesAutomation(ctx, ds, logger.With("automation", "failing_policies"), failingPoliciesSet)
+				return triggerFailingPoliciesAutomation(ctx, ds, logger.With("automation", "failing_policies"), failingPoliciesSet, newActivitySvc)
 			},
 		),
 	)
@@ -966,6 +967,7 @@ func triggerFailingPoliciesAutomation(
 	ds fleet.Datastore,
 	logger *slog.Logger,
 	failingPoliciesSet fleet.FailingPolicySet,
+	newActivitySvc activity_api.NewActivityService,
 ) error {
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
@@ -980,7 +982,7 @@ func triggerFailingPoliciesAutomation(
 		switch cfg.AutomationType {
 		case policies.FailingPolicyWebhook:
 			return webhooks.SendFailingPoliciesBatchedPOSTs(
-				ctx, policy, failingPoliciesSet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, time.Now(), logger)
+				ctx, policy, failingPoliciesSet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, time.Now(), logger, newActivitySvc)
 
 		case policies.FailingPolicyJira:
 			hosts, err := failingPoliciesSet.ListHosts(policy.ID)
@@ -1024,6 +1026,7 @@ func newWorkerIntegrationsSchedule(
 	commander *apple_mdm.MDMAppleCommander,
 	androidModule android.Service,
 	chartSvc chart_api.Service,
+	newActivitySvc activity_api.NewActivityService,
 ) (*schedule.Schedule, error) {
 	const (
 		name = string(fleet.CronWorkerIntegrations)
@@ -1045,14 +1048,16 @@ func newWorkerIntegrationsSchedule(
 	// leave the url empty for now, will be filled when the lock is acquired with
 	// the up-to-date config.
 	jira := &worker.Jira{
-		Datastore:     ds,
-		Log:           logger,
-		NewClientFunc: newJiraClient,
+		Datastore:      ds,
+		Log:            logger,
+		NewClientFunc:  newJiraClient,
+		NewActivitySvc: newActivitySvc,
 	}
 	zendesk := &worker.Zendesk{
-		Datastore:     ds,
-		Log:           logger,
-		NewClientFunc: newZendeskClient,
+		Datastore:      ds,
+		Log:            logger,
+		NewClientFunc:  newZendeskClient,
+		NewActivitySvc: newActivitySvc,
 	}
 	var (
 		depSvc *apple_mdm.DEPService

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -764,14 +764,14 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	}
 
 	if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-		return newAutomationsSchedule(ctx, instanceID, ds, logger, 5*time.Minute, failingPolicySet)
+		return newAutomationsSchedule(ctx, instanceID, ds, logger, 5*time.Minute, failingPolicySet, activitySvc)
 	}); err != nil {
 		initFatal(err, "failed to register automations schedule")
 	}
 
 	if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 		commander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
-		return newWorkerIntegrationsSchedule(ctx, instanceID, ds, logger, depStorage, commander, androidSvc, chartSvc)
+		return newWorkerIntegrationsSchedule(ctx, instanceID, ds, logger, depStorage, commander, androidSvc, chartSvc, activitySvc)
 	}); err != nil {
 		initFatal(err, "failed to register worker integrations schedule")
 	}
@@ -935,7 +935,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 				} else {
 					config.Calendar.Periodicity = 5 * time.Minute
 				}
-				return cron.NewCalendarSchedule(ctx, instanceID, ds, distributedLock, config.Calendar, logger)
+				return cron.NewCalendarSchedule(ctx, instanceID, ds, distributedLock, config.Calendar, logger, activitySvc)
 			},
 		); err != nil {
 			initFatal(err, "failed to register calendar schedule")

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -305,7 +305,7 @@ func TestAutomationsSchedule(t *testing.T) {
 	defer cancelFunc()
 
 	failingPoliciesSet := service.NewMemFailingPolicySet()
-	s, err := newAutomationsSchedule(ctx, "test_instance", ds, slog.New(slog.DiscardHandler), 5*time.Minute, failingPoliciesSet)
+	s, err := newAutomationsSchedule(ctx, "test_instance", ds, slog.New(slog.DiscardHandler), 5*time.Minute, failingPoliciesSet, &mock.MockActivityService{})
 	require.NoError(t, err)
 	s.Start()
 
@@ -1002,7 +1002,7 @@ func TestAutomationsScheduleLockDuration(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
-	s, err := newAutomationsSchedule(ctx, "test_instance", ds, slog.New(slog.DiscardHandler), 1*time.Second, service.NewMemFailingPolicySet())
+	s, err := newAutomationsSchedule(ctx, "test_instance", ds, slog.New(slog.DiscardHandler), 1*time.Second, service.NewMemFailingPolicySet(), &mock.MockActivityService{})
 	require.NoError(t, err)
 	s.Start()
 
@@ -1069,7 +1069,7 @@ func TestAutomationsScheduleIntervalChange(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
-	s, err := newAutomationsSchedule(ctx, "test_instance", ds, slog.New(slog.DiscardHandler), 200*time.Millisecond, service.NewMemFailingPolicySet())
+	s, err := newAutomationsSchedule(ctx, "test_instance", ds, slog.New(slog.DiscardHandler), 200*time.Millisecond, service.NewMemFailingPolicySet(), &mock.MockActivityService{})
 	require.NoError(t, err)
 	s.Start()
 

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -2807,6 +2807,97 @@ This activity contains the following fields:
 }
 ```
 
+## failed_webhook_policy_automation
+
+Generated when a failing policy webhook automation errors out.
+
+This activity contains the following fields:
+- "policy_id": ID of the policy whose failing-policy automation failed.
+- "status_code": HTTP status code returned by the remote server (omitted if the request never reached the server).
+- "error_response": The response body returned by the remote server (or the error message for connection-level failures).
+
+#### Example
+
+```json
+{
+  "policy_id": 123,
+  "status_code": 500,
+  "error_response": "internal server error"
+}
+```
+
+## failed_jira_policy_automation
+
+Generated when a failing policy Jira automation can no longer create the ticket after all retries are exhausted.
+
+This activity contains the following fields:
+- "policy_id": ID of the policy whose failing-policy automation failed.
+- "error_response": The error returned by Jira (including the response body when available).
+
+#### Example
+
+```json
+{
+  "policy_id": 123,
+  "error_response": "create issue: request failed. Status code: 401"
+}
+```
+
+## failed_zendesk_policy_automation
+
+Generated when a failing policy Zendesk automation can no longer create the ticket after all retries are exhausted.
+
+This activity contains the following fields:
+- "policy_id": ID of the policy whose failing-policy automation failed.
+- "error_response": The error returned by Zendesk (including the response body when available).
+
+#### Example
+
+```json
+{
+  "policy_id": 123,
+  "error_response": "422: {\"error\":\"RecordInvalid\"}"
+}
+```
+
+## failed_calendar_policy_automation
+
+Generated when a failing policy calendar (maintenance window) automation is rejected by the remote calendar provider. It is associated with the host the calendar automation failed for (the affected host appears in the per-host activity feed rather than in the fields below).
+
+This activity contains the following fields:
+- "policy_id": ID of the calendar policy whose automation failed.
+- "status_code": HTTP status code returned by the remote provider (omitted for OAuth/token errors that carry no HTTP status).
+- "error_response": The response body or message returned by the remote provider.
+
+#### Example
+
+```json
+{
+  "policy_id": 123,
+  "status_code": 403,
+  "error_response": "Rate Limit Exceeded"
+}
+```
+
+## failed_conditional_access_policy_automation
+
+Generated when a failing policy conditional access automation fails to push the host's compliance status to the remote provider. It is associated with the host the automation failed for (the affected host appears in the per-host activity feed rather than in the fields below).
+
+This activity contains the following fields:
+- "policy_id": ID of the conditional-access policy whose automation failed.
+- "status_code": HTTP status code returned by the remote provider (omitted if the request never reached the server).
+- "error_response": The response body returned by the remote provider (or the error message for connection-level failures).
+
+#### Example
+
+```json
+{
+  "policy_id": 123,
+  "status_code": 500,
+  "error_response": "500: upstream error"
+}
+```
+
 
 <meta name="title" value="Audit logs">
 <meta name="pageOrderInSection" value="1400">

--- a/ee/server/calendar/google_calendar.go
+++ b/ee/server/calendar/google_calendar.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/fleetdm/fleet/v4/pkg/str"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/google/uuid"
@@ -520,6 +521,30 @@ func isInvalidGrant(err error) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), `"error": "invalid_grant"`)
+}
+
+// RemoteError classifies err as a failure returned by the remote calendar
+// provider (as opposed to an internal Fleet error such as a database or lock
+// failure). When it is a remote failure it returns the HTTP status code (0 if
+// none, e.g. for OAuth token errors) and the response body.
+func RemoteError(err error) (isRemote bool, statusCode int, body string) {
+	if err == nil {
+		return false, 0, ""
+	}
+	if ae, ok := errors.AsType[*googleapi.Error](err); ok {
+		body := ae.Body
+		if body == "" {
+			body = ae.Message
+		}
+		return true, ae.Code, str.TruncateErrorResponse(body)
+	}
+	if isInvalidGrant(err) {
+		// invalid_grant is an OAuth error returned by Google when the service
+		// account cannot impersonate the host's email (e.g. the user is not in
+		// the Workspace domain or domain-wide delegation is misconfigured).
+		return true, 0, str.TruncateErrorResponse(err.Error())
+	}
+	return false, 0, ""
 }
 
 func isRateLimited(err error) bool {

--- a/pkg/str/str.go
+++ b/pkg/str/str.go
@@ -3,7 +3,26 @@ package str
 import (
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
+
+// MaxErrorResponseBytes is the maximum number of bytes captured from a remote
+// error response body before the string is truncated.
+const MaxErrorResponseBytes = 512 * 1024
+
+// TruncateErrorResponse caps s at MaxErrorResponseBytes bytes. When the string
+// is longer it is cut at a valid UTF-8 boundary and " [truncated]" is appended.
+func TruncateErrorResponse(s string) string {
+	if len(s) <= MaxErrorResponseBytes {
+		return s
+	}
+	cut := s[:MaxErrorResponseBytes]
+	// Step back from the cut point to ensure we end on a valid rune boundary.
+	for !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + " [truncated]"
+}
 
 func SplitAndTrim(s string, delimiter string, removeEmpty bool) []string {
 	parts := strings.Split(s, delimiter)

--- a/pkg/str/str_test.go
+++ b/pkg/str/str_test.go
@@ -1,9 +1,12 @@
 package str
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitAndTrim(t *testing.T) {
@@ -141,6 +144,40 @@ func TestParseUintList(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestTruncateErrorResponse(t *testing.T) {
+	t.Run("short string passes through unchanged", func(t *testing.T) {
+		require.Equal(t, "hello", TruncateErrorResponse("hello"))
+	})
+
+	t.Run("exactly at limit passes through unchanged", func(t *testing.T) {
+		s := strings.Repeat("x", MaxErrorResponseBytes)
+		result := TruncateErrorResponse(s)
+		require.Equal(t, s, result)
+		require.False(t, strings.HasSuffix(result, " [truncated]"))
+	})
+
+	t.Run("one byte over limit is truncated", func(t *testing.T) {
+		s := strings.Repeat("x", MaxErrorResponseBytes+1)
+		result := TruncateErrorResponse(s)
+		require.True(t, strings.HasSuffix(result, " [truncated]"))
+		require.LessOrEqual(t, len(result), MaxErrorResponseBytes+len(" [truncated]"))
+	})
+
+	t.Run("result is always valid UTF-8", func(t *testing.T) {
+		// Build a string that is over the limit and ends with a partial multi-byte rune
+		// at the cut point. U+1F600 (😀) encodes as 4 bytes; place it straddling the limit.
+		prefix := strings.Repeat("a", MaxErrorResponseBytes-1)
+		s := prefix + "😀" + strings.Repeat("b", 100)
+		result := TruncateErrorResponse(s)
+		assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+		assert.True(t, strings.HasSuffix(result, " [truncated]"))
+	})
+
+	t.Run("empty string passes through unchanged", func(t *testing.T) {
+		require.Empty(t, TruncateErrorResponse(""))
+	})
 }
 
 func TestParseStringList(t *testing.T) {

--- a/server/cron/calendar_cron.go
+++ b/server/cron/calendar_cron.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -25,6 +26,47 @@ const (
 	reloadFrequency   = 30 * time.Minute
 )
 
+// recordCalendarFailureActivity records a failed_calendar_policy_automation
+// activity for the given host when err is a failure returned by the remote
+// calendar provider (internal errors are ignored).
+func recordCalendarFailureActivity(
+	ctx context.Context,
+	newActivitySvc activity_api.NewActivityService,
+	host fleet.HostPolicyMembershipData,
+	err error,
+	logger *slog.Logger,
+) {
+	if newActivitySvc == nil {
+		return
+	}
+	isRemote, statusCode, body := calendar.ClassifyRemoteError(err)
+	if !isRemote {
+		return
+	}
+	for policyIDStr := range strings.SplitSeq(host.FailingPolicyIDs, ",") {
+		policyIDStr = strings.TrimSpace(policyIDStr)
+		if policyIDStr == "" {
+			continue
+		}
+		id, parseErr := strconv.ParseUint(policyIDStr, 10, strconv.IntSize)
+		if parseErr != nil {
+			logger.WarnContext(ctx, "parse failing policy id for calendar failure activity",
+				"policy_id", policyIDStr, "err", parseErr)
+			continue
+		}
+		policyID := uint(id)
+		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedCalendarPolicyAutomation{
+			PolicyID:      policyID,
+			HostIDList:    []uint{host.HostID},
+			StatusCode:    statusCode,
+			ErrorResponse: body,
+		}); actErr != nil {
+			logger.WarnContext(ctx, "failed to record calendar policy automation failure activity",
+				"policy_id", policyID, "host_id", host.HostID, "err", actErr)
+		}
+	}
+}
+
 func NewCalendarSchedule(
 	ctx context.Context,
 	instanceID string,
@@ -32,6 +74,7 @@ func NewCalendarSchedule(
 	distributedLock fleet.Lock,
 	serverConfig config.CalendarConfig,
 	logger *slog.Logger,
+	newActivitySvc activity_api.NewActivityService,
 ) (*schedule.Schedule, error) {
 	const (
 		name = string(fleet.CronCalendar)
@@ -50,7 +93,7 @@ func NewCalendarSchedule(
 		schedule.WithJob(
 			"calendar_events",
 			func(ctx context.Context) error {
-				return cronCalendarEvents(ctx, ds, distributedLock, serverConfig, logger)
+				return cronCalendarEvents(ctx, ds, distributedLock, serverConfig, logger, newActivitySvc)
 			},
 		),
 	)
@@ -59,7 +102,7 @@ func NewCalendarSchedule(
 }
 
 func cronCalendarEvents(ctx context.Context, ds fleet.Datastore, distributedLock fleet.Lock, serverConfig config.CalendarConfig,
-	logger *slog.Logger) error {
+	logger *slog.Logger, newActivitySvc activity_api.NewActivityService) error {
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("load app config: %w", err)
@@ -89,7 +132,7 @@ func cronCalendarEvents(ctx context.Context, ds fleet.Datastore, distributedLock
 	}
 	for _, team := range teams {
 		if err := cronCalendarEventsForTeam(
-			ctx, ds, distributedLock, localConfig, *team, appConfig.OrgInfo.OrgName, domain, logger,
+			ctx, ds, distributedLock, localConfig, *team, appConfig.OrgInfo.OrgName, domain, logger, newActivitySvc,
 		); err != nil {
 			logger.InfoContext(ctx, "events calendar cron", "team_id", team.ID, "err", err)
 		}
@@ -107,6 +150,7 @@ func cronCalendarEventsForTeam(
 	orgName string,
 	domain string,
 	logger *slog.Logger,
+	newActivitySvc activity_api.NewActivityService,
 ) error {
 	if team.Config.Integrations.GoogleCalendar == nil ||
 		!team.Config.Integrations.GoogleCalendar.Enable {
@@ -182,7 +226,7 @@ func cronCalendarEventsForTeam(
 
 	// Process hosts that are failing calendar policies.
 	start = time.Now()
-	processCalendarFailingHosts(ctx, ds, distributedLock, calendarConfig, orgName, failingHosts, logger)
+	processCalendarFailingHosts(ctx, ds, distributedLock, calendarConfig, orgName, failingHosts, logger, newActivitySvc)
 	logger.DebugContext(ctx, "failing_hosts", "took", time.Since(start))
 
 	// At last, we want to log the hosts that are failing and don't have an associated email.
@@ -204,6 +248,7 @@ func processCalendarFailingHosts(
 	orgName string,
 	hosts []fleet.HostPolicyMembershipData,
 	logger *slog.Logger,
+	newActivitySvc activity_api.NewActivityService,
 ) {
 	hosts = filterHostsWithSameEmail(hosts)
 
@@ -250,6 +295,7 @@ func processCalendarFailingHosts(
 				userCalendar := calendar.CreateUserCalendarFromConfig(ctx, calendarConfig, logger)
 				if err := userCalendar.Configure(host.Email); err != nil {
 					logger.ErrorContext(ctx, "configure user calendar", "err", err)
+					recordCalendarFailureActivity(ctx, newActivitySvc, host, err, logger)
 					continue // continue with next host
 				}
 
@@ -260,6 +306,7 @@ func processCalendarFailingHosts(
 						calendarConfig, logger,
 					); err != nil {
 						logger.InfoContext(ctx, "process failing host existing calendar event", "err", err)
+						recordCalendarFailureActivity(ctx, newActivitySvc, host, err, logger)
 						continue // continue with next host
 					}
 				case fleet.IsNotFound(err) || expiredEvent:
@@ -267,6 +314,7 @@ func processCalendarFailingHosts(
 						ctx, ds, userCalendar, orgName, host, &policyIDtoPolicy, logger,
 					); err != nil {
 						logger.InfoContext(ctx, "process failing host create calendar event", "err", err)
+						recordCalendarFailureActivity(ctx, newActivitySvc, host, err, logger)
 						continue // continue with next host
 					}
 				default:

--- a/server/cron/calendar_cron_test.go
+++ b/server/cron/calendar_cron_test.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/ee/server/calendar"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -21,6 +23,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/service/redis_lock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
 )
 
 var defaultCalendarConfig = config.CalendarConfig{Periodicity: 5 * time.Minute}
@@ -201,7 +204,7 @@ func TestEventForDifferentHost(t *testing.T) {
 	}
 
 	pool := redistest.SetupRedis(t, t.Name(), false, false, false)
-	err := cronCalendarEvents(ctx, ds, redis_lock.NewLock(pool), defaultCalendarConfig, logger)
+	err := cronCalendarEvents(ctx, ds, redis_lock.NewLock(pool), defaultCalendarConfig, logger, &mock.MockActivityService{})
 	require.NoError(t, err)
 }
 
@@ -376,7 +379,7 @@ func TestCalendarEventsMultipleHosts(t *testing.T) {
 	}
 
 	pool := redistest.SetupRedis(t, t.Name(), false, false, false)
-	err := cronCalendarEvents(ctx, ds, redis_lock.NewLock(pool), defaultCalendarConfig, logger)
+	err := cronCalendarEvents(ctx, ds, redis_lock.NewLock(pool), defaultCalendarConfig, logger, &mock.MockActivityService{})
 	require.NoError(t, err)
 
 	eventsMu.Lock()
@@ -667,7 +670,7 @@ func TestCalendarEvents1KHosts(t *testing.T) {
 
 	pool := redistest.SetupRedis(t, t.Name(), false, false, false)
 	distributedLock := redis_lock.NewLock(pool)
-	err := cronCalendarEvents(ctx, ds, distributedLock, defaultCalendarConfig, logger)
+	err := cronCalendarEvents(ctx, ds, distributedLock, defaultCalendarConfig, logger, &mock.MockActivityService{})
 	require.NoError(t, err)
 
 	createdCalendarEvents := calendar.ListGoogleMockEvents()
@@ -715,7 +718,7 @@ func TestCalendarEvents1KHosts(t *testing.T) {
 		ev.EndTime = futureStart.Add(30 * time.Minute)
 	}
 
-	err = cronCalendarEvents(ctx, ds, distributedLock, defaultCalendarConfig, logger)
+	err = cronCalendarEvents(ctx, ds, distributedLock, defaultCalendarConfig, logger, &mock.MockActivityService{})
 	require.NoError(t, err)
 
 	createdCalendarEvents = calendar.ListGoogleMockEvents()
@@ -965,7 +968,7 @@ func TestEventBody(t *testing.T) {
 	}
 
 	pool := redistest.SetupRedis(t, t.Name(), false, false, false)
-	err := cronCalendarEvents(ctx, ds, redis_lock.NewLock(pool), defaultCalendarConfig, logger)
+	err := cronCalendarEvents(ctx, ds, redis_lock.NewLock(pool), defaultCalendarConfig, logger, &mock.MockActivityService{})
 	require.NoError(t, err)
 
 	numberOfEvents := 7
@@ -997,4 +1000,72 @@ func TestEventBody(t *testing.T) {
 			assert.Contains(t, eventBody, fleet.CalendarDefaultResolution)
 		}
 	}
+}
+
+// TestRecordCalendarFailureActivity verifies that a calendar (maintenance
+// window) automation failure caused by the remote calendar provider is
+// recorded as one activity per failing policy, while internal errors and
+// the success path record nothing.
+func TestRecordCalendarFailureActivity(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	type recorded struct {
+		acts []fleet.ActivityTypeFailedCalendarPolicyAutomation
+	}
+	newRecorder := func(r *recorded) activity_api.NewActivityService {
+		return &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+			require.Nil(t, user)
+			act, ok := activity.(fleet.ActivityTypeFailedCalendarPolicyAutomation)
+			require.True(t, ok)
+			r.acts = append(r.acts, act)
+			return nil
+		}}
+	}
+
+	t.Run("googleapi error records one activity per failing policy", func(t *testing.T) {
+		var r recorded
+		host := fleet.HostPolicyMembershipData{HostID: 100, FailingPolicyIDs: "10,20"}
+		err := &googleapi.Error{Code: 403, Message: "Rate Limit Exceeded", Body: `{"error":"rateLimitExceeded"}`}
+
+		recordCalendarFailureActivity(ctx, newRecorder(&r), host, err, logger)
+
+		require.Len(t, r.acts, 2)
+		for _, act := range r.acts {
+			require.Equal(t, []uint{100}, act.HostIDList)
+			require.Equal(t, 403, act.StatusCode)
+			require.JSONEq(t, `{"error":"rateLimitExceeded"}`, act.ErrorResponse)
+		}
+		require.Equal(t, uint(10), r.acts[0].PolicyID)
+		require.Equal(t, uint(20), r.acts[1].PolicyID)
+	})
+
+	t.Run("invalid_grant oauth error is recorded", func(t *testing.T) {
+		var r recorded
+		host := fleet.HostPolicyMembershipData{HostID: 101, FailingPolicyIDs: "10"}
+		err := fmt.Errorf("configure: %w", errors.New("oauth2: cannot fetch token: 400 Bad Request\nResponse: {\n  \"error\": \"invalid_grant\"\n}"))
+
+		recordCalendarFailureActivity(ctx, newRecorder(&r), host, err, logger)
+
+		require.Len(t, r.acts, 1)
+		require.Equal(t, uint(10), r.acts[0].PolicyID)
+		require.Equal(t, 0, r.acts[0].StatusCode)
+		require.Contains(t, r.acts[0].ErrorResponse, "invalid_grant")
+	})
+
+	t.Run("internal error records nothing", func(t *testing.T) {
+		var r recorded
+		host := fleet.HostPolicyMembershipData{HostID: 102, FailingPolicyIDs: "10"}
+
+		recordCalendarFailureActivity(ctx, newRecorder(&r), host, errors.New("create calendar event on db: boom"), logger)
+
+		require.Empty(t, r.acts)
+	})
+
+	t.Run("nil activity function is a no-op", func(t *testing.T) {
+		host := fleet.HostPolicyMembershipData{HostID: 104, FailingPolicyIDs: "10"}
+		require.NotPanics(t, func() {
+			recordCalendarFailureActivity(ctx, nil, host, &googleapi.Error{Code: 500}, logger)
+		})
+	})
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1666,6 +1666,119 @@ func (a ActivityTypeBatchScriptCanceled) ActivityName() string {
 	return "canceled_script_batch"
 }
 
+// ActivityTypeFailedWebhookPolicyAutomation is recorded when a failing-policy
+// webhook automation send is rejected by the remote server. One activity is
+// recorded per failed batch POST and is associated with every host in that
+// batch.
+type ActivityTypeFailedWebhookPolicyAutomation struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	StatusCode    int    `json:"status_code,omitempty"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedWebhookPolicyAutomation) ActivityName() string {
+	return "failed_webhook_policy_automation"
+}
+
+func (a ActivityTypeFailedWebhookPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedWebhookPolicyAutomation) WasFromAutomation() bool {
+	return true
+}
+
+// ActivityTypeFailedJiraPolicyAutomation is recorded when a failing-policy Jira
+// automation can no longer create the ticket after the worker exhausts its
+// retries. It is associated with every host the failing-policy job targeted.
+type ActivityTypeFailedJiraPolicyAutomation struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedJiraPolicyAutomation) ActivityName() string {
+	return "failed_jira_policy_automation"
+}
+
+func (a ActivityTypeFailedJiraPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedJiraPolicyAutomation) WasFromAutomation() bool {
+	return true
+}
+
+// ActivityTypeFailedZendeskPolicyAutomation is recorded when a failing-policy
+// Zendesk automation can no longer create the ticket after the worker exhausts
+// its retries. It is associated with every host the failing-policy job
+// targeted.
+type ActivityTypeFailedZendeskPolicyAutomation struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedZendeskPolicyAutomation) ActivityName() string {
+	return "failed_zendesk_policy_automation"
+}
+
+func (a ActivityTypeFailedZendeskPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedZendeskPolicyAutomation) WasFromAutomation() bool {
+	return true
+}
+
+// ActivityTypeFailedCalendarPolicyAutomation is recorded when a failing-policy
+// calendar (maintenance window) automation is rejected by the remote calendar
+// provider while the events cron processes a host. One activity is recorded per
+// failing calendar policy the host belongs to, associated with that host.
+type ActivityTypeFailedCalendarPolicyAutomation struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	StatusCode    int    `json:"status_code,omitempty"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedCalendarPolicyAutomation) ActivityName() string {
+	return "failed_calendar_policy_automation"
+}
+
+func (a ActivityTypeFailedCalendarPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedCalendarPolicyAutomation) WasFromAutomation() bool {
+	return true
+}
+
+// ActivityTypeFailedConditionalAccessPolicyAutomation is recorded when a
+// failing-policy conditional access automation fails to push the host's
+// compliance status to the remote provider. One activity is recorded per
+// conditional-access policy configured for the host's team, associated with
+// that host.
+type ActivityTypeFailedConditionalAccessPolicyAutomation struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	StatusCode    int    `json:"status_code,omitempty"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedConditionalAccessPolicyAutomation) ActivityName() string {
+	return "failed_conditional_access_policy_automation"
+}
+
+func (a ActivityTypeFailedConditionalAccessPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedConditionalAccessPolicyAutomation) WasFromAutomation() bool {
+	return true
+}
+
 type ActivityTypeAddedConditionalAccessIntegrationMicrosoft struct{}
 
 func (a ActivityTypeAddedConditionalAccessIntegrationMicrosoft) ActivityName() string {

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -1,10 +1,121 @@
 package fleet
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestFailedPolicyAutomationActivities(t *testing.T) {
+	t.Run("webhook", func(t *testing.T) {
+		act := ActivityTypeFailedWebhookPolicyAutomation{
+			PolicyID:      7,
+			HostIDList:    []uint{10, 20, 30},
+			StatusCode:    500,
+			ErrorResponse: "internal server error",
+		}
+
+		assert.Equal(t, "failed_webhook_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{10, 20, 30}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 7, got["policy_id"])
+		assert.EqualValues(t, 500, got["status_code"])
+		assert.Equal(t, "internal server error", got["error_response"])
+	})
+
+	t.Run("jira", func(t *testing.T) {
+		act := ActivityTypeFailedJiraPolicyAutomation{
+			PolicyID:      8,
+			HostIDList:    []uint{11},
+			ErrorResponse: "401 Unauthorized",
+		}
+
+		assert.Equal(t, "failed_jira_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{11}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 8, got["policy_id"])
+		assert.Equal(t, "401 Unauthorized", got["error_response"])
+		// no status_code field for jira/zendesk
+		_, hasStatus := got["status_code"]
+		assert.False(t, hasStatus)
+	})
+
+	t.Run("zendesk", func(t *testing.T) {
+		act := ActivityTypeFailedZendeskPolicyAutomation{
+			PolicyID:      9,
+			HostIDList:    []uint{12, 13},
+			ErrorResponse: "422: {\"error\":\"RecordInvalid\"}",
+		}
+
+		assert.Equal(t, "failed_zendesk_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{12, 13}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 9, got["policy_id"])
+		assert.Equal(t, "422: {\"error\":\"RecordInvalid\"}", got["error_response"])
+		// no status_code field for zendesk
+		_, hasStatus := got["status_code"]
+		assert.False(t, hasStatus)
+	})
+
+	t.Run("calendar", func(t *testing.T) {
+		act := ActivityTypeFailedCalendarPolicyAutomation{
+			PolicyID:      14,
+			HostIDList:    []uint{42},
+			StatusCode:    403,
+			ErrorResponse: "Rate Limit Exceeded",
+		}
+
+		assert.Equal(t, "failed_calendar_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{42}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 14, got["policy_id"])
+		assert.EqualValues(t, 403, got["status_code"])
+		assert.Equal(t, "Rate Limit Exceeded", got["error_response"])
+	})
+
+	t.Run("conditional access", func(t *testing.T) {
+		act := ActivityTypeFailedConditionalAccessPolicyAutomation{
+			PolicyID:      15,
+			HostIDList:    []uint{43},
+			StatusCode:    500,
+			ErrorResponse: "500: upstream error",
+		}
+
+		assert.Equal(t, "failed_conditional_access_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{43}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 15, got["policy_id"])
+		assert.EqualValues(t, 500, got["status_code"])
+		assert.Equal(t, "500: upstream error", got["error_response"])
+	})
+}
 
 // TestVPPInstallFailureEmptyCommandUUIDDoesNotActivateNext exercises the
 // scenario where a VPP install is attempted during setup experience for a

--- a/server/platform/http/post_json.go
+++ b/server/platform/http/post_json.go
@@ -17,6 +17,7 @@ import (
 type errWithStatus struct {
 	err        string
 	statusCode int
+	body       string
 }
 
 // Error implements the error interface.
@@ -27,6 +28,12 @@ func (e *errWithStatus) Error() string {
 // StatusCode implements the StatusCoder interface for returning custom status codes.
 func (e *errWithStatus) StatusCode() int {
 	return e.statusCode
+}
+
+// Body returns the response body of the failed request, so callers
+// can surface what the remote server returned.
+func (e *errWithStatus) Body() string {
+	return e.body
 }
 
 // PostJSONWithTimeout marshals v as JSON and POSTs it to the given URL with a 30-second timeout.
@@ -51,17 +58,14 @@ func PostJSONWithTimeout(ctx context.Context, url string, v any, logger *slog.Lo
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 513))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		bodyStr := string(body)
-		if len(bodyStr) > 512 {
-			bodyStr = bodyStr[:512]
-		}
 		logger.DebugContext(ctx, "non-success response from POST",
 			"url", MaskSecretURLParams(url),
 			"status_code", resp.StatusCode,
 			"body", bodyStr,
 		)
-		return &errWithStatus{err: fmt.Sprintf("error posting to %s", MaskSecretURLParams(url)), statusCode: resp.StatusCode}
+		return &errWithStatus{err: fmt.Sprintf("error posting to %s", MaskSecretURLParams(url)), statusCode: resp.StatusCode, body: bodyStr}
 	}
 
 	return nil

--- a/server/service/calendar/calendar.go
+++ b/server/service/calendar/calendar.go
@@ -56,6 +56,13 @@ type PolicyLiteWithMeta struct {
 	mu  sync.Mutex
 }
 
+// ClassifyRemoteError reports whether err is a failure returned by the remote
+// calendar provider (rather than an internal Fleet error), along with the HTTP
+// status code (0 if none) and the response body or message to surface.
+func ClassifyRemoteError(err error) (isRemote bool, statusCode int, body string) {
+	return calendar.RemoteError(err)
+}
+
 func CreateUserCalendarFromConfig(ctx context.Context, config *Config, logger *slog.Logger) fleet.UserCalendar {
 	googleCalendarConfig := calendar.GoogleCalendarConfig{
 		Context:           ctx,

--- a/server/service/conditional_access_failure_activity_test.go
+++ b/server/service/conditional_access_failure_activity_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// proxyStatusErr mimics the conditional access proxy's StatusError, exposing
+// the remote HTTP status code and response body.
+type proxyStatusErr struct {
+	code int
+	body string
+}
+
+func (e *proxyStatusErr) Error() string   { return fmt.Sprintf("%d: %s", e.code, e.body) }
+func (e *proxyStatusErr) StatusCode() int { return e.code }
+func (e *proxyStatusErr) Body() string    { return e.body }
+
+// TestRecordConditionalAccessFailureActivity verifies that a failed conditional
+// access compliance push records one activity per conditional-access policy,
+// capturing the remote status code and response body.
+func TestRecordConditionalAccessFailureActivity(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	type recorded struct {
+		acts []fleet.ActivityTypeFailedConditionalAccessPolicyAutomation
+	}
+	newRecorder := func(r *recorded) activity_api.NewActivityService {
+		return &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+			require.Nil(t, user)
+			act, ok := activity.(fleet.ActivityTypeFailedConditionalAccessPolicyAutomation)
+			require.True(t, ok)
+			r.acts = append(r.acts, act)
+			return nil
+		}}
+	}
+
+	t.Run("records one activity per policy with status and body", func(t *testing.T) {
+		var r recorded
+		err := &proxyStatusErr{code: 500, body: "upstream boom"}
+
+		recordConditionalAccessFailureActivity(ctx, newRecorder(&r), 100, []uint{30, 31}, err, logger)
+
+		require.Len(t, r.acts, 2)
+		for _, act := range r.acts {
+			require.Equal(t, []uint{100}, act.HostIDList)
+			require.Equal(t, 500, act.StatusCode)
+			require.Equal(t, "upstream boom", act.ErrorResponse)
+		}
+		require.Equal(t, uint(30), r.acts[0].PolicyID)
+		require.Equal(t, uint(31), r.acts[1].PolicyID)
+	})
+
+	t.Run("falls back to error string when no body", func(t *testing.T) {
+		var r recorded
+
+		recordConditionalAccessFailureActivity(ctx, newRecorder(&r), 101, []uint{30}, errors.New("connection refused"), logger)
+
+		require.Len(t, r.acts, 1)
+		require.Equal(t, 0, r.acts[0].StatusCode)
+		require.Equal(t, "connection refused", r.acts[0].ErrorResponse)
+	})
+
+	t.Run("no policies records nothing", func(t *testing.T) {
+		var r recorded
+
+		recordConditionalAccessFailureActivity(ctx, newRecorder(&r), 103, nil, &proxyStatusErr{code: 500}, logger)
+
+		require.Empty(t, r.acts)
+	})
+
+	t.Run("nil activity function is a no-op", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			recordConditionalAccessFailureActivity(ctx, nil, 104, []uint{30}, &proxyStatusErr{code: 500}, logger)
+		})
+	})
+}

--- a/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy.go
+++ b/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/pkg/str"
 )
 
 // Proxy holds functionality to send requests to Entra via Fleet's MS proxy.
@@ -209,7 +210,7 @@ func (p *Proxy) post(path string, request interface{}, response interface{}) err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("post request failed: %s", resp.Status)
+		return newStatusError(resp)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -239,7 +240,7 @@ func (p *Proxy) get(path string, query string, response interface{}) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("get request failed: %s", resp.Status)
+		return newStatusError(resp)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -290,6 +291,36 @@ type notFoundError struct{}
 
 func (e *notFoundError) Error() string {
 	return "not found"
+}
+
+// StatusError is returned for a non-2xx response from the MS proxy. It carries
+// the HTTP status code and response body so callers can surface the remote
+// error response.
+type StatusError struct {
+	Code    int
+	RespErr string
+}
+
+func (e *StatusError) Error() string {
+	if e.RespErr == "" {
+		return fmt.Sprintf("%d", e.Code)
+	}
+	return fmt.Sprintf("%d: %s", e.Code, e.RespErr)
+}
+
+// StatusCode returns the remote HTTP status code.
+func (e *StatusError) StatusCode() int { return e.Code }
+
+// Body returns the remote response body.
+func (e *StatusError) Body() string { return e.RespErr }
+
+// newStatusError reads up to str.MaxErrorResponseBytes of the response body
+// and returns a StatusError. When the body is larger the stored string ends
+// with " [truncated]".
+func newStatusError(resp *http.Response) *StatusError {
+	lr := io.LimitReader(resp.Body, str.MaxErrorResponseBytes+1)
+	bodyBytes, _ := io.ReadAll(lr)
+	return &StatusError{Code: resp.StatusCode, RespErr: str.TruncateErrorResponse(string(bodyBytes))}
 }
 
 func (e *notFoundError) IsNotFound() bool {

--- a/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy_test.go
+++ b/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy_test.go
@@ -1,0 +1,64 @@
+package conditional_access_microsoft_proxy
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyStatusErrorCapturesBody(t *testing.T) {
+	t.Run("captures status code and body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"upstream boom"}`))
+		}))
+		defer srv.Close()
+
+		p, err := New(srv.URL, "key", func() (string, error) { return "https://fleet.example.com", nil })
+		require.NoError(t, err)
+
+		_, err = p.SetComplianceStatus(t.Context(), "tenant", "secret", "device", "upn", true, "name", "macOS", "14.0", false, time.Now())
+		require.Error(t, err)
+
+		se, ok := errors.AsType[interface {
+			error
+			StatusCode() int
+		}](err)
+		require.True(t, ok)
+		require.Equal(t, http.StatusInternalServerError, se.StatusCode())
+
+		be, ok := errors.AsType[interface {
+			error
+			Body() string
+		}](err)
+		require.True(t, ok)
+		require.Contains(t, be.Body(), "upstream boom")
+	})
+
+	t.Run("captures full body", func(t *testing.T) {
+		const bodyLen = 1000
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(strings.Repeat("x", bodyLen)))
+		}))
+		defer srv.Close()
+
+		p, err := New(srv.URL, "key", func() (string, error) { return "https://fleet.example.com", nil })
+		require.NoError(t, err)
+
+		_, err = p.SetComplianceStatus(t.Context(), "tenant", "secret", "device", "upn", true, "name", "macOS", "14.0", false, time.Now())
+		require.Error(t, err)
+
+		be, ok := errors.AsType[interface {
+			error
+			Body() string
+		}](err)
+		require.True(t, ok)
+		require.Len(t, be.Body(), bodyLen)
+	})
+}

--- a/server/service/externalsvc/jira.go
+++ b/server/service/externalsvc/jira.go
@@ -3,6 +3,8 @@ package externalsvc
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -11,6 +13,7 @@ import (
 	"github.com/andygrunwald/go-jira"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/pkg/str"
 )
 
 // Jira is a Jira client to be used to make requests to a jira external
@@ -79,16 +82,27 @@ func (j *Jira) CreateJiraIssue(ctx context.Context, issue *jira.Issue) (*jira.Is
 	issue.Fields.Project.Key = j.opts.ProjectKey
 
 	var createdIssue *jira.Issue
+	var respBody string
 	op := func() (*jira.Response, error) {
 		var (
 			err  error
 			resp *jira.Response
 		)
 		createdIssue, resp, err = j.client.Issue.CreateWithContext(ctx, issue)
+		if err != nil && resp != nil && resp.Response != nil && resp.Response.Body != nil {
+			// Cap the body to guard against OOM; no "[truncated]" marker here because
+			// OnFinalFailure stores this string as-is and the body is already bounded.
+			b, _ := io.ReadAll(io.LimitReader(resp.Response.Body, str.MaxErrorResponseBytes))
+			resp.Response.Body.Close()
+			respBody = string(b)
+		}
 		return resp, err
 	}
 
 	if err := doWithRetry(op); err != nil {
+		if respBody != "" {
+			return nil, fmt.Errorf("%w: %s", err, respBody)
+		}
 		return nil, err
 	}
 	return createdIssue, nil

--- a/server/service/externalsvc/jira_test.go
+++ b/server/service/externalsvc/jira_test.go
@@ -21,6 +21,10 @@ func TestJira(t *testing.T) {
 		case "fail":
 			w.WriteHeader(http.StatusInternalServerError)
 			return
+		case "failbody":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errorMessages":["project is required"]}`))
+			return
 		case "retrysmall":
 			if countCalls == 1 {
 				w.Header().Add("Retry-After", "1")
@@ -68,6 +72,20 @@ func TestJira(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Status code: 500")
 		require.Equal(t, 6, countCalls)
+	})
+
+	t.Run("failure-includes-response-body", func(t *testing.T) {
+		countCalls = 0
+
+		client, err := NewJiraClient(&JiraOptions{
+			BaseURL:           srv.URL,
+			BasicAuthUsername: "failbody",
+			BasicAuthPassword: "failbody",
+		})
+		require.NoError(t, err)
+		_, err = client.CreateJiraIssue(t.Context(), &jira.Issue{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "project is required")
 	})
 
 	t.Run("retry-after-small", func(t *testing.T) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -144,7 +144,7 @@ func (s *integrationEnterpriseTestSuite) SetupSuite() {
 					}
 					calendarSchedule, err = cron.NewCalendarSchedule(
 						ctx, s.T().Name(), s.ds, redis_lock.NewLock(s.redisPool), config.CalendarConfig{Periodicity: 24 * time.Hour},
-						cronLog,
+						cronLog, nil,
 					)
 					return calendarSchedule, err
 				}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
 	"github.com/fleetdm/fleet/v4/server"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
@@ -2558,14 +2559,15 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 	for _, policyID := range conditionalAccessPolicyIDs {
 		conditionalAccessPolicyIDsSet[policyID] = struct{}{}
 	}
+	var failingCAIDs []uint
 	for incomingPolicyID, incomingPolicyResult := range incomingPolicyResults {
 		if _, ok := conditionalAccessPolicyIDsSet[incomingPolicyID]; !ok {
 			// Ignore results for policies that are not for conditional access.
 			continue
 		}
 		if incomingPolicyResult != nil && !*incomingPolicyResult {
+			failingCAIDs = append(failingCAIDs, incomingPolicyID)
 			hostIsCompliantInFleet = false
-			break
 		}
 	}
 
@@ -2575,7 +2577,7 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 		return nil
 	}
 
-	svc.setHostConditionalAccessAsync(hostID, hostPlatform, hostConditionalAccessStatus, mdmEnrolled, hostIsCompliantInFleet)
+	svc.setHostConditionalAccessAsync(hostID, hostPlatform, hostConditionalAccessStatus, mdmEnrolled, hostIsCompliantInFleet, failingCAIDs)
 
 	return nil
 }
@@ -2586,6 +2588,7 @@ func (svc *Service) setHostConditionalAccessAsync(
 	hostConditionalAccessStatus *fleet.HostConditionalAccessStatus,
 	managed bool,
 	compliant bool,
+	failingPolicyIDs []uint,
 ) {
 	go func() {
 		logger := svc.logger.With(
@@ -2595,7 +2598,7 @@ func (svc *Service) setHostConditionalAccessAsync(
 			"compliant", compliant,
 		)
 		start := time.Now()
-		if err := svc.setHostConditionalAccess(hostID, hostPlatform, hostConditionalAccessStatus, managed, compliant); err != nil {
+		if err := svc.setHostConditionalAccess(hostID, hostPlatform, hostConditionalAccessStatus, managed, compliant, failingPolicyIDs); err != nil {
 			logger.ErrorContext(context.TODO(), "set host conditional access", "took", time.Since(start), "err", err)
 		}
 		logger.DebugContext(context.TODO(), "set host conditional access", "took", time.Since(start))
@@ -2612,6 +2615,7 @@ func (svc *Service) setHostConditionalAccess(
 	hostConditionalAccessStatus *fleet.HostConditionalAccessStatus,
 	managed bool,
 	compliant bool,
+	failingPolicyIDs []uint,
 ) error {
 	ctx := context.Background()
 
@@ -2648,6 +2652,7 @@ func (svc *Service) setHostConditionalAccess(
 		time.Now().UTC(),
 	)
 	if err != nil {
+		recordConditionalAccessFailureActivity(ctx, svc.activitySvc, hostID, failingPolicyIDs, err, logger)
 		return ctxerr.Wrap(ctx, err, "failed to set compliance status")
 	}
 
@@ -2664,6 +2669,12 @@ func (svc *Service) setHostConditionalAccess(
 		startTime := time.Now()
 		for range time.Tick(conditionalAccessSetWaitTime) {
 			if time.Since(startTime) > timeout {
+				// No failure activity is recorded here. SetComplianceStatus
+				// succeeded (we have a MessageID), so the push was accepted by
+				// the remote provider; we just could not confirm completion
+				// within the expected window. Recording a
+				// failed_conditional_access_policy_automation here would
+				// misrepresent an in-flight async operation as a rejection.
 				return ctxerr.Errorf(ctx, "timeout waiting for message after %s", time.Since(startTime))
 			}
 			logger.DebugContext(ctx, "get compliance status message wait")
@@ -2697,6 +2708,58 @@ func (svc *Service) setHostConditionalAccess(
 	}
 
 	return nil
+}
+
+// recordConditionalAccessFailureActivity records a
+// failed_conditional_access_policy_automation activity for the given host when
+// a compliance push to the remote provider fails. One activity is recorded per
+// failing conditional-access policy (policies the host is currently failing,
+// not all CA policies configured for the team), capturing the remote status
+// code and response body when available. Failures to record are logged and
+// swallowed so they don't mask the original error.
+func recordConditionalAccessFailureActivity(
+	ctx context.Context,
+	newActivitySvc activity_api.NewActivityService,
+	hostID uint,
+	policyIDs []uint,
+	err error,
+	logger *slog.Logger,
+) {
+	if newActivitySvc == nil || len(policyIDs) == 0 {
+		return
+	}
+
+	var statusCode int
+	if sc, ok := errors.AsType[interface {
+		error
+		StatusCode() int
+	}](err); ok {
+		statusCode = sc.StatusCode()
+	}
+
+	errResponse := ""
+	if b, ok := errors.AsType[interface {
+		error
+		Body() string
+	}](err); ok {
+		errResponse = b.Body()
+	}
+	if errResponse == "" {
+		// network-level failures (e.g. connection refused) have no server
+		// response; fall back to the error message.
+		errResponse = err.Error()
+	}
+	for _, policyID := range policyIDs {
+		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedConditionalAccessPolicyAutomation{
+			PolicyID:      policyID,
+			HostIDList:    []uint{hostID},
+			StatusCode:    statusCode,
+			ErrorResponse: errResponse,
+		}); actErr != nil {
+			logger.WarnContext(ctx, "failed to record conditional access policy automation failure activity",
+				"policy_id", policyID, "host_id", hostID, "err", actErr)
+		}
+	}
 }
 
 func (svc *Service) maybeDebugHost(

--- a/server/webhooks/failing_policies.go
+++ b/server/webhooks/failing_policies.go
@@ -3,6 +3,7 @@ package webhooks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/url"
 	"path"
@@ -11,10 +12,63 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
 )
+
+// recordWebhookFailureActivity records a failed_webhook_policy_automation
+// activity for every host in the failed batch, capturing the remote server's
+// status code and response body when available. Failures to record are logged
+// and swallowed so they don't mask the original webhook error.
+func recordWebhookFailureActivity(
+	ctx context.Context,
+	newActivitySvc activity_api.NewActivityService,
+	policy *fleet.Policy,
+	batch []fleet.PolicySetHost,
+	postErr error,
+	logger *slog.Logger,
+) {
+	if newActivitySvc == nil {
+		return
+	}
+
+	var statusCode int
+	if sc, ok := errors.AsType[interface {
+		error
+		StatusCode() int
+	}](postErr); ok {
+		statusCode = sc.StatusCode()
+	}
+
+	errResponse := ""
+	if b, ok := errors.AsType[interface {
+		error
+		Body() string
+	}](postErr); ok {
+		errResponse = b.Body()
+	}
+	if errResponse == "" {
+		// network-level failures (e.g. connection refused) have no server
+		// response; fall back to the (masked) error message.
+		errResponse = server.MaskURLError(postErr).Error()
+	}
+	hostIDs := make([]uint, len(batch))
+	for i, host := range batch {
+		hostIDs[i] = host.ID
+	}
+
+	if err := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedWebhookPolicyAutomation{
+		PolicyID:      policy.ID,
+		HostIDList:    hostIDs,
+		StatusCode:    statusCode,
+		ErrorResponse: errResponse,
+	}); err != nil {
+		logger.WarnContext(ctx, "failed to record webhook policy automation failure activity",
+			"policy_id", policy.ID, "err", err)
+	}
+}
 
 // SendFailingPoliciesBatchedPOSTs sends a failing policy to the provided
 // webhook URL. It sends in batches if hostBatchSize > 0. After a successful
@@ -28,6 +82,7 @@ func SendFailingPoliciesBatchedPOSTs(
 	webhookURL *url.URL,
 	now time.Time,
 	logger *slog.Logger,
+	newActivitySvc activity_api.NewActivityService,
 ) error {
 	hosts, err := failingPoliciesSet.ListHosts(policy.ID)
 	if err != nil {
@@ -80,6 +135,7 @@ func SendFailingPoliciesBatchedPOSTs(
 		}
 
 		if err := server.PostJSONWithTimeout(ctx, webhookURL.String(), json.RawMessage(jsonBytes), logger); err != nil {
+			recordWebhookFailureActivity(ctx, newActivitySvc, policy, batch, err, logger)
 			return ctxerr.Wrapf(ctx, server.MaskURLError(err), "posting to %q", server.MaskSecretURLParams(webhookURL.String()))
 		}
 		if err := failingPoliciesSet.RemoveHosts(policy.ID, batch); err != nil {

--- a/server/webhooks/failing_policies_test.go
+++ b/server/webhooks/failing_policies_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -100,7 +101,7 @@ func TestTriggerFailingPoliciesWebhookBasic(t *testing.T) {
 			return err
 		}
 		return SendFailingPoliciesBatchedPOSTs(
-			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, mockClock, slog.New(slog.DiscardHandler))
+			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, mockClock, slog.New(slog.DiscardHandler), &mock.MockActivityService{})
 	})
 	require.NoError(t, err)
 	timestamp, err := mockClock.MarshalJSON()
@@ -160,7 +161,7 @@ func TestTriggerFailingPoliciesWebhookBasic(t *testing.T) {
 			return err
 		}
 		return SendFailingPoliciesBatchedPOSTs(
-			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, mockClock, slog.New(slog.DiscardHandler))
+			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, mockClock, slog.New(slog.DiscardHandler), &mock.MockActivityService{})
 	})
 	require.NoError(t, err)
 	assert.Empty(t, requestBody)
@@ -291,7 +292,7 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
 			return err
 		}
 		return SendFailingPoliciesBatchedPOSTs(
-			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, now, slog.New(slog.DiscardHandler))
+			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, now, slog.New(slog.DiscardHandler), &mock.MockActivityService{})
 	})
 	require.NoError(t, err)
 
@@ -348,10 +349,99 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
 			return err
 		}
 		return SendFailingPoliciesBatchedPOSTs(
-			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, now, slog.New(slog.DiscardHandler))
+			context.Background(), pol, failingPolicySet, cfg.HostBatchSize, serverURL, cfg.WebhookURL, now, slog.New(slog.DiscardHandler), &mock.MockActivityService{})
 	})
 	require.NoError(t, err)
 	assert.Empty(t, webhookBody)
+}
+
+func TestSendFailingPoliciesWebhookRecordsFailureActivity(t *testing.T) {
+	p := &fleet.Policy{
+		PolicyData: fleet.PolicyData{
+			ID:   7,
+			Name: "policy7",
+		},
+	}
+
+	makeHosts := func(c int) []fleet.PolicySetHost {
+		hosts := make([]fleet.PolicySetHost, c)
+		for i := range hosts {
+			hosts[i] = fleet.PolicySetHost{ID: uint(i + 1), Hostname: fmt.Sprintf("h-%d", i+1)} //nolint:gosec
+		}
+		return hosts
+	}
+
+	serverURL, err := url.Parse("https://fleet.example.com")
+	require.NoError(t, err)
+	now := time.Now()
+
+	t.Run("records one activity per failed batch with status and body", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		t.Cleanup(ts.Close)
+		webhookURL, err := url.Parse(ts.URL)
+		require.NoError(t, err)
+
+		failingPolicySet := service.NewMemFailingPolicySet()
+		for _, host := range makeHosts(2) {
+			require.NoError(t, failingPolicySet.AddHost(p.ID, host))
+		}
+
+		var recorded []fleet.ActivityDetails
+		newActivitySvc := &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+			require.Nil(t, user)
+			recorded = append(recorded, activity)
+			return nil
+		}}
+
+		err = SendFailingPoliciesBatchedPOSTs(
+			t.Context(), p, failingPolicySet, 0, serverURL, webhookURL, now,
+			slog.New(slog.DiscardHandler), newActivitySvc,
+		)
+		require.Error(t, err)
+
+		require.Len(t, recorded, 1)
+		act, ok := recorded[0].(fleet.ActivityTypeFailedWebhookPolicyAutomation)
+		require.True(t, ok)
+		assert.Equal(t, p.ID, act.PolicyID)
+		assert.Equal(t, []uint{1, 2}, act.HostIDList)
+		assert.Equal(t, http.StatusInternalServerError, act.StatusCode)
+		assert.Equal(t, "boom", act.ErrorResponse)
+
+		// hosts are not removed from the set on failure (kept for retry)
+		setHosts, err := failingPolicySet.ListHosts(p.ID)
+		require.NoError(t, err)
+		assert.Len(t, setHosts, 2)
+	})
+
+	t.Run("records nothing on success", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(ts.Close)
+		webhookURL, err := url.Parse(ts.URL)
+		require.NoError(t, err)
+
+		failingPolicySet := service.NewMemFailingPolicySet()
+		for _, host := range makeHosts(2) {
+			require.NoError(t, failingPolicySet.AddHost(p.ID, host))
+		}
+
+		var recorded []fleet.ActivityDetails
+		newActivitySvc := &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, activity fleet.ActivityDetails) error {
+			recorded = append(recorded, activity)
+			return nil
+		}}
+
+		err = SendFailingPoliciesBatchedPOSTs(
+			t.Context(), p, failingPolicySet, 0, serverURL, webhookURL, now,
+			slog.New(slog.DiscardHandler), newActivitySvc,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, recorded)
+	})
 }
 
 func TestSendBatchedPOSTs(t *testing.T) {
@@ -476,6 +566,7 @@ func TestSendBatchedPOSTs(t *testing.T) {
 				webhookURL,
 				now,
 				slog.New(slog.DiscardHandler),
+				&mock.MockActivityService{},
 			)
 			require.NoError(t, err)
 			require.Len(t, allHosts, tc.hostCount)

--- a/server/worker/jira.go
+++ b/server/worker/jira.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	jira "github.com/andygrunwald/go-jira"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -119,10 +120,11 @@ type JiraClient interface {
 
 // Jira is the job processor for jira integrations.
 type Jira struct {
-	FleetURL      string
-	Datastore     fleet.Datastore
-	Log           *slog.Logger
-	NewClientFunc func(*externalsvc.JiraOptions) (JiraClient, error)
+	FleetURL       string
+	Datastore      fleet.Datastore
+	Log            *slog.Logger
+	NewClientFunc  func(*externalsvc.JiraOptions) (JiraClient, error)
+	NewActivitySvc activity_api.NewActivityService
 
 	// mu protects concurrent access to clientsCache, so that the job processor
 	// can potentially be run concurrently.
@@ -260,6 +262,29 @@ func (j *Jira) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	default:
 		return ctxerr.Errorf(ctx, "unknown integration type: %v", intgType)
 	}
+}
+
+// OnFinalFailure records a failed_jira_policy_automation host activity once the
+// worker has exhausted all retries for a failing-policy job. Vulnerability jobs
+// are ignored as they are not host- or policy-scoped.
+func (j *Jira) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+	if j.NewActivitySvc == nil {
+		return nil
+	}
+
+	var args jiraArgs
+	if err := json.Unmarshal(argsJSON, &args); err != nil {
+		return ctxerr.Wrap(ctx, err, "unmarshal args")
+	}
+	if args.FailingPolicy == nil {
+		return nil
+	}
+
+	return j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedJiraPolicyAutomation{
+		PolicyID:      args.FailingPolicy.PolicyID,
+		HostIDList:    args.FailingPolicy.hostIDs(),
+		ErrorResponse: jobErr,
+	})
 }
 
 func (j *Jira) runVuln(ctx context.Context, cli JiraClient, args jiraArgs) error {

--- a/server/worker/jira_test.go
+++ b/server/worker/jira_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	jira "github.com/andygrunwald/go-jira"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -278,6 +279,54 @@ func TestJiraQueueVulnJobs(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, io.EOF)
 		require.True(t, ds.NewJobFuncInvoked)
+	})
+}
+
+func TestJiraOnFinalFailure(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("failing policy records activity", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		j := &Jira{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+				require.Nil(t, user)
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(jiraArgs{FailingPolicy: &failingPolicyArgs{
+			PolicyID: 5,
+			Hosts:    []fleet.PolicySetHost{{ID: 1, Hostname: "h1"}, {ID: 2, Hostname: "h2"}},
+		}})
+		require.NoError(t, err)
+
+		require.NoError(t, j.OnFinalFailure(ctx, args, "create issue: 401 Unauthorized"))
+
+		require.Len(t, recorded, 1)
+		act, ok := recorded[0].(fleet.ActivityTypeFailedJiraPolicyAutomation)
+		require.True(t, ok)
+		require.Equal(t, uint(5), act.PolicyID)
+		require.Equal(t, []uint{1, 2}, act.HostIDList)
+		require.Equal(t, "create issue: 401 Unauthorized", act.ErrorResponse)
+	})
+
+	t.Run("vuln job records nothing", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		j := &Jira{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, activity fleet.ActivityDetails) error {
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(jiraArgs{Vulnerability: &vulnArgs{CVE: "CVE-2024-1"}})
+		require.NoError(t, err)
+
+		require.NoError(t, j.OnFinalFailure(ctx, args, "boom"))
+		require.Empty(t, recorded)
 	})
 }
 

--- a/server/worker/worker.go
+++ b/server/worker/worker.go
@@ -37,6 +37,14 @@ type Job interface {
 	Run(ctx context.Context, argsJSON json.RawMessage) error
 }
 
+// FinalFailureNotifier is an optional interface a Job can implement to be
+// notified once, after the worker has exhausted all retries and marked the job
+// as permanently failed. This is the right place to record terminal-failure
+// side effects (e.g. an activity) without emitting one per intermediate retry.
+type FinalFailureNotifier interface {
+	OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error
+}
+
 // failingPolicyArgs are the args common to all integrations that can process
 // failing policies.
 type failingPolicyArgs struct {
@@ -45,6 +53,16 @@ type failingPolicyArgs struct {
 	PolicyCritical bool                  `json:"policy_critical"`
 	Hosts          []fleet.PolicySetHost `json:"hosts"`
 	TeamID         *uint                 `json:"team_id,omitempty"` //nolint:apiparamcheck // these are written to the db, changing likely requires migration
+}
+
+// hostIDs returns the IDs of the hosts targeted by the failing-policy job, used
+// to associate a failure activity with each affected host.
+func (a *failingPolicyArgs) hostIDs() []uint {
+	ids := make([]uint, len(a.Hosts))
+	for i, h := range a.Hosts {
+		ids[i] = h.ID
+	}
+	return ids
 }
 
 // vulnArgs are the args common to all integrations that can process
@@ -196,6 +214,15 @@ func (w *Worker) ProcessJobs(ctx context.Context) error {
 					}
 				} else {
 					job.State = fleet.JobStateFailure
+					if notifier, ok := w.registry[job.Name].(FinalFailureNotifier); ok {
+						var args json.RawMessage
+						if job.Args != nil {
+							args = *job.Args
+						}
+						if ffErr := notifier.OnFinalFailure(ctx, args, job.Error); ffErr != nil {
+							log.ErrorContext(ctx, "on final failure handler", "err", ffErr)
+						}
+					}
 				}
 			} else {
 				job.State = fleet.JobStateSuccess

--- a/server/worker/worker_test.go
+++ b/server/worker/worker_test.go
@@ -30,6 +30,75 @@ func (t testJob) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	return t.run(ctx, argsJSON)
 }
 
+// testJobNotifier is a testJob that also implements FinalFailureNotifier.
+type testJobNotifier struct {
+	testJob
+	onFinalFailure func(ctx context.Context, argsJSON json.RawMessage, jobErr string) error
+}
+
+func (t testJobNotifier) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+	return t.onFinalFailure(ctx, argsJSON, jobErr)
+}
+
+func TestWorkerFinalFailureNotifier(t *testing.T) {
+	ds := new(mock.Store)
+
+	argsJSON := json.RawMessage(`{"arg1":"foo"}`)
+	theJob := &fleet.Job{
+		ID:      1,
+		Name:    "test",
+		Args:    &argsJSON,
+		State:   fleet.JobStateQueued,
+		Retries: 0,
+	}
+	ds.GetFilteredQueuedJobsFunc = func(ctx context.Context, maxNumJobs int, now time.Time, jobNames []string) ([]*fleet.Job, error) {
+		if theJob.State == fleet.JobStateQueued {
+			return []*fleet.Job{theJob}, nil
+		}
+		return nil, nil
+	}
+	ds.UpdateJobFunc = func(ctx context.Context, id uint, job *fleet.Job) (*fleet.Job, error) {
+		return job, nil
+	}
+
+	logger := slog.New(slog.DiscardHandler)
+	w := NewWorker(ds, logger)
+
+	var finalFailureCalls int
+	var gotArgs json.RawMessage
+	var gotErr string
+	j := testJobNotifier{
+		testJob: testJob{
+			name: "test",
+			run: func(ctx context.Context, argsJSON json.RawMessage) error {
+				return errors.New("boom")
+			},
+		},
+		onFinalFailure: func(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+			finalFailureCalls++
+			gotArgs = argsJSON
+			gotErr = jobErr
+			return nil
+		},
+	}
+	w.Register(j)
+
+	for i := range maxRetries + 1 {
+		require.NoError(t, w.ProcessJobs(t.Context()))
+		ds.GetFilteredQueuedJobsFuncInvoked = false
+		ds.UpdateJobFuncInvoked = false
+
+		// the hook must NOT fire on intermediate retries, only on final failure
+		if i < maxRetries {
+			require.Equal(t, 0, finalFailureCalls, "final failure handler fired before retries exhausted (iteration %d)", i)
+		}
+	}
+
+	require.Equal(t, 1, finalFailureCalls)
+	require.JSONEq(t, `{"arg1":"foo"}`, string(gotArgs))
+	require.Equal(t, "boom", gotErr)
+}
+
 func TestWorker(t *testing.T) {
 	ds := new(mock.Store)
 

--- a/server/worker/zendesk.go
+++ b/server/worker/zendesk.go
@@ -12,6 +12,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/str"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -120,10 +122,11 @@ type ZendeskClient interface {
 
 // Zendesk is the job processor for zendesk integrations.
 type Zendesk struct {
-	FleetURL      string
-	Datastore     fleet.Datastore
-	Log           *slog.Logger
-	NewClientFunc func(*externalsvc.ZendeskOptions) (ZendeskClient, error)
+	FleetURL       string
+	Datastore      fleet.Datastore
+	Log            *slog.Logger
+	NewClientFunc  func(*externalsvc.ZendeskOptions) (ZendeskClient, error)
+	NewActivitySvc activity_api.NewActivityService
 
 	// mu protects concurrent access to clientsCache, so that the job processor
 	// can potentially be run concurrently.
@@ -262,6 +265,29 @@ func (z *Zendesk) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	default:
 		return ctxerr.Errorf(ctx, "unknown integration type: %v", intgType)
 	}
+}
+
+// OnFinalFailure records a failed_zendesk_policy_automation host activity once
+// the worker has exhausted all retries for a failing-policy job. Vulnerability
+// jobs are ignored as they are not host- or policy-scoped.
+func (z *Zendesk) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+	if z.NewActivitySvc == nil {
+		return nil
+	}
+
+	var args zendeskArgs
+	if err := json.Unmarshal(argsJSON, &args); err != nil {
+		return ctxerr.Wrap(ctx, err, "unmarshal args")
+	}
+	if args.FailingPolicy == nil {
+		return nil
+	}
+
+	return z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedZendeskPolicyAutomation{
+		PolicyID:      args.FailingPolicy.PolicyID,
+		HostIDList:    args.FailingPolicy.hostIDs(),
+		ErrorResponse: str.TruncateErrorResponse(jobErr),
+	})
 }
 
 func (z *Zendesk) runVuln(ctx context.Context, cli ZendeskClient, args zendeskArgs) error {

--- a/server/worker/zendesk_test.go
+++ b/server/worker/zendesk_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -18,6 +19,54 @@ import (
 	zendesk "github.com/nukosuke/go-zendesk/zendesk"
 	"github.com/stretchr/testify/require"
 )
+
+func TestZendeskOnFinalFailure(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("failing policy records activity", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		z := &Zendesk{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+				require.Nil(t, user)
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(zendeskArgs{FailingPolicy: &failingPolicyArgs{
+			PolicyID: 6,
+			Hosts:    []fleet.PolicySetHost{{ID: 3, Hostname: "h3"}},
+		}})
+		require.NoError(t, err)
+
+		require.NoError(t, z.OnFinalFailure(ctx, args, `422: {"error":"RecordInvalid"}`))
+
+		require.Len(t, recorded, 1)
+		act, ok := recorded[0].(fleet.ActivityTypeFailedZendeskPolicyAutomation)
+		require.True(t, ok)
+		require.Equal(t, uint(6), act.PolicyID)
+		require.Equal(t, []uint{3}, act.HostIDList)
+		require.Equal(t, `422: {"error":"RecordInvalid"}`, act.ErrorResponse)
+	})
+
+	t.Run("vuln job records nothing", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		z := &Zendesk{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, activity fleet.ActivityDetails) error {
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(zendeskArgs{Vulnerability: &vulnArgs{CVE: "CVE-2024-2"}})
+		require.NoError(t, err)
+
+		require.NoError(t, z.OnFinalFailure(ctx, args, "boom"))
+		require.Empty(t, recorded)
+	})
+}
 
 func TestZendeskRun(t *testing.T) {
 	ds := new(mock.Store)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

Added five new activity types — failed_webhook_policy_automation, failed_jira_policy_automation, failed_zendesk_policy_automation, failed_calendar_policy_automation, and
failed_conditional_access_policy_automation — each activity is recorded only when the remote provider returns an
error

Added a FinalFailureNotifier interface to the worker so handlers can opt into post-exhaustion callbacks without changing the job state machine.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity logging added for policy automation failures: when automations to webhooks, Jira, Zendesk, Google Calendar, or Microsoft conditional access fail, per-host failure activities are recorded including HTTP status codes and captured error response bodies where available to aid visibility and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->