### PR TITLE
Fleet UI: Add self-service categories to command palette

### DIFF
--- a/frontend/components/CommandPalette/groups/commands.ts
+++ b/frontend/components/CommandPalette/groups/commands.ts
@@ -293,6 +293,26 @@ const buildCommandsItems = (
                     "sh",
                   ],
                 },
+                {
+                  id: "add-self-service-category",
+                  label: "Add self-service category",
+                  group: "Commands" as const,
+                  // SelfServiceCategoriesPage opens its Add modal on
+                  // `?add_category=1`, mirroring the Variables/Scripts pattern.
+                  path: withTeamId(
+                    `${paths.SOFTWARE_LIBRARY_CATEGORIES}?add_category=1`
+                  ),
+                  keywords: [
+                    "add category",
+                    "create category",
+                    "new category",
+                    "self service",
+                    "self-service",
+                    "create self-service category",
+                    "new self-service category",
+                    "categories",
+                  ],
+                },
               ]
             : []),
           // Script and variable actions require a team or unassigned

--- a/frontend/components/CommandPalette/groups/software.ts
+++ b/frontend/components/CommandPalette/groups/software.ts
@@ -85,6 +85,21 @@ const buildSoftwareItems = (
               "self-service",
               "library",
             ],
+            subItems: [
+              {
+                id: "software-library-categories",
+                label: "Self-service categories",
+                path: withTeamId(paths.SOFTWARE_LIBRARY_CATEGORIES),
+                keywords: [
+                  "custom categories",
+                  "self service categories",
+                  "self-service category",
+                  "groups",
+                  "grouping",
+                  "install all",
+                ],
+              },
+            ],
           },
         ]
       : []),

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -450,6 +450,7 @@ describe("CommandPalette helpers", () => {
       expect(ids).not.toContain("add-vpp-app");
       expect(ids).not.toContain("add-android-app-store-app");
       expect(ids).not.toContain("add-custom-package");
+      expect(ids).not.toContain("add-self-service-category");
       expect(ids).not.toContain("add-script");
       expect(ids).not.toContain("add-custom-variable");
     });
@@ -466,6 +467,7 @@ describe("CommandPalette helpers", () => {
       expect(ids).toContain("add-vpp-app");
       expect(ids).toContain("add-android-app-store-app");
       expect(ids).toContain("add-custom-package");
+      expect(ids).toContain("add-self-service-category");
       expect(ids).toContain("add-script");
       expect(ids).toContain("add-custom-variable");
     });
@@ -498,6 +500,7 @@ describe("CommandPalette helpers", () => {
       expect(ids).not.toContain("add-vpp-app");
       expect(ids).not.toContain("add-android-app-store-app");
       expect(ids).not.toContain("add-custom-package");
+      expect(ids).not.toContain("add-self-service-category");
       // Sanity: non-software write actions still surface.
       expect(ids).toContain("add-hosts");
     });

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
@@ -498,3 +498,107 @@ describe("SelfServiceCategoriesPage", () => {
     });
   });
 });
+
+describe("SelfServiceCategoriesPage ?add_category=1 deep-link", () => {
+  const deepLinkProps = (router: ReturnType<typeof createMockRouter>) => ({
+    router,
+    location: {
+      pathname: "/software/library/categories",
+      search: "?fleet_id=1&add_category=1",
+      query: { fleet_id: "1", add_category: "1" },
+      hash: "",
+    },
+  });
+
+  beforeEach(() => {
+    renderFlash.mockClear();
+  });
+
+  it("opens the Add category modal for managers and strips the param", async () => {
+    mockServer.use(emptySelfServiceCategoriesHandler);
+    const router = createMockRouter();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: premiumAdminContext,
+    });
+
+    render(<SelfServiceCategoriesPage {...deepLinkProps(router)} />);
+
+    await getOpenModal();
+
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: "/software/library/categories",
+      query: { fleet_id: "1" },
+    });
+  });
+
+  it("reopens the modal on a second deep-link after the first was closed", async () => {
+    mockServer.use(emptySelfServiceCategoriesHandler);
+    const router = createMockRouter();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: premiumAdminContext,
+    });
+
+    const cleanProps = {
+      router,
+      location: {
+        pathname: "/software/library/categories",
+        search: "?fleet_id=1",
+        query: { fleet_id: "1" },
+        hash: "",
+      },
+    };
+
+    // Round 1: deep-link in.
+    const { user, rerender } = render(
+      <SelfServiceCategoriesPage {...deepLinkProps(router)} />
+    );
+    await getOpenModal();
+
+    // Simulate the effect's router.replace landing us back at the clean URL.
+    rerender(<SelfServiceCategoriesPage {...cleanProps} />);
+
+    // User dismisses the modal.
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(document.querySelector(".modal__modal_container")).toBeNull();
+    });
+
+    // Round 2: palette pushes the deep-link again (new location object).
+    rerender(<SelfServiceCategoriesPage {...deepLinkProps(router)} />);
+    await getOpenModal();
+  });
+
+  it("does not open the modal for non-managers but still strips the param", async () => {
+    mockServer.use(emptySelfServiceCategoriesHandler);
+    const router = createMockRouter();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: false,
+          isGlobalMaintainer: false,
+          isTeamAdmin: false,
+          isTeamMaintainer: false,
+          currentUser: createMockUser({ global_role: "observer" }),
+          availableTeams: [mockTeam],
+          setCurrentTeam: jest.fn(),
+        },
+        notification: { renderFlash, hideFlash: jest.fn() },
+      },
+    });
+
+    render(<SelfServiceCategoriesPage {...deepLinkProps(router)} />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: "/software/library/categories",
+        query: { fleet_id: "1" },
+      });
+    });
+
+    expect(document.querySelector(".modal__modal_container")).toBeNull();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "react-query";
 import { InjectedRouter } from "react-router";
 
@@ -36,7 +36,7 @@ interface ISelfServiceCategoriesPageProps {
   location: {
     pathname: string;
     search: string;
-    query: { fleet_id?: string; team_id?: string };
+    query: { fleet_id?: string; team_id?: string; add_category?: string };
     hash?: string;
   };
 }
@@ -82,6 +82,19 @@ const SelfServiceCategoriesPage = ({
     !!isTeamMaintainer;
 
   const [showAddModal, setShowAddModal] = useState(false);
+
+  // Open the Add category modal via deep-link (e.g. from the command
+  // palette). Gate on the same predicate the in-page button uses so the
+  // param can't bypass admin/maintainer-only authoring. Strip the param
+  // either way so refreshes don't keep reopening the modal.
+  useEffect(() => {
+    if (location.query.add_category !== "1") return;
+    if (canManage) {
+      setShowAddModal(true);
+    }
+    const { add_category, ...rest } = location.query;
+    router.replace({ pathname: location.pathname, query: rest });
+  }, [location.query, location.pathname, router, canManage]);
   const [
     categoryToEdit,
     setCategoryToEdit,


### PR DESCRIPTION
## Issue
Closes #43757 
Closes #46443 

## Description
- Adds two entries: a "Self-service categories" sub-item under Software library for navigation, and an "Add self-service category" action that deep-links the page with ?add_category=1 to auto-open the modal (mirroring the Variables/Scripts pattern).

## Screenrecording

Uploading Screen Recording 2026-06-08 at 1.41.41 PM.mov…

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
