### PR TITLE
Fleet UI: Gate command palette shortcuts by platform

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tests.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tests.tsx
@@ -8,6 +8,21 @@ import CommandPalette from "./CommandPalette";
 // cmdk uses scrollIntoView which JSDOM doesn't implement
 Element.prototype.scrollIntoView = jest.fn();
 
+// CommandPalette branches on navigator.platform to pick the modifier
+// (Cmd on macOS, Ctrl elsewhere). jsdom's default is an empty string,
+// which would make the whole suite run as "non-Mac" and break every
+// {Meta>}…{/Meta} keyboard test. Default the suite to Mac and override
+// per-test when we specifically want to exercise the non-Mac branch.
+const setPlatform = (value: string) => {
+  Object.defineProperty(window.navigator, "platform", {
+    value,
+    configurable: true,
+  });
+};
+const originalPlatform = window.navigator.platform;
+beforeEach(() => setPlatform("MacIntel"));
+afterEach(() => setPlatform(originalPlatform));
+
 const adminRender = createCustomRenderer({
   withBackendMock: true,
   context: {
@@ -93,6 +108,38 @@ describe("CommandPalette", () => {
       const { user } = adminRender(<CommandPalette />);
       await openPalette(user);
       expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+    });
+
+    it("Ctrl+K does NOT open the palette on macOS (Cmd is required)", async () => {
+      // Ctrl+K is readline kill-line on macOS — we must not hijack it.
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}k{/Control}");
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(
+        screen.queryByPlaceholderText(/search/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("Ctrl+K opens the palette on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}k{/Control}");
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+      });
+    });
+
+    it("Cmd+K does NOT open the palette on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Meta>}k{/Meta}");
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(
+        screen.queryByPlaceholderText(/search/i)
+      ).not.toBeInTheDocument();
     });
 
     it("closes on Escape", async () => {
@@ -213,6 +260,40 @@ describe("CommandPalette", () => {
           screen.getByPlaceholderText("Search a fleet...")
         ).toBeInTheDocument();
       });
+    });
+
+    it("Ctrl+Shift+F does NOT open switch-fleet on macOS (Cmd is required)", async () => {
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}{Shift>}f{/Shift}{/Control}");
+
+      // Wait a tick to let any (incorrect) state update flush.
+      await new Promise((r) => setTimeout(r, 0));
+      expect(
+        screen.queryByPlaceholderText("Search a fleet...")
+      ).not.toBeInTheDocument();
+    });
+
+    it("Ctrl+Shift+F opens switch-fleet on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}{Shift>}f{/Shift}{/Control}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Search a fleet...")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("Cmd+Shift+F does NOT open switch-fleet on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Meta>}{Shift>}f{/Shift}{/Meta}");
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(
+        screen.queryByPlaceholderText("Search a fleet...")
+      ).not.toBeInTheDocument();
     });
 
     it("Escape returns to root from a sub-page instead of closing", async () => {

--- a/frontend/components/CommandPalette/CommandPalette.tests.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tests.tsx
@@ -19,9 +19,25 @@ const setPlatform = (value: string) => {
     configurable: true,
   });
 };
-const originalPlatform = window.navigator.platform;
+// Capture the original descriptor so afterEach can fully restore it —
+// not just the value. Otherwise our `configurable: true` override leaks
+// into other tests and can mask future descriptor-sensitive bugs.
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "platform"
+);
 beforeEach(() => setPlatform("MacIntel"));
-afterEach(() => setPlatform(originalPlatform));
+afterEach(() => {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(
+      window.navigator,
+      "platform",
+      originalPlatformDescriptor
+    );
+  } else {
+    delete (window.navigator as { platform?: string }).platform;
+  }
+});
 
 const adminRender = createCustomRenderer({
   withBackendMock: true,
@@ -115,10 +131,7 @@ describe("CommandPalette", () => {
       const { user } = adminRender(<CommandPalette />);
       await user.keyboard("{Control>}k{/Control}");
 
-      await new Promise((r) => setTimeout(r, 0));
-      expect(
-        screen.queryByPlaceholderText(/search/i)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     });
 
     it("Ctrl+K opens the palette on non-macOS platforms", async () => {
@@ -136,10 +149,7 @@ describe("CommandPalette", () => {
       const { user } = adminRender(<CommandPalette />);
       await user.keyboard("{Meta>}k{/Meta}");
 
-      await new Promise((r) => setTimeout(r, 0));
-      expect(
-        screen.queryByPlaceholderText(/search/i)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     });
 
     it("closes on Escape", async () => {
@@ -266,8 +276,6 @@ describe("CommandPalette", () => {
       const { user } = adminRender(<CommandPalette />);
       await user.keyboard("{Control>}{Shift>}f{/Shift}{/Control}");
 
-      // Wait a tick to let any (incorrect) state update flush.
-      await new Promise((r) => setTimeout(r, 0));
       expect(
         screen.queryByPlaceholderText("Search a fleet...")
       ).not.toBeInTheDocument();
@@ -290,7 +298,6 @@ describe("CommandPalette", () => {
       const { user } = adminRender(<CommandPalette />);
       await user.keyboard("{Meta>}{Shift>}f{/Shift}{/Meta}");
 
-      await new Promise((r) => setTimeout(r, 0));
       expect(
         screen.queryByPlaceholderText("Search a fleet...")
       ).not.toBeInTheDocument();

--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -240,7 +240,12 @@ const CommandPalette = (): JSX.Element | null => {
   useEffect(() => {
     if (isNoAccess) return undefined;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
+      // Require the platform-native modifier: Cmd on macOS, Ctrl elsewhere.
+      // Accepting either on both platforms hijacks native shortcuts —
+      // e.g. Ctrl+K readline kill-line in text fields on macOS, and
+      // Ctrl+Shift+F (find in files / system shortcut) on macOS.
+      const correctModifier = isMacPlatform ? e.metaKey : e.ctrlKey;
+      if (!correctModifier) return;
       // Normalize once so Caps Lock (or shift layouts) don't miss.
       const key = e.key.toLowerCase();
       if (key === "k") {
@@ -255,7 +260,7 @@ const CommandPalette = (): JSX.Element | null => {
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [canSwitchFleet, isNoAccess]);
+  }, [canSwitchFleet, isNoAccess, isMacPlatform]);
 
   const navigate = useCallback((path: string) => {
     setOpen(false);


### PR DESCRIPTION
## Issue
Closes #43757 

## Description

- Cmd+K and Cmd+Shift+F now require the platform-native modifier — Cmd on macOS, Ctrl elsewhere. Previously both modifiers worked on both platforms, which hijacked Ctrl+K (readline kill-line) and Ctrl+Shift+F (system/browser shortcut) on macOS.


| Shortcut        | macOS                                      | non-macOS           |
|----------------|--------------------------------------------|---------------------|
| Cmd+K          | Opens palette                              | No-op               |
| Ctrl+K         | No-op (readline kill-line preserved)       | Opens palette       |
| Cmd+Shift+F    | Opens switch-fleet                         | No-op               |
| Ctrl+Shift+F   | No-op (system shortcut preserved)          | Opens switch-fleet  |


Follow-up from:
<img width="517" height="267" alt="Screenshot 2026-06-08 at 2 35 40 PM" src="https://github.com/user-attachments/assets/b5fccd74-6848-4ca7-ae86-03817b73d976" />



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
Tested on macOS only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command palette shortcuts now require the platform-native modifier (Cmd on macOS, Ctrl on other platforms), preventing accidental activation with the wrong modifier.

* **Tests**
  * Tests made deterministic across platforms and expanded to verify shortcut behavior: correct modifiers open the palette; incorrect modifiers are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->