### PR TITLE
Fix issue exporting CSV when "agent" field is present

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tests.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 
 import { createCustomRenderer, baseUrl } from "test/test-utils";
@@ -8,6 +9,11 @@ import createMockConfig from "__mocks__/configMock";
 import createMockUser from "__mocks__/userMock";
 
 import ManageHostsPage from "./ManageHostsPage";
+
+// Exporting hosts wraps the CSV response in a File and hands it to
+// FileSaver.saveAs, which is a no-op in jsdom — mock it out so the click
+// handler completes without touching the DOM download machinery.
+jest.mock("file-saver");
 
 const mockAppContext = {
   isGlobalAdmin: true,
@@ -258,5 +264,57 @@ describe("ManageHostsPage", () => {
     expect(
       screen.getByRole("button", { name: /edit columns/i })
     ).not.toBeDisabled();
+  });
+
+  it("substitutes the display-only 'agent' column with real fields when exporting to CSV", async () => {
+    const mockHost = {
+      id: 1,
+      hostname: "test-host",
+      display_name: "test-host",
+      display_text: "test-host",
+      status: "online",
+      platform: "darwin",
+      os_version: "macOS 14.0",
+      team_id: null,
+      team_name: null,
+      seen_time: "2024-01-01T00:00:00Z",
+      issues: { total_issues_count: 0, failing_policies_count: 0 },
+    };
+
+    // Capture the `columns` query param sent to the hosts report endpoint. The
+    // "agent" column is a display-only column (it coalesces orbit and osquery
+    // versions) with no corresponding CSV field on the backend, so the request
+    // must send the underlying fields instead — otherwise the backend rejects
+    // it with "invalid column name" and the export fails (#47085).
+    let exportedColumns: string | null = null;
+    setupHandlers(1, [mockHost]);
+    mockServer.use(
+      http.get(baseUrl("/hosts/report"), ({ request }) => {
+        exportedColumns = new URL(request.url).searchParams.get("columns");
+        return HttpResponse.text("hostname\ntest-host\n");
+      })
+    );
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: { app: mockAppContext },
+    });
+
+    const user = userEvent.setup();
+    render(<ManageHostsPage {...(createMockProps() as any)} />);
+
+    expect(await screen.findByText("1 host")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /export hosts/i }));
+
+    await waitFor(() => expect(exportedColumns).not.toBeNull());
+
+    const columns = ((exportedColumns as unknown) as string).split(",");
+    // The derived "agent" column is replaced by the real CSV fields...
+    expect(columns).toContain("orbit_version");
+    expect(columns).toContain("osquery_version");
+    // ...and neither "agent" nor the display-only "selection" column is sent.
+    expect(columns).not.toContain("agent");
+    expect(columns).not.toContain("selection");
   });
 });

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1625,7 +1625,18 @@ const ManageHostsPage = ({
           .map((column) => (column.id ? column.id : ""))
           // "selection" colum does not include any relevent data for the CSV
           // so we filter it out.
-          .filter((element) => element !== "" && element !== "selection");
+          .filter((element) => element !== "" && element !== "selection")
+          // "agent" is a display-only column that coalesces orbit and osquery
+          // versions; it has no corresponding CSV field on the backend, so we
+          // substitute the real fields it's derived from.
+          .reduce((acc: string[], element) => {
+            if (element === "agent") {
+              acc.push("orbit_version", "osquery_version");
+            } else {
+              acc.push(element);
+            }
+            return acc;
+          }, []);
         visibleColumns = columnIds.join(",");
       }
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1623,7 +1623,7 @@ const ManageHostsPage = ({
 
         const columnIds = tableColumns
           .map((column) => (column.id ? column.id : ""))
-          // "selection" colum does not include any relevent data for the CSV
+          // "selection" column does not include any relevant data for the CSV
           // so we filter it out.
           .filter((element) => element !== "" && element !== "selection")
           // "agent" is a display-only column that coalesces orbit and osquery


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47085 

# Details

When "Agent" columns is visible in the hosts table, using the "export" feature caused a 400 because there's no "Agent" field in the struct with a `csv` tag.  This PR fixes the issue by exporting both osquery and orbit version columns in the CSV, which are the constituent fields that make up "Agent".

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased

## Testing

- [ ] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  - [X] on main, got the 400 trying to export hosts list with the "Agent" column present
  - [X] on this branch, exporting with "Agent" present results in the "osquery version" and "orbit version" columns in the exported CSV.

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
- [X] Alerted the release DRI if additional load testing is needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosts CSV export: empty and selection-only columns are excluded and the display-only "agent" column is replaced by the actual backend version fields, yielding cleaner, more accurate exports.
* **Tests**
  * Added automated test to verify the CSV export requests the correct columns and prevents download-side side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->