### PR TITLE
Add EJBCA REST CA integration (POC)

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -30,6 +30,7 @@ import (
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/ee/server/service/condaccess"
 	"github.com/fleetdm/fleet/v4/ee/server/service/digicert"
+	"github.com/fleetdm/fleet/v4/ee/server/service/ejbca"
 	"github.com/fleetdm/fleet/v4/ee/server/service/est"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
@@ -562,6 +563,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	eh := errorstore.NewHandler(ctx, redisPool, logger, config.Logging.ErrorRetentionPeriod)
 	scepConfigMgr := scep.NewSCEPConfigService(logger, nil)
 	digiCertService := digicert.NewService(digicert.WithLogger(logger))
+	ejbcaService := ejbca.NewService(ejbca.WithLogger(logger))
 	ctx = ctxerr.NewContext(ctx, eh)
 
 	// Declare svc early so the closure below can capture it.
@@ -611,6 +613,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		wstepCertManager,
 		scepConfigMgr,
 		digiCertService,
+		ejbcaService,
 		conditionalAccessMicrosoftProxy,
 		redis_key_value.New(redisPool),
 		androidSvc,
@@ -719,6 +722,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			redis_key_value.New(redisPool),
 			scepConfigMgr,
 			digiCertService,
+			ejbcaService,
 			androidSvc,
 			hydrantService,
 		)

--- a/docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md
+++ b/docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md
@@ -407,6 +407,46 @@ the username. You should see:
 In Admin UI → **RA Web → Search Certificates** you can also see the issued
 cert listed.
 
+## Troubleshooting
+
+Fleet's `VerifyConnection` probe at CA-save time talks to EJBCA in a layered
+TLS + HTTP exchange. When it fails, the specific error message tells you
+which layer broke. This ladder lists what we've seen during POC testing,
+top-down (cheapest fix first):
+
+| Fleet error (or curl symptom) | What it means | Where to fix |
+|---|---|---|
+| `client_p12 ... Could not decode PKCS#12 client certificate: pkcs12: error reading P12 data: asn1: syntax error: indefinite length found (not DER)` | The `openssl` subprocess isn't being invoked — Fleet fell back to a Go-native parser that rejects BER | Restart the Fleet server with the latest binary; verify `openssl` is on the server's `$PATH` |
+| `openssl failed to decode PKCS#12: Mac verify error: ...` | Wrong P12 password | Re-export from EJBCA RA Web and note the password exactly, or test the password locally: `openssl pkcs12 -in foo.p12 -passin pass:PW -nodes` |
+| `tls: failed to verify certificate: x509: certificate is valid for ejbca.local, not localhost` | Fleet's URL field uses `localhost` but the EJBCA HTTPS cert SAN is `ejbca.local` | Use `https://ejbca.local:8443` and add `/etc/hosts` mapping (see Docker setup §) |
+| `tls: failed to verify certificate: x509: certificate signed by unknown authority` | Fleet's system root store doesn't trust EJBCA's Management-CA-signed HTTPS cert | Paste the Management CA PEM into the **Trust CA bundle** field |
+| `sending EJBCA status request: ... EOF` or `Empty reply from server` from curl | TLS handshake completed but EJBCA's app layer dropped the connection. Almost always: REST protocol not enabled | Enable **REST Certificate Management** in System Configuration → Protocol Configuration (Step 0), then restart the container |
+| HTTP 401 / 403 with a JSON body | mTLS handshake succeeded; cert reached the app but isn't authorized | Verify the cert is bound to a role (Admin UI → Roles → Members), match value is the exact CN, issuer CA matches what issued the cert |
+| HTTP 404 `Could not find resource for full path` | REST is deployed and authenticated but the URL is wrong | Confirm path is `/ejbca/ejbca-rest-api/v1/ca/status` exactly |
+
+When in doubt, drop down a layer with the diagnostic commands:
+
+```bash
+# 1. DNS / port reachability
+curl -sk -o /dev/null -w "%{http_code}\n" https://ejbca.local:8443/ejbca/publicweb/healthcheck/ejbcahealth   # expect 200
+
+# 2. REST endpoint deployed and reachable (no mTLS)
+curl -sk -w "\nHTTP %{http_code}\n" https://ejbca.local:8443/ejbca/ejbca-rest-api/v1/ca/status   # 401 = enabled, 403 + HTML = disabled
+
+# 3. mTLS auth — extract P12 to PEM first because macOS curl uses LibreSSL
+openssl pkcs12 -in '/path/to/fleet_rest_service.p12' -passin pass:PW -nodes -clcerts -out /tmp/fleet_cert.pem
+openssl pkcs12 -in '/path/to/fleet_rest_service.p12' -passin pass:PW -nodes -nocerts -out /tmp/fleet_key.pem
+curl -kv --cert /tmp/fleet_cert.pem --key /tmp/fleet_key.pem https://ejbca.local:8443/ejbca/ejbca-rest-api/v1/ca/status
+shred -u /tmp/fleet_cert.pem /tmp/fleet_key.pem 2>/dev/null || rm /tmp/fleet_cert.pem /tmp/fleet_key.pem
+```
+
+When EJBCA's logs are useful, `docker logs ejbca 2>&1 | tail -50` shows
+recent audit events — successful auth shows up as `CA_USERAUTH;SUCCESS`,
+role checks as `ACCESS_CONTROL;SUCCESS`. Conspicuous absence of any log
+entry for your request usually means the request was rejected by the
+Wildfly filter chain before reaching the EJBCA app (the protocol-disabled
+case).
+
 ## Gotchas
 
 - **REST API protocols are disabled by default in `keyfactor/ejbca-ce`.**
@@ -445,6 +485,20 @@ cert listed.
   spec — the production implementation
   ([fleet#30986](https://github.com/fleetdm/fleet/issues/30986)) adds the
   required `CAConfigEJBCA` enum value and tracking write.
+- **macOS curl can't test the P12 directly.** macOS ships curl linked
+  against LibreSSL, which has limited PKCS#12 support and rejects
+  EJBCA's bundles with `LibreSSL error: PKCS12 routines:CRYPTO_internal:
+  mac verify failure`. Use the PEM-extraction-then-curl pattern in the
+  Troubleshooting section if you want to test mTLS against EJBCA
+  directly. Fleet's server-side openssl subprocess uses the full
+  OpenSSL on the host's `$PATH` (Homebrew openssl, system openssl on
+  Linux), which doesn't have this limitation.
+- **REST Certificate Management ≠ REST CA Management.** They sound
+  interchangeable. They aren't. The protocol Fleet uses is **REST
+  Certificate Management** — that one serves both `/v1/ca` and
+  `/v1/certificate` paths. **REST CA Management** serves
+  `/v1/ca_management` only and is `Unavailable` in EJBCA Community
+  Edition. Enabling the wrong one does nothing for Fleet.
 
 ## Cleanup
 

--- a/docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md
+++ b/docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md
@@ -16,7 +16,22 @@ the customer scenario for [fleet#30986](https://github.com/fleetdm/fleet/issues/
 - Docker
 - Fleet dev server running locally (with a server private key configured —
   required for encrypting the EJBCA client key at rest)
+- `openssl` on `$PATH` for the Fleet server (POC only — used to convert
+  EJBCA's BER-encoded P12 export to DER on upload; see "Known POC debt"
+  below)
 - A macOS host enrolled in your Fleet for the end-to-end test
+
+## Known POC debt
+
+The POC shells out to the `openssl` binary in the P12 decode path because
+EJBCA's RA Web emits BER-encoded PKCS#12 bundles and both Go PKCS#12
+libraries (`software.sslmate.com/src/go-pkcs12` and
+`golang.org/x/crypto/pkcs12`) require strict DER. **This subprocess approach
+must not ship to production.** The production implementation
+([fleet#30986](https://github.com/fleetdm/fleet/issues/30986)) will replace
+it with a pure-Go BER → DER normalizer so Fleet has no runtime dependency
+on the openssl binary. Tracked in
+`openspec/changes/add-ejbca-rest-ca-poc/research.md` → "Open follow-ups".
 
 ## Set up EJBCA in Docker
 
@@ -45,6 +60,26 @@ EJBCA's Admin UI is at `https://localhost:8443/ejbca/adminweb/`. First visit
 triggers a client-cert chooser (cancel it) and a TLS interstitial because the
 cert is self-signed for `ejbca.local` (click **Advanced → Proceed**).
 
+### Map `ejbca.local` to localhost
+
+The EJBCA container's HTTPS cert is issued for `ejbca.local`, matching the
+`-h ejbca.local` flag in `docker run`. Browsers accept it after the
+interstitial click-through, but Fleet's REST client does strict TLS
+verification (it's mTLS — we can't skip it) and needs the connect-time
+hostname to match the cert's SAN. Add a `/etc/hosts` entry so `ejbca.local`
+resolves to `127.0.0.1`:
+
+```bash
+echo '127.0.0.1 ejbca.local' | sudo tee -a /etc/hosts
+```
+
+When configuring Fleet below, use `https://ejbca.local:8443` (not
+`https://localhost:8443`) for the **EJBCA REST URL**.
+
+The existing SCEP dev guide sidesteps this by using the HTTP port (8480) —
+SCEP doesn't require TLS. The REST integration does (mTLS), so the
+hosts-file mapping is the cleanest dev workaround.
+
 ## CE caveats
 
 EJBCA Community Edition has two limitations that affect what we can verify
@@ -63,11 +98,69 @@ against the 30-day EJBCA Enterprise trial (see openspec
 
 ## EJBCA-side setup
 
+### 0. Enable REST API protocols
+
+**`keyfactor/ejbca-ce` ships with all REST API protocols DISABLED.** Hitting
+`/ejbca/ejbca-rest-api/v1/*` against a default container returns the
+unmistakable response:
+
+```
+<html><head><title>Error</title></head><body>This service has been disabled.</body></html>
+HTTP 403
+```
+
+Enable the REST protocol Fleet uses before doing anything else.
+
+Admin UI → top menu **System Configuration** → **Protocol Configuration**
+tab (it's a tab on the System Configuration page — *not* under "System
+Functions"):
+
+1. Find the **REST Certificate Management** row (resources
+   `/ejbca/ejbca-rest-api/v1/ca` and `/ejbca/ejbca-rest-api/v1/certificate`)
+   and click **Enable** in its Actions column. The status flips to `Enabled`
+   immediately — there's no separate page Save.
+
+That single protocol covers **both** endpoints Fleet calls: `GET /v1/ca/status`
+(the connection probe at CA-save time) and `POST /v1/certificate/pkcs10enroll`
+(the per-host enrollment) — both `/v1/ca` and `/v1/certificate` live under
+REST Certificate Management.
+
+Do **not** enable "REST CA Management" — despite the name, it serves only
+`/v1/ca_management` (CA lifecycle operations Fleet never calls), and on
+`keyfactor/ejbca-ce` it shows as `Unavailable` (can't be enabled in CE
+anyway). Enabling it does nothing for Fleet.
+
+**Heads up — you almost certainly need to restart the container after
+enabling.** Clicking Enable flips the config to `Enabled` and it persists,
+but on `keyfactor/ejbca-ce` the running REST app keeps serving the
+"This service has been disabled" 403 page until it reloads the protocol
+config on boot. Toggling the protocol off/on and waiting does not clear it.
+Restart the container and re-test:
+
+```bash
+docker restart ejbca
+# wait for it to come back, then:
+curl -sk -o /dev/null -w "%{http_code}\n" \
+    https://localhost:8443/ejbca/ejbca-rest-api/v1/certificate   # expect 401, not 403
+```
+
+A `401` (auth required — you didn't present a client cert) means the protocol
+is live; a `403` with the "disabled" page means it isn't yet. (You can also
+sanity-check that unauthenticated requests reach the app at all by hitting an
+already-enabled protocol like `/ejbca/ejbcaws/ejbcaws?wsdl`, which returns
+200.)
+
+In a real customer EJBCA deployment, the PKI admin would have already
+enabled this. For the local POC container you have to do it yourself —
+there's no Docker env-var to flip it on at boot.
+
 ### 1. Certificate Profile for the Fleet service cert
 
 Admin UI → **CA Functions → Certificate Profiles**:
 
-1. Type `fleetRESTAdmin` in **Identifier** and click **Clone** on the `ENDUSER` row.
+1. Click **Clone** on the `ENDUSER` row. A dialog appears — enter
+   `fleetRESTAdmin` as the **Name of new certificate profile** and click
+   **Create from template**.
 2. **Edit** the new `fleetRESTAdmin` row.
 3. Under **Available Key Algorithms**, ensure RSA is checked.
 4. Under **Bit Lengths**, check 2048 and 3072.
@@ -91,21 +184,28 @@ Admin UI → **RA Functions → End Entity Profiles**:
 
 ### 3. Enroll Fleet's service certificate
 
-Admin UI → **RA Web → Make New Request** (top-right menu → RA Web; the cert
-chooser dialog appears, cancel it):
+Admin UI → **RA Web** (top-right menu; the cert chooser dialog appears,
+cancel it) → **Enroll → Make New Request**:
 
 1. **Certificate Type** → `fleetRESTAdmin`.
 2. **Key-pair generation** → `By the CA`.
-3. **Subject DN** → CN: `Fleet REST Service`.
-4. **Username**: `fleet_rest_service`.
-5. **Enrollment code**: set a strong password (you will use this to download
-   the P12; Fleet stores neither this password nor the P12 itself —
-   re-uploading is fine if you lose it).
-6. Click **Enroll**.
-7. Download as **PKCS#12 (P12)**.
+3. **Key algorithm** → `RSA 2048 bits`. (This selector appears only after you
+   pick "By the CA," and defaults to `ECDSA B-163` — you must change it, or
+   you'll enroll an ECDSA service cert instead of RSA.)
+4. **Subject DN** → CN: `Fleet REST Service`.
+5. **Username**: `fleet_rest_service`.
+6. **Enrollment code** (+ **Confirm enrollment code**): set a strong password
+   (you will use this as the P12 password; Fleet stores neither this password
+   nor the P12 itself — re-uploading is fine if you lose it).
+7. Click **Download PKCS#12**. There is no separate "Enroll" step — this
+   button enrolls the end entity, generates the keypair, and downloads the
+   keystore in one action. (The sibling buttons — JKS, BCFKS, PEM — do the
+   same for other keystore formats.)
 
 You should now have `fleet_rest_service.p12` in your Downloads folder. Move
-it somewhere safe.
+it somewhere safe. To confirm the enrollment took, Admin UI → **RA Functions
+→ Search End Entities** → search status `All`: `fleet_rest_service` should
+appear with status `GENERATED`.
 
 ### 4. Admin Role + Access Rules
 
@@ -181,7 +281,8 @@ bundle" field.
 4. Fill in:
    - **Name**: `Test_EJBCA` (this becomes `$FLEET_VAR_EJBCA_DATA_Test_EJBCA`
      in profiles)
-   - **EJBCA REST URL**: `https://localhost:8443`
+   - **EJBCA REST URL**: `https://ejbca.local:8443` (requires the
+     `/etc/hosts` mapping from the Docker section above)
    - **Client certificate (.p12)**: upload `fleet_rest_service.p12`
    - **PKCS#12 password**: the password you set in step 3
    - **Trust CA bundle**: paste the Management CA PEM from step 7
@@ -206,7 +307,7 @@ curl -sk -X POST \
     -H "Content-Type: application/json" \
     -d '{"ejbca":{
           "name":"Test_EJBCA",
-          "url":"https://localhost:8443",
+          "url":"https://ejbca.local:8443",
           "client_p12":"'"$P12_BASE64"'",
           "client_p12_password":"<P12 password>",
           "trust_ca_bundle":"'"$TRUST_BUNDLE"'",
@@ -308,6 +409,15 @@ cert listed.
 
 ## Gotchas
 
+- **REST API protocols are disabled by default in `keyfactor/ejbca-ce`.**
+  Symptom: `<html><body>This service has been disabled.</body></html>` with
+  HTTP 403 on any `/ejbca/ejbca-rest-api/v1/*` URL. Fix: enable **REST
+  Certificate Management** (not "REST CA Management") in Admin UI → System
+  Configuration → Protocol Configuration tab (covered in the **Enable REST
+  API protocols** section above). If the 403 persists after enabling,
+  restart the container — the REST app re-reads protocol config on boot.
+  The TLS/mTLS layer succeeds before this check, so the failure mode from
+  Fleet's side is a silent EOF mid-request rather than a clean error.
 - **CE-only: end-entity status is consumed on use.** After successful
   issuance the EE flips from `NEW` (10) to `GENERATED` (40). Re-enrolling
   for the same host (e.g., to test rotation) requires resetting:

--- a/docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md
+++ b/docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md
@@ -1,0 +1,358 @@
+# EJBCA REST testing
+
+Sets up a local EJBCA Community CA for end-to-end testing of Fleet's REST API
+integration (the `ejbca` CA type, distinct from the custom-SCEP-proxy path
+covered by [ejbca-scep-testing.md](./ejbca-scep-testing.md)).
+
+This guide is structured to mirror what an EJBCA admin would do in production:
+enroll a service certificate for Fleet, bind it to a least-privilege admin
+role, then configure Fleet to call EJBCA's REST API over mutual TLS.
+
+Prefer this over the SCEP guide when you want to exercise the REST API path —
+the customer scenario for [fleet#30986](https://github.com/fleetdm/fleet/issues/30986).
+
+## Prerequisites
+
+- Docker
+- Fleet dev server running locally (with a server private key configured —
+  required for encrypting the EJBCA client key at rest)
+- A macOS host enrolled in your Fleet for the end-to-end test
+
+## Set up EJBCA in Docker
+
+Same container as the SCEP guide. If you already have it running for SCEP
+testing, skip to the next section — the configurations live side by side.
+
+```bash
+docker run -d --name ejbca \
+  -h ejbca.local \
+  -p 8480:8080 -p 8443:8443 \
+  -e TLS_SETUP_ENABLED=simple \
+  keyfactor/ejbca-ce
+```
+
+Wait for the server (~3 minutes):
+
+```bash
+until curl -sk -o /dev/null -w "%{http_code}\n" \
+    https://localhost:8443/ejbca/publicweb/healthcheck/ejbcahealth | grep -q 200; do
+  sleep 10
+done
+echo "EJBCA up"
+```
+
+EJBCA's Admin UI is at `https://localhost:8443/ejbca/adminweb/`. First visit
+triggers a client-cert chooser (cancel it) and a TLS interstitial because the
+cert is self-signed for `ejbca.local` (click **Advanced → Proceed**).
+
+## CE caveats
+
+EJBCA Community Edition has two limitations that affect what we can verify
+locally:
+
+- **No SCEP RA / no REST auto-create-EE.** End entities must be pre-created
+  per CSR subject DN. The customer's production EJBCA (Enterprise) will be
+  configured to auto-create on enrollment; CE cannot.
+- **No REST endpoint for end-entity management.** Pre-creation has to happen
+  via the Admin UI or `bin/ejbca.sh ra addendentity` CLI.
+
+This means our local POC test uses a single pre-created end entity (matching
+one host's enrollment). For the customer's auto-create-EE flow, validate
+against the 30-day EJBCA Enterprise trial (see openspec
+`add-ejbca-rest-ca-poc/research.md`).
+
+## EJBCA-side setup
+
+### 1. Certificate Profile for the Fleet service cert
+
+Admin UI → **CA Functions → Certificate Profiles**:
+
+1. Type `fleetRESTAdmin` in **Identifier** and click **Clone** on the `ENDUSER` row.
+2. **Edit** the new `fleetRESTAdmin` row.
+3. Under **Available Key Algorithms**, ensure RSA is checked.
+4. Under **Bit Lengths**, check 2048 and 3072.
+5. Under **Extended Key Usages**, set:
+   - Use: ✓
+   - Critical: optional
+   - Add: `Client Authentication`
+6. Validity: `1y`
+7. **Save**.
+
+### 2. End Entity Profile for the Fleet service cert
+
+Admin UI → **RA Functions → End Entity Profiles**:
+
+1. Type `fleetRESTAdmin` in **Identifier** and click **Add Profile**.
+2. Select `fleetRESTAdmin` and click **Edit End Entity Profile**.
+3. **Default Certificate Profile** → `fleetRESTAdmin`. **Available Certificate
+   Profiles** → highlight `fleetRESTAdmin`.
+4. **Default CA** → `ManagementCA`. **Available CAs** → highlight `ManagementCA`.
+5. **Save**.
+
+### 3. Enroll Fleet's service certificate
+
+Admin UI → **RA Web → Make New Request** (top-right menu → RA Web; the cert
+chooser dialog appears, cancel it):
+
+1. **Certificate Type** → `fleetRESTAdmin`.
+2. **Key-pair generation** → `By the CA`.
+3. **Subject DN** → CN: `Fleet REST Service`.
+4. **Username**: `fleet_rest_service`.
+5. **Enrollment code**: set a strong password (you will use this to download
+   the P12; Fleet stores neither this password nor the P12 itself —
+   re-uploading is fine if you lose it).
+6. Click **Enroll**.
+7. Download as **PKCS#12 (P12)**.
+
+You should now have `fleet_rest_service.p12` in your Downloads folder. Move
+it somewhere safe.
+
+### 4. Admin Role + Access Rules
+
+Admin UI → **System Functions → Roles and Access Rules → Add Role**:
+
+1. **Role Name** → `Fleet Service Account`. Click **Add**.
+2. Click **Edit Access Rules** on the new role:
+   - **Role Template** → `RA Administrators`
+   - **Authorized CAs** → check only the CA(s) that should issue device
+     certs (e.g., `ManagementCA` for the POC)
+   - **Authorized End Entity Profiles** → check only the profile(s) Fleet
+     will enroll against
+3. **Save**.
+
+### 5. Bind the Fleet service cert to the role
+
+On the `Fleet Service Account` role page, click **Members**:
+
+1. **Match with** → `X509:CN, Common name`.
+2. **CA** → `ManagementCA` (the CA that just issued the Fleet service cert).
+3. **Match value** → `Fleet REST Service` (exact CN from step 3 above).
+4. Click **Add**.
+
+### 6. Pre-create one end entity for the device test
+
+For each CSR username Fleet will use, EJBCA-CE needs a pre-created end
+entity. The username Fleet sends is the expanded `username_template` — for
+testing, use one host's hardware serial.
+
+Get the test host's serial from Fleet (Hosts page) then:
+
+```bash
+# Replace SERIAL with your test host's hardware serial
+SERIAL='YOUR-HOST-SERIAL'
+
+docker exec ejbca bin/ejbca.sh ra addendentity \
+    --username "${SERIAL}" \
+    --dn "CN=${SERIAL}" \
+    --caname ManagementCA \
+    --type 1 \
+    --token USERGENERATED \
+    --password "anyvalue" \
+    --certprofile fleetRESTAdmin \
+    --eeprofile fleetRESTAdmin
+```
+
+The `--password` value doesn't have to match anything Fleet sends — Fleet
+generates a per-issuance random password (see openspec REQ-CA-EJBCA-7). EJBCA
+auto-create-EE-enabled deployments don't need this step.
+
+### 7. Export the trust CA
+
+Optional but recommended for the POC since EJBCA's HTTPS cert is signed by
+the Management CA, which Fleet's system root store doesn't trust:
+
+```bash
+docker exec ejbca cat /opt/keyfactor/ejbca/wildfly/standalone/configuration/keystore/truststore.pem
+```
+
+Or via Admin UI → **RA Web → CA Certificates and CRLs → Download** the
+`ManagementCA` as PEM.
+
+Save the resulting PEM contents — you'll paste them into Fleet's "Trust CA
+bundle" field.
+
+## Configure Fleet
+
+### Via the UI
+
+1. Log into Fleet as a global admin.
+2. **Settings → Integrations → Certificate authorities → Add CA**.
+3. Pick **EJBCA** from the dropdown.
+4. Fill in:
+   - **Name**: `Test_EJBCA` (this becomes `$FLEET_VAR_EJBCA_DATA_Test_EJBCA`
+     in profiles)
+   - **EJBCA REST URL**: `https://localhost:8443`
+   - **Client certificate (.p12)**: upload `fleet_rest_service.p12`
+   - **PKCS#12 password**: the password you set in step 3
+   - **Trust CA bundle**: paste the Management CA PEM from step 7
+   - **EJBCA Certificate Authority name**: `ManagementCA`
+   - **EJBCA Certificate Profile name**: `fleetRESTAdmin`
+   - **EJBCA End Entity Profile name**: `fleetRESTAdmin`
+   - **Username template**: `$FLEET_VAR_HOST_HARDWARE_SERIAL`
+   - **UPN** (optional): leave empty for the basic test
+5. Click **Save**. Fleet will probe EJBCA via `GET /v1/ca/status` over mTLS
+   and reject the save if anything's off.
+
+### Via the API
+
+```bash
+FLEET_TOKEN="$(awk '/^  qa:/,/^  [a-z]/' ~/.fleet/config | awk '/token:/ {print $2}')"
+
+P12_BASE64="$(base64 < fleet_rest_service.p12)"
+TRUST_BUNDLE="$(awk '{printf "%s\\n", $0}' management_ca.pem)"
+
+curl -sk -X POST \
+    -H "Authorization: Bearer $FLEET_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"ejbca":{
+          "name":"Test_EJBCA",
+          "url":"https://localhost:8443",
+          "client_p12":"'"$P12_BASE64"'",
+          "client_p12_password":"<P12 password>",
+          "trust_ca_bundle":"'"$TRUST_BUNDLE"'",
+          "certificate_authority_name_ejbca":"ManagementCA",
+          "certificate_profile_name":"fleetRESTAdmin",
+          "end_entity_profile_name":"fleetRESTAdmin",
+          "username_template":"$FLEET_VAR_HOST_HARDWARE_SERIAL",
+          "certificate_user_principal_names":null
+        }}' \
+    https://localhost:8080/api/latest/fleet/certificate_authorities
+```
+
+Save the returned `id` — you'll need it if you want to PATCH or DELETE later.
+
+## End-to-end test
+
+### 1. Create a configuration profile that references the EJBCA CA
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>Password</key>
+      <string>$FLEET_VAR_EJBCA_PASSWORD_Test_EJBCA</string>
+      <key>PayloadCertificateFileName</key>
+      <string>ejbca-test.p12</string>
+      <key>PayloadContent</key>
+      <data>$FLEET_VAR_EJBCA_DATA_Test_EJBCA</data>
+      <key>PayloadDescription</key>
+      <string>EJBCA-issued client cert (POC)</string>
+      <key>PayloadDisplayName</key>
+      <string>EJBCA Test Cert</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.ejbca.test.cert</string>
+      <key>PayloadType</key>
+      <string>com.apple.security.pkcs12</string>
+      <key>PayloadUUID</key>
+      <string>00000000-0000-0000-0000-000000000001</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+    </dict>
+  </array>
+  <key>PayloadDisplayName</key>
+  <string>EJBCA Test Profile</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.ejbca.test</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>00000000-0000-0000-0000-000000000002</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>
+```
+
+Save as `ejbca-test.mobileconfig` and upload via **Controls → OS settings →
+Custom settings → Add profile** in Fleet's UI (or via `fleetctl apply`).
+
+### 2. Trigger profile delivery
+
+The next time the test host checks in (or run **Refetch** on the host
+details page), Fleet's MDM profile processor will:
+
+1. Detect the `$FLEET_VAR_EJBCA_*` variables in the profile XML.
+2. Expand `$FLEET_VAR_HOST_HARDWARE_SERIAL` in the username template to the
+   actual host's serial.
+3. Call EJBCA's `pkcs10enroll` REST endpoint over mTLS, generating a
+   per-host RSA 2048 keypair + CSR.
+4. Receive the issued cert (base64 DER), wrap it with the private key in a
+   PKCS#12, and substitute the base64-encoded PFX into the profile XML.
+5. Push the profile to the host via APNs.
+
+### 3. Verify the cert installed
+
+On the test host:
+
+```bash
+security find-certificate -a -p -c "$SERIAL" /Library/Keychains/System.keychain
+```
+
+You should see a PEM-encoded certificate with Subject CN = your host's
+hardware serial, issued by EJBCA's Management CA, valid for 1 year.
+
+### 4. Verify in EJBCA
+
+Admin UI → **RA Web → Search End Entities** → enter the host's serial as
+the username. You should see:
+
+- Status: `GENERATED` (cert was issued)
+- Last Cert: the cert Fleet just enrolled
+
+In Admin UI → **RA Web → Search Certificates** you can also see the issued
+cert listed.
+
+## Gotchas
+
+- **CE-only: end-entity status is consumed on use.** After successful
+  issuance the EE flips from `NEW` (10) to `GENERATED` (40). Re-enrolling
+  for the same host (e.g., to test rotation) requires resetting:
+  ```bash
+  docker exec ejbca bin/ejbca.sh ra setendentitystatus --username "${SERIAL}" -S 10
+  docker exec ejbca bin/ejbca.sh ra setpwd --username "${SERIAL}" --password "anyvalue"
+  ```
+  Customer's EJBCA Enterprise with auto-create-EE doesn't have this
+  problem — every new enrollment creates a fresh EE record.
+- **"Allow Extension Override" on the Certificate Profile.** Required if
+  you set a UPN in Fleet's CA config. Without it EJBCA rebuilds the SAN
+  from its typed fields and drops the otherName UPN. Same gotcha as the
+  existing SCEP guide.
+- **Self-signed TLS at port 8443.** Fleet's REST client requires HTTPS
+  (mTLS), so we can't use the HTTP-port shortcut from the SCEP guide.
+  You must provide the Management CA in the trust bundle field, otherwise
+  the connection probe fails at save time with a TLS verify error.
+- **The P12 password is one-shot.** Fleet uses it once during decode and
+  discards it. To rotate the service cert, use the standard edit modal
+  in Fleet — re-upload a new P12 and supply its password; the backend
+  re-validates against EJBCA before writing the new material.
+- **No managed-cert tracking row for EJBCA in the POC.** The Fleet UI's
+  host certificates page may not show the EJBCA-issued cert in its
+  "managed by Fleet" indicator. This is a known POC gap noted in the
+  spec — the production implementation
+  ([fleet#30986](https://github.com/fleetdm/fleet/issues/30986)) adds the
+  required `CAConfigEJBCA` enum value and tracking write.
+
+## Cleanup
+
+```bash
+docker rm -f ejbca
+
+# Remove the Fleet CA via API
+curl -sk -X DELETE -H "Authorization: Bearer $FLEET_TOKEN" \
+    https://localhost:8080/api/latest/fleet/certificate_authorities/<CA_ID>
+
+# Or via the UI: Settings → Integrations → Certificate authorities →
+# row menu → Delete
+```
+
+## See also
+
+- [ejbca-scep-testing.md](./ejbca-scep-testing.md) — sibling guide for the
+  custom-SCEP-proxy integration path.
+- OpenSpec change `add-ejbca-rest-ca-poc` for the design rationale, customer
+  questions, and deferred follow-ups (`openspec/changes/add-ejbca-rest-ca-poc/`).
+- [EJBCA REST Interface docs](https://docs.keyfactor.com/ejbca/latest/ejbca-rest-interface).

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -1,12 +1,15 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 
@@ -16,7 +19,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/variables"
-	"software.sslmate.com/src/go-pkcs12"
 )
 
 func (svc *Service) GetCertificateAuthority(ctx context.Context, id uint) (*fleet.CertificateAuthority, error) {
@@ -539,32 +541,83 @@ func (svc *Service) validateEJBCA(ctx context.Context, ejbcaCA *fleet.EJBCACA, e
 // supplied password and returns the PEM-encoded certificate (with any
 // intermediate chain) and private key. The password is used once here and
 // never persisted.
+//
+// POC NOTE — DO NOT SHIP THIS SUBPROCESS APPROACH TO PRODUCTION.
+// Both Go PKCS#12 libraries (software.sslmate.com/src/go-pkcs12 and
+// golang.org/x/crypto/pkcs12) require strict DER and reject BER-encoded
+// input. EJBCA's RA Web (Java/BouncyCastle) emits BER P12s with
+// indefinite-length sequences. To unblock the POC we shell out to the
+// `openssl` binary, which handles BER. This adds a runtime binary
+// dependency the Fleet server doesn't otherwise have and broadens the
+// trust surface (subprocess hardening, PATH lookup, openssl version
+// drift).
+//
+// Production (fleet#30986) should replace this with an in-process
+// BER→DER normalizer in pure Go before parsing with one of the existing
+// Go PKCS#12 libraries. See openspec/changes/add-ejbca-rest-ca-poc/
+// research.md "Open follow-ups" for the design notes.
+//
+// The password is written into the child process over an extra file
+// descriptor (consumed via openssl's `-passin fd:3`) rather than the
+// command line so it doesn't appear in `ps` listings on the Fleet host.
 func decodeEJBCAClientP12(p12Data []byte, password string) (certPEM, keyPEM string, err error) {
-	privateKey, leafCert, caCerts, err := pkcs12.DecodeChain(p12Data, password)
+	passR, passW, err := os.Pipe()
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("creating password pipe: %v", err)
 	}
-	if leafCert == nil {
-		return "", "", errors.New("PKCS#12 bundle did not contain a leaf certificate")
+	defer passR.Close()
+
+	// Write the password to the pipe in a goroutine, then close so openssl
+	// sees EOF after the single read.
+	go func() {
+		defer passW.Close()
+		_, _ = passW.Write([]byte(password))
+	}()
+
+	cmd := exec.Command("openssl", "pkcs12", "-passin", "fd:3", "-nodes")
+	cmd.ExtraFiles = []*os.File{passR} // child sees this as fd 3
+	cmd.Stdin = bytes.NewReader(p12Data)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		// openssl's stderr is user-actionable for common failures
+		// (wrong password, corrupt P12).
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = runErr.Error()
+		}
+		return "", "", fmt.Errorf("openssl failed to decode PKCS#12: %s", msg)
 	}
 
-	var certBuf strings.Builder
-	if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: leafCert.Raw}); err != nil {
-		return "", "", fmt.Errorf("encoding leaf certificate as PEM: %v", err)
-	}
-	for _, c := range caCerts {
-		if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw}); err != nil {
-			return "", "", fmt.Errorf("encoding intermediate certificate as PEM: %v", err)
+	var certBuf, keyBuf strings.Builder
+	rest := stdout.Bytes()
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		// Drop openssl's "Bag Attributes" comment headers so the resulting
+		// PEM is directly consumable by tls.X509KeyPair.
+		block.Headers = nil
+		switch block.Type {
+		case "CERTIFICATE":
+			if err := pem.Encode(&certBuf, block); err != nil {
+				return "", "", fmt.Errorf("encoding certificate PEM block: %v", err)
+			}
+		case "PRIVATE KEY", "RSA PRIVATE KEY", "EC PRIVATE KEY":
+			if err := pem.Encode(&keyBuf, block); err != nil {
+				return "", "", fmt.Errorf("encoding private key PEM block: %v", err)
+			}
 		}
 	}
 
-	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	if err != nil {
-		return "", "", fmt.Errorf("marshaling private key to PKCS#8: %v", err)
+	if certBuf.Len() == 0 {
+		return "", "", errors.New("PKCS#12 bundle did not contain a certificate")
 	}
-	var keyBuf strings.Builder
-	if err := pem.Encode(&keyBuf, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}); err != nil {
-		return "", "", fmt.Errorf("encoding private key as PEM: %v", err)
+	if keyBuf.Len() == 0 {
+		return "", "", errors.New("PKCS#12 bundle did not contain a private key")
 	}
 
 	return certBuf.String(), keyBuf.String(), nil

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/url"
@@ -14,6 +16,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/variables"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 func (svc *Service) GetCertificateAuthority(ctx context.Context, id uint) (*fleet.CertificateAuthority, error) {
@@ -156,6 +159,35 @@ func (svc *Service) NewCertificateAuthority(ctx context.Context, p fleet.Certifi
 		activity = fleet.ActivityAddedSmallstep{Name: p.Smallstep.Name}
 	}
 
+	if p.EJBCA != nil {
+		p.EJBCA.Preprocess()
+
+		// validateEJBCA decodes the uploaded P12 and populates
+		// p.EJBCA.ClientCertPEM / ClientKeyPEM, then probes the EJBCA REST API
+		// to confirm reachability and mTLS auth.
+		if err := svc.validateEJBCA(ctx, p.EJBCA, errPrefix); err != nil {
+			return nil, err
+		}
+
+		caToCreate.Type = string(fleet.CATypeEJBCA)
+		caToCreate.Name = &p.EJBCA.Name
+		caToCreate.URL = &p.EJBCA.URL
+		caToCreate.ClientCertPEM = &p.EJBCA.ClientCertPEM
+		caToCreate.ClientKeyPEM = &p.EJBCA.ClientKeyPEM
+		if p.EJBCA.TrustCABundlePEM != "" {
+			caToCreate.TrustCABundlePEM = &p.EJBCA.TrustCABundlePEM
+		}
+		caToCreate.EJBCACAName = &p.EJBCA.CertificateAuthorityNameEJBCA
+		caToCreate.EJBCACertificateProfileName = &p.EJBCA.CertificateProfileName
+		caToCreate.EJBCAEndEntityProfileName = &p.EJBCA.EndEntityProfileName
+		caToCreate.EJBCAUsernameTemplate = &p.EJBCA.UsernameTemplate
+		if len(p.EJBCA.CertificateUserPrincipalNames) > 0 {
+			caToCreate.CertificateUserPrincipalNames = &p.EJBCA.CertificateUserPrincipalNames
+		}
+		caDisplayType = "EJBCA"
+		activity = fleet.ActivityAddedEJBCA{Name: p.EJBCA.Name}
+	}
+
 	createdCA, err := svc.ds.NewCertificateAuthority(ctx, caToCreate)
 	if err != nil {
 		if errors.As(err, &fleet.ConflictError{}) {
@@ -192,6 +224,9 @@ func (svc *Service) validatePayload(p *fleet.CertificateAuthorityPayload, errPre
 		casToCreate++
 	}
 	if p.CustomESTProxy != nil {
+		casToCreate++
+	}
+	if p.EJBCA != nil {
 		casToCreate++
 	}
 	if casToCreate == 0 {
@@ -433,6 +468,124 @@ func (svc *Service) validateSmallstepSCEPProxy(ctx context.Context, smallstepSCE
 	return nil
 }
 
+// validateEJBCA verifies the EJBCA CA payload and populates ClientCertPEM /
+// ClientKeyPEM by decoding the supplied PKCS#12 once. The P12 bytes and
+// password are not stored — only the extracted PEM cert and (encrypted) PEM
+// key are persisted. Finally, probes the EJBCA REST API to confirm
+// connectivity and mTLS authentication.
+func (svc *Service) validateEJBCA(ctx context.Context, ejbcaCA *fleet.EJBCACA, errPrefix string) error {
+	if err := validateCAName(ejbcaCA.Name, errPrefix); err != nil {
+		return err
+	}
+	if err := validateURL(ejbcaCA.URL, "EJBCA", errPrefix); err != nil {
+		return err
+	}
+	if len(ejbcaCA.ClientP12) == 0 {
+		return fleet.NewInvalidArgumentError("client_p12", fmt.Sprintf("%sA PKCS#12 client certificate is required for EJBCA.", errPrefix))
+	}
+	if ejbcaCA.ClientP12Password == "" || ejbcaCA.ClientP12Password == fleet.MaskedPassword {
+		return fleet.NewInvalidArgumentError("client_p12_password", fmt.Sprintf("%sA password for the PKCS#12 client certificate is required.", errPrefix))
+	}
+
+	certPEM, keyPEM, err := decodeEJBCAClientP12(ejbcaCA.ClientP12, ejbcaCA.ClientP12Password)
+	if err != nil {
+		return fleet.NewInvalidArgumentError("client_p12", fmt.Sprintf("%sCould not decode PKCS#12 client certificate: %s", errPrefix, err.Error()))
+	}
+	ejbcaCA.ClientCertPEM = certPEM
+	ejbcaCA.ClientKeyPEM = keyPEM
+	// Discard the upload-only material so it doesn't accidentally get
+	// persisted by a downstream caller that copies the whole struct.
+	ejbcaCA.ClientP12 = nil
+	ejbcaCA.ClientP12Password = ""
+
+	if ejbcaCA.TrustCABundlePEM != "" {
+		if !x509.NewCertPool().AppendCertsFromPEM([]byte(ejbcaCA.TrustCABundlePEM)) {
+			return fleet.NewInvalidArgumentError("trust_ca_bundle", fmt.Sprintf("%strust_ca_bundle did not contain any usable certificates.", errPrefix))
+		}
+	}
+
+	if strings.TrimSpace(ejbcaCA.CertificateAuthorityNameEJBCA) == "" {
+		return fleet.NewInvalidArgumentError("certificate_authority_name_ejbca", fmt.Sprintf("%sThe EJBCA Certificate Authority name is required.", errPrefix))
+	}
+	if strings.TrimSpace(ejbcaCA.CertificateProfileName) == "" {
+		return fleet.NewInvalidArgumentError("certificate_profile_name", fmt.Sprintf("%sThe EJBCA Certificate Profile name is required.", errPrefix))
+	}
+	if strings.TrimSpace(ejbcaCA.EndEntityProfileName) == "" {
+		return fleet.NewInvalidArgumentError("end_entity_profile_name", fmt.Sprintf("%sThe EJBCA End Entity Profile name is required.", errPrefix))
+	}
+	if strings.TrimSpace(ejbcaCA.UsernameTemplate) == "" {
+		return fleet.NewInvalidArgumentError("username_template", fmt.Sprintf("%sA username template is required for EJBCA.", errPrefix))
+	}
+	if err := validateEJBCAFleetVarUsage(ejbcaCA.UsernameTemplate, "username_template", errPrefix); err != nil {
+		return err
+	}
+	for _, upn := range ejbcaCA.CertificateUserPrincipalNames {
+		if strings.TrimSpace(upn) == "" {
+			return fleet.NewInvalidArgumentError("certificate_user_principal_names", fmt.Sprintf("%sUPN entries cannot be empty.", errPrefix))
+		}
+		if err := validateEJBCAFleetVarUsage(upn, "certificate_user_principal_names", errPrefix); err != nil {
+			return err
+		}
+	}
+
+	if err := svc.ejbcaService.VerifyConnection(ctx, *ejbcaCA); err != nil {
+		svc.logger.ErrorContext(ctx, "Failed to verify EJBCA connection", "err", err)
+		return &fleet.BadRequestError{Message: fmt.Sprintf("%sCould not verify EJBCA connection: %s. Please correct and try again.", errPrefix, err.Error())}
+	}
+	return nil
+}
+
+// decodeEJBCAClientP12 decodes the uploaded PKCS#12 bundle once with the
+// supplied password and returns the PEM-encoded certificate (with any
+// intermediate chain) and private key. The password is used once here and
+// never persisted.
+func decodeEJBCAClientP12(p12Data []byte, password string) (certPEM, keyPEM string, err error) {
+	privateKey, leafCert, caCerts, err := pkcs12.DecodeChain(p12Data, password)
+	if err != nil {
+		return "", "", err
+	}
+	if leafCert == nil {
+		return "", "", errors.New("PKCS#12 bundle did not contain a leaf certificate")
+	}
+
+	var certBuf strings.Builder
+	if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: leafCert.Raw}); err != nil {
+		return "", "", fmt.Errorf("encoding leaf certificate as PEM: %v", err)
+	}
+	for _, c := range caCerts {
+		if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw}); err != nil {
+			return "", "", fmt.Errorf("encoding intermediate certificate as PEM: %v", err)
+		}
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return "", "", fmt.Errorf("marshaling private key to PKCS#8: %v", err)
+	}
+	var keyBuf strings.Builder
+	if err := pem.Encode(&keyBuf, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return "", "", fmt.Errorf("encoding private key as PEM: %v", err)
+	}
+
+	return certBuf.String(), keyBuf.String(), nil
+}
+
+// validateEJBCAFleetVarUsage enforces the same Fleet-variable allow-list used
+// by DigiCert for templated fields.
+func validateEJBCAFleetVarUsage(value, fieldName, errPrefix string) error {
+	for _, v := range variables.Find(value) {
+		switch v {
+		case string(fleet.FleetVarHostEndUserEmailIDP),
+			string(fleet.FleetVarHostHardwareSerial),
+			string(fleet.FleetVarHostPlatform):
+			// ok
+		default:
+			return fleet.NewInvalidArgumentError(fieldName, fmt.Sprintf("%sFLEET_VAR_%s is not allowed in %s for EJBCA.", errPrefix, v, fieldName))
+		}
+	}
+	return nil
+}
+
 type oauthIntrospectionResponse struct {
 	Username *string `json:"username"`
 	// Only active is required in the body by the spec
@@ -471,6 +624,10 @@ func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateA
 		}
 	case string(fleet.CATypeCustomESTProxy):
 		activity = fleet.ActivityDeletedCustomESTProxy{
+			Name: ca.Name,
+		}
+	case string(fleet.CATypeEJBCA):
+		activity = fleet.ActivityDeletedEJBCA{
 			Name: ca.Name,
 		}
 	}
@@ -1237,6 +1394,43 @@ func (svc *Service) UpdateCertificateAuthority(ctx context.Context, id uint, p f
 			caActivityName = *oldCA.Name
 		}
 		activity = fleet.ActivityEditedSmallstep{Name: caActivityName}
+	case p.EJBCACAUpdatePayload != nil:
+		if p.EJBCACAUpdatePayload.IsEmpty() {
+			return &fleet.BadRequestError{Message: fmt.Sprintf("%sEJBCA CA update payload is empty", errPrefix)}
+		}
+		if err := p.EJBCACAUpdatePayload.ValidateRelatedFields(errPrefix, *oldCA.Name); err != nil {
+			return err
+		}
+		p.EJBCACAUpdatePayload.Preprocess()
+		certPEM, keyPEM, err := svc.validateEJBCAUpdate(ctx, p.EJBCACAUpdatePayload, oldCA, errPrefix)
+		if err != nil {
+			return err
+		}
+
+		caToUpdate.Type = string(fleet.CATypeEJBCA)
+		caToUpdate.Name = p.EJBCACAUpdatePayload.Name
+		caToUpdate.URL = p.EJBCACAUpdatePayload.URL
+		// When a P12 was supplied, certPEM/keyPEM hold the decoded material;
+		// otherwise the stored values are retained (pointers stay nil so the
+		// datastore's generateUpdateQueryWithArgs skips those columns).
+		if certPEM != "" {
+			caToUpdate.ClientCertPEM = &certPEM
+		}
+		if keyPEM != "" {
+			caToUpdate.ClientKeyPEM = &keyPEM
+		}
+		caToUpdate.TrustCABundlePEM = p.EJBCACAUpdatePayload.TrustCABundlePEM
+		caToUpdate.EJBCACAName = p.EJBCACAUpdatePayload.CertificateAuthorityNameEJBCA
+		caToUpdate.EJBCACertificateProfileName = p.EJBCACAUpdatePayload.CertificateProfileName
+		caToUpdate.EJBCAEndEntityProfileName = p.EJBCACAUpdatePayload.EndEntityProfileName
+		caToUpdate.EJBCAUsernameTemplate = p.EJBCACAUpdatePayload.UsernameTemplate
+		caToUpdate.CertificateUserPrincipalNames = p.EJBCACAUpdatePayload.CertificateUserPrincipalNames
+		if caToUpdate.Name != nil {
+			caActivityName = *caToUpdate.Name
+		} else {
+			caActivityName = *oldCA.Name
+		}
+		activity = fleet.ActivityEditedEJBCA{Name: caActivityName}
 	}
 
 	if oldCA.Type != caToUpdate.Type {
@@ -1541,6 +1735,103 @@ func (svc *Service) validateSmallstepSCEPProxyUpdate(ctx context.Context, smalls
 	}
 
 	return nil
+}
+
+// validateEJBCAUpdate validates an EJBCA update payload and, when a new P12
+// is supplied, decodes it into PEM-encoded cert + key strings returned to the
+// caller. Returns empty strings when no rotation is in progress.
+//
+// After validating, probes the EJBCA REST API end-to-end with the merged
+// (new + existing) configuration to confirm the change is functional before
+// persisting.
+func (svc *Service) validateEJBCAUpdate(ctx context.Context, ejbcaUpdate *fleet.EJBCACAUpdatePayload, oldCA *fleet.CertificateAuthority, errPrefix string) (certPEM, keyPEM string, err error) {
+	if ejbcaUpdate.Name != nil {
+		if err := validateCAName(*ejbcaUpdate.Name, errPrefix); err != nil {
+			return "", "", err
+		}
+	}
+	if ejbcaUpdate.URL != nil {
+		if err := validateURL(*ejbcaUpdate.URL, "EJBCA", errPrefix); err != nil {
+			return "", "", err
+		}
+	}
+
+	if ejbcaUpdate.ClientP12 != nil {
+		certPEM, keyPEM, err = decodeEJBCAClientP12(*ejbcaUpdate.ClientP12, *ejbcaUpdate.ClientP12Password)
+		if err != nil {
+			return "", "", fleet.NewInvalidArgumentError("client_p12", fmt.Sprintf("%sCould not decode PKCS#12 client certificate: %s", errPrefix, err.Error()))
+		}
+		// Discard the upload-only material so downstream callers don't
+		// accidentally persist it.
+		ejbcaUpdate.ClientP12 = nil
+		ejbcaUpdate.ClientP12Password = nil
+	}
+
+	if ejbcaUpdate.TrustCABundlePEM != nil && *ejbcaUpdate.TrustCABundlePEM != "" {
+		if !x509.NewCertPool().AppendCertsFromPEM([]byte(*ejbcaUpdate.TrustCABundlePEM)) {
+			return "", "", fleet.NewInvalidArgumentError("trust_ca_bundle", fmt.Sprintf("%strust_ca_bundle did not contain any usable certificates.", errPrefix))
+		}
+	}
+
+	if ejbcaUpdate.UsernameTemplate != nil {
+		if strings.TrimSpace(*ejbcaUpdate.UsernameTemplate) == "" {
+			return "", "", fleet.NewInvalidArgumentError("username_template", fmt.Sprintf("%susername_template cannot be empty.", errPrefix))
+		}
+		if err := validateEJBCAFleetVarUsage(*ejbcaUpdate.UsernameTemplate, "username_template", errPrefix); err != nil {
+			return "", "", err
+		}
+	}
+	if ejbcaUpdate.CertificateUserPrincipalNames != nil {
+		for _, upn := range *ejbcaUpdate.CertificateUserPrincipalNames {
+			if strings.TrimSpace(upn) == "" {
+				return "", "", fleet.NewInvalidArgumentError("certificate_user_principal_names", fmt.Sprintf("%sUPN entries cannot be empty.", errPrefix))
+			}
+			if err := validateEJBCAFleetVarUsage(upn, "certificate_user_principal_names", errPrefix); err != nil {
+				return "", "", err
+			}
+		}
+	}
+
+	// Build the merged config (new field where supplied, old field otherwise)
+	// and probe the EJBCA REST API to confirm reachability + mTLS auth before
+	// we persist.
+	merged := fleet.EJBCACA{
+		Name:                          stringOrDeref(ejbcaUpdate.Name, oldCA.Name),
+		URL:                           stringOrDeref(ejbcaUpdate.URL, oldCA.URL),
+		ClientCertPEM:                 stringOrDeref(strPtrIf(certPEM), oldCA.ClientCertPEM),
+		ClientKeyPEM:                  stringOrDeref(strPtrIf(keyPEM), oldCA.ClientKeyPEM),
+		TrustCABundlePEM:              stringOrDeref(ejbcaUpdate.TrustCABundlePEM, oldCA.TrustCABundlePEM),
+		CertificateAuthorityNameEJBCA: stringOrDeref(ejbcaUpdate.CertificateAuthorityNameEJBCA, oldCA.EJBCACAName),
+		CertificateProfileName:        stringOrDeref(ejbcaUpdate.CertificateProfileName, oldCA.EJBCACertificateProfileName),
+		EndEntityProfileName:          stringOrDeref(ejbcaUpdate.EndEntityProfileName, oldCA.EJBCAEndEntityProfileName),
+		UsernameTemplate:              stringOrDeref(ejbcaUpdate.UsernameTemplate, oldCA.EJBCAUsernameTemplate),
+	}
+	if err := svc.ejbcaService.VerifyConnection(ctx, merged); err != nil {
+		svc.logger.ErrorContext(ctx, "Failed to verify EJBCA connection on update", "err", err)
+		return "", "", &fleet.BadRequestError{Message: fmt.Sprintf("%sCould not verify EJBCA connection: %s. Please correct and try again.", errPrefix, err.Error())}
+	}
+
+	return certPEM, keyPEM, nil
+}
+
+// stringOrDeref returns *newPtr if non-nil, else *oldPtr, else "".
+func stringOrDeref(newPtr *string, oldPtr *string) string {
+	if newPtr != nil {
+		return *newPtr
+	}
+	if oldPtr != nil {
+		return *oldPtr
+	}
+	return ""
+}
+
+// strPtrIf returns &s if s != "", else nil. Helper for routing newly-decoded
+// PEM through stringOrDeref alongside the existing pointer-based plumbing.
+func strPtrIf(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
 func fmtDuplicateCANameError(name, caType, displayCAType string) error {

--- a/ee/server/service/ejbca/ejbca.go
+++ b/ee/server/service/ejbca/ejbca.go
@@ -1,0 +1,391 @@
+// Package ejbca implements Fleet's REST client for the EJBCA Certificate
+// Authority. It speaks the EJBCA REST API over mutual TLS, using a client
+// certificate the customer's EJBCA admin enrolls and binds to an
+// administrator role with appropriate access rules.
+//
+// REST reference: https://docs.keyfactor.com/ejbca/latest/ejbca-rest-interface
+package ejbca
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/go-json-experiment/json"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+const (
+	defaultTimeout = 20 * time.Second
+	restAPIPrefix  = "/ejbca/ejbca-rest-api/v1"
+)
+
+var (
+	// Microsoft User Principal Name OID for the SubjectAltName otherName extension.
+	oidMicrosoftUPN = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 20, 2, 3}
+	// X.509 SubjectAltName extension OID.
+	oidSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
+)
+
+// Service is the EJBCA REST API client.
+type Service struct {
+	logger  *slog.Logger
+	timeout time.Duration
+}
+
+// Compile-time check that Service satisfies fleet.EJBCAService.
+var _ fleet.EJBCAService = (*Service)(nil)
+
+// NewService constructs a Service with the given options.
+func NewService(opts ...Opt) fleet.EJBCAService {
+	s := &Service{}
+	s.populateOpts(opts)
+	return s
+}
+
+// Opt configures the Service.
+type Opt func(*Service)
+
+// WithTimeout sets the per-request HTTP timeout.
+func WithTimeout(t time.Duration) Opt {
+	return func(s *Service) { s.timeout = t }
+}
+
+// WithLogger sets the slog.Logger used by the service.
+func WithLogger(logger *slog.Logger) Opt {
+	return func(s *Service) { s.logger = logger }
+}
+
+func (s *Service) populateOpts(opts []Opt) {
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.timeout <= 0 {
+		s.timeout = defaultTimeout
+	}
+	if s.logger == nil {
+		s.logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
+}
+
+// buildClient returns an HTTP client configured for mTLS against the supplied
+// EJBCA configuration. The client presents cfg.ClientCertPEM / ClientKeyPEM and
+// trusts cfg.TrustCABundlePEM (plus the system root store) for server cert
+// verification. When TrustCABundlePEM is empty, the system root store alone is
+// used — appropriate only when EJBCA's HTTPS cert is signed by a publicly
+// trusted CA, which is uncommon for self-hosted EJBCA deployments.
+func (s *Service) buildClient(ctx context.Context, cfg fleet.EJBCACA) (*http.Client, error) {
+	cert, err := tls.X509KeyPair([]byte(cfg.ClientCertPEM), []byte(cfg.ClientKeyPEM))
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "loading EJBCA client cert/key pair")
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	if cfg.TrustCABundlePEM != "" {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(cfg.TrustCABundlePEM)) {
+			return nil, ctxerr.Errorf(ctx, "EJBCA trust_ca_bundle did not contain any usable certificates")
+		}
+		tlsCfg.RootCAs = pool
+	}
+	return fleethttp.NewClient(
+		fleethttp.WithTimeout(s.timeout),
+		fleethttp.WithTLSClientConfig(tlsCfg),
+	), nil
+}
+
+// VerifyConnection probes GET /v1/ca/status over mTLS to confirm the supplied
+// EJBCA configuration reaches the API and authenticates successfully.
+func (s *Service) VerifyConnection(ctx context.Context, cfg fleet.EJBCACA) error {
+	client, err := s.buildClient(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	base := strings.TrimRight(cfg.URL, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+restAPIPrefix+"/ca/status", nil)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "creating EJBCA status request")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "sending EJBCA status request")
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fall through to body decode
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return ctxerr.Errorf(ctx,
+			"EJBCA rejected the Fleet client certificate (likely revoked, expired, or not bound to a role with sufficient access); status code: %d",
+			resp.StatusCode,
+		)
+	default:
+		return ctxerr.Errorf(ctx, "unexpected EJBCA status code on /ca/status: %d", resp.StatusCode)
+	}
+
+	var statusResp struct {
+		Status   string `json:"status"`
+		Version  string `json:"version"`
+		Revision string `json:"revision"`
+	}
+	if err := json.UnmarshalRead(resp.Body, &statusResp); err != nil {
+		return ctxerr.Wrap(ctx, err, "decoding EJBCA status response")
+	}
+	if statusResp.Status != "OK" {
+		return ctxerr.Errorf(ctx, "EJBCA reports non-OK status: %q", statusResp.Status)
+	}
+	s.logger.DebugContext(ctx, "EJBCA connection verified",
+		"version", statusResp.Version,
+		"revision", statusResp.Revision,
+	)
+	return nil
+}
+
+// GetCertificate enrolls a certificate against the supplied EJBCA configuration.
+// Fleet generates the RSA keypair locally, sends the CSR, and wraps the issued
+// X.509 cert and key in a PKCS#12 bundle for delivery via MDM profile variable
+// substitution. The caller is responsible for expanding any Fleet variables in
+// cfg fields before invoking.
+func (s *Service) GetCertificate(ctx context.Context, cfg fleet.EJBCACA) (*fleet.EJBCACertificate, error) {
+	client, err := s.buildClient(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "generating RSA private key for EJBCA enrollment")
+	}
+
+	csrTemplate := &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: cfg.UsernameTemplate},
+	}
+	if len(cfg.CertificateUserPrincipalNames) > 0 {
+		ext, err := buildUPNSANExtension(cfg.CertificateUserPrincipalNames)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "building UPN subjectAltName extension")
+		}
+		csrTemplate.ExtraExtensions = []pkix.Extension{ext}
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, privateKey)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "creating CSR for EJBCA enrollment")
+	}
+	csrPEM := strings.TrimSpace(string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrDER,
+	})))
+
+	// EJBCA's backend rejects a null `password` for any CA with
+	// useUserStorage=true (essentially every production deployment, verified
+	// in SignSessionBean.java). Under the standard auto-create-EE +
+	// permissive-password configuration we ship against, the supplied value
+	// isn't authenticating anything; the mTLS client cert + role scope is the
+	// actual security boundary (see research.md). We satisfy the requirement
+	// with a per-call random value and discard it — no persistent shared
+	// secret on Fleet's side.
+	pwBytes := make([]byte, 32)
+	if _, err := rand.Read(pwBytes); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "generating per-enrollment EJBCA password")
+	}
+	enrollmentPassword := hex.EncodeToString(pwBytes)
+
+	reqBody := map[string]any{
+		"certificate_request":        csrPEM,
+		"certificate_profile_name":   cfg.CertificateProfileName,
+		"end_entity_profile_name":    cfg.EndEntityProfileName,
+		"certificate_authority_name": cfg.CertificateAuthorityNameEJBCA,
+		"username":                   cfg.UsernameTemplate,
+		"password":                   enrollmentPassword,
+		"include_chain":              false,
+		"response_format":            "DER",
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "marshaling EJBCA pkcs10enroll body")
+	}
+
+	base := strings.TrimRight(cfg.URL, "/")
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		base+restAPIPrefix+"/certificate/pkcs10enroll", strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "creating EJBCA pkcs10enroll request")
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "sending EJBCA pkcs10enroll request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, mapEnrollError(ctx, resp)
+	}
+
+	var certResp struct {
+		Certificate    string `json:"certificate"`
+		SerialNumber   string `json:"serial_number"`
+		ResponseFormat string `json:"response_format"`
+	}
+	if err := json.UnmarshalRead(resp.Body, &certResp); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "decoding EJBCA pkcs10enroll response")
+	}
+	if certResp.Certificate == "" {
+		return nil, ctxerr.Errorf(ctx, "EJBCA returned an empty certificate")
+	}
+
+	derBytes, err := base64.StdEncoding.DecodeString(certResp.Certificate)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "base64-decoding EJBCA certificate")
+	}
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "parsing EJBCA certificate DER")
+	}
+
+	pfxPassword, err := server.GenerateRandomText(10)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "generating PKCS#12 wrapper password")
+	}
+	pfxData, err := pkcs12.Legacy.Encode(privateKey, cert, nil, pfxPassword)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "encoding EJBCA certificate as PKCS#12")
+	}
+
+	s.logger.DebugContext(ctx, "EJBCA certificate issued",
+		"serial_number", cert.SerialNumber.String(),
+		"not_after", cert.NotAfter,
+	)
+
+	return &fleet.EJBCACertificate{
+		PfxData:        pfxData,
+		Password:       pfxPassword,
+		NotValidBefore: cert.NotBefore,
+		NotValidAfter:  cert.NotAfter,
+		SerialNumber:   cert.SerialNumber.String(),
+	}, nil
+}
+
+// mapEnrollError translates a non-2xx pkcs10enroll response into a wrapped
+// error with a user-actionable message. EJBCA returns
+// {"error_code": N, "error_message": "..."} on most failures.
+func mapEnrollError(ctx context.Context, resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	var errResp struct {
+		ErrorCode    int    `json:"error_code"`
+		ErrorMessage string `json:"error_message"`
+	}
+	_ = json.Unmarshal(body, &errResp)
+	msg := errResp.ErrorMessage
+	if msg == "" {
+		msg = strings.TrimSpace(string(body))
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return ctxerr.Errorf(ctx,
+			"EJBCA rejected the Fleet client certificate (likely revoked, expired, or not bound to a role with sufficient access); status %d: %s",
+			resp.StatusCode, msg)
+	case http.StatusNotFound:
+		return ctxerr.Errorf(ctx,
+			"EJBCA reports the CA or profile name does not exist; status %d: %s",
+			resp.StatusCode, msg)
+	case http.StatusUnprocessableEntity:
+		return ctxerr.Errorf(ctx,
+			"EJBCA end-entity profile rejected the CSR; status %d: %s",
+			resp.StatusCode, msg)
+	default:
+		return ctxerr.Errorf(ctx,
+			"unexpected EJBCA pkcs10enroll status %d: %s", resp.StatusCode, msg)
+	}
+}
+
+// buildUPNSANExtension constructs an X.509 subjectAltName extension that
+// carries one or more Microsoft User Principal Names as otherName entries.
+//
+// ASN.1 (RFC 5280 + Microsoft UPN OID 1.3.6.1.4.1.311.20.2.3):
+//
+//	SubjectAltName ::= SEQUENCE OF GeneralName
+//	GeneralName    ::= CHOICE { otherName [0] OtherName, ... }
+//	OtherName      ::= SEQUENCE {
+//	                     type-id OBJECT IDENTIFIER,
+//	                     value   [0] EXPLICIT ANY DEFINED BY type-id
+//	                   }
+//
+// Go's encoding/asn1 marshals the OtherName struct with the universal SEQUENCE
+// tag (0x30); under GeneralName.otherName [0] CHOICE the outermost tag must be
+// the context-specific constructed [0] (0xA0), so we rewrite the leading byte
+// after marshaling.
+//
+// EJBCA preserves SAN exactly as supplied in the CSR only when the customer's
+// Certificate Profile has "Allow Extension Override" enabled — documented in
+// the dev guide alongside this code.
+func buildUPNSANExtension(upns []string) (pkix.Extension, error) {
+	type upnValue struct {
+		Value string `asn1:"utf8"`
+	}
+	type otherName struct {
+		TypeID asn1.ObjectIdentifier
+		Value  upnValue `asn1:"explicit,tag:0"`
+	}
+
+	var generalNames []byte
+	for _, upn := range upns {
+		on := otherName{
+			TypeID: oidMicrosoftUPN,
+			Value:  upnValue{Value: upn},
+		}
+		b, err := asn1.Marshal(on)
+		if err != nil {
+			return pkix.Extension{}, err
+		}
+		if len(b) < 1 || b[0] != 0x30 {
+			return pkix.Extension{}, errors.New("unexpected ASN.1 prefix for otherName SEQUENCE")
+		}
+		// Rewrite the universal SEQUENCE tag to context-specific [0] constructed.
+		b[0] = 0xA0
+		generalNames = append(generalNames, b...)
+	}
+
+	sanBytes, err := asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassUniversal,
+		Tag:        asn1.TagSequence,
+		IsCompound: true,
+		Bytes:      generalNames,
+	})
+	if err != nil {
+		return pkix.Extension{}, err
+	}
+
+	return pkix.Extension{
+		Id:    oidSubjectAltName,
+		Value: sanBytes,
+	}, nil
+}

--- a/ee/server/service/ejbca/ejbca_test.go
+++ b/ee/server/service/ejbca/ejbca_test.go
@@ -1,0 +1,64 @@
+package ejbca
+
+import (
+	"encoding/asn1"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildUPNSANExtension verifies the otherName-based subjectAltName encoding
+// roundtrips through Go's encoding/asn1 — a focused sanity check for the only
+// hand-rolled ASN.1 in this package. A failing assert here means EJBCA would
+// reject the CSR or strip the UPN; far cheaper to catch in a unit test than
+// during a real enrollment.
+func TestBuildUPNSANExtension(t *testing.T) {
+	upns := []string{"alice@corp.example.com", "alice.alt@corp.example.com"}
+
+	ext, err := buildUPNSANExtension(upns)
+	require.NoError(t, err)
+	assert.Equal(t, oidSubjectAltName, ext.Id)
+	assert.NotEmpty(t, ext.Value)
+
+	// Parse SubjectAltName ::= SEQUENCE OF GeneralName.
+	var generalNames []asn1.RawValue
+	rest, err := asn1.Unmarshal(ext.Value, &generalNames)
+	require.NoError(t, err)
+	assert.Empty(t, rest)
+	require.Len(t, generalNames, len(upns))
+
+	type upnValue struct {
+		Value string `asn1:"utf8"`
+	}
+	type otherName struct {
+		TypeID asn1.ObjectIdentifier
+		Value  upnValue `asn1:"explicit,tag:0"`
+	}
+
+	for i, gn := range generalNames {
+		// Each GeneralName.otherName has the context-specific [0] (0xA0) tag.
+		// Rewrite the outer byte back to universal SEQUENCE (0x30) so the
+		// standard unmarshaler decodes it.
+		fullBytes := append([]byte(nil), gn.FullBytes...)
+		require.Equal(t, byte(0xA0), fullBytes[0], "otherName outer tag should be context-specific [0] constructed")
+		fullBytes[0] = 0x30
+
+		var on otherName
+		_, err := asn1.Unmarshal(fullBytes, &on)
+		require.NoError(t, err, "unmarshal otherName %d", i)
+		assert.True(t, on.TypeID.Equal(oidMicrosoftUPN), "OID mismatch on otherName %d", i)
+		assert.Equal(t, upns[i], on.Value.Value, "UPN value mismatch on otherName %d", i)
+	}
+}
+
+// TestBuildUPNSANExtension_Empty confirms the function handles an empty input
+// slice gracefully. The caller in GetCertificate guards against this anyway,
+// but defensive behavior is cheap to verify.
+func TestBuildUPNSANExtension_Empty(t *testing.T) {
+	ext, err := buildUPNSANExtension(nil)
+	require.NoError(t, err)
+	assert.Equal(t, oidSubjectAltName, ext.Id)
+	// An empty SEQUENCE OF — 0x30 0x00 — is well-formed ASN.1.
+	assert.Equal(t, []byte{0x30, 0x00}, ext.Value)
+}

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -96,6 +96,7 @@ func setupMockDatastorePremiumService(t testing.TB) (*mock.Store, *eeservice.Ser
 		nil,
 		nil,
 		nil,
+		nil, // ejbcaService
 		nil,
 		nil,
 		nil,
@@ -126,6 +127,7 @@ func setupMockDatastorePremiumService(t testing.TB) (*mock.Store, *eeservice.Ser
 		nil,
 		nil,
 		nil,
+		nil, // ejbcaService
 		nil,
 		nil,
 	)

--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -35,6 +35,7 @@ type Service struct {
 	keyValueStore          fleet.KeyValueStore
 	scepConfigService      fleet.SCEPConfigService
 	digiCertService        fleet.DigiCertService
+	ejbcaService           fleet.EJBCAService
 	androidModule          android.Service
 	estService             fleet.ESTService
 }
@@ -57,6 +58,7 @@ func NewService(
 	keyValueStore fleet.KeyValueStore,
 	scepConfigService fleet.SCEPConfigService,
 	digiCertService fleet.DigiCertService,
+	ejbcaService fleet.EJBCAService,
 	androidService android.Service,
 	estService fleet.ESTService,
 ) (*Service, error) {
@@ -84,6 +86,7 @@ func NewService(
 		keyValueStore:          keyValueStore,
 		scepConfigService:      scepConfigService,
 		digiCertService:        digiCertService,
+		ejbcaService:           ejbcaService,
 		androidModule:          androidService,
 		estService:             estService,
 	}

--- a/frontend/interfaces/certificates.ts
+++ b/frontend/interfaces/certificates.ts
@@ -97,13 +97,43 @@ export interface ICertificatesCustomEST {
   password: string;
 }
 
+/** EJBCA REST CA. POC accepts PKCS#12 (base64) + password on create/update; the
+ * server decodes once and persists PEM cert + (encrypted) PEM key. On read the
+ * P12 fields are empty, `client_cert` returns PEM, `client_key` is masked, and
+ * `client_cert_expires_at` is populated from the stored cert for the expiry
+ * badge on the CA list. */
+export interface ICertificatesEJBCA {
+  id?: number;
+  type?: "ejbca";
+  name: string;
+  url: string;
+  /** base64-encoded PKCS#12 bytes — write-only */
+  client_p12?: string;
+  /** password for client_p12 — write-only, never returned */
+  client_p12_password?: string;
+  /** PEM cert chain — returned on read */
+  client_cert?: string;
+  /** PEM private key — returned masked unless includeSecrets */
+  client_key?: string;
+  /** PEM trust CA bundle — optional, defaults to system root store */
+  trust_ca_bundle?: string;
+  /** RFC3339 expiry parsed from the stored client cert (read-only) */
+  client_cert_expires_at?: string;
+  certificate_authority_name_ejbca: string;
+  certificate_profile_name: string;
+  end_entity_profile_name: string;
+  username_template: string;
+  certificate_user_principal_names: string[] | null;
+}
+
 export type ICertificateAuthorityType =
   | "ndes_scep_proxy"
   | "digicert"
   | "custom_scep_proxy"
   | "hydrant"
   | "smallstep"
-  | "custom_est_proxy";
+  | "custom_est_proxy"
+  | "ejbca";
 
 /** all the types of certificates */
 export type ICertificateAuthority =
@@ -112,7 +142,8 @@ export type ICertificateAuthority =
   | ICertificatesHydrant
   | ICertificatesCustomSCEP
   | ICertificatesSmallstep
-  | ICertificatesCustomEST;
+  | ICertificatesCustomEST
+  | ICertificatesEJBCA;
 
 export const isNDESCertAuthority = (
   integration: ICertificateAuthority
@@ -176,6 +207,17 @@ export const isCustomESTCertAuthority = (
     !("challenge_url" in integration) &&
     "username" in integration &&
     "password" in integration
+  );
+};
+
+export const isEJBCACertAuthority = (
+  integration: ICertificateAuthority
+): integration is ICertificatesEJBCA => {
+  return (
+    "certificate_authority_name_ejbca" in integration &&
+    "certificate_profile_name" in integration &&
+    "end_entity_profile_name" in integration &&
+    "username_template" in integration
   );
 };
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -138,44 +138,39 @@ const AddCertAuthorityModal = ({
 
   const onChangeForm = (update: { name: string; value: string }) => {
     let setFormData;
-    let formData: ICertFormData;
     switch (certAuthorityType) {
       case "digicert":
         setFormData = setDigicertFormData;
-        formData = digicertFormData;
         break;
       case "hydrant":
         setFormData = setHydrantFormData;
-        formData = hydrantFormData;
         break;
       case "ndes_scep_proxy":
         setFormData = setNDESFormData;
-        formData = ndesFormData;
         break;
       case "custom_scep_proxy":
         setFormData = setCustomSCEPFormData;
-        formData = customSCEPFormData;
         break;
       case "smallstep":
         setFormData = setSmallstepFormData;
-        formData = smallstepFormData;
         break;
       case "custom_est_proxy":
         setFormData = setCustomESTFormData;
-        formData = customESTFormData;
         break;
       case "ejbca":
         setFormData = setEJBCAFormData;
-        formData = ejbcaFormData;
         break;
       default:
         return;
     }
 
-    (setFormData as React.Dispatch<React.SetStateAction<ICertFormData>>)({
-      ...formData,
-      [update.name]: update.value,
-    });
+    // Use the functional updater form so multi-field clears within a single
+    // user action (e.g., the EJBCA form's "trash the uploaded .p12" handler
+    // that resets the base64, filename, and password in three sequential
+    // calls) don't clobber each other via stale closure.
+    (setFormData as React.Dispatch<
+      React.SetStateAction<ICertFormData>
+    >)((prev) => ({ ...prev, [update.name]: update.value }));
   };
 
   const onAddCertAuthority = async () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -19,6 +19,8 @@ import {
 
 import DigicertForm from "../DigicertForm";
 import { IDigicertFormData } from "../DigicertForm/DigicertForm";
+import EJBCAForm from "../EJBCAForm";
+import { IEJBCAFormData } from "../EJBCAForm/EJBCAForm";
 import NDESForm from "../NDESForm";
 import { INDESFormData } from "../NDESForm/NDESForm";
 import CustomSCEPForm from "../CustomSCEPForm";
@@ -38,7 +40,8 @@ export type ICertFormData =
   | INDESFormData
   | ICustomSCEPFormData
   | ISmallstepFormData
-  | ICustomESTFormData;
+  | ICustomESTFormData
+  | IEJBCAFormData;
 
 const baseClass = "add-cert-authority-modal";
 
@@ -115,6 +118,19 @@ const AddCertAuthorityModal = ({
     username: "",
     password: "",
   });
+  const [ejbcaFormData, setEJBCAFormData] = useState<IEJBCAFormData>({
+    name: "",
+    url: "",
+    clientP12Base64: "",
+    clientP12FileName: "",
+    clientP12Password: "",
+    trustCABundle: "",
+    certificateAuthorityNameEJBCA: "",
+    certificateProfileName: "",
+    endEntityProfileName: "",
+    usernameTemplate: "",
+    userPrincipalName: "",
+  });
 
   const onChangeDropdown = (value: ICertificateAuthorityType) => {
     setCertAuthorityType(value);
@@ -148,6 +164,10 @@ const AddCertAuthorityModal = ({
         setFormData = setCustomESTFormData;
         formData = customESTFormData;
         break;
+      case "ejbca":
+        setFormData = setEJBCAFormData;
+        formData = ejbcaFormData;
+        break;
       default:
         return;
     }
@@ -178,6 +198,9 @@ const AddCertAuthorityModal = ({
         break;
       case "custom_est_proxy":
         formData = customESTFormData;
+        break;
+      case "ejbca":
+        formData = ejbcaFormData;
         break;
       default:
         return;
@@ -268,6 +291,18 @@ const AddCertAuthorityModal = ({
         return (
           <CustomESTForm
             formData={customESTFormData}
+            certAuthorities={certAuthorities}
+            submitBtnText={submitBtnText}
+            isSubmitting={isAdding}
+            onChange={onChangeForm}
+            onSubmit={onAddCertAuthority}
+            onCancel={onExit}
+          />
+        );
+      case "ejbca":
+        return (
+          <EJBCAForm
+            formData={ejbcaFormData}
             certAuthorities={certAuthorities}
             submitBtnText={submitBtnText}
             isSubmitting={isAdding}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -9,6 +9,7 @@ import { getErrorReason } from "interfaces/errors";
 import CustomLink from "components/CustomLink";
 
 import { IDigicertFormData } from "../DigicertForm/DigicertForm";
+import { IEJBCAFormData } from "../EJBCAForm/EJBCAForm";
 import { ICertFormData } from "../AddCertAuthorityModal/AddCertAuthorityModal";
 import { INDESFormData } from "../NDESForm/NDESForm";
 import { ICustomSCEPFormData } from "../CustomSCEPForm/CustomSCEPForm";
@@ -28,6 +29,7 @@ const DEFAULT_CERT_AUTHORITY_OPTIONS: IDropdownOption[] = [
     value: "custom_scep_proxy",
   },
   { label: CA_LABEL_BY_TYPE.digicert, value: "digicert" },
+  { label: CA_LABEL_BY_TYPE.ejbca, value: "ejbca" },
   {
     label: CA_LABEL_BY_TYPE.hydrant,
     value: "hydrant",
@@ -169,6 +171,36 @@ export const generateAddCertAuthorityData = (
           url: customESTUrl,
           username: customESTUsername,
           password: customESTPassword,
+        },
+      };
+    }
+    case "ejbca": {
+      const {
+        name: ejbcaName,
+        url: ejbcaUrl,
+        clientP12Base64,
+        clientP12Password,
+        trustCABundle,
+        certificateAuthorityNameEJBCA,
+        certificateProfileName,
+        endEntityProfileName,
+        usernameTemplate,
+        userPrincipalName,
+      } = formData as IEJBCAFormData;
+      return {
+        ejbca: {
+          name: ejbcaName,
+          url: ejbcaUrl,
+          client_p12: clientP12Base64,
+          client_p12_password: clientP12Password,
+          trust_ca_bundle: trustCABundle || undefined,
+          certificate_authority_name_ejbca: certificateAuthorityNameEJBCA,
+          certificate_profile_name: certificateProfileName,
+          end_entity_profile_name: endEntityProfileName,
+          username_template: usernameTemplate,
+          certificate_user_principal_names: userPrincipalName
+            ? [userPrincipalName]
+            : null,
         },
       };
     }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/EJBCAForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/EJBCAForm.tsx
@@ -154,7 +154,11 @@ const EJBCAForm = ({
         }
         additionalInfo="Enroll a service certificate in EJBCA (Client Authentication EKU), bind it to a Fleet admin role, then upload the .p12 here."
         buttonMessage="Upload"
-        internalError={p12Error || formValidation.clientP12Base64?.message}
+        // Only surface concrete failures (file-read errors). The "required"
+        // state is communicated implicitly by the empty upload widget and
+        // by the disabled submit button; an always-on red error before
+        // any interaction reads as broken.
+        internalError={p12Error}
         onFileUpload={onP12Upload}
         fileDetails={
           clientP12FileName ? { name: clientP12FileName } : undefined

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/EJBCAForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/EJBCAForm.tsx
@@ -1,0 +1,257 @@
+import React, { useMemo, useState } from "react";
+
+import { ICertificateAuthorityPartial } from "interfaces/certificates";
+
+import InputField from "components/forms/fields/InputField";
+import Button from "components/buttons/Button";
+import FileUploader from "components/FileUploader";
+import TooltipWrapper from "components/TooltipWrapper";
+import {
+  generateFormValidations,
+  IEJBCAFormValidation,
+  readFileAsBase64,
+  validateFormData,
+} from "./helpers";
+
+const baseClass = "ejbca-form";
+
+export interface IEJBCAFormData {
+  name: string;
+  url: string;
+  /** base64-encoded contents of the uploaded .p12 — empty when not rotating */
+  clientP12Base64: string;
+  /** the original filename, used purely for display */
+  clientP12FileName: string;
+  clientP12Password: string;
+  trustCABundle: string;
+  certificateAuthorityNameEJBCA: string;
+  certificateProfileName: string;
+  endEntityProfileName: string;
+  usernameTemplate: string;
+  /** single UPN to embed in the SAN otherName extension; the backend accepts
+   * an array so we wrap this into [upn] on submit. Empty string = no UPN. */
+  userPrincipalName: string;
+}
+
+interface IEJBCAFormProps {
+  certAuthorities?: ICertificateAuthorityPartial[];
+  formData: IEJBCAFormData;
+  submitBtnText: string;
+  isSubmitting: boolean;
+  isEditing?: boolean;
+  isDirty?: boolean;
+  onChange: (update: { name: string; value: string }) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+const EJBCAForm = ({
+  certAuthorities,
+  formData,
+  submitBtnText,
+  isSubmitting,
+  isEditing = false,
+  isDirty = true,
+  onChange,
+  onSubmit,
+  onCancel,
+}: IEJBCAFormProps) => {
+  const validations = useMemo(
+    () => generateFormValidations(certAuthorities ?? [], isEditing),
+    [certAuthorities, isEditing]
+  );
+
+  const [formValidation, setFormValidation] = useState<IEJBCAFormValidation>(
+    () => validateFormData(formData, validations)
+  );
+  const [p12Error, setP12Error] = useState<string | undefined>();
+
+  const {
+    name,
+    url,
+    clientP12FileName,
+    clientP12Password,
+    trustCABundle,
+    certificateAuthorityNameEJBCA,
+    certificateProfileName,
+    endEntityProfileName,
+    usernameTemplate,
+    userPrincipalName,
+  } = formData;
+
+  const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    onSubmit();
+  };
+
+  const onInputChange = (update: { name: string; value: string }) => {
+    setFormValidation(
+      validateFormData(
+        { ...formData, [update.name]: update.value },
+        validations
+      )
+    );
+    onChange(update);
+  };
+
+  const onP12Upload = async (files: FileList | null) => {
+    setP12Error(undefined);
+    const file = files?.[0];
+    if (!file) {
+      return;
+    }
+    // The .p12 extension is conventional; we don't enforce it strictly
+    // because EJBCA's RA Web can also emit .pfx for the same format. The
+    // backend rejects anything that isn't a valid PKCS#12 on decode.
+    try {
+      const base64 = await readFileAsBase64(file);
+      onInputChange({ name: "clientP12Base64", value: base64 });
+      onInputChange({ name: "clientP12FileName", value: file.name });
+    } catch (err) {
+      setP12Error("Couldn't read the file. Please try again.");
+    }
+  };
+
+  const onP12Delete = () => {
+    onInputChange({ name: "clientP12Base64", value: "" });
+    onInputChange({ name: "clientP12FileName", value: "" });
+    onInputChange({ name: "clientP12Password", value: "" });
+  };
+
+  const p12Label = isEditing
+    ? "Client certificate (.p12) — upload to rotate"
+    : "Client certificate (.p12)";
+
+  return (
+    <form className={baseClass} onSubmit={onSubmitForm}>
+      <InputField
+        name="name"
+        label="Name"
+        value={name}
+        onChange={onInputChange}
+        error={formValidation.name?.message}
+        helpText="Letters, numbers, and underscores only. Fleet creates configuration profile variables with this name as suffix (e.g. $FLEET_VAR_EJBCA_DATA_WIFI_CERTIFICATE)."
+        parseTarget
+        placeholder="WIFI_CERTIFICATE"
+      />
+      <InputField
+        name="url"
+        label="EJBCA REST URL"
+        value={url}
+        onChange={onInputChange}
+        error={formValidation.url?.message}
+        parseTarget
+        helpText="Base URL of your EJBCA REST API endpoint."
+        placeholder="https://ejbca.example.com:8443"
+      />
+      <FileUploader
+        graphicName="file-pem"
+        accept=".p12,.pfx,application/x-pkcs12"
+        label={p12Label}
+        message={
+          clientP12FileName ||
+          "Drop your PKCS#12 (.p12) file here or click Upload."
+        }
+        additionalInfo="Enroll a service certificate in EJBCA (Client Authentication EKU), bind it to a Fleet admin role, then upload the .p12 here."
+        buttonMessage="Upload"
+        internalError={p12Error || formValidation.clientP12Base64?.message}
+        onFileUpload={onP12Upload}
+        fileDetails={
+          clientP12FileName ? { name: clientP12FileName } : undefined
+        }
+        onDeleteFile={onP12Delete}
+        canEdit
+      />
+      <InputField
+        type="password"
+        name="clientP12Password"
+        label={
+          isEditing
+            ? "PKCS#12 password (required only when uploading a new .p12)"
+            : "PKCS#12 password"
+        }
+        value={clientP12Password}
+        onChange={onInputChange}
+        parseTarget
+        helpText="Used once to decrypt the uploaded .p12; never stored."
+      />
+      <InputField
+        type="textarea"
+        name="trustCABundle"
+        label="Trust CA bundle (PEM) — optional"
+        value={trustCABundle}
+        onChange={onInputChange}
+        parseTarget
+        helpText="Paste the EJBCA-issuing CA chain (PEM) only if EJBCA's HTTPS certificate isn't already trusted by Fleet's system root store (typical for self-hosted EJBCA)."
+        placeholder="-----BEGIN CERTIFICATE-----..."
+      />
+      <InputField
+        name="certificateAuthorityNameEJBCA"
+        label="EJBCA Certificate Authority name"
+        value={certificateAuthorityNameEJBCA}
+        onChange={onInputChange}
+        parseTarget
+        helpText="The name of the issuing CA inside EJBCA (free text — must match your EJBCA config exactly)."
+        placeholder="WifiIssuingCA"
+      />
+      <InputField
+        name="certificateProfileName"
+        label="EJBCA Certificate Profile name"
+        value={certificateProfileName}
+        onChange={onInputChange}
+        parseTarget
+        helpText='Must permit "Allow Extension Override" if you use UPN templating.'
+        placeholder="WifiClientProfile"
+      />
+      <InputField
+        name="endEntityProfileName"
+        label="EJBCA End Entity Profile name"
+        value={endEntityProfileName}
+        onChange={onInputChange}
+        parseTarget
+        helpText="Must be configured to permit user-supplied passwords. EJBCA Enterprise also requires auto-create-EE to be enabled for fleet-scale enrollment."
+        placeholder="WifiUsers"
+      />
+      <InputField
+        name="usernameTemplate"
+        label="Username template"
+        value={usernameTemplate}
+        onChange={onInputChange}
+        parseTarget
+        helpText="Used as both the EJBCA end-entity username and the CSR Common Name (CN). Supports $FLEET_VAR_HOST_HARDWARE_SERIAL, $FLEET_VAR_HOST_PLATFORM, $FLEET_VAR_HOST_END_USER_EMAIL_IDP."
+        placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
+      />
+      <InputField
+        name="userPrincipalName"
+        label="User principal name (UPN) — optional"
+        value={userPrincipalName}
+        onChange={onInputChange}
+        parseTarget
+        helpText="Embedded in the certificate's Subject Alternative Name as a Microsoft UPN otherName. Supports the same Fleet variables as the username template."
+        placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
+      />
+      <div className="modal-cta-wrap">
+        <TooltipWrapper
+          tipContent="Complete all required fields to save."
+          underline={false}
+          position="top"
+          disableTooltip={formValidation.isValid}
+          showArrow
+        >
+          <Button
+            isLoading={isSubmitting}
+            disabled={!formValidation.isValid || isSubmitting || !isDirty}
+            type="submit"
+          >
+            {submitBtnText}
+          </Button>
+        </TooltipWrapper>
+        <Button variant="inverse" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default EJBCAForm;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/helpers.ts
@@ -68,8 +68,11 @@ export const generateFormValidations = (
         },
         {
           name: "validUrl",
+          // EJBCA is self-hosted, so localhost / IPs are legitimate URLs
+          // (dev setups, SSH tunnels, internal LBs without DNS). Unlike
+          // DigiCert which is SaaS at a fixed public domain.
           isValid: (formData: IEJBCAFormData) =>
-            valid_url({ url: formData.url }),
+            valid_url({ url: formData.url, allowLocalHost: true }),
           message: "Must be a valid URL.",
         },
       ],

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/helpers.ts
@@ -1,0 +1,193 @@
+import { ICertificateAuthorityPartial } from "interfaces/certificates";
+
+import valid_url from "components/forms/validators/valid_url";
+
+import { IEJBCAFormData } from "./EJBCAForm";
+
+export interface IEJBCAFormValidation {
+  isValid: boolean;
+  name?: { isValid: boolean; message?: string };
+  url?: { isValid: boolean; message?: string };
+  clientP12Base64?: { isValid: boolean; message?: string };
+  clientP12Password?: { isValid: boolean };
+  certificateAuthorityNameEJBCA?: { isValid: boolean };
+  certificateProfileName?: { isValid: boolean };
+  endEntityProfileName?: { isValid: boolean };
+  usernameTemplate?: { isValid: boolean };
+}
+
+type IMessageFunc = (formData: IEJBCAFormData) => string;
+type IValidationMessage = string | IMessageFunc;
+type IFormValidationKey = keyof Omit<IEJBCAFormValidation, "isValid">;
+
+interface IValidation {
+  name: string;
+  isValid: (formData: IEJBCAFormData) => boolean;
+  message?: IValidationMessage;
+}
+
+type IFormValidations = Record<
+  IFormValidationKey,
+  { validations: IValidation[] }
+>;
+
+export const generateFormValidations = (
+  certAuthorities: ICertificateAuthorityPartial[],
+  isEditing: boolean
+) => {
+  const FORM_VALIDATIONS: IFormValidations = {
+    name: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IEJBCAFormData) => formData.name.length > 0,
+        },
+        {
+          name: "invalidCharacters",
+          isValid: (formData: IEJBCAFormData) =>
+            /^[a-zA-Z0-9_]+$/.test(formData.name),
+          message:
+            "Invalid characters. Only letters, numbers and underscores allowed.",
+        },
+        {
+          name: "unique",
+          isValid: (formData: IEJBCAFormData) =>
+            isEditing ||
+            certAuthorities.find(
+              (cert) => cert.type === "ejbca" && cert.name === formData.name
+            ) === undefined,
+          message: "Name is already used by another EJBCA CA.",
+        },
+      ],
+    },
+    url: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IEJBCAFormData) => formData.url.length > 0,
+        },
+        {
+          name: "validUrl",
+          isValid: (formData: IEJBCAFormData) =>
+            valid_url({ url: formData.url }),
+          message: "Must be a valid URL.",
+        },
+      ],
+    },
+    clientP12Base64: {
+      validations: [
+        {
+          // When editing, the cert+key are already stored — uploading a new
+          // P12 is optional and only triggers a rotation.
+          name: "required",
+          isValid: (formData: IEJBCAFormData) =>
+            isEditing || formData.clientP12Base64.length > 0,
+          message: "A PKCS#12 client certificate is required.",
+        },
+      ],
+    },
+    clientP12Password: {
+      validations: [
+        {
+          // Password is only required when a new P12 has been supplied
+          // (whether on create or during edit rotation).
+          name: "required-with-p12",
+          isValid: (formData: IEJBCAFormData) =>
+            formData.clientP12Base64.length === 0 ||
+            formData.clientP12Password.length > 0,
+        },
+      ],
+    },
+    certificateAuthorityNameEJBCA: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IEJBCAFormData) =>
+            formData.certificateAuthorityNameEJBCA.length > 0,
+        },
+      ],
+    },
+    certificateProfileName: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IEJBCAFormData) =>
+            formData.certificateProfileName.length > 0,
+        },
+      ],
+    },
+    endEntityProfileName: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IEJBCAFormData) =>
+            formData.endEntityProfileName.length > 0,
+        },
+      ],
+    },
+    usernameTemplate: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IEJBCAFormData) =>
+            formData.usernameTemplate.length > 0,
+        },
+      ],
+    },
+  };
+  return FORM_VALIDATIONS;
+};
+
+const getErrorMessage = (
+  formData: IEJBCAFormData,
+  message?: IValidationMessage
+) => {
+  if (message === undefined || typeof message === "string") {
+    return message;
+  }
+  return message(formData);
+};
+
+export const validateFormData = (
+  formData: IEJBCAFormData,
+  validationConfig: IFormValidations
+) => {
+  const formValidation: IEJBCAFormValidation = { isValid: true };
+
+  Object.keys(validationConfig).forEach((key) => {
+    const objKey = key as keyof typeof validationConfig;
+    const failedValidation = validationConfig[objKey].validations.find(
+      (validation) => !validation.isValid(formData)
+    );
+
+    if (!failedValidation) {
+      formValidation[objKey] = { isValid: true };
+    } else {
+      formValidation.isValid = false;
+      formValidation[objKey] = {
+        isValid: false,
+        message: getErrorMessage(formData, failedValidation.message),
+      };
+    }
+  });
+
+  return formValidation;
+};
+
+/**
+ * Read a File into a base64 string suitable for sending to the API as
+ * `client_p12`. The server decodes the bytes with `client_p12_password`,
+ * extracts cert + key, and discards both upload fields. Strips the
+ * `data:...;base64,` prefix that FileReader prepends.
+ */
+export const readFileAsBase64 = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => {
+      const result = reader.result as string;
+      const commaIdx = result.indexOf(",");
+      resolve(commaIdx === -1 ? result : result.slice(commaIdx + 1));
+    };
+    reader.readAsDataURL(file);
+  });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EJBCAForm";

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
@@ -18,6 +18,7 @@ import {
 } from "./helpers";
 
 import DigicertForm from "../DigicertForm";
+import EJBCAForm from "../EJBCAForm";
 import { ICertFormData } from "../AddCertAuthorityModal/AddCertAuthorityModal";
 import NDESForm from "../NDESForm";
 import CustomSCEPForm from "../CustomSCEPForm";
@@ -98,6 +99,8 @@ const EditCertAuthorityModal = ({
         return CustomSCEPForm;
       case "custom_est_proxy":
         return CustomESTForm;
+      case "ejbca":
+        return EJBCAForm;
       default:
         throw new Error(
           `Unknown certificate authority type: ${certAuthority.type}`

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -11,6 +11,7 @@ import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
 import { ICertFormData } from "../AddCertAuthorityModal/AddCertAuthorityModal";
 import { getDisplayErrMessage } from "../AddCertAuthorityModal/helpers";
 import { IDigicertFormData } from "../DigicertForm/DigicertForm";
+import { IEJBCAFormData } from "../EJBCAForm/EJBCAForm";
 import { INDESFormData } from "../NDESForm/NDESForm";
 import { ICustomSCEPFormData } from "../CustomSCEPForm/CustomSCEPForm";
 import { IHydrantFormData } from "../HydrantForm/HydrantForm";
@@ -68,6 +69,24 @@ export const generateDefaultFormData = (
         url: certAuthority.url,
         username: certAuthority.username,
         password: certAuthority.password,
+      };
+    case "ejbca":
+      return {
+        name: certAuthority.name,
+        url: certAuthority.url,
+        // Edit form leaves the upload fields empty unless the admin uploads
+        // a new .p12 to rotate.
+        clientP12Base64: "",
+        clientP12FileName: "",
+        clientP12Password: "",
+        trustCABundle: certAuthority.trust_ca_bundle ?? "",
+        certificateAuthorityNameEJBCA:
+          certAuthority.certificate_authority_name_ejbca,
+        certificateProfileName: certAuthority.certificate_profile_name,
+        endEntityProfileName: certAuthority.end_entity_profile_name,
+        usernameTemplate: certAuthority.username_template,
+        userPrincipalName:
+          certAuthority.certificate_user_principal_names?.[0] ?? "",
       };
     default:
       throw new Error(
@@ -215,6 +234,44 @@ export const generateEditCertAuthorityData = (
       }
       return diff;
     }
+    case "ejbca": {
+      const {
+        name: ejbcaName,
+        url: ejbcaUrl,
+        clientP12Base64,
+        clientP12Password,
+        trustCABundle,
+        certificateAuthorityNameEJBCA,
+        certificateProfileName,
+        endEntityProfileName,
+        usernameTemplate,
+        userPrincipalName,
+      } = formData as IEJBCAFormData;
+      // Compute the diff against the stored EJBCA fields, then inject the
+      // P12 + password only when the admin actually uploaded a new bundle
+      // (rotation). Both must travel together — the backend rejects one
+      // without the other.
+      const diff = deepDifference(
+        {
+          name: ejbcaName,
+          url: ejbcaUrl,
+          trust_ca_bundle: trustCABundle,
+          certificate_authority_name_ejbca: certificateAuthorityNameEJBCA,
+          certificate_profile_name: certificateProfileName,
+          end_entity_profile_name: endEntityProfileName,
+          username_template: usernameTemplate,
+          certificate_user_principal_names: userPrincipalName
+            ? [userPrincipalName]
+            : null,
+        },
+        certAuthWithoutType
+      ) as Record<string, unknown>;
+      if (clientP12Base64) {
+        diff.client_p12 = clientP12Base64;
+        diff.client_p12_password = clientP12Password;
+      }
+      return { ejbca: diff };
+    }
     default:
       throw new Error(
         `Unknown certificate authority type: ${certAuthority.type}`
@@ -332,6 +389,12 @@ export const updateFormData = (
       }
       break;
     }
+    case "ejbca":
+      // No special "clear other fields" behavior for EJBCA edits. The
+      // rotation case (new P12 + password) is handled by the form
+      // itself — both fields travel together when present, and neither
+      // is auto-cleared by editing a different field.
+      break;
     default:
       throw new Error(
         `Unknown certificate authority type: ${certAuthority.type}`

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/helpers.tsx
@@ -4,6 +4,7 @@ const CA_LABEL_BY_TYPE: Record<ICertificateAuthorityType, string> = {
   custom_est_proxy: "Custom Enrollment Over Secure Transport (EST)",
   custom_scep_proxy: "Custom Simple Certificate Enrollment Protocol (SCEP)",
   digicert: "DigiCert",
+  ejbca: "EJBCA",
   hydrant: "Hydrant Enrollment Over Secure Transport (EST)",
   ndes_scep_proxy:
     "Dynamic SCEP - Okta CA or Microsoft Network Device Enrollment Service (NDES)",

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -6,6 +6,7 @@ import {
   ICertificateAuthority,
   ICertificatesCustomSCEP,
   ICertificatesDigicert,
+  ICertificatesEJBCA,
   ICertificatesHydrant,
   ICertificatesNDES,
   ICertificatesSmallstep,
@@ -35,7 +36,8 @@ export type IAddCertAuthorityFormData =
   | { custom_scep_proxy: ICertificatesCustomSCEP }
   | { hydrant: ICertificatesHydrant }
   | { smallstep: ICertificatesSmallstep }
-  | { custom_est_proxy: ICertificatesCustomEST };
+  | { custom_est_proxy: ICertificatesCustomEST }
+  | { ejbca: ICertificatesEJBCA };
 
 export type IEditCertAuthorityFormData =
   | { digicert: Partial<ICertificatesDigicert> }
@@ -43,7 +45,8 @@ export type IEditCertAuthorityFormData =
   | { custom_scep_proxy: Partial<ICertificatesCustomSCEP> }
   | { hydrant: Partial<ICertificatesHydrant> }
   | { smallstep: Partial<ICertificatesSmallstep> }
-  | { custom_est_proxy: Partial<ICertificatesCustomEST> };
+  | { custom_est_proxy: Partial<ICertificatesCustomEST> }
+  | { ejbca: Partial<ICertificatesEJBCA> };
 
 interface IGetCertsParams extends PaginationParams {
   // not supported: after, order key, order direction, match query, meta (always included)

--- a/openspec/changes/add-ejbca-rest-ca-poc/customer-design-review.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/customer-design-review.md
@@ -1,0 +1,397 @@
+# EJBCA integration — design review
+
+A summary of the proposed Fleet ↔ EJBCA integration, the design choices
+we've made (with rationale and recommendations), and the open questions
+we'd like to confirm before we cut the production release.
+
+Audience: product, design, and the prospective customer
+([`prospect-homerus`](https://github.com/fleetdm/fleet/issues/29176)).
+The technical companion to this doc is
+[`research.md`](./research.md).
+
+## At a glance
+
+- **What**: A new "EJBCA" certificate authority option in Fleet's
+  Settings → Integrations → Certificate authorities, alongside the
+  existing DigiCert, NDES SCEP, Smallstep, Hydrant, and Custom-SCEP
+  integrations.
+- **Why**: Lets IT admins migrating from AD CS to EJBCA continue
+  deploying certificates to macOS hosts (WiFi / VPN) through Fleet
+  without managing PKI on the side.
+- **How (one sentence)**: The admin uploads a service certificate from
+  their EJBCA to Fleet; Fleet uses it to enroll a per-host certificate
+  via EJBCA's REST API and delivers it to the host through MDM.
+- **State**: POC complete and verified end-to-end against EJBCA
+  Community Edition; this doc is the bridge to the customer
+  conversation and the production-release scoping.
+
+## Background
+
+The customer is moving their certificate authority from Microsoft
+**AD CS to EJBCA** and wants to keep using Fleet to deploy WiFi/VPN
+certificates to macOS hosts. They're a cert-native shop — the team
+already operates PKI day-to-day — so the design assumes PKI fluency on
+their side. Fleet already integrates with EJBCA over SCEP (the
+existing "Custom SCEP Proxy" path); this work adds EJBCA's **REST
+API** as a parallel, more modern path that customer expectations
+increasingly assume.
+
+## What we're building
+
+From the IT admin's perspective:
+
+1. Their EJBCA admin enrolls a service certificate that represents
+   Fleet's identity inside EJBCA, and binds it to a custom admin role
+   with narrow permissions (only the right CA, only the right
+   end-entity profile).
+2. They add an **EJBCA certificate authority** in Fleet's UI: upload
+   the service certificate (as a `.p12` bundle with its password),
+   paste the URL and a few EJBCA-side names, save.
+3. They create a Fleet **configuration profile** that references the
+   new CA (`$FLEET_VAR_EJBCA_DATA_<name>` /
+   `$FLEET_VAR_EJBCA_PASSWORD_<name>` in the `<data>` and `<password>`
+   fields of a `com.apple.security.pkcs12` payload).
+4. As macOS hosts pick up the profile, Fleet enrolls a unique
+   certificate per host from EJBCA and the host installs it into its
+   keychain. WiFi or VPN clients then use the cert to authenticate.
+
+The admin doesn't write code or schedule certificate renewals — Fleet
+handles per-host enrollment automatically.
+
+## What the customer needs to have configured on EJBCA's side
+
+These are not Fleet design decisions; they're prerequisites the
+customer's PKI admin must have in place on their EJBCA before the
+integration can function. We document them so the customer-onboarding
+guide can call them out as a checklist.
+
+- **End Entity Profile configured to auto-create end entities during
+  enrollment.** Without this, every macOS host that requests a cert
+  fails until someone manually pre-creates an entry in EJBCA. This is
+  a standard EJBCA Enterprise capability; the customer's PKI admin
+  toggles it in the EE profile. EJBCA Community Edition cannot do it
+  (which limits us to single-host testing for the POC against CE; the
+  customer's production EJBCA Enterprise handles it natively).
+- **A custom administrator role in EJBCA bound to Fleet's service
+  certificate**, with narrowly-scoped access rules (only the right
+  issuing CA, only the right End Entity Profile). We strongly
+  recommend against using EJBCA's built-in Super Administrator role
+  for Fleet's identity — least privilege is the right shape and means
+  a compromise of Fleet's host doesn't expose the rest of the customer's
+  PKI.
+- **The relevant REST API protocols enabled** in EJBCA's system
+  configuration (specifically "REST Certificate Management" — covers
+  both the connection probe and certificate enrollment endpoints).
+  Disabled by default in some EJBCA versions; enabled by default in
+  production Enterprise deployments. We'll surface a clear error if
+  the customer hits a disabled-protocol response.
+
+## Already confirmed with the customer
+
+### Authentication method: mTLS (mutual TLS)
+
+Fleet authenticates to the customer's EJBCA by presenting a client
+certificate — the same way EJBCA admins authenticate to its UI. The
+customer's PKI admin enrolls a service certificate for Fleet, hands it
+to us as a `.p12`, and binds that certificate to an admin role in
+EJBCA. Confirmed with the customer; OAuth (the alternative we
+considered) remains a deferred follow-up for shops that prefer it.
+
+## Design decisions for review
+
+Each subsection states **what's being decided**, **the
+recommendation**, and **why**. Where there are realistic alternatives
+we mention them briefly.
+
+### Client certificate upload format
+
+**Decision: Fleet accepts a PKCS#12 (`.p12`) file with its password
+for the service certificate.**
+
+When an EJBCA admin enrolls Fleet's service certificate, EJBCA's web
+UI hands them a `.p12` file (a standard PKI bundle containing both
+the certificate and its private key, encrypted with a password). We
+accept that format directly in Fleet's UI: drag-and-drop or click-to-
+upload the `.p12`, enter the password the admin set when downloading
+it, and Fleet handles the rest.
+
+The alternative format would be **PEM** — separate text files for the
+certificate and the private key. Admins who export from a secrets
+manager often have PEM; admins who download straight from EJBCA's UI
+get `.p12`. For v1 we ship the `.p12` path only because that's the
+default EJBCA workflow. PEM-direct upload is a small follow-up if
+customers request it.
+
+### Per-enrollment password handling
+
+**Decision: Fleet generates a unique random password per enrollment
+internally; no admin-visible field.**
+
+EJBCA's enrollment API requires a `password` field on every
+certificate request. Historically, this dates back to a pattern where
+a human admin would pre-create an "end entity" with a known password,
+then hand the password to the user, who would present it during
+enrollment as proof of authorization. In modern automated integrations
+(Fleet → EJBCA), this two-party flow doesn't apply: the mTLS client
+certificate already authenticates Fleet, and EJBCA's access rules
+control what Fleet can do.
+
+Under the customer's typical configuration (auto-create end entities,
+permissive password policy), the password EJBCA receives isn't
+actually authenticating anything — it's a required field with no
+gating role. Rather than surface a configurable field that's
+misleading about its security value, **Fleet generates a unique
+random password on each enrollment and discards it.** No persistent
+shared secret to rotate, no audit story confused by reused passwords,
+no admin-facing field to explain.
+
+If a customer's EJBCA is configured to require a specific shared
+password (uncommon but possible), the configurable-field variant is a
+small follow-up. Customer question #7 below asks if that's the case
+for `prospect-homerus`.
+
+### Trust CA bundle (verifying EJBCA's TLS certificate)
+
+**Decision: optional but strongly recommended field in the UI.**
+
+When Fleet talks to EJBCA, the connection is over HTTPS, which means
+Fleet has to verify EJBCA's TLS certificate. If the customer's EJBCA
+is fronted by a publicly-trusted certificate (e.g., from a public CA
+like DigiCert), Fleet's built-in trust store handles verification
+automatically and the customer doesn't need to do anything. If
+EJBCA's TLS cert is signed by an internal CA (the more common case
+for self-hosted EJBCA — most of our deployments), Fleet needs to be
+explicitly told to trust that internal CA.
+
+We expose a **"Trust CA bundle"** field on the EJBCA add-CA form
+where the admin can paste the CA chain. It's labeled optional because
+the publicly-trusted case is real, but UI help text and error
+messages strongly nudge customers in the more-common self-hosted
+case to fill it in. When the connection probe fails because of an
+untrusted cert, Fleet returns a specific error guiding them to this
+field.
+
+### mTLS service certificate: rotation and expiry notification
+
+**Decision (recommendation: pull into v1 scope): show client-cert
+expiry on the CA list and warn before it expires.**
+
+Fleet's service certificate inside EJBCA has a lifetime (commonly 1
+year). When it expires, Fleet's enrollment requests start failing
+silently — existing host certificates keep working, but new
+enrollments stop. From the admin's perspective, the failure mode is
+"WiFi worked last month, why is it broken for new hires now?" — a
+very expensive bug to debug.
+
+Rotation itself works through the standard CA edit flow: open the
+EJBCA CA in Fleet, re-upload the new `.p12`, save. We strongly
+recommend **also shipping a proactive warning**:
+
+- On the certificate authorities list page, show the days-until-expiry
+  for each EJBCA CA as a badge
+- Visual warning state ≤30 days, error state ≤7 days
+- Optional: email or in-app notification at the same thresholds
+
+The backend already parses and exposes the expiry date as part of the
+POC; the work is purely surfacing it in the UI. Without this, the
+customer's first rotation experience will be a production outage.
+
+### Apple MDM payload coverage
+
+**Decision: same coverage as the existing DigiCert integration.**
+
+Fleet's existing DigiCert integration supports a defined set of
+macOS configuration profile payload types (WiFi with EAP-TLS, VPN,
+generic PKCS#12 distribution). The EJBCA integration adopts the same
+surface so customers migrating from DigiCert have a 1:1 experience,
+and so we don't expand the payload-validation surface area beyond
+what the existing flow already handles. Subject Alternative Name
+support also follows DigiCert: Common Name (always) plus Microsoft
+User Principal Name (optional, embedded as an `otherName` SAN
+extension).
+
+### Relationship to the existing SCEP-EJBCA integration
+
+**Decision: both paths coexist as alternatives; no migration required.**
+
+Fleet already integrates with EJBCA via the "Custom SCEP Proxy" CA
+type, which uses EJBCA's SCEP endpoint rather than its REST API.
+That integration continues to work; customers using it don't need to
+switch. The new EJBCA (REST) integration is offered alongside,
+positioned for customers who:
+
+- Are setting up a new EJBCA integration today (REST is the more
+  modern path that EJBCA itself documents first)
+- Want to take advantage of EJBCA Enterprise's auto-create-EE flow
+  that doesn't require pre-registering every host
+
+The two paths are independently configurable; a customer could even
+run both side-by-side against the same EJBCA if they had a reason to.
+
+### Platform scope
+
+**Decision: macOS only in v1.**
+
+The customer's stated use case is macOS WiFi/VPN. Each additional
+platform (Windows, Linux, Android) has its own MDM profile schema
+and would expand the validation/templating surface area meaningfully.
+Other platforms remain on the roadmap as follow-ups for any customer
+that asks; the EJBCA backend client we're building is platform-
+agnostic, so this is a UI-and-validation scope decision, not a deep
+architectural one.
+
+### GitOps configuration
+
+**Decision (recommendation: in v1): EJBCA CAs configurable via GitOps
+alongside the UI and API paths.**
+
+Fleet's existing CA types — DigiCert, NDES SCEP, Custom SCEP,
+Smallstep, Hydrant, Custom EST — all support being configured via
+GitOps YAML in the `certificate_authorities` block, in addition to
+the UI and API. Customers using GitOps to manage their Fleet
+configuration as code expect new CA types to participate in that same
+flow on day one; shipping without it creates a real wart for
+infrastructure-as-code shops who'd otherwise have to configure their
+EJBCA CA out-of-band and remember not to overwrite it.
+
+The mechanical pattern follows the existing CA types directly. The
+one EJBCA-specific shape: because GitOps YAML can't carry binary
+files natively, the service certificate (`.p12`) is supplied as a
+base64-encoded string in the YAML — typically combined with Fleet's
+existing `$ENV_VAR` substitution so the actual bytes stay in a
+secrets manager and don't get committed to git.
+
+```yaml
+certificate_authorities:
+  ejbca:
+    - name: Corp_EJBCA
+      url: https://ejbca.corp.example.com:8443
+      client_p12_base64: $FLEET_SECRET_EJBCA_P12_B64
+      client_p12_password: $FLEET_SECRET_EJBCA_P12_PASSWORD
+      trust_ca_bundle: |
+        -----BEGIN CERTIFICATE-----
+        ...
+      certificate_authority_name_ejbca: WifiIssuingCA
+      certificate_profile_name:        WifiClientProfile
+      end_entity_profile_name:         WifiUsers
+      username_template:               $FLEET_VAR_HOST_HARDWARE_SERIAL
+```
+
+The POC scoped GitOps out for time; the production work brings it in.
+
+## Notes on existing Fleet behavior that applies here
+
+Things the customer should know about, but that aren't decisions —
+these match how every other CA type in Fleet already works.
+
+- **Updating a CA in Fleet does not re-issue certificates on hosts.**
+  When the admin edits a CA configuration (rotates credentials,
+  changes EJBCA-side profile names, updates the trust bundle), only
+  *future* enrollments use the new config. Existing host certificates
+  remain installed and valid until they expire naturally. This is the
+  safe default and matches every other CA type — auto-reissuing on
+  every config edit would hammer the customer's CA and force
+  unnecessary cert churn on hosts.
+- **Rotating Fleet's service certificate is the standard edit flow.**
+  When Fleet's service cert in EJBCA expires (or before), the admin
+  opens the EJBCA CA in Fleet, re-uploads the new `.p12`, saves.
+  Fleet re-verifies against EJBCA before persisting; existing host
+  certs are unaffected; new enrollments use the new credentials.
+
+## Open questions for the customer
+
+We've grouped these by what hinges on the answer.
+
+**Functional prerequisites — confirming these unblocks the rest:**
+
+1. Is your production EJBCA configured to **auto-create end entities**
+   during certificate enrollment? *(EJBCA Enterprise supports this;
+   we assume yes given your migration plan, but it's worth a sanity
+   check.)*
+2. Will you be providing a **trust CA bundle** for Fleet (your EJBCA's
+   internal issuing CA chain), or is your EJBCA fronted by a
+   publicly-trusted TLS certificate?
+3. Are you comfortable binding Fleet's service certificate to a
+   **custom least-privilege admin role** in EJBCA rather than Super
+   Administrator? We'll document the minimum set of access rules.
+
+**Strategic / posture questions — informs whether to bring OAuth
+forward:**
+
+4. Does your organization run an **OIDC Identity Provider** (Okta,
+   EntraID, Keycloak, PingID) you'd want Fleet's EJBCA access to flow
+   through eventually, or is mTLS the long-term fit?
+5. What's your **expected lifetime** for Fleet's service certificate,
+   and how do you typically rotate machine credentials?
+6. Will Fleet be deployed as **Fleet Cloud (hosted)** or **self-hosted**
+   on your infrastructure?
+
+**Workflow questions — confirms our chosen defaults fit how you'll
+actually use this:**
+
+7. Will any of your existing automation depend on Fleet sending a
+   **specific, known enrollment code** (a shared secret you've
+   configured in your EJBCA's End Entity Profile)? If yes, we'd add a
+   configurable field; if no, the simpler "Fleet generates one
+   internally" design fits.
+8. Are you planning to use **UPN SAN** for the issued certificates
+   (Microsoft User Principal Name embedded in Subject Alternative
+   Name)? We support it; if you're using DNS or email SAN instead, the
+   defaults for new certs would change.
+
+## What's deferred to a later release
+
+Not gone, just not in v1. Each is captured in the technical design
+with enough notes for the production work to pick up.
+
+- **OAuth 2.0 bearer-token authentication** (alternative to mTLS, for
+  shops that prefer OIDC-based service-to-service auth)
+- **PEM-direct upload** for the service certificate (alternative to
+  `.p12`)
+- **A dedicated "Replace credentials" UX action** (rotation today goes
+  through the standard edit modal, which is functional but not as
+  prominent as a dedicated workflow)
+- **User-configurable enrollment code** (Fleet currently generates a
+  random password per call internally; configurable is a follow-up if
+  any customer has the use case)
+- **Windows / Linux / Android cert delivery** paths
+- A small set of engineering-side cleanups around how Fleet packages
+  EJBCA's certificate bundle for upload (production-grade replacement
+  for a tactical POC shortcut — see `research.md`)
+
+## Success criteria
+
+We'll know we got this right when:
+
+1. The customer's IT admin can add an EJBCA CA in Fleet, save it, and
+   immediately see Fleet's connection probe to their EJBCA succeed.
+2. A macOS host receiving the relevant configuration profile picks up
+   a real, unique certificate issued by their EJBCA and uses it
+   successfully for WiFi/VPN authentication.
+3. Rotating Fleet's service certificate (when it expires) is a
+   no-drama edit-and-save flow that doesn't disturb already-deployed
+   host certificates **and the admin is warned via UI before it
+   expires** (per the recommendation in §"mTLS service certificate:
+   rotation and expiry notification").
+4. The customer can run the full setup end-to-end from our
+   contributor docs without us on the call.
+
+All four are demonstrably true in the POC against a local EJBCA
+container. Customer confirmation will validate them against a real
+production EJBCA shape.
+
+## What we're asking of you (the customer)
+
+A 30–45 minute call to walk through:
+
+- The eight open questions above
+- Any pieces of the workflow that don't match how your team would
+  actually use this
+- Whether anything in the deferred list is a blocker for your initial
+  rollout
+- Confirmation on whether the **expiry-notification work in v1** (our
+  recommendation) is something you'd actively use, or whether you'd
+  prefer we ship without it and add it later
+
+We'll capture your answers in our internal design doc and use them
+to scope the production release for **Fleet 4.88.0**.

--- a/openspec/changes/add-ejbca-rest-ca-poc/design.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/design.md
@@ -1,0 +1,391 @@
+# Design: EJBCA REST CA integration (POC)
+
+## Architecture
+
+EJBCA slots into Fleet's existing pluggable CA framework. The integration sits
+in the same place DigiCert does, with the same caller shape:
+
+```
+   Apple MDM profile processor
+   ─────────────────────────────
+   (server/mdm/apple/profile_processor.go)
+              │
+              │ for each FLEET_VAR_EJBCA_DATA_<name>:
+              │   1. resolve <name> → EJBCACA row
+              │   2. expand FLEET_VAR_* on per-host fields
+              │   3. call ejbcaService.GetCertificate(ctx, ca)
+              │   4. substitute base64 PKCS12 + password into profile XML
+              ▼
+   ejbca.Service        ◄──── new package
+   ─────────────────────
+   (ee/server/service/ejbca/ejbca.go)
+              │
+              │ HTTP over mTLS
+              ▼
+   ┌──────────────────────────────────┐
+   │  EJBCA REST API                  │
+   │  GET  /v1/ca/status              │  ← verify connection
+   │  POST /v1/certificate/pkcs10enroll │  ← enroll certificate
+   └──────────────────────────────────┘
+```
+
+## Data model
+
+### New type: `fleet.EJBCACA`
+
+In `server/fleet/certificate_authorities.go`, two related shapes — the stored
+record and the create/update payload. (Same pattern as `DigiCertCA` /
+`DigiCertCAUpdatePayload`.)
+
+```go
+// Stored / GET-returned shape. After the server has decoded the uploaded
+// PKCS#12, the cert and key live here as PEM.
+type EJBCACA struct {
+    ID   uint   `json:"id,omitempty"`
+    Name string `json:"name"`
+
+    URL string `json:"url"` // https://ejbca.example.com:8443
+
+    // Server-derived from the uploaded P12. Returned masked when
+    // includeSecrets=false. The original P12 and its password are NOT stored.
+    ClientCertPEM string `json:"client_cert"`     // PEM cert chain (public)
+    ClientKeyPEM  string `json:"client_key"`      // PEM private key (sensitive, encrypted at rest)
+
+    // Optional trust override for EJBCA's HTTPS cert.
+    // Empty = use system root store.
+    TrustCABundlePEM string `json:"trust_ca_bundle,omitempty"`
+
+    // EJBCA-side names — free text, must match EJBCA config exactly.
+    CertificateAuthorityNameEJBCA string `json:"certificate_authority_name_ejbca"`
+    CertificateProfileName        string `json:"certificate_profile_name"`
+    EndEntityProfileName          string `json:"end_entity_profile_name"`
+
+    // Per-enrollment fields. Username template may use Fleet vars.
+    UsernameTemplate              string   `json:"username_template"`
+    CertificateUserPrincipalNames []string `json:"certificate_user_principal_names,omitempty"` // optional UPNs for SAN otherName
+}
+
+// Create/update input shape. The user uploads a P12 + password; the server
+// decodes it, populates the PEM fields on EJBCACA, then discards both the
+// P12 bytes and the password. Neither is ever persisted.
+type EJBCACACreatePayload struct {
+    Name string `json:"name"`
+    URL  string `json:"url"`
+
+    ClientP12         []byte `json:"client_p12"`           // raw P12 bytes
+    ClientP12Password string `json:"client_p12_password"`  // discarded after decode
+
+    TrustCABundlePEM string `json:"trust_ca_bundle,omitempty"`
+
+    CertificateAuthorityNameEJBCA string `json:"certificate_authority_name_ejbca"`
+    CertificateProfileName        string `json:"certificate_profile_name"`
+    EndEntityProfileName          string `json:"end_entity_profile_name"`
+
+    UsernameTemplate              string   `json:"username_template"`
+    CertificateUserPrincipalNames []string `json:"certificate_user_principal_names,omitempty"`
+}
+```
+
+The `CertificateAuthority` polymorphic wrapper gains an `EJBCA *EJBCACA` field
+in `CertificateAuthorityPayload`, plus update-payload and validation methods
+that mirror `DigiCertCA`. PEM-direct upload is deferred — when it lands, it
+becomes an additional set of optional fields on `EJBCACACreatePayload`
+(`client_cert_pem`, `client_key_pem`) with a server-side "exactly one of
+P12 or PEM" check.
+
+### Constants
+
+```go
+// server/fleet/certificate_authorities.go
+const CATypeEJBCA = "ejbca"
+
+// server/fleet/mdm.go
+const (
+    FleetVarEJBCADataPrefix     FleetVarName = "EJBCA_DATA_"
+    FleetVarEJBCAPasswordPrefix FleetVarName = "EJBCA_PASSWORD_" //nolint:gosec
+)
+```
+
+Both prefixes added to the allow-list in `mdm.go`'s prefix check (line ~99) and
+to the EJBCA-aware branches in `profile_processor.go` (`isCAConfigured`,
+`expandVars`).
+
+### Migration
+
+Add columns to the `certificate_authorities` table:
+
+```sql
+ALTER TABLE certificate_authorities
+  ADD COLUMN client_cert_pem            BLOB,
+  ADD COLUMN client_key_encrypted       BLOB,
+  ADD COLUMN trust_ca_bundle_pem        BLOB,
+  ADD COLUMN ejbca_ca_name              VARCHAR(255),
+  ADD COLUMN ejbca_certificate_profile  VARCHAR(255),
+  ADD COLUMN ejbca_end_entity_profile   VARCHAR(255),
+  ADD COLUMN ejbca_username_template    VARCHAR(255);
+```
+
+The `type` ENUM is extended with `'ejbca'`. There is no enrollment-code
+column in the POC — the EJBCA `password` value is generated at issuance
+time and never persisted.
+
+Encryption follows the existing pattern: `serverPrivateKey` symmetric
+encryption for `client_key_encrypted`. The client cert is **not
+encrypted** — it's a public artifact and we display the subject / expiry
+in the UI later. Trust CA bundle is likewise public.
+
+Postprocessing on read masks the PEM private key with
+`fleet.MaskedPassword` when `includeSecrets=false`.
+
+## HTTP client: `ee/server/service/ejbca`
+
+New package mirroring `ee/server/service/digicert`. Two exported methods:
+
+```go
+type Service struct {
+    logger  *slog.Logger
+    timeout time.Duration
+}
+
+var _ fleet.EJBCAService = (*Service)(nil)
+
+func (s *Service) VerifyConnection(ctx context.Context, cfg fleet.EJBCACA) error
+func (s *Service) GetCertificate(ctx context.Context, cfg fleet.EJBCACA) (*fleet.EJBCACertificate, error)
+```
+
+### TLS plumbing
+
+EJBCA requires mTLS, so the client needs a custom `tls.Config`. Add a small
+helper:
+
+```go
+func buildTLSClient(timeout time.Duration, cfg fleet.EJBCACA) (*http.Client, error) {
+    cert, err := tls.X509KeyPair([]byte(cfg.ClientCertPEM), []byte(cfg.ClientKeyPEM))
+    if err != nil {
+        return nil, ctxerr.Wrap(ctx, err, "loading client cert keypair")
+    }
+
+    tlsCfg := &tls.Config{
+        Certificates: []tls.Certificate{cert},
+        MinVersion:   tls.VersionTLS12,
+    }
+    if cfg.TrustCABundlePEM != "" {
+        pool := x509.NewCertPool()
+        if !pool.AppendCertsFromPEM([]byte(cfg.TrustCABundlePEM)) {
+            return nil, errors.New("trust_ca_bundle did not contain any usable certificates")
+        }
+        tlsCfg.RootCAs = pool
+    }
+
+    return fleethttp.NewClient(
+        fleethttp.WithTimeout(timeout),
+        fleethttp.WithTLSClientConfig(tlsCfg),
+    ), nil
+}
+```
+
+`fleethttp.WithTLSClientConfig` already exists (verified in
+`pkg/fleethttp/fleethttp.go:36`) — no fleethttp changes needed.
+
+### `VerifyConnection`
+
+```go
+// GET {URL}/ejbca/ejbca-rest-api/v1/ca/status
+// 200 → ok
+// 401/403 → mTLS auth failed; report distinctly
+// timeout / x509 error → wrap and surface
+```
+
+The response body is JSON `{"status":"OK","version":"...","revision":"..."}`.
+We require `status == "OK"`.
+
+### `GetCertificate`
+
+```go
+// 1. Generate RSA 2048 keypair locally.
+// 2. Build CSR with CommonName = expanded username template.
+//    If CertificateUserPrincipalNames is non-empty, add a subjectAltName
+//    extension to the CSR with one otherName per UPN (OID
+//    1.3.6.1.4.1.311.20.2.3, value type UTF8String). This must be
+//    constructed via raw ASN.1 — Go's stdlib x509.CertificateRequest
+//    doesn't have first-class UPN otherName support. The customer's EJBCA
+//    Certificate Profile must have "Allow Extension Override" enabled or
+//    the SAN will be dropped during issuance (per the existing SCEP dev
+//    guide's gotchas).
+// 3. Generate a 32-byte cryptographically-random value, hex-encode it,
+//    use it as the `password` field. NOT persisted — created at call
+//    time, sent, discarded. EJBCA's backend rejects null password for
+//    any user-storage-enabled CA, so we have to send something; the
+//    value is otherwise transparent to Fleet's operation under the
+//    common auto-create-EE + permissive-password configuration.
+// 4. POST /ejbca/ejbca-rest-api/v1/certificate/pkcs10enroll
+//      {
+//        "certificate_request": <PEM CSR>,
+//        "certificate_profile_name": cfg.CertificateProfileName,
+//        "end_entity_profile_name": cfg.EndEntityProfileName,
+//        "certificate_authority_name": cfg.CertificateAuthorityNameEJBCA,
+//        "username": <expanded UsernameTemplate>,
+//        "password": <generated random hex>,
+//        "include_chain": false,
+//        "response_format": "DER",
+//      }
+// 5. Response 201 → base64-DER cert in .certificate field.
+//    Decode → x509.Parse → wrap (key, cert) in PKCS12 with a generated password.
+// 6. Return EJBCACertificate{PfxData, Password, NotBefore, NotAfter, SerialNumber}.
+```
+
+Error handling: EJBCA returns `{"error_code":N,"error_message":"..."}` on
+failures. Surface the message in `ctxerr.Wrap`. Distinguish 401/403
+(authentication or authorization), 404 (CA/profile name typo), 422 (CSR
+rejected by profile rules) with their own wrapped messages.
+
+### `EJBCACertificate`
+
+```go
+// server/fleet/ejbca.go (new file)
+type EJBCACertificate struct {
+    PfxData        []byte
+    Password       string
+    NotValidBefore time.Time
+    NotValidAfter  time.Time
+    SerialNumber   string
+}
+
+type EJBCAService interface {
+    VerifyConnection(ctx context.Context, cfg EJBCACA) error
+    GetCertificate(ctx context.Context, cfg EJBCACA) (*EJBCACertificate, error)
+}
+```
+
+## Service layer
+
+`ee/server/service/certificate_authorities.go` grows EJBCA-aware branches:
+
+- `NewCertificateAuthority` validates an EJBCA payload then calls
+  `svc.ejbcaService.VerifyConnection`.
+- `UpdateCertificateAuthority` follows the same pattern.
+- A new private helper `validateEJBCA(payload)` mirrors `validateDigicert`:
+  required fields, URL parse, PEM cert / key parse, X509 keypair match, optional
+  trust bundle parse. Username template may reference the same allow-listed
+  Fleet vars as DigiCert (`HOST_END_USER_EMAIL_IDP`, `HOST_HARDWARE_SERIAL`,
+  `HOST_PLATFORM`).
+
+The service struct gains an `ejbcaService fleet.EJBCAService` field, injected
+at construction.
+
+## Profile processor wiring
+
+In `server/mdm/apple/profile_processor.go`:
+
+- Add `FleetVarEJBCADataPrefix` and `FleetVarEJBCAPasswordPrefix` to the prefix
+  scan in `isCAConfigured` and the per-host expansion branch.
+- The expansion calls `ejbcaService.GetCertificate(ctx, caCopy)` where
+  `caCopy` has had Fleet vars replaced in `UsernameTemplate`.
+- Resulting `PfxData` is base64-encoded and substituted into the profile XML,
+  matching the DigiCert pattern exactly (`ReplaceExactFleetPrefixVariableInXML`).
+
+## Datastore
+
+Methods are reused — `NewCertificateAuthority`, `GetCertificateAuthorityByID`,
+etc. are already polymorphic on `type`. The only datastore work is:
+
+- Add EJBCA fields to the SQL select/insert helpers in
+  `server/datastore/mysql/certificate_authorities.go`.
+- Add EJBCA branch to `GroupCertificateAuthoritiesByType` (in
+  `server/fleet/certificate_authorities.go`).
+- Add EJBCA branch to the `postprocessRetrievedCertificateAuthority` masking
+  logic.
+
+## Endpoints
+
+No new endpoints. The existing `POST/GET/PATCH/DELETE /fleet/certificate_authorities`
+endpoints handle EJBCA via type dispatch. The same is true for
+`request_certificate`. The GitOps spec endpoints are not extended for
+EJBCA in this change — see "GitOps — deferred" below.
+
+## GitOps — deferred
+
+Not in this change. See "What this design does *not* solve". When pulled
+forward, the shape will mirror DigiCert / NDES / SCEP entries in the
+existing `certificate_authorities` spec, with the P12 carried as a
+base64-encoded string (`client_p12_base64`) plus `client_p12_password`
+since YAML can't carry binary files.
+
+## Frontend
+
+New form component at
+`frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/`,
+modeled on `DigicertForm`. Field types:
+
+- `url`: text
+- `client_p12`: file upload (`.p12` only) **— required**
+- `client_p12_password`: password input **— required**
+- `trust_ca_bundle`: file upload (PEM, optional but strongly recommended)
+- `certificate_authority_name_ejbca`, `certificate_profile_name`,
+  `end_entity_profile_name`: text
+- `username_template`: text with Fleet-var helper popover
+
+The form has no enrollment-code field. Fleet generates the EJBCA
+`password` value internally per enrollment (see proposal.md decision #5
+and the design's `GetCertificate` walkthrough).
+
+Server-side accepts only PKCS#12 in the POC. It decodes the bundle once,
+extracts cert and key, persists them as PEM (key encrypted at rest), and
+throws the P12 password away. PEM-direct upload (separate cert + key files)
+is deferred — see proposal.md "Out of scope (deferred)".
+
+## What this design does *not* solve
+
+- **Token-based auth (OAuth bearer)**. Deferred. When added, expect to introduce
+  a `client_id`/`client_secret`/`token_url` set of columns and a token cache
+  layer. The `EJBCAService` interface will not need to change; a new
+  `Service` implementation in the same package can be selected by config shape.
+- **Dedicated "replace credentials" UX**. The POC uses the standard edit
+  modal — re-upload the P12, save, done. A separate action surface (with
+  its own confirmation flow, etc.) is deferred. Client-cert expiry IS
+  surfaced in the POC (REQ-CA-EJBCA-12), so admins can see rotation coming
+  via the CA list page.
+- **Profile/CA name validation against EJBCA.** EJBCA has no list endpoint for
+  profiles; we trust user input and surface the runtime error.
+- **User-configurable enrollment code.** POC generates the `password`
+  field internally per issuance. A customer-configurable field for
+  scenarios where their workflow requires a specific shared value is a
+  small follow-up — see proposal.md decision #5 for the customer-call
+  question.
+- **GitOps support.** POC ships API + UI only. No changes to
+  `ValidateCertificateAuthoritiesSpec`, `BatchApplyCertificateAuthorities`,
+  or the GitOps YAML schema. Follow-up alongside the production
+  implementation.
+- **PEM-direct upload of cert + key.** POC is P12-only. PEM-direct is a small
+  follow-up — backend stores PEM either way, so only the upload form and one
+  payload-parsing branch are new.
+
+## Resolved engineering decisions
+
+These were raised during exploration and answered by mirroring DigiCert /
+checking the codebase. Captured here so reviewers don't relitigate.
+
+- **`fleethttp` TLS config plumbing.** `WithTLSClientConfig` already exists
+  in `pkg/fleethttp/fleethttp.go:36`. Use it directly. No package changes.
+- **CSR CommonName.** Set to the expanded `username_template`. EJBCA's EE
+  profile may override based on its config; we set the most informative
+  value we have. Matches DigiCert's pattern of setting CN from a templated
+  field.
+- **`trust_ca_bundle` parsing.** Accepts multiple PEM blocks; append all to
+  the `CertPool`. If no blocks decode, return a validation error at save.
+- **GitOps secret handling.** N/A — GitOps support is deferred. When
+  the follow-up pulls GitOps in, `client_p12_password` SHOULD be
+  referenced via Fleet's existing `$ENV_VAR` substitution rather than
+  committed in plaintext, mirroring how DigiCert's `api_token` is
+  handled in the same spec today.
+- **Validation behavior under transient EJBCA outages.** Hard-reject the
+  create/update if `VerifyConnection` fails for any reason (timeout,
+  connection refused, TLS error, non-200). The admin retries. Matches
+  DigiCert behavior. Save-and-warn is not implemented for the POC; the
+  admin's clearer signal is a failed save.
+- **Activity logging scope.** Emit dedicated activity events for the
+  EJBCA CA lifecycle: `created_ejbca_ca`, `edited_ejbca_ca`,
+  `deleted_ejbca_ca` (mirroring the existing DigiCert pattern at
+  `ee/server/service/certificate_authorities.go:1122` etc.). Per-host
+  enrollment events use the existing generic profile-delivery activity —
+  no EJBCA-specific event for that path.

--- a/openspec/changes/add-ejbca-rest-ca-poc/proposal.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/proposal.md
@@ -199,18 +199,29 @@ These are the questions for the customer call. Capture answers in
 The POC is complete when all of these are demonstrably true on a developer
 machine:
 
-1. A Fleet admin can create an EJBCA CA via API and via the UI, supplying URL,
-   client cert/key, profile names, username template, and password.
-2. Fleet rejects the CA on save if the connection probe fails (bad URL, wrong
-   client cert, revoked cert, untrusted server cert).
-3. A macOS host with a configuration profile referencing
-   `FLEET_VAR_EJBCA_DATA_<name>` / `FLEET_VAR_EJBCA_PASSWORD_<name>` receives a
-   working certificate provisioned through EJBCA.
-4. The CA list page shows the client-cert expiry for each EJBCA CA, and a
-   re-upload of the P12 via the edit modal rolls the stored cert+key without
-   disturbing existing host certificates.
-5. The dev guide for running the POC against a local EJBCA Community Edition
-   container exists in `docs/Contributing/product-groups/security-compliance/`
-   and an engineer who has never touched EJBCA can follow it from scratch.
+1. ✅ A Fleet admin can create an EJBCA CA via API and via the UI, supplying
+   URL, client cert/key, profile names, username template, and password.
+   *Verified end-to-end against `keyfactor/ejbca-ce` 9.x.*
+2. ✅ Fleet rejects the CA on save if the connection probe fails (bad URL,
+   wrong client cert, revoked cert, untrusted server cert).
+   *Verified — each failure mode surfaces a distinct error message; see the
+   troubleshooting ladder in the dev guide.*
+3. ✅ A macOS host with a configuration profile referencing
+   `FLEET_VAR_EJBCA_DATA_<name>` / `FLEET_VAR_EJBCA_PASSWORD_<name>` receives
+   a working certificate provisioned through EJBCA.
+   *Verified — host installs the issued cert; EJBCA logs show the
+   `pkcs10enroll` request and `CERT_CREATION` for the host's CN.*
+4. ✅/🔲 The CA list page shows the client-cert expiry for each EJBCA CA,
+   and a re-upload of the P12 via the edit modal rolls the stored cert+key
+   without disturbing existing host certificates. *Backend exposes
+   `client_cert_expires_at`; CA list badge UI was deferred from the POC
+   (see Phase 8 in tasks.md). Edit-modal P12 rotation is wired and
+   functional.*
+5. ✅ The dev guide for running the POC against a local EJBCA Community
+   Edition container exists in
+   `docs/Contributing/product-groups/security-compliance/` and an engineer
+   who has never touched EJBCA can follow it from scratch.
+   *Verified — guide includes a Troubleshooting ladder mapping every
+   failure mode hit during testing to its fix.*
 6. The customer's open questions (above) are captured with answers in
    research.md.

--- a/openspec/changes/add-ejbca-rest-ca-poc/proposal.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/proposal.md
@@ -1,0 +1,209 @@
+# Proposal: EJBCA REST CA integration (POC)
+
+## Summary
+
+Add EJBCA as a new Certificate Authority type in Fleet's CA framework, enrolling
+certificates via EJBCA's REST API over mTLS. The integration mirrors the existing
+DigiCert CA in shape (CSR-based enrollment, PKCS12-wrapped delivery via MDM profile
+variable substitution) but uses client-certificate authentication instead of a
+static API token, since EJBCA does not offer a static API key.
+
+This proposal scopes the **POC**: a working end-to-end path that exercises every
+new piece of plumbing once, against a real EJBCA instance, with a documented
+customer setup flow. Production polish (rotation UX, audit-grade error messages,
+full test coverage, OAuth bearer auth) is deferred to the follow-up implementation
+captured in [fleet#30986](https://github.com/fleetdm/fleet/issues/30986).
+
+## Why
+
+- **Customer commitment.** [`prospect-homerus`](https://github.com/fleetdm/fleet/issues/29176)
+  is migrating from AD CS to EJBCA and wants Fleet to deploy WiFi/VPN certificates
+  to macOS hosts. Tagged `~customer promise`.
+- **Milestone**: 4.87.0 (POC, this proposal). The customer-facing implementation
+  is 4.88.0 (#30986, T-shirt M).
+- **Strategic fit.** EJBCA is one of the dominant non-AD-CS enterprise CAs.
+  Supporting it removes a recurring blocker for prospects with PKI teams.
+- **Reuses existing CA framework.** Endpoints, DB schema, and MDM
+  profile-variable substitution are already in place from the DigiCert
+  work. Net new surface is small. (GitOps support exists in the framework
+  but is deferred for the EJBCA POC.)
+
+## Scope
+
+### In scope
+
+- New `CertificateAuthority` type `ejbca` with mTLS authentication.
+- EJBCA REST client supporting two operations: connection verification
+  (`GET /v1/ca/status`) and certificate enrollment (`POST /v1/certificate/pkcs10enroll`).
+- **Feature parity with DigiCert's certificate-templating surface.** The
+  EJBCA CA accepts the same per-enrollment templating fields the DigiCert
+  CA does today:
+  - `username_template` (used as both the EJBCA end-entity username AND the
+    CSR CommonName — parallels DigiCert's `certificate_common_name`)
+  - `certificate_user_principal_names []string` — UPNs included in the CSR's
+    SAN extension as `otherName` entries (OID 1.3.6.1.4.1.311.20.2.3). Matches
+    what DigiCert's integration supports.
+  Other SAN types (DNS, email, IP) are out of scope — DigiCert doesn't
+  template them today, so EJBCA matches.
+- **Apple MDM payload coverage matches DigiCert's**: same payload types
+  Fleet supports for DigiCert today (Wi-Fi EAP-TLS, VPN). No new MDM
+  payload work in this change.
+- **Positioning vs the existing SCEP-EJBCA path.** Fleet's custom-SCEP-proxy
+  CA already works against EJBCA's SCEP endpoint. The REST integration is an
+  **alternative** path for customers who prefer or require the REST API —
+  not a migration or replacement. Customers can choose either or both. This
+  is intentionally stated to avoid product-positioning confusion on review.
+- DB migration adding columns for the client cert, private key, and optional
+  trust CA bundle (encrypted at rest).
+- Validation on CA create/update: probe the EJBCA endpoint and confirm
+  authentication succeeds.
+- MDM profile variable substitution: `FLEET_VAR_EJBCA_DATA_<name>` and
+  `FLEET_VAR_EJBCA_PASSWORD_<name>` mirroring the DigiCert prefix pattern.
+- Minimal frontend form to create/edit/delete an EJBCA CA (parity with the
+  DigiCert form, not polished UX).
+- Developer-facing dev guide for running the POC against a local EJBCA Community
+  Edition Docker container, as a sibling to the existing
+  `docs/Contributing/product-groups/security-compliance/ejbca-scep-testing.md`.
+
+### Out of scope (deferred)
+
+- OAuth 2.0 bearer-token authentication. EJBCA supports it (see
+  [research.md](./research.md)) but adds an IdP dependency and meaningful new
+  surface area. Note in spec for follow-up. Likely shares code with Fleet's
+  existing SSO/OIDC support.
+- PEM-direct client cert/key upload (separate `.pem` cert + `.pem` key files).
+  POC accepts PKCS#12 only. PEM-direct is a small follow-up — same backend,
+  just a different upload path — and can be pulled in later if customers
+  request it.
+- User-configurable enrollment code. POC generates the EJBCA `password`
+  field internally per issuance. A customer-supplied static value (for
+  workflows that require it — see proposal decision #5) is a small follow-up.
+- **GitOps support for the EJBCA CA type.** POC does not extend the
+  `certificate_authorities` GitOps spec, the `ValidateCertificateAuthoritiesSpec`
+  parser, or `BatchApplyCertificateAuthorities`. Follow-up work — same
+  pattern as the existing DigiCert / NDES / SCEP types — to be picked up
+  alongside the production implementation in #30986. POC scope is the
+  API + UI path only.
+- Distinct error messages for cert-revoked vs cert-expired vs role-misconfigured
+  TLS handshake failures (POC returns a generic "TLS handshake failed" with
+  the wrapped server error; production tightens this).
+- A dedicated "Replace credentials" button on the CA list. In the POC, rotation
+  happens through the regular edit modal — re-upload the P12, save. No
+  separate action surface.
+- Comprehensive test suite. Per the POC's learning intent, write tests only
+  where they accelerate iteration, not for coverage.
+- Activity-log entries beyond what reusing the generic CA activity wiring gives
+  for free.
+- Windows / Linux / Android cert delivery paths. macOS only (matches #30986's
+  scope and the customer's stated need).
+- Production-grade frontend polish, file-format validation UX, drag-and-drop
+  upload, etc.
+
+## Auth decisions requiring customer confirmation
+
+These are the decisions that materially affect the customer's EJBCA admin work
+and the field shape of Fleet's UI. They cannot be answered from EJBCA docs alone
+— each is a per-customer choice. **Confirm with `prospect-homerus` before
+implementation begins.**
+
+1. **mTLS as the auth method for the POC.** ✅ Confirmed with customer.
+   - Decision: client-certificate authentication, no OAuth bearer in the POC.
+   - Customer impact: their EJBCA admin must enroll a service certificate for
+     Fleet, bind it to an Administrator Role with appropriate access rules, and
+     hand Fleet a `.p12` bundle (with its password) plus the issuing CA chain.
+   - Status: customer confirmed mTLS is their preferred auth method.
+     OAuth bearer remains a real follow-up (see research.md).
+
+2. **Client cert input format — P12 only in POC.**
+   - Decision: the POC accepts **PKCS#12 only** (file + password). PEM-direct
+     upload (separate cert + key files) is deferred. P12 is what EJBCA's RA
+     Web emits by default, so this is the friendlier first-time path and
+     matches the expected customer workflow.
+   - Customer question: confirm this is acceptable. Does their security team
+     require PEM-direct upload (e.g., to avoid handling P12 passwords, or
+     because their secrets tooling exports PEM)? If yes, raise PEM-direct
+     out of "deferred" and into the POC.
+
+3. **Trust CA bundle for EJBCA's server cert.**
+   - Proposed: optional field. If empty, Fleet uses its system root store.
+   - Customer question: is EJBCA fronted by a publicly-trusted TLS cert in
+     their environment, or is it Management-CA-issued / self-signed? If the
+     latter, they must provide the CA chain.
+
+4. **End entity auto-creation requirement.**
+   - Proposed: Fleet assumes their EJBCA is configured to auto-create end
+     entities during `pkcs10enroll`. This requires their End Entity Profile
+     to permit auto-add (EJBCA Enterprise feature) or for them to pre-create
+     end entities per host (CE limitation, untenable at scale).
+   - Customer question: confirm they will run EJBCA Enterprise in production
+     and that their EE profile is configured to auto-create. If they're on
+     Community Edition or unwilling to enable auto-create, the integration is
+     non-viable for fleet-scale provisioning.
+
+5. **Enrollment code / password handling.**
+   - Decision: Fleet generates a cryptographically-random `password` per
+     enrollment internally and never persists it. EJBCA's `pkcs10enroll`
+     API requires a non-null password (the backend rejects null for any
+     CA with `useUserStorage=true`), but in the typical auto-create-EE
+     configuration the value isn't authenticating anything — the mTLS
+     client cert + EJBCA role scope is the actual security boundary.
+     Generating internally satisfies the API requirement without adding a
+     persistent shared secret on Fleet's side or a customer-facing
+     configuration field.
+   - Customer question: are they planning to use a workflow that
+     *requires* a specific configurable enrollment code? Examples:
+     - Their EE profile is configured to validate the password against a
+       specific server-side value rather than accepting any
+     - They want EJBCA audit logs to contain a recognizable
+       "fleet-integration" string rather than per-call random values
+     - Internal governance requires explicitly-configured integration
+       credentials
+     If yes for any of these, pull forward the deferred "user-configurable
+     enrollment code" feature from the spec's Deferred section — small
+     follow-up, doesn't block the POC.
+
+6. **Least-privilege admin role.**
+   - Proposed: encourage the customer to bind the Fleet service cert to a
+     **custom** EJBCA admin role with narrow access rules (read on issuing CA,
+     create/edit on relevant EE profile, issue on cert profile) rather than
+     Super Administrator.
+   - Customer question: are they willing to set up a custom role, or will
+     their PKI admin prefer Super Administrator for simplicity? This is a
+     security-posture conversation, not a Fleet feature flag.
+
+7. **Cert rotation cadence.**
+   - Mechanism (POC): the standard edit modal on the CA accepts a new P12 +
+     password. Saving re-validates against EJBCA and replaces the stored
+     PEM cert+key. Existing host certificates are unaffected — they remain
+     installed on devices and valid (per REQ-CA-EJBCA-11). Next enrollment
+     uses the new mTLS material.
+   - Fleet shows "expires in N days" on the CA list (REQ-CA-EJBCA-12) so the
+     admin sees rotation coming and doesn't get caught by a silent stoppage
+     of new enrollments.
+   - Customer question: what is their typical service-cert lifetime (1y is
+     usual)? Are they comfortable with the standard "edit modal → re-upload
+     P12" rotation workflow?
+
+These are the questions for the customer call. Capture answers in
+[research.md](./research.md) → "Decisions confirmed with customer".
+
+## Success criteria for the POC
+
+The POC is complete when all of these are demonstrably true on a developer
+machine:
+
+1. A Fleet admin can create an EJBCA CA via API and via the UI, supplying URL,
+   client cert/key, profile names, username template, and password.
+2. Fleet rejects the CA on save if the connection probe fails (bad URL, wrong
+   client cert, revoked cert, untrusted server cert).
+3. A macOS host with a configuration profile referencing
+   `FLEET_VAR_EJBCA_DATA_<name>` / `FLEET_VAR_EJBCA_PASSWORD_<name>` receives a
+   working certificate provisioned through EJBCA.
+4. The CA list page shows the client-cert expiry for each EJBCA CA, and a
+   re-upload of the P12 via the edit modal rolls the stored cert+key without
+   disturbing existing host certificates.
+5. The dev guide for running the POC against a local EJBCA Community Edition
+   container exists in `docs/Contributing/product-groups/security-compliance/`
+   and an engineer who has never touched EJBCA can follow it from scratch.
+6. The customer's open questions (above) are captured with answers in
+   research.md.

--- a/openspec/changes/add-ejbca-rest-ca-poc/proposal.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/proposal.md
@@ -84,6 +84,13 @@ captured in [fleet#30986](https://github.com/fleetdm/fleet/issues/30986).
   pattern as the existing DigiCert / NDES / SCEP types — to be picked up
   alongside the production implementation in #30986. POC scope is the
   API + UI path only.
+- **In-process BER → DER normalization for the PKCS#12 decode path.**
+  POC shells out to the `openssl` binary to convert EJBCA's BER P12
+  output before parsing (both Go PKCS#12 libraries are strict-DER). The
+  subprocess approach **must not ship to production** — it adds a
+  runtime binary dependency and broadens the trust surface. Production
+  (#30986) must replace it with a pure-Go BER → DER normalizer. See
+  research.md → "Open follow-ups" for design options.
 - Distinct error messages for cert-revoked vs cert-expired vs role-misconfigured
   TLS handshake failures (POC returns a generic "TLS handshake failed" with
   the wrapped server error; production tightens this).

--- a/openspec/changes/add-ejbca-rest-ca-poc/research.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/research.md
@@ -1,0 +1,395 @@
+# Research: EJBCA REST CA integration
+
+Informational doc capturing what we learned during the EJBCA POC investigation,
+the risks we surfaced, and the decisions that still need customer
+confirmation. This is not a spec — it's the durable record of the thinking that
+fed [proposal.md](./proposal.md), [design.md](./design.md), and
+[tasks.md](./tasks.md). If you're picking up this work mid-flight or revisiting
+it in six months, start here.
+
+## Customer + business context
+
+- **Customer**: `prospect-homerus`, migrating their certificate authority from
+  Microsoft AD CS to EJBCA. Use case is WiFi/VPN certificates on macOS hosts.
+  Tagged `~customer promise` once they sign.
+- **Upstream issues**:
+  - [#30986](https://github.com/fleetdm/fleet/issues/30986) — user story (P2,
+    4.88.0, T-shirt M).
+  - [#45505](https://github.com/fleetdm/fleet/issues/45505) — this POC
+    (4.87.0, `:release` `~timebox`).
+  - [#29176](https://github.com/fleetdm/fleet/issues/29176) — parent /
+    business tracker, links to EJBCA REST docs.
+- **No Gong links** in any of those issues. No Figma. No prior design draft.
+  Spec is being authored here for the first time.
+- **Customer profile inference**: AD-CS-native. They have PKI muscle. mTLS will
+  be a familiar mental model. They almost certainly buy EJBCA Enterprise (not
+  Community Edition) in production.
+
+## EJBCA authentication methods
+
+EJBCA's REST API supports three authentication modes. Notably, **there is no
+static API key** like DigiCert offers — EJBCA does not issue long-lived tokens
+that a user can paste into a config. Every auth method below traces back to
+either a certificate or an external identity provider.
+
+### 1. mTLS client certificate — POC choice
+
+**What it is.** During the TLS handshake, the client (Fleet) presents an X.509
+certificate that EJBCA validates against its truststore (typically the
+Management CA) and matches against role-member rules. If a matching role is
+found, the certificate's effective permissions are the union of that role's
+access rules.
+
+**Intended purpose per EJBCA.** This is EJBCA's **default and canonical** auth
+mode for both human admins (Admin UI / RA UI) and machine clients. EJBCA is
+itself a CA — they expect every customer to use certs they've issued for
+their own internal authentication. It is universally available across CE and
+EE.
+
+**Fits which customer profile.** Every EJBCA customer, by definition. Best fit
+for orgs whose ops muscle is cert-based (AD CS migrators, classic enterprise
+PKI shops). `prospect-homerus` fits squarely here.
+
+**Tradeoffs.**
+- ✅ Universal — works with any EJBCA install, CE or EE, no extra infrastructure.
+- ✅ Posture matches the customer's existing PKI workflow.
+- ❌ Service certs are long-lived (typically 1y) and must be rotated by hand —
+  no automatic refresh.
+- ❌ If Fleet's host is compromised, the attacker has a cert valid until the
+  EJBCA admin revokes it.
+
+### 2. OAuth 2.0 bearer token (OIDC) — deferred
+
+**What it is.** The customer points EJBCA at an external Identity Provider
+(EntraID, Okta, Keycloak, PingID are EJBCA-tested). API clients obtain a
+short-lived JWT from that IdP and send it as `Authorization: Bearer <token>`.
+EJBCA validates the JWT signature against the IdP's JWKS, then maps claims
+(usually `sub` or a custom claim) to EJBCA roles in the same Roles & Access
+Rules system.
+
+**Intended purpose per EJBCA.** Added in 7.5 (Enterprise) and 9.3 (Community).
+EJBCA's own marketing positions it for two distinct audiences:
+
+- **Human admins**: log into Admin UI / RA UI via existing corporate SSO
+  instead of carrying around a P12 in their browser. Inherit MFA, conditional
+  access, deprovisioning, audit from the IdP.
+- **Machine-to-machine API clients**, especially cloud-native / Kubernetes
+  shops, where workload identity can mint short-lived tokens with no
+  long-lived secret on the calling host's disk.
+
+**Fits which customer profile.** Orgs that already run an OIDC IdP for
+everything else and want EJBCA access to live in the same identity surface.
+
+**Tradeoffs for Fleet → EJBCA specifically.**
+- ✅ Short-lived tokens at the EJBCA boundary — IdP revocation propagates fast.
+- ✅ Single audit/governance plane with the customer's other M2M integrations.
+- ⚠️ Fleet still stores **long-lived secrets to the IdP** (typically
+  `client_id` + `client_secret` for the OAuth client-credentials grant). The
+  "no static credentials" pitch only fully lands when Fleet itself runs with
+  cloud workload identity (GKE WI, EKS IRSA, EntraID WI), which doesn't fit
+  most Fleet deployments — Fleet Cloud and many self-hosted Fleet installs
+  don't.
+- ❌ Requires the customer to operate an OIDC IdP and configure it as an
+  EJBCA OAuth provider. Net new infrastructure for orgs that don't have it.
+
+**Why deferred from POC.** Adds a meaningful new surface (IdP-registered
+client, token endpoint, token cache, refresh handling, JWKS rotation) without
+unlocking the customer who's asking for the feature today. Likely shares code
+with Fleet's existing OIDC SSO support — same JWKS verification, audience
+validation, etc. — so the follow-up is smaller than its scope suggests.
+
+### 3. Public / anonymous access — not applicable
+
+**What it is.** EJBCA can be configured to expose a subset of RA endpoints
+without authentication, for trust-on-first-use enrollment scenarios.
+
+**Intended purpose per EJBCA.** Bootstrap end-user enrollment in trusted
+networks. EJBCA's docs explicitly call this "highly discouraged" for the CA
+endpoints (the ones Fleet uses for `pkcs10enroll`).
+
+**Why irrelevant for Fleet.** The endpoints Fleet calls
+(`/v1/ca/status`, `/v1/certificate/pkcs10enroll`) are CA-functionality
+endpoints that always require authentication in production setups. We do not
+build for or support this mode.
+
+### Summary
+
+| Method | POC | Customer impact | Best fit |
+|---|---|---|---|
+| mTLS client cert | ✅ chosen | EJBCA admin enrolls + binds a service cert | Cert-native shops (this customer) |
+| OAuth bearer | deferred | Customer registers Fleet as an OAuth client in their IdP | Customers with existing OIDC IdP |
+| Public/anonymous | ❌ not built | n/a | n/a — discouraged by EJBCA |
+
+OAuth remains a real follow-up. The proposal calls it out and design.md notes
+that the `EJBCAService` interface doesn't need to change; only a new auth-
+layer wrapper is needed when we eventually add it.
+
+### Customer questions about authentication
+
+These are exploratory — not POC-implementation decisions (those live in
+[proposal.md → Auth decisions](./proposal.md#auth-decisions-requiring-customer-confirmation)).
+They help us understand the customer's longer-term auth posture and how soon
+OAuth follow-up work is likely to be asked for.
+
+1. **Do you run an OIDC Identity Provider for other internal systems?**
+   If yes, which? (EntraID, Okta, Keycloak, PingID are the EJBCA-tested set —
+   if they use something else, OAuth follow-up gets riskier.)
+
+2. **How do your existing automated systems authenticate to AD CS today?**
+   Cert-based, Kerberos/Windows-auth, NDES-with-challenge, something else?
+   This calibrates whether mTLS to EJBCA feels like a natural continuation or
+   a step sideways.
+
+3. **What's your typical service-account credential lifetime, and rotation
+   cadence?** A shop that rotates every 90 days experiences mTLS as
+   high-friction (manual rotation work); a shop that rotates yearly barely
+   notices. Influences how strongly OAuth becomes attractive over time.
+
+4. **Will Fleet be deployed via Fleet Cloud (Fleet-hosted) or self-hosted on
+   your own infrastructure?** Self-hosted in a cloud-native environment opens
+   the door to workload-identity OAuth (the "no static creds on disk"
+   version). Fleet Cloud and on-prem VMs don't.
+
+5. **Does your security team have a stated policy preference between
+   long-lived static credentials and short-lived IdP-issued tokens for M2M
+   integrations?** If short-lived is mandated by policy, OAuth follow-up
+   moves to higher priority — possibly into the 4.88.0 production
+   implementation rather than a later release.
+
+6. **For the POC window, are you OK starting with mTLS only and revisiting
+   OAuth after the integration is proven end-to-end?** Sets expectations on
+   delivery shape.
+
+Capture answers in the "Decisions confirmed with customer" table below — add
+rows for these strategic questions as they come up.
+
+## EJBCA REST API surface we actually use
+
+| Operation | Method | Path | Notes |
+|---|---|---|---|
+| Connection probe | `GET` | `/ejbca/ejbca-rest-api/v1/ca/status` | Returns `{"status":"OK","version":"...","revision":"..."}` |
+| Enroll cert | `POST` | `/ejbca/ejbca-rest-api/v1/certificate/pkcs10enroll` | CSR-based; response is base64-DER in `.certificate` |
+
+That's it. Two endpoints. Discovery (list of CAs / profiles / EE profiles) is
+intentionally out of scope — EJBCA has no list endpoint we can probe, and the
+customer's EJBCA admin will type the names by hand.
+
+## Edition matrix (CE vs EE)
+
+What's in each edition that affects us:
+
+| Feature | Community | Enterprise |
+|---|---|---|
+| `pkcs10enroll` REST endpoint | ✅ | ✅ |
+| `GET /v1/ca/status` | ✅ | ✅ |
+| mTLS authentication | ✅ | ✅ |
+| OAuth bearer authentication | ✅ in 9.3+ | ✅ since 7.5 |
+| `endentity` REST endpoint (manage EEs via API) | ❌ | ✅ |
+| Auto-create end entity during `pkcs10enroll` | ❌ | ✅ (with config) |
+| SCEP RA mode | ❌ | ✅ |
+
+**The Fleet integration code does not change between editions.** Same
+endpoint, same body, same auth. The delta is operational:
+
+- On CE, the EJBCA admin must pre-create one end entity per CSR subject. This
+  is untenable at fleet scale but fine for POC testing — the existing
+  [ejbca-scep-testing.md](../../../docs/Contributing/product-groups/security-compliance/ejbca-scep-testing.md)
+  guide documents the `bin/ejbca.sh ra addendentity` workflow we'll reuse.
+- On EE, with `Use auto-add` enabled on the End Entity Profile, EJBCA creates
+  the end entity on the fly. This is the production-realistic flow.
+
+**Customer assumption**: `prospect-homerus` will run EE in production and
+their EE profile will be configured for auto-add. We need to confirm this
+on the customer call (see proposal § Auth decisions, item 4).
+
+## EJBCA Enterprise trial
+
+EJBCA EE is paid (Keyfactor). For verifying the auto-create-EE flow we cannot
+test on CE, Keyfactor offers:
+
+- **30-day AWS/Azure free trial** at https://www.keyfactor.com/try-ejbca-enterprise/
+- **Recorded demo + personalized walkthrough** (sales motion)
+- **Keyfactor PQC Lab Test Drive** on Azure Marketplace — pre-configured EE
+  9.2 instance
+
+Plan: build and primarily test against the CE Docker container. Spin up the
+30-day trial near the end of the POC for an EE-specific validation pass that
+exercises auto-create-EE end-to-end.
+
+## Customer setup flow (EJBCA admin side)
+
+```
+1. Certificate Profile        →  CA Functions → Certificate Profiles
+   Clone ENDUSER → "fleetRESTAdmin"
+   EKU: Client Authentication; KU: Digital Signature, Key Encipherment
+   Validity: 1y typical
+
+2. End Entity Profile         →  RA Functions → End Entity Profiles
+   Name: "fleetRESTAdmin"
+   Default + Available Cert Profile: fleetRESTAdmin
+   Default + Available CA: Management CA
+
+3. Enroll the Fleet service   →  RA Web → Make New Request
+   cert. Username: fleet_rest_service. CN: Fleet REST Service
+   Download as PKCS#12, password set by admin
+
+4. Administrator Role         →  System Functions → Roles and Access Rules
+   Template: RA Administrators
+   Authorized CAs: <issuing CA for device certs>
+   Authorized EE Profiles: <the EE profile Fleet will enroll against>
+   Access rules: read CA, create/edit end entity, view+issue cert
+
+5. Bind cert → role           →  Role → Members
+   Match with: X509:CN, CA: Management CA, Value: "Fleet REST Service"
+
+6. (Optional) Export the      →  RA Web → CA Certificates and CRLs
+   Management CA cert as PEM     For the trust bundle Fleet will use to
+                                  verify EJBCA's HTTPS server cert
+```
+
+What Fleet receives from the admin:
+- The PKCS#12 file containing Fleet's client cert + private key
+- The P12 password (used once to decrypt; not persisted)
+- Optional: trust CA bundle (PEM; required when EJBCA's HTTPS cert isn't
+  publicly trusted, which is the typical self-hosted case)
+- EJBCA REST URL
+- CA name, cert profile name, EE profile name (all free-text)
+- Username template (uses Fleet vars)
+- Enrollment code
+
+POC accepts **PKCS#12 only**. PEM-direct upload (separate cert + key files)
+is deferred — small follow-up, same backend.
+
+## Risks
+
+### High
+
+- **End-entity auto-creation assumption.** The whole integration depends on
+  EJBCA being configured to auto-create end entities. If the customer's EE
+  profile doesn't permit it, every `pkcs10enroll` returns "user not found"
+  and the integration is non-functional at fleet scale. This is the single
+  biggest "you have to do X on your EJBCA" requirement and must be confirmed
+  with the customer before commit.
+- **Cert revocation drift.** If the EJBCA admin revokes the Fleet service
+  cert for any reason, all enrollments break with a TLS handshake error.
+  Fleet has no way to detect this proactively until the next save. POC
+  acceptable; production needs a periodic probe.
+
+### Medium
+
+- **Self-signed EJBCA in dev.** Most dev EJBCA instances use a Management-CA-
+  issued HTTPS cert. The trust-bundle upload handles this, but skipping it
+  yields a confusing TLS error. Doc clearly.
+- **CSR DN sensitivity.** EJBCA may enforce strict matching of CSR subject to
+  end-entity DN. The existing SCEP guide notes "CN-only subjects" is the safe
+  default. Stick with it; document it.
+- **Username template footguns.** If the user picks a template that doesn't
+  uniquify per host (e.g., a constant), EJBCA reuses the same end-entity and
+  the password is consumed after first enrollment. POC should either:
+  - validate that the template references at least one host-scoped Fleet var, or
+  - accept this and document it.
+- **No discovery, no validation of profile names.** A typo in any of the
+  three names surfaces only on first enrollment, not on CA save. POC
+  acceptable; production should have a better error message.
+
+### Low
+
+- *(none currently outstanding — see "Resolved" below for previously
+  flagged items that have since been answered.)*
+
+### Resolved (kept for posterity)
+
+- **"How does PATCH affect existing certs?"** — confirmed by reading
+  `ee/server/service/certificate_authorities.go:1072` (`UpdateCertificate-
+  Authority`). PATCH is a metadata update only: validate → write row →
+  log activity → return. No re-enrollment is queued, no profile is re-
+  resolved, no per-host work. Existing host certificates are unaffected.
+  Same behavior as every other CA type. This is the right design — auto-
+  reissuance on every CA edit would hammer the customer's CA and break
+  reversibility. The expiry surfacing in REQ-CA-EJBCA-12 exists precisely
+  because the "no automatic action" property means expired mTLS material
+  silently breaks new enrollments while existing hosts keep working.
+- **"Hot-swap on the CA row vs delete-and-recreate"** — non-issue. The
+  existing PATCH endpoint supports updating any field including
+  `client_p12` + `client_p12_password`. The edit modal in the UI just
+  re-exposes the same fields as create. No separate "hot-swap" code path
+  is needed; only a dedicated "Replace credentials" button is deferred,
+  which is purely a UX nicety.
+- **"Migration-phase EJBCA naming churn"** — also non-issue. Renaming an
+  EJBCA CA / cert profile / EE profile during the customer's PKI
+  migration is handled by the same PATCH mechanism. Existing host certs
+  are unaffected; admin updates Fleet's CA row to the new name and new
+  enrollments resume. Same flow as a DigiCert profile_id change or a
+  SCEP URL change.
+- **`fleethttp.WithTLSClientConfig` already exists** at
+  `pkg/fleethttp/fleethttp.go:36`. No package additions needed for the
+  mTLS plumbing.
+- **Enrollment code: required by API, not authenticating in our config.**
+  Verified by reading `SignSessionBean.java` in the EJBCA source: the
+  backend rejects `password=null` for any CA with `useUserStorage=true`
+  (which is essentially all production EJBCA deployments). So we have
+  to send a non-null value. Verified separately that the
+  `EnrollCertificateRestRequest` JSON-schema layer has *no*
+  `@NotNull`/`@NotEmpty`/`@NotBlank` annotation on `password` — the
+  requirement comes purely from backend validation.
+
+  Under the auto-create-EE + permissive-password configuration we're
+  designing against, a static enrollment code doesn't authenticate
+  anything — an attacker holding the mTLS cert can supply any value
+  and EJBCA will accept it. So the field has essentially no security
+  value at that configuration.
+
+  Decision: POC removes the user-facing `enrollment_code` field
+  entirely. Fleet generates 32 bytes of `crypto/rand` per enrollment,
+  hex-encodes, sends as `password`, discards. This satisfies the API
+  without introducing a persistent shared secret or a customer
+  configuration question that has no real effect.
+
+  User-configurable enrollment code is captured as a deferred follow-up
+  for customers whose EE profile genuinely requires a specific value
+  or whose workflow depends on a known shared secret (see proposal.md
+  decision #5 — a customer-call question to determine if the follow-up
+  needs to be pulled forward).
+
+## Decisions confirmed with customer
+
+> Fill in during/after the customer call. One row per question from
+> [proposal.md → Auth decisions](./proposal.md#auth-decisions-requiring-customer-confirmation).
+
+| # | Decision | Customer answer | Date | Notes |
+|---|---|---|---|---|
+| 1 | mTLS-only POC, OAuth deferred | ✅ Confirmed | 2026-06-04 | Customer confirmed mTLS is preferred auth method |
+| 2 | POC accepts PKCS#12 only. PEM-direct deferred — acceptable? | TBD | | |
+| 3 | Will customer provide a trust CA bundle? | TBD | | |
+| 4 | EE profile auto-creates end entities? | TBD | | |
+| 5 | Workflow requires a configurable enrollment code? (POC generates internally) | TBD | | |
+| 6 | Custom EJBCA admin role (vs Super Admin)? | TBD | | |
+| 7 | Service-cert lifetime + rotation via standard edit modal acceptable? | TBD | | |
+
+## Open follow-ups
+
+- OAuth 2.0 bearer-token authentication. Probably shares code with Fleet's
+  existing OIDC SSO support — the same JWKS verification, audience
+  validation, etc. File a follow-up issue under #30986 once POC merges.
+- Hot-swap of client cert/key on an existing CA row, without re-creating it.
+- UI surfacing of client-cert expiry on the CA list page.
+- Cert-revocation detection (periodic probe).
+- User-configurable enrollment code (for customers whose workflow
+  requires a specific shared value — see proposal decision #5).
+- Windows / Linux / Android cert delivery paths via EJBCA.
+- Profile-name validation against EJBCA's APIs (none today; would need a
+  Keyfactor feature request or a `GET /endentityprofile` if EE adds one).
+
+## Source references
+
+- [EJBCA REST Interface](https://docs.keyfactor.com/ejbca/latest/ejbca-rest-interface)
+- [EJBCA Authentication Methods](https://docs.keyfactor.com/ejbca/latest/authentication-methods)
+- [EJBCA OAuth Providers](https://docs.keyfactor.com/ejbca/latest/oauth-providers)
+- [Understanding OAuth in EJBCA](https://www.ejbca.org/resources/understanding-oauth-in-ejbca-and-how-it-can-help-you-get-started/) — vendor positioning
+- [Tutorial — Create roles in EJBCA](https://docs.keyfactor.com/ejbca/latest/tutorial-create-roles-in-ejbca)
+- [ServiceNow REST Integration — Configure EJBCA](https://docs.keyfactor.com/ejbca/latest/servicenow-rest-integration-configure-ejbca) — closest analog
+- [RA Administrator Access Rules](https://docs.keyfactor.com/ejbca/latest/ra-administrator-access-rules)
+- [Keyfactor/ejbca-ce Discussion #635](https://github.com/Keyfactor/ejbca-ce/discussions/635) — CE pre-creation requirement
+- [Try EJBCA Enterprise (30-day trial)](https://www.keyfactor.com/try-ejbca-enterprise/)
+- Local repo: [ejbca-scep-testing.md](../../../docs/Contributing/product-groups/security-compliance/ejbca-scep-testing.md) —
+  existing SCEP dev guide, sibling to the REST guide we'll write.

--- a/openspec/changes/add-ejbca-rest-ca-poc/research.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/research.md
@@ -362,36 +362,65 @@ is deferred — small follow-up, same backend.
   Mac. Workaround documented in the dev guide's Troubleshooting
   section: pre-extract to PEM with openssl, then use curl with
   `--cert/--key` on the PEM files.
-- **End-to-end happy path verified.** With (a) openssl subprocess
-  decode in place, (b) `REST Certificate Management` enabled, (c)
-  `ejbca.local` in `/etc/hosts`, (d) the Management CA in Fleet's
-  trust bundle field, (e) the Fleet service cert bound to a custom
-  admin role with appropriate access rules: Add CA via Fleet's UI
-  completes, the connection probe (`GET /v1/ca/status`) returns 200,
-  and the EJBCA CA row lands in Fleet's database. The per-host
-  enrollment path (`pkcs10enroll`) is unit-tested for UPN SAN
-  encoding but hasn't yet been exercised against real EJBCA via the
-  MDM profile-delivery flow — pending Phase 10 / manual verification.
-- **MDM profile Fleet-var support has TWO checkpoints, not one.**
-  Phase 6's `preprocessProfileContents` handles the *runtime*
-  expansion path (per-host enrollment when the profile is delivered).
-  Separately, there's an *upload-time* validator in
-  `server/service/mdm_profiles.go` that maintains an allow-list of
-  Fleet-var prefixes accepted in `.mobileconfig` uploads and tracks
-  DATA+PASSWORD pair completeness per CA via `*VarsFound` structs.
-  The original Phase 6 spec didn't separate these two concerns, so
-  the upload validator wasn't extended for EJBCA in the initial
-  implementation. Uploading the test profile failed with "Fleet
-  variable $FLEET_VAR_EJBCA_… is not supported in configuration
-  profiles" before the runtime path ever ran. Resolved by adding an
-  `EJBCAVarsFound` struct (mirrors `DigiCertVarsFound`), a fifth
-  `additionalEJBCAValidation` parameter to
-  `validateProfileCertificateAuthorityVariables` (nil in POC), and
-  the EJBCA prefix entries in the upload allow-list. The full
-  production implementation should also implement
-  `additionalEJBCAValidation` to mirror DigiCert's structural check
-  that the vars only appear inside a `com.apple.security.pkcs12`
-  payload.
+- **End-to-end happy path verified, including per-host enrollment.**
+  With (a) openssl subprocess decode in place, (b)
+  `REST Certificate Management` enabled, (c) `ejbca.local` in
+  `/etc/hosts`, (d) the Management CA in Fleet's trust bundle
+  field, (e) the Fleet service cert bound to a custom admin role
+  with appropriate access rules: Add CA via Fleet's UI completes,
+  the connection probe (`GET /v1/ca/status`) returns 200, the EJBCA
+  CA row lands in Fleet's database, and a `.mobileconfig` referencing
+  `$FLEET_VAR_EJBCA_DATA_<name>` / `_PASSWORD_<name>` pushed to a
+  macOS host triggers a real `pkcs10enroll` against EJBCA over mTLS,
+  receives the issued cert, wraps + delivers it via MDM, and the
+  host installs the cert into its keychain. The full happy path
+  works end-to-end against `keyfactor/ejbca-ce` 9.x.
+- **MDM profile Fleet-var support has FOUR registration points,
+  not one.** This is the most important lesson from the end-to-end
+  test pass and likely the highest-risk gap for the production
+  implementation (#30986) to miss. The original Phase 6 design
+  identified only the runtime expander; testing surfaced three
+  additional code sites that any new CA-data variable needs to be
+  registered in. For EJBCA the full list is:
+
+  1. **Runtime expander** —
+     `server/mdm/apple/profile_processor.go` `preprocessProfileContents`.
+     Recognizes the `FLEET_VAR_<CA>_DATA_/PASSWORD_` prefixes in
+     profile content, calls the per-CA enrollment service per host,
+     substitutes the base64-encoded PFX and password into the XML.
+     This is the only one Phase 6 originally captured.
+  2. **Upload allow-list** —
+     `server/service/apple_mdm.go` `validateConfigProfileFleetVariables`.
+     Lists every prefix that's accepted in an uploaded `.mobileconfig`.
+     Missing entry surfaces as `"Fleet variable $FLEET_VAR_<…> is not
+     supported in configuration profiles"` at upload time, before any
+     of the rest of the pipeline runs.
+  3. **Upload structural validator** —
+     `server/service/mdm_profiles.go`
+     `validateProfileCertificateAuthorityVariables`. Confirms each
+     referenced CA name exists in `groupedCAs` and tracks DATA +
+     PASSWORD pair completeness per-CA via a `*VarsFound` struct
+     (we added `EJBCAVarsFound` mirroring `DigiCertVarsFound`).
+     Takes a per-CA "additional structural validator" callback (e.g.
+     `additionalDigiCertValidation` enforces vars only appear inside
+     `com.apple.security.pkcs12` payloads); POC passes nil for
+     `additionalEJBCAValidation`, leaving that as a follow-up.
+  4. **Plist pre-parse scrubber** —
+     `server/variables/variables.go` `ProfileDataVariableRegex`.
+     Apple's plist parser strict-validates that `<data>` field
+     contents are base64; a literal `$FLEET_VAR_..._DATA_X` is not.
+     This regex matches the placeholder in `<data>` fields so it
+     can be stripped (or substituted with placeholder base64) before
+     the plist parser runs. Missing entry surfaces as `"failed to
+     parse config profile: ... plist: error parsing XML property
+     list: illegal base64 data at input byte 0"` at upload time,
+     even before the upload allow-list runs.
+
+  All four were extended during POC implementation; testing surfaced
+  #2, #3, and #4 in sequence because they fail in that order during
+  upload processing. **The production implementation must keep these
+  in lockstep** — adding a new CA-data variable to one without the
+  others is a latent failure mode.
 - **Enrollment code: required by API, not authenticating in our config.**
   Verified by reading `SignSessionBean.java` in the EJBCA source: the
   backend rejects `password=null` for any CA with `useUserStorage=true`

--- a/openspec/changes/add-ejbca-rest-ca-poc/research.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/research.md
@@ -368,6 +368,32 @@ is deferred — small follow-up, same backend.
 
 ## Open follow-ups
 
+- **BER → DER normalization for the PKCS#12 decode path. PRODUCTION
+  BLOCKER for #30986.** EJBCA's RA Web (Java/BouncyCastle) emits BER
+  PKCS#12 bundles with indefinite-length sequences. Both Go PKCS#12
+  libraries — `software.sslmate.com/src/go-pkcs12` and
+  `golang.org/x/crypto/pkcs12` — require strict DER and reject BER. The
+  POC unblocks this by shelling out to the `openssl` binary, which
+  handles BER. **This subprocess approach must not ship to production**:
+  it adds a runtime binary dependency Fleet doesn't otherwise have,
+  expands the trust surface (subprocess hardening, PATH lookup, openssl
+  version drift across host OS distros), and complicates the security
+  posture around password handling.
+
+  Production options, ranked:
+  1. *Implement an in-process BER → DER normalizer in pure Go.* The
+     conversion is mechanical (recursively replace indefinite-length
+     constructs with definite-length equivalents). Roughly 200–300 lines
+     including tests against EJBCA's actual output. No runtime
+     dependency. Best long-term shape.
+  2. *Patch BER support into one of the Go PKCS#12 libraries upstream
+     and depend on the patched version.* Cleaner externally but slower
+     (depends on maintainer cycles).
+  3. *Accept an additional upload format (e.g., separate PEM cert + PEM
+     key)* — sidesteps the BER issue entirely for customers who can
+     produce PEM out of EJBCA via openssl on their side. Already on
+     this Open follow-ups list under "PEM-direct upload".
+
 - OAuth 2.0 bearer-token authentication. Probably shares code with Fleet's
   existing OIDC SSO support — the same JWKS verification, audience
   validation, etc. File a follow-up issue under #30986 once POC merges.

--- a/openspec/changes/add-ejbca-rest-ca-poc/research.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/research.md
@@ -324,6 +324,74 @@ is deferred — small follow-up, same backend.
 - **`fleethttp.WithTLSClientConfig` already exists** at
   `pkg/fleethttp/fleethttp.go:36`. No package additions needed for the
   mTLS plumbing.
+
+### Confirmed during end-to-end testing against `keyfactor/ejbca-ce`
+
+- **EJBCA RA Web emits BER-encoded PKCS#12 bundles** (indefinite-length
+  ASN.1, leading bytes `30 80 02 01 03 30 80 ...`). Both Go PKCS#12
+  decoders (`software.sslmate.com/src/go-pkcs12` and
+  `golang.org/x/crypto/pkcs12`) use the strict-DER `encoding/asn1` and
+  reject these inputs. Resolved for the POC by an openssl subprocess
+  in `decodeEJBCAClientP12` — explicitly flagged as PROD-BLOCKER in
+  the same function's doc comment.
+- **`keyfactor/ejbca-ce` ships with all REST API protocols DISABLED.**
+  The 403 response carries an HTML body (`This service has been
+  disabled`), and the failure presents as a silent `EOF` mid-request
+  from Fleet's side because the TLS handshake completes before the
+  protocol-disabled check runs. Enable via Admin UI → System
+  Configuration → Protocol Configuration tab → **REST Certificate
+  Management** (despite the name, this is the module that serves
+  `/v1/ca/status` and `/v1/certificate/pkcs10enroll`). A container
+  restart is required after enabling — the running app doesn't reload
+  protocol config in place. **REST CA Management** is a different
+  module (serves `/v1/ca_management`) and is `Unavailable` in CE
+  anyway. Customer-side production EJBCA admins will already have the
+  right module enabled; this only matters for local POC dev.
+- **EJBCA container HTTPS cert has SAN = `ejbca.local`.** Fleet's mTLS
+  client does strict TLS verification (can't skip — it's mTLS). Local
+  workaround: `/etc/hosts` mapping for `ejbca.local → 127.0.0.1` and
+  configure Fleet's URL field as `https://ejbca.local:8443`. The SCEP
+  dev guide sidesteps this by using HTTP port 8480; the REST path
+  can't.
+- **macOS curl + EJBCA P12 don't mix directly.** macOS curl links
+  against LibreSSL which rejects EJBCA's P12 bundles
+  (`LibreSSL error: PKCS12 routines:CRYPTO_internal:mac verify failure`).
+  Doesn't affect Fleet — its server-side openssl subprocess uses the
+  full OpenSSL on `$PATH`. Only matters when developers try to use
+  curl's `--cert-type P12` directly for diagnostic mTLS testing on a
+  Mac. Workaround documented in the dev guide's Troubleshooting
+  section: pre-extract to PEM with openssl, then use curl with
+  `--cert/--key` on the PEM files.
+- **End-to-end happy path verified.** With (a) openssl subprocess
+  decode in place, (b) `REST Certificate Management` enabled, (c)
+  `ejbca.local` in `/etc/hosts`, (d) the Management CA in Fleet's
+  trust bundle field, (e) the Fleet service cert bound to a custom
+  admin role with appropriate access rules: Add CA via Fleet's UI
+  completes, the connection probe (`GET /v1/ca/status`) returns 200,
+  and the EJBCA CA row lands in Fleet's database. The per-host
+  enrollment path (`pkcs10enroll`) is unit-tested for UPN SAN
+  encoding but hasn't yet been exercised against real EJBCA via the
+  MDM profile-delivery flow — pending Phase 10 / manual verification.
+- **MDM profile Fleet-var support has TWO checkpoints, not one.**
+  Phase 6's `preprocessProfileContents` handles the *runtime*
+  expansion path (per-host enrollment when the profile is delivered).
+  Separately, there's an *upload-time* validator in
+  `server/service/mdm_profiles.go` that maintains an allow-list of
+  Fleet-var prefixes accepted in `.mobileconfig` uploads and tracks
+  DATA+PASSWORD pair completeness per CA via `*VarsFound` structs.
+  The original Phase 6 spec didn't separate these two concerns, so
+  the upload validator wasn't extended for EJBCA in the initial
+  implementation. Uploading the test profile failed with "Fleet
+  variable $FLEET_VAR_EJBCA_… is not supported in configuration
+  profiles" before the runtime path ever ran. Resolved by adding an
+  `EJBCAVarsFound` struct (mirrors `DigiCertVarsFound`), a fifth
+  `additionalEJBCAValidation` parameter to
+  `validateProfileCertificateAuthorityVariables` (nil in POC), and
+  the EJBCA prefix entries in the upload allow-list. The full
+  production implementation should also implement
+  `additionalEJBCAValidation` to mirror DigiCert's structural check
+  that the vars only appear inside a `com.apple.security.pkcs12`
+  payload.
 - **Enrollment code: required by API, not authenticating in our config.**
   Verified by reading `SignSessionBean.java` in the EJBCA source: the
   backend rejects `password=null` for any CA with `useUserStorage=true`

--- a/openspec/changes/add-ejbca-rest-ca-poc/specs/certificate-authorities/spec.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/specs/certificate-authorities/spec.md
@@ -202,4 +202,10 @@ must be surfaced administratively.
   change. Follow-up alongside the production implementation will mirror
   the existing DigiCert / NDES / SCEP shapes, with the P12 carried as a
   base64-encoded string.
+- **Pure-Go BER → DER normalization for the PKCS#12 decode path.** POC
+  shells out to the `openssl` binary to convert EJBCA's BER-encoded P12
+  to DER before parsing — both Go PKCS#12 libraries are strict-DER and
+  reject EJBCA's output. Production (#30986) must replace this with a
+  pure-Go normalizer so Fleet has no runtime dependency on the openssl
+  binary. See research.md → "Open follow-ups" for design options.
 - Windows, Linux, and Android cert delivery paths.

--- a/openspec/changes/add-ejbca-rest-ca-poc/specs/certificate-authorities/spec.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/specs/certificate-authorities/spec.md
@@ -1,0 +1,205 @@
+# Certificate Authorities — EJBCA capability
+
+## Added requirements
+
+### REQ-CA-EJBCA-1: EJBCA CA type
+
+Fleet SHALL support a new `CertificateAuthority` type with `type = "ejbca"`.
+An EJBCA CA represents the configuration needed to enroll TLS/client
+certificates from a customer's EJBCA instance via EJBCA's REST API over
+mTLS.
+
+### REQ-CA-EJBCA-2: Required configuration fields
+
+An EJBCA CA SHALL require, at create time, the following fields:
+
+- `name` — unique within the EJBCA CA type.
+- `url` — base URL of the EJBCA REST API
+  (e.g., `https://ejbca.example.com:8443`).
+- `client_p12` — PKCS#12 bundle containing the client certificate chain and
+  matching private key. **POC accepts P12 only**; PEM-direct upload is
+  deferred. The server decodes the P12 once at submission using
+  `client_p12_password`, extracts the cert chain and private key, persists
+  them as PEM (private key encrypted), and discards the P12 password.
+- `client_p12_password` — password protecting the uploaded P12. **Not
+  persisted** — used only to decode the bundle at submission time.
+- `certificate_authority_name_ejbca` — name of the issuing CA inside
+  EJBCA, used as `certificate_authority_name` in `pkcs10enroll` requests.
+- `certificate_profile_name` — name of the certificate profile in EJBCA.
+- `end_entity_profile_name` — name of the end entity profile in EJBCA.
+- `username_template` — string used as both the EJBCA end-entity username
+  and the CSR CommonName. MAY contain Fleet variables from the existing
+  allow-list (`$FLEET_VAR_HOST_HARDWARE_SERIAL`, `$FLEET_VAR_HOST_PLATFORM`,
+  `$FLEET_VAR_HOST_END_USER_EMAIL_IDP`).
+
+The `password` field that EJBCA's `pkcs10enroll` API requires SHALL be
+generated internally by Fleet per-enrollment (REQ-CA-EJBCA-7). It is not
+a user-configurable field in this iteration. See "Deferred" for the
+user-configurable variant.
+
+### REQ-CA-EJBCA-2a: Subject Alternative Name templating (UPN)
+
+An EJBCA CA SHALL accept an optional list of Microsoft User Principal
+Names to embed in the CSR's `subjectAltName` extension as `otherName`
+entries (OID `1.3.6.1.4.1.311.20.2.3`):
+
+- `certificate_user_principal_names` — `[]string`, optional. Each entry MAY
+  contain Fleet variables from the allow-list. Empty list means no SAN
+  extension is added to the CSR.
+
+This matches the templating surface Fleet's DigiCert CA supports today.
+Other SAN attribute types (DNS, email, IP, URI) are out of scope for this
+change. The customer's EJBCA Certificate Profile MUST have "Allow Extension
+Override" enabled to preserve the SAN through issuance (documented in the
+dev guide).
+
+### REQ-CA-EJBCA-3: Optional configuration fields
+
+- `trust_ca_bundle` — PEM-encoded CA bundle used to verify EJBCA's HTTPS
+  server certificate. When empty, Fleet uses its system root store.
+
+### REQ-CA-EJBCA-4: Encrypted-at-rest secrets
+
+The following EJBCA CA fields SHALL be encrypted with `serverPrivateKey`
+when stored in MySQL:
+
+- the PEM private key extracted from the uploaded P12
+
+The PEM certificate chain extracted from the P12 and the `trust_ca_bundle`
+are public artifacts and SHALL be stored unencrypted (matching existing
+patterns for public PEM material).
+
+The `client_p12_password` supplied at submission SHALL NOT be persisted.
+The per-enrollment `password` value Fleet generates for `pkcs10enroll`
+SHALL NOT be persisted — it is created at issuance time, sent, and
+discarded.
+
+### REQ-CA-EJBCA-5: Secret masking on read
+
+When `includeSecrets=false`, reads of EJBCA CA records SHALL return
+`fleet.MaskedPassword` for the stored PEM private key, matching the
+existing DigiCert `api_token` masking behavior.
+
+### REQ-CA-EJBCA-6: Connection verification on create/update
+
+On create and update of an EJBCA CA, Fleet SHALL:
+
+1. Validate field presence and parseability (URL parses; uploaded P12
+   decodes with the supplied password; extracted cert and key pair
+   correctly; trust bundle parses if present).
+2. Build an HTTP client with the configured mTLS material and call
+   `GET {url}/ejbca/ejbca-rest-api/v1/ca/status`.
+3. Reject the create/update with a wrapped error if:
+   - any TLS handshake fails (server cert untrusted, client cert revoked or
+     not bound to a role, expired, etc.),
+   - the HTTP response is not 200 with `status == "OK"`.
+
+### REQ-CA-EJBCA-7: Certificate enrollment
+
+To enroll a certificate from an EJBCA CA, Fleet SHALL:
+
+1. Generate a fresh RSA 2048 keypair in-memory.
+2. Build a CSR with `CommonName` set to the expanded
+   `username_template`. If `certificate_user_principal_names` is non-empty,
+   include a `subjectAltName` extension on the CSR with one `otherName`
+   entry per UPN (OID `1.3.6.1.4.1.311.20.2.3`, value type `UTF8String`,
+   value = the expanded UPN string).
+3. Generate a cryptographically-random 32-byte value, hex-encode it, and
+   use it as the `password` field in the request body. This value is
+   not persisted; it satisfies EJBCA's API requirement (the backend
+   rejects null `password` for any CA with `useUserStorage=true`) and
+   is otherwise transparent to Fleet's operation.
+4. POST to `{url}/ejbca/ejbca-rest-api/v1/certificate/pkcs10enroll` with a
+   JSON body containing the PEM CSR, profile names, expanded username, the
+   generated password, `include_chain=false`, and `response_format="DER"`.
+5. On HTTP 201: base64-decode the `certificate` field, parse as an X.509
+   cert, wrap (key, cert) in a PKCS#12 with a randomly generated password,
+   and return an `EJBCACertificate` containing the PFX bytes, password, not-
+   before / not-after, and serial number.
+6. On non-201: return a wrapped error containing EJBCA's `error_message`,
+   with status code mapping per REQ-CA-EJBCA-9.
+
+### REQ-CA-EJBCA-8: MDM profile variable substitution
+
+Apple MDM configuration profiles SHALL support two new variable prefixes:
+
+- `$FLEET_VAR_EJBCA_DATA_<ca_name>` — replaced with the base64-encoded
+  PKCS#12 PFX data for the per-host enrolled certificate.
+- `$FLEET_VAR_EJBCA_PASSWORD_<ca_name>` — replaced with the randomly
+  generated PKCS#12 password.
+
+`<ca_name>` is the EJBCA CA's `name` field. Per-host Fleet variables in
+the CA's `username_template` SHALL be expanded against the receiving host
+before each enrollment.
+
+### REQ-CA-EJBCA-9: Error response mapping
+
+The EJBCA REST client SHALL distinguish the following error classes in
+wrapped error messages:
+
+- HTTP 401 / 403 → "EJBCA rejected the Fleet client certificate (likely
+  revoked, expired, or not bound to a role with sufficient access)"
+- HTTP 404 → "EJBCA reports the CA or profile name does not exist"
+- HTTP 422 → "EJBCA end-entity profile rejected the CSR: <error_message>"
+- All other non-2xx → wrap EJBCA's `error_message` verbatim with the HTTP
+  status code
+
+### REQ-CA-EJBCA-11: Update semantics — no automatic re-enrollment
+
+Updates to an existing EJBCA CA row (via PATCH or UI edit; GitOps apply
+is deferred for the POC) SHALL NOT trigger re-enrollment of certificates
+previously issued to hosts.
+Existing host certificates remain installed and valid; the updated CA
+configuration takes effect only on subsequent enrollments triggered by
+ordinary profile-delivery events (new host assignment, profile
+re-application, manual `ResendHostMDMProfile`, host MDM re-enrollment).
+
+This matches the existing behavior for all other CA types in Fleet and is
+intentional: cert validity at the protocol layer (WiFi server, VPN
+gateway, etc.) is independent of Fleet's stored configuration, so a
+rotation of Fleet's mTLS material or EJBCA-side profile names does not
+require — and SHOULD NOT cause — fleet-wide reissuance.
+
+### REQ-CA-EJBCA-12: Client certificate expiry surfacing
+
+Fleet SHALL parse the `notAfter` date from the stored EJBCA client
+certificate and expose it on:
+
+- the certificate authority list response (`GET /fleet/certificate_authorities`)
+  as a `client_cert_expires_at` field on each EJBCA CA entry
+- the certificate authority list page in the UI as an "Expires in N days"
+  badge alongside each EJBCA CA name
+
+When `client_cert_expires_at` is less than 30 days in the future, the UI
+SHALL render the badge with a warning visual style. Less than 7 days
+SHALL render as an error style.
+
+This requirement exists because once Fleet's mTLS client cert expires,
+*new* enrollments silently stop while *existing* host certs continue to
+work — a failure mode that is undetectable from device-side health and
+must be surfaced administratively.
+
+## Deferred (not in this change)
+
+- OAuth 2.0 bearer-token authentication as an alternative to mTLS.
+- PEM-direct upload of client cert + key (separate `.pem` files). POC is
+  P12-only.
+- A dedicated "replace credentials" UX action on the CA list page. In the
+  POC, rotating the mTLS material is done via the standard edit modal —
+  re-upload the P12, save. The backend already re-validates and re-persists.
+- **User-configurable enrollment code.** POC generates the `password`
+  field internally per-issuance (REQ-CA-EJBCA-7). A configurable
+  optional field — for customers whose EJBCA End Entity Profile is
+  configured to require a specific shared password, or whose workflow
+  depends on a known shared secret — is a small follow-up: one optional
+  field on the create/update payload, one if-empty branch in
+  `GetCertificate`. Pull forward only if a customer confirms they need
+  it (see proposal.md decision #5).
+- **GitOps support for the EJBCA CA type.** POC ships API + UI only.
+  The `certificate_authorities` GitOps spec, the
+  `ValidateCertificateAuthoritiesSpec` parser, and
+  `BatchApplyCertificateAuthorities` are NOT extended for EJBCA in this
+  change. Follow-up alongside the production implementation will mirror
+  the existing DigiCert / NDES / SCEP shapes, with the P12 carried as a
+  base64-encoded string.
+- Windows, Linux, and Android cert delivery paths.

--- a/openspec/changes/add-ejbca-rest-ca-poc/specs/certificate-authorities/spec.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/specs/certificate-authorities/spec.md
@@ -208,4 +208,13 @@ must be surfaced administratively.
   reject EJBCA's output. Production (#30986) must replace this with a
   pure-Go normalizer so Fleet has no runtime dependency on the openssl
   binary. See research.md → "Open follow-ups" for design options.
+- **Structural `additionalEJBCAValidation` for `.mobileconfig` uploads.**
+  Mirrors `additionalDigiCertValidation`'s check that EJBCA Fleet
+  variables only appear inside a `com.apple.security.pkcs12` payload,
+  and that the Password / PayloadContent fields exactly match the
+  expected variable patterns. POC accepts the uploaded profile as
+  long as the DATA + PASSWORD pair is complete and the CA name
+  exists (the framework hooks are already in place — see the fifth
+  parameter `additionalEJBCAValidation` on
+  `validateProfileCertificateAuthorityVariables`, currently nil).
 - Windows, Linux, and Android cert delivery paths.

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -274,9 +274,17 @@ Frontend lint + prettier + TypeScript compile all clean.
 
 ## 12. Linting + final hygiene
 
-- [ ] `make lint-go-incremental` — clean.
-- [ ] `make lint-js` — clean.
-- [ ] `go test ./server/fleet/... ./server/service/...` — at minimum no
-      mock crashes.
+- [x] `make lint-go` — 0 issues (full sweep, not just incremental). One
+      gofmt whitespace alignment in `server/fleet/certificate_authorities.go`
+      caught by the final sweep and fixed.
+- [x] `make lint-js` — 0 errors. 306 warnings exist in the codebase but
+      none are in EJBCA-touched files; all are pre-existing tech debt.
+- [x] `go test ./server/fleet/... ./ee/server/service/ejbca/...
+      ./server/variables/...` — all pass.
+- [x] `go test ./server/service/` — compile + mocks unaffected by the
+      EJBCAService interface addition (no test crashes).
+- [x] `MYSQL_TEST=1 FLEET_MYSQL_TEST_PORT=3309 go test
+      ./server/datastore/mysql/migrations/tables/ -run
+      TestUp_20260605080208` — migration applies cleanly.
 - [ ] PR description: link to this proposal, list what was skipped, note
       open questions for the customer call.

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -1,0 +1,201 @@
+# Tasks: EJBCA REST CA integration (POC)
+
+Implementation checklist for the POC. Tasks are listed in the order they
+unblock each other. Skip tests except where they accelerate iteration —
+this is a learning POC, not a production ship.
+
+## 0. Pre-implementation
+
+- [ ] Get customer confirmation on the seven auth decisions in
+      [proposal.md → "Auth decisions requiring customer confirmation"](./proposal.md#auth-decisions-requiring-customer-confirmation).
+      Capture answers in [research.md → "Decisions confirmed with customer"](./research.md#decisions-confirmed-with-customer).
+- [ ] Stand up a local EJBCA Community Edition Docker container per the
+      existing
+      [ejbca-scep-testing.md](../../../docs/Contributing/product-groups/security-compliance/ejbca-scep-testing.md)
+      Docker section. We'll reuse the container.
+
+## 1. EJBCA-side dev setup (one-time, in your local EJBCA)
+
+- [ ] Create a `fleetRESTAdmin` Certificate Profile (CA Functions →
+      Certificate Profiles): clone ENDUSER, EKU = Client Authentication.
+- [ ] Create a `fleetRESTAdmin` End Entity Profile (RA Functions → End Entity
+      Profiles), default cert profile = above.
+- [ ] Enroll a service certificate via RA Web → Make New Request. Username
+      `fleet_rest_service`. Download as PKCS#12 with a known password.
+- [ ] Create an Administrator Role bound to that cert (System Functions →
+      Roles and Access Rules). Use RA Administrators template, narrow Access
+      CAs and EE profiles to just what the enrollment requires.
+- [ ] Add the cert to the role's Members: Match X509:CN = "Fleet REST Service",
+      CA = Management CA.
+- [ ] Export the Management CA cert as PEM (RA Web → CA Certificates and
+      CRLs). This becomes the trust bundle for the POC.
+- [ ] Verify `curl --cert fleet_rest_service.p12 ...` against
+      `https://localhost:8443/ejbca/ejbca-rest-api/v1/ca/status` returns 200.
+
+## 2. Backend types
+
+- [x] Add `EJBCACA` struct to `server/fleet/certificate_authorities.go`
+      (mirror `DigiCertCA`).
+- [x] Add `CATypeEJBCA = "ejbca"` constant.
+- [x] Extend `CertificateAuthority` polymorphic struct with EJBCA pointer
+      fields.
+- [x] Extend `CertificateAuthorityPayload` and `CertificateAuthorityUpdatePayload`
+      with `EJBCA *EJBCACA`.
+- [x] Add `Equals`, `Preprocess`, and `EJBCACAUpdatePayload.Validate` methods.
+- [x] Add `EJBCAService` interface and `EJBCACertificate` struct in
+      `server/fleet/ejbca.go` (new file).
+- [x] Add `FleetVarEJBCADataPrefix` and `FleetVarEJBCAPasswordPrefix`
+      constants in `server/fleet/mdm.go` and add both to the allow-list at
+      `mdm.go:99`.
+- [x] Add a `ClientCertExpiresAt time.Time` field to `EJBCACA` (omitempty
+      JSON). Populated server-side at read time by parsing `notAfter` from
+      the stored PEM client cert. Used by the frontend to render the
+      "Expires in N days" badge (REQ-CA-EJBCA-12).
+- [x] Add a `CertificateUserPrincipalNames []string` field to `EJBCACA`
+      and `EJBCACACreatePayload` (optional, json omitempty). Mirrors
+      DigiCert's same-named field.
+- [x] Add `ActivityAddedEJBCA`, `ActivityEditedEJBCA`,
+      `ActivityDeletedEJBCA` activity types in `server/fleet/activities.go`
+      (mirror the existing Hydrant/Smallstep types). Wiring into the
+      service methods happens in Phase 5.
+
+## 3. HTTP client package
+
+- [ ] Create `ee/server/service/ejbca/ejbca.go`.
+- [ ] Implement `buildTLSClient` helper that builds a `tls.Config` from
+      `ClientCertPEM` + `ClientKeyPEM` + optional `TrustCABundlePEM`. Pass
+      via `fleethttp.WithTLSClientConfig` (already exists in
+      `pkg/fleethttp/fleethttp.go:36`).
+- [ ] Implement `VerifyConnection`: `GET /ejbca/ejbca-rest-api/v1/ca/status`,
+      decode `{"status":"OK"}`.
+- [ ] Implement `GetCertificate`: generate RSA 2048, build CSR with CN =
+      username, POST `pkcs10enroll`, decode base64-DER cert, wrap in PKCS12,
+      return `EJBCACertificate`.
+- [ ] In `GetCertificate`, generate a 32-byte cryptographically-random
+      value (via `crypto/rand`) hex-encoded as the `password` field on
+      each `pkcs10enroll` call. Do not persist it. Required because
+      EJBCA's backend rejects null `password` for any CA with
+      `useUserStorage=true` (verified in `SignSessionBean.java`).
+- [ ] In `GetCertificate`, if `CertificateUserPrincipalNames` is non-empty,
+      attach a `subjectAltName` extension to the CSR with one `otherName`
+      per UPN (OID `1.3.6.1.4.1.311.20.2.3`, value type UTF8String).
+      Construct via raw ASN.1 — Go's stdlib doesn't have first-class UPN
+      otherName support. Reference: there is no existing helper for this
+      in Fleet, so write it cleanly with comments.
+- [ ] Error distinction: 401/403 → "EJBCA rejected the Fleet client cert
+      (revoked or not bound to a role with sufficient access)". 404 → "CA or
+      profile name not found in EJBCA". 422 → "EE profile rejected the CSR".
+      Other → wrap message verbatim from EJBCA's `error_message`.
+
+## 4. Datastore + migration
+
+- [ ] Write migration adding columns (per [design.md → Migration](./design.md#migration)).
+- [ ] Extend `type` ENUM with `'ejbca'`.
+- [ ] Update insert / select / encrypt / decrypt helpers in
+      `server/datastore/mysql/certificate_authorities.go`.
+- [ ] Update `GroupCertificateAuthoritiesByType` in
+      `server/fleet/certificate_authorities.go`.
+- [ ] Update `postprocessRetrievedCertificateAuthority` to mask
+      the encrypted PEM private key when
+      `includeSecrets=false`.
+- [ ] After datastore method additions, run `go test ./server/service/`
+      to confirm mocks aren't broken. Run `make generate-mock` if needed.
+
+## 5. Service layer wiring
+
+- [ ] Add `ejbcaService fleet.EJBCAService` to the EE service struct;
+      inject in `cmd/fleet` setup.
+- [ ] Implement `validateEJBCA(payload)` (mirror `validateDigicert`):
+      required-field checks, URL parse, PEM cert+key parse,
+      `tls.X509KeyPair()` to confirm they match, optional trust bundle parse.
+- [ ] Wire `NewCertificateAuthority` EJBCA branch: validate → encrypt →
+      persist → call `VerifyConnection` → on failure, return wrapped error
+      (do not persist).
+- [ ] Wire `UpdateCertificateAuthority` EJBCA branch: same shape.
+- [ ] Skip GitOps for the POC. `BatchApplyCertificateAuthorities` and
+      `ValidateCertificateAuthoritiesSpec` are NOT extended for EJBCA in
+      this change — see proposal.md "Out of scope" and design.md "GitOps
+      — deferred". Follow-up alongside the production implementation.
+
+## 6. MDM profile processor
+
+- [ ] Add EJBCA branches in `server/mdm/apple/profile_processor.go`:
+      - `isCAConfigured` → recognize `FLEET_VAR_EJBCA_*` prefixes.
+      - validation phase → ensure the named CA exists.
+      - expansion phase → per host, deep-copy CA, expand
+        `UsernameTemplate`, call `ejbcaService.GetCertificate`, substitute
+        `FLEET_VAR_EJBCA_DATA_<name>` (base64 PFX) and
+        `FLEET_VAR_EJBCA_PASSWORD_<name>` in the profile XML.
+
+## 7. Endpoints
+
+- [ ] Confirm `request_certificate` endpoint dispatches correctly to EJBCA
+      via type switch (it should — endpoint is generic).
+- [ ] Smoke-test all five CRUD endpoints (`POST`, `GET list`, `GET id`,
+      `PATCH`, `DELETE`) with EJBCA payloads.
+
+## 8. Frontend (minimal POC)
+
+- [ ] Create `frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/` —
+      mirror `DigicertForm.tsx`.
+- [ ] Add EJBCA option in `AddCertAuthorityModal`.
+- [ ] Add EJBCA branch in `EditCertAuthorityModal`.
+- [ ] Form accepts **only** PKCS#12 upload + password. Reject any other
+      filetype client-side with a clear "EJBCA expects a .p12 file" message.
+- [ ] Server-side: decode the P12 with the supplied password using
+      `software.sslmate.com/src/go-pkcs12`, extract cert + key, persist as
+      PEM (key encrypted). Discard the P12 password — it is never stored.
+- [ ] Edit modal exposes the same fields as create. Re-uploading a P12 in
+      edit mode replaces the stored cert+key (the rotation workflow — no
+      separate "Replace credentials" button in the POC).
+- [ ] On the CA list page, parse `not_after` from the stored EJBCA client
+      cert and render an "Expires in N days" badge per REQ-CA-EJBCA-12.
+      Warning visual <30 days; error visual <7 days.
+- [ ] No polish work — just enough for an end-to-end manual test.
+
+## 9. Dev guide
+
+- [ ] Write `docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md`
+      as a sibling to the existing SCEP guide. Cover:
+      - Reuse of the same Docker container.
+      - The one-time EJBCA-side setup from §1 above.
+      - How to create the EJBCA CA in Fleet (curl examples for both API and
+        the create-via-UI flow).
+      - End-to-end: create CA → push a profile with `FLEET_VAR_EJBCA_*` to
+        an enrolled host → verify the cert installs.
+      - Gotchas:
+        - CE requires pre-creating end entities (covered by reusing the
+          existing SCEP guide's `bin/ejbca.sh ra addendentity` snippet);
+          EE auto-creates if the EE profile permits.
+        - **"Allow Extension Override" must be checked** on the
+          Certificate Profile if you use UPN templating — otherwise EJBCA
+          drops the SAN extension during issuance. Same gotcha as the
+          existing SCEP guide.
+        - GitOps is deferred for the POC — the dev guide covers the API
+          and UI paths only. (Fleet generates the EJBCA `password`
+          internally per enrollment; there is no enrollment-code field
+          anywhere in the POC surface.)
+
+## 10. Manual verification (POC success criteria)
+
+- [ ] All five proposal success criteria are demonstrably true on a
+      developer machine.
+- [ ] Customer auth-decision questions are answered and captured.
+- [ ] Run the full new dev guide from scratch on a clean machine.
+
+## 11. Skipped on purpose (call out in PR description)
+
+- Tests: write only what helps debug. No comprehensive coverage.
+- Activity logging beyond what the generic CA wiring gives for free.
+- Cert-expiry surfacing, in-place rotation UX, distinct error UI.
+- OAuth bearer auth (file as follow-up issue referencing #30986).
+- Windows / Linux / Android cert delivery paths.
+
+## 12. Linting + final hygiene
+
+- [ ] `make lint-go-incremental` — clean.
+- [ ] `make lint-js` — clean.
+- [ ] `go test ./server/fleet/... ./server/service/...` — at minimum no
+      mock crashes.
+- [ ] PR description: link to this proposal, list what was skipped, note
+      open questions for the customer call.

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -153,24 +153,37 @@ this is a learning POC, not a production ship.
         add `CAConfigEJBCA` and tracking. Noted inline.
 - [x] Existing `preprocessProfileContents` tests updated to pass a real
       ejbca service instead of nil (satisfies nilaway flow analysis).
-- [x] **Follow-up discovered during end-to-end testing**: there's a
-      separate upload-time validator distinct from the runtime expander.
-      `validateConfigProfileFleetVariables` (server/service/apple_mdm.go)
-      maintains an allow-list of Fleet-var prefixes accepted in
-      `.mobileconfig` uploads, and
-      `validateProfileCertificateAuthorityVariables`
-      (server/service/mdm_profiles.go) tracks DATA+PASSWORD pair
-      completeness per CA via `*VarsFound` structs. Both needed EJBCA
-      support — without them an upload of an otherwise-valid profile is
-      rejected at validate-time with "Fleet variable $FLEET_VAR_EJBCA_…
-      is not supported in configuration profiles", before the runtime
-      expander ever runs. Added: `EJBCAVarsFound` struct mirroring
-      `DigiCertVarsFound` (DATA+PASSWORD pair check), an `ejbca` case
-      in the switch, a 5th parameter `additionalEJBCAValidation` (POC
-      passes nil — structural pkcs12-payload check is a follow-up),
-      and the EJBCA prefix entries in the upload allow-list. The
-      Windows-profile and test callers were updated to pass nil for
-      the new parameter.
+- [x] **Follow-up registration points discovered during end-to-end
+      testing.** Phase 6 originally registered EJBCA in only one of
+      four places that need to know about the `FLEET_VAR_EJBCA_*`
+      prefixes. The full set (documented in research.md → "Confirmed
+      during end-to-end testing"):
+
+      1. *Runtime expander* (originally captured) —
+         `server/mdm/apple/profile_processor.go`
+         `preprocessProfileContents`.
+      2. *Upload allow-list* —
+         `server/service/apple_mdm.go`
+         `validateConfigProfileFleetVariables`. Without it, upload
+         fails with "Fleet variable $FLEET_VAR_EJBCA_… is not
+         supported in configuration profiles".
+      3. *Upload structural validator* —
+         `server/service/mdm_profiles.go`
+         `validateProfileCertificateAuthorityVariables`. Tracks
+         DATA + PASSWORD pair completeness via `*VarsFound`. Added
+         `EJBCAVarsFound` (mirrors `DigiCertVarsFound`) and a fifth
+         `additionalEJBCAValidation` parameter (nil in POC).
+      4. *Plist pre-parse scrubber* —
+         `server/variables/variables.go` `ProfileDataVariableRegex`.
+         Without it, upload fails with "illegal base64 data at
+         input byte 0" because Apple's plist parser rejects a
+         non-base64 placeholder in `<data>` fields. Regex extended
+         to match `EJBCA_DATA_*` alongside `DIGICERT_DATA_*`.
+
+      Windows-profile and test callers updated to pass nil for the
+      new structural-validator parameter. End-to-end test verified
+      against `keyfactor/ejbca-ce`: profile uploads, host enrolls,
+      cert installs.
 
 ## 7. Endpoints
 
@@ -238,10 +251,18 @@ Frontend lint + prettier + TypeScript compile all clean.
 
 ## 10. Manual verification (POC success criteria)
 
-- [ ] All five proposal success criteria are demonstrably true on a
-      developer machine.
+- [x] **Happy path verified end-to-end against `keyfactor/ejbca-ce`**:
+      Add CA via Fleet UI succeeds, VerifyConnection probe returns 200,
+      DB row lands. A `.mobileconfig` referencing
+      `$FLEET_VAR_EJBCA_DATA_<name>` / `_PASSWORD_<name>` pushed to a
+      macOS host triggers a real `pkcs10enroll` against EJBCA over
+      mTLS, the issued cert is wrapped + delivered via MDM, and the
+      host installs the cert into its keychain.
 - [ ] Customer auth-decision questions are answered and captured.
-- [ ] Run the full new dev guide from scratch on a clean machine.
+      Tracked in research.md "Decisions confirmed with customer" table.
+- [ ] Run the full new dev guide from scratch on a clean machine —
+      verifies the prerequisites + EJBCA setup steps are complete and
+      reproducible.
 
 ## 11. Skipped on purpose (call out in PR description)
 

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -105,16 +105,24 @@ this is a learning POC, not a production ship.
 
 ## 5. Service layer wiring
 
-- [ ] Add `ejbcaService fleet.EJBCAService` to the EE service struct;
-      inject in `cmd/fleet` setup.
-- [ ] Implement `validateEJBCA(payload)` (mirror `validateDigicert`):
-      required-field checks, URL parse, PEM cert+key parse,
-      `tls.X509KeyPair()` to confirm they match, optional trust bundle parse.
-- [ ] Wire `NewCertificateAuthority` EJBCA branch: validate → encrypt →
-      persist → call `VerifyConnection` → on failure, return wrapped error
-      (do not persist).
-- [ ] Wire `UpdateCertificateAuthority` EJBCA branch: same shape.
-- [ ] Skip GitOps for the POC. `BatchApplyCertificateAuthorities` and
+- [x] Add `ejbcaService fleet.EJBCAService` to the EE service struct;
+      inject in `cmd/fleet` setup. Also added to the core service.Service
+      and threaded through svctest + testing_utils + mdm_external_test
+      callers.
+- [x] Implement `validateEJBCA(payload)`: name + URL + profile-name
+      checks, P12 + password required, decode P12 once (extract cert +
+      key as PEM, discard the bundle and password), trust bundle parse
+      if provided, Fleet-var allow-list check on username_template + UPNs,
+      probe EJBCA via `VerifyConnection`.
+- [x] Wire `NewCertificateAuthority` EJBCA branch: validate (which
+      includes the VerifyConnection probe) → set caToCreate fields →
+      datastore insert → activity log.
+- [x] Wire `UpdateCertificateAuthority` EJBCA branch: validateEJBCAUpdate
+      decodes any new P12 and probes the merged (new + existing) config
+      before persistence. Returns the decoded PEM cert/key for the
+      caller to plumb into caToUpdate.
+- [x] Wire `DeleteCertificateAuthority` EJBCA branch (ActivityDeletedEJBCA).
+- [x] Skip GitOps for the POC. `BatchApplyCertificateAuthorities` and
       `ValidateCertificateAuthoritiesSpec` are NOT extended for EJBCA in
       this change — see proposal.md "Out of scope" and design.md "GitOps
       — deferred". Follow-up alongside the production implementation.

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -205,26 +205,18 @@ Frontend lint + prettier + TypeScript compile all clean.
 
 ## 9. Dev guide
 
-- [ ] Write `docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md`
-      as a sibling to the existing SCEP guide. Cover:
-      - Reuse of the same Docker container.
-      - The one-time EJBCA-side setup from §1 above.
-      - How to create the EJBCA CA in Fleet (curl examples for both API and
-        the create-via-UI flow).
-      - End-to-end: create CA → push a profile with `FLEET_VAR_EJBCA_*` to
-        an enrolled host → verify the cert installs.
-      - Gotchas:
-        - CE requires pre-creating end entities (covered by reusing the
-          existing SCEP guide's `bin/ejbca.sh ra addendentity` snippet);
-          EE auto-creates if the EE profile permits.
-        - **"Allow Extension Override" must be checked** on the
-          Certificate Profile if you use UPN templating — otherwise EJBCA
-          drops the SAN extension during issuance. Same gotcha as the
-          existing SCEP guide.
-        - GitOps is deferred for the POC — the dev guide covers the API
-          and UI paths only. (Fleet generates the EJBCA `password`
-          internally per enrollment; there is no enrollment-code field
-          anywhere in the POC surface.)
+- [x] Wrote `docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md`
+      as a sibling to the existing SCEP guide. Covers:
+      - Reuse of the same `keyfactor/ejbca-ce` Docker container.
+      - One-time EJBCA-side setup: Certificate Profile + End Entity Profile
+        + service-cert enrollment + admin role + cert-to-role binding +
+        pre-creation of one end entity for the local test + trust CA export.
+      - Configuring Fleet via both UI and curl (with base64-encoded P12).
+      - End-to-end test: create CA → push a `.mobileconfig` referencing
+        `FLEET_VAR_EJBCA_*` → verify cert installs on the host.
+      - Gotchas: CE end-entity status reset, "Allow Extension Override" for
+        UPN SAN, self-signed TLS / trust bundle requirement, P12 password
+        one-shot use, managed-cert tracking row deferred to follow-up.
 
 ## 10. Manual verification (POC success criteria)
 

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -156,10 +156,22 @@ this is a learning POC, not a production ship.
 
 ## 7. Endpoints
 
-- [ ] Confirm `request_certificate` endpoint dispatches correctly to EJBCA
-      via type switch (it should — endpoint is generic).
-- [ ] Smoke-test all five CRUD endpoints (`POST`, `GET list`, `GET id`,
-      `PATCH`, `DELETE`) with EJBCA payloads.
+- [x] **Audit only — no code changes required.** All five CRUD endpoints
+      dispatch generically and are covered by Phases 4 and 5:
+      - `POST /fleet/certificate_authorities` → Phase 5 EJBCA branch
+      - `GET /fleet/certificate_authorities` → generic, returns
+        `CertificateAuthoritySummary`
+      - `GET /fleet/certificate_authorities/{id}` → Phase 4 polymorphic
+        SELECT + postprocess
+      - `PATCH /fleet/certificate_authorities/{id}` → Phase 5
+        `validateEJBCAUpdate`
+      - `DELETE /fleet/certificate_authorities/{id}` → Phase 5
+        ActivityDeletedEJBCA
+- [x] **`request_certificate` endpoint** intentionally rejects non-
+      Hydrant/EST types with the existing message; EJBCA inherits this
+      rejection by design (same as DigiCert). The EJBCA enrollment path
+      is the MDM profile processor (Phase 6), not this endpoint.
+- [x] **GitOps batch endpoints** deferred per proposal.
 
 ## 8. Frontend (minimal POC)
 

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -153,6 +153,24 @@ this is a learning POC, not a production ship.
         add `CAConfigEJBCA` and tracking. Noted inline.
 - [x] Existing `preprocessProfileContents` tests updated to pass a real
       ejbca service instead of nil (satisfies nilaway flow analysis).
+- [x] **Follow-up discovered during end-to-end testing**: there's a
+      separate upload-time validator distinct from the runtime expander.
+      `validateConfigProfileFleetVariables` (server/service/apple_mdm.go)
+      maintains an allow-list of Fleet-var prefixes accepted in
+      `.mobileconfig` uploads, and
+      `validateProfileCertificateAuthorityVariables`
+      (server/service/mdm_profiles.go) tracks DATA+PASSWORD pair
+      completeness per CA via `*VarsFound` structs. Both needed EJBCA
+      support — without them an upload of an otherwise-valid profile is
+      rejected at validate-time with "Fleet variable $FLEET_VAR_EJBCA_…
+      is not supported in configuration profiles", before the runtime
+      expander ever runs. Added: `EJBCAVarsFound` struct mirroring
+      `DigiCertVarsFound` (DATA+PASSWORD pair check), an `ejbca` case
+      in the switch, a 5th parameter `additionalEJBCAValidation` (POC
+      passes nil — structural pkcs12-payload check is a follow-up),
+      and the EJBCA prefix entries in the upload allow-list. The
+      Windows-profile and test callers were updated to pass nil for
+      the new parameter.
 
 ## 7. Endpoints
 

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -61,28 +61,27 @@ this is a learning POC, not a production ship.
 
 ## 3. HTTP client package
 
-- [ ] Create `ee/server/service/ejbca/ejbca.go`.
-- [ ] Implement `buildTLSClient` helper that builds a `tls.Config` from
+- [x] Create `ee/server/service/ejbca/ejbca.go`.
+- [x] Implement `buildTLSClient` helper that builds a `tls.Config` from
       `ClientCertPEM` + `ClientKeyPEM` + optional `TrustCABundlePEM`. Pass
       via `fleethttp.WithTLSClientConfig` (already exists in
       `pkg/fleethttp/fleethttp.go:36`).
-- [ ] Implement `VerifyConnection`: `GET /ejbca/ejbca-rest-api/v1/ca/status`,
+- [x] Implement `VerifyConnection`: `GET /ejbca/ejbca-rest-api/v1/ca/status`,
       decode `{"status":"OK"}`.
-- [ ] Implement `GetCertificate`: generate RSA 2048, build CSR with CN =
+- [x] Implement `GetCertificate`: generate RSA 2048, build CSR with CN =
       username, POST `pkcs10enroll`, decode base64-DER cert, wrap in PKCS12,
       return `EJBCACertificate`.
-- [ ] In `GetCertificate`, generate a 32-byte cryptographically-random
+- [x] In `GetCertificate`, generate a 32-byte cryptographically-random
       value (via `crypto/rand`) hex-encoded as the `password` field on
       each `pkcs10enroll` call. Do not persist it. Required because
       EJBCA's backend rejects null `password` for any CA with
       `useUserStorage=true` (verified in `SignSessionBean.java`).
-- [ ] In `GetCertificate`, if `CertificateUserPrincipalNames` is non-empty,
+- [x] In `GetCertificate`, if `CertificateUserPrincipalNames` is non-empty,
       attach a `subjectAltName` extension to the CSR with one `otherName`
       per UPN (OID `1.3.6.1.4.1.311.20.2.3`, value type UTF8String).
       Construct via raw ASN.1 — Go's stdlib doesn't have first-class UPN
-      otherName support. Reference: there is no existing helper for this
-      in Fleet, so write it cleanly with comments.
-- [ ] Error distinction: 401/403 → "EJBCA rejected the Fleet client cert
+      otherName support. Unit-tested via `ejbca_test.go`.
+- [x] Error distinction: 401/403 → "EJBCA rejected the Fleet client cert
       (revoked or not bound to a role with sufficient access)". 404 → "CA or
       profile name not found in EJBCA". 422 → "EE profile rejected the CSR".
       Other → wrap message verbatim from EJBCA's `error_message`.

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -88,17 +88,20 @@ this is a learning POC, not a production ship.
 
 ## 4. Datastore + migration
 
-- [ ] Write migration adding columns (per [design.md → Migration](./design.md#migration)).
-- [ ] Extend `type` ENUM with `'ejbca'`.
-- [ ] Update insert / select / encrypt / decrypt helpers in
+- [x] Write migration adding columns (per [design.md → Migration](./design.md#migration)).
+- [x] Extend `type` ENUM with `'ejbca'`.
+- [x] Update insert / select / encrypt / decrypt helpers in
       `server/datastore/mysql/certificate_authorities.go`.
-- [ ] Update `GroupCertificateAuthoritiesByType` in
+- [x] Update `GroupCertificateAuthoritiesByType` in
       `server/fleet/certificate_authorities.go`.
-- [ ] Update `postprocessRetrievedCertificateAuthority` to mask
-      the encrypted PEM private key when
-      `includeSecrets=false`.
-- [ ] After datastore method additions, run `go test ./server/service/`
-      to confirm mocks aren't broken. Run `make generate-mock` if needed.
+- [x] Update `postprocessRetrievedCertificateAuthority` to mask
+      the encrypted PEM private key when `includeSecrets=false`.
+      Also parses `notAfter` from the stored client cert PEM into
+      `ClientCertExpiresAt` for REQ-CA-EJBCA-12.
+- [x] After datastore method additions, run `go test ./server/service/`
+      to confirm mocks aren't broken. No new datastore interface
+      methods were added — only SQL queries and helpers — so mocks
+      are unaffected.
 
 ## 5. Service layer wiring
 

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -175,22 +175,33 @@ this is a learning POC, not a production ship.
 
 ## 8. Frontend (minimal POC)
 
-- [ ] Create `frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/` —
-      mirror `DigicertForm.tsx`.
-- [ ] Add EJBCA option in `AddCertAuthorityModal`.
-- [ ] Add EJBCA branch in `EditCertAuthorityModal`.
-- [ ] Form accepts **only** PKCS#12 upload + password. Reject any other
-      filetype client-side with a clear "EJBCA expects a .p12 file" message.
-- [ ] Server-side: decode the P12 with the supplied password using
-      `software.sslmate.com/src/go-pkcs12`, extract cert + key, persist as
-      PEM (key encrypted). Discard the P12 password — it is never stored.
-- [ ] Edit modal exposes the same fields as create. Re-uploading a P12 in
-      edit mode replaces the stored cert+key (the rotation workflow — no
-      separate "Replace credentials" button in the POC).
-- [ ] On the CA list page, parse `not_after` from the stored EJBCA client
-      cert and render an "Expires in N days" badge per REQ-CA-EJBCA-12.
-      Warning visual <30 days; error visual <7 days.
-- [ ] No polish work — just enough for an end-to-end manual test.
+- [x] Create `frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EJBCAForm/` —
+      `EJBCAForm.tsx`, `helpers.ts`, `index.ts`. Mirrors `DigicertForm`
+      but uses `FileUploader` for the P12 (Fleet's existing component;
+      accepts `.p12`/`.pfx`).
+- [x] Add EJBCA option in `AddCertAuthorityModal` (state, change/submit
+      branches, dropdown option, generateAddCertAuthorityData branch).
+- [x] Add EJBCA branch in `EditCertAuthorityModal` (form mapping in
+      getFormComponent, generateDefaultFormData, generateEditCertAuthorityData
+      with diff+inject-P12-on-rotation, updateFormData passthrough).
+- [x] Form accepts only PKCS#12 upload + password. Client-side `accept`
+      attribute is `.p12,.pfx,application/x-pkcs12`; backend rejects
+      anything else on decode (Phase 5).
+- [x] Server-side decode + persist — already done in Phase 5
+      (`decodeEJBCAClientP12`).
+- [x] Edit modal: re-uploading a P12 triggers rotation via the standard
+      edit flow. Validation makes the P12 + password optional on edit
+      (only required when uploading a new one); the helper injects them
+      into the diff only when a new P12 is supplied.
+- [ ] **Deferred from POC**: "Expires in N days" badge on the CA list
+      page. Backend exposes `client_cert_expires_at` from Phase 4; the
+      list-page rendering is a follow-up — see the deferred section of
+      the spec.
+- [x] Type definitions: `ICertificatesEJBCA` and `isEJBCACertAuthority`
+      added to `frontend/interfaces/certificates.ts`; service-layer
+      types in `frontend/services/entities/certificates.ts` extended.
+
+Frontend lint + prettier + TypeScript compile all clean.
 
 ## 9. Dev guide
 

--- a/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
+++ b/openspec/changes/add-ejbca-rest-ca-poc/tasks.md
@@ -129,13 +129,30 @@ this is a learning POC, not a production ship.
 
 ## 6. MDM profile processor
 
-- [ ] Add EJBCA branches in `server/mdm/apple/profile_processor.go`:
-      - `isCAConfigured` → recognize `FLEET_VAR_EJBCA_*` prefixes.
-      - validation phase → ensure the named CA exists.
-      - expansion phase → per host, deep-copy CA, expand
-        `UsernameTemplate`, call `ejbcaService.GetCertificate`, substitute
-        `FLEET_VAR_EJBCA_DATA_<name>` (base64 PFX) and
+- [x] Add EJBCA branches in `server/mdm/apple/profile_processor.go`:
+      - `ProcessAndEnqueueProfiles` constructs an `ejbca.NewService(...)`
+        and passes it to `preprocessProfileContents`.
+      - `preprocessProfileContents` takes a new `ejbcaService` parameter
+        and declares an `ejbcaCAs` cache.
+      - `variablesUpdatedAt` window includes EJBCA prefixes so
+        validation timestamps are tracked.
+      - Validation phase recognizes `FLEET_VAR_EJBCA_*` and calls
+        `isEJBCAConfigured` (new helper that mirrors
+        `isDigiCertConfigured`: premium-license check, lookup in
+        `groupedCAs.EJBCA`, cache hit).
+      - Expansion phase: per host, deep-copy CA (clone the UPN slice),
+        expand `UsernameTemplate` and each UPN via
+        `replaceFleetVarInItem`, call `ejbcaService.GetCertificate`,
+        substitute `FLEET_VAR_EJBCA_DATA_<name>` (base64 PFX) and
         `FLEET_VAR_EJBCA_PASSWORD_<name>` in the profile XML.
+      - On enrollment failure, marks the host's profile failed with the
+        EJBCA error message, mirroring the DigiCert failure path.
+      - POC does NOT emit a `BulkUpsertMDMManagedCertificates` record
+        for EJBCA — the legacy `CAConfigAssetType` enum doesn't have an
+        `ejbca` entry. The production implementation in #30986 should
+        add `CAConfigEJBCA` and tracking. Noted inline.
+- [x] Existing `preprocessProfileContents` tests updated to pass a real
+      ejbca service instead of nil (satisfies nilaway flow analysis).
 
 ## 7. Endpoints
 

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -2,8 +2,10 @@ package mysql
 
 import (
 	"context"
+	"crypto/x509"
 	"database/sql"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"strings"
@@ -22,6 +24,10 @@ type certificateAuthorityWithEncryptedSecrets struct {
 	ChallengeEncrypted               []byte `db:"challenge_encrypted"`
 	ClientSecretEncrypted            []byte `db:"client_secret_encrypted"`
 	CertificateUserPrincipalNamesRaw []byte `db:"certificate_user_principal_names"`
+	// EJBCA — only the encrypted private key needs a wrapper field. The PEM
+	// client cert and trust CA bundle are public material and map directly
+	// to fleet.CertificateAuthority via its own db tags.
+	ClientKeyEncrypted []byte `db:"client_key_encrypted"`
 }
 
 func (ds *Datastore) GetCertificateAuthorityByID(ctx context.Context, id uint, includeSecrets bool) (*fleet.CertificateAuthority, error) {
@@ -43,6 +49,13 @@ func (ds *Datastore) GetCertificateAuthorityByID(ctx context.Context, id uint, i
 		challenge_encrypted,
 		client_id,
 		client_secret_encrypted,
+		client_cert_pem,
+		client_key_encrypted,
+		trust_ca_bundle_pem,
+		ejbca_ca_name,
+		ejbca_certificate_profile,
+		ejbca_end_entity_profile,
+		ejbca_username_template,
 		created_at,
 		updated_at
 		FROM
@@ -97,6 +110,13 @@ func (ds *Datastore) postprocessRetrievedCertificateAuthority(ctx context.Contex
 			}
 			ca.ClientSecret = ptr.String(string(decryptedClientSecret))
 		}
+		if ca.ClientKeyEncrypted != nil {
+			decryptedClientKey, err := decrypt(ca.ClientKeyEncrypted, ds.serverPrivateKey)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, fmt.Sprintf("decrypting EJBCA client key for certificate authority %d", ca.ID))
+			}
+			ca.ClientKeyPEM = new(string(decryptedClientKey))
+		}
 	} else {
 		if ca.APITokenEncrypted != nil {
 			ca.APIToken = ptr.String(fleet.MaskedPassword)
@@ -110,10 +130,25 @@ func (ds *Datastore) postprocessRetrievedCertificateAuthority(ctx context.Contex
 		if ca.ClientSecretEncrypted != nil {
 			ca.ClientSecret = ptr.String(fleet.MaskedPassword)
 		}
+		if ca.ClientKeyEncrypted != nil {
+			ca.ClientKeyPEM = new(fleet.MaskedPassword)
+		}
 	}
 	if ca.CertificateUserPrincipalNamesRaw != nil {
 		if err := json.Unmarshal(ca.CertificateUserPrincipalNamesRaw, &ca.CertificateUserPrincipalNames); err != nil {
 			return ctxerr.Wrap(ctx, err, "unmarshalling certificate user principal names")
+		}
+	}
+	// Parse the EJBCA client cert's NotAfter for the UI's expiry badge
+	// (REQ-CA-EJBCA-12). Non-EJBCA rows have nil ClientCertPEM and skip this
+	// silently; malformed PEM on an EJBCA row is non-fatal — we just omit the
+	// timestamp.
+	if ca.ClientCertPEM != nil && *ca.ClientCertPEM != "" {
+		if block, _ := pem.Decode([]byte(*ca.ClientCertPEM)); block != nil {
+			if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+				notAfter := cert.NotAfter
+				ca.ClientCertExpiresAt = &notAfter
+			}
 		}
 	}
 	return nil
@@ -138,6 +173,13 @@ func (ds *Datastore) GetAllCertificateAuthorities(ctx context.Context, includeSe
 		challenge_encrypted,
 		client_id,
 		client_secret_encrypted,
+		client_cert_pem,
+		client_key_encrypted,
+		trust_ca_bundle_pem,
+		ejbca_ca_name,
+		ejbca_certificate_profile,
+		ejbca_end_entity_profile,
+		ejbca_username_template,
 		created_at,
 		updated_at
 		FROM
@@ -210,7 +252,7 @@ func (ds *Datastore) NewCertificateAuthority(ctx context.Context, ca *fleet.Cert
 	return ca, nil
 }
 
-const argsCountInsertCertificateAuthority = 15
+const argsCountInsertCertificateAuthority = 22
 
 const sqlInsertCertificateAuthority = `INSERT INTO certificate_authorities (
 	type,
@@ -227,7 +269,14 @@ const sqlInsertCertificateAuthority = `INSERT INTO certificate_authorities (
 	password_encrypted,
 	challenge_encrypted,
 	client_id,
-	client_secret_encrypted
+	client_secret_encrypted,
+	client_cert_pem,
+	client_key_encrypted,
+	trust_ca_bundle_pem,
+	ejbca_ca_name,
+	ejbca_certificate_profile,
+	ejbca_end_entity_profile,
+	ejbca_username_template
 ) VALUES %s`
 
 const sqlUpsertCertificateAuthority = sqlInsertCertificateAuthority + ` ON DUPLICATE KEY UPDATE
@@ -245,7 +294,14 @@ const sqlUpsertCertificateAuthority = sqlInsertCertificateAuthority + ` ON DUPLI
 	password_encrypted = VALUES(password_encrypted),
 	challenge_encrypted = VALUES(challenge_encrypted),
 	client_id = VALUES(client_id),
-	client_secret_encrypted = VALUES(client_secret_encrypted)`
+	client_secret_encrypted = VALUES(client_secret_encrypted),
+	client_cert_pem = VALUES(client_cert_pem),
+	client_key_encrypted = VALUES(client_key_encrypted),
+	trust_ca_bundle_pem = VALUES(trust_ca_bundle_pem),
+	ejbca_ca_name = VALUES(ejbca_ca_name),
+	ejbca_certificate_profile = VALUES(ejbca_certificate_profile),
+	ejbca_end_entity_profile = VALUES(ejbca_end_entity_profile),
+	ejbca_username_template = VALUES(ejbca_username_template)`
 
 func sqlGenerateArgsForInsertCertificateAuthority(ctx context.Context, serverPrivateKey string, ca *fleet.CertificateAuthority) ([]interface{}, string, error) {
 	var upns []byte
@@ -253,6 +309,7 @@ func sqlGenerateArgsForInsertCertificateAuthority(ctx context.Context, serverPri
 	var encryptedChallenge []byte
 	var encryptedAPIToken []byte
 	var encryptedClientSecret []byte
+	var encryptedClientKey []byte
 	var err error
 
 	if ca.CertificateUserPrincipalNames != nil {
@@ -285,6 +342,12 @@ func sqlGenerateArgsForInsertCertificateAuthority(ctx context.Context, serverPri
 			return nil, "", ctxerr.Wrap(ctx, err, "encrypting client secret for new certificate authority")
 		}
 	}
+	if ca.ClientKeyPEM != nil {
+		encryptedClientKey, err = encrypt([]byte(*ca.ClientKeyPEM), serverPrivateKey)
+		if err != nil {
+			return nil, "", ctxerr.Wrap(ctx, err, "encrypting EJBCA client key for new certificate authority")
+		}
+	}
 
 	args := []interface{}{
 		ca.Type,
@@ -302,8 +365,15 @@ func sqlGenerateArgsForInsertCertificateAuthority(ctx context.Context, serverPri
 		encryptedChallenge,
 		ca.ClientID,
 		encryptedClientSecret,
+		ca.ClientCertPEM,
+		encryptedClientKey,
+		ca.TrustCABundlePEM,
+		ca.EJBCACAName,
+		ca.EJBCACertificateProfileName,
+		ca.EJBCAEndEntityProfileName,
+		ca.EJBCAUsernameTemplate,
 	}
-	placeholders := "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+	placeholders := "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
 
 	return args, placeholders, nil
 }
@@ -605,6 +675,55 @@ func (ds *Datastore) generateUpdateQueryWithArgs(ctx context.Context, ca *fleet.
 				return "", ctxerr.Wrap(ctx, err, "encrypting password for new certificate authority")
 			}
 			*args = append(*args, encryptedPassword)
+		}
+	case string(fleet.CATypeEJBCA):
+		if ca.Name != nil {
+			updates = append(updates, "name = ?")
+			*args = append(*args, *ca.Name)
+		}
+		if ca.URL != nil {
+			updates = append(updates, "url = ?")
+			*args = append(*args, *ca.URL)
+		}
+		if ca.ClientCertPEM != nil {
+			updates = append(updates, "client_cert_pem = ?")
+			*args = append(*args, *ca.ClientCertPEM)
+		}
+		if ca.ClientKeyPEM != nil {
+			updates = append(updates, "client_key_encrypted = ?")
+			encryptedClientKey, err := encrypt([]byte(*ca.ClientKeyPEM), ds.serverPrivateKey)
+			if err != nil {
+				return "", ctxerr.Wrap(ctx, err, "encrypting EJBCA client key for updating certificate authority")
+			}
+			*args = append(*args, encryptedClientKey)
+		}
+		if ca.TrustCABundlePEM != nil {
+			updates = append(updates, "trust_ca_bundle_pem = ?")
+			*args = append(*args, *ca.TrustCABundlePEM)
+		}
+		if ca.EJBCACAName != nil {
+			updates = append(updates, "ejbca_ca_name = ?")
+			*args = append(*args, *ca.EJBCACAName)
+		}
+		if ca.EJBCACertificateProfileName != nil {
+			updates = append(updates, "ejbca_certificate_profile = ?")
+			*args = append(*args, *ca.EJBCACertificateProfileName)
+		}
+		if ca.EJBCAEndEntityProfileName != nil {
+			updates = append(updates, "ejbca_end_entity_profile = ?")
+			*args = append(*args, *ca.EJBCAEndEntityProfileName)
+		}
+		if ca.EJBCAUsernameTemplate != nil {
+			updates = append(updates, "ejbca_username_template = ?")
+			*args = append(*args, *ca.EJBCAUsernameTemplate)
+		}
+		if ca.CertificateUserPrincipalNames != nil {
+			updates = append(updates, "certificate_user_principal_names = ?")
+			upns, err := json.Marshal(*ca.CertificateUserPrincipalNames)
+			if err != nil {
+				return "", ctxerr.Wrap(ctx, err, "marshalling certificate user principal names for updating EJBCA certificate authority")
+			}
+			*args = append(*args, upns)
 		}
 	default:
 		return "", fmt.Errorf("unknown certificate authority type: %s", ca.Type)

--- a/server/datastore/mysql/migrations/tables/20260605080208_AddEJBCAColumnsToCertificateAuthorities.go
+++ b/server/datastore/mysql/migrations/tables/20260605080208_AddEJBCAColumnsToCertificateAuthorities.go
@@ -1,0 +1,51 @@
+package tables
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20260605080208, Down_20260605080208)
+}
+
+// Up_20260605080208 extends the certificate_authorities table to support EJBCA
+// REST integration. Adds the mTLS material columns (client cert + encrypted key
+// + optional trust bundle) plus the four EJBCA-side identifier columns the API
+// requires on each pkcs10enroll call. The `type` ENUM is extended with 'ejbca'.
+//
+// No enrollment-code column: Fleet generates the per-issuance EJBCA `password`
+// internally per enrollment and never persists it (see openspec
+// add-ejbca-rest-ca-poc REQ-CA-EJBCA-7).
+//
+// certificate_user_principal_names already exists for DigiCert and is reused
+// for EJBCA's UPN SAN templating.
+func Up_20260605080208(tx *sql.Tx) error {
+	stmt := `
+ALTER TABLE certificate_authorities
+	MODIFY COLUMN type ENUM(
+		'digicert',
+		'ndes_scep_proxy',
+		'custom_scep_proxy',
+		'hydrant',
+		'custom_est_proxy',
+		'smallstep',
+		'ejbca'
+	) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+	ADD COLUMN client_cert_pem BLOB,
+	ADD COLUMN client_key_encrypted BLOB,
+	ADD COLUMN trust_ca_bundle_pem BLOB,
+	ADD COLUMN ejbca_ca_name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	ADD COLUMN ejbca_certificate_profile VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	ADD COLUMN ejbca_end_entity_profile VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	ADD COLUMN ejbca_username_template VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+`
+	if _, err := tx.Exec(stmt); err != nil {
+		return fmt.Errorf("alter certificate_authorities for EJBCA support: %w", err)
+	}
+	return nil
+}
+
+func Down_20260605080208(tx *sql.Tx) error {
+	return nil
+}

--- a/server/datastore/mysql/migrations/tables/20260605080208_AddEJBCAColumnsToCertificateAuthorities_test.go
+++ b/server/datastore/mysql/migrations/tables/20260605080208_AddEJBCAColumnsToCertificateAuthorities_test.go
@@ -1,0 +1,41 @@
+package tables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUp_20260605080208(t *testing.T) {
+	db := applyUpToPrev(t)
+
+	applyNext(t, db)
+
+	// The new columns should be readable, and the ENUM should accept 'ejbca'.
+	_, err := db.Exec(`
+INSERT INTO certificate_authorities (
+	type, name, url,
+	client_cert_pem, client_key_encrypted, trust_ca_bundle_pem,
+	ejbca_ca_name, ejbca_certificate_profile, ejbca_end_entity_profile,
+	ejbca_username_template
+) VALUES (
+	'ejbca', 'TestEJBCA', 'https://ejbca.example.com:8443',
+	?, ?, ?,
+	'WifiIssuingCA', 'WifiClientProfile', 'WifiUsers',
+	'$FLEET_VAR_HOST_HARDWARE_SERIAL'
+)`,
+		[]byte("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"),
+		[]byte("encrypted-key-bytes"),
+		[]byte("-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"),
+	)
+	require.NoError(t, err, "insert with EJBCA type and new columns should succeed")
+
+	var (
+		caName  string
+		profile string
+	)
+	err = db.QueryRow(`SELECT ejbca_ca_name, ejbca_certificate_profile FROM certificate_authorities WHERE name = 'TestEJBCA'`).Scan(&caName, &profile)
+	require.NoError(t, err)
+	require.Equal(t, "WifiIssuingCA", caName)
+	require.Equal(t, "WifiClientProfile", profile)
+}

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1531,6 +1531,30 @@ func (a ActivityDeletedSmallstep) ActivityName() string {
 	return "deleted_smallstep"
 }
 
+type ActivityAddedEJBCA struct {
+	Name string `json:"name"`
+}
+
+func (a ActivityAddedEJBCA) ActivityName() string {
+	return "added_ejbca"
+}
+
+type ActivityDeletedEJBCA struct {
+	Name string `json:"name"`
+}
+
+func (a ActivityDeletedEJBCA) ActivityName() string {
+	return "deleted_ejbca"
+}
+
+type ActivityEditedEJBCA struct {
+	Name string `json:"name"`
+}
+
+func (a ActivityEditedEJBCA) ActivityName() string {
+	return "edited_ejbca"
+}
+
 type ActivityEditedSmallstep struct {
 	Name string `json:"name"`
 }

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -658,6 +658,7 @@ type GroupedCertificateAuthorities struct {
 	NDESSCEP        *NDESSCEPProxyCA       `json:"ndes_scep_proxy"`
 	CustomScepProxy []CustomSCEPProxyCA    `json:"custom_scep_proxy"`
 	Smallstep       []SmallstepSCEPProxyCA `json:"smallstep"`
+	EJBCA           []EJBCACA              `json:"ejbca"`
 }
 
 // ToCustomSCEPProxyCAMap converts the CustomScepProxy slice to a map keyed by CA name
@@ -677,6 +678,7 @@ func GroupCertificateAuthoritiesByType(cas []*CertificateAuthority) (*GroupedCer
 		CustomScepProxy: []CustomSCEPProxyCA{},
 		NDESSCEP:        nil,
 		Smallstep:       []SmallstepSCEPProxyCA{},
+		EJBCA:           []EJBCACA{},
 	}
 
 	for _, ca := range cas {
@@ -737,6 +739,26 @@ func GroupCertificateAuthoritiesByType(cas []*CertificateAuthority) (*GroupedCer
 				Username:     *ca.Username,
 				Password:     *ca.Password,
 			})
+		case string(CATypeEJBCA):
+			entry := EJBCACA{
+				ID:                            ca.ID,
+				Name:                          *ca.Name,
+				URL:                           *ca.URL,
+				ClientCertPEM:                 *ca.ClientCertPEM,
+				ClientKeyPEM:                  *ca.ClientKeyPEM,
+				CertificateAuthorityNameEJBCA: *ca.EJBCACAName,
+				CertificateProfileName:        *ca.EJBCACertificateProfileName,
+				EndEntityProfileName:          *ca.EJBCAEndEntityProfileName,
+				UsernameTemplate:              *ca.EJBCAUsernameTemplate,
+				ClientCertExpiresAt:           ca.ClientCertExpiresAt,
+			}
+			if ca.TrustCABundlePEM != nil {
+				entry.TrustCABundlePEM = *ca.TrustCABundlePEM
+			}
+			if ca.CertificateUserPrincipalNames != nil {
+				entry.CertificateUserPrincipalNames = *ca.CertificateUserPrincipalNames
+			}
+			grouped.EJBCA = append(grouped.EJBCA, entry)
 		}
 	}
 

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -69,6 +69,7 @@ const (
 	CATypeHydrant         CAType = "hydrant"
 	CATypeCustomESTProxy  CAType = "custom_est_proxy" // Enrollment over Secure Transport
 	CATypeSmallstep       CAType = "smallstep"
+	CATypeEJBCA           CAType = "ejbca"
 )
 
 type CertificateAuthoritySummary struct {
@@ -110,6 +111,17 @@ type CertificateAuthority struct {
 	ClientID     *string `json:"client_id,omitempty" db:"client_id"`
 	ClientSecret *string `json:"client_secret,omitempty" db:"-"`
 
+	// EJBCA. Client cert + trust bundle stored as PEM, client key encrypted at rest.
+	// CertificateUserPrincipalNames is shared with DigiCert above.
+	ClientCertPEM                 *string    `json:"client_cert,omitempty" db:"client_cert_pem"`
+	ClientKeyPEM                  *string    `json:"client_key,omitempty" db:"-"`
+	TrustCABundlePEM              *string    `json:"trust_ca_bundle,omitempty" db:"trust_ca_bundle_pem"`
+	EJBCACAName                   *string    `json:"certificate_authority_name_ejbca,omitempty" db:"ejbca_ca_name"`
+	EJBCACertificateProfileName   *string    `json:"certificate_profile_name,omitempty" db:"ejbca_certificate_profile"`
+	EJBCAEndEntityProfileName     *string    `json:"end_entity_profile_name,omitempty" db:"ejbca_end_entity_profile"`
+	EJBCAUsernameTemplate         *string    `json:"username_template,omitempty" db:"ejbca_username_template"`
+	ClientCertExpiresAt           *time.Time `json:"client_cert_expires_at,omitempty" db:"-"`
+
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 }
@@ -125,6 +137,7 @@ type CertificateAuthorityPayload struct {
 	Hydrant         *HydrantCA            `json:"hydrant,omitempty"`
 	CustomESTProxy  *ESTProxyCA           `json:"custom_est_proxy,omitempty"`
 	Smallstep       *SmallstepSCEPProxyCA `json:"smallstep,omitempty"`
+	EJBCA           *EJBCACA              `json:"ejbca,omitempty"`
 }
 
 // If you update this struct, make sure to adjust the Equals and NeedToVerify methods below
@@ -154,6 +167,73 @@ func (d *DigiCertCA) Preprocess() {
 	d.Name = Preprocess(d.Name)
 	d.URL = Preprocess(d.URL)
 	d.ProfileID = Preprocess(d.ProfileID)
+}
+
+// EJBCACA configures Fleet's mTLS REST integration with an EJBCA instance.
+// On create/update, the client supplies ClientP12 + ClientP12Password — the
+// service decodes the P12 once, populates ClientCertPEM and ClientKeyPEM,
+// and discards the P12 bytes and password (neither is persisted).
+//
+// On read, ClientCertPEM is returned as-is (public material); ClientKeyPEM
+// is returned masked. ClientCertExpiresAt is populated from the stored cert
+// at read time so the UI can render an expiry badge.
+//
+// The EJBCA `password` field required by pkcs10enroll is generated
+// internally per enrollment in the EJBCA client (see ee/server/service/ejbca/)
+// and is not represented on this struct.
+//
+// If you update this struct, make sure to adjust the Equals method below.
+type EJBCACA struct {
+	ID   uint   `json:"-"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+
+	// Upload-only — provided on create/update, never persisted.
+	ClientP12         []byte `json:"client_p12,omitempty"`
+	ClientP12Password string `json:"client_p12_password,omitempty"`
+
+	// Stored / returned. ClientKeyPEM is encrypted at rest and masked on
+	// read unless secrets are explicitly requested.
+	ClientCertPEM       string     `json:"client_cert,omitempty"`
+	ClientKeyPEM        string     `json:"client_key,omitempty"`
+	TrustCABundlePEM    string     `json:"trust_ca_bundle,omitempty"`
+	ClientCertExpiresAt *time.Time `json:"client_cert_expires_at,omitempty"`
+
+	// EJBCA-side identifiers — free text, must match the customer's EJBCA
+	// configuration exactly. EJBCA exposes no list endpoint, so typos
+	// surface only at first enrollment.
+	CertificateAuthorityNameEJBCA string `json:"certificate_authority_name_ejbca"`
+	CertificateProfileName        string `json:"certificate_profile_name"`
+	EndEntityProfileName          string `json:"end_entity_profile_name"`
+
+	// Per-enrollment. UsernameTemplate may contain Fleet variables and is
+	// used as both the EJBCA username and the CSR CommonName.
+	UsernameTemplate              string   `json:"username_template"`
+	CertificateUserPrincipalNames []string `json:"certificate_user_principal_names,omitempty"`
+}
+
+// Equals checks if two EJBCACA instances are equal. The ClientP12 + password
+// upload pair is intentionally excluded (they're use-once and not persisted).
+// Equality is based on the persistent representation.
+func (e *EJBCACA) Equals(other *EJBCACA) bool {
+	return e.Name == other.Name &&
+		e.URL == other.URL &&
+		e.ClientCertPEM == other.ClientCertPEM &&
+		(e.ClientKeyPEM == "" || e.ClientKeyPEM == MaskedPassword || e.ClientKeyPEM == other.ClientKeyPEM) &&
+		e.TrustCABundlePEM == other.TrustCABundlePEM &&
+		e.CertificateAuthorityNameEJBCA == other.CertificateAuthorityNameEJBCA &&
+		e.CertificateProfileName == other.CertificateProfileName &&
+		e.EndEntityProfileName == other.EndEntityProfileName &&
+		e.UsernameTemplate == other.UsernameTemplate &&
+		slices.Equal(e.CertificateUserPrincipalNames, other.CertificateUserPrincipalNames)
+}
+
+func (e *EJBCACA) Preprocess() {
+	e.Name = Preprocess(e.Name)
+	e.URL = Preprocess(e.URL)
+	e.CertificateAuthorityNameEJBCA = Preprocess(e.CertificateAuthorityNameEJBCA)
+	e.CertificateProfileName = Preprocess(e.CertificateProfileName)
+	e.EndEntityProfileName = Preprocess(e.EndEntityProfileName)
 }
 
 // Enrollment over Secure Transport Certificate Authority
@@ -259,6 +339,7 @@ type CertificateAuthorityUpdatePayload struct {
 	*HydrantCAUpdatePayload            `json:"hydrant,omitempty"`
 	*CustomESTCAUpdatePayload          `json:"custom_est_proxy,omitempty"`
 	*SmallstepSCEPProxyCAUpdatePayload `json:"smallstep,omitempty"`
+	*EJBCACAUpdatePayload              `json:"ejbca,omitempty"`
 }
 
 // ValidatePayload checks that only one CA type is specified in the update payload and that the private key is provided.
@@ -280,6 +361,9 @@ func (p *CertificateAuthorityUpdatePayload) ValidatePayload(privateKey string, e
 		caInPayload++
 	}
 	if p.SmallstepSCEPProxyCAUpdatePayload != nil {
+		caInPayload++
+	}
+	if p.EJBCACAUpdatePayload != nil {
 		caInPayload++
 	}
 	if caInPayload == 0 {
@@ -331,6 +415,64 @@ func (dcp *DigiCertCAUpdatePayload) Preprocess() {
 	}
 	if dcp.ProfileID != nil {
 		*dcp.ProfileID = Preprocess(*dcp.ProfileID)
+	}
+}
+
+type EJBCACAUpdatePayload struct {
+	Name *string `json:"name"`
+	URL  *string `json:"url"`
+
+	// Upload-only — when present, the service decodes the new P12 with
+	// ClientP12Password and replaces the stored cert + key. When nil, the
+	// existing stored material is retained.
+	ClientP12         *[]byte `json:"client_p12"`
+	ClientP12Password *string `json:"client_p12_password"`
+
+	TrustCABundlePEM *string `json:"trust_ca_bundle"`
+
+	CertificateAuthorityNameEJBCA *string   `json:"certificate_authority_name_ejbca"`
+	CertificateProfileName        *string   `json:"certificate_profile_name"`
+	EndEntityProfileName          *string   `json:"end_entity_profile_name"`
+	UsernameTemplate              *string   `json:"username_template"`
+	CertificateUserPrincipalNames *[]string `json:"certificate_user_principal_names"`
+}
+
+func (ep EJBCACAUpdatePayload) IsEmpty() bool {
+	return ep.Name == nil && ep.URL == nil &&
+		ep.ClientP12 == nil && ep.ClientP12Password == nil &&
+		ep.TrustCABundlePEM == nil &&
+		ep.CertificateAuthorityNameEJBCA == nil &&
+		ep.CertificateProfileName == nil &&
+		ep.EndEntityProfileName == nil &&
+		ep.UsernameTemplate == nil &&
+		ep.CertificateUserPrincipalNames == nil
+}
+
+// ValidateRelatedFields verifies fields that are related to each other. The
+// P12 + password are use-once and only meaningful together: if one is
+// supplied, the other must be too.
+func (ep *EJBCACAUpdatePayload) ValidateRelatedFields(errPrefix string, certName string) error {
+	if (ep.ClientP12 != nil) != (ep.ClientP12Password != nil) {
+		return &BadRequestError{Message: fmt.Sprintf(`%s"client_p12" and "client_p12_password" must be set together when rotating credentials for: %s`, errPrefix, certName)}
+	}
+	return nil
+}
+
+func (ep *EJBCACAUpdatePayload) Preprocess() {
+	if ep.Name != nil {
+		*ep.Name = Preprocess(*ep.Name)
+	}
+	if ep.URL != nil {
+		*ep.URL = Preprocess(*ep.URL)
+	}
+	if ep.CertificateAuthorityNameEJBCA != nil {
+		*ep.CertificateAuthorityNameEJBCA = Preprocess(*ep.CertificateAuthorityNameEJBCA)
+	}
+	if ep.CertificateProfileName != nil {
+		*ep.CertificateProfileName = Preprocess(*ep.CertificateProfileName)
+	}
+	if ep.EndEntityProfileName != nil {
+		*ep.EndEntityProfileName = Preprocess(*ep.EndEntityProfileName)
 	}
 }
 

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -113,14 +113,14 @@ type CertificateAuthority struct {
 
 	// EJBCA. Client cert + trust bundle stored as PEM, client key encrypted at rest.
 	// CertificateUserPrincipalNames is shared with DigiCert above.
-	ClientCertPEM                 *string    `json:"client_cert,omitempty" db:"client_cert_pem"`
-	ClientKeyPEM                  *string    `json:"client_key,omitempty" db:"-"`
-	TrustCABundlePEM              *string    `json:"trust_ca_bundle,omitempty" db:"trust_ca_bundle_pem"`
-	EJBCACAName                   *string    `json:"certificate_authority_name_ejbca,omitempty" db:"ejbca_ca_name"`
-	EJBCACertificateProfileName   *string    `json:"certificate_profile_name,omitempty" db:"ejbca_certificate_profile"`
-	EJBCAEndEntityProfileName     *string    `json:"end_entity_profile_name,omitempty" db:"ejbca_end_entity_profile"`
-	EJBCAUsernameTemplate         *string    `json:"username_template,omitempty" db:"ejbca_username_template"`
-	ClientCertExpiresAt           *time.Time `json:"client_cert_expires_at,omitempty" db:"-"`
+	ClientCertPEM               *string    `json:"client_cert,omitempty" db:"client_cert_pem"`
+	ClientKeyPEM                *string    `json:"client_key,omitempty" db:"-"`
+	TrustCABundlePEM            *string    `json:"trust_ca_bundle,omitempty" db:"trust_ca_bundle_pem"`
+	EJBCACAName                 *string    `json:"certificate_authority_name_ejbca,omitempty" db:"ejbca_ca_name"`
+	EJBCACertificateProfileName *string    `json:"certificate_profile_name,omitempty" db:"ejbca_certificate_profile"`
+	EJBCAEndEntityProfileName   *string    `json:"end_entity_profile_name,omitempty" db:"ejbca_end_entity_profile"`
+	EJBCAUsernameTemplate       *string    `json:"username_template,omitempty" db:"ejbca_username_template"`
+	ClientCertExpiresAt         *time.Time `json:"client_cert_expires_at,omitempty" db:"-"`
 
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`

--- a/server/fleet/ejbca.go
+++ b/server/fleet/ejbca.go
@@ -1,0 +1,30 @@
+package fleet
+
+import (
+	"context"
+	"time"
+)
+
+// EJBCACertificate is the result of a successful certificate enrollment against
+// an EJBCA REST API. Fleet generates the keypair locally, sends the CSR, then
+// wraps the issued cert and its key in a PKCS#12 for delivery to MDM hosts.
+type EJBCACertificate struct {
+	PfxData        []byte
+	Password       string
+	NotValidBefore time.Time
+	NotValidAfter  time.Time
+	SerialNumber   string
+}
+
+// EJBCAService is the contract for the EJBCA REST API client. Implementation
+// lives in ee/server/service/ejbca/.
+type EJBCAService interface {
+	// VerifyConnection probes GET /v1/ca/status over mTLS to confirm the CA
+	// configuration (URL + client cert + trust bundle) reaches EJBCA and
+	// authenticates successfully.
+	VerifyConnection(ctx context.Context, config EJBCACA) error
+	// GetCertificate enrolls a certificate via POST /v1/certificate/pkcs10enroll
+	// using the supplied EJBCACA configuration. Caller is responsible for
+	// expanding any Fleet variables in config fields before calling.
+	GetCertificate(ctx context.Context, config EJBCACA) (*EJBCACertificate, error)
+}

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -88,6 +88,8 @@ const (
 	FleetVarSmallstepSCEPChallengePrefix FleetVarName = "SMALLSTEP_SCEP_CHALLENGE_"
 	FleetVarSmallstepSCEPProxyURLPrefix  FleetVarName = "SMALLSTEP_SCEP_PROXY_URL_"
 	FleetVarSCEPWindowsCertificateID     FleetVarName = "SCEP_WINDOWS_CERTIFICATE_ID" // nolint:gosec // G101: Potential hardcoded credentials
+	FleetVarEJBCADataPrefix              FleetVarName = "EJBCA_DATA_"
+	FleetVarEJBCAPasswordPrefix          FleetVarName = "EJBCA_PASSWORD_" // nolint:gosec // G101: Potential hardcoded credentials
 
 	// OneTimeChallengeTTL is the time to live for one-time challenges.
 	OneTimeChallengeTTL = 1 * time.Hour
@@ -102,7 +104,8 @@ func HasCAVariables(fleetVars []string) bool {
 			v == string(FleetVarSCEPRenewalID) || v == string(FleetVarCertificateRenewalID) || v == string(FleetVarSCEPWindowsCertificateID) ||
 			strings.HasPrefix(v, string(FleetVarDigiCertDataPrefix)) || strings.HasPrefix(v, string(FleetVarDigiCertPasswordPrefix)) ||
 			strings.HasPrefix(v, string(FleetVarCustomSCEPChallengePrefix)) || strings.HasPrefix(v, string(FleetVarCustomSCEPProxyURLPrefix)) ||
-			strings.HasPrefix(v, string(FleetVarSmallstepSCEPChallengePrefix)) || strings.HasPrefix(v, string(FleetVarSmallstepSCEPProxyURLPrefix)) {
+			strings.HasPrefix(v, string(FleetVarSmallstepSCEPChallengePrefix)) || strings.HasPrefix(v, string(FleetVarSmallstepSCEPProxyURLPrefix)) ||
+			strings.HasPrefix(v, string(FleetVarEJBCADataPrefix)) || strings.HasPrefix(v, string(FleetVarEJBCAPasswordPrefix)) {
 			return true
 		}
 	}

--- a/server/mdm/apple/profile_processor.go
+++ b/server/mdm/apple/profile_processor.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/ee/server/service/digicert"
+	"github.com/fleetdm/fleet/v4/ee/server/service/ejbca"
 	"github.com/fleetdm/fleet/v4/ee/server/service/scep"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
@@ -70,6 +71,7 @@ func ProcessAndEnqueueProfiles(ctx context.Context,
 	err = preprocessProfileContents(ctx, appConfig, ds,
 		scep.NewSCEPConfigService(logger, nil),
 		digicert.NewService(digicert.WithLogger(logger)),
+		ejbca.NewService(ejbca.WithLogger(logger)),
 		logger, installTargets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	if err != nil {
 		return nil, err
@@ -156,6 +158,7 @@ func preprocessProfileContents(
 	ds fleet.Datastore,
 	scepConfig fleet.SCEPConfigService,
 	digiCertService fleet.DigiCertService,
+	ejbcaService fleet.EJBCAService,
 	logger *slog.Logger,
 	targets map[string]*fleet.CmdTarget,
 	profileContents map[string]mobileconfig.Mobileconfig,
@@ -173,6 +176,7 @@ func preprocessProfileContents(
 		digiCertCAs   map[string]*fleet.DigiCertCA
 		customSCEPCAs map[string]*fleet.CustomSCEPProxyCA
 		smallstepCAs  map[string]*fleet.SmallstepSCEPProxyCA
+		ejbcaCAs      map[string]*fleet.EJBCACA
 	)
 
 	// this is used to cache the host ID corresponding to the UUID, so we don't
@@ -208,7 +212,8 @@ func preprocessProfileContents(
 				fleetVar == string(fleet.FleetVarNDESSCEPChallenge) || fleetVar == string(fleet.FleetVarNDESSCEPProxyURL) || fleetVar == string(fleet.FleetVarHostUUID) ||
 				strings.HasPrefix(fleetVar, string(fleet.FleetVarSmallstepSCEPChallengePrefix)) || strings.HasPrefix(fleetVar, string(fleet.FleetVarSmallstepSCEPProxyURLPrefix)) ||
 				strings.HasPrefix(fleetVar, string(fleet.FleetVarDigiCertPasswordPrefix)) || strings.HasPrefix(fleetVar, string(fleet.FleetVarDigiCertDataPrefix)) ||
-				strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPChallengePrefix)) || strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPProxyURLPrefix)) {
+				strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPChallengePrefix)) || strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPProxyURLPrefix)) ||
+				strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCADataPrefix)) || strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCAPasswordPrefix)) {
 				// Give a few minutes leeway to account for clock skew
 				variablesUpdatedAt = ptr.Time(time.Now().UTC().Add(-3 * time.Minute))
 				break
@@ -247,6 +252,24 @@ func preprocessProfileContents(
 				configured, err := isDigiCertConfigured(ctx, logger, groupedCAs, ds, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, digiCertCAs, profUUID, target, caName, fleetVar)
 				if err != nil {
 					return ctxerr.Wrap(ctx, err, "checking DigiCert configuration")
+				}
+				if !configured {
+					valid = false
+					break initialFleetVarLoop
+				}
+
+			case strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCAPasswordPrefix)) || strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCADataPrefix)):
+				caName, found := strings.CutPrefix(fleetVar, string(fleet.FleetVarEJBCAPasswordPrefix))
+				if !found {
+					caName, _ = strings.CutPrefix(fleetVar, string(fleet.FleetVarEJBCADataPrefix))
+				}
+
+				if ejbcaCAs == nil {
+					ejbcaCAs = make(map[string]*fleet.EJBCACA)
+				}
+				configured, err := isEJBCAConfigured(ctx, logger, groupedCAs, ds, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, ejbcaCAs, profUUID, target, caName, fleetVar)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "checking EJBCA configuration")
 				}
 				if !configured {
 					valid = false
@@ -627,6 +650,79 @@ func preprocessProfileContents(
 						Serial:         &cert.SerialNumber,
 					})
 
+				case strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCAPasswordPrefix)):
+					// Replaced below when we populate the certificate data.
+
+				case strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCADataPrefix)):
+					caName := strings.TrimPrefix(fleetVar, string(fleet.FleetVarEJBCADataPrefix))
+					ca, ok := ejbcaCAs[caName]
+					if !ok {
+						logger.ErrorContext(ctx, "EJBCA CA not found. "+
+							"This error should never happen since we validated/populated CAs earlier", "ca_name", caName)
+						continue
+					}
+					// Deep-copy the cached config so per-host Fleet-var
+					// expansion can't bleed into other hosts via shared slice
+					// backing arrays (mirrors DigiCert's pattern above).
+					caCopy := *ca
+					caCopy.CertificateUserPrincipalNames = slices.Clone(ca.CertificateUserPrincipalNames)
+
+					caVarsCache := make(map[string]string)
+
+					ok, err := replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.UsernameTemplate, onMismatchedHostCount)
+					if err != nil {
+						return ctxerr.Wrap(ctx, err, "populating Fleet variables in EJBCA username template")
+					}
+					if !ok {
+						failed = true
+						break fleetVarLoop
+					}
+					if len(caCopy.CertificateUserPrincipalNames) > 0 {
+						for i := range caCopy.CertificateUserPrincipalNames {
+							ok, err = replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateUserPrincipalNames[i], onMismatchedHostCount)
+							if err != nil {
+								return ctxerr.Wrap(ctx, err, "populating Fleet variables in EJBCA UPN")
+							}
+							if !ok {
+								failed = true
+								break fleetVarLoop
+							}
+						}
+					}
+
+					cert, err := ejbcaService.GetCertificate(ctx, caCopy)
+					if err != nil {
+						detail := fmt.Sprintf("Couldn't get certificate from EJBCA for %s. %s", caCopy.Name, err)
+						err = ds.UpdateOrDeleteHostMDMAppleProfile(ctx, &fleet.HostMDMAppleProfile{
+							CommandUUID:        target.CmdUUID,
+							HostUUID:           hostUUID,
+							Status:             &fleet.MDMDeliveryFailed,
+							Detail:             detail,
+							OperationType:      fleet.MDMOperationTypeInstall,
+							VariablesUpdatedAt: variablesUpdatedAt,
+						})
+						if err != nil {
+							return ctxerr.Wrap(ctx, err, "updating host MDM Apple profile for EJBCA")
+						}
+						failed = true
+						break fleetVarLoop
+					}
+					hostContents, err = profiles.ReplaceExactFleetPrefixVariableInXML(string(fleet.FleetVarEJBCADataPrefix), caName, hostContents,
+						base64.StdEncoding.EncodeToString(cert.PfxData))
+					if err != nil {
+						return ctxerr.Wrap(ctx, err, "replacing Fleet variable for EJBCA data")
+					}
+					hostContents, err = profiles.ReplaceExactFleetPrefixVariableInXML(string(fleet.FleetVarEJBCAPasswordPrefix), caName, hostContents, cert.Password)
+					if err != nil {
+						return ctxerr.Wrap(ctx, err, "replacing Fleet variable for EJBCA password")
+					}
+					// EJBCA's CA type isn't represented in the legacy
+					// CAConfigAssetType enum used for managed-cert
+					// tracking — for the POC we skip the
+					// BulkUpsertMDMManagedCertificates record. Production
+					// implementation in #30986 should add a CAConfigEJBCA
+					// enum value and a tracking row here.
+
 				default:
 					// This was handled in the above switch statement, so we should never reach this case
 				}
@@ -748,6 +844,35 @@ func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *flee
 			// We should not reach this since we validated the variables when saving app config
 		}
 	}
+	return true, nil
+}
+
+func isEJBCAConfigured(ctx context.Context, logger *slog.Logger, groupedCAs *fleet.GroupedCertificateAuthorities, ds fleet.Datastore,
+	hostProfilesToInstallMap map[fleet.HostProfileUUID]*fleet.MDMAppleBulkUpsertHostProfilePayload,
+	userEnrollmentsToHostUUIDsMap map[string]string,
+	existingEJBCACAs map[string]*fleet.EJBCACA, profUUID string, target *fleet.CmdTarget, caName string, fleetVar string,
+) (bool, error) {
+	if !license.IsPremium(ctx) {
+		return fleet.MarkProfilesFailed(ctx, ds, logger, target, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, profUUID, "EJBCA integration requires a Fleet Premium license.", ptr.Time(time.Now().UTC()))
+	}
+	if _, ok := existingEJBCACAs[caName]; ok {
+		return true, nil
+	}
+	var ejbcaCA *fleet.EJBCACA
+	if groupedCAs != nil && len(groupedCAs.EJBCA) > 0 {
+		for _, ca := range groupedCAs.EJBCA {
+			if ca.Name == caName {
+				ejbcaCA = &ca
+				break
+			}
+		}
+	}
+	if ejbcaCA == nil {
+		return fleet.MarkProfilesFailed(ctx, ds, logger, target, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, profUUID,
+			fmt.Sprintf("Fleet couldn't populate $%s because %s certificate authority doesn't exist.", fleetVar, caName), ptr.Time(time.Now().UTC()))
+	}
+
+	existingEJBCACAs[caName] = ejbcaCA
 	return true, nil
 }
 

--- a/server/mdm/apple/profile_processor_test.go
+++ b/server/mdm/apple/profile_processor_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/ee/server/service/digicert"
+	"github.com/fleetdm/fleet/v4/ee/server/service/ejbca"
 	"github.com/fleetdm/fleet/v4/ee/server/service/scep"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -36,7 +37,8 @@ func TestPreprocessProfileContents(t *testing.T) {
 	// No-op
 	svc := scep.NewSCEPConfigService(logger, nil)
 	digiCertService := digicert.NewService(digicert.WithLogger(logger))
-	err := preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, logger, nil, nil, nil, nil, nil)
+	ejbcaService := ejbca.NewService(ejbca.WithLogger(logger))
+	err := preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, ejbcaService, logger, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	hostUUID := "host-1"
@@ -79,7 +81,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	// Can't use NDES SCEP proxy with free tier
 	ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: fleet.TierFree})
-	err = preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, nil)
+	err = preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, nil)
 	require.NoError(t, err)
 	require.NotNil(t, updatedPayload)
 	assert.Contains(t, updatedPayload.Detail, "Premium license")
@@ -89,7 +91,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: fleet.TierPremium})
 	updatedPayload = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, &fleet.GroupedCertificateAuthorities{})
+	err = preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, &fleet.GroupedCertificateAuthorities{})
 	require.NoError(t, err)
 	require.NotNil(t, updatedPayload)
 	assert.Contains(t, updatedPayload.Detail, "not configured")
@@ -102,7 +104,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedPayload = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, nil)
+	err = preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, nil)
 	require.NoError(t, err)
 	require.NotNil(t, updatedPayload)
 	assert.Contains(t, updatedPayload.Detail, "FLEET_VAR_BOZO")
@@ -160,7 +162,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 		assert.Empty(t, payload) // no profiles to update since FLEET VAR could not be populated
 		return nil
 	}
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	require.NotNil(t, updatedProfile)
 	assert.Contains(t, updatedProfile.Detail, "FLEET_VAR_"+fleet.FleetVarNDESSCEPChallenge)
@@ -175,7 +177,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedProfile = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	require.NotNil(t, updatedProfile)
 	assert.Contains(t, updatedProfile.Detail, "FLEET_VAR_"+fleet.FleetVarNDESSCEPChallenge)
@@ -190,7 +192,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedProfile = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	require.NotNil(t, updatedProfile)
 	assert.Contains(t, updatedProfile.Detail, "FLEET_VAR_"+fleet.FleetVarNDESSCEPChallenge)
@@ -205,7 +207,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedProfile = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	require.NotNil(t, updatedProfile)
 	assert.Contains(t, updatedProfile.Detail, "FLEET_VAR_"+fleet.FleetVarNDESSCEPChallenge)
@@ -233,7 +235,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 		assert.NotNil(t, payload[0].ChallengeRetrievedAt)
 		return nil
 	}
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	assert.Nil(t, updatedProfile)
 	require.NotEmpty(t, targets)
@@ -256,7 +258,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 		assert.Empty(t, payload)
 		return nil
 	}
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	assert.Nil(t, updatedProfile)
 	require.NotEmpty(t, targets)
@@ -277,7 +279,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedProfile = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	require.NotNil(t, updatedProfile)
 	assert.Contains(t, updatedProfile.Detail, "FLEET_VAR_"+fleet.FleetVarHostEndUserEmailIDP)
@@ -291,7 +293,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedProfile = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	assert.Nil(t, updatedProfile)
 	require.NotEmpty(t, targets)
@@ -315,7 +317,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedProfile = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	assert.Nil(t, updatedProfile)
 	require.NotEmpty(t, targets)
@@ -334,7 +336,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 	}
 	updatedProfile = nil
 	populateTargets()
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	require.NotNil(t, updatedProfile)
 	assert.Contains(t, updatedProfile.Detail, "Unexpected number of hosts (0) for UUID")
@@ -397,7 +399,7 @@ func TestPreprocessProfileContents(t *testing.T) {
 		}
 		return nil
 	}
-	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
+	err = preprocessProfileContents(ctx, appCfg, ds, scepConfig, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, groupedCAs)
 	require.NoError(t, err)
 	require.NotEmpty(t, targets)
 	assert.Len(t, targets, 3)
@@ -431,6 +433,7 @@ func TestPreprocessProfileContentsDigiCertUPNIsUniqueForMultipleHosts(t *testing
 	ds := new(mock.Store)
 
 	svc := scep.NewSCEPConfigService(logger, nil)
+	ejbcaService := ejbca.NewService(ejbca.WithLogger(logger))
 
 	const caName = "myCA"
 	const host1UUID = "host-uuid-1"
@@ -539,7 +542,7 @@ func TestPreprocessProfileContentsDigiCertUPNIsUniqueForMultipleHosts(t *testing
 		return nil
 	}
 
-	err := preprocessProfileContents(ctx, appCfg, ds, svc, mockDigiCert, logger, targets, profileContents, hostProfilesToInstallMap, make(map[string]string), groupedCAs)
+	err := preprocessProfileContents(ctx, appCfg, ds, svc, mockDigiCert, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, make(map[string]string), groupedCAs)
 	require.NoError(t, err)
 
 	// Both hosts must have received GetCertificate calls with their own serial.
@@ -560,6 +563,7 @@ func TestPreprocessProfileContentsEndUserIDP(t *testing.T) {
 
 	svc := scep.NewSCEPConfigService(logger, nil)
 	digiCertService := digicert.NewService(digicert.WithLogger(logger))
+	ejbcaService := ejbca.NewService(ejbca.WithLogger(logger))
 
 	hostUUID := "host-1"
 	cmdUUID := "cmd-1"
@@ -981,7 +985,7 @@ func TestPreprocessProfileContentsEndUserIDP(t *testing.T) {
 			updatedPayload = nil
 			updatedProfile = nil
 
-			err := preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, nil)
+			err := preprocessProfileContents(ctx, appCfg, ds, svc, digiCertService, ejbcaService, logger, targets, profileContents, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, nil)
 			require.NoError(t, err)
 			var output string
 			if expectedStatus == fleet.MDMDeliveryFailed {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -521,13 +521,20 @@ func validateConfigProfileFleetVariables(contents string, lic *fleet.LicenseInfo
 			!strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPProxyURLPrefix)) &&
 			!strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPChallengePrefix)) &&
 			!strings.HasPrefix(fleetVar, string(fleet.FleetVarSmallstepSCEPProxyURLPrefix)) &&
-			!strings.HasPrefix(fleetVar, string(fleet.FleetVarSmallstepSCEPChallengePrefix)) {
+			!strings.HasPrefix(fleetVar, string(fleet.FleetVarSmallstepSCEPChallengePrefix)) &&
+			!strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCADataPrefix)) &&
+			!strings.HasPrefix(fleetVar, string(fleet.FleetVarEJBCAPasswordPrefix)) {
 			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("Fleet variable $FLEET_VAR_%s is not supported in configuration profiles.", fleetVar)}
 		}
 	}
 
 	err := validateProfileCertificateAuthorityVariables(contents, lic, groupedCAs,
-		additionalDigiCertValidation, additionalCustomSCEPValidation, additionalNDESValidation, additionalSmallstepValidation)
+		additionalDigiCertValidation, additionalCustomSCEPValidation, additionalNDESValidation, additionalSmallstepValidation,
+		// POC: no structural validation for EJBCA. DigiCert's
+		// additionalDigiCertValidation enforces that the var only appears
+		// in a com.apple.security.pkcs12 payload; equivalent EJBCA
+		// structural check is a follow-up for #30986.
+		nil)
 	// We avoid checking for all nil here (due to no variables, as we ran our own variable check above.)
 	if err != nil {
 		return nil, err

--- a/server/service/mdm_profiles.go
+++ b/server/service/mdm_profiles.go
@@ -86,6 +86,83 @@ func (d *DigiCertVarsFound) SetPassword(value string) (*DigiCertVarsFound, bool)
 	return d, !alreadyPresent
 }
 
+// EJBCAVarsFound mirrors DigiCertVarsFound's DATA+PASSWORD pair-tracking
+// semantics for the FLEET_VAR_EJBCA_DATA_<name> / _PASSWORD_<name>
+// variables. Both must appear in the same profile for each CA referenced.
+type EJBCAVarsFound struct {
+	dataCA     map[string]struct{}
+	passwordCA map[string]struct{}
+}
+
+func (e *EJBCAVarsFound) Ok() bool {
+	if e == nil {
+		return true
+	}
+	if len(e.dataCA) != len(e.passwordCA) {
+		return false
+	}
+	for ca := range e.dataCA {
+		if _, ok := e.passwordCA[ca]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *EJBCAVarsFound) Found() bool {
+	return e != nil
+}
+
+func (e *EJBCAVarsFound) CAs() []string {
+	if e == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(e.dataCA))
+	for key := range e.dataCA {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (e *EJBCAVarsFound) ErrorMessage() string {
+	for ca := range e.passwordCA {
+		if _, ok := e.dataCA[ca]; !ok {
+			return fmt.Sprintf("Missing $FLEET_VAR_%s%s in the profile", fleet.FleetVarEJBCADataPrefix, ca)
+		}
+	}
+	for ca := range e.dataCA {
+		if _, ok := e.passwordCA[ca]; !ok {
+			return fmt.Sprintf("Missing $FLEET_VAR_%s%s in the profile", fleet.FleetVarEJBCAPasswordPrefix, ca)
+		}
+	}
+	return fmt.Sprintf("CA name mismatch between $FLEET_VAR_%s<ca_name> and $FLEET_VAR_%s<ca_name> in the profile.",
+		fleet.FleetVarEJBCADataPrefix, fleet.FleetVarEJBCAPasswordPrefix)
+}
+
+func (e *EJBCAVarsFound) SetData(value string) (*EJBCAVarsFound, bool) {
+	if e == nil {
+		e = &EJBCAVarsFound{}
+	}
+	if e.dataCA == nil {
+		e.dataCA = make(map[string]struct{})
+	}
+	_, alreadyPresent := e.dataCA[value]
+	e.dataCA[value] = struct{}{}
+	return e, !alreadyPresent
+}
+
+func (e *EJBCAVarsFound) SetPassword(value string) (*EJBCAVarsFound, bool) {
+	if e == nil {
+		e = &EJBCAVarsFound{}
+	}
+	if e.passwordCA == nil {
+		e.passwordCA = make(map[string]struct{})
+	}
+	_, alreadyPresent := e.passwordCA[value]
+	e.passwordCA[value] = struct{}{}
+	return e, !alreadyPresent
+}
+
 type NDESVarsFound struct {
 	urlFound       bool
 	challengeFound bool
@@ -356,6 +433,7 @@ func validateProfileCertificateAuthorityVariables(profileContents string, lic *f
 	additionalCustomSCEPValidation func(contents string, customSCEPVars *CustomSCEPVarsFound) error,
 	additionalNDESValidation func(contents string, ndesVars *NDESVarsFound) error,
 	additionalSmallstepValidation func(contents string, smallstepVars *SmallstepVarsFound) error,
+	additionalEJBCAValidation func(contents string, ejbcaVars *EJBCAVarsFound) error,
 ) error {
 	fleetVars := variables.FindKeepDuplicates(profileContents)
 	if len(fleetVars) == 0 {
@@ -372,6 +450,7 @@ func validateProfileCertificateAuthorityVariables(profileContents string, lic *f
 		ndesVars       *NDESVarsFound
 		smallstepVars  *SmallstepVarsFound
 		customSCEPVars *CustomSCEPVarsFound
+		ejbcaVars      *EJBCAVarsFound
 	)
 	for _, k := range fleetVars {
 		caFound := false
@@ -449,6 +528,30 @@ func validateProfileCertificateAuthorityVariables(profileContents string, lic *f
 			if !caFound {
 				ok = false
 			}
+		case strings.HasPrefix(k, string(fleet.FleetVarEJBCADataPrefix)):
+			caName := strings.TrimPrefix(k, string(fleet.FleetVarEJBCADataPrefix))
+			for _, ca := range groupedCAs.EJBCA {
+				if ca.Name == caName {
+					caFound = true
+					ejbcaVars, ok = ejbcaVars.SetData(caName)
+					break
+				}
+			}
+			if !caFound {
+				ok = false
+			}
+		case strings.HasPrefix(k, string(fleet.FleetVarEJBCAPasswordPrefix)):
+			caName := strings.TrimPrefix(k, string(fleet.FleetVarEJBCAPasswordPrefix))
+			for _, ca := range groupedCAs.EJBCA {
+				if ca.Name == caName {
+					caFound = true
+					ejbcaVars, ok = ejbcaVars.SetPassword(caName)
+					break
+				}
+			}
+			if !caFound {
+				ok = false
+			}
 		case k == string(fleet.FleetVarNDESSCEPProxyURL):
 			caFound = true
 			ndesVars, ok = ndesVars.SetURL()
@@ -491,6 +594,18 @@ func validateProfileCertificateAuthorityVariables(profileContents string, lic *f
 		}
 		if additionalDigiCertValidation != nil {
 			err := additionalDigiCertValidation(profileContents, digiCertVars)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if ejbcaVars.Found() {
+		if !ejbcaVars.Ok() {
+			return &fleet.BadRequestError{Message: ejbcaVars.ErrorMessage()}
+		}
+		if additionalEJBCAValidation != nil {
+			err := additionalEJBCAValidation(profileContents, ejbcaVars)
 			if err != nil {
 				return err
 			}

--- a/server/service/mdm_profiles_test.go
+++ b/server/service/mdm_profiles_test.go
@@ -192,7 +192,7 @@ func TestValidateProfileCertificateAuthorityVariables(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Pass a premium license for testing (we're not testing license validation here)
 			premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
-			err := validateProfileCertificateAuthorityVariables(tc.profile, premiumLic, groupedCAs, nil, nil, nil, nil)
+			err := validateProfileCertificateAuthorityVariables(tc.profile, premiumLic, groupedCAs, nil, nil, nil, nil, nil)
 			if tc.errMsg != "" {
 				require.ErrorContains(t, err, tc.errMsg)
 			} else {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -65,6 +65,7 @@ type Service struct {
 	wstepCertManager  microsoft_mdm.CertManager
 	scepConfigService fleet.SCEPConfigService
 	digiCertService   fleet.DigiCertService
+	ejbcaService      fleet.EJBCAService
 
 	conditionalAccessMicrosoftProxy ConditionalAccessMicrosoftProxy
 
@@ -151,6 +152,7 @@ func NewService(
 	wstepCertManager microsoft_mdm.CertManager,
 	scepConfigService fleet.SCEPConfigService,
 	digiCertService fleet.DigiCertService,
+	ejbcaService fleet.EJBCAService,
 	conditionalAccessProxy ConditionalAccessMicrosoftProxy,
 	keyValueStore fleet.KeyValueStore,
 	androidSvc android.Service,
@@ -190,6 +192,7 @@ func NewService(
 		wstepCertManager:     wstepCertManager,
 		scepConfigService:    scepConfigService,
 		digiCertService:      digiCertService,
+		ejbcaService:         ejbcaService,
 
 		conditionalAccessMicrosoftProxy: conditionalAccessProxy,
 		keyValueStore:                   keyValueStore,

--- a/server/service/svctest/service.go
+++ b/server/service/svctest/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/WatchBeam/clock"
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/ee/server/service/digicert"
+	"github.com/fleetdm/fleet/v4/ee/server/service/ejbca"
 	"github.com/fleetdm/fleet/v4/ee/server/service/est"
 	"github.com/fleetdm/fleet/v4/ee/server/service/scep"
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
@@ -67,6 +68,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		c                               clock.Clock                   = clock.C
 		scepConfigService                                             = scep.NewSCEPConfigService(logger, nil)
 		digiCertService                                               = digicert.NewService(digicert.WithLogger(logger))
+		ejbcaService                                                  = ejbca.NewService(ejbca.WithLogger(logger))
 		estCAService                                                  = est.NewService(est.WithLogger(logger))
 		conditionalAccessMicrosoftProxy service.ConditionalAccessMicrosoftProxy
 
@@ -214,6 +216,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		wstepManager,
 		scepConfigService,
 		digiCertService,
+		ejbcaService,
 		conditionalAccessMicrosoftProxy,
 		keyValueStore,
 		androidService,
@@ -256,6 +259,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 			keyValueStore,
 			scepConfigService,
 			digiCertService,
+			ejbcaService,
 			androidModule,
 			estCAService,
 		)

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -28,6 +28,7 @@ import (
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/ee/server/service/condaccess"
 	"github.com/fleetdm/fleet/v4/ee/server/service/digicert"
+	"github.com/fleetdm/fleet/v4/ee/server/service/ejbca"
 	"github.com/fleetdm/fleet/v4/ee/server/service/est"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
@@ -104,6 +105,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		c                               clock.Clock                   = clock.C
 		scepConfigService                                             = scep.NewSCEPConfigService(logger, nil)
 		digiCertService                                               = digicert.NewService(digicert.WithLogger(logger))
+		ejbcaService                                                  = ejbca.NewService(ejbca.WithLogger(logger))
 		estCAService                                                  = est.NewService(est.WithLogger(logger))
 		conditionalAccessMicrosoftProxy ConditionalAccessMicrosoftProxy
 
@@ -251,6 +253,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		wstepManager,
 		scepConfigService,
 		digiCertService,
+		ejbcaService,
 		conditionalAccessMicrosoftProxy,
 		keyValueStore,
 		androidService,
@@ -293,6 +296,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 			keyValueStore,
 			scepConfigService,
 			digiCertService,
+			ejbcaService,
 			androidModule,
 			estCAService,
 		)

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -246,7 +246,7 @@ func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInf
 		}
 	}
 
-	err := validateProfileCertificateAuthorityVariables(contents, lic, groupedCAs, nil, additionalCustomSCEPValidationForWindowsProfiles, additionalNDESValidationForWindowsProfiles, nil)
+	err := validateProfileCertificateAuthorityVariables(contents, lic, groupedCAs, nil, additionalCustomSCEPValidationForWindowsProfiles, additionalNDESValidationForWindowsProfiles, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/variables/variables.go
+++ b/server/variables/variables.go
@@ -17,9 +17,23 @@ import (
 // The regex captures the variable name (without the FLEET_VAR_ prefix) in named groups.
 var fleetVariableRegex = regexp.MustCompile(`(\$FLEET_VAR_(?P<name1>\w+))|(\${FLEET_VAR_(?P<name2>\w+)})`)
 
-// ProfileDataVariableRegex matches variables present in <data> section of Apple profile, which may cause validation issues.
-// This is specific to DigiCert certificate data variables.
-var ProfileDataVariableRegex = regexp.MustCompile(`(\$FLEET_VAR_DIGICERT_DATA_(?P<name1>\w+))|(\${FLEET_VAR_DIGICERT_DATA_(?P<name2>\w+)})`)
+// ProfileDataVariableRegex matches variables present in <data> section of
+// Apple profile, which may cause validation issues. These variables are
+// substituted (with empty string or a base64 placeholder) before the plist
+// parser runs, so that the parser doesn't choke on a non-base64 placeholder
+// where it expects base64-encoded bytes. Add a new alternation here whenever
+// a new CA type stores PKCS#12-style bytes via a `<data>$FLEET_VAR_..._DATA_X</data>`
+// pattern in MDM profiles.
+//
+// The capture groups are named only for documentation; nothing consumes them
+// by name. Each alternation gets its own name to satisfy Go's regexp
+// requirement that named groups within a single regex are unique.
+var ProfileDataVariableRegex = regexp.MustCompile(
+	`(\$FLEET_VAR_DIGICERT_DATA_(?P<digicert1>\w+))` +
+		`|(\${FLEET_VAR_DIGICERT_DATA_(?P<digicert2>\w+)})` +
+		`|(\$FLEET_VAR_EJBCA_DATA_(?P<ejbca1>\w+))` +
+		`|(\${FLEET_VAR_EJBCA_DATA_(?P<ejbca2>\w+)})`,
+)
 
 // Find finds all Fleet variables in the given content and returns them as a map
 // without the FLEET_VAR_ prefix. Returns nil if no variables are found.


### PR DESCRIPTION
> ⚠️ **This PR is not meant to be merged.** It is a working POC that
> accompanies the design proposal for [fleet#30986](https://github.com/fleetdm/fleet/issues/30986).
> Its purpose is to (a) prove the integration is feasible end-to-end,
> (b) surface the gotchas that don't show up in design docs alone, and
> (c) give product, design, and the prospective customer a working
> reference to react to. The actual production implementation will be
> a separate PR against the production-release scope.

**Related issue:** Resolves #45505

## What this is

A working proof-of-concept that adds **EJBCA** as a new Certificate
Authority type in Fleet, parallel to the existing DigiCert /
NDES SCEP / Smallstep / Custom SCEP / Custom EST / Hydrant types.
The customer (`prospect-homerus`) is migrating from AD CS to EJBCA
and needs to keep deploying WiFi/VPN certificates to macOS hosts
through Fleet.

POC verified end-to-end against `keyfactor/ejbca-ce` 9.x: Add CA via
UI succeeds, connection probe returns 200, a profile referencing
`$FLEET_VAR_EJBCA_DATA_<name>` / `_PASSWORD_<name>` pushed to a host
triggers a real `pkcs10enroll` over mTLS, and the host installs the
issued cert.

## How to use this PR

This is a **reference + discussion artifact**, not a merge candidate.
Anyone reviewing should read it for:

- **Design validation** — does the integration shape feel right?
- **Customer-decision input** — the eight open questions in
  `customer-design-review.md` need product + customer answers before
  the production release is scoped
- **Gotchas surfaced by real testing** — captured in
  `research.md → "Confirmed during end-to-end testing"` so the
  production work doesn't rediscover them
- **Engineering reality check** — there are POC shortcuts (most
  notably the openssl subprocess for PKCS#12 decoding) that
  **must not ship to production**; explicitly flagged in the code
  and in the docs

The actual production implementation for fleet#30986 will be a
separate PR; this one stays as a draft reference.

## Where to start the review

The OpenSpec change directory carries the design, scope decisions,
and what was learned during end-to-end testing:

- [`customer-design-review.md`](./openspec/changes/add-ejbca-rest-ca-poc/customer-design-review.md) — plain-language summary for product, design, and the customer call. **Recommended starting read** for non-engineering reviewers.
- [`proposal.md`](./openspec/changes/add-ejbca-rest-ca-poc/proposal.md) — scope, success criteria, customer-confirmation decisions
- [`design.md`](./openspec/changes/add-ejbca-rest-ca-poc/design.md) — data model, HTTP client, profile-processor wiring, frontend
- [`specs/certificate-authorities/spec.md`](./openspec/changes/add-ejbca-rest-ca-poc/specs/certificate-authorities/spec.md) — REQ-CA-EJBCA-1..12 + Deferred list
- [`research.md`](./openspec/changes/add-ejbca-rest-ca-poc/research.md) — investigation + end-to-end test findings (incl. the "registration map" of four code sites that need to know about a new CA-data variable)
- [`tasks.md`](./openspec/changes/add-ejbca-rest-ca-poc/tasks.md) — implementation checklist

Dev guide for running it locally:
[`docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md`](./docs/Contributing/product-groups/security-compliance/ejbca-rest-testing.md)
— sibling to the existing SCEP guide, with a troubleshooting ladder
mapping each failure mode hit during testing to its fix.

## What's deliberately POC-only and must not ship as-is

Captured with design rationale in
[`customer-design-review.md`](./openspec/changes/add-ejbca-rest-ca-poc/customer-design-review.md)
and [`research.md`](./openspec/changes/add-ejbca-rest-ca-poc/research.md);
short list:

- **The decode path shells out to `openssl`** because EJBCA emits
  BER-encoded PKCS#12 bundles and both Go libs are strict-DER.
  Production work must replace with a pure-Go BER→DER normalizer.
- No structural `additionalEJBCAValidation` (DigiCert has one)
- No `host_mdm_managed_certificates` tracking record for EJBCA-issued
  certs (`CAConfigEJBCA` enum value not added)
- No "expires in N days" badge on the CA list page (recommended in v1)
- No GitOps configurability (recommended in v1)
- mTLS-only auth, P12-only upload, macOS-only platform coverage