### PR TITLE
Use brightest color for checkerboard when only one is available

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
@@ -317,6 +317,60 @@ describe("CheckerboardViz", () => {
     }
   });
 
+  it("renders all non-zero cells at the brightest level when relativeScale has a single distinct value", async () => {
+    // With only one distinct non-zero value there's no range to grade
+    // against (min === max). Rather than collapsing everything to the
+    // dimmest level, every non-zero cell should render at level-5.
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 0,
+        percentage: 0,
+      },
+      {
+        timestamp: "2026-03-01T02:00:00",
+        label: "Mar 1, 2am",
+        value: 7,
+        percentage: 1,
+      },
+      {
+        timestamp: "2026-03-01T04:00:00",
+        label: "Mar 1, 4am",
+        value: 7,
+        percentage: 1,
+      },
+      {
+        timestamp: "2026-03-01T06:00:00",
+        label: "Mar 1, 6am",
+        value: 7,
+        percentage: 1,
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={points} selectedDays={1} relativeScale />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    const classNames = Array.from(container.querySelectorAll("rect")).map(
+      (r) => r.getAttribute("class") || ""
+    );
+    // 0% still renders at level-0.
+    expect(classNames.some((c) => c.includes("--level-0"))).toBe(true);
+    // Every non-zero cell renders at the brightest level (5)...
+    classNames
+      .filter((c) => !c.includes("--level-0"))
+      .forEach((c) => {
+        expect(c).toContain("--level-5");
+      });
+    // ...and none fall through to the dimmest non-zero level (1).
+    expect(classNames.some((c) => c.includes("--level-1"))).toBe(false);
+  });
+
   it("trims leading days when given more days than selectedDays", async () => {
     // Caller requests `selectedDays + 1` days of data so the trailing
     // `selectedDays` calendar days are full even for users west of UTC.

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -81,10 +81,14 @@ const CheckerboardViz = ({
     const nonZeroValues = data.map((d) => d.value).filter((p) => p > 0);
     const minVal = nonZeroValues.length ? Math.min(...nonZeroValues) : 0;
     const maxVal = nonZeroValues.length ? Math.max(...nonZeroValues) : 0;
-    const range = maxVal - minVal || 1; // avoid divide-by-zero
+    const range = maxVal - minVal;
 
     getColorLevel = (cell: ICellData): number => {
       if (cell.value === 0) return 0;
+      // When every non-zero cell shares the same value there's no range to
+      // grade against, so render them all at the brightest level rather than
+      // the dimmest.
+      if (range === 0) return 5;
       const scaled = ((cell.value - minVal) / range) * 5;
       // Level zero is reserved for real 0, so ensure we return
       // something between 1 and 5.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47128

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased 

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
on main:
<img width="499" height="404" alt="Image" src="https://github.com/user-attachments/assets/3d5c3663-61de-444b-ba42-3ebab984d7a3" />

on branch:
<img width="493" height="409" alt="image" src="https://github.com/user-attachments/assets/0e7c7fd1-b729-4de8-bb77-41d1e593e926" />

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkerboard visualization color scaling to properly render non-zero data cells at the brightest color level when all non-zero values are identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->