### PR TITLE
Cherry-pick #47129: Use brightest color for checkerboard when only one is available

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
@@ -317,6 +317,60 @@ describe("CheckerboardViz", () => {
     }
   });
 
+  it("renders all non-zero cells at the brightest level when relativeScale has a single distinct value", async () => {
+    // With only one distinct non-zero value there's no range to grade
+    // against (min === max). Rather than collapsing everything to the
+    // dimmest level, every non-zero cell should render at level-5.
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 0,
+        percentage: 0,
+      },
+      {
+        timestamp: "2026-03-01T02:00:00",
+        label: "Mar 1, 2am",
+        value: 7,
+        percentage: 1,
+      },
+      {
+        timestamp: "2026-03-01T04:00:00",
+        label: "Mar 1, 4am",
+        value: 7,
+        percentage: 1,
+      },
+      {
+        timestamp: "2026-03-01T06:00:00",
+        label: "Mar 1, 6am",
+        value: 7,
+        percentage: 1,
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={points} selectedDays={1} relativeScale />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    const classNames = Array.from(container.querySelectorAll("rect")).map(
+      (r) => r.getAttribute("class") || ""
+    );
+    // 0% still renders at level-0.
+    expect(classNames.some((c) => c.includes("--level-0"))).toBe(true);
+    // Every non-zero cell renders at the brightest level (5)...
+    classNames
+      .filter((c) => !c.includes("--level-0"))
+      .forEach((c) => {
+        expect(c).toContain("--level-5");
+      });
+    // ...and none fall through to the dimmest non-zero level (1).
+    expect(classNames.some((c) => c.includes("--level-1"))).toBe(false);
+  });
+
   it("trims leading days when given more days than selectedDays", async () => {
     // Caller requests `selectedDays + 1` days of data so the trailing
     // `selectedDays` calendar days are full even for users west of UTC.

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -81,10 +81,14 @@ const CheckerboardViz = ({
     const nonZeroValues = data.map((d) => d.value).filter((p) => p > 0);
     const minVal = nonZeroValues.length ? Math.min(...nonZeroValues) : 0;
     const maxVal = nonZeroValues.length ? Math.max(...nonZeroValues) : 0;
-    const range = maxVal - minVal || 1; // avoid divide-by-zero
+    const range = maxVal - minVal;
 
     getColorLevel = (cell: ICellData): number => {
       if (cell.value === 0) return 0;
+      // When every non-zero cell shares the same value there's no range to
+      // grade against, so render them all at the brightest level rather than
+      // the dimmest.
+      if (range === 0) return 5;
       const scaled = ((cell.value - minVal) / range) * 5;
       // Level zero is reserved for real 0, so ensure we return
       // something between 1 and 5.


### PR DESCRIPTION
Cherry-pick of #47129 into the rc-minor-fleet-v4.87.0 RC branch.