### PR TITLE
Add CI check for PR template

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,6 +52,10 @@ The following terms were recently renamed. Use the new terms in conversation and
 - When checking for duplicates, exclude the current entity to avoid false conflicts on upserts.
 - Run `go test ./server/service/` after adding new datastore interface methods — uninitialized mocks crash other tests.
 
+## Opening a pull request
+
+- The PR description MUST start from `.github/pull_request_template.md`. When creating a PR (e.g. `gh pr create`), use that file as the body and fill it in — do not open a PR with an empty or freeform description. A CI check (`check-pr-template`) fails PRs whose description is missing the template.
+
 ## Development commands
 
 Check the `Makefile` for the full list of available targets. Key ones below.

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,0 +1,20 @@
+name: Check PR template
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+permissions:
+  pull-requests: read
+jobs:
+  check-template:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR body contains the PR template
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          marker="QA'd all new/changed functionality manually"
+          if ! grep -qF "$marker" <<< "$BODY"; then
+            echo "::error::PR description is missing the PR template. Please fill in .github/pull_request_template.md (expected line: \"$marker\")."
+            exit 1
+          fi
+          echo "PR template present."

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,6 +1,6 @@
 name: Check PR template
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 permissions:
   pull-requests: read


### PR DESCRIPTION
Resolves #46352.

## Testing

- [X] QA'd all new/changed functionality manually.

Tested on this PR:
Before having the QA item:
<img width="1056" height="274" alt="Screenshot 2026-06-08 at 6 36 23 PM" src="https://github.com/user-attachments/assets/cbcaeefd-ff12-41b0-81d5-b40de6cd0bff" />
After adding the QA item:
<img width="686" height="81" alt="Screenshot 2026-06-08 at 6 36 53 PM" src="https://github.com/user-attachments/assets/5af6b42c-34fe-4515-ac4c-253a0e788d31" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated check that validates pull request descriptions include the required QA confirmation. The check runs on PR events, fails the check and annotates the PR when the confirmation is missing, and emits a confirmation message when present to help maintain consistent review readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->