### PR TITLE
Fix GCS checksum flag derived from wrong endpoint key

### DIFF
--- a/server/datastore/s3/bootstrap_package.go
+++ b/server/datastore/s3/bootstrap_package.go
@@ -20,8 +20,6 @@ func NewBootstrapPackageStore(config config.S3Config) (*BootstrapPackageStore, e
 			s3store:    s3store,
 			pathPrefix: bootstrapPackagePrefix,
 			fileLabel:  "bootstrap package",
-
-			gcs: isGCS(config.EndpointURL),
 		},
 	}, nil
 }

--- a/server/datastore/s3/carves.go
+++ b/server/datastore/s3/carves.go
@@ -32,8 +32,6 @@ const (
 type CarveStore struct {
 	*s3store
 	metadatadb fleet.CarveStore
-
-	gcs bool
 }
 
 // NewCarveStore creates a new store with the given config
@@ -46,8 +44,6 @@ func NewCarveStore(config config.S3Config, metadatadb fleet.CarveStore) (*CarveS
 	return &CarveStore{
 		s3store:    s3store,
 		metadatadb: metadatadb,
-
-		gcs: isGCS(config.EndpointURL),
 	}, nil
 }
 

--- a/server/datastore/s3/common_file_store.go
+++ b/server/datastore/s3/common_file_store.go
@@ -35,8 +35,6 @@ type commonFileStore struct {
 	*s3store
 	pathPrefix string
 	fileLabel  string // how to call the file in error messages
-
-	gcs bool
 }
 
 func isGCS(endpointURL string) bool {

--- a/server/datastore/s3/org_logo.go
+++ b/server/datastore/s3/org_logo.go
@@ -29,7 +29,6 @@ func NewOrgLogoStore(cfg config.S3Config) (*OrgLogoStore, error) {
 			s3store:    s3store,
 			pathPrefix: "org-logos",
 			fileLabel:  "org logo",
-			gcs:        isGCS(cfg.EndpointURL),
 		},
 	}, nil
 }

--- a/server/datastore/s3/s3.go
+++ b/server/datastore/s3/s3.go
@@ -38,6 +38,7 @@ type s3store struct {
 	bucket           string
 	prefix           string
 	cloudFrontConfig *config.S3CloudFrontConfig
+	gcs              bool
 }
 
 type installerNotFoundError struct{}
@@ -174,6 +175,7 @@ func newS3Store(cfg config.S3ConfigInternal) (*s3store, error) {
 		bucket:           cfg.Bucket,
 		prefix:           cfg.Prefix,
 		cloudFrontConfig: cfg.CloudFrontConfig,
+		gcs:              gcsEndpoint,
 	}, nil
 }
 

--- a/server/datastore/s3/s3_test.go
+++ b/server/datastore/s3/s3_test.go
@@ -136,6 +136,41 @@ func TestSoftwareInstallerStoreGCSIAMAuthUsesBearerToken(t *testing.T) {
 	}
 }
 
+func TestSoftwareInstallerStoreGCSFlagFromPrefixedEndpoint(t *testing.T) {
+	// Top-level EndpointURL deliberately empty: the documented GCS config
+	// sets only the per-prefix endpoint, and gcs must still resolve true.
+	store, err := NewSoftwareInstallerStore(config.S3Config{
+		SoftwareInstallersBucket:      "bucket",
+		SoftwareInstallersPrefix:      "prefix",
+		SoftwareInstallersRegion:      "us-east-1",
+		SoftwareInstallersEndpointURL: "https://storage.googleapis.com",
+	})
+	require.NoError(t, err)
+	require.True(t, store.gcs)
+}
+
+func TestSoftwareInstallerStoreGCSFlagFalseForNonGCSEndpoint(t *testing.T) {
+	store, err := NewSoftwareInstallerStore(config.S3Config{
+		SoftwareInstallersBucket:      "bucket",
+		SoftwareInstallersPrefix:      "prefix",
+		SoftwareInstallersRegion:      "us-east-1",
+		SoftwareInstallersEndpointURL: "https://s3.example.com",
+	})
+	require.NoError(t, err)
+	require.False(t, store.gcs)
+}
+
+func TestCarveStoreGCSFlagFromPrefixedEndpoint(t *testing.T) {
+	store, err := NewCarveStore(config.S3Config{
+		CarvesBucket:      "carves-bucket",
+		CarvesPrefix:      "carves-prefix",
+		CarvesRegion:      "us-east-1",
+		CarvesEndpointURL: "https://storage.googleapis.com",
+	}, nil)
+	require.NoError(t, err)
+	require.True(t, store.gcs)
+}
+
 func TestCarveStoreGCSIAMAuthUsesBearerToken(t *testing.T) {
 	type requestInfo struct {
 		AuthHeader string

--- a/server/datastore/s3/software_installer.go
+++ b/server/datastore/s3/software_installer.go
@@ -21,8 +21,6 @@ func NewSoftwareInstallerStore(config config.S3Config) (*SoftwareInstallerStore,
 			s3store:    s3store,
 			pathPrefix: softwareInstallersPrefix,
 			fileLabel:  "software installer",
-
-			gcs: isGCS(config.EndpointURL),
 		},
 	}, nil
 }
@@ -36,14 +34,13 @@ func NewTestSoftwareInstallerStore(conf config.S3Config) (*SoftwareInstallerStor
 			SigningPublicKeyID: conf.SoftwareInstallersCloudFrontURLSigningPublicKeyID,
 			Signer:             conf.SoftwareInstallersCloudFrontSigner,
 		},
+		gcs: isGCS(conf.EndpointURL),
 	}
 	return &SoftwareInstallerStore{
 		&commonFileStore{
 			s3store:    store,
 			pathPrefix: softwareInstallersPrefix,
 			fileLabel:  "software installer",
-
-			gcs: isGCS(conf.EndpointURL),
 		},
 	}, nil
 }

--- a/server/datastore/s3/software_title_icon.go
+++ b/server/datastore/s3/software_title_icon.go
@@ -19,8 +19,6 @@ func NewSoftwareTitleIconStore(config config.S3Config) (*SoftwareTitleIconStore,
 			s3store:    s3store,
 			pathPrefix: "software-title-icons",
 			fileLabel:  "software title icon",
-
-			gcs: isGCS(config.EndpointURL),
 		},
 	}, nil
 }


### PR DESCRIPTION
Fixes https://github.com/fleetdm/fleet/issues/47142

The wrapper stores derived their `gcs` boolean from S3Config.EndpointURL, but the underlying S3 client is built from the per-prefix internal config. With the documented GCS configuration (only software_installers_endpoint_url set), `gcs` resolved to false and the CRC32C checksum branch was skipped. Uploads still worked because GCS accepts CRC32 under bearer auth, but the safeguard was silently bypassed.

This hoists the `gcs` field onto s3store itself so it's derived from the same endpoint URL the S3 client uses. The wrappers no longer compute it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal storage configuration architecture to centralize endpoint type detection.

* **Tests**
  * Added test coverage for Google Cloud Storage endpoint detection and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->