### PR TITLE
update codeql to not run on only contributing docs PR's

### DIFF
--- a/.github/workflows/config/codeql.yml
+++ b/.github/workflows/config/codeql.yml
@@ -2,3 +2,4 @@ name: Fleet CodeQL
 
 paths-ignore:
   - website/assets/dependencies/
+  - docs/Contributing/


### PR DESCRIPTION
I saw CodeQL being run on this PR https://github.com/fleetdm/fleet/pull/47154
But it only modified a .MD file inside the docs/Contributing path, we also only have MD files in there, so I think it's wasteful to run on those changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize pipeline efficiency by excluding documentation changes from code analysis triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->