### PR TITLE
Update Go to 1.26.4

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.26.3-trixie@sha256:6b3de2e6b4ccfc5fae404042cb1a025b1de13c73458e50455e3143bf12e98eae
+FROM --platform=linux/amd64 golang:1.26.4-trixie@sha256:0dcba0d95dbfb072e9917a106b9e07d7cc298097dc83e9307056ef1889de654d
 LABEL maintainer="Fleet Developers"
 
 RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*

--- a/changes/update-go-1.26.4
+++ b/changes/update-go-1.26.4
@@ -1,0 +1,1 @@
+* Updated go to 1.26.4

--- a/changes/update-go-1.26.4
+++ b/changes/update-go-1.26.4
@@ -1,1 +1,1 @@
-* Updated go to 1.26.4
+* Updated Go to 1.26.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/pubsub v1.50.1

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.23@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git

--- a/orbit/changes/update-go-1.26.4
+++ b/orbit/changes/update-go-1.26.4
@@ -1,0 +1,1 @@
+* Updated go to 1.26.4

--- a/third_party/goval-dictionary/go.mod
+++ b/third_party/goval-dictionary/go.mod
@@ -1,6 +1,6 @@
 module github.com/vulsio/goval-dictionary
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7

--- a/third_party/vuln-check/go.mod
+++ b/third_party/vuln-check/go.mod
@@ -9,7 +9,7 @@
 
 module github.com/fleetdm/fleet/v4/third_party/vuln-check
 
-go 1.26.3
+go 1.26.4
 
 require (
 	// NanoMDM - Apple MDM server (server/mdm/nanomdm/)

--- a/tools/ci/setboolcheck/go.mod
+++ b/tools/ci/setboolcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/ci/setboolcheck
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/tools/fleet-mcp/go.mod
+++ b/tools/fleet-mcp/go.mod
@@ -1,6 +1,6 @@
 module fleet-mcp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/tools/github-manage/go.mod
+++ b/tools/github-manage/go.mod
@@ -1,6 +1,6 @@
 module fleetdm/gm
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.23@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 ARG TAG
 RUN go install github.com/fleetdm/fleet/v4/tools/mdm/migration/mdmproxy@${TAG}
 

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.26.3
+go 1.26.4
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/qacheck/go.mod
+++ b/tools/qacheck/go.mod
@@ -1,6 +1,6 @@
 module qacheck
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Resolves #47159.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to 1.26.4 across modules, Docker build stages, and build/configuration records to standardize the toolchain version used for builds and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->