### PR TITLE
Use "Example payload" for all payload example buttons and always enable example buttons

### DIFF
--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -125,8 +125,7 @@ interface ISoftwareCountResponse {
 // *FormData instead, even for programmatic request bodies (e.g.
 // IDeleteQueriesFormData). One consistent suffix is easier to follow than
 // asking each dev to judge "is this form-driven enough?"
-// *PreviewPayload is fine for outgoing webhook shapes (matches the
-// "Preview payload" UI terminology).
+// *PreviewPayload is fine for outgoing webhook shapes.
 ```
 
 ## Utilities

--- a/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
+++ b/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
@@ -160,8 +160,8 @@ const ActivityFeedAutomationsModal = ({
           <RevealButton
             isShowing={showExamplePayload}
             className={`${baseClass}__show-example-payload-toggle`}
-            hideText="Hide example payload"
-            showText="Show example payload"
+            hideText="Example payload"
+            showText="Example payload"
             caretPosition="after"
             onClick={() => {
               setShowExamplePayload(!showExamplePayload);

--- a/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
+++ b/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 
 import { IWebhookActivities } from "interfaces/webhook";
 
-import useGitOpsMode from "hooks/useGitOpsMode";
 import Modal from "components/Modal";
 import validURL from "components/forms/validators/valid_url";
 import Slider from "components/forms/fields/Slider";
@@ -44,8 +43,6 @@ const ActivityFeedAutomationsModal = ({
     {}
   );
   const [showExamplePayload, setShowExamplePayload] = useState(false);
-
-  const { gitOpsModeEnabled } = useGitOpsMode();
 
   const validateForm = (newFormData: IAFAMFormData) => {
     const errors: Record<string, string> = {};
@@ -170,7 +167,6 @@ const ActivityFeedAutomationsModal = ({
           onClick={() => {
             setShowExamplePayload(!showExamplePayload);
           }}
-          disabled={!formData.enabled && !gitOpsModeEnabled}
         />
         {showExamplePayload && renderExamplePayload()}
         <div className="modal-cta-wrap">

--- a/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
+++ b/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import { IWebhookActivities } from "interfaces/webhook";
 
+import useGitOpsMode from "hooks/useGitOpsMode";
 import Modal from "components/Modal";
 import validURL from "components/forms/validators/valid_url";
 import Slider from "components/forms/fields/Slider";
@@ -43,6 +44,8 @@ const ActivityFeedAutomationsModal = ({
     {}
   );
   const [showExamplePayload, setShowExamplePayload] = useState(false);
+
+  const { gitOpsModeEnabled } = useGitOpsMode();
 
   const validateForm = (newFormData: IAFAMFormData) => {
     const errors: Record<string, string> = {};
@@ -157,19 +160,19 @@ const ActivityFeedAutomationsModal = ({
             helpText="Fleet will send a JSON payload to this URL whenever a new activity is generated."
             disabled={!formData.enabled}
           />
-          <RevealButton
-            isShowing={showExamplePayload}
-            className={`${baseClass}__show-example-payload-toggle`}
-            hideText="Example payload"
-            showText="Example payload"
-            caretPosition="after"
-            onClick={() => {
-              setShowExamplePayload(!showExamplePayload);
-            }}
-            disabled={!formData.enabled}
-          />
-          {showExamplePayload && renderExamplePayload()}
         </div>
+        <RevealButton
+          isShowing={showExamplePayload}
+          className={`${baseClass}__show-example-payload-toggle`}
+          hideText="Example payload"
+          showText="Example payload"
+          caretPosition="after"
+          onClick={() => {
+            setShowExamplePayload(!showExamplePayload);
+          }}
+          disabled={!formData.enabled && !gitOpsModeEnabled}
+        />
+        {showExamplePayload && renderExamplePayload()}
         <div className="modal-cta-wrap">
           <Button
             type="submit"

--- a/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
+++ b/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
@@ -9,6 +9,7 @@ import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
 import RevealButton from "components/buttons/RevealButton";
 
+import useGitOpsMode from "hooks/useGitOpsMode";
 import { syntaxHighlight } from "utilities/helpers";
 import CustomLink from "components/CustomLink";
 
@@ -43,6 +44,8 @@ const ActivityFeedAutomationsModal = ({
     {}
   );
   const [showExamplePayload, setShowExamplePayload] = useState(false);
+
+  const { gitOpsModeEnabled } = useGitOpsMode();
 
   const validateForm = (newFormData: IAFAMFormData) => {
     const errors: Record<string, string> = {};
@@ -143,6 +146,7 @@ const ActivityFeedAutomationsModal = ({
           onChange={onFeatureEnabledChange}
           inactiveText="Disabled"
           activeText="Enabled"
+          disabled={gitOpsModeEnabled}
         />
         <div
           className={`form ${formData.enabled ? "" : "form-fields--disabled"}`}
@@ -155,7 +159,7 @@ const ActivityFeedAutomationsModal = ({
             value={formData.url}
             error={formErrors.url}
             helpText="Fleet will send a JSON payload to this URL whenever a new activity is generated."
-            disabled={!formData.enabled}
+            disabled={!formData.enabled || gitOpsModeEnabled}
           />
         </div>
         <RevealButton

--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
@@ -473,7 +473,7 @@ const ManageAutomationsModal = ({
           onClick={togglePreviewPayloadModal}
           disabled={!softwareAutomationsEnabled}
         >
-          Preview payload
+          Example payload
         </Button>
       </>
     );

--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
@@ -471,7 +471,6 @@ const ManageAutomationsModal = ({
           type="button"
           variant="inverse"
           onClick={togglePreviewPayloadModal}
-          disabled={!softwareAutomationsEnabled && !gitOpsModeEnabled}
         >
           Example payload
         </Button>

--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
@@ -471,7 +471,7 @@ const ManageAutomationsModal = ({
           type="button"
           variant="inverse"
           onClick={togglePreviewPayloadModal}
-          disabled={!softwareAutomationsEnabled}
+          disabled={!softwareAutomationsEnabled && !gitOpsModeEnabled}
         >
           Example payload
         </Button>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EndUserMigrationSection/EndUserMigrationSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EndUserMigrationSection/EndUserMigrationSection.tsx
@@ -245,7 +245,7 @@ const EndUserMigrationSection = ({ router }: IEndUserMigrationSectionProps) => {
           variant="inverse"
           onClick={toggleExamplePayloadModal}
         >
-          Preview payload
+          Example payload
         </Button>
         <GitOpsModeTooltipWrapper
           tipOffset={8}

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -195,7 +195,6 @@ const CalendarEventsModal = forwardRef<
                 showText="Example payload"
                 caretPosition="after"
                 onClick={() => setShowExamplePayload(!showExamplePayload)}
-                disabled={!formData.enabled && !gitOpsModeEnabled}
               />
               {showExamplePayload && renderExamplePayload()}
             </>

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -190,8 +190,8 @@ const CalendarEventsModal = forwardRef<
                 <RevealButton
                   isShowing={showExamplePayload}
                   className={`${baseClass}__show-example-payload-toggle`}
-                  hideText="Hide example payload"
-                  showText="Show example payload"
+                  hideText="Example payload"
+                  showText="Example payload"
                   caretPosition="after"
                   onClick={() => setShowExamplePayload(!showExamplePayload)}
                   disabled={!formData.enabled}

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -187,17 +187,17 @@ const CalendarEventsModal = forwardRef<
                   helpText="A request will be sent to this URL during the calendar event. Use it to trigger auto-remediation."
                   disabled={!formData.enabled || gitOpsModeEnabled}
                 />
-                <RevealButton
-                  isShowing={showExamplePayload}
-                  className={`${baseClass}__show-example-payload-toggle`}
-                  hideText="Example payload"
-                  showText="Example payload"
-                  caretPosition="after"
-                  onClick={() => setShowExamplePayload(!showExamplePayload)}
-                  disabled={!formData.enabled}
-                />
-                {showExamplePayload && renderExamplePayload()}
               </div>
+              <RevealButton
+                isShowing={showExamplePayload}
+                className={`${baseClass}__show-example-payload-toggle`}
+                hideText="Example payload"
+                showText="Example payload"
+                caretPosition="after"
+                onClick={() => setShowExamplePayload(!showExamplePayload)}
+                disabled={!formData.enabled && !gitOpsModeEnabled}
+              />
+              {showExamplePayload && renderExamplePayload()}
             </>
           )}
         </div>

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -244,8 +244,8 @@ const OtherWorkflowsModal = forwardRef<
         <RevealButton
           isShowing={showExamplePayload}
           className={baseClass}
-          hideText="Hide example payload"
-          showText="Show example payload"
+          hideText="Example payload"
+          showText="Example payload"
           caretPosition="after"
           onClick={() => setShowExamplePayload(!showExamplePayload)}
           disabled={!isPolicyAutomationsEnabled}

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -352,7 +352,6 @@ const OtherWorkflowsModal = forwardRef<
               showText="Example payload"
               caretPosition="after"
               onClick={() => setShowExamplePayload(!showExamplePayload)}
-              disabled={!isPolicyAutomationsEnabled && !gitOpsModeEnabled}
             />
             {showExamplePayload && <ExamplePayload />}
           </>

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -241,16 +241,6 @@ const OtherWorkflowsModal = forwardRef<
           tooltip="Provide a URL to deliver a webhook request to."
           disabled={!isPolicyAutomationsEnabled || gitOpsModeEnabled}
         />
-        <RevealButton
-          isShowing={showExamplePayload}
-          className={baseClass}
-          hideText="Example payload"
-          showText="Example payload"
-          caretPosition="after"
-          onClick={() => setShowExamplePayload(!showExamplePayload)}
-          disabled={!isPolicyAutomationsEnabled}
-        />
-        {showExamplePayload && <ExamplePayload />}
       </>
     );
 
@@ -353,6 +343,20 @@ const OtherWorkflowsModal = forwardRef<
           </div>
           {isWebhookEnabled ? renderWebhook() : renderIntegrations()}
         </div>
+        {isWebhookEnabled && (
+          <>
+            <RevealButton
+              isShowing={showExamplePayload}
+              className={baseClass}
+              hideText="Example payload"
+              showText="Example payload"
+              caretPosition="after"
+              onClick={() => setShowExamplePayload(!showExamplePayload)}
+              disabled={!isPolicyAutomationsEnabled && !gitOpsModeEnabled}
+            />
+            {showExamplePayload && <ExamplePayload />}
+          </>
+        )}
       </div>
     );
   }

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -230,7 +230,7 @@ const ManageQueryAutomationsModal = ({
           onClick={togglePreviewDataModal}
           className={`${baseClass}__preview-data`}
         >
-          Preview data
+          Example data
         </Button>
         <div className="modal-cta-wrap">
           <GitOpsModeTooltipWrapper


### PR DESCRIPTION
**Related issue:** #44719

Also, make sure the **Dashboard > Activity > Automations** modal is grayed out when in GitOps mode.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized button labels across modals to use "Example payload" / "Example data" consistently instead of mixed "Preview" or "Show/Hide" variants.
* **Bug Fixes**
  * Disabled relevant controls (example toggles, payload preview, destination URL inputs, toggles) when GitOps mode is enabled so UI reflects read-only mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->