### PR TITLE
Add check for deprecated methods to incremental lint.

### DIFF
--- a/.golangci-incremental.yml
+++ b/.golangci-incremental.yml
@@ -17,7 +17,15 @@ linters:
     - setboolcheck
     - depguard
     - apiparamcheck
+    - staticcheck
   settings:
+    staticcheck:
+      # Only enable SA1019 (deprecated function/method/field usage) here. It is disabled in the full
+      # lint (.golangci.yml) because existing code has many deprecated usages, but we want to catch new
+      # ones. All other staticcheck rules are owned by the full lint to avoid duplicate findings.
+      checks:
+        - "-all"
+        - "SA1019"
     gosec:
       # Only enable rules that are too noisy on existing code but valuable for new code.
       # Existing violations were audited during the v2.7.1 -> v2.11.3 upgrade and found


### PR DESCRIPTION
This is needed to catch usage of deprecated methods such as `ptr.String`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to streamline incremental code quality checks by refining rule scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->