### PR TITLE
Fleet UI: Cherry-picks (command palette followups, label action unreleased)

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tests.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tests.tsx
@@ -8,6 +8,37 @@ import CommandPalette from "./CommandPalette";
 // cmdk uses scrollIntoView which JSDOM doesn't implement
 Element.prototype.scrollIntoView = jest.fn();
 
+// CommandPalette branches on navigator.platform to pick the modifier
+// (Cmd on macOS, Ctrl elsewhere). jsdom's default is an empty string,
+// which would make the whole suite run as "non-Mac" and break every
+// {Meta>}…{/Meta} keyboard test. Default the suite to Mac and override
+// per-test when we specifically want to exercise the non-Mac branch.
+const setPlatform = (value: string) => {
+  Object.defineProperty(window.navigator, "platform", {
+    value,
+    configurable: true,
+  });
+};
+// Capture the original descriptor so afterEach can fully restore it —
+// not just the value. Otherwise our `configurable: true` override leaks
+// into other tests and can mask future descriptor-sensitive bugs.
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "platform"
+);
+beforeEach(() => setPlatform("MacIntel"));
+afterEach(() => {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(
+      window.navigator,
+      "platform",
+      originalPlatformDescriptor
+    );
+  } else {
+    delete (window.navigator as { platform?: string }).platform;
+  }
+});
+
 const adminRender = createCustomRenderer({
   withBackendMock: true,
   context: {
@@ -93,6 +124,32 @@ describe("CommandPalette", () => {
       const { user } = adminRender(<CommandPalette />);
       await openPalette(user);
       expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+    });
+
+    it("Ctrl+K does NOT open the palette on macOS (Cmd is required)", async () => {
+      // Ctrl+K is readline kill-line on macOS — we must not hijack it.
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}k{/Control}");
+
+      expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    });
+
+    it("Ctrl+K opens the palette on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}k{/Control}");
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+      });
+    });
+
+    it("Cmd+K does NOT open the palette on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Meta>}k{/Meta}");
+
+      expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     });
 
     it("closes on Escape", async () => {
@@ -213,6 +270,37 @@ describe("CommandPalette", () => {
           screen.getByPlaceholderText("Search a fleet...")
         ).toBeInTheDocument();
       });
+    });
+
+    it("Ctrl+Shift+F does NOT open switch-fleet on macOS (Cmd is required)", async () => {
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}{Shift>}f{/Shift}{/Control}");
+
+      expect(
+        screen.queryByPlaceholderText("Search a fleet...")
+      ).not.toBeInTheDocument();
+    });
+
+    it("Ctrl+Shift+F opens switch-fleet on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Control>}{Shift>}f{/Shift}{/Control}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Search a fleet...")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("Cmd+Shift+F does NOT open switch-fleet on non-macOS platforms", async () => {
+      setPlatform("Win32");
+      const { user } = adminRender(<CommandPalette />);
+      await user.keyboard("{Meta>}{Shift>}f{/Shift}{/Meta}");
+
+      expect(
+        screen.queryByPlaceholderText("Search a fleet...")
+      ).not.toBeInTheDocument();
     });
 
     it("Escape returns to root from a sub-page instead of closing", async () => {

--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -240,7 +240,12 @@ const CommandPalette = (): JSX.Element | null => {
   useEffect(() => {
     if (isNoAccess) return undefined;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
+      // Require the platform-native modifier: Cmd on macOS, Ctrl elsewhere.
+      // Accepting either on both platforms hijacks native shortcuts —
+      // e.g. Ctrl+K readline kill-line in text fields on macOS, and
+      // Ctrl+Shift+F (find in files / system shortcut) on macOS.
+      const correctModifier = isMacPlatform ? e.metaKey : e.ctrlKey;
+      if (!correctModifier) return;
       // Normalize once so Caps Lock (or shift layouts) don't miss.
       const key = e.key.toLowerCase();
       if (key === "k") {
@@ -255,7 +260,7 @@ const CommandPalette = (): JSX.Element | null => {
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [canSwitchFleet, isNoAccess]);
+  }, [canSwitchFleet, isNoAccess, isMacPlatform]);
 
   const navigate = useCallback((path: string) => {
     setOpen(false);

--- a/frontend/components/CommandPalette/groups/commands.ts
+++ b/frontend/components/CommandPalette/groups/commands.ts
@@ -293,6 +293,26 @@ const buildCommandsItems = (
                     "sh",
                   ],
                 },
+                {
+                  id: "add-self-service-category",
+                  label: "Add self-service category",
+                  group: "Commands" as const,
+                  // SelfServiceCategoriesPage opens its Add modal on
+                  // `?add_category=1`, mirroring the Variables/Scripts pattern.
+                  path: withTeamId(
+                    `${paths.SOFTWARE_LIBRARY_CATEGORIES}?add_category=1`
+                  ),
+                  keywords: [
+                    "add category",
+                    "create category",
+                    "new category",
+                    "self service",
+                    "self-service",
+                    "create self-service category",
+                    "new self-service category",
+                    "categories",
+                  ],
+                },
               ]
             : []),
           // Script and variable actions require a team or unassigned

--- a/frontend/components/CommandPalette/groups/software.ts
+++ b/frontend/components/CommandPalette/groups/software.ts
@@ -85,6 +85,21 @@ const buildSoftwareItems = (
               "self-service",
               "library",
             ],
+            subItems: [
+              {
+                id: "software-library-categories",
+                label: "Self-service categories",
+                path: withTeamId(paths.SOFTWARE_LIBRARY_CATEGORIES),
+                keywords: [
+                  "custom categories",
+                  "self service categories",
+                  "self-service category",
+                  "groups",
+                  "grouping",
+                  "install all",
+                ],
+              },
+            ],
           },
         ]
       : []),

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -450,6 +450,7 @@ describe("CommandPalette helpers", () => {
       expect(ids).not.toContain("add-vpp-app");
       expect(ids).not.toContain("add-android-app-store-app");
       expect(ids).not.toContain("add-custom-package");
+      expect(ids).not.toContain("add-self-service-category");
       expect(ids).not.toContain("add-script");
       expect(ids).not.toContain("add-custom-variable");
     });
@@ -466,6 +467,7 @@ describe("CommandPalette helpers", () => {
       expect(ids).toContain("add-vpp-app");
       expect(ids).toContain("add-android-app-store-app");
       expect(ids).toContain("add-custom-package");
+      expect(ids).toContain("add-self-service-category");
       expect(ids).toContain("add-script");
       expect(ids).toContain("add-custom-variable");
     });
@@ -498,6 +500,7 @@ describe("CommandPalette helpers", () => {
       expect(ids).not.toContain("add-vpp-app");
       expect(ids).not.toContain("add-android-app-store-app");
       expect(ids).not.toContain("add-custom-package");
+      expect(ids).not.toContain("add-self-service-category");
       // Sanity: non-software write actions still surface.
       expect(ids).toContain("add-hosts");
     });

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
@@ -3,10 +3,7 @@ import PATHS from "router/paths";
 import { browserHistory } from "react-router";
 import classnames from "classnames";
 
-import { IDropdownOption } from "interfaces/dropdownOption";
-
 import Button from "components/buttons/Button";
-import ActionsDropdown from "components/ActionsDropdown";
 import Icon from "components/Icon";
 import { getPathWithQueryParams, QueryParams } from "utilities/url";
 
@@ -19,14 +16,12 @@ interface IHostLinkProps {
   condensed?: boolean;
   excludeChevron?: boolean;
   responsive?: boolean;
-  /** Custom text replaces "View all hosts" in button or "Actions" in dropdown */
+  /** Custom text replaces "View all hosts" */
   customText?: string;
   /** Table links shows on row hover and tab focus only */
   rowHover?: boolean;
   /** Don't actually create a button, useful when click is handled by an ancestor */
   noLink?: boolean;
-  /** When provided, replaces View all hosts button with ActionDropdown */
-  dropdown?: { options: IDropdownOption[]; onChange: (value: string) => void };
 }
 
 const baseClass = "view-all-hosts-button";
@@ -41,7 +36,6 @@ const ViewAllHostsButton = ({
   customText,
   rowHover = false,
   noLink = false,
-  dropdown,
 }: IHostLinkProps): JSX.Element => {
   const viewAllHostsButtonClass = classnames(baseClass, className, {
     [`${baseClass}__condensed`]: condensed,
@@ -63,19 +57,6 @@ const ViewAllHostsButton = ({
       }
     }
   };
-
-  if (dropdown) {
-    return (
-      <ActionsDropdown
-        className={viewAllHostsButtonClass}
-        options={dropdown.options}
-        onChange={dropdown.onChange}
-        placeholder={customText || "Actions"}
-        variant="small-button"
-        menuAlign="right"
-      />
-    );
-  }
 
   return (
     <Button

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
@@ -498,3 +498,107 @@ describe("SelfServiceCategoriesPage", () => {
     });
   });
 });
+
+describe("SelfServiceCategoriesPage ?add_category=1 deep-link", () => {
+  const deepLinkProps = (router: ReturnType<typeof createMockRouter>) => ({
+    router,
+    location: {
+      pathname: "/software/library/categories",
+      search: "?fleet_id=1&add_category=1",
+      query: { fleet_id: "1", add_category: "1" },
+      hash: "",
+    },
+  });
+
+  beforeEach(() => {
+    renderFlash.mockClear();
+  });
+
+  it("opens the Add category modal for managers and strips the param", async () => {
+    mockServer.use(emptySelfServiceCategoriesHandler);
+    const router = createMockRouter();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: premiumAdminContext,
+    });
+
+    render(<SelfServiceCategoriesPage {...deepLinkProps(router)} />);
+
+    await getOpenModal();
+
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: "/software/library/categories",
+      query: { fleet_id: "1" },
+    });
+  });
+
+  it("reopens the modal on a second deep-link after the first was closed", async () => {
+    mockServer.use(emptySelfServiceCategoriesHandler);
+    const router = createMockRouter();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: premiumAdminContext,
+    });
+
+    const cleanProps = {
+      router,
+      location: {
+        pathname: "/software/library/categories",
+        search: "?fleet_id=1",
+        query: { fleet_id: "1" },
+        hash: "",
+      },
+    };
+
+    // Round 1: deep-link in.
+    const { user, rerender } = render(
+      <SelfServiceCategoriesPage {...deepLinkProps(router)} />
+    );
+    await getOpenModal();
+
+    // Simulate the effect's router.replace landing us back at the clean URL.
+    rerender(<SelfServiceCategoriesPage {...cleanProps} />);
+
+    // User dismisses the modal.
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(document.querySelector(".modal__modal_container")).toBeNull();
+    });
+
+    // Round 2: palette pushes the deep-link again (new location object).
+    rerender(<SelfServiceCategoriesPage {...deepLinkProps(router)} />);
+    await getOpenModal();
+  });
+
+  it("does not open the modal for non-managers but still strips the param", async () => {
+    mockServer.use(emptySelfServiceCategoriesHandler);
+    const router = createMockRouter();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: false,
+          isGlobalMaintainer: false,
+          isTeamAdmin: false,
+          isTeamMaintainer: false,
+          currentUser: createMockUser({ global_role: "observer" }),
+          availableTeams: [mockTeam],
+          setCurrentTeam: jest.fn(),
+        },
+        notification: { renderFlash, hideFlash: jest.fn() },
+      },
+    });
+
+    render(<SelfServiceCategoriesPage {...deepLinkProps(router)} />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: "/software/library/categories",
+        query: { fleet_id: "1" },
+      });
+    });
+
+    expect(document.querySelector(".modal__modal_container")).toBeNull();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "react-query";
 import { InjectedRouter } from "react-router";
 
@@ -36,7 +36,7 @@ interface ISelfServiceCategoriesPageProps {
   location: {
     pathname: string;
     search: string;
-    query: { fleet_id?: string; team_id?: string };
+    query: { fleet_id?: string; team_id?: string; add_category?: string };
     hash?: string;
   };
 }
@@ -82,6 +82,19 @@ const SelfServiceCategoriesPage = ({
     !!isTeamMaintainer;
 
   const [showAddModal, setShowAddModal] = useState(false);
+
+  // Open the Add category modal via deep-link (e.g. from the command
+  // palette). Gate on the same predicate the in-page button uses so the
+  // param can't bypass admin/maintainer-only authoring. Strip the param
+  // either way so refreshes don't keep reopening the modal.
+  useEffect(() => {
+    if (location.query.add_category !== "1") return;
+    if (canManage) {
+      setShowAddModal(true);
+    }
+    const { add_category, ...rest } = location.query;
+    router.replace({ pathname: location.pathname, query: rest });
+  }, [location.query, location.pathname, router, canManage]);
   const [
     categoryToEdit,
     setCategoryToEdit,

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
@@ -15,8 +15,8 @@ import {
   isTeamTechnician,
 } from "utilities/permissions/permissions";
 import { IUser } from "interfaces/user";
+import ActionsDropdown from "components/ActionsDropdown";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
-import ViewAllHostsLink from "components/ViewAllHostsLink";
 import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
 
 interface IHeaderProps {
@@ -175,14 +175,12 @@ const generateTableHeaders = (
           repoURL
         );
         return (
-          <ViewAllHostsLink
-            rowHover
-            noLink
-            excludeChevron
-            dropdown={{
-              options: dropdownOptions,
-              onChange: (value: string) => onClickAction(value, label),
-            }}
+          <ActionsDropdown
+            options={dropdownOptions}
+            onChange={(value: string) => onClickAction(value, label)}
+            placeholder="Actions"
+            menuAlign="right"
+            variant="small-button"
           />
         );
       },

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
@@ -1,18 +1,33 @@
+// Selectors nest under .data-table-block to outrank the global rule
+// `.data-table-block .data-table tbody td { max-width: 500px }`, which
+// otherwise wins on a class-vs-element specificity tie. `width: 100%;
+// max-width: 0` is the table idiom for "absorb the remaining row width
+// and let TooltipTruncatedTextCell truncate the overflow."
 .labels-table {
-  .view-all-hosts-link,
-  .view-all-hosts-link * {
-    text-decoration: none;
-    color: initial;
-    font-weight: initial;
-    font-size: $x-small;
+  .data-table-block .name__cell {
+    width: $col-lg;
+    max-width: $col-lg;
   }
 
-  .data-table-block .data-table__wrapper {
-    overflow-x: auto;
+  // Description flexes so it can't push the table past the viewport; name
+  // stays at $col-lg.
+  .data-table-block .description__cell {
+    width: 100%;
+    max-width: 0;
   }
 
-  .name__cell,
-  .description__cell {
-    min-width: $col-md;
+  // Roles swap at the narrowest viewport: description locks small so it
+  // stays readable, name takes whatever's left.
+  @media (max-width: $break-sm) {
+    .data-table-block .description__cell {
+      width: 185px;
+      min-width: 185px;
+      max-width: 185px;
+    }
+
+    .data-table-block .name__cell {
+      width: 100%;
+      max-width: 0;
+    }
   }
 }


### PR DESCRIPTION
## Issue
Closes #43757 
Closes #46812 

## Description
- This is a cherry-pick of 3 PRs into the 4.87.0 RC
- Each PR has previously been merged into `main`

1. Command + K vs. Ctrl + K and Command + Shift + F vs Ctrl + Shift + F are designated by user platform
2. Self service categories are a part of command palette
3. Unreleased bug fix for label actions dropdown that was rendering within the table


```
 1082  git fetch origin
 1083  git checkout origin/rc-minor-fleet-v4.87.0
 1084  git checkout -b cherry-picks-rachel-4.87
 1085  git cherry-pick 99d7cd5 
 1086  git cherry-pick  3178cac 
 1087  git cherry-pick 2bf5106 
 1088  git push -u origin cherry-picks-rachel-4.87
```