### PR TITLE
Record per-host ticket policy automation activities

### DIFF
--- a/changes/38670-policy-status-page
+++ b/changes/38670-policy-status-page
@@ -1,1 +1,0 @@
-- Added per-host activity log entries when policy ticket automations (Jira or Zendesk) fail after all retries are exhausted or succeed (ticket created).

--- a/changes/38670-policy-status-page
+++ b/changes/38670-policy-status-page
@@ -1,0 +1,1 @@
+- Added per-host activity log entries when policy ticket automations (Jira or Zendesk) fail after all retries are exhausted or succeed (ticket created).

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1024,6 +1024,7 @@ func newWorkerIntegrationsSchedule(
 	commander *apple_mdm.MDMAppleCommander,
 	androidModule android.Service,
 	chartSvc chart_api.Service,
+	newActivitySvc activity_api.NewActivityService,
 ) (*schedule.Schedule, error) {
 	const (
 		name = string(fleet.CronWorkerIntegrations)
@@ -1045,14 +1046,16 @@ func newWorkerIntegrationsSchedule(
 	// leave the url empty for now, will be filled when the lock is acquired with
 	// the up-to-date config.
 	jira := &worker.Jira{
-		Datastore:     ds,
-		Log:           logger,
-		NewClientFunc: newJiraClient,
+		Datastore:      ds,
+		Log:            logger,
+		NewClientFunc:  newJiraClient,
+		NewActivitySvc: newActivitySvc,
 	}
 	zendesk := &worker.Zendesk{
-		Datastore:     ds,
-		Log:           logger,
-		NewClientFunc: newZendeskClient,
+		Datastore:      ds,
+		Log:            logger,
+		NewClientFunc:  newZendeskClient,
+		NewActivitySvc: newActivitySvc,
 	}
 	var (
 		depSvc *apple_mdm.DEPService

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -771,7 +771,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 
 	if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 		commander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
-		return newWorkerIntegrationsSchedule(ctx, instanceID, ds, logger, depStorage, commander, androidSvc, chartSvc)
+		return newWorkerIntegrationsSchedule(ctx, instanceID, ds, logger, depStorage, commander, androidSvc, chartSvc, activitySvc)
 	}); err != nil {
 		initFatal(err, "failed to register worker integrations schedule")
 	}

--- a/pkg/str/str.go
+++ b/pkg/str/str.go
@@ -3,7 +3,26 @@ package str
 import (
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
+
+// MaxErrorResponseBytes is the maximum number of bytes captured from a remote
+// error response body before the string is truncated.
+const MaxErrorResponseBytes = 512 * 1024
+
+// TruncateErrorResponse caps s at MaxErrorResponseBytes bytes. When the string
+// is longer it is cut at a valid UTF-8 boundary and " [truncated]" is appended.
+func TruncateErrorResponse(s string) string {
+	if len(s) <= MaxErrorResponseBytes {
+		return s
+	}
+	cut := s[:MaxErrorResponseBytes]
+	// Step back from the cut point to ensure we end on a valid rune boundary.
+	for !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + " [truncated]"
+}
 
 func SplitAndTrim(s string, delimiter string, removeEmpty bool) []string {
 	parts := strings.Split(s, delimiter)

--- a/pkg/str/str_test.go
+++ b/pkg/str/str_test.go
@@ -1,9 +1,12 @@
 package str
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitAndTrim(t *testing.T) {
@@ -141,6 +144,40 @@ func TestParseUintList(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestTruncateErrorResponse(t *testing.T) {
+	t.Run("short string passes through unchanged", func(t *testing.T) {
+		require.Equal(t, "hello", TruncateErrorResponse("hello"))
+	})
+
+	t.Run("exactly at limit passes through unchanged", func(t *testing.T) {
+		s := strings.Repeat("x", MaxErrorResponseBytes)
+		result := TruncateErrorResponse(s)
+		require.Equal(t, s, result)
+		require.False(t, strings.HasSuffix(result, " [truncated]"))
+	})
+
+	t.Run("one byte over limit is truncated", func(t *testing.T) {
+		s := strings.Repeat("x", MaxErrorResponseBytes+1)
+		result := TruncateErrorResponse(s)
+		require.True(t, strings.HasSuffix(result, " [truncated]"))
+		require.LessOrEqual(t, len(result), MaxErrorResponseBytes+len(" [truncated]"))
+	})
+
+	t.Run("result is always valid UTF-8", func(t *testing.T) {
+		// Build a string that is over the limit and ends with a partial multi-byte rune
+		// at the cut point. U+1F600 (😀) encodes as 4 bytes; place it straddling the limit.
+		prefix := strings.Repeat("a", MaxErrorResponseBytes-1)
+		s := prefix + "😀" + strings.Repeat("b", 100)
+		result := TruncateErrorResponse(s)
+		assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+		assert.True(t, strings.HasSuffix(result, " [truncated]"))
+	})
+
+	t.Run("empty string passes through unchanged", func(t *testing.T) {
+		require.Empty(t, TruncateErrorResponse(""))
+	})
 }
 
 func TestParseStringList(t *testing.T) {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -2029,35 +2029,12 @@ func (a ActivityTypeDeletedSelfServiceCategory) ActivityName() string {
 	return "deleted_self_service_category"
 }
 
-// ActivityTypeFailedTicketPolicyAutomation is recorded when a failing-policy
-// ticket automation (Jira or Zendesk) can no longer create the ticket after the
-// worker exhausts its retries. It is associated with every host the
-// failing-policy job targeted. The Type field is "jira" or "zendesk".
-type ActivityTypeFailedTicketPolicyAutomation struct {
-	PolicyID      uint   `json:"policy_id"`
-	HostIDList    []uint `json:"-"`
-	Type          string `json:"type"`
-	ErrorResponse string `json:"error_response"`
-}
-
-func (a ActivityTypeFailedTicketPolicyAutomation) ActivityName() string {
-	return "failed_ticket_policy_automation"
-}
-
-func (a ActivityTypeFailedTicketPolicyAutomation) HostIDs() []uint {
-	return a.HostIDList
-}
-
-func (a ActivityTypeFailedTicketPolicyAutomation) WasFromAutomation() bool {
-	return true
-}
-
-// ActivityTypeQueuedTicketPolicyAutomation is recorded when a failing-policy
+// ActivityTypeRanAutomationTicket is recorded when a failing-policy
 // ticket automation (Jira or Zendesk) successfully creates the ticket. It is
 // associated with every host the failing-policy job targeted. The Type field is
 // "jira" or "zendesk". For Jira, TicketKey holds the issue key (e.g. "ENG-24");
 // for Zendesk, TicketID holds the numeric ticket ID.
-type ActivityTypeQueuedTicketPolicyAutomation struct {
+type ActivityTypeRanAutomationTicket struct {
 	PolicyID   uint   `json:"policy_id"`
 	HostIDList []uint `json:"-"`
 	Type       string `json:"type"`
@@ -2065,14 +2042,37 @@ type ActivityTypeQueuedTicketPolicyAutomation struct {
 	TicketID   int64  `json:"ticket_id,omitempty"`
 }
 
-func (a ActivityTypeQueuedTicketPolicyAutomation) ActivityName() string {
-	return "queued_ticket_policy_automation"
+func (a ActivityTypeRanAutomationTicket) ActivityName() string {
+	return "ran_automation_ticket"
 }
 
-func (a ActivityTypeQueuedTicketPolicyAutomation) HostIDs() []uint {
+func (a ActivityTypeRanAutomationTicket) HostIDs() []uint {
 	return a.HostIDList
 }
 
-func (a ActivityTypeQueuedTicketPolicyAutomation) WasFromAutomation() bool {
+func (a ActivityTypeRanAutomationTicket) WasFromAutomation() bool {
+	return true
+}
+
+// ActivityTypeFailedAutomationTicket is recorded when a failing-policy
+// ticket automation (Jira or Zendesk) can no longer create the ticket after the
+// worker exhausts its retries. It is associated with every host the
+// failing-policy job targeted. The Type field is "jira" or "zendesk".
+type ActivityTypeFailedAutomationTicket struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	Type          string `json:"type"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedAutomationTicket) ActivityName() string {
+	return "failed_automation_ticket"
+}
+
+func (a ActivityTypeFailedAutomationTicket) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedAutomationTicket) WasFromAutomation() bool {
 	return true
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -2028,3 +2028,51 @@ type ActivityTypeDeletedSelfServiceCategory struct {
 func (a ActivityTypeDeletedSelfServiceCategory) ActivityName() string {
 	return "deleted_self_service_category"
 }
+
+// ActivityTypeFailedTicketPolicyAutomation is recorded when a failing-policy
+// ticket automation (Jira or Zendesk) can no longer create the ticket after the
+// worker exhausts its retries. It is associated with every host the
+// failing-policy job targeted. The Type field is "jira" or "zendesk".
+type ActivityTypeFailedTicketPolicyAutomation struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	Type          string `json:"type"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedTicketPolicyAutomation) ActivityName() string {
+	return "failed_ticket_policy_automation"
+}
+
+func (a ActivityTypeFailedTicketPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedTicketPolicyAutomation) WasFromAutomation() bool {
+	return true
+}
+
+// ActivityTypeQueuedTicketPolicyAutomation is recorded when a failing-policy
+// ticket automation (Jira or Zendesk) successfully creates the ticket. It is
+// associated with every host the failing-policy job targeted. The Type field is
+// "jira" or "zendesk". For Jira, TicketKey holds the issue key (e.g. "ENG-24");
+// for Zendesk, TicketID holds the numeric ticket ID.
+type ActivityTypeQueuedTicketPolicyAutomation struct {
+	PolicyID   uint   `json:"policy_id"`
+	HostIDList []uint `json:"-"`
+	Type       string `json:"type"`
+	TicketKey  string `json:"ticket_key,omitempty"`
+	TicketID   int64  `json:"ticket_id,omitempty"`
+}
+
+func (a ActivityTypeQueuedTicketPolicyAutomation) ActivityName() string {
+	return "queued_ticket_policy_automation"
+}
+
+func (a ActivityTypeQueuedTicketPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeQueuedTicketPolicyAutomation) WasFromAutomation() bool {
+	return true
+}

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -1,10 +1,123 @@
 package fleet
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestFailedPolicyAutomationActivities(t *testing.T) {
+	t.Run("ticket (jira)", func(t *testing.T) {
+		act := ActivityTypeFailedTicketPolicyAutomation{
+			PolicyID:      8,
+			HostIDList:    []uint{11},
+			Type:          "jira",
+			ErrorResponse: "401 Unauthorized",
+		}
+
+		assert.Equal(t, "failed_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{11}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 8, got["policy_id"])
+		assert.Equal(t, "jira", got["type"])
+		assert.Equal(t, "401 Unauthorized", got["error_response"])
+		_, hasStatus := got["status_code"]
+		assert.False(t, hasStatus)
+	})
+
+	t.Run("ticket (zendesk)", func(t *testing.T) {
+		act := ActivityTypeFailedTicketPolicyAutomation{
+			PolicyID:      9,
+			HostIDList:    []uint{12, 13},
+			Type:          "zendesk",
+			ErrorResponse: "422: {\"error\":\"RecordInvalid\"}",
+		}
+
+		assert.Equal(t, "failed_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{12, 13}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 9, got["policy_id"])
+		assert.Equal(t, "zendesk", got["type"])
+		assert.Equal(t, "422: {\"error\":\"RecordInvalid\"}", got["error_response"])
+		_, hasStatus := got["status_code"]
+		assert.False(t, hasStatus)
+	})
+}
+
+func TestSuccessPolicyAutomationActivities(t *testing.T) {
+	// assertNoHostIDsOrPolicyName fails if the marshaled details leak the
+	// host ID list or a policy name (both are intentionally omitted; hosts
+	// live one-per-row in activity_host_past).
+	assertNoHostIDsOrPolicyName := func(t *testing.T, got map[string]any) {
+		t.Helper()
+		_, hasHostIDs := got["host_ids"]
+		assert.False(t, hasHostIDs)
+		_, hasPolicyName := got["policy_name"]
+		assert.False(t, hasPolicyName)
+	}
+
+	t.Run("ticket queued (jira)", func(t *testing.T) {
+		act := ActivityTypeQueuedTicketPolicyAutomation{
+			PolicyID:   8,
+			HostIDList: []uint{11},
+			Type:       "jira",
+			TicketKey:  "ABC-123",
+		}
+
+		assert.Equal(t, "queued_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{11}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 8, got["policy_id"])
+		assert.Equal(t, "jira", got["type"])
+		assert.Equal(t, "ABC-123", got["ticket_key"])
+		// ticket_id omitted for jira
+		_, hasTicketID := got["ticket_id"]
+		assert.False(t, hasTicketID)
+		assertNoHostIDsOrPolicyName(t, got)
+	})
+
+	t.Run("ticket queued (zendesk)", func(t *testing.T) {
+		act := ActivityTypeQueuedTicketPolicyAutomation{
+			PolicyID:   9,
+			HostIDList: []uint{12, 13},
+			Type:       "zendesk",
+			TicketID:   4567,
+		}
+
+		assert.Equal(t, "queued_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{12, 13}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 9, got["policy_id"])
+		assert.Equal(t, "zendesk", got["type"])
+		assert.EqualValues(t, 4567, got["ticket_id"])
+		// ticket_key omitted for zendesk
+		_, hasTicketKey := got["ticket_key"]
+		assert.False(t, hasTicketKey)
+		assertNoHostIDsOrPolicyName(t, got)
+	})
+}
 
 // TestVPPInstallFailureEmptyCommandUUIDDoesNotActivateNext exercises the
 // scenario where a VPP install is attempted during setup experience for a
@@ -13,8 +126,6 @@ import (
 // CommandUUID is empty. In that case the next upcoming activity must NOT
 // be activated, because the current activity was never truly started —
 // activating the next one would break the intended sequential ordering.
-//
-// See commit 159194acc9d92843bb2de933309f159c84a501aa for the fix.
 func TestVPPInstallFailureEmptyCommandUUIDDoesNotActivateNext(t *testing.T) {
 	t.Parallel()
 

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFailedPolicyAutomationActivities(t *testing.T) {
+func TestFailedAutomationTicketActivities(t *testing.T) {
 	t.Run("ticket (jira)", func(t *testing.T) {
-		act := ActivityTypeFailedTicketPolicyAutomation{
+		act := ActivityTypeFailedAutomationTicket{
 			PolicyID:      8,
 			HostIDList:    []uint{11},
 			Type:          "jira",
 			ErrorResponse: "401 Unauthorized",
 		}
 
-		assert.Equal(t, "failed_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, "failed_automation_ticket", act.ActivityName())
 		assert.Equal(t, []uint{11}, act.HostIDs())
 		assert.True(t, act.WasFromAutomation())
 
@@ -33,14 +33,14 @@ func TestFailedPolicyAutomationActivities(t *testing.T) {
 	})
 
 	t.Run("ticket (zendesk)", func(t *testing.T) {
-		act := ActivityTypeFailedTicketPolicyAutomation{
+		act := ActivityTypeFailedAutomationTicket{
 			PolicyID:      9,
 			HostIDList:    []uint{12, 13},
 			Type:          "zendesk",
 			ErrorResponse: "422: {\"error\":\"RecordInvalid\"}",
 		}
 
-		assert.Equal(t, "failed_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, "failed_automation_ticket", act.ActivityName())
 		assert.Equal(t, []uint{12, 13}, act.HostIDs())
 		assert.True(t, act.WasFromAutomation())
 
@@ -56,7 +56,7 @@ func TestFailedPolicyAutomationActivities(t *testing.T) {
 	})
 }
 
-func TestSuccessPolicyAutomationActivities(t *testing.T) {
+func TestRanAutomationTicketActivities(t *testing.T) {
 	// assertNoHostIDsOrPolicyName fails if the marshaled details leak the
 	// host ID list or a policy name (both are intentionally omitted; hosts
 	// live one-per-row in activity_host_past).
@@ -68,15 +68,15 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 		assert.False(t, hasPolicyName)
 	}
 
-	t.Run("ticket queued (jira)", func(t *testing.T) {
-		act := ActivityTypeQueuedTicketPolicyAutomation{
+	t.Run("ticket (jira)", func(t *testing.T) {
+		act := ActivityTypeRanAutomationTicket{
 			PolicyID:   8,
 			HostIDList: []uint{11},
 			Type:       "jira",
 			TicketKey:  "ABC-123",
 		}
 
-		assert.Equal(t, "queued_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, "ran_automation_ticket", act.ActivityName())
 		assert.Equal(t, []uint{11}, act.HostIDs())
 		assert.True(t, act.WasFromAutomation())
 
@@ -93,15 +93,15 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 		assertNoHostIDsOrPolicyName(t, got)
 	})
 
-	t.Run("ticket queued (zendesk)", func(t *testing.T) {
-		act := ActivityTypeQueuedTicketPolicyAutomation{
+	t.Run("ticket (zendesk)", func(t *testing.T) {
+		act := ActivityTypeRanAutomationTicket{
 			PolicyID:   9,
 			HostIDList: []uint{12, 13},
 			Type:       "zendesk",
 			TicketID:   4567,
 		}
 
-		assert.Equal(t, "queued_ticket_policy_automation", act.ActivityName())
+		assert.Equal(t, "ran_automation_ticket", act.ActivityName())
 		assert.Equal(t, []uint{12, 13}, act.HostIDs())
 		assert.True(t, act.WasFromAutomation())
 

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -126,6 +126,8 @@ func TestRanAutomationTicketActivities(t *testing.T) {
 // CommandUUID is empty. In that case the next upcoming activity must NOT
 // be activated, because the current activity was never truly started —
 // activating the next one would break the intended sequential ordering.
+//
+// See commit 159194acc9d92843bb2de933309f159c84a501aa for the fix.
 func TestVPPInstallFailureEmptyCommandUUIDDoesNotActivateNext(t *testing.T) {
 	t.Parallel()
 

--- a/server/service/externalsvc/jira.go
+++ b/server/service/externalsvc/jira.go
@@ -90,11 +90,11 @@ func (j *Jira) CreateJiraIssue(ctx context.Context, issue *jira.Issue) (*jira.Is
 		)
 		createdIssue, resp, err = j.client.Issue.CreateWithContext(ctx, issue)
 		if err != nil && resp != nil && resp.Response != nil && resp.Response.Body != nil {
-			// Cap the body to guard against OOM; no "[truncated]" marker here because
-			// OnFinalFailure stores this string as-is and the body is already bounded.
-			b, _ := io.ReadAll(io.LimitReader(resp.Response.Body, str.MaxErrorResponseBytes))
+			// Read one byte past the limit so TruncateErrorResponse can detect
+			// overflow and append "[truncated]" while cutting at a valid UTF-8 boundary.
+			b, _ := io.ReadAll(io.LimitReader(resp.Response.Body, int64(str.MaxErrorResponseBytes)+1))
 			resp.Response.Body.Close()
-			respBody = string(b)
+			respBody = str.TruncateErrorResponse(string(b))
 		}
 		return resp, err
 	}

--- a/server/service/externalsvc/jira.go
+++ b/server/service/externalsvc/jira.go
@@ -3,6 +3,8 @@ package externalsvc
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -11,6 +13,7 @@ import (
 	"github.com/andygrunwald/go-jira"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/pkg/str"
 )
 
 // Jira is a Jira client to be used to make requests to a jira external
@@ -79,16 +82,27 @@ func (j *Jira) CreateJiraIssue(ctx context.Context, issue *jira.Issue) (*jira.Is
 	issue.Fields.Project.Key = j.opts.ProjectKey
 
 	var createdIssue *jira.Issue
+	var respBody string
 	op := func() (*jira.Response, error) {
 		var (
 			err  error
 			resp *jira.Response
 		)
 		createdIssue, resp, err = j.client.Issue.CreateWithContext(ctx, issue)
+		if err != nil && resp != nil && resp.Response != nil && resp.Response.Body != nil {
+			// Cap the body to guard against OOM; no "[truncated]" marker here because
+			// OnFinalFailure stores this string as-is and the body is already bounded.
+			b, _ := io.ReadAll(io.LimitReader(resp.Response.Body, str.MaxErrorResponseBytes))
+			resp.Response.Body.Close()
+			respBody = string(b)
+		}
 		return resp, err
 	}
 
 	if err := doWithRetry(op); err != nil {
+		if respBody != "" {
+			return nil, fmt.Errorf("%w: %s", err, respBody)
+		}
 		return nil, err
 	}
 	return createdIssue, nil

--- a/server/service/externalsvc/jira_test.go
+++ b/server/service/externalsvc/jira_test.go
@@ -21,6 +21,10 @@ func TestJira(t *testing.T) {
 		case "fail":
 			w.WriteHeader(http.StatusInternalServerError)
 			return
+		case "failbody":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errorMessages":["project is required"]}`))
+			return
 		case "retrysmall":
 			if countCalls == 1 {
 				w.Header().Add("Retry-After", "1")
@@ -68,6 +72,20 @@ func TestJira(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Status code: 500")
 		require.Equal(t, 6, countCalls)
+	})
+
+	t.Run("failure-includes-response-body", func(t *testing.T) {
+		countCalls = 0
+
+		client, err := NewJiraClient(&JiraOptions{
+			BaseURL:           srv.URL,
+			BasicAuthUsername: "failbody",
+			BasicAuthPassword: "failbody",
+		})
+		require.NoError(t, err)
+		_, err = client.CreateJiraIssue(t.Context(), &jira.Issue{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "project is required")
 	})
 
 	t.Run("retry-after-small", func(t *testing.T) {

--- a/server/worker/jira.go
+++ b/server/worker/jira.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	jira "github.com/andygrunwald/go-jira"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -119,10 +120,11 @@ type JiraClient interface {
 
 // Jira is the job processor for jira integrations.
 type Jira struct {
-	FleetURL      string
-	Datastore     fleet.Datastore
-	Log           *slog.Logger
-	NewClientFunc func(*externalsvc.JiraOptions) (JiraClient, error)
+	FleetURL       string
+	Datastore      fleet.Datastore
+	Log            *slog.Logger
+	NewClientFunc  func(*externalsvc.JiraOptions) (JiraClient, error)
+	NewActivitySvc activity_api.NewActivityService
 
 	// mu protects concurrent access to clientsCache, so that the job processor
 	// can potentially be run concurrently.
@@ -262,6 +264,30 @@ func (j *Jira) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	}
 }
 
+// OnFinalFailure records a failed_ticket_policy_automation host activity once
+// the worker has exhausted all retries for a failing-policy job. Vulnerability
+// jobs are ignored as they are not host- or policy-scoped.
+func (j *Jira) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+	if j.NewActivitySvc == nil {
+		return nil
+	}
+
+	var args jiraArgs
+	if err := json.Unmarshal(argsJSON, &args); err != nil {
+		return ctxerr.Wrap(ctx, err, "unmarshal args")
+	}
+	if args.FailingPolicy == nil {
+		return nil
+	}
+
+	return j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedTicketPolicyAutomation{
+		PolicyID:      args.FailingPolicy.PolicyID,
+		HostIDList:    args.FailingPolicy.hostIDs(),
+		Type:          "jira",
+		ErrorResponse: jobErr,
+	})
+}
+
 func (j *Jira) runVuln(ctx context.Context, cli JiraClient, args jiraArgs) error {
 	vargs := args.Vulnerability
 	if vargs == nil {
@@ -325,6 +351,18 @@ func (j *Jira) runFailingPolicy(ctx context.Context, cli JiraClient, args jiraAr
 		attrs = append(attrs, "team_id", *args.FailingPolicy.TeamID)
 	}
 	j.Log.DebugContext(ctx, "created jira issue for failing policy", attrs...)
+
+	if j.NewActivitySvc != nil {
+		if err := j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeQueuedTicketPolicyAutomation{
+			PolicyID:   args.FailingPolicy.PolicyID,
+			HostIDList: args.FailingPolicy.hostIDs(),
+			Type:       "jira",
+			TicketKey:  createdIssue.Key,
+		}); err != nil {
+			j.Log.WarnContext(ctx, "failed to record jira policy automation queued activity",
+				"policy_id", args.FailingPolicy.PolicyID, "err", err)
+		}
+	}
 	return nil
 }
 

--- a/server/worker/jira.go
+++ b/server/worker/jira.go
@@ -268,10 +268,6 @@ func (j *Jira) Run(ctx context.Context, argsJSON json.RawMessage) error {
 // the worker has exhausted all retries for a failing-policy job. Vulnerability
 // jobs are ignored as they are not host- or policy-scoped.
 func (j *Jira) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
-	if j.NewActivitySvc == nil {
-		return nil
-	}
-
 	var args jiraArgs
 	if err := json.Unmarshal(argsJSON, &args); err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshal args")
@@ -352,16 +348,14 @@ func (j *Jira) runFailingPolicy(ctx context.Context, cli JiraClient, args jiraAr
 	}
 	j.Log.DebugContext(ctx, "created jira issue for failing policy", attrs...)
 
-	if j.NewActivitySvc != nil {
-		if err := j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeRanAutomationTicket{
-			PolicyID:   args.FailingPolicy.PolicyID,
-			HostIDList: args.FailingPolicy.hostIDs(),
-			Type:       "jira",
-			TicketKey:  createdIssue.Key,
-		}); err != nil {
-			j.Log.WarnContext(ctx, "failed to record jira policy automation queued activity",
-				"policy_id", args.FailingPolicy.PolicyID, "err", err)
-		}
+	if err := j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeRanAutomationTicket{
+		PolicyID:   args.FailingPolicy.PolicyID,
+		HostIDList: args.FailingPolicy.hostIDs(),
+		Type:       "jira",
+		TicketKey:  createdIssue.Key,
+	}); err != nil {
+		j.Log.WarnContext(ctx, "failed to record jira policy automation queued activity",
+			"policy_id", args.FailingPolicy.PolicyID, "err", err)
 	}
 	return nil
 }

--- a/server/worker/jira.go
+++ b/server/worker/jira.go
@@ -264,7 +264,7 @@ func (j *Jira) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	}
 }
 
-// OnFinalFailure records a failed_ticket_policy_automation host activity once
+// OnFinalFailure records a failed_automation_ticket host activity once
 // the worker has exhausted all retries for a failing-policy job. Vulnerability
 // jobs are ignored as they are not host- or policy-scoped.
 func (j *Jira) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
@@ -280,7 +280,7 @@ func (j *Jira) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, job
 		return nil
 	}
 
-	return j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedTicketPolicyAutomation{
+	return j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedAutomationTicket{
 		PolicyID:      args.FailingPolicy.PolicyID,
 		HostIDList:    args.FailingPolicy.hostIDs(),
 		Type:          "jira",
@@ -353,7 +353,7 @@ func (j *Jira) runFailingPolicy(ctx context.Context, cli JiraClient, args jiraAr
 	j.Log.DebugContext(ctx, "created jira issue for failing policy", attrs...)
 
 	if j.NewActivitySvc != nil {
-		if err := j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeQueuedTicketPolicyAutomation{
+		if err := j.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeRanAutomationTicket{
 			PolicyID:   args.FailingPolicy.PolicyID,
 			HostIDList: args.FailingPolicy.hostIDs(),
 			Type:       "jira",

--- a/server/worker/jira_test.go
+++ b/server/worker/jira_test.go
@@ -305,7 +305,7 @@ func TestJiraOnFinalFailure(t *testing.T) {
 		require.NoError(t, j.OnFinalFailure(ctx, args, "create issue: 401 Unauthorized"))
 
 		require.Len(t, recorded, 1)
-		act, ok := recorded[0].(fleet.ActivityTypeFailedTicketPolicyAutomation)
+		act, ok := recorded[0].(fleet.ActivityTypeFailedAutomationTicket)
 		require.True(t, ok)
 		require.Equal(t, uint(5), act.PolicyID)
 		require.Equal(t, []uint{1, 2}, act.HostIDList)
@@ -370,7 +370,7 @@ func TestJiraRunRecordsCreatedActivity(t *testing.T) {
 		require.NoError(t, j.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
 
 		require.Len(t, recorded, 1)
-		act, ok := recorded[0].(fleet.ActivityTypeQueuedTicketPolicyAutomation)
+		act, ok := recorded[0].(fleet.ActivityTypeRanAutomationTicket)
 		require.True(t, ok)
 		require.Equal(t, uint(5), act.PolicyID)
 		require.Equal(t, []uint{1, 2}, act.HostIDList)

--- a/server/worker/jira_test.go
+++ b/server/worker/jira_test.go
@@ -208,6 +208,9 @@ func TestJiraRun(t *testing.T) {
 				NewClientFunc: func(opts *externalsvc.JiraOptions) (JiraClient, error) {
 					return client, nil
 				},
+				NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, _ fleet.ActivityDetails) error {
+					return nil
+				}},
 			}
 
 			expectedSummary = c.expectedSummary
@@ -378,19 +381,6 @@ func TestJiraRunRecordsCreatedActivity(t *testing.T) {
 		require.Equal(t, "ED-24", act.TicketKey)
 	})
 
-	t.Run("nil activity service is a no-op", func(t *testing.T) {
-		j := &Jira{
-			FleetURL:  "https://fleetdm.com",
-			Datastore: ds,
-			Log:       slog.New(slog.DiscardHandler),
-			NewClientFunc: func(opts *externalsvc.JiraOptions) (JiraClient, error) {
-				return client, nil
-			},
-		}
-
-		args := json.RawMessage(`{"failing_policy":{"policy_id":5,"policy_name":"p5","hosts":[]}}`)
-		require.NoError(t, j.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
-	})
 }
 
 func TestJiraQueueFailingPolicyJob(t *testing.T) {
@@ -527,6 +517,9 @@ func TestJiraRunClientUpdate(t *testing.T) {
 			clients = append(clients, client)
 			return client, nil
 		},
+		NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, _ fleet.ActivityDetails) error {
+			return nil
+		}},
 	}
 
 	ctx := license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree})

--- a/server/worker/jira_test.go
+++ b/server/worker/jira_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	jira "github.com/andygrunwald/go-jira"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -278,6 +279,117 @@ func TestJiraQueueVulnJobs(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, io.EOF)
 		require.True(t, ds.NewJobFuncInvoked)
+	})
+}
+
+func TestJiraOnFinalFailure(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("failing policy records activity", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		j := &Jira{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+				require.Nil(t, user)
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(jiraArgs{FailingPolicy: &failingPolicyArgs{
+			PolicyID: 5,
+			Hosts:    []fleet.PolicySetHost{{ID: 1, Hostname: "h1"}, {ID: 2, Hostname: "h2"}},
+		}})
+		require.NoError(t, err)
+
+		require.NoError(t, j.OnFinalFailure(ctx, args, "create issue: 401 Unauthorized"))
+
+		require.Len(t, recorded, 1)
+		act, ok := recorded[0].(fleet.ActivityTypeFailedTicketPolicyAutomation)
+		require.True(t, ok)
+		require.Equal(t, uint(5), act.PolicyID)
+		require.Equal(t, []uint{1, 2}, act.HostIDList)
+		require.Equal(t, "jira", act.Type)
+		require.Equal(t, "create issue: 401 Unauthorized", act.ErrorResponse)
+	})
+
+	t.Run("vuln job records nothing", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		j := &Jira{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, activity fleet.ActivityDetails) error {
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(jiraArgs{Vulnerability: &vulnArgs{CVE: "CVE-2024-1"}})
+		require.NoError(t, err)
+
+		require.NoError(t, j.OnFinalFailure(ctx, args, "boom"))
+		require.Empty(t, recorded)
+	})
+}
+
+func TestJiraRunRecordsCreatedActivity(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{Integrations: fleet.Integrations{
+			Jira: []*fleet.JiraIntegration{
+				{EnableFailingPolicies: true},
+			},
+		}}, nil
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"10000","key":"ED-24"}`))
+	}))
+	defer srv.Close()
+
+	client, err := externalsvc.NewJiraClient(&externalsvc.JiraOptions{BaseURL: srv.URL})
+	require.NoError(t, err)
+
+	t.Run("failing policy records created activity", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		j := &Jira{
+			FleetURL:  "https://fleetdm.com",
+			Datastore: ds,
+			Log:       slog.New(slog.DiscardHandler),
+			NewClientFunc: func(opts *externalsvc.JiraOptions) (JiraClient, error) {
+				return client, nil
+			},
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+				require.Nil(t, user)
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args := json.RawMessage(`{"failing_policy":{"policy_id":5,"policy_name":"p5","hosts":[{"id":1,"hostname":"h1"},{"id":2,"hostname":"h2"}]}}`)
+		require.NoError(t, j.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
+
+		require.Len(t, recorded, 1)
+		act, ok := recorded[0].(fleet.ActivityTypeQueuedTicketPolicyAutomation)
+		require.True(t, ok)
+		require.Equal(t, uint(5), act.PolicyID)
+		require.Equal(t, []uint{1, 2}, act.HostIDList)
+		require.Equal(t, "jira", act.Type)
+		require.Equal(t, "ED-24", act.TicketKey)
+	})
+
+	t.Run("nil activity service is a no-op", func(t *testing.T) {
+		j := &Jira{
+			FleetURL:  "https://fleetdm.com",
+			Datastore: ds,
+			Log:       slog.New(slog.DiscardHandler),
+			NewClientFunc: func(opts *externalsvc.JiraOptions) (JiraClient, error) {
+				return client, nil
+			},
+		}
+
+		args := json.RawMessage(`{"failing_policy":{"policy_id":5,"policy_name":"p5","hosts":[]}}`)
+		require.NoError(t, j.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
 	})
 }
 

--- a/server/worker/worker.go
+++ b/server/worker/worker.go
@@ -37,6 +37,14 @@ type Job interface {
 	Run(ctx context.Context, argsJSON json.RawMessage) error
 }
 
+// FinalFailureNotifier is an optional interface a Job can implement to be
+// notified once, after the worker has exhausted all retries and marked the job
+// as permanently failed. This is the right place to record terminal-failure
+// side effects (e.g. an activity) without emitting one per intermediate retry.
+type FinalFailureNotifier interface {
+	OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error
+}
+
 // failingPolicyArgs are the args common to all integrations that can process
 // failing policies.
 type failingPolicyArgs struct {
@@ -45,6 +53,16 @@ type failingPolicyArgs struct {
 	PolicyCritical bool                  `json:"policy_critical"`
 	Hosts          []fleet.PolicySetHost `json:"hosts"`
 	TeamID         *uint                 `json:"team_id,omitempty"` //nolint:apiparamcheck // these are written to the db, changing likely requires migration
+}
+
+// hostIDs returns the IDs of the hosts targeted by the failing-policy job, used
+// to associate a failure activity with each affected host.
+func (a *failingPolicyArgs) hostIDs() []uint {
+	ids := make([]uint, len(a.Hosts))
+	for i, h := range a.Hosts {
+		ids[i] = h.ID
+	}
+	return ids
 }
 
 // vulnArgs are the args common to all integrations that can process
@@ -196,6 +214,15 @@ func (w *Worker) ProcessJobs(ctx context.Context) error {
 					}
 				} else {
 					job.State = fleet.JobStateFailure
+					if notifier, ok := w.registry[job.Name].(FinalFailureNotifier); ok {
+						var args json.RawMessage
+						if job.Args != nil {
+							args = *job.Args
+						}
+						if ffErr := notifier.OnFinalFailure(ctx, args, job.Error); ffErr != nil {
+							log.ErrorContext(ctx, "on final failure handler", "err", ffErr)
+						}
+					}
 				}
 			} else {
 				job.State = fleet.JobStateSuccess

--- a/server/worker/worker_test.go
+++ b/server/worker/worker_test.go
@@ -30,7 +30,6 @@ func (t testJob) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	return t.run(ctx, argsJSON)
 }
 
-// testJobNotifier is a testJob that also implements FinalFailureNotifier.
 type testJobNotifier struct {
 	testJob
 	onFinalFailure func(ctx context.Context, argsJSON json.RawMessage, jobErr string) error

--- a/server/worker/worker_test.go
+++ b/server/worker/worker_test.go
@@ -30,6 +30,75 @@ func (t testJob) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	return t.run(ctx, argsJSON)
 }
 
+// testJobNotifier is a testJob that also implements FinalFailureNotifier.
+type testJobNotifier struct {
+	testJob
+	onFinalFailure func(ctx context.Context, argsJSON json.RawMessage, jobErr string) error
+}
+
+func (t testJobNotifier) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+	return t.onFinalFailure(ctx, argsJSON, jobErr)
+}
+
+func TestWorkerFinalFailureNotifier(t *testing.T) {
+	ds := new(mock.Store)
+
+	argsJSON := json.RawMessage(`{"arg1":"foo"}`)
+	theJob := &fleet.Job{
+		ID:      1,
+		Name:    "test",
+		Args:    &argsJSON,
+		State:   fleet.JobStateQueued,
+		Retries: 0,
+	}
+	ds.GetFilteredQueuedJobsFunc = func(ctx context.Context, maxNumJobs int, now time.Time, jobNames []string) ([]*fleet.Job, error) {
+		if theJob.State == fleet.JobStateQueued {
+			return []*fleet.Job{theJob}, nil
+		}
+		return nil, nil
+	}
+	ds.UpdateJobFunc = func(ctx context.Context, id uint, job *fleet.Job) (*fleet.Job, error) {
+		return job, nil
+	}
+
+	logger := slog.New(slog.DiscardHandler)
+	w := NewWorker(ds, logger)
+
+	var finalFailureCalls int
+	var gotArgs json.RawMessage
+	var gotErr string
+	j := testJobNotifier{
+		testJob: testJob{
+			name: "test",
+			run: func(ctx context.Context, argsJSON json.RawMessage) error {
+				return errors.New("boom")
+			},
+		},
+		onFinalFailure: func(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+			finalFailureCalls++
+			gotArgs = argsJSON
+			gotErr = jobErr
+			return nil
+		},
+	}
+	w.Register(j)
+
+	for i := range maxRetries + 1 {
+		require.NoError(t, w.ProcessJobs(t.Context()))
+		ds.GetFilteredQueuedJobsFuncInvoked = false
+		ds.UpdateJobFuncInvoked = false
+
+		// the hook must NOT fire on intermediate retries, only on final failure
+		if i < maxRetries {
+			require.Equal(t, 0, finalFailureCalls, "final failure handler fired before retries exhausted (iteration %d)", i)
+		}
+	}
+
+	require.Equal(t, 1, finalFailureCalls)
+	require.JSONEq(t, `{"arg1":"foo"}`, string(gotArgs))
+	require.Equal(t, "boom", gotErr)
+}
+
 func TestWorker(t *testing.T) {
 	ds := new(mock.Store)
 

--- a/server/worker/zendesk.go
+++ b/server/worker/zendesk.go
@@ -271,10 +271,6 @@ func (z *Zendesk) Run(ctx context.Context, argsJSON json.RawMessage) error {
 // the worker has exhausted all retries for a failing-policy job. Vulnerability
 // jobs are ignored as they are not host- or policy-scoped.
 func (z *Zendesk) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
-	if z.NewActivitySvc == nil {
-		return nil
-	}
-
 	var args zendeskArgs
 	if err := json.Unmarshal(argsJSON, &args); err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshal args")
@@ -354,16 +350,14 @@ func (z *Zendesk) runFailingPolicy(ctx context.Context, cli ZendeskClient, args 
 	}
 	z.Log.DebugContext(ctx, "created zendesk ticket for failing policy", attrs...)
 
-	if z.NewActivitySvc != nil {
-		if err := z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeRanAutomationTicket{
-			PolicyID:   args.FailingPolicy.PolicyID,
-			HostIDList: args.FailingPolicy.hostIDs(),
-			Type:       "zendesk",
-			TicketID:   createdTicket.ID,
-		}); err != nil {
-			z.Log.WarnContext(ctx, "failed to record zendesk policy automation queued activity",
-				"policy_id", args.FailingPolicy.PolicyID, "err", err)
-		}
+	if err := z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeRanAutomationTicket{
+		PolicyID:   args.FailingPolicy.PolicyID,
+		HostIDList: args.FailingPolicy.hostIDs(),
+		Type:       "zendesk",
+		TicketID:   createdTicket.ID,
+	}); err != nil {
+		z.Log.WarnContext(ctx, "failed to record zendesk policy automation queued activity",
+			"policy_id", args.FailingPolicy.PolicyID, "err", err)
 	}
 	return nil
 }

--- a/server/worker/zendesk.go
+++ b/server/worker/zendesk.go
@@ -267,7 +267,7 @@ func (z *Zendesk) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	}
 }
 
-// OnFinalFailure records a failed_ticket_policy_automation host activity once
+// OnFinalFailure records a failed_automation_ticket host activity once
 // the worker has exhausted all retries for a failing-policy job. Vulnerability
 // jobs are ignored as they are not host- or policy-scoped.
 func (z *Zendesk) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
@@ -283,7 +283,7 @@ func (z *Zendesk) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, 
 		return nil
 	}
 
-	return z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedTicketPolicyAutomation{
+	return z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedAutomationTicket{
 		PolicyID:      args.FailingPolicy.PolicyID,
 		HostIDList:    args.FailingPolicy.hostIDs(),
 		Type:          "zendesk",
@@ -355,7 +355,7 @@ func (z *Zendesk) runFailingPolicy(ctx context.Context, cli ZendeskClient, args 
 	z.Log.DebugContext(ctx, "created zendesk ticket for failing policy", attrs...)
 
 	if z.NewActivitySvc != nil {
-		if err := z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeQueuedTicketPolicyAutomation{
+		if err := z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeRanAutomationTicket{
 			PolicyID:   args.FailingPolicy.PolicyID,
 			HostIDList: args.FailingPolicy.hostIDs(),
 			Type:       "zendesk",

--- a/server/worker/zendesk.go
+++ b/server/worker/zendesk.go
@@ -12,6 +12,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/str"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -120,10 +122,11 @@ type ZendeskClient interface {
 
 // Zendesk is the job processor for zendesk integrations.
 type Zendesk struct {
-	FleetURL      string
-	Datastore     fleet.Datastore
-	Log           *slog.Logger
-	NewClientFunc func(*externalsvc.ZendeskOptions) (ZendeskClient, error)
+	FleetURL       string
+	Datastore      fleet.Datastore
+	Log            *slog.Logger
+	NewClientFunc  func(*externalsvc.ZendeskOptions) (ZendeskClient, error)
+	NewActivitySvc activity_api.NewActivityService
 
 	// mu protects concurrent access to clientsCache, so that the job processor
 	// can potentially be run concurrently.
@@ -264,6 +267,30 @@ func (z *Zendesk) Run(ctx context.Context, argsJSON json.RawMessage) error {
 	}
 }
 
+// OnFinalFailure records a failed_ticket_policy_automation host activity once
+// the worker has exhausted all retries for a failing-policy job. Vulnerability
+// jobs are ignored as they are not host- or policy-scoped.
+func (z *Zendesk) OnFinalFailure(ctx context.Context, argsJSON json.RawMessage, jobErr string) error {
+	if z.NewActivitySvc == nil {
+		return nil
+	}
+
+	var args zendeskArgs
+	if err := json.Unmarshal(argsJSON, &args); err != nil {
+		return ctxerr.Wrap(ctx, err, "unmarshal args")
+	}
+	if args.FailingPolicy == nil {
+		return nil
+	}
+
+	return z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedTicketPolicyAutomation{
+		PolicyID:      args.FailingPolicy.PolicyID,
+		HostIDList:    args.FailingPolicy.hostIDs(),
+		Type:          "zendesk",
+		ErrorResponse: str.TruncateErrorResponse(jobErr),
+	})
+}
+
 func (z *Zendesk) runVuln(ctx context.Context, cli ZendeskClient, args zendeskArgs) error {
 	vargs := args.Vulnerability
 	if vargs == nil {
@@ -326,6 +353,18 @@ func (z *Zendesk) runFailingPolicy(ctx context.Context, cli ZendeskClient, args 
 		attrs = append(attrs, "team_id", *args.FailingPolicy.TeamID)
 	}
 	z.Log.DebugContext(ctx, "created zendesk ticket for failing policy", attrs...)
+
+	if z.NewActivitySvc != nil {
+		if err := z.NewActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeQueuedTicketPolicyAutomation{
+			PolicyID:   args.FailingPolicy.PolicyID,
+			HostIDList: args.FailingPolicy.hostIDs(),
+			Type:       "zendesk",
+			TicketID:   createdTicket.ID,
+		}); err != nil {
+			z.Log.WarnContext(ctx, "failed to record zendesk policy automation queued activity",
+				"policy_id", args.FailingPolicy.PolicyID, "err", err)
+		}
+	}
 	return nil
 }
 

--- a/server/worker/zendesk_test.go
+++ b/server/worker/zendesk_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -18,6 +19,117 @@ import (
 	zendesk "github.com/nukosuke/go-zendesk/zendesk"
 	"github.com/stretchr/testify/require"
 )
+
+func TestZendeskOnFinalFailure(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("failing policy records activity", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		z := &Zendesk{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+				require.Nil(t, user)
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(zendeskArgs{FailingPolicy: &failingPolicyArgs{
+			PolicyID: 6,
+			Hosts:    []fleet.PolicySetHost{{ID: 3, Hostname: "h3"}},
+		}})
+		require.NoError(t, err)
+
+		require.NoError(t, z.OnFinalFailure(ctx, args, `422: {"error":"RecordInvalid"}`))
+
+		require.Len(t, recorded, 1)
+		act, ok := recorded[0].(fleet.ActivityTypeFailedTicketPolicyAutomation)
+		require.True(t, ok)
+		require.Equal(t, uint(6), act.PolicyID)
+		require.Equal(t, []uint{3}, act.HostIDList)
+		require.Equal(t, "zendesk", act.Type)
+		require.Equal(t, `422: {"error":"RecordInvalid"}`, act.ErrorResponse)
+	})
+
+	t.Run("vuln job records nothing", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		z := &Zendesk{
+			Log: slog.New(slog.DiscardHandler),
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, activity fleet.ActivityDetails) error {
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args, err := json.Marshal(zendeskArgs{Vulnerability: &vulnArgs{CVE: "CVE-2024-2"}})
+		require.NoError(t, err)
+
+		require.NoError(t, z.OnFinalFailure(ctx, args, "boom"))
+		require.Empty(t, recorded)
+	})
+}
+
+func TestZendeskRunRecordsCreatedActivity(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{Integrations: fleet.Integrations{
+			Zendesk: []*fleet.ZendeskIntegration{
+				{EnableFailingPolicies: true},
+			},
+		}}, nil
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ticket":{"id":4567}}`))
+	}))
+	defer srv.Close()
+
+	client, err := externalsvc.NewZendeskTestClient(&externalsvc.ZendeskOptions{URL: srv.URL, GroupID: int64(123)})
+	require.NoError(t, err)
+
+	t.Run("failing policy records created activity", func(t *testing.T) {
+		var recorded []fleet.ActivityDetails
+		z := &Zendesk{
+			FleetURL:  "https://fleetdm.com",
+			Datastore: ds,
+			Log:       slog.New(slog.DiscardHandler),
+			NewClientFunc: func(opts *externalsvc.ZendeskOptions) (ZendeskClient, error) {
+				return client, nil
+			},
+			NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+				require.Nil(t, user)
+				recorded = append(recorded, activity)
+				return nil
+			}},
+		}
+
+		args := json.RawMessage(`{"failing_policy":{"policy_id":6,"policy_name":"p6","hosts":[{"id":3,"hostname":"h3"}]}}`)
+		require.NoError(t, z.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
+
+		require.Len(t, recorded, 1)
+		act, ok := recorded[0].(fleet.ActivityTypeQueuedTicketPolicyAutomation)
+		require.True(t, ok)
+		require.Equal(t, uint(6), act.PolicyID)
+		require.Equal(t, []uint{3}, act.HostIDList)
+		require.Equal(t, "zendesk", act.Type)
+		require.Equal(t, int64(4567), act.TicketID)
+	})
+
+	t.Run("nil activity service is a no-op", func(t *testing.T) {
+		z := &Zendesk{
+			FleetURL:  "https://fleetdm.com",
+			Datastore: ds,
+			Log:       slog.New(slog.DiscardHandler),
+			NewClientFunc: func(opts *externalsvc.ZendeskOptions) (ZendeskClient, error) {
+				return client, nil
+			},
+		}
+
+		args := json.RawMessage(`{"failing_policy":{"policy_id":6,"policy_name":"p6","hosts":[]}}`)
+		require.NoError(t, z.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
+	})
+}
 
 func TestZendeskRun(t *testing.T) {
 	ds := new(mock.Store)

--- a/server/worker/zendesk_test.go
+++ b/server/worker/zendesk_test.go
@@ -116,19 +116,6 @@ func TestZendeskRunRecordsCreatedActivity(t *testing.T) {
 		require.Equal(t, int64(4567), act.TicketID)
 	})
 
-	t.Run("nil activity service is a no-op", func(t *testing.T) {
-		z := &Zendesk{
-			FleetURL:  "https://fleetdm.com",
-			Datastore: ds,
-			Log:       slog.New(slog.DiscardHandler),
-			NewClientFunc: func(opts *externalsvc.ZendeskOptions) (ZendeskClient, error) {
-				return client, nil
-			},
-		}
-
-		args := json.RawMessage(`{"failing_policy":{"policy_id":6,"policy_name":"p6","hosts":[]}}`)
-		require.NoError(t, z.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
-	})
 }
 
 func TestZendeskRun(t *testing.T) {
@@ -298,6 +285,9 @@ func TestZendeskRun(t *testing.T) {
 				NewClientFunc: func(opts *externalsvc.ZendeskOptions) (ZendeskClient, error) {
 					return client, nil
 				},
+				NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, _ fleet.ActivityDetails) error {
+					return nil
+				}},
 			}
 
 			expectedSubject = c.expectedSubject
@@ -506,6 +496,9 @@ func TestZendeskRunClientUpdate(t *testing.T) {
 			clients = append(clients, c)
 			return c, nil
 		},
+		NewActivitySvc: &mock.MockActivityService{NewActivityFunc: func(_ context.Context, _ *activity_api.User, _ fleet.ActivityDetails) error {
+			return nil
+		}},
 	}
 
 	ctx := license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree})

--- a/server/worker/zendesk_test.go
+++ b/server/worker/zendesk_test.go
@@ -43,7 +43,7 @@ func TestZendeskOnFinalFailure(t *testing.T) {
 		require.NoError(t, z.OnFinalFailure(ctx, args, `422: {"error":"RecordInvalid"}`))
 
 		require.Len(t, recorded, 1)
-		act, ok := recorded[0].(fleet.ActivityTypeFailedTicketPolicyAutomation)
+		act, ok := recorded[0].(fleet.ActivityTypeFailedAutomationTicket)
 		require.True(t, ok)
 		require.Equal(t, uint(6), act.PolicyID)
 		require.Equal(t, []uint{3}, act.HostIDList)
@@ -108,7 +108,7 @@ func TestZendeskRunRecordsCreatedActivity(t *testing.T) {
 		require.NoError(t, z.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), args))
 
 		require.Len(t, recorded, 1)
-		act, ok := recorded[0].(fleet.ActivityTypeQueuedTicketPolicyAutomation)
+		act, ok := recorded[0].(fleet.ActivityTypeRanAutomationTicket)
 		require.True(t, ok)
 		require.Equal(t, uint(6), act.PolicyID)
 		require.Equal(t, []uint{3}, act.HostIDList)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/46899

Added per-host activity log entries when policy ticket automations (Jira or Zendesk) fail after all retries are exhausted or succeed (ticket created).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-host activity logging for policy ticket automation outcomes across Jira and Zendesk, capturing both successful ticket creation and automation failures after all retries are exhausted.

* **Improvements**
  * Enhanced error reporting for ticket creation failures by capturing and displaying error response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->