### PR TITLE
Record per-host conditional access policy automation activities

### DIFF
--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -2177,3 +2177,49 @@ func (a ActivityTypeRanAutomationWebhook) HostIDs() []uint {
 func (a ActivityTypeRanAutomationWebhook) WasFromAutomation() bool {
 	return true
 }
+
+// ActivityTypeFailedConditionalAccessPolicyAutomation is recorded when a
+// failing-policy conditional access automation fails to push the host's
+// compliance status to the remote provider. One activity is recorded per
+// conditional-access policy configured for the host's team, associated with
+// that host.
+type ActivityTypeFailedConditionalAccessPolicyAutomation struct {
+	PolicyID      uint   `json:"policy_id"`
+	HostIDList    []uint `json:"-"`
+	StatusCode    int    `json:"status_code,omitempty"`
+	ErrorResponse string `json:"error_response"`
+}
+
+func (a ActivityTypeFailedConditionalAccessPolicyAutomation) ActivityName() string {
+	return "failed_conditional_access_policy_automation"
+}
+
+func (a ActivityTypeFailedConditionalAccessPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeFailedConditionalAccessPolicyAutomation) WasFromAutomation() bool {
+	return true
+}
+
+// ActivityTypeBlockedSingleSignOnPolicyAutomation is recorded when a
+// failing-policy conditional access automation successfully pushes the host's
+// compliance status to the remote provider as non-compliant, blocking single
+// sign-on. One activity is recorded per conditional-access policy the host is
+// failing, associated with that host.
+type ActivityTypeBlockedSingleSignOnPolicyAutomation struct {
+	PolicyID   uint   `json:"policy_id"`
+	HostIDList []uint `json:"-"`
+}
+
+func (a ActivityTypeBlockedSingleSignOnPolicyAutomation) ActivityName() string {
+	return "blocked_single_sign_on_policy_automation"
+}
+
+func (a ActivityTypeBlockedSingleSignOnPolicyAutomation) HostIDs() []uint {
+	return a.HostIDList
+}
+
+func (a ActivityTypeBlockedSingleSignOnPolicyAutomation) WasFromAutomation() bool {
+	return true
+}

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -2178,48 +2178,48 @@ func (a ActivityTypeRanAutomationWebhook) WasFromAutomation() bool {
 	return true
 }
 
-// ActivityTypeFailedConditionalAccessPolicyAutomation is recorded when a
+// ActivityTypeFailedAutomationConditionalAccess is recorded when a
 // failing-policy conditional access automation fails to push the host's
 // compliance status to the remote provider. One activity is recorded per
 // conditional-access policy configured for the host's team, associated with
 // that host.
-type ActivityTypeFailedConditionalAccessPolicyAutomation struct {
+type ActivityTypeFailedAutomationConditionalAccess struct {
 	PolicyID      uint   `json:"policy_id"`
 	HostIDList    []uint `json:"-"`
 	StatusCode    int    `json:"status_code,omitempty"`
 	ErrorResponse string `json:"error_response"`
 }
 
-func (a ActivityTypeFailedConditionalAccessPolicyAutomation) ActivityName() string {
-	return "failed_conditional_access_policy_automation"
+func (a ActivityTypeFailedAutomationConditionalAccess) ActivityName() string {
+	return "failed_automation_conditional_access"
 }
 
-func (a ActivityTypeFailedConditionalAccessPolicyAutomation) HostIDs() []uint {
+func (a ActivityTypeFailedAutomationConditionalAccess) HostIDs() []uint {
 	return a.HostIDList
 }
 
-func (a ActivityTypeFailedConditionalAccessPolicyAutomation) WasFromAutomation() bool {
+func (a ActivityTypeFailedAutomationConditionalAccess) WasFromAutomation() bool {
 	return true
 }
 
-// ActivityTypeBlockedSingleSignOnPolicyAutomation is recorded when a
+// ActivityTypeRanAutomationConditionalAccess is recorded when a
 // failing-policy conditional access automation successfully pushes the host's
 // compliance status to the remote provider as non-compliant, blocking single
 // sign-on. One activity is recorded per conditional-access policy the host is
 // failing, associated with that host.
-type ActivityTypeBlockedSingleSignOnPolicyAutomation struct {
+type ActivityTypeRanAutomationConditionalAccess struct {
 	PolicyID   uint   `json:"policy_id"`
 	HostIDList []uint `json:"-"`
 }
 
-func (a ActivityTypeBlockedSingleSignOnPolicyAutomation) ActivityName() string {
-	return "blocked_single_sign_on_policy_automation"
+func (a ActivityTypeRanAutomationConditionalAccess) ActivityName() string {
+	return "ran_automation_conditional_access"
 }
 
-func (a ActivityTypeBlockedSingleSignOnPolicyAutomation) HostIDs() []uint {
+func (a ActivityTypeRanAutomationConditionalAccess) HostIDs() []uint {
 	return a.HostIDList
 }
 
-func (a ActivityTypeBlockedSingleSignOnPolicyAutomation) WasFromAutomation() bool {
+func (a ActivityTypeRanAutomationConditionalAccess) WasFromAutomation() bool {
 	return true
 }

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -223,6 +223,60 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 	})
 }
 
+func TestFailedPolicyAutomationActivities(t *testing.T) {
+	t.Run("conditional access", func(t *testing.T) {
+		act := ActivityTypeFailedConditionalAccessPolicyAutomation{
+			PolicyID:      15,
+			HostIDList:    []uint{43},
+			StatusCode:    500,
+			ErrorResponse: "500: upstream error",
+		}
+
+		assert.Equal(t, "failed_conditional_access_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{43}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 15, got["policy_id"])
+		assert.EqualValues(t, 500, got["status_code"])
+		assert.Equal(t, "500: upstream error", got["error_response"])
+	})
+}
+
+func TestSuccessPolicyAutomationActivities(t *testing.T) {
+	// assertNoHostIDsOrPolicyName fails if the marshaled details leak the
+	// host ID list or a policy name (both are intentionally omitted; hosts
+	// live one-per-row in activity_host_past).
+	assertNoHostIDsOrPolicyName := func(t *testing.T, got map[string]any) {
+		t.Helper()
+		_, hasHostIDs := got["host_ids"]
+		assert.False(t, hasHostIDs)
+		_, hasPolicyName := got["policy_name"]
+		assert.False(t, hasPolicyName)
+	}
+
+	t.Run("single sign-on blocked", func(t *testing.T) {
+		act := ActivityTypeBlockedSingleSignOnPolicyAutomation{
+			PolicyID:   15,
+			HostIDList: []uint{43},
+		}
+
+		assert.Equal(t, "blocked_single_sign_on_policy_automation", act.ActivityName())
+		assert.Equal(t, []uint{43}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 15, got["policy_id"])
+		assertNoHostIDsOrPolicyName(t, got)
+	})
+}
+
 // TestVPPInstallFailureEmptyCommandUUIDDoesNotActivateNext exercises the
 // scenario where a VPP install is attempted during setup experience for a
 // host that has other upcoming activities queued. If the VPP call fails

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -225,14 +225,14 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 
 func TestFailedPolicyAutomationActivities(t *testing.T) {
 	t.Run("conditional access", func(t *testing.T) {
-		act := ActivityTypeFailedConditionalAccessPolicyAutomation{
+		act := ActivityTypeFailedAutomationConditionalAccess{
 			PolicyID:      15,
 			HostIDList:    []uint{43},
 			StatusCode:    500,
 			ErrorResponse: "500: upstream error",
 		}
 
-		assert.Equal(t, "failed_conditional_access_policy_automation", act.ActivityName())
+		assert.Equal(t, "failed_automation_conditional_access", act.ActivityName())
 		assert.Equal(t, []uint{43}, act.HostIDs())
 		assert.True(t, act.WasFromAutomation())
 
@@ -259,12 +259,12 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 	}
 
 	t.Run("single sign-on blocked", func(t *testing.T) {
-		act := ActivityTypeBlockedSingleSignOnPolicyAutomation{
+		act := ActivityTypeRanAutomationConditionalAccess{
 			PolicyID:   15,
 			HostIDList: []uint{43},
 		}
 
-		assert.Equal(t, "blocked_single_sign_on_policy_automation", act.ActivityName())
+		assert.Equal(t, "ran_automation_conditional_access", act.ActivityName())
 		assert.Equal(t, []uint{43}, act.HostIDs())
 		assert.True(t, act.WasFromAutomation())
 

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -161,6 +161,27 @@ func TestFailedPolicyAutomationActivities(t *testing.T) {
 		assert.EqualValues(t, 500, got["status_code"])
 		assert.Equal(t, "internal server error", got["error_response"])
 	})
+
+	t.Run("conditional access", func(t *testing.T) {
+		act := ActivityTypeFailedAutomationConditionalAccess{
+			PolicyID:      15,
+			HostIDList:    []uint{43},
+			StatusCode:    500,
+			ErrorResponse: "500: upstream error",
+		}
+
+		assert.Equal(t, "failed_automation_conditional_access", act.ActivityName())
+		assert.Equal(t, []uint{43}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 15, got["policy_id"])
+		assert.EqualValues(t, 500, got["status_code"])
+		assert.Equal(t, "500: upstream error", got["error_response"])
+	})
 }
 
 func TestSuccessPolicyAutomationActivities(t *testing.T) {
@@ -221,61 +242,6 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 		_, hasStatus := got["status_code"]
 		assert.False(t, hasStatus)
 	})
-}
-
-func TestFailedPolicyAutomationActivities(t *testing.T) {
-	t.Run("conditional access", func(t *testing.T) {
-		act := ActivityTypeFailedAutomationConditionalAccess{
-			PolicyID:      15,
-			HostIDList:    []uint{43},
-			StatusCode:    500,
-			ErrorResponse: "500: upstream error",
-		}
-
-		assert.Equal(t, "failed_automation_conditional_access", act.ActivityName())
-		assert.Equal(t, []uint{43}, act.HostIDs())
-		assert.True(t, act.WasFromAutomation())
-
-		b, err := json.Marshal(act)
-		require.NoError(t, err)
-		var got map[string]any
-		require.NoError(t, json.Unmarshal(b, &got))
-		assert.EqualValues(t, 15, got["policy_id"])
-		assert.EqualValues(t, 500, got["status_code"])
-		assert.Equal(t, "500: upstream error", got["error_response"])
-	})
-}
-
-func TestSuccessPolicyAutomationActivities(t *testing.T) {
-	// assertNoHostIDsOrPolicyName fails if the marshaled details leak the
-	// host ID list or a policy name (both are intentionally omitted; hosts
-	// live one-per-row in activity_host_past).
-	assertNoHostIDsOrPolicyName := func(t *testing.T, got map[string]any) {
-		t.Helper()
-		_, hasHostIDs := got["host_ids"]
-		assert.False(t, hasHostIDs)
-		_, hasPolicyName := got["policy_name"]
-		assert.False(t, hasPolicyName)
-	}
-
-	t.Run("calendar event ran", func(t *testing.T) {
-		act := ActivityTypeRanAutomationCalendarEvent{
-			PolicyID:   14,
-			HostIDList: []uint{42},
-		}
-
-		assert.Equal(t, "ran_automation_calendar_event", act.ActivityName())
-		assert.Equal(t, []uint{42}, act.HostIDs())
-		assert.True(t, act.WasFromAutomation())
-
-		b, err := json.Marshal(act)
-		require.NoError(t, err)
-		var got map[string]any
-		require.NoError(t, json.Unmarshal(b, &got))
-		assert.EqualValues(t, 14, got["policy_id"])
-		assertNoHostIDsOrPolicyName(t, got)
-	})
-
 	t.Run("single sign-on blocked", func(t *testing.T) {
 		act := ActivityTypeRanAutomationConditionalAccess{
 			PolicyID:   15,

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -258,6 +258,24 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 		assert.False(t, hasPolicyName)
 	}
 
+	t.Run("calendar event ran", func(t *testing.T) {
+		act := ActivityTypeRanAutomationCalendarEvent{
+			PolicyID:   14,
+			HostIDList: []uint{42},
+		}
+
+		assert.Equal(t, "ran_automation_calendar_event", act.ActivityName())
+		assert.Equal(t, []uint{42}, act.HostIDs())
+		assert.True(t, act.WasFromAutomation())
+
+		b, err := json.Marshal(act)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.EqualValues(t, 14, got["policy_id"])
+		assertNoHostIDsOrPolicyName(t, got)
+	})
+
 	t.Run("single sign-on blocked", func(t *testing.T) {
 		act := ActivityTypeRanAutomationConditionalAccess{
 			PolicyID:   15,

--- a/server/service/conditional_access_failure_activity_test.go
+++ b/server/service/conditional_access_failure_activity_test.go
@@ -78,12 +78,6 @@ func TestRecordConditionalAccessFailureActivity(t *testing.T) {
 
 		require.Empty(t, r.acts)
 	})
-
-	t.Run("nil activity function is a no-op", func(t *testing.T) {
-		require.NotPanics(t, func() {
-			recordConditionalAccessFailureActivity(ctx, nil, 104, []uint{30}, &proxyStatusErr{code: 500}, logger)
-		})
-	})
 }
 
 // TestRecordSingleSignOnBlockedActivity verifies that a successful non-compliant

--- a/server/service/conditional_access_failure_activity_test.go
+++ b/server/service/conditional_access_failure_activity_test.go
@@ -33,12 +33,12 @@ func TestRecordConditionalAccessFailureActivity(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	type recorded struct {
-		acts []fleet.ActivityTypeFailedConditionalAccessPolicyAutomation
+		acts []fleet.ActivityTypeFailedAutomationConditionalAccess
 	}
 	newRecorder := func(r *recorded) activity_api.NewActivityService {
 		return &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
 			require.Nil(t, user)
-			act, ok := activity.(fleet.ActivityTypeFailedConditionalAccessPolicyAutomation)
+			act, ok := activity.(fleet.ActivityTypeFailedAutomationConditionalAccess)
 			require.True(t, ok)
 			r.acts = append(r.acts, act)
 			return nil
@@ -87,19 +87,19 @@ func TestRecordConditionalAccessFailureActivity(t *testing.T) {
 }
 
 // TestRecordSingleSignOnBlockedActivity verifies that a successful non-compliant
-// compliance push records one blocked_single_sign_on_policy_automation activity
+// compliance push records one ran_automation_conditional_access activity
 // per conditional-access policy the host is failing.
 func TestRecordSingleSignOnBlockedActivity(t *testing.T) {
 	ctx := t.Context()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	type recorded struct {
-		acts []fleet.ActivityTypeBlockedSingleSignOnPolicyAutomation
+		acts []fleet.ActivityTypeRanAutomationConditionalAccess
 	}
 	newRecorder := func(r *recorded) activity_api.NewActivityService {
 		return &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
 			require.Nil(t, user)
-			act, ok := activity.(fleet.ActivityTypeBlockedSingleSignOnPolicyAutomation)
+			act, ok := activity.(fleet.ActivityTypeRanAutomationConditionalAccess)
 			require.True(t, ok)
 			r.acts = append(r.acts, act)
 			return nil

--- a/server/service/conditional_access_failure_activity_test.go
+++ b/server/service/conditional_access_failure_activity_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// proxyStatusErr mimics the conditional access proxy's StatusError, exposing
+// the remote HTTP status code and response body.
+type proxyStatusErr struct {
+	code int
+	body string
+}
+
+func (e *proxyStatusErr) Error() string   { return fmt.Sprintf("%d: %s", e.code, e.body) }
+func (e *proxyStatusErr) StatusCode() int { return e.code }
+func (e *proxyStatusErr) Body() string    { return e.body }
+
+// TestRecordConditionalAccessFailureActivity verifies that a failed conditional
+// access compliance push records one activity per conditional-access policy,
+// capturing the remote status code and response body.
+func TestRecordConditionalAccessFailureActivity(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	type recorded struct {
+		acts []fleet.ActivityTypeFailedConditionalAccessPolicyAutomation
+	}
+	newRecorder := func(r *recorded) activity_api.NewActivityService {
+		return &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+			require.Nil(t, user)
+			act, ok := activity.(fleet.ActivityTypeFailedConditionalAccessPolicyAutomation)
+			require.True(t, ok)
+			r.acts = append(r.acts, act)
+			return nil
+		}}
+	}
+
+	t.Run("records one activity per policy with status and body", func(t *testing.T) {
+		var r recorded
+		err := &proxyStatusErr{code: 500, body: "upstream boom"}
+
+		recordConditionalAccessFailureActivity(ctx, newRecorder(&r), 100, []uint{30, 31}, err, logger)
+
+		require.Len(t, r.acts, 2)
+		for _, act := range r.acts {
+			require.Equal(t, []uint{100}, act.HostIDList)
+			require.Equal(t, 500, act.StatusCode)
+			require.Equal(t, "upstream boom", act.ErrorResponse)
+		}
+		require.Equal(t, uint(30), r.acts[0].PolicyID)
+		require.Equal(t, uint(31), r.acts[1].PolicyID)
+	})
+
+	t.Run("falls back to error string when no body", func(t *testing.T) {
+		var r recorded
+
+		recordConditionalAccessFailureActivity(ctx, newRecorder(&r), 101, []uint{30}, errors.New("connection refused"), logger)
+
+		require.Len(t, r.acts, 1)
+		require.Equal(t, 0, r.acts[0].StatusCode)
+		require.Equal(t, "connection refused", r.acts[0].ErrorResponse)
+	})
+
+	t.Run("no policies records nothing", func(t *testing.T) {
+		var r recorded
+
+		recordConditionalAccessFailureActivity(ctx, newRecorder(&r), 103, nil, &proxyStatusErr{code: 500}, logger)
+
+		require.Empty(t, r.acts)
+	})
+
+	t.Run("nil activity function is a no-op", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			recordConditionalAccessFailureActivity(ctx, nil, 104, []uint{30}, &proxyStatusErr{code: 500}, logger)
+		})
+	})
+}
+
+// TestRecordSingleSignOnBlockedActivity verifies that a successful non-compliant
+// compliance push records one blocked_single_sign_on_policy_automation activity
+// per conditional-access policy the host is failing.
+func TestRecordSingleSignOnBlockedActivity(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	type recorded struct {
+		acts []fleet.ActivityTypeBlockedSingleSignOnPolicyAutomation
+	}
+	newRecorder := func(r *recorded) activity_api.NewActivityService {
+		return &mock.MockActivityService{NewActivityFunc: func(_ context.Context, user *activity_api.User, activity fleet.ActivityDetails) error {
+			require.Nil(t, user)
+			act, ok := activity.(fleet.ActivityTypeBlockedSingleSignOnPolicyAutomation)
+			require.True(t, ok)
+			r.acts = append(r.acts, act)
+			return nil
+		}}
+	}
+
+	t.Run("records one activity per policy", func(t *testing.T) {
+		var r recorded
+
+		recordSingleSignOnBlockedActivity(ctx, newRecorder(&r), 100, []uint{30, 31}, logger)
+
+		require.Len(t, r.acts, 2)
+		for _, act := range r.acts {
+			require.Equal(t, []uint{100}, act.HostIDList)
+		}
+		require.Equal(t, uint(30), r.acts[0].PolicyID)
+		require.Equal(t, uint(31), r.acts[1].PolicyID)
+	})
+
+	t.Run("no policies records nothing", func(t *testing.T) {
+		var r recorded
+
+		recordSingleSignOnBlockedActivity(ctx, newRecorder(&r), 103, nil, logger)
+
+		require.Empty(t, r.acts)
+	})
+
+	t.Run("nil activity function is a no-op", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			recordSingleSignOnBlockedActivity(ctx, nil, 104, []uint{30}, logger)
+		})
+	})
+}

--- a/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy.go
+++ b/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/pkg/str"
 )
 
 // Proxy holds functionality to send requests to Entra via Fleet's MS proxy.
@@ -209,7 +210,7 @@ func (p *Proxy) post(path string, request interface{}, response interface{}) err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("post request failed: %s", resp.Status)
+		return newStatusError(resp)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -239,7 +240,7 @@ func (p *Proxy) get(path string, query string, response interface{}) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("get request failed: %s", resp.Status)
+		return newStatusError(resp)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -290,6 +291,36 @@ type notFoundError struct{}
 
 func (e *notFoundError) Error() string {
 	return "not found"
+}
+
+// StatusError is returned for a non-2xx response from the MS proxy. It carries
+// the HTTP status code and response body so callers can surface the remote
+// error response.
+type StatusError struct {
+	Code    int
+	RespErr string
+}
+
+func (e *StatusError) Error() string {
+	if e.RespErr == "" {
+		return fmt.Sprintf("%d", e.Code)
+	}
+	return fmt.Sprintf("%d: %s", e.Code, e.RespErr)
+}
+
+// StatusCode returns the remote HTTP status code.
+func (e *StatusError) StatusCode() int { return e.Code }
+
+// Body returns the remote response body.
+func (e *StatusError) Body() string { return e.RespErr }
+
+// newStatusError reads up to str.MaxErrorResponseBytes of the response body
+// and returns a StatusError. When the body is larger the stored string ends
+// with " [truncated]".
+func newStatusError(resp *http.Response) *StatusError {
+	lr := io.LimitReader(resp.Body, str.MaxErrorResponseBytes+1)
+	bodyBytes, _ := io.ReadAll(lr)
+	return &StatusError{Code: resp.StatusCode, RespErr: str.TruncateErrorResponse(string(bodyBytes))}
 }
 
 func (e *notFoundError) IsNotFound() bool {

--- a/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy_test.go
+++ b/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy_test.go
@@ -1,0 +1,64 @@
+package conditional_access_microsoft_proxy
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyStatusErrorCapturesBody(t *testing.T) {
+	t.Run("captures status code and body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"upstream boom"}`))
+		}))
+		defer srv.Close()
+
+		p, err := New(srv.URL, "key", func() (string, error) { return "https://fleet.example.com", nil })
+		require.NoError(t, err)
+
+		_, err = p.SetComplianceStatus(t.Context(), "tenant", "secret", "device", "upn", true, "name", "macOS", "14.0", false, time.Now())
+		require.Error(t, err)
+
+		se, ok := errors.AsType[interface {
+			error
+			StatusCode() int
+		}](err)
+		require.True(t, ok)
+		require.Equal(t, http.StatusInternalServerError, se.StatusCode())
+
+		be, ok := errors.AsType[interface {
+			error
+			Body() string
+		}](err)
+		require.True(t, ok)
+		require.Contains(t, be.Body(), "upstream boom")
+	})
+
+	t.Run("captures full body", func(t *testing.T) {
+		const bodyLen = 1000
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(strings.Repeat("x", bodyLen)))
+		}))
+		defer srv.Close()
+
+		p, err := New(srv.URL, "key", func() (string, error) { return "https://fleet.example.com", nil })
+		require.NoError(t, err)
+
+		_, err = p.SetComplianceStatus(t.Context(), "tenant", "secret", "device", "upn", true, "name", "macOS", "14.0", false, time.Now())
+		require.Error(t, err)
+
+		be, ok := errors.AsType[interface {
+			error
+			Body() string
+		}](err)
+		require.True(t, ok)
+		require.Len(t, be.Body(), bodyLen)
+	})
+}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2788,7 +2788,7 @@ func recordConditionalAccessFailureActivity(
 	err error,
 	logger *slog.Logger,
 ) {
-	if newActivitySvc == nil || len(policyIDs) == 0 {
+	if len(policyIDs) == 0 {
 		return
 	}
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
 	"github.com/fleetdm/fleet/v4/server"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
@@ -2615,14 +2616,15 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 	for _, policyID := range conditionalAccessPolicyIDs {
 		conditionalAccessPolicyIDsSet[policyID] = struct{}{}
 	}
+	var failingCAIDs []uint
 	for incomingPolicyID, incomingPolicyResult := range incomingPolicyResults {
 		if _, ok := conditionalAccessPolicyIDsSet[incomingPolicyID]; !ok {
 			// Ignore results for policies that are not for conditional access.
 			continue
 		}
 		if incomingPolicyResult != nil && !*incomingPolicyResult {
+			failingCAIDs = append(failingCAIDs, incomingPolicyID)
 			hostIsCompliantInFleet = false
-			break
 		}
 	}
 
@@ -2632,7 +2634,7 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 		return nil
 	}
 
-	svc.setHostConditionalAccessAsync(hostID, hostPlatform, hostConditionalAccessStatus, mdmEnrolled, hostIsCompliantInFleet)
+	svc.setHostConditionalAccessAsync(hostID, hostPlatform, hostConditionalAccessStatus, mdmEnrolled, hostIsCompliantInFleet, failingCAIDs)
 
 	return nil
 }
@@ -2643,6 +2645,7 @@ func (svc *Service) setHostConditionalAccessAsync(
 	hostConditionalAccessStatus *fleet.HostConditionalAccessStatus,
 	managed bool,
 	compliant bool,
+	failingPolicyIDs []uint,
 ) {
 	go func() {
 		logger := svc.logger.With(
@@ -2652,7 +2655,7 @@ func (svc *Service) setHostConditionalAccessAsync(
 			"compliant", compliant,
 		)
 		start := time.Now()
-		if err := svc.setHostConditionalAccess(hostID, hostPlatform, hostConditionalAccessStatus, managed, compliant); err != nil {
+		if err := svc.setHostConditionalAccess(hostID, hostPlatform, hostConditionalAccessStatus, managed, compliant, failingPolicyIDs); err != nil {
 			logger.ErrorContext(context.TODO(), "set host conditional access", "took", time.Since(start), "err", err)
 		}
 		logger.DebugContext(context.TODO(), "set host conditional access", "took", time.Since(start))
@@ -2669,6 +2672,7 @@ func (svc *Service) setHostConditionalAccess(
 	hostConditionalAccessStatus *fleet.HostConditionalAccessStatus,
 	managed bool,
 	compliant bool,
+	failingPolicyIDs []uint,
 ) error {
 	ctx := context.Background()
 
@@ -2705,6 +2709,7 @@ func (svc *Service) setHostConditionalAccess(
 		time.Now().UTC(),
 	)
 	if err != nil {
+		recordConditionalAccessFailureActivity(ctx, svc.activitySvc, hostID, failingPolicyIDs, err, logger)
 		return ctxerr.Wrap(ctx, err, "failed to set compliance status")
 	}
 
@@ -2721,6 +2726,12 @@ func (svc *Service) setHostConditionalAccess(
 		startTime := time.Now()
 		for range time.Tick(conditionalAccessSetWaitTime) {
 			if time.Since(startTime) > timeout {
+				// No failure activity is recorded here. SetComplianceStatus
+				// succeeded (we have a MessageID), so the push was accepted by
+				// the remote provider; we just could not confirm completion
+				// within the expected window. Recording a
+				// failed_conditional_access_policy_automation here would
+				// misrepresent an in-flight async operation as a rejection.
 				return ctxerr.Errorf(ctx, "timeout waiting for message after %s", time.Since(startTime))
 			}
 			logger.DebugContext(ctx, "get compliance status message wait")
@@ -2753,7 +2764,92 @@ func (svc *Service) setHostConditionalAccess(
 		return ctxerr.Wrap(ctx, err, "set conditional access status on datastore")
 	}
 
+	if !compliant {
+		// The host was pushed non-compliant, which blocks single sign-on. The
+		// push has been accepted (and, for macOS, confirmed) at this point.
+		recordSingleSignOnBlockedActivity(ctx, svc.activitySvc, hostID, failingPolicyIDs, logger)
+	}
+
 	return nil
+}
+
+// recordConditionalAccessFailureActivity records a
+// failed_conditional_access_policy_automation activity for the given host when
+// a compliance push to the remote provider fails. One activity is recorded per
+// failing conditional-access policy (policies the host is currently failing,
+// not all CA policies configured for the team), capturing the remote status
+// code and response body when available. Failures to record are logged and
+// swallowed so they don't mask the original error.
+func recordConditionalAccessFailureActivity(
+	ctx context.Context,
+	newActivitySvc activity_api.NewActivityService,
+	hostID uint,
+	policyIDs []uint,
+	err error,
+	logger *slog.Logger,
+) {
+	if newActivitySvc == nil || len(policyIDs) == 0 {
+		return
+	}
+
+	var statusCode int
+	if sc, ok := errors.AsType[interface {
+		error
+		StatusCode() int
+	}](err); ok {
+		statusCode = sc.StatusCode()
+	}
+
+	errResponse := ""
+	if b, ok := errors.AsType[interface {
+		error
+		Body() string
+	}](err); ok {
+		errResponse = b.Body()
+	}
+	if errResponse == "" {
+		// network-level failures (e.g. connection refused) have no server
+		// response; fall back to the error message.
+		errResponse = err.Error()
+	}
+	for _, policyID := range policyIDs {
+		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedConditionalAccessPolicyAutomation{
+			PolicyID:      policyID,
+			HostIDList:    []uint{hostID},
+			StatusCode:    statusCode,
+			ErrorResponse: errResponse,
+		}); actErr != nil {
+			logger.WarnContext(ctx, "failed to record conditional access policy automation failure activity",
+				"policy_id", policyID, "host_id", hostID, "err", actErr)
+		}
+	}
+}
+
+// recordSingleSignOnBlockedActivity records a
+// blocked_single_sign_on_policy_automation activity for the given host once its
+// non-compliant status has been successfully pushed to the remote provider,
+// blocking single sign-on. One activity is recorded per conditional-access
+// policy the host is failing. Failures to record are logged and swallowed so
+// they don't affect the compliance push.
+func recordSingleSignOnBlockedActivity(
+	ctx context.Context,
+	newActivitySvc activity_api.NewActivityService,
+	hostID uint,
+	policyIDs []uint,
+	logger *slog.Logger,
+) {
+	if newActivitySvc == nil || len(policyIDs) == 0 {
+		return
+	}
+	for _, policyID := range policyIDs {
+		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeBlockedSingleSignOnPolicyAutomation{
+			PolicyID:   policyID,
+			HostIDList: []uint{hostID},
+		}); actErr != nil {
+			logger.WarnContext(ctx, "failed to record single sign-on blocked policy automation activity",
+				"policy_id", policyID, "host_id", hostID, "err", actErr)
+		}
+	}
 }
 
 func (svc *Service) maybeDebugHost(

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2730,7 +2730,7 @@ func (svc *Service) setHostConditionalAccess(
 				// succeeded (we have a MessageID), so the push was accepted by
 				// the remote provider; we just could not confirm completion
 				// within the expected window. Recording a
-				// failed_conditional_access_policy_automation here would
+				// failed_automation_conditional_access here would
 				// misrepresent an in-flight async operation as a rejection.
 				return ctxerr.Errorf(ctx, "timeout waiting for message after %s", time.Since(startTime))
 			}
@@ -2774,7 +2774,7 @@ func (svc *Service) setHostConditionalAccess(
 }
 
 // recordConditionalAccessFailureActivity records a
-// failed_conditional_access_policy_automation activity for the given host when
+// failed_automation_conditional_access activity for the given host when
 // a compliance push to the remote provider fails. One activity is recorded per
 // failing conditional-access policy (policies the host is currently failing,
 // not all CA policies configured for the team), capturing the remote status
@@ -2813,7 +2813,7 @@ func recordConditionalAccessFailureActivity(
 		errResponse = err.Error()
 	}
 	for _, policyID := range policyIDs {
-		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedConditionalAccessPolicyAutomation{
+		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeFailedAutomationConditionalAccess{
 			PolicyID:      policyID,
 			HostIDList:    []uint{hostID},
 			StatusCode:    statusCode,
@@ -2826,7 +2826,7 @@ func recordConditionalAccessFailureActivity(
 }
 
 // recordSingleSignOnBlockedActivity records a
-// blocked_single_sign_on_policy_automation activity for the given host once its
+// ran_automation_conditional_access activity for the given host once its
 // non-compliant status has been successfully pushed to the remote provider,
 // blocking single sign-on. One activity is recorded per conditional-access
 // policy the host is failing. Failures to record are logged and swallowed so
@@ -2842,7 +2842,7 @@ func recordSingleSignOnBlockedActivity(
 		return
 	}
 	for _, policyID := range policyIDs {
-		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeBlockedSingleSignOnPolicyAutomation{
+		if actErr := newActivitySvc.NewActivity(ctx, nil, fleet.ActivityTypeRanAutomationConditionalAccess{
 			PolicyID:   policyID,
 			HostIDList: []uint{hostID},
 		}); actErr != nil {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/46899

Added per-host activity log entries when policy Microsoft conditional access automations fail or succeed (single sign-on blocked).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activity logging for Microsoft conditional access policy automation, capturing both enforcement successes and failures, including scenarios where single sign-on is blocked due to non-compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->