### PR TITLE
Policies: Include/Exclude label targeting in Save policy modal (#33441)

### DIFF
--- a/changes/33441-policies-include-exclude-targets
+++ b/changes/33441-policies-include-exclude-targets
@@ -1,0 +1,1 @@
+* Added the ability to target a policy to hosts using a combination of "include" and "exclude" labels.

--- a/frontend/components/TargetLabelSelector/_styles.scss
+++ b/frontend/components/TargetLabelSelector/_styles.scss
@@ -121,6 +121,8 @@
     gap: $pad-small;
     justify-content: center;
     text-align: center;
+    border: 1px solid $ui-fleet-black-10;
+    border-radius: $border-radius-large;
 
     span {
       color: $ui-fleet-black-75;

--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -58,6 +58,7 @@ export interface IPolicy {
   labels_include_any?: ILabelPolicy[];
   labels_include_all?: ILabelPolicy[];
   labels_exclude_any?: ILabelPolicy[];
+  labels_exclude_all?: ILabelPolicy[];
 }
 export interface IPolicySoftwareToInstall {
   name: string;
@@ -130,6 +131,7 @@ export interface IPolicyFormData {
   labels_include_any?: string[];
   labels_include_all?: string[];
   labels_exclude_any?: string[];
+  labels_exclude_all?: string[];
   /** Required for creating patch policy */
   type?: "dynamic" | "patch";
   /** Required for creating patch policy */

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -919,6 +919,7 @@ const PolicyForm = ({
             automationsConfig={automationsConfig}
             globalConfig={config ?? undefined}
             fleetName={automationsFleetName}
+            router={router}
           />
         )}
       </>

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
-import { createCustomRenderer } from "test/test-utils";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import createMockUser from "__mocks__/userMock";
 import createMockConfig from "__mocks__/configMock";
 import userEvent from "@testing-library/user-event";
@@ -63,6 +63,7 @@ describe("SaveNewPolicyModal", () => {
     automationsConfig: createMockConfig(),
     globalConfig: createMockConfig(),
     fleetName: "All fleets",
+    router: createMockRouter(),
   };
 
   it("should not show the target selector in the free tier", async () => {
@@ -184,28 +185,107 @@ describe("SaveNewPolicyModal", () => {
 
       // Set a label.
       await userEvent.click(screen.getByLabelText("Custom"));
+      await userEvent.click(screen.getByText("Exclude"));
       await userEvent.click(
         await screen.findByRole("checkbox", { name: "Fun" })
       );
-
-      // Click "Include any" to open the dropdown.
-      const includeAnyOption = screen.getByRole("option", {
-        name: "Include any",
-      });
-      await userEvent.click(includeAnyOption);
-
-      // Click "Exclude any" to select it.
-      let excludeAnyOption: unknown;
-      await waitFor(() => {
-        excludeAnyOption = screen.getByRole("option", { name: "Exclude any" });
-      });
-      await userEvent.click(excludeAnyOption as Element);
 
       await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       expect(onCreatePolicy.mock.calls[0][0].labels_exclude_any).toEqual([
         "Fun",
       ]);
+    });
+
+    it("should send labels_include_all when the include mode is All", async () => {
+      const onCreatePolicy = jest.fn();
+      const props = { ...defaultProps, onCreatePolicy };
+      render(
+        <PolicyProvider>
+          <SaveNewPolicyModal {...props} />
+        </PolicyProvider>
+      );
+      await waitFor(() => {
+        expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText("Name"),
+        "A Brand New Policy!"
+      );
+
+      await userEvent.click(screen.getByLabelText("Custom"));
+      await userEvent.click(screen.getByLabelText("All"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "Fun" })
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      const payload = onCreatePolicy.mock.calls[0][0];
+      expect(payload.labels_include_all).toEqual(["Fun"]);
+      expect(payload.labels_include_any).toEqual([]);
+    });
+
+    it("should send labels_exclude_all when the exclude mode is All", async () => {
+      const onCreatePolicy = jest.fn();
+      const props = { ...defaultProps, onCreatePolicy };
+      render(
+        <PolicyProvider>
+          <SaveNewPolicyModal {...props} />
+        </PolicyProvider>
+      );
+      await waitFor(() => {
+        expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText("Name"),
+        "A Brand New Policy!"
+      );
+
+      await userEvent.click(screen.getByLabelText("Custom"));
+      await userEvent.click(screen.getByText("Exclude"));
+      await userEvent.click(screen.getByLabelText("All"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "Fun" })
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      const payload = onCreatePolicy.mock.calls[0][0];
+      expect(payload.labels_exclude_all).toEqual(["Fun"]);
+      expect(payload.labels_exclude_any).toEqual([]);
+    });
+
+    it("should send both include and exclude labels when both tabs have selections", async () => {
+      const onCreatePolicy = jest.fn();
+      const props = { ...defaultProps, onCreatePolicy };
+      render(
+        <PolicyProvider>
+          <SaveNewPolicyModal {...props} />
+        </PolicyProvider>
+      );
+      await waitFor(() => {
+        expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText("Name"),
+        "A Brand New Policy!"
+      );
+
+      await userEvent.click(screen.getByLabelText("Custom"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "Fun" })
+      );
+      await userEvent.click(screen.getByText("Exclude"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "Fresh" })
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      const payload = onCreatePolicy.mock.calls[0][0];
+      expect(payload.labels_include_any).toEqual(["Fun"]);
+      expect(payload.labels_exclude_any).toEqual(["Fresh"]);
     });
 
     it("should clear labels when saving a new policy in All hosts target mode", async () => {

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -9,12 +9,9 @@ import React, {
 import { size } from "lodash";
 import classNames from "classnames";
 import { useQueryClient } from "react-query";
+import { InjectedRouter } from "react-router";
 
-import {
-  getCustomTargetOptions,
-  LabelScope,
-} from "components/TargetLabelSelector/labelScopes";
-
+import PATHS from "router/paths";
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import { IPlatformSelector } from "hooks/usePlatformSelector";
@@ -26,6 +23,7 @@ import { ITeamConfig } from "interfaces/team";
 import useDeepEffect from "hooks/useDeepEffect";
 
 import configAPI from "services/entities/config";
+import { listNamesFromSelectedLabels } from "services/entities/labels";
 import teamPoliciesAPI from "services/entities/team_policies";
 import teamsAPI from "services/entities/teams";
 
@@ -34,7 +32,12 @@ import Checkbox from "components/forms/fields/Checkbox";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
-import { DropdownTargetLabelSelector } from "components/TargetLabelSelector";
+import {
+  TargetLabelSelector,
+  ILabelTabConfig,
+  LabelTargetMode,
+  TargetType,
+} from "components/TargetLabelSelector";
 import Icon from "components/Icon";
 
 import PolicyAutomationsFields, {
@@ -71,6 +74,7 @@ export interface ISaveNewPolicyModalProps {
   globalConfig: IConfig | undefined;
   /** Display name of the fleet the new policy belongs to. */
   fleetName: string;
+  router: InjectedRouter;
 }
 
 const validatePolicyName = (name: string) => {
@@ -103,6 +107,7 @@ const SaveNewPolicyModal = ({
   automationsConfig,
   globalConfig,
   fleetName,
+  router,
 }: ISaveNewPolicyModalProps): JSX.Element => {
   const { isPremiumTier, setConfig } = useContext(AppContext);
   const queryClient = useQueryClient();
@@ -123,15 +128,23 @@ const SaveNewPolicyModal = ({
     backendValidators
   );
 
-  const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
-  const [selectedCustomTarget, setSelectedCustomTarget] = useState<LabelScope>(
-    "labelsIncludeAny"
+  const [selectedTargetType, setSelectedTargetType] = useState<TargetType>(
+    "All hosts"
   );
-  const [selectedLabels, setSelectedLabels] = useState({});
-  const customTargetOptions = useMemo(
-    () => getCustomTargetOptions({ entity: "policy", isPremiumTier }),
-    [isPremiumTier]
-  );
+  const [
+    selectedIncludeMode,
+    setSelectedIncludeMode,
+  ] = useState<LabelTargetMode>("any");
+  const [
+    selectedExcludeMode,
+    setSelectedExcludeMode,
+  ] = useState<LabelTargetMode>("any");
+  const [selectedIncludeLabels, setSelectedIncludeLabels] = useState<
+    Record<string, boolean>
+  >({});
+  const [selectedExcludeLabels, setSelectedExcludeLabels] = useState<
+    Record<string, boolean>
+  >({});
 
   const [showAutomations, setShowAutomations] = useState(false);
   const automationsRef = useRef<IPolicyAutomationsFieldsHandle>(null);
@@ -148,28 +161,38 @@ const SaveNewPolicyModal = ({
     [policyTeamId]
   );
 
-  const onSelectLabel = ({
-    name: labelName,
-    value,
-  }: {
-    name: string;
-    value: boolean;
-  }) => {
-    setSelectedLabels({
-      ...selectedLabels,
-      [labelName]: value,
-    });
+  const includeTab: ILabelTabConfig = {
+    selectedLabels: selectedIncludeLabels,
+    onSelectLabel: ({ name, value }) =>
+      setSelectedIncludeLabels((prev) => ({ ...prev, [name]: value })),
+    showModeToggle: true,
+    mode: selectedIncludeMode,
+    onSelectMode: setSelectedIncludeMode,
+    anyTooltip: "Will only target hosts that have any of these labels.",
+    allTooltip: "Will only target hosts that have all of these labels.",
   };
+
+  const excludeTab: ILabelTabConfig = {
+    selectedLabels: selectedExcludeLabels,
+    onSelectLabel: ({ name, value }) =>
+      setSelectedExcludeLabels((prev) => ({ ...prev, [name]: value })),
+    showModeToggle: true,
+    mode: selectedExcludeMode,
+    onSelectMode: setSelectedExcludeMode,
+    anyTooltip: "Will not target hosts that have any of these labels.",
+    allTooltip: "Will not target hosts that have all of these labels.",
+  };
+
+  const hasCustomLabels =
+    listNamesFromSelectedLabels(selectedIncludeLabels).length > 0 ||
+    listNamesFromSelectedLabels(selectedExcludeLabels).length > 0;
 
   const disableForm =
     isFetchingAutofillDescription || isFetchingAutofillResolution;
   const disableSave =
     !platformSelector.isAnyPlatformSelected ||
     disableForm ||
-    (selectedTargetType === "Custom" &&
-      !Object.entries(selectedLabels).some(([, value]) => {
-        return value;
-      }));
+    (selectedTargetType === "Custom" && !hasCustomLabels);
 
   useDeepEffect(() => {
     if (lastEditedQueryName) {
@@ -217,18 +240,22 @@ const SaveNewPolicyModal = ({
       critical: lastEditedQueryCritical,
     };
     if (isPremiumTier) {
-      const customLabelNames =
+      const includeNames =
         selectedTargetType === "Custom"
-          ? Object.entries(selectedLabels)
-              .filter(([, selected]) => selected)
-              .map(([labelName]) => labelName)
+          ? listNamesFromSelectedLabels(selectedIncludeLabels)
+          : [];
+      const excludeNames =
+        selectedTargetType === "Custom"
+          ? listNamesFromSelectedLabels(selectedExcludeLabels)
           : [];
       payload.labels_include_any =
-        selectedCustomTarget === "labelsIncludeAny" ? customLabelNames : [];
+        selectedIncludeMode === "any" ? includeNames : [];
       payload.labels_include_all =
-        selectedCustomTarget === "labelsIncludeAll" ? customLabelNames : [];
+        selectedIncludeMode === "all" ? includeNames : [];
       payload.labels_exclude_any =
-        selectedCustomTarget === "labelsExcludeAny" ? customLabelNames : [];
+        selectedExcludeMode === "any" ? excludeNames : [];
+      payload.labels_exclude_all =
+        selectedExcludeMode === "all" ? excludeNames : [];
     }
 
     // The create endpoint deliberately ignores automation fields (see the
@@ -397,19 +424,15 @@ const SaveNewPolicyModal = ({
         />
         {platformSelector.render()}
         {isPremiumTier && (
-          <DropdownTargetLabelSelector
-            selectedTargetType={selectedTargetType}
-            selectedCustomTarget={selectedCustomTarget}
-            customTargetOptions={customTargetOptions}
-            onSelectCustomTarget={(val) =>
-              setSelectedCustomTarget(val as LabelScope)
-            }
-            selectedLabels={selectedLabels}
+          <TargetLabelSelector
             className={`${baseClass}__target`}
+            selectedTargetType={selectedTargetType}
             onSelectTargetType={setSelectedTargetType}
-            onSelectLabel={onSelectLabel}
             labels={labels || []}
-            suppressTitle
+            include={includeTab}
+            exclude={excludeTab}
+            emptyStateDescription="Add a label to target a group of hosts."
+            onAddLabel={() => router.push(PATHS.LABEL_NEW_DYNAMIC)}
             disableOptions={disableForm}
           />
         )}

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -168,8 +168,24 @@ const SaveNewPolicyModal = ({
     showModeToggle: true,
     mode: selectedIncludeMode,
     onSelectMode: setSelectedIncludeMode,
-    anyTooltip: "Will only target hosts that have any of these labels.",
-    allTooltip: "Will only target hosts that have all of these labels.",
+    anyTooltip: (
+      <>
+        Will only target hosts that have{" "}
+        <em>
+          <b>any</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
+    allTooltip: (
+      <>
+        Will only target hosts that have{" "}
+        <em>
+          <b>all</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
   };
 
   const excludeTab: ILabelTabConfig = {
@@ -179,8 +195,24 @@ const SaveNewPolicyModal = ({
     showModeToggle: true,
     mode: selectedExcludeMode,
     onSelectMode: setSelectedExcludeMode,
-    anyTooltip: "Will not target hosts that have any of these labels.",
-    allTooltip: "Will not target hosts that have all of these labels.",
+    anyTooltip: (
+      <>
+        Will not target hosts that have{" "}
+        <em>
+          <b>any</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
+    allTooltip: (
+      <>
+        Will not target hosts that have{" "}
+        <em>
+          <b>all</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
   };
 
   const hasCustomLabels =

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -81,6 +81,7 @@ export default {
       labels_include_any,
       labels_include_all,
       labels_exclude_any,
+      labels_exclude_all,
       type,
       patch_software_title_id,
       // note absence of automations-related fields, which are only set by the UI via update
@@ -99,6 +100,7 @@ export default {
       labels_include_any,
       labels_include_all,
       labels_exclude_any,
+      labels_exclude_all,
       type,
       patch_software_title_id,
     });
@@ -122,6 +124,7 @@ export default {
       labels_include_any,
       labels_include_all,
       labels_exclude_any,
+      labels_exclude_all,
     } = data;
     const { TEAMS } = endpoints;
     const path = `${TEAMS}/${team_id}/policies/${id}`;
@@ -141,6 +144,7 @@ export default {
       labels_include_any,
       labels_include_all,
       labels_exclude_any,
+      labels_exclude_all,
     });
   },
   destroy: (teamId: number | undefined, ids: number[]) => {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46583 

Figma: https://www.figma.com/design/0F1sw63SuYaKVWlcL7mnc6/-33441-Policies--Custom-targets-with-%22Include-any%22-and-%22Exclude-any%22?node-id=5303-5687&t=Fszpf83KhcZ7ViWh-0

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Note: policy creation will fail if more than one inclusion/exclusion option is provided. This will be addressed as part of https://github.com/fleetdm/fleet/issues/46582 (we'll relax that check to make sure we can accept a combination).


https://github.com/user-attachments/assets/9cfbcbca-54ce-4978-8248-7d550f18785b


https://github.com/user-attachments/assets/16138fb1-da7c-4838-8819-f370bf7072c1

Empty state:

<img width="850" height="628" alt="Screenshot 2026-06-10 at 11 30 45 AM" src="https://github.com/user-attachments/assets/141c4d26-e464-4ae1-b6ed-94d24a640e1c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add optional "exclude all" label targeting for policies (labels_exclude_all) and tab-based Include/Exclude targeting UI.

* **Improvements**
  * In-modal navigation to add new labels; Custom targeting requires at least one selected label to enable Save.
  * Payloads now include include/exclude label fields when using Custom targeting.

* **Tests**
  * Updated modal tests to cover exclude-tab label selection.

* **Style**
  * Improved empty-state border styling in label selector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->