### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/libreoffice/windows.json
+++ b/ee/maintained-apps/outputs/libreoffice/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.2.3.2",
+      "version": "26.2.4.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'LibreOffice %' AND publisher = 'The Document Foundation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'LibreOffice %' AND publisher = 'The Document Foundation' AND version_compare(version, '26.2.3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'LibreOffice %' AND publisher = 'The Document Foundation' AND version_compare(version, '26.2.4.2') < 0);"
       },
-      "installer_url": "https://download.documentfoundation.org/libreoffice/stable/26.2.3/win/x86_64/LibreOffice_26.2.3_Win_x86-64.msi",
+      "installer_url": "https://download.documentfoundation.org/libreoffice/stable/26.2.4/win/x86_64/LibreOffice_26.2.4_Win_x86-64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "731830d4",
-      "sha256": "468d1fb3880af3bcddac002e9054155912c70b45d105bfa1c82036f33456133d",
+      "sha256": "202f26cda071c5aa4996a5a28412fddceb3891dceb0366982c62650456c0730f",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.52",
+      "version": "149.0.4022.62",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.52') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.62') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/175d61fb-7a6d-4b2c-87c3-2b8cfcf3247e/MicrosoftEdge-149.0.4022.52.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/aebb5d3f-6026-4857-939c-c4019c60c7c0/MicrosoftEdge-149.0.4022.62.dmg",
       "install_script_ref": "caf6f785",
       "uninstall_script_ref": "3b06f51c",
-      "sha256": "a08d2b67e5b655f46d1aaba13fd60c2db48bd5a12391809ed47135bf2be6a601",
+      "sha256": "89ef7ee52cbb3c9494c8119b968def0413e47eb8e54ee7aff2662136dfc9487a",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated LibreOffice Windows release metadata to version 26.2.4.2
* Updated Microsoft Edge macOS release metadata to version 149.0.4022.62

<!-- end of auto-generated comment: release notes by coderabbit.ai -->