### PR TITLE
Adding changes for Fleet v4.86.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Fleet 4.86.2 (Jun 12, 2026)
+
+### Bug fixes
+
+- Fixed Fleet failing to start on a read-only root filesystem by storing custom org logos in the database when no S3 software installers bucket is configured, instead of writing to local disk.
+- Fixed a bug where host vitals labels (e.g. IdP group/department labels) scoped to a fleet/team never got any hosts. The membership cron only looked at global labels, and team-scoped IdP labels also failed to populate due to an incorrect SQL join.
+- Fixed a server out-of-memory crash that could occur when Apple's VPP (App and Book Management) API repeatedly returned transient errors (HTTP 500 with Retry-After, or error 9646) during VPP API operations (e.g., app installs, user registration, license seat releases).
+- Improved Apple MDM enrollment and device management request parsing
+- Improved SAMLResponse validation by rejecting large responses, deeply nested documents, or documents with too many nodes.
+- Added rate limiting to the SSO callback endpoint.
+
 ## Fleet 4.86.1 (Jun 03, 2026)
 
 ### Bug fixes

--- a/changes/46656-vpp-api-derecursion-oom
+++ b/changes/46656-vpp-api-derecursion-oom
@@ -1,1 +1,0 @@
-* Fixed a server out-of-memory crash that could occur when Apple's VPP (App and Book Management) API repeatedly returned transient errors (HTTP 500 with Retry-After, or error 9646) during VPP API operations (e.g., app installs, user registration, license seat releases).

--- a/changes/46869-idp-team-vitals-labels
+++ b/changes/46869-idp-team-vitals-labels
@@ -1,1 +1,0 @@
-- Fixed a bug where host vitals labels (e.g. IdP group/department labels) scoped to a fleet/team never got any hosts. The membership cron only looked at global labels, and team-scoped IdP labels also failed to populate due to an incorrect SQL join.

--- a/changes/47090-org-logo-readonly-fs
+++ b/changes/47090-org-logo-readonly-fs
@@ -1,1 +1,0 @@
-* Fixed Fleet failing to start on a read-only root filesystem by storing custom org logos in the database when no S3 software installers bucket is configured, instead of writing to local disk.

--- a/changes/improve-sso-samlresponse-validation
+++ b/changes/improve-sso-samlresponse-validation
@@ -1,2 +1,0 @@
-* Improved SAMLResponse validation by rejecting large responses, deeply nested documents, or documents with too many nodes.
-* Added rate limiting to the SSO callback endpoint.

--- a/changes/mdm-apple-plist-parsing
+++ b/changes/mdm-apple-plist-parsing
@@ -1,1 +1,0 @@
-* Improved Apple MDM enrollment and device management request parsing

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v7.0.6
+version: v7.0.7
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.86.1
+appVersion: v4.86.2
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.86.1 # Version of Fleet to deploy
+imageTag: v4.86.2 # Version of Fleet to deploy
 # imagePullPolicy is optional. If unset, Kubernetes defaults to IfNotPresent
 # for tagged images and Always for the :latest tag. Valid values: Always,
 # IfNotPresent, Never.

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.86.1"
+  default     = "fleetdm/fleet:v4.86.2"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.86.1"
+  default = "fleetdm/fleet:v4.86.2"
 }
 
 variable "software_installers_bucket_name" {

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.86.1",
+  "version": "v4.86.2",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where team-scoped host vitals labels (from IdP attributes) failed to populate associated hosts correctly.

* **Chores**
  * Updated Fleet/Helm chart versions and container image/CLI package tags from v4.86.1 to v4.86.2 across the deployment chart, values, infrastructure defaults, and tooling manifest, with no other configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->