### PR TITLE
Website: update deal registration form on partners page

### DIFF
--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -401,8 +401,8 @@
             <div class="invalid-feedback" v-if="formErrors.expectedClose" focus-first>Please select an option</div>
           </div>
           <div class="form-group">
-            <label for="reseller-number-of-devices">Estimated number of devices *</label>
-            <select class="form-control custom-select" :class="[formErrors.numberOfHosts ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.numberOfHosts">
+            <label for="number-of-devices">Estimated number of devices *</label>
+            <select id="number-of-devices" class="form-control custom-select" :class="[formErrors.numberOfHosts ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.numberOfHosts">
               <option :value="undefined">Select</option>
               <option value="500 - 1000">500 - 1,000</option>
               <option value="1000 - 5000">1,000 - 5,000</option>

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -404,8 +404,7 @@
             <label for="reseller-number-of-devices">Estimated number of devices *</label>
             <select class="form-control custom-select" :class="[formErrors.numberOfHosts ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.numberOfHosts">
               <option :value="undefined">Select</option>
-              <option value="1 - 100">1 - 100</option>
-              <option value="100 - 1000">100 - 1,000</option>
+              <option value="500 - 1000">500 - 1,000</option>
               <option value="1000 - 5000">1,000 - 5,000</option>
               <option value="5000+">5,000+</option>
             </select>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/47185

Changes:
- Updated the options for the "Estimated number of devices" input on the deal registration form on the /partners page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In the deal registration modal, the "Estimated number of devices" dropdown now uses an updated field label and consolidates prior lower-range choices into a single "500–1,000" option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->