### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/arduino-ide/darwin.json
+++ b/ee/maintained-apps/outputs/arduino-ide/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.3.9",
+      "version": "2.3.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2' AND version_compare(bundle_short_version, '2.3.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cc.arduino.IDE2' AND version_compare(bundle_short_version, '2.3.10') < 0);"
       },
-      "installer_url": "https://github.com/arduino/arduino-ide/releases/download/2.3.9/arduino-ide_2.3.9_macOS_ARM64.dmg",
+      "installer_url": "https://github.com/arduino/arduino-ide/releases/download/2.3.10/arduino-ide_2.3.10_macOS_ARM64.dmg",
       "install_script_ref": "323dc006",
       "uninstall_script_ref": "6fdce371",
-      "sha256": "88dcbe0360a6d96e811413110fc4c72e66e14e0c2fd93994bc1c82fc90ef3917",
+      "sha256": "8811860dc8782b6cd6bb0076e9215255849f404b1b9e6f38069fdc4f5c43648e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.1.91.168",
+      "version": "149.1.91.171",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '149.1.91.168') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '149.1.91.171') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/191.168/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/191.171/Brave-Browser-arm64.dmg",
       "install_script_ref": "013e53e8",
       "uninstall_script_ref": "9a376609",
-      "sha256": "7b85fd3d16837c205f7e26631e0f8c5cd921bcbd0f9a2632fd90c6b52b14648c",
+      "sha256": "b5a02de0cb1e007d1335aaf51aedfd35253da5515674f73771f6c651b856e289",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.11187.4",
+      "version": "1.11847.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.11187.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.11847.5') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.11187.4/Claude-58400536f3ccde1cff9a129de6c3112dc8cb489a.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.11847.5/Claude-9692f0b44ffa0158a501a91309e361c0d48ed8e4.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "ab256a225373d58d4f80163de3438e076fa2d04d75e30eccbee6d9d4b4b1fc5b",
+      "sha256": "55f007762a4920f043d0d285bab8f303186ab353a1ee7c4b82555dbcfb92b162",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.32.4",
+      "version": "0.32.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.32.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.32.5') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.32.4/CodexBar-macos-universal-0.32.4.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.32.5/CodexBar-macos-universal-0.32.5.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "f8863df7e9f584da6397a085377a3040d96881a4138557855de694321df9e401",
+      "sha256": "2c5f751544e3a882c97b5e307f34f487e277c96d7d6801378397ba32ce6a6b36",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/crossover/darwin.json
+++ b/ee/maintained-apps/outputs/crossover/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.0",
+      "version": "26.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.codeweavers.CrossOver';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.codeweavers.CrossOver' AND version_compare(bundle_short_version, '26.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.codeweavers.CrossOver' AND version_compare(bundle_short_version, '26.2.0') < 0);"
       },
-      "installer_url": "https://media.codeweavers.com/pub/crossover/cxmac/demo/crossover-26.1.0.zip",
+      "installer_url": "https://media.codeweavers.com/pub/crossover/cxmac/demo/crossover-26.2.0.zip",
       "install_script_ref": "e73b42a9",
       "uninstall_script_ref": "ab2b4be1",
-      "sha256": "99812be77501995533a9fd4553efa75a4237eac6a20c5639ff43ad46660d9256",
+      "sha256": "ab39680927a0d9c313cad27fed33dd15a799be40c93bfc432bef70518af10aa4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/libreoffice/windows.json
+++ b/ee/maintained-apps/outputs/libreoffice/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.2.3.2",
+      "version": "26.2.4.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'LibreOffice %' AND publisher = 'The Document Foundation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'LibreOffice %' AND publisher = 'The Document Foundation' AND version_compare(version, '26.2.3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'LibreOffice %' AND publisher = 'The Document Foundation' AND version_compare(version, '26.2.4.2') < 0);"
       },
-      "installer_url": "https://download.documentfoundation.org/libreoffice/stable/26.2.3/win/x86_64/LibreOffice_26.2.3_Win_x86-64.msi",
+      "installer_url": "https://download.documentfoundation.org/libreoffice/stable/26.2.4/win/x86_64/LibreOffice_26.2.4_Win_x86-64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "731830d4",
-      "sha256": "468d1fb3880af3bcddac002e9054155912c70b45d105bfa1c82036f33456133d",
+      "sha256": "202f26cda071c5aa4996a5a28412fddceb3891dceb0366982c62650456c0730f",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.52",
+      "version": "149.0.4022.62",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.52') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.62') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/175d61fb-7a6d-4b2c-87c3-2b8cfcf3247e/MicrosoftEdge-149.0.4022.52.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/aebb5d3f-6026-4857-939c-c4019c60c7c0/MicrosoftEdge-149.0.4022.62.dmg",
       "install_script_ref": "caf6f785",
       "uninstall_script_ref": "3b06f51c",
-      "sha256": "a08d2b67e5b655f46d1aaba13fd60c2db48bd5a12391809ed47135bf2be6a601",
+      "sha256": "89ef7ee52cbb3c9494c8119b968def0413e47eb8e54ee7aff2662136dfc9487a",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported application versions across multiple platforms: Arduino IDE (2.3.10), Brave Browser (149.1.91.171), Claude (1.11847.5), CodexBar (0.32.5), Crossover (26.2.0), LibreOffice (26.2.4.2), and Microsoft Edge (149.0.4022.62). Corresponding metadata updated for each application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->