### PR TITLE
Drop contents: write to read in release workflows

### DIFF
--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -177,8 +177,6 @@ jobs:
     runs-on: windows-2022
     permissions:
       contents: read
-      id-token: write # required for attestations
-      attestations: write # required for attestations
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -234,8 +232,6 @@ jobs:
     runs-on: windows-2022
     permissions:
       contents: read
-      id-token: write # required for attestations
-      attestations: write # required for attestations
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -17,9 +17,9 @@ jobs:
   goreleaser-macos:
     runs-on: macos-latest
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: read
+      id-token: write # required for attestations
+      attestations: write # required for attestations
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -83,9 +83,9 @@ jobs:
   goreleaser-linux:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: read
+      id-token: write # required for attestations
+      attestations: write # required for attestations
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -131,9 +131,9 @@ jobs:
   goreleaser-linux-arm64:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: read
+      id-token: write # required for attestations
+      attestations: write # required for attestations
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -176,9 +176,9 @@ jobs:
   goreleaser-windows:
     runs-on: windows-2022
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: read
+      id-token: write # required for attestations
+      attestations: write # required for attestations
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -233,9 +233,9 @@ jobs:
   goreleaser-windows-arm64:
     runs-on: windows-2022
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: read
+      id-token: write # required for attestations
+      attestations: write # required for attestations
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/release-fleetctl-docker-deps.yaml
+++ b/.github/workflows/release-fleetctl-docker-deps.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-4core
     environment: Docker Hub
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
**Related issue:** Closes Scorecard Token-Permissions alerts #2102-#2107 (fleetdm/fleet security tab)

## Summary

The `goreleaser-orbit` and `release-fleetctl-docker-deps` workflow jobs declared `contents: write` at the job level, but they don't actually write to the repository:

- `goreleaser` runs with `--skip=publish`
- `actions/attest-build-provenance` needs `id-token: write` + `attestations: write` only (not `contents`)
- `actions/upload-artifact` writes to workflow artifact storage, not repo contents
- `release-fleetctl-docker-deps` pushes to Docker Hub using a dedicated token (`DOCKERHUB_ACCESS_TOKEN`), not GITHUB_TOKEN
- The macOS goreleaser job overrides `GITHUB_TOKEN` with `FLEET_RELEASE_GITHUB_PAT` anyway

Drops the unused write scope to `contents: read` while keeping `id-token: write` and `attestations: write` where they're needed by `attest-build-provenance` (now annotated inline).

## Test plan

These workflows only fire on release tags (`orbit-*`, `fleetctl-docker-deps-*`), so CI on this PR will not exercise them.

- [ ] Workflow YAML is syntactically valid (Actions linter on this PR)
- [ ] Next `orbit-*` pre-release tag confirms goreleaser still builds and `attest-build-provenance` still signs successfully across macOS, Linux (amd64 + arm64), and Windows (amd64 + arm64)
- [ ] Next `fleetctl-docker-deps-*` tag confirms Docker Hub push still succeeds
- [ ] Scorecard re-scan confirms #2102-#2107 are closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI/CD workflow permissions for release pipelines: several release jobs now have repository contents set to read-only.
  * Preserved attestation and token write permissions for select macOS/Linux release jobs where required.
  * Removed attestation/token entries from Windows release jobs and updated Docker-deps release job to read-only contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->