### PR TITLE
Remove front end name validation for add certificate modal

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -214,7 +214,6 @@ const Certificates = ({
       {renderContent()}
       {showAddCertModal && (
         <AddCertModal
-          existingCerts={certs}
           onExit={() => setShowAddCertModal(false)}
           onSuccess={onUpdateSuccess}
           currentTeamId={currentTeamId}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { http, HttpResponse } from "msw";
 import { screen, waitFor } from "@testing-library/react";
-import { ICertificate } from "services/entities/certificates";
 import mockServer from "test/mock-server";
 import { baseUrl, createCustomRenderer } from "test/test-utils";
 
@@ -13,7 +12,6 @@ import {
   NAME_REQUIRED_MSG,
   NAME_TOO_LONG_MSG,
   SUBJECT_NAME_REQUIRED_MSG,
-  USED_NAME_MSG,
 } from "./helpers";
 
 const mockOnExit = jest.fn();
@@ -53,26 +51,12 @@ const addCertHandler = http.post(
   }
 );
 
-const mockExistingCerts: ICertificate[] = [
-  {
-    id: 1,
-    name: "Existing Certificate",
-    certificate_authority_id: 1,
-    certificate_authority_name: "Test CA 1",
-    created_at: "2024-01-01T00:00:00Z",
-  },
-];
-
 // Renders the modal and waits for the form to be interactive (the Name input present).
 // Returns userEvent + the rendered scope.
-const renderModal = async ({ existingCerts = [] as ICertificate[] } = {}) => {
+const renderModal = async () => {
   const render = createCustomRenderer({ withBackendMock: true });
   const result = render(
-    <AddCertModal
-      existingCerts={existingCerts}
-      onExit={mockOnExit}
-      onSuccess={mockOnSuccess}
-    />
+    <AddCertModal onExit={mockOnExit} onSuccess={mockOnSuccess} />
   );
   await screen.findByPlaceholderText(NAME_PLACEHOLDER);
   return result;
@@ -152,19 +136,6 @@ describe("AddCertModal", () => {
 
     await waitFor(() => {
       expect(screen.getByText(INVALID_NAME_MSG)).toBeInTheDocument();
-    });
-  });
-
-  it("shows inline error for duplicate Name as user types", async () => {
-    const { user } = await renderModal({ existingCerts: mockExistingCerts });
-
-    await user.type(
-      screen.getByPlaceholderText(NAME_PLACEHOLDER),
-      "Existing Certificate"
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText(USED_NAME_MSG)).toBeInTheDocument();
     });
   });
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
@@ -7,7 +7,7 @@ import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import paths from "router/paths";
 
 import { NotificationContext } from "context/notification";
-import certificatesAPI, { ICertificate } from "services/entities/certificates";
+import certificatesAPI from "services/entities/certificates";
 import { getErrorReason } from "interfaces/errors";
 
 import InputField from "components/forms/fields/InputField";
@@ -35,14 +35,12 @@ export interface IAddCertFormData {
 }
 
 interface IAddCertModalProps {
-  existingCerts: ICertificate[];
   onExit: () => void;
   onSuccess: () => void;
   currentTeamId?: number;
 }
 
 const AddCertModal = ({
-  existingCerts: existingCTs,
   onExit,
   onSuccess,
   currentTeamId,
@@ -64,10 +62,7 @@ const AddCertModal = ({
     subjectAlternativeName?: string;
   }>({});
 
-  const validations = useMemo(
-    () => generateFormValidations(existingCTs || []),
-    [existingCTs]
-  );
+  const validations = useMemo(() => generateFormValidations(), []);
 
   // formValidation is derived from formData + attemptedSubmit; computing it during render via
   // useMemo keeps it in lockstep with its inputs without scattering setFormValidation calls

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/helpers.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/helpers.ts
@@ -1,4 +1,3 @@
-import { ICertificate } from "services/entities/certificates";
 import { IAddCertFormData } from "./AddCertificateModal";
 
 export interface IAddCertFormValidation {
@@ -11,7 +10,6 @@ export interface IAddCertFormValidation {
 
 export const INVALID_NAME_MSG =
   "Invalid characters. Only letters, numbers, spaces, dashes, and underscores allowed.";
-export const USED_NAME_MSG = "Name is already used by another certificate.";
 export const NAME_TOO_LONG_MSG = "Name is too long. Maximum is 255 characters.";
 export const NAME_REQUIRED_MSG = "Name must be completed.";
 export const CA_REQUIRED_MSG = "Certificate authority must be completed.";
@@ -35,9 +33,7 @@ type IFormValidations = Record<
   { validations: IValidation[] }
 >;
 
-export const generateFormValidations = (
-  existingCerts: ICertificate[]
-): IFormValidations => {
+export const generateFormValidations = (): IFormValidations => {
   const FORM_VALIDATIONS: IFormValidations = {
     name: {
       validations: [
@@ -55,18 +51,6 @@ export const generateFormValidations = (
             return /^[a-zA-Z0-9 \-_]+$/.test(formData.name);
           },
           message: INVALID_NAME_MSG,
-        },
-        {
-          name: "unique",
-          isValid: (formData: IAddCertFormData) => {
-            return (
-              existingCerts.find(
-                (cert) =>
-                  cert.name.toLowerCase() === formData.name.toLowerCase()
-              ) === undefined
-            );
-          },
-          message: USED_NAME_MSG,
         },
         {
           name: "maxLength",


### PR DESCRIPTION
**Related issue:** Resolves #44821
Related PR: [#46414](https://github.com/fleetdm/fleet/pull/46414)

key to note that the server side validation is now the only validation that will happen to detect duplicate names.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed client-side duplicate certificate name validation; certificate name uniqueness is now validated server-side.

* **Tests**
  * Updated certificate validation tests to reflect server-side validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->