### PR TITLE
Added GET /api/v1/fleet/policies/:id/automation_activities endpoint

### DIFF
--- a/changes/38670-policy-status-page
+++ b/changes/38670-policy-status-page
@@ -1,2 +1,3 @@
 - Added `POST /api/v1/fleet/policies/:policy_id/reset` endpoint to reset a policy's pass/fail results, clearing counts and membership immediately.
 - Updated policy details page to show automations and labels as a single property. Also changed the layout of policy properties.
+- Added `GET /api/v1/fleet/policies/:id/automation_activities` endpoint to list automation activities for a policy.

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -45,12 +45,15 @@ var policyAutomationActivityTypes = func() []string {
 	return all
 }()
 
-// Unqualified names are required because the ORDER BY is applied to the outer
-// subquery that wraps the UNION ALL — not directly to any aliased table.
+// The ORDER BY (and cursor WHERE) are applied to the outer subquery that wraps
+// the UNION ALL, which is aliased `t` (see ListPolicyAutomationActivities). The
+// inner per-branch aliases (ap, hsr, ...) are not in scope there, so columns are
+// qualified with `t` — which also keeps the ORDER BY unambiguous if the outer
+// query ever gains a JOIN.
 var policyAutomationActivityAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
-	"id":            "id",
-	"created_at":    "created_at",
-	"activity_type": "activity_type",
+	"id":            "t.id",
+	"created_at":    "t.created_at",
+	"activity_type": "t.activity_type",
 }
 
 // ListHostUpcomingActivities returns the list of activities pending execution
@@ -1595,18 +1598,34 @@ const policyAutomationHostJoin = `
     JOIN  hosts               h   ON h.id            = ahp.host_id
     LEFT JOIN host_display_names hdn ON hdn.host_id  = ahp.host_id`
 
-// policyAutomationNamedStatusCols projects the status/output columns for the
-// named automation branch. Named activities encode their outcome in the type
-// name — every error type is prefixed "failed_" — and carry no script or
-// install output, so the output columns are NULL. Each UNION branch must
-// project these columns in the same order.
-const policyAutomationNamedStatusCols = `
-    IF(ap.activity_type LIKE 'failed\_%', 'error', 'success') AS status,
-    NULL AS output`
+// statusOutputCols renders the trailing "status, output" column pair that every
+// UNION branch must project after policyAutomationCols. Modeling it as a struct
+// (rather than a raw SQL fragment) makes the positional contract that UNION ALL
+// relies on impossible to break by hand: both columns are always present,
+// always aliased, and always in this order, so no branch can silently reorder
+// or drop one. status and output are SQL expressions; use "NULL" for output
+// when the branch has nothing to surface.
+type statusOutputCols struct {
+	status string
+	output string
+}
+
+func (c statusOutputCols) sql() string {
+	return fmt.Sprintf("%s AS status, %s AS output", c.status, c.output)
+}
+
+// policyAutomationNamedStatusCols projects the status/output pair for the named
+// automation branch. Named activities encode their outcome in the type name —
+// every error type is prefixed "failed_" — and carry no script or install
+// output, so output is NULL.
+var policyAutomationNamedStatusCols = statusOutputCols{
+	status: `IF(ap.activity_type LIKE 'failed\_%', 'error', 'success')`,
+	output: "NULL",
+}
 
 // policyAutomationTaskBranch describes a UNION branch whose link to the policy
 // and whose success/failure state both live in a task result table (scripts,
-// in-house installs, VPP installs) rather than in the activity details.
+// in-house installs, VPP installs) rather than in the activity_past.details column.
 type policyAutomationTaskBranch struct {
 	// activityType is the activity_past.activity_type this branch matches.
 	activityType string
@@ -1618,14 +1637,15 @@ type policyAutomationTaskBranch struct {
 	// applied, so internal OR/AND precedence is preserved.
 	errorCond   string
 	successCond string
-	// statusCols projects the status/output columns for this branch, in the same
-	// order as policyAutomationNamedStatusCols: status, output.
-	statusCols string
+	// statusCols projects the status/output pair for this branch. The
+	// statusOutputCols type guarantees the columns and their order stay in sync
+	// with every other branch.
+	statusCols statusOutputCols
 }
 
 // policyAutomationTaskBranches are the non-named-automation sources of policy
 // activities: their rows are joined to the policy through a result table's
-// policy_id column rather than through details.policy_id.
+// policy_id column rather than through activity_past.details.policy_id.
 var policyAutomationTaskBranches = []policyAutomationTaskBranch{
 	{
 		activityType: "ran_script",
@@ -1636,9 +1656,10 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
                 AND hsr.policy_id    = ?`,
 		errorCond:   "hsr.exit_code IS NOT NULL AND hsr.exit_code != 0",
 		successCond: "hsr.exit_code = 0",
-		statusCols: `
-            IF(hsr.exit_code = 0, 'success', 'error') AS status,
-            hsr.output AS output`,
+		statusCols: statusOutputCols{
+			status: "IF(hsr.exit_code = 0, 'success', 'error')",
+			output: "hsr.output",
+		},
 	},
 	{
 		activityType: "installed_software",
@@ -1649,9 +1670,10 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
                 AND hsi.policy_id    = ?`,
 		errorCond:   "hsi.status = 'failed_install'",
 		successCond: "hsi.status = 'installed'",
-		statusCols: `
-            IF(hsi.status = 'installed', 'success', 'error') AS status,
-            hsi.install_script_output AS output`,
+		statusCols: statusOutputCols{
+			status: "IF(hsi.status = 'installed', 'success', 'error')",
+			output: "hsi.install_script_output",
+		},
 	},
 	{
 		activityType: "installed_app_store_app",
@@ -1670,9 +1692,10 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
 		successCond: "hvsi.verification_at IS NOT NULL",
 		// VPP apps are installed via MDM command, not a script, so there is no
 		// script output to surface.
-		statusCols: `
-            IF(hvsi.verification_at IS NOT NULL, 'success', 'error') AS status,
-            NULL AS output`,
+		statusCols: statusOutputCols{
+			status: "IF(hvsi.verification_at IS NOT NULL, 'success', 'error')",
+			output: "NULL",
+		},
 	},
 }
 
@@ -1689,7 +1712,7 @@ type policyAutomationBranch struct {
 func buildPolicyAutomationBranches(ds *Datastore, policyID uint, filter fleet.TeamFilter, status string) ([]policyAutomationBranch, error) {
 	teamFilterSQL := ds.whereFilterHostsByTeams(filter, "h")
 	// Named automation activities (webhook/ticket/calendar/CA) are selected by
-	// activity_type and linked to the policy through details.policy_id. The
+	// activity_type and linked to the policy through activity_past.details.policy_id. The
 	// status filter chooses which set of types to match.
 	namedTypes := policyAutomationActivityTypes
 	switch status {
@@ -1701,7 +1724,7 @@ func buildPolicyAutomationBranches(ds *Datastore, policyID uint, filter fleet.Te
 	namedSQL, namedArgs, err := sqlx.In(fmt.Sprintf(`SELECT %s, %s FROM activity_past ap %s
         WHERE ap.activity_type IN (?)
           AND ap.details->>'$.policy_id' = ?
-          AND %s`, policyAutomationCols, policyAutomationNamedStatusCols, policyAutomationHostJoin, teamFilterSQL), namedTypes, policyID)
+          AND %s`, policyAutomationCols, policyAutomationNamedStatusCols.sql(), policyAutomationHostJoin, teamFilterSQL), namedTypes, policyID)
 	if err != nil {
 		return nil, err
 	}
@@ -1713,7 +1736,7 @@ func buildPolicyAutomationBranches(ds *Datastore, policyID uint, filter fleet.Te
 		// The policy_id placeholder lives in the joins (before WHERE), so it is
 		// bound before the activity_type placeholder.
 		sql := fmt.Sprintf("SELECT %s, %s FROM activity_past ap %s %s WHERE ap.activity_type = ? AND %s",
-			policyAutomationCols, b.statusCols, policyAutomationHostJoin, b.joins, teamFilterSQL)
+			policyAutomationCols, b.statusCols.sql(), policyAutomationHostJoin, b.joins, teamFilterSQL)
 		args := []any{policyID, b.activityType}
 		switch status {
 		case "error":

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -24,6 +24,35 @@ var deleteIDsBatchSize = 1000
 // ORDER BY and the service layer forces opt.OrderKey to "".
 var hostUpcomingActivitiesAllowedOrderKeys = common_mysql.OrderKeyAllowlist{}
 
+var policyAutomationErrorActivityTypes = []string{
+	"failed_automation_webhook",
+	"failed_automation_ticket",
+	"failed_automation_calendar_event",
+	"failed_automation_conditional_access",
+}
+
+var policyAutomationSuccessActivityTypes = []string{
+	"ran_automation_webhook",
+	"ran_automation_ticket",
+	"ran_automation_calendar_event",
+	"ran_automation_conditional_access",
+}
+
+var policyAutomationActivityTypes = func() []string {
+	all := make([]string, 0, len(policyAutomationErrorActivityTypes)+len(policyAutomationSuccessActivityTypes))
+	all = append(all, policyAutomationErrorActivityTypes...)
+	all = append(all, policyAutomationSuccessActivityTypes...)
+	return all
+}()
+
+// Unqualified names are required because the ORDER BY is applied to the outer
+// subquery that wraps the UNION ALL — not directly to any aliased table.
+var policyAutomationActivityAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
+	"id":            "id",
+	"created_at":    "created_at",
+	"activity_type": "activity_type",
+}
+
 // ListHostUpcomingActivities returns the list of activities pending execution
 // or processing for the specific host. It is the "unified queue" of work to be
 // done on the host. That queue is "virtual" in the sense that it pulls from a
@@ -1542,4 +1571,229 @@ WHERE
 		}
 	}
 	return nil
+}
+
+// policyAutomationCols is the common SELECT column list for all UNION branches.
+// All branches must project the same columns in the same order.
+const policyAutomationCols = `
+    ap.id,
+    ap.created_at,
+    ap.activity_type,
+    ap.user_id,
+    ap.user_name   AS name,
+    ap.user_email,
+    ap.fleet_initiated,
+    ap.details,
+    ahp.host_id,
+    COALESCE(hdn.display_name, '') AS host_display_name`
+
+// policyAutomationHostJoin is the JOIN from activity_past to hosts, shared
+// across all branches. The hosts table is included so whereFilterHostsByTeams
+// can filter by h.team_id.
+const policyAutomationHostJoin = `
+    JOIN  activity_host_past  ahp ON ahp.activity_id = ap.id
+    JOIN  hosts               h   ON h.id            = ahp.host_id
+    LEFT JOIN host_display_names hdn ON hdn.host_id  = ahp.host_id`
+
+// policyAutomationNamedStatusCols projects the status/output columns for the
+// named automation branch. Named activities encode their outcome in the type
+// name — every error type is prefixed "failed_" — and carry no script or
+// install output, so the output columns are NULL. Each UNION branch must
+// project these columns in the same order.
+const policyAutomationNamedStatusCols = `
+    IF(ap.activity_type LIKE 'failed\_%', 'error', 'success') AS status,
+    NULL AS output`
+
+// policyAutomationTaskBranch describes a UNION branch whose link to the policy
+// and whose success/failure state both live in a task result table (scripts,
+// in-house installs, VPP installs) rather than in the activity details.
+type policyAutomationTaskBranch struct {
+	// activityType is the activity_past.activity_type this branch matches.
+	activityType string
+	// joins are the additional JOINs binding the result table to the policy.
+	// They contain exactly one placeholder, for the policy ID.
+	joins string
+	// errorCond and successCond are the WHERE fragments selecting failed and
+	// successful tasks respectively. They are wrapped in parentheses when
+	// applied, so internal OR/AND precedence is preserved.
+	errorCond   string
+	successCond string
+	// statusCols projects the status/output columns for this branch, in the same
+	// order as policyAutomationNamedStatusCols: status, output.
+	statusCols string
+}
+
+// policyAutomationTaskBranches are the non-named-automation sources of policy
+// activities: their rows are joined to the policy through a result table's
+// policy_id column rather than through details.policy_id.
+var policyAutomationTaskBranches = []policyAutomationTaskBranch{
+	{
+		activityType: "ran_script",
+		joins: `
+            INNER JOIN host_script_results hsr
+                ON  hsr.host_id      = ahp.host_id
+                AND hsr.execution_id = ap.details->>'$.script_execution_id'
+                AND hsr.policy_id    = ?`,
+		errorCond:   "hsr.exit_code IS NOT NULL AND hsr.exit_code != 0",
+		successCond: "hsr.exit_code = 0",
+		statusCols: `
+            IF(hsr.exit_code = 0, 'success', 'error') AS status,
+            hsr.output AS output`,
+	},
+	{
+		activityType: "installed_software",
+		joins: `
+            INNER JOIN host_software_installs hsi
+                ON  hsi.host_id      = ahp.host_id
+                AND hsi.execution_id = ap.details->>'$.install_uuid'
+                AND hsi.policy_id    = ?`,
+		errorCond:   "hsi.status = 'failed_install'",
+		successCond: "hsi.status = 'installed'",
+		statusCols: `
+            IF(hsi.status = 'installed', 'success', 'error') AS status,
+            hsi.install_script_output AS output`,
+	},
+	{
+		activityType: "installed_app_store_app",
+		joins: `
+            INNER JOIN host_vpp_software_installs hvsi
+                ON  hvsi.host_id      = ahp.host_id
+                AND hvsi.command_uuid = ap.details->>'$.command_uuid'
+                AND hvsi.policy_id    = ?
+            LEFT JOIN nano_command_results ncr
+                ON  ncr.command_uuid = hvsi.command_uuid
+                AND ncr.id = (SELECT uuid FROM hosts WHERE id = ahp.host_id)`,
+		errorCond: "hvsi.verification_failed_at IS NOT NULL OR ncr.status IN ('Error', 'CommandFormatError')",
+		// verification_at IS NOT NULL is the canonical "installed" indicator: it
+		// is set by Fleet after the MDM command result is confirmed, independently
+		// of the nano_command_results row.
+		successCond: "hvsi.verification_at IS NOT NULL",
+		// VPP apps are installed via MDM command, not a script, so there is no
+		// script output to surface.
+		statusCols: `
+            IF(hvsi.verification_at IS NOT NULL, 'success', 'error') AS status,
+            NULL AS output`,
+	},
+}
+
+// policyAutomationBranch is a single UNION ALL branch: a complete SELECT (minus
+// the optional host-name filter) together with its bound arguments.
+type policyAutomationBranch struct {
+	sql  string
+	args []any
+}
+
+// buildPolicyAutomationBranches assembles every UNION branch contributing to
+// the policy automation activity feed, filtered by status ("error", "success",
+// or "" for both) and scoped to the hosts visible to the viewer via filter.
+func buildPolicyAutomationBranches(ds *Datastore, policyID uint, filter fleet.TeamFilter, status string) ([]policyAutomationBranch, error) {
+	teamFilterSQL := ds.whereFilterHostsByTeams(filter, "h")
+	// Named automation activities (webhook/ticket/calendar/CA) are selected by
+	// activity_type and linked to the policy through details.policy_id. The
+	// status filter chooses which set of types to match.
+	namedTypes := policyAutomationActivityTypes
+	switch status {
+	case "error":
+		namedTypes = policyAutomationErrorActivityTypes
+	case "success":
+		namedTypes = policyAutomationSuccessActivityTypes
+	}
+	namedSQL, namedArgs, err := sqlx.In(fmt.Sprintf(`SELECT %s, %s FROM activity_past ap %s
+        WHERE ap.activity_type IN (?)
+          AND ap.details->>'$.policy_id' = ?
+          AND %s`, policyAutomationCols, policyAutomationNamedStatusCols, policyAutomationHostJoin, teamFilterSQL), namedTypes, policyID)
+	if err != nil {
+		return nil, err
+	}
+	branches := []policyAutomationBranch{{sql: namedSQL, args: namedArgs}}
+
+	// Task activities are linked to the policy through a result table; their
+	// success/failure condition is appended based on the requested status.
+	for _, b := range policyAutomationTaskBranches {
+		// The policy_id placeholder lives in the joins (before WHERE), so it is
+		// bound before the activity_type placeholder.
+		sql := fmt.Sprintf("SELECT %s, %s FROM activity_past ap %s %s WHERE ap.activity_type = ? AND %s",
+			policyAutomationCols, b.statusCols, policyAutomationHostJoin, b.joins, teamFilterSQL)
+		args := []any{policyID, b.activityType}
+		switch status {
+		case "error":
+			sql += " AND (" + b.errorCond + ")"
+		case "success":
+			sql += " AND (" + b.successCond + ")"
+		}
+		branches = append(branches, policyAutomationBranch{sql: sql, args: args})
+	}
+	return branches, nil
+}
+
+// ListPolicyAutomationActivities returns automation activities for the given
+// policy. Each row is one (activity, host) pair. The result set combines four
+// branches via UNION ALL:
+//  1. Named policy automation activities (webhook/ticket/calendar/CA), linked
+//     via details.policy_id.
+//  2. Script-run activities (ran_script), linked via host_script_results.
+//  3. In-house software-install activities (installed_software), linked via
+//     host_software_installs.
+//  4. VPP software-install activities (installed_app_store_app), linked via
+//     host_vpp_software_installs.
+func (ds *Datastore) ListPolicyAutomationActivities(ctx context.Context, policyID uint, filter fleet.TeamFilter, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+	branches, err := buildPolicyAutomationBranches(ds, policyID, filter, status)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "build policy automation branches")
+	}
+
+	// Apply the optional host-name filter (shared by every branch) and collect
+	// each branch's SQL and args in order.
+	parts := make([]string, 0, len(branches))
+	var allArgs []any
+	var likeArg string
+	if opts.MatchQuery != "" {
+		// Escape LIKE wildcards so host names containing '_' or '%' match literally.
+		escaped := strings.ReplaceAll(opts.MatchQuery, "_", "\\_")
+		escaped = strings.ReplaceAll(escaped, "%", "\\%")
+		likeArg = escaped + "%"
+	}
+	for _, b := range branches {
+		sql, args := b.sql, b.args
+		if opts.MatchQuery != "" {
+			sql += " AND hdn.display_name LIKE ?"
+			args = append(args, likeArg)
+		}
+		parts = append(parts, "("+sql+")")
+		allArgs = append(allArgs, args...)
+	}
+
+	// Wrap the UNION in a subquery so ORDER BY / cursor pagination apply to the
+	// combined result set rather than to any single branch.
+	unionCore := strings.Join(parts, " UNION ALL ")
+	listSQL := fmt.Sprintf("SELECT * FROM (%s) AS t", unionCore)
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM (%s) AS t_cnt", unionCore)
+
+	listSQL, listArgs, err := appendListOptionsWithCursorToSQLSecure(listSQL, allArgs, &opts, policyAutomationActivityAllowedOrderKeys)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "apply list options")
+	}
+
+	var activities []*fleet.PolicyAutomationActivity
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, listSQL, listArgs...); err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "select policy automation activities")
+	}
+
+	var meta *fleet.PaginationMetadata
+	if opts.IncludeMetadata {
+		var count uint
+		if err := sqlx.GetContext(ctx, ds.reader(ctx), &count, countSQL, allArgs...); err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "count policy automation activities")
+		}
+		meta = &fleet.PaginationMetadata{
+			HasPreviousResults: opts.Page > 0,
+			TotalResults:       count,
+		}
+		if len(activities) > int(opts.PerPage) { //nolint:gosec // G115: bounded by maxPolicyAutomationActivitiesPerPage
+			meta.HasNextResults = true
+			activities = activities[:len(activities)-1]
+		}
+	}
+
+	return activities, meta, nil
 }

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -46,6 +46,7 @@ func TestActivity(t *testing.T) {
 		{"ActivateRegularPackageInstall", testActivateRegularPackageInstall},
 		{"ActivateDeletedInstallerShowsPlaceholder", testActivateDeletedInstallerShowsPlaceholder},
 		{"ActivateScriptPackageUninstallWithCorruptPayload", testActivateScriptPackageUninstallWithCorruptPayload},
+		{"ListPolicyAutomationActivities", testListPolicyAutomationActivities},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2318,4 +2319,456 @@ func testActivateScriptPackageUninstallWithCorruptPayload(t *testing.T, ds *Data
 	require.NotNil(t, result.SoftwareTitleID)
 	require.Equal(t, uint(titleID), *result.SoftwareTitleID) //nolint:gosec // dismiss G115
 	require.Equal(t, "Test Uninstall Script", result.SoftwareTitleName)
+}
+
+func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	activitySvc := NewTestActivityService(t, ds)
+
+	// adminFilter sees all hosts regardless of team.
+	adminFilter := fleet.TeamFilter{
+		User:            &fleet.User{GlobalRole: new("admin")},
+		IncludeObserver: true,
+	}
+
+	// Create a policy to hang activities on.
+	policy, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{Name: "test-policy", Query: "SELECT 1"})
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+
+	// Create a second policy; its activities must NOT appear in results for the first.
+	otherPolicy, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{Name: "other-policy", Query: "SELECT 2"})
+	require.NoError(t, err)
+	require.NotNil(t, otherPolicy)
+
+	// Create two hosts so we can test per-host rows and the host-name filter.
+	h1 := test.NewHost(t, ds, "host-alpha", "1.1.1.1", "key1", "uuid1", time.Now())
+	h2 := test.NewHost(t, ds, "host-beta", "2.2.2.2", "key2", "uuid2", time.Now())
+
+	makeDetails := func(policyID uint) map[string]any {
+		return map[string]any{"policy_id": policyID}
+	}
+
+	// Seed one activity of each type for policy 1 linked to h1,
+	// plus one success activity linked to both hosts (tests multi-host expansion).
+	errorTypes := []string{
+		"failed_automation_webhook",
+		"failed_automation_ticket",
+		"failed_automation_calendar_event",
+		"failed_automation_conditional_access",
+	}
+	successTypes := []string{
+		"ran_automation_webhook",
+		"ran_automation_ticket",
+		"ran_automation_calendar_event",
+		"ran_automation_conditional_access",
+	}
+
+	for _, typ := range errorTypes {
+		require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+			name:    typ,
+			details: makeDetails(policy.ID),
+			hostIDs: []uint{h1.ID},
+		}))
+	}
+	for _, typ := range successTypes {
+		require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+			name:    typ,
+			details: makeDetails(policy.ID),
+			hostIDs: []uint{h1.ID},
+		}))
+	}
+
+	// One activity linked to both hosts — produces two rows.
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "ran_automation_webhook",
+		details: makeDetails(policy.ID),
+		hostIDs: []uint{h1.ID, h2.ID},
+	}))
+
+	// Activity for the other policy — must not appear in results for policy 1.
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "failed_automation_webhook",
+		details: makeDetails(otherPolicy.ID),
+		hostIDs: []uint{h1.ID},
+	}))
+
+	listOpts := func(extra ...fleet.ListOptions) fleet.ListOptions {
+		opts := fleet.ListOptions{OrderKey: "id", IncludeMetadata: true}
+		if len(extra) > 0 {
+			if extra[0].PerPage != 0 {
+				opts.PerPage = extra[0].PerPage
+			}
+			if extra[0].Page != 0 {
+				opts.Page = extra[0].Page
+			}
+			if extra[0].MatchQuery != "" {
+				opts.MatchQuery = extra[0].MatchQuery
+			}
+		}
+		return opts
+	}
+
+	t.Run("returns all types by default", func(t *testing.T) {
+		// 8 single-host activities + 2 rows from the dual-host one = 10 rows.
+		activities, meta, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "")
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		require.Len(t, activities, 10)
+		for _, a := range activities {
+			require.NotZero(t, a.HostID)
+		}
+	})
+
+	t.Run("status=error returns only failed types", func(t *testing.T) {
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "error")
+		require.NoError(t, err)
+		require.Len(t, activities, 4)
+		for _, a := range activities {
+			require.Contains(t, a.Type, "failed_")
+		}
+	})
+
+	t.Run("status=success returns only positive types", func(t *testing.T) {
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "success")
+		require.NoError(t, err)
+		// 4 single-host success activities + 2 rows from dual-host = 6
+		require.Len(t, activities, 6)
+		for _, a := range activities {
+			require.NotContains(t, a.Type, "failed_")
+		}
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		activities, meta, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{PerPage: 3}), "")
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		require.Len(t, activities, 3)
+		require.True(t, meta.HasNextResults)
+		require.False(t, meta.HasPreviousResults)
+
+		page2, meta2, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{PerPage: 3, Page: 1}), "")
+		require.NoError(t, err)
+		require.NotNil(t, meta2)
+		require.Len(t, page2, 3)
+		require.True(t, meta2.HasPreviousResults)
+	})
+
+	t.Run("host name query filters rows", func(t *testing.T) {
+		// "host-alpha" matches h1 only.
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{MatchQuery: "host-alpha"}), "")
+		require.NoError(t, err)
+		require.NotEmpty(t, activities)
+		for _, a := range activities {
+			require.Equal(t, h1.ID, a.HostID)
+			require.Equal(t, "host-alpha", a.HostDisplayName)
+		}
+		// "host-b" matches h2 only.
+		activities, _, err = ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{MatchQuery: "host-b"}), "")
+		require.NoError(t, err)
+		require.NotEmpty(t, activities)
+		for _, a := range activities {
+			require.Equal(t, h2.ID, a.HostID)
+		}
+	})
+
+	t.Run("other policy activities excluded", func(t *testing.T) {
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, otherPolicy.ID, adminFilter, listOpts(), "")
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+		require.Equal(t, h1.ID, activities[0].HostID)
+	})
+
+	t.Run("invalid order_key returns error", func(t *testing.T) {
+		_, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, fleet.ListOptions{OrderKey: "invalid_column"}, "")
+		require.Error(t, err)
+	})
+
+	t.Run("include_metadata false returns nil meta", func(t *testing.T) {
+		opts := fleet.ListOptions{OrderKey: "id", IncludeMetadata: false}
+		_, meta, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, opts, "")
+		require.NoError(t, err)
+		require.Nil(t, meta)
+	})
+
+	t.Run("query with wildcard characters matches literally", func(t *testing.T) {
+		// host-alpha has no '_' in its name; a query of "host_alpha" must NOT match
+		// it (the underscore is a literal character, not a SQL wildcard).
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{MatchQuery: "host_alpha"}), "")
+		require.NoError(t, err)
+		require.Empty(t, activities)
+	})
+
+	t.Run("team filter scopes hosts", func(t *testing.T) {
+		// Use a dedicated policy so activities seeded here don't affect count
+		// assertions in other subtests.
+		teamScopePolicy, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{Name: "team-scope-policy", Query: "SELECT 3"})
+		require.NoError(t, err)
+		require.NotNil(t, teamScopePolicy)
+
+		// Create two teams and assign one host to each.
+		teamA, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-A"})
+		require.NoError(t, err)
+		teamB, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-B"})
+		require.NoError(t, err)
+
+		hA := test.NewHost(t, ds, "host-team-a", "10.0.0.1", "keyA", "uuidA", time.Now())
+		hB := test.NewHost(t, ds, "host-team-b", "10.0.0.2", "keyB", "uuidB", time.Now())
+		// Assign hosts to teams directly to avoid policy-membership side-effects.
+		_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET team_id = ? WHERE id = ?`, teamA.ID, hA.ID)
+		require.NoError(t, err)
+		_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET team_id = ? WHERE id = ?`, teamB.ID, hB.ID)
+		require.NoError(t, err)
+
+		// Seed activities for both hosts on the dedicated policy.
+		for _, typ := range errorTypes {
+			require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+				name:    typ,
+				details: makeDetails(teamScopePolicy.ID),
+				hostIDs: []uint{hA.ID, hB.ID},
+			}))
+		}
+
+		// A team-A observer filter sees only hA.
+		filterA := fleet.TeamFilter{
+			User: &fleet.User{
+				Teams: []fleet.UserTeam{{Team: fleet.Team{ID: teamA.ID}, Role: fleet.RoleObserver}},
+			},
+			IncludeObserver: true,
+		}
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, teamScopePolicy.ID, filterA, listOpts(), "")
+		require.NoError(t, err)
+		require.NotEmpty(t, activities)
+		for _, a := range activities {
+			require.Equal(t, hA.ID, a.HostID, "team-A filter must not return host from team-B")
+		}
+	})
+
+	// ── Script-run, software-install and VPP-install branches ─────────────────
+	// Disable FK checks so we can insert result rows without satisfying every
+	// foreign key in the test setup.
+	_, err = ds.writer(ctx).ExecContext(ctx, "SET FOREIGN_KEY_CHECKS=0")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = ds.writer(ctx).ExecContext(ctx, "SET FOREIGN_KEY_CHECKS=1")
+	}()
+
+	// ── ran_script ────────────────────────────────────────────────────────────
+	scriptSuccessExecID := "script-success-exec-1"
+	scriptFailureExecID := "script-failure-exec-1"
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO host_script_results (host_id, execution_id, output, exit_code, policy_id)
+         VALUES (?, ?, 'script ok output', 0, ?), (?, ?, 'script fail output', 1, ?)`,
+		h1.ID, scriptSuccessExecID, policy.ID,
+		h1.ID, scriptFailureExecID, policy.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "ran_script",
+		details: map[string]any{"script_execution_id": scriptSuccessExecID, "script_name": "my-script.sh"},
+		hostIDs: []uint{h1.ID},
+	}))
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "ran_script",
+		details: map[string]any{"script_execution_id": scriptFailureExecID, "script_name": "my-script.sh"},
+		hostIDs: []uint{h1.ID},
+	}))
+
+	// ── installed_software ────────────────────────────────────────────────────
+	swSuccessExecID := "sw-success-exec-1"
+	swFailureExecID := "sw-failure-exec-1"
+	// insert_script_exit_code=0 → execution_status='installed'; exit_code=1 → 'failed_install'
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO host_software_installs
+            (host_id, execution_id, software_installer_id, install_script_exit_code,
+             install_script_output, pre_install_query_output, post_install_script_output, policy_id)
+         VALUES
+            (?, ?, 1, 0, 'install ok', 'pre ok', 'post ok', ?),
+            (?, ?, 1, 1, 'install fail', 'pre fail', 'post fail', ?)`,
+		h1.ID, swSuccessExecID, policy.ID,
+		h1.ID, swFailureExecID, policy.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "installed_software",
+		details: map[string]any{"install_uuid": swSuccessExecID, "software_title": "My Software"},
+		hostIDs: []uint{h1.ID},
+	}))
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "installed_software",
+		details: map[string]any{"install_uuid": swFailureExecID, "software_title": "My Software"},
+		hostIDs: []uint{h1.ID},
+	}))
+
+	// ── installed_app_store_app (VPP) ─────────────────────────────────────────
+	vppSuccessCmdUUID := "vpp-success-cmd-1"
+	vppFailureCmdUUID := "vpp-failure-cmd-1"
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO host_vpp_software_installs (host_id, adam_id, command_uuid, policy_id, platform, verification_at)
+         VALUES (?, 'A001', ?, ?, 'darwin', NOW())`,
+		h1.ID, vppSuccessCmdUUID, policy.ID)
+	require.NoError(t, err)
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO host_vpp_software_installs (host_id, adam_id, command_uuid, policy_id, platform, verification_failed_at)
+         VALUES (?, 'A002', ?, ?, 'darwin', NOW())`,
+		h1.ID, vppFailureCmdUUID, policy.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "installed_app_store_app",
+		details: map[string]any{"command_uuid": vppSuccessCmdUUID, "software_title": "My VPP App"},
+		hostIDs: []uint{h1.ID},
+	}))
+	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+		name:    "installed_app_store_app",
+		details: map[string]any{"command_uuid": vppFailureCmdUUID, "software_title": "My VPP App"},
+		hostIDs: []uint{h1.ID},
+	}))
+
+	t.Run("script_software_vpp appear in all", func(t *testing.T) {
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "")
+		require.NoError(t, err)
+		types := make(map[string]int)
+		for _, a := range activities {
+			types[a.Type]++
+		}
+		require.Positive(t, types["ran_script"])
+		require.Positive(t, types["installed_software"])
+		require.Positive(t, types["installed_app_store_app"])
+	})
+
+	t.Run("status=error includes script_software_vpp failures", func(t *testing.T) {
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "error")
+		require.NoError(t, err)
+		types := make(map[string]int)
+		for _, a := range activities {
+			types[a.Type]++
+		}
+		// Named automation failures still present.
+		require.Equal(t, 4, types["failed_automation_webhook"]+
+			types["failed_automation_ticket"]+
+			types["failed_automation_calendar_event"]+
+			types["failed_automation_conditional_access"])
+		// Script/software/VPP failures present.
+		require.Positive(t, types["ran_script"])
+		require.Positive(t, types["installed_software"])
+		require.Positive(t, types["installed_app_store_app"])
+	})
+
+	t.Run("status=success includes script_software_vpp successes", func(t *testing.T) {
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "success")
+		require.NoError(t, err)
+		types := make(map[string]int)
+		for _, a := range activities {
+			types[a.Type]++
+		}
+		// Named automation successes still present.
+		require.Positive(t, types["ran_automation_webhook"]+
+			types["ran_automation_ticket"]+
+			types["ran_automation_calendar_event"]+
+			types["ran_automation_conditional_access"])
+		// Script/software/VPP successes present.
+		require.Positive(t, types["ran_script"])
+		require.Positive(t, types["installed_software"])
+		require.Positive(t, types["installed_app_store_app"])
+	})
+
+	t.Run("task activities are independent of policy_membership", func(t *testing.T) {
+		// Modifying a policy's query or targets wipes/prunes policy_membership.
+		// Automation history must survive that, so deleting all membership rows
+		// for the policy must not drop the script/software/VPP activities.
+		_, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM policy_membership WHERE policy_id = ?`, policy.ID)
+		require.NoError(t, err)
+
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "")
+		require.NoError(t, err)
+		types := make(map[string]int)
+		for _, a := range activities {
+			types[a.Type]++
+		}
+		require.Positive(t, types["ran_script"])
+		require.Positive(t, types["installed_software"])
+		require.Positive(t, types["installed_app_store_app"])
+	})
+
+	t.Run("status and output are populated per activity", func(t *testing.T) {
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "")
+		require.NoError(t, err)
+
+		var sawScriptSuccess, sawScriptFailure bool
+		var sawSwSuccess, sawSwFailure bool
+		var sawVPPSuccess, sawVPPFailure bool
+		var sawNamedError, sawNamedSuccess bool
+
+		// detailsValue extracts a string field from an activity's details blob.
+		detailsValue := func(a *fleet.PolicyAutomationActivity, key string) string {
+			require.NotNil(t, a.Details, "type %s missing details", a.Type)
+			var m map[string]any
+			require.NoError(t, json.Unmarshal(*a.Details, &m))
+			s, _ := m[key].(string)
+			return s
+		}
+
+		for _, a := range activities {
+			// Every activity carries an explicit error/success status.
+			require.Contains(t, []string{"error", "success"}, a.Status, "type %s", a.Type)
+
+			switch a.Type {
+			case "ran_script":
+				// Scripts always carry output; the script name comes through in
+				// the details blob.
+				require.NotNil(t, a.Output)
+				require.Equal(t, "my-script.sh", detailsValue(a, "script_name"))
+				if a.Status == "success" {
+					sawScriptSuccess = true
+					require.Equal(t, "script ok output", *a.Output)
+				} else {
+					sawScriptFailure = true
+					require.Equal(t, "script fail output", *a.Output)
+				}
+			case "installed_software":
+				// Software installs carry the install-script output; the software
+				// title comes through in the details blob.
+				require.NotNil(t, a.Output)
+				require.Equal(t, "My Software", detailsValue(a, "software_title"))
+				if a.Status == "success" {
+					sawSwSuccess = true
+					require.Equal(t, "install ok", *a.Output)
+				} else {
+					sawSwFailure = true
+					require.Equal(t, "install fail", *a.Output)
+				}
+			case "installed_app_store_app":
+				// VPP apps are installed via MDM command, so there is no output;
+				// the software title comes through in the details blob.
+				require.Nil(t, a.Output)
+				require.Equal(t, "My VPP App", detailsValue(a, "software_title"))
+				if a.Status == "success" {
+					sawVPPSuccess = true
+				} else {
+					sawVPPFailure = true
+				}
+			default:
+				// Named automation activities encode outcome in the type and have
+				// no output.
+				require.Nil(t, a.Output)
+				if strings.HasPrefix(a.Type, "failed_") {
+					sawNamedError = true
+					require.Equal(t, "error", a.Status)
+				} else {
+					sawNamedSuccess = true
+					require.Equal(t, "success", a.Status)
+				}
+			}
+		}
+
+		require.True(t, sawScriptSuccess, "expected a successful ran_script")
+		require.True(t, sawScriptFailure, "expected a failed ran_script")
+		require.True(t, sawSwSuccess, "expected a successful installed_software")
+		require.True(t, sawSwFailure, "expected a failed installed_software")
+		require.True(t, sawVPPSuccess, "expected a successful installed_app_store_app")
+		require.True(t, sawVPPFailure, "expected a failed installed_app_store_app")
+		require.True(t, sawNamedError, "expected a failed named automation")
+		require.True(t, sawNamedSuccess, "expected a successful named automation")
+	})
 }

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -2436,6 +2436,7 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 		require.Len(t, activities, 6)
 		for _, a := range activities {
 			require.NotContains(t, a.Type, "failed_")
+			require.Contains(t, successTypes, a.Type)
 		}
 	})
 
@@ -2455,18 +2456,18 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 	})
 
 	t.Run("host name query filters rows", func(t *testing.T) {
-		// "host-alpha" matches h1 only.
+		// "host-alpha" matches h1 only: 4 error + 4 success + 1 dual-host row = 9.
 		activities, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{MatchQuery: "host-alpha"}), "")
 		require.NoError(t, err)
-		require.NotEmpty(t, activities)
+		require.Len(t, activities, 9)
 		for _, a := range activities {
 			require.Equal(t, h1.ID, a.HostID)
 			require.Equal(t, "host-alpha", a.HostDisplayName)
 		}
-		// "host-b" matches h2 only.
+		// "host-b" matches h2 only, which appears in just the dual-host activity.
 		activities, _, err = ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{MatchQuery: "host-b"}), "")
 		require.NoError(t, err)
-		require.NotEmpty(t, activities)
+		require.Len(t, activities, 1)
 		for _, a := range activities {
 			require.Equal(t, h2.ID, a.HostID)
 		}

--- a/server/fleet/api_policies.go
+++ b/server/fleet/api_policies.go
@@ -281,3 +281,42 @@ type ModifyTeamPolicyResponse struct {
 }
 
 func (r ModifyTeamPolicyResponse) Error() error { return r.Err }
+
+/////////////////////////////////////////////////////////////////////////////////
+// Policy Automation Activities - List
+/////////////////////////////////////////////////////////////////////////////////
+
+// PolicyAutomationActivity is a fleet.Activity enriched with the host it
+// belongs to, as recorded in activity_host_past.
+type PolicyAutomationActivity struct {
+	Activity
+	HostID          uint   `json:"host_id" db:"host_id"`
+	HostDisplayName string `json:"host_display_name" db:"host_display_name"`
+	// Status is the outcome of the activity: "error" or "success". It is set for
+	// every activity, including the named automations (webhook/ticket/calendar/CA)
+	// whose outcome is otherwise only encoded in the activity type.
+	Status string `json:"status" db:"status"`
+	// Output is the combined script output for ran_script activities and the
+	// install-script output for installed_software activities. It is null for
+	// named automation and VPP (installed_app_store_app) activities, which carry
+	// no script output.
+	Output *string `json:"output" db:"output"`
+}
+
+// ListPolicyAutomationActivitiesRequest is the request type for
+// GET /api/_version_/fleet/policies/{policy_id}/automation_activities.
+type ListPolicyAutomationActivitiesRequest struct {
+	PolicyID uint        `url:"policy_id"`
+	Opts     ListOptions `url:"list_options"`
+	// Status filters by outcome: "error" (failed_* types), "success" (positive
+	// types), or empty (all types). Any other value returns HTTP 422.
+	Status string `query:"status,optional"`
+}
+
+type ListPolicyAutomationActivitiesResponse struct {
+	Activities []*PolicyAutomationActivity `json:"activities"`
+	Meta       *PaginationMetadata         `json:"meta"`
+	Err        error                       `json:"error,omitempty"`
+}
+
+func (r ListPolicyAutomationActivitiesResponse) Error() error { return r.Err }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -937,6 +937,7 @@ type Datastore interface {
 	NewGlobalPolicy(ctx context.Context, authorID *uint, args PolicyPayload) (*Policy, error)
 	Policy(ctx context.Context, id uint) (*Policy, error)
 	PolicyLite(ctx context.Context, id uint) (*PolicyLite, error)
+	ListPolicyAutomationActivities(ctx context.Context, policyID uint, filter TeamFilter, opts ListOptions, status string) ([]*PolicyAutomationActivity, *PaginationMetadata, error)
 
 	// SavePolicy updates some fields of the given policy on the datastore.
 	//

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -746,6 +746,7 @@ type Service interface {
 	ModifyGlobalPolicy(ctx context.Context, id uint, p ModifyPolicyPayload) (*Policy, error)
 	GetPolicyByID(ctx context.Context, policyID uint) (*Policy, error)
 	ResetPolicy(ctx context.Context, policyID uint) error
+	ListPolicyAutomationActivities(ctx context.Context, policyID uint, opts ListOptions, status string) ([]*PolicyAutomationActivity, *PaginationMetadata, error)
 	ApplyPolicySpecs(ctx context.Context, policies []*PolicySpec) error
 	CountGlobalPolicies(ctx context.Context, matchQuery string) (int, error)
 	AutofillPolicySql(ctx context.Context, sql string) (description string, resolution string, err error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -672,6 +672,8 @@ type PolicyFunc func(ctx context.Context, id uint) (*fleet.Policy, error)
 
 type PolicyLiteFunc func(ctx context.Context, id uint) (*fleet.PolicyLite, error)
 
+type ListPolicyAutomationActivitiesFunc func(ctx context.Context, policyID uint, filter fleet.TeamFilter, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error)
+
 type SavePolicyFunc func(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error
 
 type ResetPolicyFunc func(ctx context.Context, policyID uint) error
@@ -3056,6 +3058,9 @@ type DataStore struct {
 
 	PolicyLiteFunc        PolicyLiteFunc
 	PolicyLiteFuncInvoked bool
+
+	ListPolicyAutomationActivitiesFunc        ListPolicyAutomationActivitiesFunc
+	ListPolicyAutomationActivitiesFuncInvoked bool
 
 	SavePolicyFunc        SavePolicyFunc
 	SavePolicyFuncInvoked bool
@@ -7444,6 +7449,13 @@ func (s *DataStore) PolicyLite(ctx context.Context, id uint) (*fleet.PolicyLite,
 	s.PolicyLiteFuncInvoked = true
 	s.mu.Unlock()
 	return s.PolicyLiteFunc(ctx, id)
+}
+
+func (s *DataStore) ListPolicyAutomationActivities(ctx context.Context, policyID uint, filter fleet.TeamFilter, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+	s.mu.Lock()
+	s.ListPolicyAutomationActivitiesFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListPolicyAutomationActivitiesFunc(ctx, policyID, filter, opts, status)
 }
 
 func (s *DataStore) SavePolicy(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -464,6 +464,8 @@ type GetPolicyByIDFunc func(ctx context.Context, policyID uint) (*fleet.Policy, 
 
 type ResetPolicyFunc func(ctx context.Context, policyID uint) error
 
+type ListPolicyAutomationActivitiesFunc func(ctx context.Context, policyID uint, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error)
+
 type ApplyPolicySpecsFunc func(ctx context.Context, policies []*fleet.PolicySpec) error
 
 type CountGlobalPoliciesFunc func(ctx context.Context, matchQuery string) (int, error)
@@ -1608,6 +1610,9 @@ type Service struct {
 
 	ResetPolicyFunc        ResetPolicyFunc
 	ResetPolicyFuncInvoked bool
+
+	ListPolicyAutomationActivitiesFunc        ListPolicyAutomationActivitiesFunc
+	ListPolicyAutomationActivitiesFuncInvoked bool
 
 	ApplyPolicySpecsFunc        ApplyPolicySpecsFunc
 	ApplyPolicySpecsFuncInvoked bool
@@ -3881,6 +3886,13 @@ func (s *Service) ResetPolicy(ctx context.Context, policyID uint) error {
 	s.ResetPolicyFuncInvoked = true
 	s.mu.Unlock()
 	return s.ResetPolicyFunc(ctx, policyID)
+}
+
+func (s *Service) ListPolicyAutomationActivities(ctx context.Context, policyID uint, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+	s.mu.Lock()
+	s.ListPolicyAutomationActivitiesFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListPolicyAutomationActivitiesFunc(ctx, policyID, opts, status)
 }
 
 func (s *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.PolicySpec) error {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -349,6 +349,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/policies/count", countGlobalPoliciesEndpoint, fleet.CountGlobalPoliciesRequest{})
 	ue.EndingAtVersion("v1").GET("/api/_version_/fleet/global/policies/{policy_id}", getPolicyByIDEndpoint, fleet.GetPolicyByIDRequest{})
 	ue.StartingAtVersion("2022-04").GET("/api/_version_/fleet/policies/{policy_id}", getPolicyByIDEndpoint, fleet.GetPolicyByIDRequest{})
+	ue.StartingAtVersion("2022-04").GET("/api/_version_/fleet/policies/{policy_id}/automation_activities", listPolicyAutomationActivitiesEndpoint, fleet.ListPolicyAutomationActivitiesRequest{})
 	ue.EndingAtVersion("v1").POST("/api/_version_/fleet/global/policies/delete", deleteGlobalPoliciesEndpoint, fleet.DeleteGlobalPoliciesRequest{})
 	ue.StartingAtVersion("2022-04").POST("/api/_version_/fleet/policies/delete", deleteGlobalPoliciesEndpoint, fleet.DeleteGlobalPoliciesRequest{})
 	ue.EndingAtVersion("v1").PATCH("/api/_version_/fleet/global/policies/{policy_id}", modifyGlobalPolicyEndpoint, fleet.ModifyGlobalPolicyRequest{})

--- a/server/service/policies.go
+++ b/server/service/policies.go
@@ -2,11 +2,17 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
+
+// maxPolicyAutomationActivitiesPerPage is the upper bound for per_page on the
+// list-policy-automation-activities endpoint.
+const maxPolicyAutomationActivitiesPerPage = 10_000
 
 /////////////////////////////////////////////////////////////////////////////////
 // Get policy by id.
@@ -101,4 +107,63 @@ func (svc Service) ResetPolicy(ctx context.Context, policyID uint) error {
 		return ctxerr.Wrap(ctx, err, "create activity for policy reset")
 	}
 	return nil
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+// List policy automation activities.
+/////////////////////////////////////////////////////////////////////////////////
+
+func listPolicyAutomationActivitiesEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*fleet.ListPolicyAutomationActivitiesRequest)
+	activities, meta, err := svc.ListPolicyAutomationActivities(ctx, req.PolicyID, req.Opts, req.Status)
+	if err != nil {
+		return fleet.ListPolicyAutomationActivitiesResponse{Err: err}, nil
+	}
+	return fleet.ListPolicyAutomationActivitiesResponse{
+		Activities: activities,
+		Meta:       meta,
+	}, nil
+}
+
+func (svc Service) ListPolicyAutomationActivities(ctx context.Context, policyID uint, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+	policy, err := svc.ds.Policy(ctx, policyID)
+	if err != nil {
+		svc.SkipAuth(ctx)
+		return nil, nil, err
+	}
+
+	if err := svc.authz.Authorize(ctx, policy, fleet.ActionRead); err != nil {
+		return nil, nil, err
+	}
+
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return nil, nil, fleet.ErrNoContext
+	}
+	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
+
+	switch status {
+	case "", "error", "success":
+		// valid
+	default:
+		return nil, nil, fleet.NewInvalidArgumentError("status", `must be "error", "success", or empty`)
+	}
+
+	if opts.PerPage == 0 {
+		opts.PerPage = 50
+	} else if opts.PerPage > maxPolicyAutomationActivitiesPerPage {
+		return nil, nil, fleet.NewInvalidArgumentError("per_page", fmt.Sprintf("must be no greater than %d", maxPolicyAutomationActivitiesPerPage))
+	}
+	if opts.OrderKey == "" {
+		// Default to newest activity first.
+		opts.OrderKey = "created_at"
+		opts.OrderDirection = fleet.OrderDescending
+	}
+	opts.IncludeMetadata = true
+
+	activities, meta, err := svc.ds.ListPolicyAutomationActivities(ctx, policyID, filter, opts, status)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "list policy automation activities")
+	}
+	return activities, meta, nil
 }

--- a/server/service/policies_test.go
+++ b/server/service/policies_test.go
@@ -1,0 +1,192 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListPolicyAutomationActivities(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	globalPolicy := &fleet.Policy{PolicyData: fleet.PolicyData{ID: 1}}
+	teamPolicy := &fleet.Policy{PolicyData: fleet.PolicyData{ID: 2, TeamID: new(uint)}}
+	*teamPolicy.TeamID = 42
+
+	ds.PolicyFunc = func(_ context.Context, id uint) (*fleet.Policy, error) {
+		switch id {
+		case 1:
+			return globalPolicy, nil
+		case 2:
+			return teamPolicy, nil
+		default:
+			return nil, &notFoundError{}
+		}
+	}
+
+	returnedActivities := []*fleet.PolicyAutomationActivity{
+		{HostID: 10, HostDisplayName: "host-a"},
+	}
+	returnedMeta := &fleet.PaginationMetadata{HasNextResults: false}
+
+	ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, _ fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+		return returnedActivities, returnedMeta, nil
+	}
+
+	t.Run("global admin sees global policy", func(t *testing.T) {
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		activities, meta, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "")
+		require.NoError(t, err)
+		require.Equal(t, returnedActivities, activities)
+		require.Equal(t, returnedMeta, meta)
+		require.True(t, ds.ListPolicyAutomationActivitiesFuncInvoked)
+		ds.ListPolicyAutomationActivitiesFuncInvoked = false
+	})
+
+	t.Run("global observer sees global policy", func(t *testing.T) {
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("observer")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "")
+		require.NoError(t, err)
+		ds.ListPolicyAutomationActivitiesFuncInvoked = false
+	})
+
+	t.Run("team observer sees own fleet policy", func(t *testing.T) {
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 42}, Role: fleet.RoleObserver}},
+		}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 2, fleet.ListOptions{}, "")
+		require.NoError(t, err)
+		ds.ListPolicyAutomationActivitiesFuncInvoked = false
+	})
+
+	t.Run("team observer cannot see other fleet policy", func(t *testing.T) {
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 99}, Role: fleet.RoleObserver}},
+		}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 2, fleet.ListOptions{}, "")
+		require.Error(t, err)
+		var forbidden *authz.Forbidden
+		require.ErrorAs(t, err, &forbidden)
+		require.False(t, ds.ListPolicyAutomationActivitiesFuncInvoked)
+	})
+
+	t.Run("policy not found returns 404", func(t *testing.T) {
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 999, fleet.ListOptions{}, "")
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err))
+	})
+
+	t.Run("invalid status returns 422", func(t *testing.T) {
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "invalid")
+		require.Error(t, err)
+		var invErr *fleet.InvalidArgumentError
+		require.ErrorAs(t, err, &invErr)
+	})
+
+	t.Run("status=error passes through to datastore", func(t *testing.T) {
+		var capturedStatus string
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, _ fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			capturedStatus = status
+			return nil, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "error")
+		require.NoError(t, err)
+		require.Equal(t, "error", capturedStatus)
+	})
+
+	t.Run("status=success passes through to datastore", func(t *testing.T) {
+		var capturedStatus string
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, _ fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			capturedStatus = status
+			return nil, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "success")
+		require.NoError(t, err)
+		require.Equal(t, "success", capturedStatus)
+	})
+
+	t.Run("per_page exceeds max returns 422", func(t *testing.T) {
+		ds.ListPolicyAutomationActivitiesFuncInvoked = false
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{PerPage: maxPolicyAutomationActivitiesPerPage + 1}, "")
+		require.Error(t, err)
+		var invErr *fleet.InvalidArgumentError
+		require.ErrorAs(t, err, &invErr)
+		require.False(t, ds.ListPolicyAutomationActivitiesFuncInvoked)
+	})
+
+	t.Run("per_page defaults to 50 when unset", func(t *testing.T) {
+		var capturedOpts fleet.ListOptions
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, opts fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			capturedOpts = opts
+			return nil, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "")
+		require.NoError(t, err)
+		require.Equal(t, uint(50), capturedOpts.PerPage)
+	})
+
+	t.Run("per_page at max is accepted", func(t *testing.T) {
+		var capturedOpts fleet.ListOptions
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, opts fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			capturedOpts = opts
+			return nil, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{PerPage: maxPolicyAutomationActivitiesPerPage}, "")
+		require.NoError(t, err)
+		require.Equal(t, uint(maxPolicyAutomationActivitiesPerPage), capturedOpts.PerPage)
+	})
+
+	t.Run("match_query passes through to datastore via opts", func(t *testing.T) {
+		var capturedOpts fleet.ListOptions
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, opts fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			capturedOpts = opts
+			return nil, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{MatchQuery: "my-host"}, "")
+		require.NoError(t, err)
+		require.Equal(t, "my-host", capturedOpts.MatchQuery)
+	})
+
+	t.Run("order defaults to created_at descending when omitted", func(t *testing.T) {
+		var capturedOpts fleet.ListOptions
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, opts fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			capturedOpts = opts
+			return nil, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "")
+		require.NoError(t, err)
+		require.Equal(t, "created_at", capturedOpts.OrderKey)
+		require.Equal(t, fleet.OrderDescending, capturedOpts.OrderDirection)
+	})
+
+	t.Run("team filter carries viewer user to datastore", func(t *testing.T) {
+		user := &fleet.User{
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 42}, Role: fleet.RoleObserver}},
+		}
+		var capturedFilter fleet.TeamFilter
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, filter fleet.TeamFilter, _ fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			capturedFilter = filter
+			return nil, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: user})
+		_, _, err := svc.ListPolicyAutomationActivities(userCtx, 2, fleet.ListOptions{}, "")
+		require.NoError(t, err)
+		require.Equal(t, user, capturedFilter.User)
+		require.True(t, capturedFilter.IncludeObserver)
+	})
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Closes #46902

Returns a paginated list of policy automation activities for a given policy.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to list and view automation activities associated with a specific policy, including support for filtering results by activity status (success or error) and pagination options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->