### PR TITLE
validate label scoping on fleet free unassigned

### DIFF
--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -37,6 +37,7 @@ var (
 	CantEnablePINRequiredIfDiskEncryptionEnabled = "Couldn't enable BitLocker PIN requirement, you must enable disk encryption first."
 	CantResendAppleDeclarationProfilesMessage    = "Can't resend declaration (DDM) profiles. Unlike configuration profiles (.mobileconfig), the host automatically checks in to get the latest DDM profiles."
 	CantAddSoftwareConflictMessage               = "Couldn't add software. %s already has an installer available for the %s fleet."
+	ConfigProfileLabelScopingPremiumCauseMsg     = "Scoping configuration profiles with labels"
 )
 
 // ErrWithStatusCode is an interface for errors that should set a specific HTTP
@@ -233,9 +234,17 @@ func (e *OTAForbiddenError) IsClientError() bool {
 // licenseError is returned when the application is not properly licensed.
 type licenseError struct {
 	ErrorWithUUID
+	cause *string
+}
+
+func NewLicenseErrorWithCause(cause string) *licenseError {
+	return &licenseError{cause: &cause}
 }
 
 func (e *licenseError) Error() string {
+	if e.cause != nil {
+		return fmt.Sprintf("%s requires Fleet Premium license", *e.cause)
+	}
 	return "Requires Fleet Premium license"
 }
 

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -241,6 +241,11 @@ func NewLicenseErrorWithCause(cause string) *licenseError {
 	return &licenseError{cause: &cause}
 }
 
+func (e *licenseError) Is(target error) bool {
+	_, ok := target.(*licenseError)
+	return ok
+}
+
 func (e *licenseError) Error() string {
 	if e.cause != nil {
 		return fmt.Sprintf("%s requires Fleet Premium license", *e.cause)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -890,6 +890,11 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 		}
 		teamName = tm.Name
 	}
+	if len(labelsInclude) > 0 || len(labelsExcludeAny) > 0 {
+		if lic == nil || !lic.IsPremium() {
+			return nil, ctxerr.Wrap(ctx, fleet.NewLicenseErrorWithCause(fleet.ConfigProfileLabelScopingPremiumCauseMsg), "checking license for declaration profile label scoping")
+		}
+	}
 
 	if overlap := fleet.ProfileLabelOverlap(labelsInclude, labelsExcludeAny); overlap != "" {
 		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("labels", fmt.Sprintf("label %q cannot appear in both include and exclude lists", overlap)))

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -379,9 +379,13 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, d
 		return nil, ctxerr.Wrap(ctx, err)
 	}
 
+	lic, err := svc.License(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "checking license")
+	}
+
 	var teamName string
 	if teamID > 0 {
-		lic, _ := license.FromContext(ctx)
 		if lic == nil || !lic.IsPremium() {
 			return nil, ctxerr.Wrap(ctx, fleet.ErrMissingLicense)
 		}
@@ -390,6 +394,12 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, d
 			return nil, ctxerr.Wrap(ctx, err)
 		}
 		teamName = tm.Name
+	}
+
+	if len(labelsInclude) > 0 || len(labelsExcludeAny) > 0 {
+		if lic == nil || !lic.IsPremium() {
+			return nil, ctxerr.Wrap(ctx, fleet.NewLicenseErrorWithCause(fleet.ConfigProfileLabelScopingPremiumCauseMsg), "checking license for profile label scoping")
+		}
 	}
 
 	// Check for secrets in profile name before expansion
@@ -401,12 +411,6 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, d
 	expanded, secretsUpdatedAt, err := svc.ds.ExpandEmbeddedSecretsAndUpdatedAt(ctx, string(data))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", err.Error()))
-	}
-
-	// Get license for validation
-	lic, err := svc.License(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "checking license")
 	}
 
 	groupedCAs, err := svc.ds.GetGroupedCertificateAuthorities(ctx, true)

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -834,11 +834,11 @@ func TestNewMDMAppleConfigProfile(t *testing.T) {
 	svc, ctx, _, _ = setup(t, &fleet.LicenseInfo{Tier: fleet.TierFree}, "identifier")
 	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, []string{"test-label"}, fleet.LabelsIncludeAll, nil)
 	require.ErrorIs(t, err, fleet.ErrMissingLicense)
-	require.ErrorContains(t, err, "requires Fleet Premium license")
+	require.ErrorContains(t, err, "Scoping configuration profiles")
 
 	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, []string{"test-label"})
 	require.ErrorIs(t, err, fleet.ErrMissingLicense)
-	require.ErrorContains(t, err, "requires Fleet Premium license")
+	require.ErrorContains(t, err, "Scoping configuration profiles")
 
 	// succeeds without labels on free license
 	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
@@ -900,11 +900,13 @@ func TestNewMDMAppleDeclarationFreeLicenseLabels(t *testing.T) {
 
 	b := declBytesForTest("D1", "d1content")
 
-	_, err := svc.NewMDMAppleDeclaration(ctx, 1, b, []string{"label-1"}, "name", fleet.LabelsIncludeAll, nil)
-	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
+	_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, []string{"label-1"}, "name", fleet.LabelsIncludeAll, nil)
+	require.ErrorIs(t, err, fleet.ErrMissingLicense)
+	require.ErrorContains(t, err, "Scoping configuration profile")
 
-	_, err = svc.NewMDMAppleDeclaration(ctx, 1, b, nil, "name", fleet.LabelsIncludeAll, []string{"label-1"})
-	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
+	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, []string{"label-1"})
+	require.ErrorIs(t, err, fleet.ErrMissingLicense)
+	require.ErrorContains(t, err, "Scoping configuration profile")
 }
 
 func TestNewMDMAppleDeclaration(t *testing.T) {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -786,25 +786,32 @@ func TestMDMAppleConfigProfileAuthz(t *testing.T) {
 }
 
 func TestNewMDMAppleConfigProfile(t *testing.T) {
-	svc, ctx, ds, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
-	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
-
 	identifier := "Bar.$FLEET_VAR_HOST_END_USER_EMAIL_IDP"
-	mcBytes := mcBytesForTest("Foo", identifier, "UUID")
+	setup := func(t *testing.T, license *fleet.LicenseInfo, identifier string) (fleet.Service, context.Context, *mock.Store, *TestServerOpts) {
+		svc, ctx, ds, _ := setupAppleMDMService(t, license)
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
 
-	ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAppleConfigProfile, usesVars []fleet.FleetVarName) (*fleet.MDMAppleConfigProfile, error) {
-		require.Equal(t, "Foo", cp.Name)
-		assert.Equal(t, identifier, cp.Identifier)
-		require.Equal(t, mcBytes, []byte(cp.Mobileconfig))
-		return &cp, nil
+		mcBytes := mcBytesForTest("Foo", identifier, "UUID")
+
+		ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAppleConfigProfile, usesVars []fleet.FleetVarName) (*fleet.MDMAppleConfigProfile, error) {
+			require.Equal(t, "Foo", cp.Name)
+			assert.Equal(t, identifier, cp.Identifier)
+			require.Equal(t, mcBytes, []byte(cp.Mobileconfig))
+			return &cp, nil
+		}
+		ds.BulkSetPendingMDMHostProfilesFunc = func(ctx context.Context, hids, tids []uint, puuids, uuids []string,
+		) (updates fleet.MDMProfilesUpdates, err error) {
+			return fleet.MDMProfilesUpdates{}, nil
+		}
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
+
+		return svc, ctx, ds, nil
 	}
-	ds.BulkSetPendingMDMHostProfilesFunc = func(ctx context.Context, hids, tids []uint, puuids, uuids []string,
-	) (updates fleet.MDMProfilesUpdates, err error) {
-		return fleet.MDMProfilesUpdates{}, nil
-	}
-	ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
-		return &fleet.GroupedCertificateAuthorities{}, nil
-	}
+
+	svc, ctx, _, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium}, identifier)
+	mcBytes := mcBytesForTest("Foo", identifier, "UUID")
 
 	cp, err := svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
 	require.NoError(t, err)
@@ -821,6 +828,16 @@ func TestNewMDMAppleConfigProfile(t *testing.T) {
 	mcBytes = mcBytesForTest("Profile $FLEET_SECRET_PASSWORD", "test.identifier", "UUID")
 	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
 	assert.ErrorContains(t, err, "PayloadDisplayName cannot contain FLEET_SECRET variables")
+
+	// Fails on free license with labels
+	mcBytes = mcBytesForTest("Foo", "identifier", "UUID")
+	svc, ctx, _, _ = setup(t, &fleet.LicenseInfo{Tier: fleet.TierFree}, "identifier")
+	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, []string{"test-label"}, fleet.LabelsIncludeAll, nil)
+	require.ErrorContains(t, err, "requires Fleet Premium license")
+
+	// succeeds without labels on free license
+	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+	require.NoError(t, err)
 }
 
 func mcBytesForTest(name, identifier, uuid string) []byte {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -833,6 +833,11 @@ func TestNewMDMAppleConfigProfile(t *testing.T) {
 	mcBytes = mcBytesForTest("Foo", "identifier", "UUID")
 	svc, ctx, _, _ = setup(t, &fleet.LicenseInfo{Tier: fleet.TierFree}, "identifier")
 	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, []string{"test-label"}, fleet.LabelsIncludeAll, nil)
+	require.ErrorIs(t, err, fleet.ErrMissingLicense)
+	require.ErrorContains(t, err, "requires Fleet Premium license")
+
+	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, []string{"test-label"})
+	require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	require.ErrorContains(t, err, "requires Fleet Premium license")
 
 	// succeeds without labels on free license
@@ -886,6 +891,19 @@ func TestNewMDMAppleDeclarationFreeLicenseTeam(t *testing.T) {
 	b := declBytesForTest("D1", "d1content")
 
 	_, err := svc.NewMDMAppleDeclaration(ctx, 1, b, nil, "name", fleet.LabelsIncludeAll, nil)
+	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
+}
+
+func TestNewMDMAppleDeclarationFreeLicenseLabels(t *testing.T) {
+	svc, ctx, _, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierFree})
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+	b := declBytesForTest("D1", "d1content")
+
+	_, err := svc.NewMDMAppleDeclaration(ctx, 1, b, []string{"label-1"}, "name", fleet.LabelsIncludeAll, nil)
+	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
+
+	_, err = svc.NewMDMAppleDeclaration(ctx, 1, b, nil, "name", fleet.LabelsIncludeAll, []string{"label-1"})
 	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
 }
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -789,7 +789,7 @@ func TestNewMDMAppleConfigProfile(t *testing.T) {
 	identifier := "Bar.$FLEET_VAR_HOST_END_USER_EMAIL_IDP"
 	setup := func(t *testing.T, license *fleet.LicenseInfo, identifier string) (fleet.Service, context.Context, *mock.Store, *TestServerOpts) {
 		svc, ctx, ds, _ := setupAppleMDMService(t, license)
-		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
 
 		mcBytes := mcBytesForTest("Foo", identifier, "UUID")
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1852,9 +1852,9 @@ func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint,
 		return nil, ctxerr.Wrap(ctx, err, "check android MDM enabled")
 	}
 
+	lic, _ := license.FromContext(ctx)
 	var teamName string
 	if teamID > 0 {
-		lic, _ := license.FromContext(ctx)
 		if lic == nil || !lic.IsPremium() {
 			return nil, ctxerr.Wrap(ctx, fleet.ErrMissingLicense)
 		}
@@ -1863,6 +1863,12 @@ func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint,
 			return nil, ctxerr.Wrap(ctx, err)
 		}
 		teamName = tm.Name
+	}
+
+	if len(labelsInclude) > 0 || len(labelsExcludeAny) > 0 {
+		if lic == nil || !lic.IsPremium() {
+			return nil, ctxerr.Wrap(ctx, fleet.NewLicenseErrorWithCause(fleet.ConfigProfileLabelScopingPremiumCauseMsg), "checking license for profile label scoping")
+		}
 	}
 
 	cp := fleet.MDMAndroidConfigProfile{
@@ -2126,6 +2132,11 @@ func (svc *Service) BatchSetMDMProfiles(
 		appCfg.MDM.WindowsEnabledAndConfigured = *assumeEnabled
 	}
 
+	lic, err := svc.License(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "checking license")
+	}
+
 	// Process labels first, since we do not need to expand secrets in the profiles for this validation.
 	labels := []string{}
 	for i := range profiles {
@@ -2141,6 +2152,11 @@ func (svc *Service) BatchSetMDMProfiles(
 		labels = append(labels, profiles[i].LabelsIncludeAny...)
 		labels = append(labels, profiles[i].LabelsExcludeAny...)
 	}
+
+	if len(labels) > 0 && lic != nil && !lic.IsPremium() {
+		return ctxerr.Wrap(ctx, fleet.NewLicenseErrorWithCause(fleet.ConfigProfileLabelScopingPremiumCauseMsg), "checking license for profile label scoping")
+	}
+
 	var labelMap map[string]fleet.ConfigurationProfileLabel
 	if !dryRun {
 		labelMap, err = svc.batchValidateProfileLabels(ctx, tmID, labels)
@@ -2198,12 +2214,6 @@ func (svc *Service) BatchSetMDMProfiles(
 
 	if err := svc.validateCrossPlatformProfileNames(ctx, appleProfiles, windowsProfiles, appleDecls, androidProfiles); err != nil {
 		return ctxerr.Wrap(ctx, err, "validating cross-platform profile names")
-	}
-
-	// Get license for validation
-	lic, err := svc.License(ctx)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "checking license")
 	}
 
 	profilesVariablesByIdentifierMap, err := validateFleetVariables(ctx, svc.ds, appCfg, lic, appleProfiles, windowsProfiles, appleDecls)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2153,7 +2153,7 @@ func (svc *Service) BatchSetMDMProfiles(
 		labels = append(labels, profiles[i].LabelsExcludeAny...)
 	}
 
-	if len(labels) > 0 && lic != nil && !lic.IsPremium() {
+	if len(labels) > 0 && (lic == nil || !lic.IsPremium()) {
 		return ctxerr.Wrap(ctx, fleet.NewLicenseErrorWithCause(fleet.ConfigProfileLabelScopingPremiumCauseMsg), "checking license for profile label scoping")
 	}
 

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -3234,12 +3234,12 @@ func TestNewMDMAndroidConfigProfileLicense(t *testing.T) {
 		_, err := svc.NewMDMAndroidConfigProfile(ctx, 0, "profile1", []byte(`{"screenCaptureDisabled": true}`), nil, fleet.LabelsIncludeAll, []string{"label1"})
 		require.Error(t, err)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
-		require.ErrorContains(t, err, "requires Fleet Premium license")
+		require.ErrorContains(t, err, "Scoping configuration profile")
 
 		_, err = svc.NewMDMAndroidConfigProfile(ctx, 0, "profile1", []byte(`{"screenCaptureDisabled": true}`), []string{"label1"}, fleet.LabelsIncludeAll, nil)
 		require.Error(t, err)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
-		require.ErrorContains(t, err, "requires Fleet Premium license")
+		require.ErrorContains(t, err, "Scoping configuration profile")
 	})
 
 	t.Run("profile without labels allowed with free license", func(t *testing.T) {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1956,6 +1956,18 @@ func TestMDMBatchSetProfiles(t *testing.T) {
 			"Fleet variable",
 			true,
 		},
+		{
+			"profiles with labels fails on free license",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			false,
+			nil,
+			nil,
+			[]fleet.MDMProfileBatchPayload{
+				{Name: "N1", Contents: mobileconfigForTest("N1", "I1"), LabelsIncludeAll: []string{"a"}},
+			},
+			"Scoping configuration profiles with labels requires Fleet Premium license",
+			true,
+		},
 	}
 
 	for _, tt := range testCases {
@@ -3124,6 +3136,95 @@ func TestNewMDMProfilePremiumOnlyAndroid(t *testing.T) {
 			require.False(t, ds.NewMDMAndroidConfigProfileFuncInvoked)
 		})
 	}
+}
+
+func TestNewMDMAndroidConfigProfileLicense(t *testing.T) {
+	setup := func(premium bool) (fleet.Service, *mock.Store, context.Context) {
+		ds := new(mock.Store)
+		license := &fleet.LicenseInfo{Tier: fleet.TierFree}
+		if premium {
+			license.Tier = fleet.TierPremium
+		}
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				OrgInfo: fleet.OrgInfo{
+					OrgName: "Foo Inc.",
+				},
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: "https://foo.example.com",
+				},
+				MDM: fleet.MDM{
+					EnabledAndConfigured:        false,
+					WindowsEnabledAndConfigured: false,
+					AndroidEnabledAndConfigured: true,
+				},
+			}, nil
+		}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			return &fleet.Team{ID: 1, Name: name}, nil
+		}
+		ds.TeamWithExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+			return &fleet.Team{ID: id, Name: "team"}, nil
+		}
+		ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, documents []string) error {
+			return nil
+		}
+		ds.ExpandEmbeddedSecretsAndUpdatedAtFunc = func(ctx context.Context, document string) (string, *time.Time, error) {
+			return document, nil, nil
+		}
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
+		ds.NewMDMAndroidConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAndroidConfigProfile) (*fleet.MDMAndroidConfigProfile, error) {
+			return &cp, nil
+		}
+		ds.BulkSetPendingMDMHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs []uint, profileUUIDs, hostUUIDs []string) (updates fleet.MDMProfilesUpdates, err error) {
+			return fleet.MDMProfilesUpdates{}, nil
+		}
+		ds.LabelIDsByNameFunc = func(ctx context.Context, labels []string, filter fleet.TeamFilter) (map[string]uint, error) {
+			m := map[string]uint{}
+			for _, label := range labels {
+				m[label] = uint(len(label)) // dummy ID
+			}
+			return m, nil
+		}
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			m := map[string]*fleet.Label{}
+			for _, name := range names {
+				m[name] = &fleet.Label{
+					ID:   uint(len(name)), // dummy ID
+					Name: name,
+				}
+			}
+			return m, nil
+		}
+
+		return svc, ds, ctx
+	}
+
+	t.Run("labels not allowed with free license", func(t *testing.T) {
+		svc, _, ctx := setup(false)
+		_, err := svc.NewMDMAndroidConfigProfile(ctx, 0, "profile1", []byte(`{"screenCaptureDisabled": true}`), nil, fleet.LabelsIncludeAll, []string{"label1"})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "requires Fleet Premium license")
+	})
+
+	t.Run("profile without labels allowed with free license", func(t *testing.T) {
+		svc, _, ctx := setup(false)
+		profile, err := svc.NewMDMAndroidConfigProfile(ctx, 0, "profile1", []byte(`{"screenCaptureDisabled": true}`), nil, fleet.LabelsIncludeAll, nil)
+		require.NoError(t, err)
+		require.NotNil(t, profile)
+	})
+
+	t.Run("labels allowed with premium license", func(t *testing.T) {
+		svc, _, ctx := setup(true)
+		profile, err := svc.NewMDMAndroidConfigProfile(ctx, 0, "profile1", []byte(`{"screenCaptureDisabled": true}`), nil, fleet.LabelsIncludeAll, []string{"label1"})
+		require.NoError(t, err)
+		require.NotNil(t, profile)
+	})
 }
 
 func TestProcessIncomingMDMCmdsWipeFailedActivity(t *testing.T) {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1958,7 +1958,7 @@ func TestMDMBatchSetProfiles(t *testing.T) {
 		},
 		{
 			"profiles with labels fails on free license",
-			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			&fleet.User{GlobalRole: new(fleet.RoleAdmin)},
 			false,
 			nil,
 			nil,

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1957,13 +1957,37 @@ func TestMDMBatchSetProfiles(t *testing.T) {
 			true,
 		},
 		{
-			"profiles with labels fails on free license",
+			"profiles with include all labels fails on free license",
 			&fleet.User{GlobalRole: new(fleet.RoleAdmin)},
 			false,
 			nil,
 			nil,
 			[]fleet.MDMProfileBatchPayload{
 				{Name: "N1", Contents: mobileconfigForTest("N1", "I1"), LabelsIncludeAll: []string{"a"}},
+			},
+			"Scoping configuration profiles with labels requires Fleet Premium license",
+			true,
+		},
+		{
+			"profiles with include any labels fails on free license",
+			&fleet.User{GlobalRole: new(fleet.RoleAdmin)},
+			false,
+			nil,
+			nil,
+			[]fleet.MDMProfileBatchPayload{
+				{Name: "N1", Contents: mobileconfigForTest("N1", "I1"), LabelsIncludeAny: []string{"a"}},
+			},
+			"Scoping configuration profiles with labels requires Fleet Premium license",
+			true,
+		},
+		{
+			"profiles with exclude labels fails on free license",
+			&fleet.User{GlobalRole: new(fleet.RoleAdmin)},
+			false,
+			nil,
+			nil,
+			[]fleet.MDMProfileBatchPayload{
+				{Name: "N1", Contents: mobileconfigForTest("N1", "I1"), LabelsExcludeAny: []string{"a"}},
 			},
 			"Scoping configuration profiles with labels requires Fleet Premium license",
 			true,
@@ -3209,6 +3233,12 @@ func TestNewMDMAndroidConfigProfileLicense(t *testing.T) {
 		svc, _, ctx := setup(false)
 		_, err := svc.NewMDMAndroidConfigProfile(ctx, 0, "profile1", []byte(`{"screenCaptureDisabled": true}`), nil, fleet.LabelsIncludeAll, []string{"label1"})
 		require.Error(t, err)
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
+		require.ErrorContains(t, err, "requires Fleet Premium license")
+
+		_, err = svc.NewMDMAndroidConfigProfile(ctx, 0, "profile1", []byte(`{"screenCaptureDisabled": true}`), []string{"label1"}, fleet.LabelsIncludeAll, nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "requires Fleet Premium license")
 	})
 

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -32,6 +32,11 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 		return nil, ctxerr.Wrap(ctx, err, "check windows MDM enabled")
 	}
 
+	lic, err := svc.License(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "checking license")
+	}
+
 	var teamName string
 	if teamID > 0 {
 		lic, _ := license.FromContext(ctx)
@@ -43,6 +48,12 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 			return nil, ctxerr.Wrap(ctx, err)
 		}
 		teamName = tm.Name
+	}
+
+	if len(labelsInclude) > 0 || len(labelsExcludeAny) > 0 {
+		if lic == nil || !lic.IsPremium() {
+			return nil, ctxerr.Wrap(ctx, fleet.NewLicenseErrorWithCause(fleet.ConfigProfileLabelScopingPremiumCauseMsg), "checking license for profile label scoping")
+		}
 	}
 
 	cp := fleet.MDMWindowsConfigProfile{
@@ -84,12 +95,6 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 
 	if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{string(cp.SyncML)}); err != nil {
 		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", err.Error()))
-	}
-
-	// Get license for validation
-	lic, err := svc.License(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "checking license")
 	}
 
 	groupedCAs, err := svc.ds.GetGroupedCertificateAuthorities(ctx, true)

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -39,7 +39,6 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 
 	var teamName string
 	if teamID > 0 {
-		lic, _ := license.FromContext(ctx)
 		if lic == nil || !lic.IsPremium() {
 			return nil, ctxerr.Wrap(ctx, fleet.ErrMissingLicense)
 		}

--- a/server/service/windows_mdm_profiles_test.go
+++ b/server/service/windows_mdm_profiles_test.go
@@ -447,3 +447,74 @@ func TestNewMDMWindowsConfigProfileSoftwareUpdate(t *testing.T) {
 		assert.False(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
 	})
 }
+
+func TestNewMDMWindowsConfigProfileLicense(t *testing.T) {
+	// For now this only verifies if labels are blocked on free tier
+	syncML := syncMLForTest("./Device/Vendor/MSFT/Policy/Config/Camera/AllowCamera")
+
+	setup := func(t *testing.T, premium bool) (fleet.Service, context.Context, *mock.Store) {
+		lic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+		if !premium {
+			lic = &fleet.LicenseInfo{Tier: fleet.TierFree}
+		}
+		svc, ctx, ds, _ := setupAppleMDMService(t, lic)
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			ac := &fleet.AppConfig{}
+			ac.MDM.WindowsEnabledAndConfigured = true
+			return ac, nil
+		}
+		ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, documents []string) error {
+			return nil
+		}
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
+		ds.NewMDMWindowsConfigProfileFunc = func(ctx context.Context, cp fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
+			cp.ProfileUUID = "w-profile-uuid"
+			return &cp, nil
+		}
+		ds.LabelIDsByNameFunc = func(ctx context.Context, labels []string, filter fleet.TeamFilter) (map[string]uint, error) {
+			m := make(map[string]uint)
+			for i, label := range labels {
+				m[label] = uint(i + 1)
+			}
+			return m, nil
+		}
+		ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+			m := make(map[string]*fleet.Label)
+			for i, name := range names {
+				m[name] = &fleet.Label{ID: uint(i + 1), Name: name}
+			}
+			return m, nil
+		}
+		return svc, ctx, ds
+	}
+
+	t.Run("labels not allowed on free tier", func(t *testing.T) {
+		svc, ctx, ds := setup(t, false)
+
+		_, err := svc.NewMDMWindowsConfigProfile(ctx, 0, "with-labels", syncML, nil, fleet.LabelsIncludeAll, []string{"label1"})
+		require.ErrorContains(t, err, "requires Fleet Premium license")
+		assert.False(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
+	})
+
+	t.Run("profile without labels allowed on free tier", func(t *testing.T) {
+		svc, ctx, ds := setup(t, false)
+
+		p, err := svc.NewMDMWindowsConfigProfile(ctx, 0, "without-labels", syncML, nil, fleet.LabelsIncludeAll, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+		assert.True(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
+	})
+
+	t.Run("labels allowed on premium tier", func(t *testing.T) {
+		svc, ctx, ds := setup(t, true)
+
+		p, err := svc.NewMDMWindowsConfigProfile(ctx, 0, "with-labels", syncML, nil, fleet.LabelsIncludeAll, []string{"label1"})
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+		assert.True(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
+	})
+}

--- a/server/service/windows_mdm_profiles_test.go
+++ b/server/service/windows_mdm_profiles_test.go
@@ -496,6 +496,12 @@ func TestNewMDMWindowsConfigProfileLicense(t *testing.T) {
 		svc, ctx, ds := setup(t, false)
 
 		_, err := svc.NewMDMWindowsConfigProfile(ctx, 0, "with-labels", syncML, nil, fleet.LabelsIncludeAll, []string{"label1"})
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
+		require.ErrorContains(t, err, "requires Fleet Premium license")
+		assert.False(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
+
+		_, err = svc.NewMDMWindowsConfigProfile(ctx, 0, "with-labels", syncML, []string{"label1"}, fleet.LabelsIncludeAll, nil)
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "requires Fleet Premium license")
 		assert.False(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
 	})

--- a/server/service/windows_mdm_profiles_test.go
+++ b/server/service/windows_mdm_profiles_test.go
@@ -497,12 +497,12 @@ func TestNewMDMWindowsConfigProfileLicense(t *testing.T) {
 
 		_, err := svc.NewMDMWindowsConfigProfile(ctx, 0, "with-labels", syncML, nil, fleet.LabelsIncludeAll, []string{"label1"})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
-		require.ErrorContains(t, err, "requires Fleet Premium license")
+		require.ErrorContains(t, err, "Scoping configuration profile")
 		assert.False(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
 
 		_, err = svc.NewMDMWindowsConfigProfile(ctx, 0, "with-labels", syncML, []string{"label1"}, fleet.LabelsIncludeAll, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
-		require.ErrorContains(t, err, "requires Fleet Premium license")
+		require.ErrorContains(t, err, "Scoping configuration profile")
 		assert.False(t, ds.NewMDMWindowsConfigProfileFuncInvoked)
 	})
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47191

Opted for the following error message: `Scoping configuration profiles with labels requires Fleet Premium license` since only showing `Requires Fleet Premium license` made me think I'm unsure what part specifically requires the license.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced Fleet Premium license for MDM config profile label scoping across Apple, Android, Windows, and batch operations.
* **Bug Fixes**
  * License errors now include the specific feature cause in the message when premium is required and are matchable with standard error checks.
* **Tests**
  * Added and updated tests to verify premium-gating for profile label scoping and related behaviors on free vs. premium tiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->