### PR TITLE
Fleet UI: fix labels unreleased double scroll bug

### DIFF
--- a/frontend/pages/labels/ManageLabelsPage/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/_styles.scss
@@ -1,4 +1,9 @@
 .manage-labels-page {
+  // Opt out of MainContent's `overflow: auto` so the actions dropdown menu
+  // can spill below the page without triggering a second scrollbar on
+  // MainContent. Matches the pattern used by `.admin-wrapper`.
+  overflow: visible;
+
   @include vertical-page-layout;
 
   &__header-wrap {


### PR DESCRIPTION
## Issue
Closes #46812 

## Description
- Fix label double scroll bar unreleased bug

## Screen recording of fix

https://github.com/user-attachments/assets/d88d0899-1c5c-4379-b3c9-5d48b5543147

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed dropdown display on the Manage Labels page to appear without being cut off by page boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->