### PR TITLE
update applebmapi tool with command flag and ability to fetch ADUE service discovery

### DIFF
--- a/tools/mdm/apple/applebmapi/main.go
+++ b/tools/mdm/apple/applebmapi/main.go
@@ -38,7 +38,9 @@ func main() {
 	if *orgName == "" {
 		log.Fatal("must provide -org-name")
 	}
-	if *profileUUID != "" && *serialNum != "" && *command != "" {
+	if (*profileUUID != "" && *serialNum != "") ||
+		(*profileUUID != "" && *command != "") ||
+		(*serialNum != "" && *command != "") {
 		log.Fatal("only one of -profile-uuid, -serial-number, or -command must be provided")
 	}
 

--- a/tools/mdm/apple/applebmapi/main.go
+++ b/tools/mdm/apple/applebmapi/main.go
@@ -24,21 +24,22 @@ import (
 
 func main() {
 	mysqlAddr := flag.String("mysql", "localhost:3306", "mysql address")
-	serverPrivateKey := flag.String("server-private-key", "", "fleet server's private key (to decrypt MDM assets)")
+	serverPrivateKey := flag.String("key", "", "fleet server's private key (to decrypt MDM assets)")
 	profileUUID := flag.String("profile-uuid", "", "the Apple profile UUID to retrieve")
 	serialNum := flag.String("serial-number", "", "serial number of a device to get the device details")
+	command := flag.String("command", "", "the supported command to execute, if not providing profile-uuid or serial-number.")
 	orgName := flag.String("org-name", "", "organization name of the token")
 
 	flag.Parse()
 
 	if *serverPrivateKey == "" {
-		log.Fatal("must provide -server-private-key")
+		log.Fatal("must provide -key")
 	}
 	if *orgName == "" {
 		log.Fatal("must provide -org-name")
 	}
-	if *profileUUID != "" && *serialNum != "" {
-		log.Fatal("only one of -profile-uuid or -serial-number must be provided")
+	if *profileUUID != "" && *serialNum != "" && *command != "" {
+		log.Fatal("only one of -profile-uuid, -serial-number, or -command must be provided")
 	}
 
 	if len(*serverPrivateKey) > 32 {
@@ -85,6 +86,8 @@ func main() {
 		res, err = depClient.GetProfile(ctx, *orgName, *profileUUID)
 	case *serialNum != "":
 		res, err = depClient.GetDeviceDetails(ctx, *orgName, *serialNum)
+	case *command == "adue":
+		res, err = depClient.FetchAccountDrivenEnrollmentServiceDiscovery(ctx, *orgName)
 	default:
 		res, err = depClient.AccountDetail(ctx, *orgName)
 	}


### PR DESCRIPTION
Small tool update to support fetching the service discovery URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `-command` flag to enable a new operation mode; when set to `adue` the CLI performs the account-driven enrollment discovery flow, otherwise it falls back to the existing account detail behavior.

* **Chores**
  * Simplified the server private key flag to `-key`.
  * Strengthened input validation to require both `-key` and `-org-name`.
  * Enforced mutual exclusivity among operation flags (`-profile-uuid`, `-serial-number`, `-command`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->