### PR TITLE
Used user idp card data for android device name

### DIFF
--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -1006,8 +1006,7 @@ func getComputerName(ctx context.Context, ds fleet.Datastore, device *androidman
 	}
 
 	if len(endUsers) > 0 && endUsers[0].IdpFullName != "" {
-		parts := strings.Fields(endUsers[0].IdpFullName)
-		return strings.Join(parts[:max(1, len(parts)-1)], " ") + "'s " + hardwareModel, nil
+		return endUsers[0].IdpFullName + "'s " + hardwareModel, nil
 	}
 
 	var idpAcct *fleet.MDMIdPAccount
@@ -1024,8 +1023,7 @@ func getComputerName(ctx context.Context, ds fleet.Datastore, device *androidman
 
 	if idpAcct != nil {
 		if name := strings.TrimSpace(idpAcct.Fullname); name != "" {
-			parts := strings.Fields(name)
-			return strings.Join(parts[:max(1, len(parts)-1)], " ") + "'s " + hardwareModel, nil
+			return name + "'s " + hardwareModel, nil
 		}
 	}
 

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -729,17 +729,12 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 	}
 	host.Device.DeviceID = deviceID
 
-	var idpFullname string
-	idpAcct, err := svc.fleetDS.GetMDMIdPAccountByHostUUID(ctx, host.Host.UUID)
-	if err != nil && !fleet.IsNotFound(err) {
-		return ctxerr.Wrap(ctx, err, "getting IdP account for host")
+	computerName, err := getComputerName(ctx, svc.fleetDS, device, &host.Host.ID, host.Host.UUID, "")
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting computer name for host")
 	}
-	if idpAcct != nil {
-		idpFullname = idpAcct.Fullname
-	}
-
-	host.Host.ComputerName = getComputerName(device, idpFullname)
-	host.Host.Hostname = getComputerName(device, idpFullname)
+	host.Host.ComputerName = computerName
+	host.Host.Hostname = computerName
 	host.Host.Platform = "android"
 	host.Host.OSVersion = "Android " + device.SoftwareInfo.AndroidVersion
 	host.Host.Build = device.SoftwareInfo.AndroidBuildNumber
@@ -897,22 +892,16 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 
 	gigsTotalDiskSpace, gigsDiskSpaceAvailable, percentDiskSpaceAvailable := svc.calculateAndroidStorageMetrics(ctx, device, false)
 
-	var idpFullname string
-	if enrollmentTokenRequest.IdpUUID != "" {
-		idpAcct, err := svc.ds.GetMDMIdPAccountByUUID(ctx, enrollmentTokenRequest.IdpUUID)
-		if err != nil && !fleet.IsNotFound(err) {
-			return ctxerr.Wrap(ctx, err, "getting IdP account for new host")
-		}
-		if idpAcct != nil {
-			idpFullname = idpAcct.Fullname
-		}
+	computerName, err := getComputerName(ctx, svc.fleetDS, device, nil, "", enrollmentTokenRequest.IdpUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting computer name for new host")
 	}
 
 	host := &fleet.AndroidHost{
 		Host: &fleet.Host{
 			TeamID:                    teamID,
-			ComputerName:              getComputerName(device, idpFullname),
-			Hostname:                  getComputerName(device, idpFullname),
+			ComputerName:              computerName,
+			Hostname:                  computerName,
 			Platform:                  "android",
 			OSVersion:                 "Android " + device.SoftwareInfo.AndroidVersion,
 			Build:                     device.SoftwareInfo.AndroidBuildNumber,
@@ -1001,13 +990,46 @@ func getHardwareModel(device *androidmanagement.Device) string {
 	return cases.Title(language.English, cases.Compact).String(device.HardwareInfo.Brand) + " " + device.HardwareInfo.Model
 }
 
-func getComputerName(device *androidmanagement.Device, idpFullname string) string {
+// Priority: SCIM full name (via GetEndUsers) → IdP fullname (mdm_idp_accounts) → hardware model.
+// For existing hosts pass hostID + hostUUID
+// For new hosts (not yet inserted) pass hostID=nil and enrollmentIdpUUID from the enrollment token.
+func getComputerName(ctx context.Context, ds fleet.Datastore, device *androidmanagement.Device, hostID *uint, hostUUID, enrollmentIdpUUID string) (string, error) {
 	hardwareModel := getHardwareModel(device)
-	name := strings.TrimSpace(idpFullname)
-	if name == "" {
-		return hardwareModel
+
+	var endUsers []fleet.HostEndUser
+	if hostID != nil {
+		var err error
+		endUsers, err = fleet.GetEndUsers(ctx, ds, *hostID)
+		if err != nil {
+			return "", ctxerr.Wrap(ctx, err, "getting end users")
+		}
 	}
-	return name + "'s " + hardwareModel
+
+	if len(endUsers) > 0 && endUsers[0].IdpFullName != "" {
+		parts := strings.Fields(endUsers[0].IdpFullName)
+		return strings.Join(parts[:max(1, len(parts)-1)], " ") + "'s " + hardwareModel, nil
+	}
+
+	var idpAcct *fleet.MDMIdPAccount
+	var err error
+	switch {
+	case hostUUID != "":
+		idpAcct, err = ds.GetMDMIdPAccountByHostUUID(ctx, hostUUID)
+	case enrollmentIdpUUID != "":
+		idpAcct, err = ds.GetMDMIdPAccountByUUID(ctx, enrollmentIdpUUID)
+	}
+	if err != nil && !fleet.IsNotFound(err) {
+		return "", ctxerr.Wrap(ctx, err, "getting IdP account")
+	}
+
+	if idpAcct != nil {
+		if name := strings.TrimSpace(idpAcct.Fullname); name != "" {
+			parts := strings.Fields(name)
+			return strings.Join(parts[:max(1, len(parts)-1)], " ") + "'s " + hardwareModel, nil
+		}
+	}
+
+	return hardwareModel, nil
 }
 
 func (svc *Service) getHostIfPresent(ctx context.Context, enterpriseSpecificID string) (*fleet.AndroidHost, error) {

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -1286,7 +1286,7 @@ func TestUpdateHost(t *testing.T) {
 }
 
 func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
-	t.Run("updateHost uses IdP first name in computer name", func(t *testing.T) {
+	t.Run("updateHost uses IdP fullname when no SCIM user", func(t *testing.T) {
 		svc, mockDS := createAndroidService(t)
 
 		const enterpriseSpecificID = "IDP-TEST-UUID"
@@ -1311,13 +1311,14 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 			}, nil
 		}
 
-		// Mock IdP account lookup to return a user with a full name
+		mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+			return nil, common_mysql.NotFound("scim user")
+		}
+		mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+			return nil, nil
+		}
 		mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
-			return &fleet.MDMIdPAccount{
-				UUID:     "idp-acct-uuid",
-				Fullname: "John Smith",
-				Email:    "ksykulev@test.com",
-			}, nil
+			return &fleet.MDMIdPAccount{Fullname: "John Smith"}, nil
 		}
 
 		var capturedHost *fleet.AndroidHost
@@ -1349,12 +1350,155 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "John Smith's Samsung SM-A176U1", capturedHost.Host.ComputerName)
-		require.Equal(t, "John Smith's Samsung SM-A176U1", capturedHost.Host.Hostname)
+		require.Equal(t, "John's Samsung SM-A176U1", capturedHost.Host.ComputerName)
+		require.Equal(t, "John's Samsung SM-A176U1", capturedHost.Host.Hostname)
 		require.Equal(t, "Samsung SM-A176U1", capturedHost.Host.HardwareModel)
 	})
 
-	t.Run("updateHost falls back to hardware model when no IdP account", func(t *testing.T) {
+	t.Run("updateHost uses SCIM full name over IdP username", func(t *testing.T) {
+		svc, mockDS := createAndroidService(t)
+
+		const enterpriseSpecificID = "SCIM-WINS-UUID"
+
+		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
+			}, nil
+		}
+
+		mockDS.AndroidHostLiteFunc = func(ctx context.Context, esID string) (*fleet.AndroidHost, error) {
+			return &fleet.AndroidHost{
+				Host: &fleet.Host{
+					ID:   3,
+					UUID: enterpriseSpecificID,
+				},
+				Device: &android.Device{
+					HostID:               3,
+					DeviceID:             "device-3",
+					EnterpriseSpecificID: new(enterpriseSpecificID),
+				},
+			}, nil
+		}
+
+		// SCIM user linked — IdpFullName ("Andrey Ivanov") wins over IdP fullname.
+		mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+			givenName := "Andrey"
+			familyName := "Ivanov"
+			return &fleet.ScimUser{
+				UserName:   "andrey.ivanov",
+				GivenName:  &givenName,
+				FamilyName: &familyName,
+			}, nil
+		}
+		mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+			return nil, nil
+		}
+		// GetEndUsers returns IdpFullName="Andrey Ivanov", so GetMDMIdPAccountByHostUUID is never called.
+
+		var capturedHost *fleet.AndroidHost
+		mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
+			capturedHost = host
+			return nil
+		}
+
+		device := androidmanagement.Device{
+			Name: createAndroidDeviceId("test-scim-wins"),
+			HardwareInfo: &androidmanagement.HardwareInfo{
+				EnterpriseSpecificId: enterpriseSpecificID,
+				Brand:                "samsung",
+				Model:                "SM-S906U1",
+			},
+			SoftwareInfo:         &androidmanagement.SoftwareInfo{AndroidVersion: "14"},
+			MemoryInfo:           &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
+			LastStatusReportTime: "2024-01-01T12:00:00Z",
+		}
+
+		deviceBytes, err := json.Marshal(device)
+		require.NoError(t, err)
+		message := &android.PubSubMessage{
+			Attributes: map[string]string{"notificationType": string(android.PubSubStatusReport)},
+			Data:       base64.StdEncoding.EncodeToString(deviceBytes),
+		}
+
+		err = svc.ProcessPubSubPush(t.Context(), "value", message)
+		require.NoError(t, err)
+		require.NotNil(t, capturedHost)
+
+		require.Equal(t, "Andrey's Samsung SM-S906U1", capturedHost.Host.ComputerName)
+		require.Equal(t, "Andrey's Samsung SM-S906U1", capturedHost.Host.Hostname)
+	})
+
+	t.Run("updateHost falls back to IdP fullname when SCIM has no full name", func(t *testing.T) {
+		svc, mockDS := createAndroidService(t)
+
+		const enterpriseSpecificID = "SCIM-NO-GIVEN-UUID"
+
+		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
+			}, nil
+		}
+
+		mockDS.AndroidHostLiteFunc = func(ctx context.Context, esID string) (*fleet.AndroidHost, error) {
+			return &fleet.AndroidHost{
+				Host: &fleet.Host{
+					ID:   4,
+					UUID: enterpriseSpecificID,
+				},
+				Device: &android.Device{
+					HostID:               4,
+					DeviceID:             "device-4",
+					EnterpriseSpecificID: new(enterpriseSpecificID),
+				},
+			}, nil
+		}
+
+		// SCIM user linked but no given_name/family_name — IdpFullName will be empty,
+		// so we fall back to mdm_idp_accounts.Fullname.
+		mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+			return &fleet.ScimUser{UserName: "maria.garcia", GivenName: nil}, nil
+		}
+		mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+			return nil, nil
+		}
+		mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+			return &fleet.MDMIdPAccount{Fullname: "Maria Garcia"}, nil
+		}
+
+		var capturedHost *fleet.AndroidHost
+		mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
+			capturedHost = host
+			return nil
+		}
+
+		device := androidmanagement.Device{
+			Name: createAndroidDeviceId("test-scim-no-given"),
+			HardwareInfo: &androidmanagement.HardwareInfo{
+				EnterpriseSpecificId: enterpriseSpecificID,
+				Brand:                "google",
+				Model:                "Pixel 8",
+			},
+			SoftwareInfo:         &androidmanagement.SoftwareInfo{AndroidVersion: "14"},
+			MemoryInfo:           &androidmanagement.MemoryInfo{TotalRam: int64(8 * 1024 * 1024 * 1024)},
+			LastStatusReportTime: "2024-01-01T12:00:00Z",
+		}
+
+		deviceBytes, err := json.Marshal(device)
+		require.NoError(t, err)
+		message := &android.PubSubMessage{
+			Attributes: map[string]string{"notificationType": string(android.PubSubStatusReport)},
+			Data:       base64.StdEncoding.EncodeToString(deviceBytes),
+		}
+
+		err = svc.ProcessPubSubPush(t.Context(), "value", message)
+		require.NoError(t, err)
+		require.NotNil(t, capturedHost)
+
+		require.Equal(t, "Maria's Google Pixel 8", capturedHost.Host.ComputerName)
+		require.Equal(t, "Maria's Google Pixel 8", capturedHost.Host.Hostname)
+	})
+
+	t.Run("updateHost falls back to hardware model when no IdP account and no SCIM", func(t *testing.T) {
 		svc, mockDS := createAndroidService(t)
 
 		const enterpriseSpecificID = "NO-IDP-UUID"
@@ -1377,6 +1521,13 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 					EnterpriseSpecificID: new(enterpriseSpecificID),
 				},
 			}, nil
+		}
+
+		mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+			return nil, common_mysql.NotFound("scim user")
+		}
+		mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+			return nil, nil
 		}
 
 		var capturedHost *fleet.AndroidHost
@@ -1413,7 +1564,7 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.Equal(t, "Google Pixel 7", capturedHost.Host.HardwareModel)
 	})
 
-	t.Run("addNewHost uses IdP name when IdP UUID is present", func(t *testing.T) {
+	t.Run("addNewHost uses IdP fullname when IdP UUID is present", func(t *testing.T) {
 		svc, mockDS := createAndroidService(t)
 
 		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -1434,6 +1585,7 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 			return &fleet.MDMIdPAccount{
 				UUID:     uuid,
 				Fullname: "Jane Doe",
+				Username: "jane.doe",
 				Email:    "jane@test.com",
 			}, nil
 		}
@@ -1467,12 +1619,12 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Jane Doe's Testbrand TestModel", capturedHost.Host.ComputerName)
-		require.Equal(t, "Jane Doe's Testbrand TestModel", capturedHost.Host.Hostname)
+		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.ComputerName)
+		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.Hostname)
 		require.Equal(t, "Testbrand TestModel", capturedHost.Host.HardwareModel)
 	})
 
-	t.Run("addNewHost falls back when IdP fullname is empty", func(t *testing.T) {
+	t.Run("addNewHost falls back to hardware model when IdP fullname is empty", func(t *testing.T) {
 		svc, mockDS := createAndroidService(t)
 
 		mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -1493,6 +1645,7 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 			return &fleet.MDMIdPAccount{
 				UUID:     uuid,
 				Fullname: "",
+				Username: "nofullname",
 				Email:    "nofullname@test.com",
 			}, nil
 		}
@@ -1526,10 +1679,10 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		// Falls back to Brand + Model when fullname is empty
 		require.Equal(t, "Testbrand TestModel", capturedHost.Host.ComputerName)
 		require.Equal(t, "Testbrand TestModel", capturedHost.Host.Hostname)
 	})
+
 }
 
 func TestAndroidStorageExtraction(t *testing.T) {

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -378,6 +378,15 @@ func TestPubSubEnrollment(t *testing.T) {
 		mockDS.ClearHostMDMActionsFunc = func(ctx context.Context, hostID uint) error {
 			return nil
 		}
+		mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+			return nil, common_mysql.NotFound("scim user")
+		}
+		mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+			return nil, nil
+		}
+		mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+			return nil, common_mysql.NotFound("mdm idp account")
+		}
 
 		var capturedHostUUID, capturedIdpUUID string
 		mockDS.AssociateHostMDMIdPAccountFuncInvoked = false
@@ -562,6 +571,15 @@ func TestStatusReportPolicyValidation(t *testing.T) {
 	}
 	mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
 		return nil
+	}
+	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return nil, common_mysql.NotFound("scim user")
+	}
+	mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, common_mysql.NotFound("mdm idp account")
 	}
 
 	t.Run("single install pending profile with empty compliance details", func(t *testing.T) {
@@ -871,6 +889,16 @@ func TestUpdateHostEmptyUUIDGetsPopulated(t *testing.T) {
 		return nil, common_mysql.NotFound("android host")
 	}
 
+	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return nil, common_mysql.NotFound("scim user")
+	}
+	mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, common_mysql.NotFound("mdm idp account")
+	}
+
 	// Capture what gets sent to UpdateAndroidHost (and thus to the API)
 	var capturedHost *fleet.AndroidHost
 	mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
@@ -945,6 +973,15 @@ func TestStatusReportPopulatesOperatingSystem(t *testing.T) {
 	}
 	mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
 		return nil
+	}
+	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return nil, common_mysql.NotFound("scim user")
+	}
+	mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, common_mysql.NotFound("mdm idp account")
 	}
 
 	var capturedHostID uint
@@ -1043,6 +1080,16 @@ func TestHostPayloadUUIDForFrontend(t *testing.T) {
 				return nil, common_mysql.NotFound("android host")
 			}
 
+			mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+				return nil, common_mysql.NotFound("scim user")
+			}
+			mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+				return nil, nil
+			}
+			mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+				return nil, common_mysql.NotFound("mdm idp account")
+			}
+
 			// Capture the host payload that would be sent to frontend
 			var hostPayload *fleet.AndroidHost
 			mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
@@ -1124,6 +1171,16 @@ func TestUpdateHost(t *testing.T) {
 			return existingHost, nil
 		}
 		return nil, common_mysql.NotFound("android host")
+	}
+
+	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return nil, common_mysql.NotFound("scim user")
+	}
+	mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, common_mysql.NotFound("mdm idp account")
 	}
 
 	// verify UUID is set correctly
@@ -1350,8 +1407,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "John's Samsung SM-A176U1", capturedHost.Host.ComputerName)
-		require.Equal(t, "John's Samsung SM-A176U1", capturedHost.Host.Hostname)
+		require.Equal(t, "John Smith's Samsung SM-A176U1", capturedHost.Host.ComputerName)
+		require.Equal(t, "John Smith's Samsung SM-A176U1", capturedHost.Host.Hostname)
 		require.Equal(t, "Samsung SM-A176U1", capturedHost.Host.HardwareModel)
 	})
 
@@ -1380,12 +1437,12 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 			}, nil
 		}
 
-		// SCIM user linked — IdpFullName ("Andrey Ivanov") wins over IdP fullname.
+		// SCIM user linked — IdpFullName wins over IdP fullname.
 		mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
-			givenName := "Andrey"
-			familyName := "Ivanov"
+			givenName := "Alice"
+			familyName := "Smith"
 			return &fleet.ScimUser{
-				UserName:   "andrey.ivanov",
+				UserName:   "alice.smith",
 				GivenName:  &givenName,
 				FamilyName: &familyName,
 			}, nil
@@ -1424,8 +1481,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Andrey's Samsung SM-S906U1", capturedHost.Host.ComputerName)
-		require.Equal(t, "Andrey's Samsung SM-S906U1", capturedHost.Host.Hostname)
+		require.Equal(t, "Alice Smith's Samsung SM-S906U1", capturedHost.Host.ComputerName)
+		require.Equal(t, "Alice Smith's Samsung SM-S906U1", capturedHost.Host.Hostname)
 	})
 
 	t.Run("updateHost falls back to IdP fullname when SCIM has no full name", func(t *testing.T) {
@@ -1494,8 +1551,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Maria's Google Pixel 8", capturedHost.Host.ComputerName)
-		require.Equal(t, "Maria's Google Pixel 8", capturedHost.Host.Hostname)
+		require.Equal(t, "Maria Garcia's Google Pixel 8", capturedHost.Host.ComputerName)
+		require.Equal(t, "Maria Garcia's Google Pixel 8", capturedHost.Host.Hostname)
 	})
 
 	t.Run("updateHost falls back to hardware model when no IdP account and no SCIM", func(t *testing.T) {
@@ -1619,8 +1676,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedHost)
 
-		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.ComputerName)
-		require.Equal(t, "Jane's Testbrand TestModel", capturedHost.Host.Hostname)
+		require.Equal(t, "Jane Doe's Testbrand TestModel", capturedHost.Host.ComputerName)
+		require.Equal(t, "Jane Doe's Testbrand TestModel", capturedHost.Host.Hostname)
 		require.Equal(t, "Testbrand TestModel", capturedHost.Host.HardwareModel)
 	})
 
@@ -2083,6 +2140,15 @@ func TestStatusReportAppInstallVerification(t *testing.T) {
 	mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
 		return nil
 	}
+	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return nil, common_mysql.NotFound("scim user")
+	}
+	mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, common_mysql.NotFound("mdm idp account")
+	}
 	mockDS.ListHostMDMAndroidProfilesPendingOrFailedInstallWithVersionFunc = func(ctx context.Context, hostUUID string, version int64) ([]*fleet.MDMAndroidProfilePayload, error) {
 		return nil, nil
 	}
@@ -2444,6 +2510,15 @@ func TestPubSubStatusReportHostDeletedFromFleet(t *testing.T) {
 	}
 	mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
 		return nil
+	}
+	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return nil, common_mysql.NotFound("scim user")
+	}
+	mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, common_mysql.NotFound("mdm idp account")
 	}
 
 	// Minimal device: no AppliedPolicyName / ApplicationReports, so the status report
@@ -2976,6 +3051,15 @@ func TestPubSubEnrollment_ClearsHostMDMActionsOnReEnroll(t *testing.T) {
 		require.Nil(t, host.Device.AppliedPolicyVersion, "re-enroll must reset stale applied_policy_version")
 		require.Nil(t, host.Device.LastPolicySyncTime, "re-enroll must reset stale last_policy_sync_time")
 		return nil
+	}
+	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return nil, common_mysql.NotFound("scim user")
+	}
+	mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	mockDS.GetMDMIdPAccountByHostUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.MDMIdPAccount, error) {
+		return nil, common_mysql.NotFound("mdm idp account")
 	}
 	mockDS.ClearHostMDMActionsFunc = func(ctx context.Context, hostID uint) error {
 		require.Equal(t, existingHostID, hostID)

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -1412,7 +1412,7 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		require.Equal(t, "Samsung SM-A176U1", capturedHost.Host.HardwareModel)
 	})
 
-	t.Run("updateHost uses SCIM full name over IdP username", func(t *testing.T) {
+	t.Run("updateHost uses SCIM full name over IdP account fullname", func(t *testing.T) {
 		svc, mockDS := createAndroidService(t)
 
 		const enterpriseSpecificID = "SCIM-WINS-UUID"
@@ -1437,7 +1437,7 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 			}, nil
 		}
 
-		// SCIM user linked — IdpFullName wins over IdP fullname.
+		// SCIM user linked — SCIM full name (given_name + family_name) takes priority over mdm_idp_accounts fullname.
 		mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
 			givenName := "Alice"
 			familyName := "Smith"
@@ -1450,7 +1450,8 @@ func TestAndroidHostDisplayNameWithIdP(t *testing.T) {
 		mockDS.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
 			return nil, nil
 		}
-		// GetEndUsers returns IdpFullName="Andrey Ivanov", so GetMDMIdPAccountByHostUUID is never called.
+		// GetEndUsers sets IdpFullName from the SCIM user's DisplayName ("Alice Smith"),
+		// so the IdP account lookup is skipped entirely.
 
 		var capturedHost *fleet.AndroidHost
 		mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {


### PR DESCRIPTION
**Related issue:** Resolves #41053

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [x] Alerted the release DRI if additional load testing is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android device display-name resolution and formatting: SCIM end-user full name → IdP full name → hardware model; applies to existing and newly enrolled devices and formats names like "Alice's iPhone" when a fullname is available.
* **Tests**
  * Expanded test coverage for display-name precedence and fallbacks; added mocks so enrollment, status, app install, and re‑enrollment flows run when SCIM/IdP data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->