### PR TITLE
Update Okta SSO related actions in Sails apps

### DIFF
--- a/ee/fleet-agent-downloader/api/controllers/entrance/signup-okta-user-or-redirect.js
+++ b/ee/fleet-agent-downloader/api/controllers/entrance/signup-okta-user-or-redirect.js
@@ -15,12 +15,15 @@ module.exports = {
 
 
   fn: async function () {
-
+    // If the okta sso hook is not configured, redirect the user to the login page.
+    if(!sails.config.custom.oktaClientSecret) {
+      throw {redirect: '/login'};
+    }
     if(!this.req.session) {// If the requesting user does not have a session, redirect them to the login page.
       throw {redirect: '/login'};
     }
     // If the requesting user has a session, but it does not contain a passport object, we'll redirect them to the login page.
-    if (!this.req.session.passport.user) {
+    if (!this.req.session.passport || !this.req.session.passport.user) {
       throw {redirect: '/login'};
     }
 

--- a/ee/vulnerability-dashboard/api/controllers/entrance/signup-okta-user-or-redirect.js
+++ b/ee/vulnerability-dashboard/api/controllers/entrance/signup-okta-user-or-redirect.js
@@ -15,12 +15,15 @@ module.exports = {
 
 
   fn: async function () {
-
+    // If the okta sso hook is not configured, redirect the user to the login page.
+    if(!sails.config.custom.oktaClientSecret) {
+      throw {redirect: '/login'};
+    }
     if(!this.req.session) {// If the requesting user does not have a session, redirect them to the login page.
       throw {redirect: '/login'};
     }
     // If the requesting user has a session, but it does not contain a passport object, we'll redirect them to the login page.
-    if (!this.req.session.passport.user) {
+    if (!this.req.session.passport || !this.req.session.passport.user) {
       throw {redirect: '/login'};
     }
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/47252

Changes:
- Updated the `signup-okta-user-or-redirect` action in the vulnerability dashboard and Fleet agent downloader apps to redirect users to the /login page if the Okta SSO hook is not enabled, or if their session does not contain a `passport` object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Okta Single Sign-On security by adding validation checks to ensure proper configuration and valid session authentication. Users are now correctly redirected to login when conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->