### PR TITLE
Policies: Include/Exclude label targeting on edit policy page (#33441)

### DIFF
--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tests.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tests.tsx
@@ -4,16 +4,14 @@ import { noop } from "lodash";
 
 import { ILabelSummary } from "interfaces/label";
 
-import TargetLabelSelector, { ILabelTabConfig } from "./TargetLabelSelector";
+import TargetLabelSelector, { ILabelConfig } from "./TargetLabelSelector";
 
 const LABELS: ILabelSummary[] = [
   { id: 1, name: "label 1", label_type: "regular" },
   { id: 2, name: "label 2", label_type: "regular" },
 ];
 
-const makeTab = (
-  overrides: Partial<ILabelTabConfig> = {}
-): ILabelTabConfig => ({
+const makeTab = (overrides: Partial<ILabelConfig> = {}): ILabelConfig => ({
   selectedLabels: {},
   onSelectLabel: noop,
   ...overrides,
@@ -27,8 +25,8 @@ const renderSelector = (
       selectedTargetType="Custom"
       onSelectTargetType={noop}
       labels={LABELS}
-      include={makeTab({ showModeToggle: true, mode: "any" })}
-      exclude={makeTab()}
+      includeConfig={makeTab({ showModeToggle: true, mode: "any" })}
+      excludeConfig={makeTab()}
       emptyStateDescription="Add a label to target a group of hosts."
       onAddLabel={noop}
       {...props}
@@ -62,7 +60,7 @@ describe("TargetLabelSelector (tabbed) component", () => {
   });
 
   it("does not render the mode toggle on the exclude tab when showModeToggle is false", () => {
-    renderSelector({ exclude: makeTab({ showModeToggle: false }) });
+    renderSelector({ excludeConfig: makeTab({ showModeToggle: false }) });
 
     fireEvent.click(screen.getByText("Exclude"));
 
@@ -76,7 +74,7 @@ describe("TargetLabelSelector (tabbed) component", () => {
 
   it("renders selected labels as checked", () => {
     renderSelector({
-      include: makeTab({
+      includeConfig: makeTab({
         showModeToggle: true,
         mode: "any",
         selectedLabels: { "label 1": true, "label 2": false },
@@ -89,7 +87,7 @@ describe("TargetLabelSelector (tabbed) component", () => {
 
   it("disables a label in the include tab when it is selected in the exclude tab", () => {
     renderSelector({
-      exclude: makeTab({ selectedLabels: { "label 1": true } }),
+      excludeConfig: makeTab({ selectedLabels: { "label 1": true } }),
     });
 
     expect(screen.getByRole("checkbox", { name: "label 1" })).toHaveAttribute(

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -20,7 +20,7 @@ const baseClass = "target-label-selector";
 export type LabelTargetMode = "any" | "all";
 export type TargetType = "All hosts" | "Custom";
 
-export interface ILabelTabConfig {
+export interface ILabelConfig {
   selectedLabels: Record<string, boolean>;
   onSelectLabel: (arg: { name: string; value: boolean }) => void;
   /** When true, shows an "Any"/"All" radio that switches this tab between its
@@ -168,7 +168,7 @@ const LabelModeToggle = ({
 };
 
 interface ILabelTabContentProps {
-  tab: ILabelTabConfig;
+  tab: ILabelConfig;
   filteredLabels: ILabelSummary[];
   /** Labels selected in the other tab; disabled here to prevent overlap. */
   disabledLabels: Record<string, boolean>;
@@ -214,8 +214,8 @@ const LabelTabContent = ({
 
 interface ICustomTargetTabsProps {
   labels: ILabelSummary[];
-  include: ILabelTabConfig;
-  exclude: ILabelTabConfig;
+  include: ILabelConfig;
+  exclude: ILabelConfig;
   emptyStateDescription: ReactNode;
   onAddLabel: () => void;
   isLoadingLabels: boolean;
@@ -356,8 +356,8 @@ export interface ITargetLabelSelectorProps {
   selectedTargetType: TargetType;
   onSelectTargetType: (val: TargetType) => void;
   labels: ILabelSummary[];
-  include: ILabelTabConfig;
-  exclude: ILabelTabConfig;
+  includeConfig: ILabelConfig;
+  excludeConfig: ILabelConfig;
   emptyStateDescription: ReactNode;
   onAddLabel: () => void;
   isLoadingLabels?: boolean;
@@ -375,8 +375,8 @@ const TargetLabelSelector = ({
   selectedTargetType,
   onSelectTargetType,
   labels,
-  include,
-  exclude,
+  includeConfig,
+  excludeConfig,
   emptyStateDescription,
   onAddLabel,
   isLoadingLabels = false,
@@ -396,8 +396,8 @@ const TargetLabelSelector = ({
       {selectedTargetType === "Custom" && (
         <CustomTargetTabs
           labels={labels || []}
-          include={include}
-          exclude={exclude}
+          include={includeConfig}
+          exclude={excludeConfig}
           emptyStateDescription={emptyStateDescription}
           onAddLabel={onAddLabel}
           isLoadingLabels={isLoadingLabels}

--- a/frontend/components/TargetLabelSelector/index.ts
+++ b/frontend/components/TargetLabelSelector/index.ts
@@ -1,6 +1,6 @@
 export { default as TargetLabelSelector } from "./TargetLabelSelector";
 export type {
-  ILabelTabConfig,
+  ILabelConfig,
   ITargetLabelSelectorProps,
 } from "./TargetLabelSelector";
 

--- a/frontend/context/policy.tsx
+++ b/frontend/context/policy.tsx
@@ -30,6 +30,7 @@ interface ISetLastEditedQueryInfo {
   lastEditedQueryLabelsIncludeAny?: ILabelPolicy[];
   lastEditedQueryLabelsExcludeAny?: ILabelPolicy[];
   lastEditedQueryLabelsIncludeAll?: ILabelPolicy[];
+  lastEditedQueryLabelsExcludeAll?: ILabelPolicy[];
   defaultPolicy?: boolean;
 }
 
@@ -63,6 +64,7 @@ type InitialStateType = {
   lastEditedQueryLabelsIncludeAny: ILabelPolicy[];
   lastEditedQueryLabelsIncludeAll: ILabelPolicy[];
   lastEditedQueryLabelsExcludeAny: ILabelPolicy[];
+  lastEditedQueryLabelsExcludeAll: ILabelPolicy[];
   defaultPolicy: boolean;
   setLastEditedQueryId: (value: number | null) => void;
   setLastEditedQueryName: (value: string) => void;
@@ -76,6 +78,7 @@ type InitialStateType = {
   setLastEditedQueryLabelsIncludeAny: (value: ILabelPolicy[]) => void;
   setLastEditedQueryLabelsIncludeAll: (value: ILabelPolicy[]) => void;
   setLastEditedQueryLabelsExcludeAny: (value: ILabelPolicy[]) => void;
+  setLastEditedQueryLabelsExcludeAll: (value: ILabelPolicy[]) => void;
   setDefaultPolicy: (value: boolean) => void;
   policyTeamId: number;
   setPolicyTeamId: (id: number) => void;
@@ -100,6 +103,7 @@ const initialState = {
   lastEditedQueryLabelsIncludeAny: [],
   lastEditedQueryLabelsIncludeAll: [],
   lastEditedQueryLabelsExcludeAny: [],
+  lastEditedQueryLabelsExcludeAll: [],
   defaultPolicy: false,
   setLastEditedQueryId: () => null,
   setLastEditedQueryName: () => null,
@@ -111,6 +115,7 @@ const initialState = {
   setLastEditedQueryLabelsIncludeAny: () => null,
   setLastEditedQueryLabelsIncludeAll: () => null,
   setLastEditedQueryLabelsExcludeAny: () => null,
+  setLastEditedQueryLabelsExcludeAll: () => null,
   setDefaultPolicy: () => null,
   policyTeamId: 0,
   setPolicyTeamId: () => null,
@@ -175,6 +180,10 @@ const reducer = (state: InitialStateType, action: IAction) => {
           typeof action.lastEditedQueryLabelsExcludeAny === "undefined"
             ? state.lastEditedQueryLabelsExcludeAny
             : action.lastEditedQueryLabelsExcludeAny,
+        lastEditedQueryLabelsExcludeAll:
+          typeof action.lastEditedQueryLabelsExcludeAll === "undefined"
+            ? state.lastEditedQueryLabelsExcludeAll
+            : action.lastEditedQueryLabelsExcludeAll,
         defaultPolicy:
           typeof action.defaultPolicy === "undefined"
             ? state.defaultPolicy
@@ -283,6 +292,15 @@ const PolicyProvider = ({ children }: Props): JSX.Element => {
     },
     []
   );
+  const setLastEditedQueryLabelsExcludeAll = useCallback(
+    (lastEditedQueryLabelsExcludeAll: ILabelPolicy[]) => {
+      dispatch({
+        type: ACTIONS.SET_LAST_EDITED_QUERY_INFO,
+        lastEditedQueryLabelsExcludeAll,
+      });
+    },
+    []
+  );
   const setDefaultPolicy = useCallback((defaultPolicy: boolean) => {
     dispatch({
       type: ACTIONS.SET_LAST_EDITED_QUERY_INFO,
@@ -306,6 +324,7 @@ const PolicyProvider = ({ children }: Props): JSX.Element => {
       lastEditedQueryLabelsIncludeAny: state.lastEditedQueryLabelsIncludeAny,
       lastEditedQueryLabelsIncludeAll: state.lastEditedQueryLabelsIncludeAll,
       lastEditedQueryLabelsExcludeAny: state.lastEditedQueryLabelsExcludeAny,
+      lastEditedQueryLabelsExcludeAll: state.lastEditedQueryLabelsExcludeAll,
       defaultPolicy: state.defaultPolicy,
       setLastEditedQueryId,
       setLastEditedQueryName,
@@ -317,6 +336,7 @@ const PolicyProvider = ({ children }: Props): JSX.Element => {
       setLastEditedQueryLabelsIncludeAny,
       setLastEditedQueryLabelsIncludeAll,
       setLastEditedQueryLabelsExcludeAny,
+      setLastEditedQueryLabelsExcludeAll,
       setDefaultPolicy,
       policyTeamId: state.policyTeamId,
       setPolicyTeamId,
@@ -334,6 +354,7 @@ const PolicyProvider = ({ children }: Props): JSX.Element => {
       setLastEditedQueryLabelsIncludeAny,
       setLastEditedQueryLabelsIncludeAll,
       setLastEditedQueryLabelsExcludeAny,
+      setLastEditedQueryLabelsExcludeAll,
       setLastEditedQueryResolution,
       setPolicyTeamId,
       setSelectedOsqueryTable,
@@ -347,6 +368,7 @@ const PolicyProvider = ({ children }: Props): JSX.Element => {
       state.lastEditedQueryLabelsIncludeAny,
       state.lastEditedQueryLabelsIncludeAll,
       state.lastEditedQueryLabelsExcludeAny,
+      state.lastEditedQueryLabelsExcludeAll,
       state.lastEditedQueryResolution,
       state.policyTeamId,
       state.selectedOsqueryTable,

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
@@ -22,7 +22,7 @@ import Modal from "components/Modal";
 import Spinner from "components/Spinner";
 import {
   TargetLabelSelector,
-  ILabelTabConfig,
+  ILabelConfig,
   LabelTargetMode,
   TargetType,
 } from "components/TargetLabelSelector";
@@ -210,7 +210,7 @@ const AddProfileModal = ({
     }
   };
 
-  const includeTab: ILabelTabConfig = {
+  const includeTab: ILabelConfig = {
     selectedLabels: selectedIncludeLabels,
     onSelectLabel: ({ name, value }) =>
       setSelectedIncludeLabels((prev) => ({ ...prev, [name]: value })),
@@ -237,7 +237,7 @@ const AddProfileModal = ({
     ),
   };
 
-  const excludeTab: ILabelTabConfig = {
+  const excludeTab: ILabelConfig = {
     selectedLabels: selectedExcludeLabels,
     onSelectLabel: ({ name, value }) =>
       setSelectedExcludeLabels((prev) => ({ ...prev, [name]: value })),
@@ -267,8 +267,8 @@ const AddProfileModal = ({
                 selectedTargetType={selectedTargetType}
                 onSelectTargetType={setSelectedTargetType}
                 labels={labels || []}
-                include={includeTab}
-                exclude={excludeTab}
+                includeConfig={includeTab}
+                excludeConfig={excludeTab}
                 isLoadingLabels={isFetchingLabels}
                 isErrorLabels={isErrorLabels}
                 emptyStateDescription="Add a label to target your configuration profile."

--- a/frontend/pages/policies/constants.ts
+++ b/frontend/pages/policies/constants.ts
@@ -1,6 +1,9 @@
 import { IPolicyNew } from "interfaces/policy";
 import { CommaSeparatedPlatformString } from "interfaces/platform";
 
+export const POLICY_TARGET_EMPTY_STATE_DESCRIPTION =
+  "Add a label to target a group of hosts.";
+
 const DEFAULT_POLICY_PLATFORM: CommaSeparatedPlatformString = "";
 
 export const DEFAULT_POLICY = {

--- a/frontend/pages/policies/edit/EditPolicyPage.tsx
+++ b/frontend/pages/policies/edit/EditPolicyPage.tsx
@@ -70,6 +70,7 @@ const PolicyPage = ({
     setLastEditedQueryLabelsIncludeAny,
     setLastEditedQueryLabelsIncludeAll,
     setLastEditedQueryLabelsExcludeAny,
+    setLastEditedQueryLabelsExcludeAll,
     setPolicyTeamId,
   } = useContext(PolicyContext);
 
@@ -171,6 +172,9 @@ const PolicyPage = ({
         );
         setLastEditedQueryLabelsExcludeAny(
           returnedQuery.labels_exclude_any || []
+        );
+        setLastEditedQueryLabelsExcludeAll(
+          returnedQuery.labels_exclude_all || []
         );
         // TODO(sarah): What happens if the team id in the policy response doesn't match the
         // url param? In theory, the backend should ensure this doesn't happen.

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
@@ -518,6 +518,55 @@ describe("PolicyForm - component", () => {
         });
       });
 
+      it("preloads Custom + the Exclude tab when the policy already excludes labels", async () => {
+        const renderWithExcludeLabels = createCustomRenderer({
+          withBackendMock: true,
+          context: {
+            app: {
+              currentUser: createMockUser(),
+              currentTeam: createMockTeamSummary(),
+              isGlobalAdmin: true,
+              isOnGlobalTeam: true,
+              isPremiumTier: true,
+              config: createMockConfig(),
+            },
+            policy: {
+              policyTeamId: undefined,
+              lastEditedQueryId: mockPolicy.id,
+              lastEditedQueryName: "sumthin sumthin",
+              lastEditedQueryDescription: mockPolicy.description,
+              lastEditedQueryBody: mockPolicy.query,
+              lastEditedQueryResolution: mockPolicy.resolution,
+              lastEditedQueryCritical: mockPolicy.critical,
+              lastEditedQueryPlatform: "linux",
+              lastEditedQueryLabelsIncludeAny: [],
+              lastEditedQueryLabelsIncludeAll: [],
+              lastEditedQueryLabelsExcludeAny: [{ id: 2, name: "Fresh" }],
+              lastEditedQueryLabelsExcludeAll: [],
+              setLastEditedQueryName: jest.fn(),
+              setLastEditedQueryDescription: jest.fn(),
+              setLastEditedQueryBody: jest.fn(),
+              setLastEditedQueryResolution: jest.fn(),
+              setLastEditedQueryCritical: jest.fn(),
+              setLastEditedQueryPlatform: jest.fn(),
+            },
+          },
+        });
+
+        renderWithExcludeLabels(<PolicyForm {...defaultProps} />);
+
+        // Custom target is preselected because the policy has an exclude label.
+        await waitFor(() => {
+          expect(screen.getByLabelText("Custom")).toBeChecked();
+        });
+
+        // The excluded label round-trips into the Exclude tab as checked.
+        await userEvent.click(screen.getByText("Exclude"));
+        expect(
+          await screen.findByRole("checkbox", { name: "Fresh" })
+        ).toBeChecked();
+      });
+
       it("should disable the save button in Custom target mode when no labels are selected, and enable it once labels are selected", async () => {
         render(<PolicyForm {...defaultProps} />);
         let allHosts;
@@ -574,28 +623,14 @@ describe("PolicyForm - component", () => {
           expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
         });
 
-        // Set a label.
+        // Switch to the Exclude tab and select a label there.
         await userEvent.click(screen.getByLabelText("Custom"));
+        await userEvent.click(screen.getByText("Exclude"));
         await userEvent.click(
           await screen.findByRole("checkbox", {
             name: "Fun",
           })
         );
-
-        // Click "Include any" to open the dropdown.
-        const includeAnyOption = screen.getByRole("option", {
-          name: "Include any",
-        });
-        await userEvent.click(includeAnyOption);
-
-        // Click "Exclude any" to select it.
-        let excludeAnyOption: unknown;
-        await waitFor(() => {
-          excludeAnyOption = screen.getByRole("option", {
-            name: "Exclude any",
-          });
-        });
-        await userEvent.click(excludeAnyOption as Element);
 
         const saveButton = screen.getByRole("button", { name: "Save" });
         expect(saveButton).toBeEnabled();
@@ -606,7 +641,7 @@ describe("PolicyForm - component", () => {
         expect(onUpdate.mock.calls[0][0].labels_include_all).toEqual([]);
       });
 
-      it("should set labels_include_all when picking the Include all option", async () => {
+      it("should set labels_include_all when the include mode is All", async () => {
         const onUpdate = jest.fn();
         const props = { ...defaultProps, onUpdate };
         render(<PolicyForm {...props} />);
@@ -615,23 +650,13 @@ describe("PolicyForm - component", () => {
         });
 
         await userEvent.click(screen.getByLabelText("Custom"));
+        // Include tab is the default; switch its mode to "All".
+        await userEvent.click(screen.getByLabelText("All"));
         await userEvent.click(
           await screen.findByRole("checkbox", {
             name: "Fun",
           })
         );
-
-        // Open the scope dropdown and pick "Include all".
-        await userEvent.click(
-          screen.getByRole("option", { name: "Include any" })
-        );
-        let includeAllOption: unknown;
-        await waitFor(() => {
-          includeAllOption = screen.getByRole("option", {
-            name: "Include all",
-          });
-        });
-        await userEvent.click(includeAllOption as Element);
 
         const saveButton = screen.getByRole("button", { name: "Save" });
         expect(saveButton).toBeEnabled();
@@ -640,6 +665,32 @@ describe("PolicyForm - component", () => {
         expect(onUpdate.mock.calls[0][0].labels_include_all).toEqual(["Fun"]);
         expect(onUpdate.mock.calls[0][0].labels_include_any).toEqual([]);
         expect(onUpdate.mock.calls[0][0].labels_exclude_any).toEqual([]);
+      });
+
+      it("should send both include and exclude labels when both tabs have selections", async () => {
+        const onUpdate = jest.fn();
+        const props = { ...defaultProps, onUpdate };
+        render(<PolicyForm {...props} />);
+        await waitFor(() => {
+          expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByLabelText("Custom"));
+        // Include tab (default): select "Fun".
+        await userEvent.click(
+          await screen.findByRole("checkbox", { name: "Fun" })
+        );
+        // Exclude tab: select "Fresh".
+        await userEvent.click(screen.getByText("Exclude"));
+        await userEvent.click(
+          await screen.findByRole("checkbox", { name: "Fresh" })
+        );
+
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        const payload = onUpdate.mock.calls[0][0];
+        expect(payload.labels_include_any).toEqual(["Fun"]);
+        expect(payload.labels_exclude_any).toEqual(["Fresh"]);
       });
 
       it("should clear labels when saving a new query in All hosts target mode", async () => {

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 /* eslint-disable jsx-a11y/interactive-supports-focus */
-import React, { useState, useContext, useEffect, useMemo, useRef } from "react";
+import React, { useState, useContext, useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "react-query";
 
 import { Ace } from "ace-builds";
@@ -14,10 +14,6 @@ import { PolicyContext } from "context/policy";
 import usePlatformCompatibility from "hooks/usePlatformCompatibility";
 import usePlatformSelector from "hooks/usePlatformSelector";
 import PATHS from "router/paths";
-import {
-  getCustomTargetOptions,
-  LabelScope,
-} from "components/TargetLabelSelector/labelScopes";
 import { getPathWithQueryParams } from "utilities/url";
 
 import { IPolicy, IPolicyFormData } from "interfaces/policy";
@@ -28,12 +24,12 @@ import {
   APP_CONTEXT_NO_TEAM_SUMMARY,
 } from "interfaces/team";
 import { CommaSeparatedPlatformString } from "interfaces/platform";
-import { DEFAULT_POLICIES } from "pages/policies/constants";
-
 import {
-  DEFAULT_USE_QUERY_OPTIONS,
-  LEARN_MORE_ABOUT_BASE_LINK,
-} from "utilities/constants";
+  DEFAULT_POLICIES,
+  POLICY_TARGET_EMPTY_STATE_DESCRIPTION,
+} from "pages/policies/constants";
+
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
 import SQLEditor from "components/SQLEditor";
 import {
@@ -49,12 +45,7 @@ import Icon from "components/Icon/Icon";
 import InputField from "components/forms/fields/InputField";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import CustomLink from "components/CustomLink";
-import { DropdownTargetLabelSelector } from "components/TargetLabelSelector";
-
-import labelsAPI, {
-  getCustomLabels,
-  ILabelsSummaryResponse,
-} from "services/entities/labels";
+import { TargetLabelSelector } from "components/TargetLabelSelector";
 
 import teamPoliciesAPI from "services/entities/team_policies";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
@@ -64,7 +55,10 @@ import PolicyAutomationsFields, {
   IPolicyAutomationsPayload,
 } from "pages/policies/components/PolicyAutomationsFields";
 import { PatchAutomationCta } from "pages/policies/components";
-import { useUpdatePolicyAutomations } from "pages/policies/hooks";
+import {
+  useUpdatePolicyAutomations,
+  usePolicyLabelTargets,
+} from "pages/policies/hooks";
 
 import SaveNewPolicyModal from "../SaveNewPolicyModal";
 
@@ -137,12 +131,6 @@ const PolicyForm = ({
     false
   );
 
-  const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
-  const [selectedCustomTarget, setSelectedCustomTarget] = useState<LabelScope>(
-    "labelsIncludeAny"
-  );
-  const [selectedLabels, setSelectedLabels] = useState({});
-
   const isPatchPolicy = storedPolicy?.type === "patch";
   const [isAddingAutomation, setIsAddingAutomation] = useState(false);
 
@@ -159,6 +147,7 @@ const PolicyForm = ({
     lastEditedQueryLabelsIncludeAny,
     lastEditedQueryLabelsIncludeAll,
     lastEditedQueryLabelsExcludeAny,
+    lastEditedQueryLabelsExcludeAll,
     defaultPolicy,
     setLastEditedQueryName,
     setLastEditedQueryDescription,
@@ -168,18 +157,17 @@ const PolicyForm = ({
     setLastEditedQueryPlatform,
   } = useContext(PolicyContext);
 
-  const onSelectLabel = ({
-    name: labelName,
-    value,
-  }: {
-    name: string;
-    value: boolean;
-  }) => {
-    setSelectedLabels({
-      ...selectedLabels,
-      [labelName]: value,
-    });
-  };
+  const {
+    selectorProps,
+    selectedTargetType,
+    hasCustomLabels,
+    getLabelsPayload,
+  } = usePolicyLabelTargets({
+    includeAny: lastEditedQueryLabelsIncludeAny,
+    includeAll: lastEditedQueryLabelsIncludeAll,
+    excludeAny: lastEditedQueryLabelsExcludeAny,
+    excludeAll: lastEditedQueryLabelsExcludeAll,
+  });
 
   const { renderFlash } = useContext(NotificationContext);
   const queryClient = useQueryClient();
@@ -194,30 +182,6 @@ const PolicyForm = ({
     config,
     isFreeTier,
   } = useContext(AppContext);
-
-  const customTargetOptions = useMemo(
-    () => getCustomTargetOptions({ entity: "policy", isPremiumTier }),
-    [isPremiumTier]
-  );
-
-  const { data: { labels } = { labels: [] } } = useQuery<
-    ILabelsSummaryResponse,
-    Error
-  >(
-    ["custom_labels", currentTeam],
-    () => labelsAPI.summary(currentTeam?.id, true),
-    {
-      ...DEFAULT_USE_QUERY_OPTIONS,
-      // Wait for the current team to load from context before pulling labels, otherwise on a page load
-      // directly on the policies new/edit page this gets called with currentTeam not set, then again
-      // with the correct team value. If we don't trigger on currentTeam changes we'll just start with a
-      // null team ID here and never populate with the correct team unless we navigate from another page
-      // where team context is already set prior to navigation.
-      enabled: isPremiumTier && !!currentTeam,
-      staleTime: 10000,
-      select: (res) => ({ labels: getCustomLabels(res.labels) }),
-    }
-  );
 
   const disabledLiveQuery = config?.server_settings.live_query_disabled;
   const aiFeaturesDisabled =
@@ -354,45 +318,6 @@ const PolicyForm = ({
     storedPolicy?.team_id,
     router,
     teamIdForApi,
-  ]);
-
-  useEffect(() => {
-    setSelectedTargetType(
-      !lastEditedQueryLabelsIncludeAny.length &&
-        !lastEditedQueryLabelsIncludeAll.length &&
-        !lastEditedQueryLabelsExcludeAny.length
-        ? "All hosts"
-        : "Custom"
-    );
-
-    let customTarget: LabelScope | undefined;
-    let activeLabels: typeof lastEditedQueryLabelsIncludeAny = [];
-    if (lastEditedQueryLabelsExcludeAny.length) {
-      customTarget = "labelsExcludeAny";
-      activeLabels = lastEditedQueryLabelsExcludeAny;
-    } else if (lastEditedQueryLabelsIncludeAll.length) {
-      customTarget = "labelsIncludeAll";
-      activeLabels = lastEditedQueryLabelsIncludeAll;
-    } else if (lastEditedQueryLabelsIncludeAny.length) {
-      customTarget = "labelsIncludeAny";
-      activeLabels = lastEditedQueryLabelsIncludeAny;
-    }
-    if (customTarget) {
-      setSelectedCustomTarget(customTarget);
-    }
-
-    setSelectedLabels(
-      activeLabels.reduce((acc, label) => {
-        return {
-          ...acc,
-          [label.name]: true,
-        };
-      }, {})
-    );
-  }, [
-    lastEditedQueryLabelsIncludeAny,
-    lastEditedQueryLabelsIncludeAll,
-    lastEditedQueryLabelsExcludeAny,
   ]);
 
   useEffect(() => {
@@ -550,18 +475,7 @@ const PolicyForm = ({
         platform: newPlatformString,
       };
       if (isPremiumTier) {
-        const customLabelNames =
-          selectedTargetType === "Custom"
-            ? Object.entries(selectedLabels)
-                .filter(([, selected]) => selected)
-                .map(([labelName]) => labelName)
-            : [];
-        payload.labels_include_any =
-          selectedCustomTarget === "labelsIncludeAny" ? customLabelNames : [];
-        payload.labels_include_all =
-          selectedCustomTarget === "labelsIncludeAll" ? customLabelNames : [];
-        payload.labels_exclude_any =
-          selectedCustomTarget === "labelsExcludeAny" ? customLabelNames : [];
+        Object.assign(payload, getLabelsPayload());
         payload.critical = lastEditedQueryCritical;
       }
       await onUpdate(payload);
@@ -732,10 +646,7 @@ const PolicyForm = ({
       isAddingAutomation ||
       (isEditMode && !isPatchPolicy && !isAnyPlatformSelected) ||
       (lastEditedQueryName === "" && !!lastEditedQueryId) ||
-      (selectedTargetType === "Custom" &&
-        !Object.entries(selectedLabels).some(([, value]) => {
-          return value;
-        })) ||
+      (selectedTargetType === "Custom" && !hasCustomLabels) ||
       errors.query === EMPTY_QUERY_ERR;
 
     return (
@@ -759,20 +670,12 @@ const PolicyForm = ({
           {renderResolution()}
           {isEditMode && !isPatchPolicy && platformSelector.render()}
           {isEditMode && isPremiumTier && !isPatchPolicy && (
-            <DropdownTargetLabelSelector
-              selectedTargetType={selectedTargetType}
-              selectedCustomTarget={selectedCustomTarget}
-              customTargetOptions={customTargetOptions}
-              onSelectCustomTarget={(val) =>
-                setSelectedCustomTarget(val as LabelScope)
-              }
-              selectedLabels={selectedLabels}
+            <TargetLabelSelector
+              {...selectorProps}
               className={`${baseClass}__target`}
-              onSelectTargetType={setSelectedTargetType}
-              onSelectLabel={onSelectLabel}
-              labels={labels || []}
+              emptyStateDescription={POLICY_TARGET_EMPTY_STATE_DESCRIPTION}
+              onAddLabel={() => router.push(PATHS.LABEL_NEW_DYNAMIC)}
               disableOptions={gitOpsModeEnabled}
-              suppressTitle
             />
           )}
           {isEditMode && !!storedPolicy && !!automationsConfig && (
@@ -913,7 +816,6 @@ const PolicyForm = ({
             isFetchingAutofillResolution={isFetchingAutofillResolution}
             onClickAutofillDescription={onClickAutofillDescription}
             onClickAutofillResolution={onClickAutofillResolution}
-            labels={labels}
             isGlobalPolicy={isGlobalPolicy}
             policyTeamId={automationsTeamId}
             automationsConfig={automationsConfig}

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import createMockUser from "__mocks__/userMock";
 import createMockConfig from "__mocks__/configMock";
+import { createMockTeamSummary } from "__mocks__/teamMock";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import mockServer from "test/mock-server";
@@ -57,7 +58,6 @@ describe("SaveNewPolicyModal", () => {
     isFetchingAutofillResolution: false,
     onClickAutofillDescription: jest.fn(),
     onClickAutofillResolution: jest.fn(),
-    labels: mockLabels,
     isGlobalPolicy: true,
     policyTeamId: undefined,
     automationsConfig: createMockConfig(),
@@ -99,6 +99,7 @@ describe("SaveNewPolicyModal", () => {
           isOnGlobalTeam: true,
           isPremiumTier: true,
           isSandboxMode: false,
+          currentTeam: createMockTeamSummary(),
           config: createMockConfig(),
         },
       },

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -16,14 +16,12 @@ import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import { IPlatformSelector } from "hooks/usePlatformSelector";
 import { IConfig } from "interfaces/config";
-import { ILabelSummary } from "interfaces/label";
 import { IPolicy, IPolicyFormData } from "interfaces/policy";
 import { CommaSeparatedPlatformString } from "interfaces/platform";
 import { ITeamConfig } from "interfaces/team";
 import useDeepEffect from "hooks/useDeepEffect";
 
 import configAPI from "services/entities/config";
-import { listNamesFromSelectedLabels } from "services/entities/labels";
 import teamPoliciesAPI from "services/entities/team_policies";
 import teamsAPI from "services/entities/teams";
 
@@ -32,17 +30,14 @@ import Checkbox from "components/forms/fields/Checkbox";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
-import {
-  TargetLabelSelector,
-  ILabelTabConfig,
-  LabelTargetMode,
-  TargetType,
-} from "components/TargetLabelSelector";
+import { TargetLabelSelector } from "components/TargetLabelSelector";
 import Icon from "components/Icon";
 
 import PolicyAutomationsFields, {
   IPolicyAutomationsFieldsHandle,
 } from "pages/policies/components/PolicyAutomationsFields";
+import { usePolicyLabelTargets } from "pages/policies/hooks";
+import { POLICY_TARGET_EMPTY_STATE_DESCRIPTION } from "pages/policies/constants";
 
 export interface ISaveNewPolicyModalProps {
   baseClass: string;
@@ -60,7 +55,6 @@ export interface ISaveNewPolicyModalProps {
   isFetchingAutofillResolution: boolean;
   onClickAutofillDescription: () => Promise<void>;
   onClickAutofillResolution: () => Promise<void>;
-  labels: ILabelSummary[];
   /** True when the new policy targets "All fleets" (global); only the
    *  webhook/ticket row is shown in the automations table. */
   isGlobalPolicy: boolean;
@@ -101,7 +95,6 @@ const SaveNewPolicyModal = ({
   isFetchingAutofillResolution,
   onClickAutofillDescription,
   onClickAutofillResolution,
-  labels,
   isGlobalPolicy,
   policyTeamId,
   automationsConfig,
@@ -128,23 +121,12 @@ const SaveNewPolicyModal = ({
     backendValidators
   );
 
-  const [selectedTargetType, setSelectedTargetType] = useState<TargetType>(
-    "All hosts"
-  );
-  const [
-    selectedIncludeMode,
-    setSelectedIncludeMode,
-  ] = useState<LabelTargetMode>("any");
-  const [
-    selectedExcludeMode,
-    setSelectedExcludeMode,
-  ] = useState<LabelTargetMode>("any");
-  const [selectedIncludeLabels, setSelectedIncludeLabels] = useState<
-    Record<string, boolean>
-  >({});
-  const [selectedExcludeLabels, setSelectedExcludeLabels] = useState<
-    Record<string, boolean>
-  >({});
+  const {
+    selectorProps,
+    selectedTargetType,
+    hasCustomLabels,
+    getLabelsPayload,
+  } = usePolicyLabelTargets();
 
   const [showAutomations, setShowAutomations] = useState(false);
   const automationsRef = useRef<IPolicyAutomationsFieldsHandle>(null);
@@ -160,64 +142,6 @@ const SaveNewPolicyModal = ({
       } as IPolicy),
     [policyTeamId]
   );
-
-  const includeTab: ILabelTabConfig = {
-    selectedLabels: selectedIncludeLabels,
-    onSelectLabel: ({ name, value }) =>
-      setSelectedIncludeLabels((prev) => ({ ...prev, [name]: value })),
-    showModeToggle: true,
-    mode: selectedIncludeMode,
-    onSelectMode: setSelectedIncludeMode,
-    anyTooltip: (
-      <>
-        Will only target hosts that have{" "}
-        <em>
-          <b>any</b>
-        </em>{" "}
-        of these labels.
-      </>
-    ),
-    allTooltip: (
-      <>
-        Will only target hosts that have{" "}
-        <em>
-          <b>all</b>
-        </em>{" "}
-        of these labels.
-      </>
-    ),
-  };
-
-  const excludeTab: ILabelTabConfig = {
-    selectedLabels: selectedExcludeLabels,
-    onSelectLabel: ({ name, value }) =>
-      setSelectedExcludeLabels((prev) => ({ ...prev, [name]: value })),
-    showModeToggle: true,
-    mode: selectedExcludeMode,
-    onSelectMode: setSelectedExcludeMode,
-    anyTooltip: (
-      <>
-        Will not target hosts that have{" "}
-        <em>
-          <b>any</b>
-        </em>{" "}
-        of these labels.
-      </>
-    ),
-    allTooltip: (
-      <>
-        Will not target hosts that have{" "}
-        <em>
-          <b>all</b>
-        </em>{" "}
-        of these labels.
-      </>
-    ),
-  };
-
-  const hasCustomLabels =
-    listNamesFromSelectedLabels(selectedIncludeLabels).length > 0 ||
-    listNamesFromSelectedLabels(selectedExcludeLabels).length > 0;
 
   const disableForm =
     isFetchingAutofillDescription || isFetchingAutofillResolution;
@@ -272,22 +196,7 @@ const SaveNewPolicyModal = ({
       critical: lastEditedQueryCritical,
     };
     if (isPremiumTier) {
-      const includeNames =
-        selectedTargetType === "Custom"
-          ? listNamesFromSelectedLabels(selectedIncludeLabels)
-          : [];
-      const excludeNames =
-        selectedTargetType === "Custom"
-          ? listNamesFromSelectedLabels(selectedExcludeLabels)
-          : [];
-      payload.labels_include_any =
-        selectedIncludeMode === "any" ? includeNames : [];
-      payload.labels_include_all =
-        selectedIncludeMode === "all" ? includeNames : [];
-      payload.labels_exclude_any =
-        selectedExcludeMode === "any" ? excludeNames : [];
-      payload.labels_exclude_all =
-        selectedExcludeMode === "all" ? excludeNames : [];
+      Object.assign(payload, getLabelsPayload());
     }
 
     // The create endpoint deliberately ignores automation fields (see the
@@ -457,13 +366,9 @@ const SaveNewPolicyModal = ({
         {platformSelector.render()}
         {isPremiumTier && (
           <TargetLabelSelector
+            {...selectorProps}
             className={`${baseClass}__target`}
-            selectedTargetType={selectedTargetType}
-            onSelectTargetType={setSelectedTargetType}
-            labels={labels || []}
-            include={includeTab}
-            exclude={excludeTab}
-            emptyStateDescription="Add a label to target a group of hosts."
+            emptyStateDescription={POLICY_TARGET_EMPTY_STATE_DESCRIPTION}
             onAddLabel={() => router.push(PATHS.LABEL_NEW_DYNAMIC)}
             disableOptions={disableForm}
           />

--- a/frontend/pages/policies/edit/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/edit/screens/QueryEditor.tsx
@@ -161,6 +161,7 @@ const QueryEditor = ({
         labels_include_any: formData.labels_include_any,
         labels_include_all: formData.labels_include_all,
         labels_exclude_any: formData.labels_exclude_any,
+        labels_exclude_all: formData.labels_exclude_all,
       };
       if (isPremiumTier) {
         payload.critical = formData.critical;

--- a/frontend/pages/policies/hooks/index.ts
+++ b/frontend/pages/policies/hooks/index.ts
@@ -3,3 +3,6 @@ export type {
   IPolicyAutomationUpdate,
   IUpdatePolicyAutomationsVars,
 } from "./useUpdatePolicyAutomations";
+
+export { default as usePolicyLabelTargets } from "./usePolicyLabelTargets";
+export type { IUsePolicyLabelTargets } from "./usePolicyLabelTargets";

--- a/frontend/pages/policies/hooks/usePolicyLabelTargets.tests.tsx
+++ b/frontend/pages/policies/hooks/usePolicyLabelTargets.tests.tsx
@@ -7,6 +7,7 @@ import mockServer from "test/mock-server";
 import { AppContext, IAppContext, initialState } from "context/app";
 import { createMockTeamSummary } from "__mocks__/teamMock";
 import { ILabelPolicy, ILabelSummary } from "interfaces/label";
+import labelsAPI from "services/entities/labels";
 
 import usePolicyLabelTargets from "./usePolicyLabelTargets";
 
@@ -21,6 +22,8 @@ const mockLabels: ILabelSummary[] = [
 // they are in production, where they come from PolicyContext), so define them
 // once rather than inline in the render callback.
 const STORED_INCLUDE_ANY: ILabelPolicy[] = [{ id: 1, name: "Fun" }];
+const STORED_INCLUDE_ALL: ILabelPolicy[] = [{ id: 1, name: "Fun" }];
+const STORED_EXCLUDE_ANY: ILabelPolicy[] = [{ id: 2, name: "Fresh" }];
 const STORED_EXCLUDE_ALL: ILabelPolicy[] = [{ id: 2, name: "Fresh" }];
 
 const labelSummariesHandler = http.get(baseUrl("/labels/summary"), () =>
@@ -51,6 +54,10 @@ describe("usePolicyLabelTargets", () => {
     mockServer.use(labelSummariesHandler);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("defaults to All hosts and an empty payload when no initial labels are given", async () => {
     const { result } = renderHook(() => usePolicyLabelTargets(), {
       wrapper: premiumWrapper(),
@@ -79,12 +86,14 @@ describe("usePolicyLabelTargets", () => {
     });
   });
 
-  it("does not fetch labels when no team is selected", async () => {
+  it("does not fetch labels when no team is selected", () => {
+    const summarySpy = jest.spyOn(labelsAPI, "summary");
+
     const { result } = renderHook(() => usePolicyLabelTargets(), {
       wrapper: buildWrapper({ isPremiumTier: true, currentTeam: undefined }),
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(summarySpy).not.toHaveBeenCalled();
     expect(result.current.selectorProps.labels).toEqual([]);
   });
 
@@ -159,5 +168,176 @@ describe("usePolicyLabelTargets", () => {
     act(() => result.current.selectorProps.onSelectTargetType("All hosts"));
 
     expect(result.current.getLabelsPayload().labels_include_any).toEqual([]);
+  });
+
+  it("seeds Custom + include-all from a policy's stored include_all labels", async () => {
+    const { result } = renderHook(
+      () => usePolicyLabelTargets({ includeAll: STORED_INCLUDE_ALL }),
+      { wrapper: premiumWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTargetType).toBe("Custom");
+    });
+    expect(result.current.hasCustomLabels).toBe(true);
+    expect(result.current.selectorProps.includeConfig.mode).toBe("all");
+    expect(result.current.getLabelsPayload()).toMatchObject({
+      labels_include_all: ["Fun"],
+      labels_include_any: [],
+      labels_exclude_any: [],
+      labels_exclude_all: [],
+    });
+  });
+
+  it("seeds Custom + exclude-any from a policy's stored exclude_any labels", async () => {
+    const { result } = renderHook(
+      () => usePolicyLabelTargets({ excludeAny: STORED_EXCLUDE_ANY }),
+      { wrapper: premiumWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTargetType).toBe("Custom");
+    });
+    expect(result.current.hasCustomLabels).toBe(true);
+    expect(result.current.selectorProps.excludeConfig.mode).toBe("any");
+    expect(result.current.getLabelsPayload()).toMatchObject({
+      labels_exclude_any: ["Fresh"],
+      labels_exclude_all: [],
+      labels_include_any: [],
+      labels_include_all: [],
+    });
+  });
+
+  it("moves the include selection to labels_include_all when its mode switches to All", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    act(() => result.current.selectorProps.onSelectTargetType("Custom"));
+    act(() =>
+      result.current.selectorProps.includeConfig.onSelectLabel({
+        name: "Fun",
+        value: true,
+      })
+    );
+    expect(result.current.getLabelsPayload().labels_include_any).toEqual([
+      "Fun",
+    ]);
+
+    act(() => result.current.selectorProps.includeConfig.onSelectMode?.("all"));
+
+    expect(result.current.selectorProps.includeConfig.mode).toBe("all");
+    expect(result.current.getLabelsPayload()).toMatchObject({
+      labels_include_all: ["Fun"],
+      labels_include_any: [],
+    });
+  });
+
+  it("moves the exclude selection to labels_exclude_all when its mode switches to All", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    act(() => result.current.selectorProps.onSelectTargetType("Custom"));
+    act(() =>
+      result.current.selectorProps.excludeConfig.onSelectLabel({
+        name: "Fresh",
+        value: true,
+      })
+    );
+    expect(result.current.getLabelsPayload().labels_exclude_any).toEqual([
+      "Fresh",
+    ]);
+
+    act(() => result.current.selectorProps.excludeConfig.onSelectMode?.("all"));
+
+    expect(result.current.selectorProps.excludeConfig.mode).toBe("all");
+    expect(result.current.getLabelsPayload()).toMatchObject({
+      labels_exclude_all: ["Fresh"],
+      labels_exclude_any: [],
+    });
+  });
+
+  it("removes a label from the payload when it is deselected", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    act(() => result.current.selectorProps.onSelectTargetType("Custom"));
+    act(() =>
+      result.current.selectorProps.includeConfig.onSelectLabel({
+        name: "Fun",
+        value: true,
+      })
+    );
+    expect(result.current.hasCustomLabels).toBe(true);
+
+    act(() =>
+      result.current.selectorProps.includeConfig.onSelectLabel({
+        name: "Fun",
+        value: false,
+      })
+    );
+
+    expect(result.current.hasCustomLabels).toBe(false);
+    expect(result.current.getLabelsPayload().labels_include_any).toEqual([]);
+  });
+
+  it("builds a combined payload with both include and exclude selections", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    act(() => result.current.selectorProps.onSelectTargetType("Custom"));
+    act(() =>
+      result.current.selectorProps.includeConfig.onSelectLabel({
+        name: "Fun",
+        value: true,
+      })
+    );
+    act(() =>
+      result.current.selectorProps.excludeConfig.onSelectLabel({
+        name: "Fresh",
+        value: true,
+      })
+    );
+
+    expect(result.current.getLabelsPayload()).toMatchObject({
+      labels_include_any: ["Fun"],
+      labels_exclude_any: ["Fresh"],
+      labels_include_all: [],
+      labels_exclude_all: [],
+    });
+  });
+
+  it("reports a loading state while labels are being fetched", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    expect(result.current.selectorProps.isLoadingLabels).toBe(true);
+    await waitFor(() => {
+      expect(result.current.selectorProps.isLoadingLabels).toBe(false);
+    });
+  });
+
+  it("surfaces an error state when the labels request fails", async () => {
+    // A 4xx is terminal under DEFAULT_USE_QUERY_OPTIONS' retry policy, so the
+    // error surfaces immediately (a 5xx would retry and outrun waitFor).
+    mockServer.use(
+      http.get(
+        baseUrl("/labels/summary"),
+        () => new HttpResponse(null, { status: 403 })
+      )
+    );
+
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectorProps.isErrorLabels).toBe(true);
+    });
+    expect(result.current.selectorProps.labels).toEqual([]);
   });
 });

--- a/frontend/pages/policies/hooks/usePolicyLabelTargets.tests.tsx
+++ b/frontend/pages/policies/hooks/usePolicyLabelTargets.tests.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { http, HttpResponse } from "msw";
+import mockServer from "test/mock-server";
+
+import { AppContext, IAppContext, initialState } from "context/app";
+import { createMockTeamSummary } from "__mocks__/teamMock";
+import { ILabelPolicy, ILabelSummary } from "interfaces/label";
+
+import usePolicyLabelTargets from "./usePolicyLabelTargets";
+
+const baseUrl = (path: string) => `/api/latest/fleet${path}`;
+
+const mockLabels: ILabelSummary[] = [
+  { id: 1, name: "Fun", description: "", label_type: "regular" },
+  { id: 2, name: "Fresh", description: "", label_type: "regular" },
+];
+
+// Stored-policy label arrays must be referentially stable across renders (as
+// they are in production, where they come from PolicyContext), so define them
+// once rather than inline in the render callback.
+const STORED_INCLUDE_ANY: ILabelPolicy[] = [{ id: 1, name: "Fun" }];
+const STORED_EXCLUDE_ALL: ILabelPolicy[] = [{ id: 2, name: "Fresh" }];
+
+const labelSummariesHandler = http.get(baseUrl("/labels/summary"), () =>
+  HttpResponse.json({ labels: mockLabels })
+);
+
+const buildWrapper = (appOverrides: Partial<IAppContext>) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, cacheTime: 0 } },
+  });
+  const value: IAppContext = { ...initialState, ...appOverrides };
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <AppContext.Provider value={value}>{children}</AppContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+const premiumWrapper = (appOverrides: Partial<IAppContext> = {}) =>
+  buildWrapper({
+    isPremiumTier: true,
+    currentTeam: createMockTeamSummary(),
+    ...appOverrides,
+  });
+
+describe("usePolicyLabelTargets", () => {
+  beforeEach(() => {
+    mockServer.use(labelSummariesHandler);
+  });
+
+  it("defaults to All hosts and an empty payload when no initial labels are given", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    expect(result.current.selectedTargetType).toBe("All hosts");
+    expect(result.current.hasCustomLabels).toBe(false);
+    expect(result.current.getLabelsPayload()).toEqual({
+      labels_include_any: [],
+      labels_include_all: [],
+      labels_exclude_any: [],
+      labels_exclude_all: [],
+    });
+  });
+
+  it("fetches the team's custom labels and exposes them via selectorProps", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectorProps.labels.map((l) => l.name)).toEqual([
+        "Fresh",
+        "Fun",
+      ]);
+    });
+  });
+
+  it("does not fetch labels when no team is selected", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: buildWrapper({ isPremiumTier: true, currentTeam: undefined }),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(result.current.selectorProps.labels).toEqual([]);
+  });
+
+  it("seeds Custom + include-any from a policy's stored include labels", async () => {
+    const { result } = renderHook(
+      () => usePolicyLabelTargets({ includeAny: STORED_INCLUDE_ANY }),
+      { wrapper: premiumWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTargetType).toBe("Custom");
+    });
+    expect(result.current.hasCustomLabels).toBe(true);
+    expect(result.current.selectorProps.includeConfig.mode).toBe("any");
+    expect(result.current.getLabelsPayload()).toMatchObject({
+      labels_include_any: ["Fun"],
+      labels_include_all: [],
+      labels_exclude_any: [],
+      labels_exclude_all: [],
+    });
+  });
+
+  it("seeds the exclude-all scope when a policy stores exclude_all labels", async () => {
+    const { result } = renderHook(
+      () => usePolicyLabelTargets({ excludeAll: STORED_EXCLUDE_ALL }),
+      { wrapper: premiumWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTargetType).toBe("Custom");
+    });
+    expect(result.current.selectorProps.excludeConfig.mode).toBe("all");
+    expect(result.current.getLabelsPayload()).toMatchObject({
+      labels_exclude_all: ["Fresh"],
+      labels_exclude_any: [],
+      labels_include_any: [],
+    });
+  });
+
+  it("builds the include-any payload after the user selects Custom and a label", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    act(() => result.current.selectorProps.onSelectTargetType("Custom"));
+    act(() =>
+      result.current.selectorProps.includeConfig.onSelectLabel({
+        name: "Fun",
+        value: true,
+      })
+    );
+
+    expect(result.current.selectedTargetType).toBe("Custom");
+    expect(result.current.hasCustomLabels).toBe(true);
+    expect(result.current.getLabelsPayload().labels_include_any).toEqual([
+      "Fun",
+    ]);
+  });
+
+  it("clears the payload when the user switches back to All hosts", async () => {
+    const { result } = renderHook(() => usePolicyLabelTargets(), {
+      wrapper: premiumWrapper(),
+    });
+
+    act(() => result.current.selectorProps.onSelectTargetType("Custom"));
+    act(() =>
+      result.current.selectorProps.includeConfig.onSelectLabel({
+        name: "Fun",
+        value: true,
+      })
+    );
+    act(() => result.current.selectorProps.onSelectTargetType("All hosts"));
+
+    expect(result.current.getLabelsPayload().labels_include_any).toEqual([]);
+  });
+});

--- a/frontend/pages/policies/hooks/usePolicyLabelTargets.tsx
+++ b/frontend/pages/policies/hooks/usePolicyLabelTargets.tsx
@@ -1,0 +1,255 @@
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { useQuery } from "react-query";
+
+import { AppContext } from "context/app";
+import {
+  ILabelConfig,
+  ITargetLabelSelectorProps,
+  LabelTargetMode,
+  TargetType,
+} from "components/TargetLabelSelector";
+import labelsAPI, {
+  getCustomLabels,
+  listNamesFromSelectedLabels,
+  ILabelsSummaryResponse,
+} from "services/entities/labels";
+import { ILabelPolicy, ILabelSummary } from "interfaces/label";
+import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+
+type LabelSelection = Record<string, boolean>;
+
+const labelsToSelection = (labels: ILabelPolicy[]): LabelSelection =>
+  labels.reduce<LabelSelection>((acc, label) => {
+    acc[label.name] = true;
+    return acc;
+  }, {});
+
+interface IBuildPolicyLabelsPayloadArgs {
+  targetType: TargetType;
+  includeMode: LabelTargetMode;
+  includeLabels: LabelSelection;
+  excludeMode: LabelTargetMode;
+  excludeLabels: LabelSelection;
+}
+
+/** Maps the include/exclude selections + modes to the snake_case label arrays
+ * the policy API expects. Inactive scopes are sent as empty arrays so the
+ * backend clears them. */
+const buildPolicyLabelsPayload = ({
+  targetType,
+  includeMode,
+  includeLabels,
+  excludeMode,
+  excludeLabels,
+}: IBuildPolicyLabelsPayloadArgs) => {
+  const include =
+    targetType === "Custom" ? listNamesFromSelectedLabels(includeLabels) : [];
+  const exclude =
+    targetType === "Custom" ? listNamesFromSelectedLabels(excludeLabels) : [];
+  return {
+    labels_include_any: includeMode === "any" ? include : [],
+    labels_include_all: includeMode === "all" ? include : [],
+    labels_exclude_any: excludeMode === "any" ? exclude : [],
+    labels_exclude_all: excludeMode === "all" ? exclude : [],
+  };
+};
+
+interface IDerivePolicyTargetStateArgs {
+  includeAny?: ILabelPolicy[];
+  includeAll?: ILabelPolicy[];
+  excludeAny?: ILabelPolicy[];
+  excludeAll?: ILabelPolicy[];
+}
+
+/** Derives the selector's controlled state from a policy's stored label arrays */
+const derivePolicyTargetState = ({
+  includeAny = [],
+  includeAll = [],
+  excludeAny = [],
+  excludeAll = [],
+}: IDerivePolicyTargetStateArgs): {
+  targetType: TargetType;
+  includeMode: LabelTargetMode;
+  includeLabels: LabelSelection;
+  excludeMode: LabelTargetMode;
+  excludeLabels: LabelSelection;
+} => {
+  const hasAnyScope = !!(
+    includeAny.length ||
+    includeAll.length ||
+    excludeAny.length ||
+    excludeAll.length
+  );
+  const includeMode: LabelTargetMode = includeAll.length ? "all" : "any";
+  const excludeMode: LabelTargetMode = excludeAll.length ? "all" : "any";
+
+  return {
+    targetType: hasAnyScope ? "Custom" : "All hosts",
+    includeMode,
+    includeLabels: labelsToSelection(
+      includeMode === "all" ? includeAll : includeAny
+    ),
+    excludeMode,
+    excludeLabels: labelsToSelection(
+      excludeMode === "all" ? excludeAll : excludeAny
+    ),
+  };
+};
+
+interface IUsePolicyLabelTargetsArgs {
+  includeAny?: ILabelPolicy[];
+  includeAll?: ILabelPolicy[];
+  excludeAny?: ILabelPolicy[];
+  excludeAll?: ILabelPolicy[];
+}
+
+export interface IUsePolicyLabelTargets {
+  selectorProps: Pick<
+    ITargetLabelSelectorProps,
+    | "selectedTargetType"
+    | "onSelectTargetType"
+    | "labels"
+    | "isLoadingLabels"
+    | "isErrorLabels"
+    | "includeConfig"
+    | "excludeConfig"
+  >;
+  selectedTargetType: TargetType;
+  hasCustomLabels: boolean;
+  getLabelsPayload: () => ReturnType<typeof buildPolicyLabelsPayload>;
+}
+
+const usePolicyLabelTargets = ({
+  includeAny,
+  includeAll,
+  excludeAny,
+  excludeAll,
+}: IUsePolicyLabelTargetsArgs = {}): IUsePolicyLabelTargets => {
+  const { isPremiumTier, currentTeam } = useContext(AppContext);
+
+  const [selectedTargetType, setSelectedTargetType] = useState<TargetType>(
+    "All hosts"
+  );
+  const [includeMode, setIncludeMode] = useState<LabelTargetMode>("any");
+  const [excludeMode, setExcludeMode] = useState<LabelTargetMode>("any");
+  const [includeLabels, setIncludeLabels] = useState<LabelSelection>({});
+  const [excludeLabels, setExcludeLabels] = useState<LabelSelection>({});
+
+  const {
+    data: labels = [],
+    isLoading: isLoadingLabels,
+    isError: isErrorLabels,
+  } = useQuery<ILabelsSummaryResponse, Error, ILabelSummary[]>(
+    ["custom_labels", currentTeam],
+    () => labelsAPI.summary(currentTeam?.id, true),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: isPremiumTier && !!currentTeam,
+      staleTime: 10000,
+      select: (res) => getCustomLabels(res.labels),
+    }
+  );
+
+  // Seed the selection from a policy's stored labels; empty arrays resolve to
+  // "All hosts" (create).
+  useEffect(() => {
+    const seed = derivePolicyTargetState({
+      includeAny,
+      includeAll,
+      excludeAny,
+      excludeAll,
+    });
+    setSelectedTargetType(seed.targetType);
+    setIncludeMode(seed.includeMode);
+    setIncludeLabels(seed.includeLabels);
+    setExcludeMode(seed.excludeMode);
+    setExcludeLabels(seed.excludeLabels);
+  }, [includeAny, includeAll, excludeAny, excludeAll]);
+
+  const includeConfig: ILabelConfig = {
+    selectedLabels: includeLabels,
+    onSelectLabel: ({ name, value }) =>
+      setIncludeLabels((prev) => ({ ...prev, [name]: value })),
+    showModeToggle: true,
+    mode: includeMode,
+    onSelectMode: setIncludeMode,
+    anyTooltip: (
+      <>
+        Will only target hosts that have{" "}
+        <em>
+          <b>any</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
+    allTooltip: (
+      <>
+        Will only target hosts that have{" "}
+        <em>
+          <b>all</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
+  };
+
+  const excludeConfig: ILabelConfig = {
+    selectedLabels: excludeLabels,
+    onSelectLabel: ({ name, value }) =>
+      setExcludeLabels((prev) => ({ ...prev, [name]: value })),
+    showModeToggle: true,
+    mode: excludeMode,
+    onSelectMode: setExcludeMode,
+    anyTooltip: (
+      <>
+        Will not target hosts that have{" "}
+        <em>
+          <b>any</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
+    allTooltip: (
+      <>
+        Will not target hosts that have{" "}
+        <em>
+          <b>all</b>
+        </em>{" "}
+        of these labels.
+      </>
+    ),
+  };
+
+  const hasCustomLabels =
+    listNamesFromSelectedLabels(includeLabels).length > 0 ||
+    listNamesFromSelectedLabels(excludeLabels).length > 0;
+
+  const getLabelsPayload = useCallback(
+    () =>
+      buildPolicyLabelsPayload({
+        targetType: selectedTargetType,
+        includeMode,
+        includeLabels,
+        excludeMode,
+        excludeLabels,
+      }),
+    [selectedTargetType, includeMode, includeLabels, excludeMode, excludeLabels]
+  );
+
+  return {
+    selectorProps: {
+      selectedTargetType,
+      onSelectTargetType: setSelectedTargetType,
+      labels,
+      isLoadingLabels,
+      isErrorLabels,
+      includeConfig,
+      excludeConfig,
+    },
+    selectedTargetType,
+    hasCustomLabels,
+    getLabelsPayload,
+  };
+};
+
+export default usePolicyLabelTargets;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46583

Figma: https://www.figma.com/design/0F1sw63SuYaKVWlcL7mnc6/-33441-Policies--Custom-targets-with-%22Include-any%22-and-%22Exclude-any%22?node-id=5319-2300&t=Fszpf83KhcZ7ViWh-0

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Note: selecting `Exclude All` will fail since BE doesn't support it yet.  Will be tackled as part of https://github.com/fleetdm/fleet/issues/46582.

https://github.com/user-attachments/assets/12316264-b5b0-4588-b714-8f0aea11c604




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for excluding labels when targeting policy hosts, enabling more granular control over which hosts receive specific policy configurations.

* **Refactor**
  * Streamlined label-targeting state management and UI components for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->