### PR TITLE
Fleet UI: preserve raw software name for icon matching when display name overrides are set

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -83,8 +83,13 @@ Use helpers from `frontend/utilities/strings/stringUtils.ts`:
 - `stripQuotes(str)`, `strToBool(str)` — input parsing
 - `enforceFleetSentenceCasing(str)` — respects Fleet stylization rules
 
-## Software titles — display name
+## Software titles
+
+### Display name
 Render software title names via `getDisplayedSoftwareName(name, display_name)` from `pages/SoftwarePage/helpers.tsx` — never raw `t.name` or open-coded `display_name || name`. See `frontend/docs/patterns.md`.
+
+### Icons
+`<SoftwareIcon name={...}>` uses `name` for fallback icon matching when `icon_url` is null (Fleet-maintained apps depend entirely on this). Pass the **raw** `name`, never `getDisplayedSoftwareName(...)` or `display_name`, or admin renames will break the icon match. When a flattened row carries only one name field, add a sibling `iconName` (raw) field and feed THAT to `<SoftwareIcon>`. See `frontend/docs/patterns.md` and #47123.
 
 ## Styling (SCSS + BEM)
 - Define `const baseClass = "component-name"` at the top of the component

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareProcessCell/SetupSoftwareProcessCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareProcessCell/SetupSoftwareProcessCell.tsx
@@ -5,13 +5,21 @@ const baseClass = "setup-software-process-cell";
 
 interface ISetupSoftwareProcessCell {
   name: string;
+  /** Raw software name used for SoftwareIcon fallback matching when url is null.
+   * Display-name overrides won't match the known-icon lookup (e.g. FMAs without
+   * a custom icon_url), so pass the raw title name here. Defaults to `name`. */
+  iconName?: string;
   url?: string | null;
 }
 
-const SetupSoftwareProcessCell = ({ name, url }: ISetupSoftwareProcessCell) => {
+const SetupSoftwareProcessCell = ({
+  name,
+  iconName,
+  url,
+}: ISetupSoftwareProcessCell) => {
   return (
     <span className={baseClass}>
-      <SoftwareIcon name={name || ""} size="small" url={url} />
+      <SoftwareIcon name={iconName ?? name ?? ""} size="small" url={url} />
       <div>
         Install <b>{name || "Unknown software"}</b>
       </div>

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -148,12 +148,17 @@ export default {
 }
 ```
 
-### Display names for software titles
+### Software titles
 
 Software titles have two fields that look like a name:
 
 - `name` — the raw title from the installer/package metadata (e.g. `Microsoft.CompanyPortal`)
 - `display_name` — an optional custom name set per fleet by an admin
+
+Render the label from the resolved display name, but pass the **raw** `name` to
+`<SoftwareIcon>` — the icon matcher only knows raw, well-known names.
+
+#### Display name
 
 **Never render `name` directly in the UI.** Always route software names through
 `getDisplayedSoftwareName(name, display_name)` from `pages/SoftwarePage/helpers.tsx`.
@@ -178,6 +183,41 @@ The same rule applies to any object shape that carries both fields
 `IPolicySoftwareToInstall`, etc.). The `ISoftwareTitle.name` JSDoc states the
 expectation: "All software names displayed by UI is ran through
 getDisplayedSoftwareName."
+
+#### Icons
+
+`<SoftwareIcon name={...}>` uses the `name` prop for **fallback icon matching**
+via `getMatchedSoftwareIcon({ name, source })` when `icon_url` is null. That
+matcher only knows the raw, well-known names (`notion`, `microsoft.companyportal`,
+etc.). If you pass it a resolved display name like `getDisplayedSoftwareName(...)`
+or `display_name || name`, an admin who renames the title to anything not in the
+match table will lose the icon to a generic fallback. Fleet-maintained apps are
+the highest-risk surface because they have no `icon_url` — they depend
+entirely on name matching. See #47123.
+
+When you have both fields, pass the raw `name` to the icon and the resolved
+name to the label:
+
+```tsx
+// good — icon matches against raw name, label shows resolved display name
+const displayName = getDisplayedSoftwareName(title.name, title.display_name);
+<>
+  <SoftwareIcon name={title.name} source={title.source} url={title.icon_url} />
+  {displayName}
+</>
+
+// bad — admin renames break the icon match for FMAs and other matched titles
+<SoftwareIcon name={displayName} ... />
+```
+
+When the data has been flattened into a single `name` field upstream (e.g. for a
+row object or table-cell renderer), carry the raw name alongside it as a
+separate field (`iconName`, `rawName`, etc.) and feed THAT to `<SoftwareIcon>`.
+See `frontend/pages/policies/ManagePoliciesPage/helpers.tsx`'s
+`ISoftwareAutomationData.iconName` for the established pattern.
+
+`SoftwareNameCell` already does this internally — when you can use it, prefer
+it over hand-rolling icon + label rendering.
 
 ## Components
 

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
@@ -24,6 +24,7 @@ const generateColumnConfigs = (): ISetupStatusTableConfig[] => [
         return (
           <SetupSoftwareProcessCell
             name={getDisplayedSoftwareName(name, display_name)}
+            iconName={name ?? ""}
             url={icon_url}
           />
         );

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -69,11 +69,11 @@ interface IDataColumn {
 
 const AUTOMATION_ICON_RENDERERS: Record<
   IAutomationData["type"],
-  (args: { name: string; iconUrl?: string }) => JSX.Element
+  (args: { name: string; iconName?: string; iconUrl?: string }) => JSX.Element
 > = {
-  software: ({ name, iconUrl }) => (
+  software: ({ name, iconName, iconUrl }) => (
     <span className="automations__software-icon">
-      <SoftwareIcon name={name} url={iconUrl} size="small" />
+      <SoftwareIcon name={iconName ?? name} url={iconUrl} size="small" />
     </span>
   ),
   script: ({ name }) => (
@@ -142,10 +142,12 @@ const AutomationsCell = ({
 
   const handleEdit = () => onOpenManageAutomationsModal?.(policy);
 
-  const renderAutomationIcon = ({ type, name, iconUrl }: IAutomationData) => {
-    return AUTOMATION_ICON_RENDERERS[type]({
-      name,
-      iconUrl: iconUrl ?? undefined,
+  const renderAutomationIcon = (automation: IAutomationData) => {
+    return AUTOMATION_ICON_RENDERERS[automation.type]({
+      name: automation.name,
+      iconName:
+        automation.type === "software" ? automation.iconName : undefined,
+      iconUrl: automation.iconUrl ?? undefined,
     });
   };
 

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
@@ -345,6 +345,22 @@ describe("getAutomationsForPolicy", () => {
     expect(result[0].name).toBe("Company Portal");
   });
 
+  it("preserves the raw install_software.name as iconName for fallback icon matching (regression: #47123)", () => {
+    const result = getAutomationsForPolicy({
+      ...basePolicy,
+      install_software: {
+        name: "Zoom",
+        display_name: "Custom Renamed App",
+        software_title_id: 42,
+      },
+    });
+    expect(result[0]).toMatchObject({
+      type: "software",
+      name: "Custom Renamed App",
+      iconName: "Zoom",
+    });
+  });
+
   it("returns script automation with file name", () => {
     const result = getAutomationsForPolicy({
       ...basePolicy,

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
@@ -16,6 +16,10 @@ export type AutomationDisplayType =
 interface ISoftwareAutomationData {
   type: "software";
   name: string;
+  /** Raw software name passed to SoftwareIcon for name-based fallback matching.
+   * Display-name overrides won't match the known-icon lookup (e.g. FMAs without
+   * a custom icon_url), so we keep the raw name available alongside `name`. */
+  iconName: string;
   softwareTitleId: number;
   iconUrl?: string | null;
 }
@@ -23,6 +27,7 @@ interface ISoftwareAutomationData {
 interface INonSoftwareAutomationData {
   type: Exclude<AutomationDisplayType, "software">;
   name: string;
+  iconName?: never;
   softwareTitleId?: never;
   iconUrl?: never;
 }
@@ -52,6 +57,7 @@ export const getAutomationsForPolicy = (
         policy.install_software.name,
         policy.install_software.display_name
       ),
+      iconName: policy.install_software.name,
       softwareTitleId: policy.install_software.software_title_id,
       iconUrl: policy.install_software.icon_url,
     });

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
@@ -6,11 +6,16 @@ import ENDPOINTS from "utilities/endpoints";
 
 import PolicyAutomationsList from "./PolicyAutomationsList";
 
-// Stub SoftwareIcon to avoid asset resolution in tests; surface the url prop so
-// we can assert the custom icon path is forwarded.
+// Stub SoftwareIcon to avoid asset resolution in tests; surface the url and
+// name props so we can assert the raw software name (used for fallback icon
+// matching) and the custom icon path are forwarded.
 jest.mock("pages/SoftwarePage/components/icons/SoftwareIcon", () => {
-  return ({ url }: { url?: string | null }) => (
-    <span data-testid="software-icon" data-url={url ?? ""} />
+  return ({ name, url }: { name?: string; url?: string | null }) => (
+    <span
+      data-testid="software-icon"
+      data-name={name ?? ""}
+      data-url={url ?? ""}
+    />
   );
 });
 
@@ -133,6 +138,31 @@ describe("PolicyAutomationsList", () => {
         "data-url",
         ""
       );
+    });
+
+    it("passes the raw install_software.name to SoftwareIcon even when a display_name override is set (regression: #47123)", () => {
+      // The display name is what users see, but SoftwareIcon's fallback
+      // matcher needs the raw name to find FMA / well-known icons; otherwise
+      // a custom display name causes it to fall through to the generic icon.
+      render(
+        <PolicyAutomationsList
+          storedPolicy={createMockPolicy({
+            install_software: {
+              name: "Zoom",
+              display_name: "Custom Renamed App",
+              software_title_id: 42,
+            },
+          })}
+          currentAutomatedPolicies={[]}
+        />
+      );
+
+      expect(screen.getByTestId("software-icon")).toHaveAttribute(
+        "data-name",
+        "Zoom"
+      );
+      // sanity check: label still uses the display name override
+      expect(screen.getByText("Custom Renamed App")).toBeInTheDocument();
     });
 
     it("shows script automation row", () => {

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
@@ -19,6 +19,9 @@ const OTHER_AUTOMATION_NAMES: Record<OtherAutomationType, string> = {
 
 interface IAutomationDisplayRow {
   name: string;
+  /** Raw software name forwarded to SoftwareIcon for name-based fallback
+   * matching; display-name overrides break the known-icon lookup. */
+  iconName?: string;
   type: string;
   graphicName?: GraphicNames;
   isSoftware?: boolean;
@@ -51,6 +54,7 @@ const PolicyAutomationsList = ({
     );
     automationRows.push({
       name: displayedName,
+      iconName: storedPolicy.install_software.name,
       type: "Software",
       isSoftware: true,
       iconUrl: storedPolicy.install_software.icon_url,
@@ -128,7 +132,7 @@ const PolicyAutomationsList = ({
               <div className={`${baseClass}__row-name`}>
                 {row.isSoftware ? (
                   <SoftwareIcon
-                    name={row.name}
+                    name={row.iconName ?? row.name}
                     url={row.iconUrl}
                     size="small"
                   />


### PR DESCRIPTION
## Issue
Closes #47123 

## Description
After PR #47084 routed software titles through `getDisplayedSoftwareName`, several call sites started forwarding the resolved display name to SoftwareIcon, which uses that prop for name-based fallback matching. FMAs (and other titles without a custom uploaded icon) couldn't be matched once an admin renamed them, so they rendered the generic Fleet icon. Pass the raw title name separately for the matcher and keep the display name for the label.

Fixed sites:
- policy automations list and table
- edit appearance self-service preview
- device user setup status table.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
 Didn't test setup experience

 QA plan for #47123

  Setup (once):
  - Premium tier, Fleet on a team with at least one host enrolled.
  - Add an FMA with a recognizable icon — e.g. Notion, Slack, or Zoom — to the team's software library. FMAs don't have a custom uploaded icon, so the icon depends entirely on
   name-based SVG matching. This is the regression class.
  - Also add Microsoft Company Portal (microsoft.companyportal) — exercises the WELL_KNOWN_SOFTWARE_TITLES normalization path even with no admin override.
  - Optional: a custom installer (.pkg/.deb/.msi) with an uploaded PNG icon — sanity check that the custom-icon path still works alongside renames.
  
  Repro check (golden path — should now PASS):
  1. Go to Software → Library, click the Notion FMA.
  2. Click Actions → Edit appearance, set Display name to Wikifier, Save.
  3. Confirm the title icon on the details page stays as the Notion icon (this path was already correct but worth a sanity check).
  4. Now exercise each fixed surface below.

  ---
  Fixed site 1: Policy automations list (right rail on policy detail)
  
  PolicyAutomationsList.tsx

  1. Policies tab → create or open a policy → Manage automations → Install software → pick Wikifier (the renamed Notion FMA) → Save.
  2. On the policy detail page, the Automations card now shows a row for the install-software automation.
  3. ✅ Expected: the row label reads "Wikifier", the icon next to it is the Notion icon.
  4. ❌ Was: generic gray package icon.

  Repeat with the renamed Company Portal FMA — icon should be the Intune Company Portal icon, label "Company Portal" (or whatever you renamed it to).

  Fixed site 2: Policies table automations cell
  
  PoliciesTableConfig.tsx

  1. Go to Policies list page on the team where you wired up the automation above.
  2. Find the row for the policy you configured. Look at the Automations column.
  3. ✅ Expected: the small icon in the cell matches the underlying software (Notion icon, Company Portal icon, etc.) — not generic.
  4. Edge case: a policy with two automations (install software + run script). Make sure the software icon is still correct and the script icon (.sh / .ps1 graphic) is unaffected.

  Fixed site 3: Device user "Setting up your device" status table

  SetupStatusTableConfig.tsx + SetupSoftwareProcessCell.tsx
  
  This is the trickiest to repro because it requires the macOS setup-experience flow.

  1. On the team, enable Setup experience → Install software for the renamed Notion FMA (and ideally the Company Portal FMA).
  2. Enroll a fresh test Mac (or wipe/re-enroll) so it goes through ADE setup.
  3. While the device sits on the "Setting up your device" page (/device/:token), or open that URL post-enrollment, look at the Process column of the status table.
  4. ✅ Expected: each software install row shows the software's matched icon (Notion, Company Portal) next to "Install Wikifier" / "Install Company Portal".
  5. ❌ Was: generic package icon.

  If you don't have a spare Mac to ADE-enroll, the table is also reachable on /device/:token for any host mid-setup — even a manually triggered setup-experience entry will
  exercise the rendering.

  ---
  Regression checks (should remain unchanged)
  
  These were audited as already-correct and shouldn't break:

  - Software → Library and Software → Inventory table icons (uses SoftwareNameCell — raw name was already passed correctly).
  - Software title details page header icon (uses SoftwareDetailsSummary — raw name was already passed correctly).
  - My device → Self-service tiles and update cards on /device/:token.
  - Hosts page filtered by software pill — label only, no icon.
  - Software vulnerability version table icons.

  For each: rename the software's display name (where applicable), confirm the matched icon still renders. Then upload a custom PNG icon on a renamed title and confirm the
  custom icon wins everywhere (/api/.../titles/X/icon?fleet_id=Y path).

  Test types to cover

  Software type: FMA without custom icon
  Why test: Primary regression — bug only manifests on name-matched fallbacks                      
  ────────────────────────────────────────
  Software type: VPP App Store app with rename         
  Why test: app_store_app.icon_url (Apple CDN) should win regardless of rename
  ────────────────────────────────────────             
  Software type: Custom installer with uploaded PNG
  Why test: software_title_icons API URL should win regardless of rename
  ────────────────────────────────────────
  Software type: Custom installer without uploaded icon (e.g. .deb)
  Why test: Source-prefix fallback (getMatchedSoftwareIcon source map) — confirm rename doesn't break it
  ────────────────────────────────────────
  Software type: microsoft.companyportal (well-known)
  Why test: Normalization path — even with NO admin override, display_name resolves to "Company Portal" via WELL_KNOWN_SOFTWARE_TITLES, but the icon must still match


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed software automation icon fallback so original software identifiers are used for icon lookup while still showing user-configured display names.
* **UI**
  * Ensures icons and labels render consistently across policy management lists and device setup status tables.
* **Tests**
  * Added regression tests to verify icon-name fallback behavior and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->