### PR TITLE
Add weekly 'Talk to us' Calendly check

### DIFF
--- a/handbook/finance/finance.rituals.yml
+++ b/handbook/finance/finance.rituals.yml
@@ -189,3 +189,12 @@
   autoIssue:
     labels: [":help-gtm-ops"]
     repo: "confidential"
+- task: "Check Talk to us Calendly links"
+  startedOn: "2026-06-12"
+  frequency: "Weekly"
+  description: "Sam Pfluger checks all Talk to us Calendly links to ensure demos can be booked."
+  moreInfoUrl: "https://fleetdm.com/handbook/finance#update-salesforce-placards"
+  dri: "sampfluger88"
+  autoIssue:
+    labels: [":help-gtm-ops"]
+    repo: "confidential"

--- a/handbook/finance/finance.rituals.yml
+++ b/handbook/finance/finance.rituals.yml
@@ -193,7 +193,7 @@
   startedOn: "2026-06-12"
   frequency: "Weekly"
   description: "Sam Pfluger checks all Talk to us Calendly links to ensure demos can be booked."
-  moreInfoUrl: "https://fleetdm.com/handbook/finance#update-salesforce-placards"
+  moreInfoUrl:
   dri: "sampfluger88"
   autoIssue:
     labels: [":help-gtm-ops"]


### PR DESCRIPTION
QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a weekly ritual "Check Talk to us Calendly links" (effective 2026-06-12) to ensure demo booking links are working; includes automated issue creation for any problems and a placeholder for additional documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->