### PR TITLE
Fix command line flags in agent settings UI

### DIFF
--- a/changes/47412-render-command-line-flags-as-is
+++ b/changes/47412-render-command-line-flags-as-is
@@ -1,0 +1,1 @@
+* Updated the agent settings YAML editor (global and fleet-level) to render `command_line_flags` as-is when set to `{}` or `null`, instead of hiding it behind a comment, since those values have special semantics (they clear all local osquery flags on hosts).

--- a/changes/47412-render-command-line-flags-as-is
+++ b/changes/47412-render-command-line-flags-as-is
@@ -1,1 +1,1 @@
-* Updated the agent settings YAML editor (global and fleet-level) to render `command_line_flags` as-is when set to `{}` or `null`, instead of hiding it behind a comment, since those values have special semantics (they clear all local osquery flags on hosts).
+* Fixed the agent settings YAML editor (global and fleet-level) hiding `command_line_flags` behind a comment when set to `{}` or `null` — those values now render as-is, since they have special semantics (they clear all local osquery flags on hosts).

--- a/frontend/utilities/yaml/index.ts
+++ b/frontend/utilities/yaml/index.ts
@@ -18,21 +18,15 @@ export const agentOptionsToYaml = (agentOpts: any) => {
     delete agentOpts.overrides;
   }
 
-  // add a comment besides the "command_line_flags" if it is empty
-  let addFlagsComment = false;
-  if (
-    !agentOpts.command_line_flags ||
-    Object.keys(agentOpts.command_line_flags).length === 0
-  ) {
-    // delete it so it does not render, and will add it explicitly after (along with the comment)
-    delete agentOpts.command_line_flags;
-    addFlagsComment = true;
-  }
-
+  // when the "command_line_flags" key is absent, suggest it with a comment.
+  // If it is present — even set to {} or null — render it as-is, since those
+  // empty values have special semantics.
   let yamlString = yaml.dump(agentOpts);
-  if (addFlagsComment) {
+  if (!("command_line_flags" in agentOpts)) {
     yamlString +=
-      "# Requires Fleet's osquery installer\n# command_line_flags: {}\n";
+      "# Requires Fleet's osquery installer\n" +
+      "# Setting this to null or {} will clear all local osquery flags on hosts\n" +
+      "# command_line_flags: {}\n";
   }
 
   return yamlString;

--- a/frontend/utilities/yaml/index.ts
+++ b/frontend/utilities/yaml/index.ts
@@ -18,15 +18,20 @@ export const agentOptionsToYaml = (agentOpts: any) => {
     delete agentOpts.overrides;
   }
 
-  // when the "command_line_flags" key is absent, suggest it with a comment.
-  // If it is present — even set to {} or null — render it as-is, since those
-  // empty values have special semantics.
+  const flagsComment = "# Requires fleetd agent\n";
+
+  // always show the informational comment above "command_line_flags". When
+  // the key is present — even set to {} or null — render it as-is, since
+  // those empty values have special semantics; when absent, suggest it with
+  // a commented-out placeholder.
   let yamlString = yaml.dump(agentOpts);
-  if (!("command_line_flags" in agentOpts)) {
-    yamlString +=
-      "# Requires Fleet's osquery installer\n" +
-      "# Setting this to null or {} will clear all local osquery flags on hosts\n" +
-      "# command_line_flags: {}\n";
+  if ("command_line_flags" in agentOpts) {
+    yamlString = yamlString.replace(
+      /^command_line_flags:/m,
+      `${flagsComment}command_line_flags:`
+    );
+  } else {
+    yamlString += `${flagsComment}# command_line_flags: {}\n`;
   }
 
   return yamlString;

--- a/frontend/utilities/yaml/yaml.tests.ts
+++ b/frontend/utilities/yaml/yaml.tests.ts
@@ -1,0 +1,49 @@
+import { agentOptionsToYaml } from "utilities/yaml";
+
+const FLAGS_COMMENT =
+  "# Requires Fleet's osquery installer\n" +
+  "# Setting this to null or {} will clear all local osquery flags on hosts\n" +
+  "# command_line_flags: {}\n";
+
+describe("agentOptionsToYaml", () => {
+  it("adds a command_line_flags comment when the key is absent", () => {
+    expect(agentOptionsToYaml({ config: {} })).toContain(FLAGS_COMMENT);
+  });
+
+  it("adds a command_line_flags comment when agent options are unset", () => {
+    expect(agentOptionsToYaml(null)).toContain(FLAGS_COMMENT);
+  });
+
+  it("renders command_line_flags set to an empty object as-is", () => {
+    const result = agentOptionsToYaml({
+      config: {},
+      command_line_flags: {},
+    });
+    expect(result).toContain("command_line_flags: {}");
+    expect(result).not.toContain(FLAGS_COMMENT);
+  });
+
+  it("renders command_line_flags set to null as-is", () => {
+    const result = agentOptionsToYaml({
+      config: {},
+      command_line_flags: null,
+    });
+    expect(result).toContain("command_line_flags: null");
+    expect(result).not.toContain(FLAGS_COMMENT);
+  });
+
+  it("renders non-empty command_line_flags without the comment", () => {
+    const result = agentOptionsToYaml({
+      config: {},
+      command_line_flags: { verbose: true },
+    });
+    expect(result).toContain("command_line_flags:\n  verbose: true");
+    expect(result).not.toContain(FLAGS_COMMENT);
+  });
+
+  it("omits an empty overrides key", () => {
+    expect(agentOptionsToYaml({ config: {}, overrides: {} })).not.toContain(
+      "overrides"
+    );
+  });
+});

--- a/frontend/utilities/yaml/yaml.tests.ts
+++ b/frontend/utilities/yaml/yaml.tests.ts
@@ -1,44 +1,47 @@
 import { agentOptionsToYaml } from "utilities/yaml";
 
-const FLAGS_COMMENT =
-  "# Requires Fleet's osquery installer\n" +
-  "# Setting this to null or {} will clear all local osquery flags on hosts\n" +
-  "# command_line_flags: {}\n";
+const FLAGS_COMMENT = "# Requires fleetd agent\n";
 
 describe("agentOptionsToYaml", () => {
-  it("adds a command_line_flags comment when the key is absent", () => {
-    expect(agentOptionsToYaml({ config: {} })).toContain(FLAGS_COMMENT);
+  it("adds a commented-out placeholder when the command_line_flags key is absent", () => {
+    expect(agentOptionsToYaml({ config: {} })).toContain(
+      `${FLAGS_COMMENT}# command_line_flags: {}\n`
+    );
   });
 
-  it("adds a command_line_flags comment when agent options are unset", () => {
-    expect(agentOptionsToYaml(null)).toContain(FLAGS_COMMENT);
+  it("adds a commented-out placeholder when agent options are unset", () => {
+    expect(agentOptionsToYaml(null)).toContain(
+      `${FLAGS_COMMENT}# command_line_flags: {}\n`
+    );
   });
 
-  it("renders command_line_flags set to an empty object as-is", () => {
+  it("renders command_line_flags set to an empty object as-is, with the comment above it", () => {
     const result = agentOptionsToYaml({
       config: {},
       command_line_flags: {},
     });
-    expect(result).toContain("command_line_flags: {}");
-    expect(result).not.toContain(FLAGS_COMMENT);
+    expect(result).toContain(`${FLAGS_COMMENT}command_line_flags: {}`);
+    expect(result).not.toContain("# command_line_flags: {}");
   });
 
-  it("renders command_line_flags set to null as-is", () => {
+  it("renders command_line_flags set to null as-is, with the comment above it", () => {
     const result = agentOptionsToYaml({
       config: {},
       command_line_flags: null,
     });
-    expect(result).toContain("command_line_flags: null");
-    expect(result).not.toContain(FLAGS_COMMENT);
+    expect(result).toContain(`${FLAGS_COMMENT}command_line_flags: null`);
+    expect(result).not.toContain("# command_line_flags: {}");
   });
 
-  it("renders non-empty command_line_flags without the comment", () => {
+  it("renders non-empty command_line_flags with the comment above it", () => {
     const result = agentOptionsToYaml({
       config: {},
       command_line_flags: { verbose: true },
     });
-    expect(result).toContain("command_line_flags:\n  verbose: true");
-    expect(result).not.toContain(FLAGS_COMMENT);
+    expect(result).toContain(
+      `${FLAGS_COMMENT}command_line_flags:\n  verbose: true`
+    );
+    expect(result).not.toContain("# command_line_flags: {}");
   });
 
   it("omits an empty overrides key", () => {


### PR DESCRIPTION
Resolves #47412.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent settings editor now renders empty or null command-line flags visibly (instead of hiding them), preserving their clearing behavior for host-level settings.

* **Tests**
  * Added tests to validate YAML output and formatting for command-line flags, missing keys, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->