### PR TITLE
Mark Dell Display Manager input as frozen

### DIFF
--- a/ee/maintained-apps/inputs/winget/dell-display-manager.json
+++ b/ee/maintained-apps/inputs/winget/dell-display-manager.json
@@ -10,5 +10,6 @@
   "installer_scope": "machine",
   "default_categories": ["Productivity"],
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/dell_display_manager_install.ps1",
-  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/dell_display_manager_uninstall.ps1"
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/dell_display_manager_uninstall.ps1",
+  "frozen": true
 }


### PR DESCRIPTION
Add a "frozen": true field to ee/maintained-apps/inputs/winget/dell-display-manager.json to mark this maintained-app input as frozen. This indicates the input should not receive further automated updates and clarifies its maintenance state.
