### PR TITLE
Fix fleet admin permissions with multi-fleet users.

### DIFF
--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
@@ -376,8 +376,8 @@ const UsersPage = ({ location, router }: ITeamSubnavProps): JSX.Element => {
   }, [teamUsers?.length, searchString]);
 
   const columnConfigs = useMemo(
-    () => generateColumnConfigs(onActionSelection),
-    [onActionSelection]
+    () => generateColumnConfigs(onActionSelection, currentUser),
+    [onActionSelection, currentUser]
   );
 
   if (!isRouteOk) {

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
@@ -195,8 +195,10 @@ const generateColumnConfigs = (
             showArrow
             underline={false}
             tipContent={
+              <>
                 This user can&apos;t be managed because they&apos;re a member of
                 other fleets you&apos;re not an admin of.
+              </>
             }
           >
             {dropdown}

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
@@ -195,10 +195,8 @@ const generateColumnConfigs = (
             showArrow
             underline={false}
             tipContent={
-              <>
-                This user can&apos;t be edited because they&apos;re a member of
+                This user can&apos;t be managed because they&apos;re a member of
                 other fleets you&apos;re not an admin of.
-              </>
             }
           >
             {dropdown}

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import stringUtils from "utilities/strings";
+import permissions from "utilities/permissions";
 import { IUser, UserRole } from "interfaces/user";
 import { ITeam } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
@@ -82,7 +83,8 @@ export const renderApiUserIndicator = () => {
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 const generateColumnConfigs = (
-  actionSelectHandler: (value: string, user: IUser) => void
+  actionSelectHandler: (value: string, user: IUser) => void,
+  currentUser: IUser | null
 ): IDataColumn[] => {
   return [
     {
@@ -162,16 +164,47 @@ const generateColumnConfigs = (
       Header: "",
       disableSortBy: true,
       accessor: "actions",
-      Cell: (cellProps: IActionsDropdownProps) => (
-        <ActionsDropdown
-          options={cellProps.cell.value}
-          onChange={(value: string) =>
-            actionSelectHandler(value, cellProps.row.original)
-          }
-          placeholder="Actions"
-          variant="small-button"
-        />
-      ),
+      Cell: (cellProps: IActionsDropdownProps) => {
+        const rowUser = cellProps.row.original;
+        // A team admin can only manage users that are members of fleets they
+        // administer. If the user also belongs to other fleets the current user
+        // is not an admin of, the actions are disabled (mirrors the backend
+        // authorization rule).
+        const canManageUser = permissions.isAdminForAllUserTeams(
+          currentUser,
+          rowUser
+        );
+
+        const dropdown = (
+          <ActionsDropdown
+            options={cellProps.cell.value}
+            onChange={(value: string) => actionSelectHandler(value, rowUser)}
+            placeholder="Actions"
+            variant="small-button"
+            disabled={!canManageUser}
+          />
+        );
+
+        if (canManageUser) {
+          return dropdown;
+        }
+
+        return (
+          <TooltipWrapper
+            position="top"
+            showArrow
+            underline={false}
+            tipContent={
+              <>
+                This user can&apos;t be edited because they&apos;re a member of
+                other fleets you&apos;re not an admin of.
+              </>
+            }
+          >
+            {dropdown}
+          </TooltipWrapper>
+        );
+      },
     },
   ];
 };

--- a/frontend/utilities/permissions/permissions.tests.ts
+++ b/frontend/utilities/permissions/permissions.tests.ts
@@ -1,0 +1,110 @@
+import createMockUser from "__mocks__/userMock";
+
+import permissions from ".";
+
+describe("permissions - isAdminForAllUserTeams", () => {
+  const globalAdmin = createMockUser({ global_role: "admin", teams: [] });
+  const teamAdminTeam1 = createMockUser({
+    global_role: null,
+    teams: [{ id: 1, name: "Team 1", role: "admin" }],
+  });
+  const teamAdminTeam1And2 = createMockUser({
+    global_role: null,
+    teams: [
+      { id: 1, name: "Team 1", role: "admin" },
+      { id: 2, name: "Team 2", role: "admin" },
+    ],
+  });
+  const teamAdminTeam1ObserverTeam2 = createMockUser({
+    global_role: null,
+    teams: [
+      { id: 1, name: "Team 1", role: "admin" },
+      { id: 2, name: "Team 2", role: "observer" },
+    ],
+  });
+
+  it("returns false when there is no current user", () => {
+    const target = createMockUser({
+      global_role: null,
+      teams: [{ id: 1, name: "Team 1", role: "observer" }],
+    });
+    expect(permissions.isAdminForAllUserTeams(null, target)).toBe(false);
+  });
+
+  it("allows a global admin to manage any user", () => {
+    const target = createMockUser({
+      global_role: null,
+      teams: [
+        { id: 1, name: "Team 1", role: "observer" },
+        { id: 2, name: "Team 2", role: "admin" },
+      ],
+    });
+    expect(permissions.isAdminForAllUserTeams(globalAdmin, target)).toBe(true);
+  });
+
+  it("allows a team admin to manage a user that only belongs to fleets they administer", () => {
+    const target = createMockUser({
+      global_role: null,
+      teams: [{ id: 1, name: "Team 1", role: "observer" }],
+    });
+    expect(permissions.isAdminForAllUserTeams(teamAdminTeam1, target)).toBe(
+      true
+    );
+  });
+
+  it("prevents a team admin from managing a user that also belongs to fleets they do not administer", () => {
+    const target = createMockUser({
+      global_role: null,
+      teams: [
+        { id: 1, name: "Team 1", role: "observer" },
+        { id: 2, name: "Team 2", role: "admin" },
+      ],
+    });
+    expect(permissions.isAdminForAllUserTeams(teamAdminTeam1, target)).toBe(
+      false
+    );
+  });
+
+  it("allows a team admin of all the user's fleets to manage that user", () => {
+    const target = createMockUser({
+      global_role: null,
+      teams: [
+        { id: 1, name: "Team 1", role: "observer" },
+        { id: 2, name: "Team 2", role: "admin" },
+      ],
+    });
+    expect(
+      permissions.isAdminForAllUserTeams(teamAdminTeam1And2, target)
+    ).toBe(true);
+  });
+
+  it("prevents a team admin of one fleet but only observer of another from managing a user that belongs to both", () => {
+    const target = createMockUser({
+      global_role: null,
+      teams: [
+        { id: 1, name: "Team 1", role: "observer" },
+        { id: 2, name: "Team 2", role: "observer" },
+      ],
+    });
+    expect(
+      permissions.isAdminForAllUserTeams(teamAdminTeam1ObserverTeam2, target)
+    ).toBe(false);
+  });
+
+  it("prevents a team admin from managing a user with a global role", () => {
+    const target = createMockUser({
+      global_role: "observer",
+      teams: [{ id: 1, name: "Team 1", role: "observer" }],
+    });
+    expect(permissions.isAdminForAllUserTeams(teamAdminTeam1, target)).toBe(
+      false
+    );
+  });
+
+  it("prevents a team admin from managing a user with no fleets", () => {
+    const target = createMockUser({ global_role: null, teams: [] });
+    expect(permissions.isAdminForAllUserTeams(teamAdminTeam1, target)).toBe(
+      false
+    );
+  });
+});

--- a/frontend/utilities/permissions/permissions.tests.ts
+++ b/frontend/utilities/permissions/permissions.tests.ts
@@ -73,9 +73,9 @@ describe("permissions - isAdminForAllUserTeams", () => {
         { id: 2, name: "Team 2", role: "admin" },
       ],
     });
-    expect(
-      permissions.isAdminForAllUserTeams(teamAdminTeam1And2, target)
-    ).toBe(true);
+    expect(permissions.isAdminForAllUserTeams(teamAdminTeam1And2, target)).toBe(
+      true
+    );
   });
 
   it("prevents a team admin of one fleet but only observer of another from managing a user that belongs to both", () => {

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -68,6 +68,32 @@ export const isTeamAdmin = (
   return userTeamRole === "admin";
 };
 
+// isAdminForAllUserTeams returns true if `user` is allowed to manage `otherUser`
+// based on team membership: a global admin can manage anyone, otherwise `user`
+// must be a team admin of EVERY team `otherUser` belongs to (and `otherUser`
+// must belong to at least one team and have no global role). This mirrors the
+// backend authorization rule that prevents a team admin from editing users who
+// also belong to fleets the admin doesn't manage.
+export const isAdminForAllUserTeams = (
+  user: IUser | null,
+  otherUser: IUser
+): boolean => {
+  if (!user) {
+    return false;
+  }
+  if (isGlobalAdmin(user)) {
+    return true;
+  }
+  // Only a global admin can manage a user that has a global role.
+  if (otherUser.global_role) {
+    return false;
+  }
+  if (otherUser.teams.length === 0) {
+    return false;
+  }
+  return otherUser.teams.every((team) => isTeamAdmin(user, team.id));
+};
+
 const isTeamMaintainerOrTeamAdmin = (
   user: IUser | null,
   teamId: number | null
@@ -185,6 +211,7 @@ export default {
   isAnyTeamMaintainer,
   isAnyTeamMaintainerOrTeamAdmin,
   isTeamAdmin,
+  isAdminForAllUserTeams,
   isAnyTeamAdmin,
   isTeamTechnician,
   isAnyTeamTechnician,

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -53,6 +53,15 @@ team_role(subject, team_id) = role {
 	role := subject_team.role
 }
 
+# team_role_or_none is like team_role but returns "" (instead of undefined) when
+# the subject has no explicit role for the team. This allows expressing "for all
+# teams" checks that must also reject teams the subject has no role in.
+team_role_or_none(subject, team_id) = role {
+	role := team_role(subject, team_id)
+} else = "" {
+	true
+}
+
 ##
 # Global config
 ##
@@ -158,11 +167,25 @@ allow {
   action == read
 }
 
-# Team admins can perform all operations on the team users (except changing their password).
+# Team admins can perform all operations on the team users (except changing their
+# password), but only if they are an admin of EVERY team the object user belongs
+# to. Otherwise a team admin could grant a user access to (or modify a user in) a
+# team they don't administer, including teams they have no role in at all.
 allow {
   object.type == "user"
-  team_role(subject, object.teams[_].id) == admin
   action == [read, write, write_role][_]
+  # The object user must belong to at least one team.
+  object.teams[_]
+  # The subject must not be a non-admin of any of the object user's teams, i.e.
+  # the subject is a team admin of all of the object user's teams.
+  not subject_not_admin_of_some_object_team
+}
+
+# subject_not_admin_of_some_object_team is true if there is at least one team of
+# the object user for which the subject is not a team admin (this includes teams
+# in which the subject has no role at all).
+subject_not_admin_of_some_object_team {
+  team_role_or_none(subject, object.teams[_].id) != admin
 }
 
 ##

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -199,6 +199,29 @@ func TestAuthorizeUser(t *testing.T) {
 		ID:    102,
 		Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}},
 	}
+	// A team admin of both team 1 and team 2.
+	twoTeamsAdmin := &fleet.User{
+		ID: 103,
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin},
+			{Team: fleet.Team{ID: 2}, Role: fleet.RoleAdmin},
+		},
+	}
+	// A user (object) that belongs to both team 1 and team 2.
+	teamUserTeam1AndTeam2 := &fleet.User{
+		ID: 104,
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver},
+			{Team: fleet.Team{ID: 2}, Role: fleet.RoleObserver},
+		},
+	}
+	// A new user (object) being created in both team 1 and team 2.
+	newUserTeam1AndTeam2 := &fleet.User{
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin},
+			{Team: fleet.Team{ID: 2}, Role: fleet.RoleAdmin},
+		},
+	}
 
 	runTestCases(t, []authTestCase{
 		{user: nil, object: user, action: read, allow: false},
@@ -302,6 +325,23 @@ func TestAuthorizeUser(t *testing.T) {
 		{user: teamAdmin, object: teamAdmin, action: write, allow: true},
 		{user: teamAdmin, object: teamAdmin, action: writeRole, allow: true},
 		{user: teamAdmin, object: teamAdmin, action: changePwd, allow: true},
+
+		// A team admin of only team 1 cannot read/write/create a user that belongs to
+		// a team they don't administer (regression test for the privilege escalation
+		// where a team admin could create/modify users in other teams).
+		{user: teamAdmin, object: teamUserTeam1AndTeam2, action: read, allow: false},
+		{user: teamAdmin, object: teamUserTeam1AndTeam2, action: write, allow: false},
+		{user: teamAdmin, object: teamUserTeam1AndTeam2, action: writeRole, allow: false},
+		{user: teamAdmin, object: newUserTeam1AndTeam2, action: write, allow: false},
+
+		// A team admin of both team 1 and team 2 can read/write/create a user that
+		// belongs to those teams.
+		{user: twoTeamsAdmin, object: teamUserTeam1AndTeam2, action: read, allow: true},
+		{user: twoTeamsAdmin, object: teamUserTeam1AndTeam2, action: write, allow: true},
+		{user: twoTeamsAdmin, object: teamUserTeam1AndTeam2, action: writeRole, allow: true},
+		{user: twoTeamsAdmin, object: newUserTeam1AndTeam2, action: write, allow: true},
+		// And a user that only belongs to one of the teams they administer.
+		{user: twoTeamsAdmin, object: newTeamUser, action: write, allow: true},
 	})
 }
 

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -10,7 +10,6 @@ import (
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
-	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -207,6 +206,14 @@ func TestAuthorizeUser(t *testing.T) {
 			{Team: fleet.Team{ID: 2}, Role: fleet.RoleAdmin},
 		},
 	}
+	// An admin of team 1 but only an observer of team 2.
+	team1AdminTeam2Observer := &fleet.User{
+		ID: 105,
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin},
+			{Team: fleet.Team{ID: 2}, Role: fleet.RoleObserver},
+		},
+	}
 	// A user (object) that belongs to both team 1 and team 2.
 	teamUserTeam1AndTeam2 := &fleet.User{
 		ID: 104,
@@ -342,6 +349,14 @@ func TestAuthorizeUser(t *testing.T) {
 		{user: twoTeamsAdmin, object: newUserTeam1AndTeam2, action: write, allow: true},
 		// And a user that only belongs to one of the teams they administer.
 		{user: twoTeamsAdmin, object: newTeamUser, action: write, allow: true},
+
+		// An admin of team 1 that is only an observer of team 2 cannot read/write a
+		// user that belongs to both teams (being an admin of one of the user's teams
+		// is not enough; admin is required on all of them).
+		{user: team1AdminTeam2Observer, object: teamUserTeam1AndTeam2, action: read, allow: false},
+		{user: team1AdminTeam2Observer, object: teamUserTeam1AndTeam2, action: write, allow: false},
+		{user: team1AdminTeam2Observer, object: teamUserTeam1AndTeam2, action: writeRole, allow: false},
+		{user: team1AdminTeam2Observer, object: newUserTeam1AndTeam2, action: write, allow: false},
 	})
 }
 
@@ -407,7 +422,7 @@ func TestAuthorizeEnrollSecret(t *testing.T) {
 		},
 	}
 	globalSecret := &fleet.EnrollSecret{TeamID: nil}
-	teamSecret := &fleet.EnrollSecret{TeamID: ptr.Uint(1)}
+	teamSecret := &fleet.EnrollSecret{TeamID: new(uint(1))}
 	runTestCases(t, []authTestCase{
 		// No access
 		{user: nil, object: globalSecret, action: read, allow: false},
@@ -583,7 +598,7 @@ func TestAuthorizeLabel(t *testing.T) {
 		return fleet.Label{TeamID: &user.Teams[0].ID}
 	}
 	differentTeamLabel := func(_ *fleet.User) fleet.Label {
-		return fleet.Label{TeamID: ptr.Uint(999)}
+		return fleet.Label{TeamID: new(uint(999))}
 	}
 
 	runTestCases(t, []authTestCase{
@@ -685,8 +700,8 @@ func TestAuthorizeSoftwareInventory(t *testing.T) {
 	t.Parallel()
 
 	softwareInventory := &fleet.AuthzSoftwareInventory{}
-	team1SoftwareInventory := &fleet.AuthzSoftwareInventory{TeamID: ptr.Uint(1)}
-	team2SoftwareInventory := &fleet.AuthzSoftwareInventory{TeamID: ptr.Uint(2)}
+	team1SoftwareInventory := &fleet.AuthzSoftwareInventory{TeamID: new(uint(1))}
+	team2SoftwareInventory := &fleet.AuthzSoftwareInventory{TeamID: new(uint(2))}
 	runTestCases(t, []authTestCase{
 		{user: nil, object: softwareInventory, action: read, allow: false},
 		{user: test.UserNoRoles, object: softwareInventory, action: read, allow: false},
@@ -708,8 +723,8 @@ func TestAuthorizeSoftwareInstaller(t *testing.T) {
 	t.Parallel()
 
 	noTeamInstaller := &fleet.SoftwareInstaller{}
-	team1Installer := &fleet.SoftwareInstaller{TeamID: ptr.Uint(1)}
-	team2Installer := &fleet.SoftwareInstaller{TeamID: ptr.Uint(2)}
+	team1Installer := &fleet.SoftwareInstaller{TeamID: new(uint(1))}
+	team2Installer := &fleet.SoftwareInstaller{TeamID: new(uint(2))}
 	runTestCases(t, []authTestCase{
 		{user: nil, object: noTeamInstaller, action: read, allow: false},
 		{user: nil, object: noTeamInstaller, action: write, allow: false},
@@ -839,8 +854,8 @@ func TestAuthorizeHostSoftwareInstallerResult(t *testing.T) {
 	t.Parallel()
 
 	noTeamInstallResult := &fleet.HostSoftwareInstallerResultAuthz{}
-	team1InstallResult := &fleet.HostSoftwareInstallerResultAuthz{HostTeamID: ptr.Uint(1)}
-	team2InstallResult := &fleet.HostSoftwareInstallerResultAuthz{HostTeamID: ptr.Uint(2)}
+	team1InstallResult := &fleet.HostSoftwareInstallerResultAuthz{HostTeamID: new(uint(1))}
+	team2InstallResult := &fleet.HostSoftwareInstallerResultAuthz{HostTeamID: new(uint(2))}
 	runTestCases(t, []authTestCase{
 		// Write permissions
 		{user: nil, object: noTeamInstallResult, action: write, allow: false},
@@ -992,8 +1007,8 @@ func TestAuthorizeHost(t *testing.T) {
 		},
 	}
 	host := &fleet.Host{}
-	hostTeam1 := &fleet.Host{TeamID: ptr.Uint(1)}
-	hostTeam2 := &fleet.Host{TeamID: ptr.Uint(2)}
+	hostTeam1 := &fleet.Host{TeamID: new(uint(1))}
+	hostTeam2 := &fleet.Host{TeamID: new(uint(2))}
 	runTestCases(t, []authTestCase{
 		// No access
 		{user: nil, object: host, action: read, allow: false},
@@ -1433,27 +1448,27 @@ func TestAuthorizeQuery(t *testing.T) {
 
 	teamAdminQuery := &fleet.Query{
 		ID:             1,
-		AuthorID:       ptr.Uint(teamAdmin.ID),
+		AuthorID:       new(teamAdmin.ID),
 		ObserverCanRun: false,
-		TeamID:         ptr.Uint(1),
+		TeamID:         new(uint(1)),
 	}
 	teamMaintQuery := &fleet.Query{
 		ID:             2,
-		AuthorID:       ptr.Uint(teamMaintainer.ID),
+		AuthorID:       new(teamMaintainer.ID),
 		ObserverCanRun: false,
-		TeamID:         ptr.Uint(1),
+		TeamID:         new(uint(1)),
 	}
-	globalAdminQuery := &fleet.Query{ID: 3, AuthorID: ptr.Uint(test.UserAdmin.ID), ObserverCanRun: false}
-	globalGitOpsQuery := &fleet.Query{ID: 4, AuthorID: ptr.Uint(test.UserGitOps.ID), ObserverCanRun: false}
+	globalAdminQuery := &fleet.Query{ID: 3, AuthorID: new(test.UserAdmin.ID), ObserverCanRun: false}
+	globalGitOpsQuery := &fleet.Query{ID: 4, AuthorID: new(test.UserGitOps.ID), ObserverCanRun: false}
 	teamGitOpsQuery := &fleet.Query{
-		ID: 5, AuthorID: ptr.Uint(teamGitOps.ID),
+		ID: 5, AuthorID: new(teamGitOps.ID),
 		ObserverCanRun: false,
-		TeamID:         ptr.Uint(1),
+		TeamID:         new(uint(1)),
 	}
 	observerQueryOnTeam3 := &fleet.Query{
 		ID:             6,
 		ObserverCanRun: true,
-		TeamID:         ptr.Uint(3),
+		TeamID:         new(uint(3)),
 	}
 	observerQueryOnTeam3TargetedToTeam3 := &fleet.TargetedQuery{
 		HostTargets: fleet.HostTargets{TeamIDs: []uint{3}},
@@ -1470,7 +1485,7 @@ func TestAuthorizeQuery(t *testing.T) {
 	observerQueryOnTeam1 := &fleet.Query{
 		ID:             7,
 		ObserverCanRun: true,
-		TeamID:         ptr.Uint(1),
+		TeamID:         new(uint(1)),
 	}
 	observerQueryOnTeam1TargetedToTeam1 := &fleet.TargetedQuery{
 		HostTargets: fleet.HostTargets{TeamIDs: []uint{1}},
@@ -1487,7 +1502,7 @@ func TestAuthorizeQuery(t *testing.T) {
 	observerQueryOnTeam2 := &fleet.Query{
 		ID:             8,
 		ObserverCanRun: true,
-		TeamID:         ptr.Uint(2),
+		TeamID:         new(uint(2)),
 	}
 	observerQueryOnTeam2TargetedToTeam2 := &fleet.TargetedQuery{
 		HostTargets: fleet.HostTargets{TeamIDs: []uint{2}},
@@ -2035,12 +2050,12 @@ func TestAuthorizeTeamPolicy(t *testing.T) {
 
 	team1Policy := &fleet.Policy{
 		PolicyData: fleet.PolicyData{
-			TeamID: ptr.Uint(1),
+			TeamID: new(uint(1)),
 		},
 	}
 	team2Policy := &fleet.Policy{
 		PolicyData: fleet.PolicyData{
-			TeamID: ptr.Uint(2),
+			TeamID: new(uint(2)),
 		},
 	}
 	runTestCases(t, []authTestCase{
@@ -2111,7 +2126,7 @@ func TestAuthorizeMDMConfigProfile(t *testing.T) {
 
 	globalProfile := &fleet.MDMConfigProfileAuthz{}
 	team1Profile := &fleet.MDMConfigProfileAuthz{
-		TeamID: ptr.Uint(1),
+		TeamID: new(uint(1)),
 	}
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalProfile, action: write, allow: false},
@@ -2216,7 +2231,7 @@ func TestAuthorizeMDMAppleSettings(t *testing.T) {
 
 	globalSettings := &fleet.MDMAppleSettingsPayload{}
 	team1Settings := &fleet.MDMAppleSettingsPayload{
-		TeamID: ptr.Uint(1),
+		TeamID: new(uint(1)),
 	}
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalSettings, action: write, allow: false},
@@ -2316,7 +2331,7 @@ func TestAuthorizeMDMAppleSetupAssistant(t *testing.T) {
 
 	globalSettings := &fleet.MDMAppleSetupAssistant{}
 	team1Settings := &fleet.MDMAppleSetupAssistant{
-		TeamID: ptr.Uint(1),
+		TeamID: new(uint(1)),
 	}
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalSettings, action: write, allow: false},
@@ -2593,7 +2608,7 @@ func TestAuthorizeMDMCommand(t *testing.T) {
 
 	globalCommand := &fleet.MDMCommandAuthz{}
 	team1Command := &fleet.MDMCommandAuthz{
-		TeamID: ptr.Uint(1),
+		TeamID: new(uint(1)),
 	}
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalCommand, action: write, allow: false},
@@ -2697,9 +2712,9 @@ func TestAuthorizeHostScriptResult(t *testing.T) {
 	t.Parallel()
 
 	globalScript := &fleet.HostScriptResult{}
-	globalSavedScript := &fleet.HostScriptResult{ScriptID: ptr.Uint(1)}
-	team1Script := &fleet.HostScriptResult{TeamID: ptr.Uint(1)}
-	team1SavedScript := &fleet.HostScriptResult{TeamID: ptr.Uint(1), ScriptID: ptr.Uint(1)}
+	globalSavedScript := &fleet.HostScriptResult{ScriptID: new(uint(1))}
+	team1Script := &fleet.HostScriptResult{TeamID: new(uint(1))}
+	team1SavedScript := &fleet.HostScriptResult{TeamID: new(uint(1)), ScriptID: new(uint(1))}
 
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalScript, action: write, allow: false},
@@ -2880,7 +2895,7 @@ func TestAuthorizeScript(t *testing.T) {
 
 	globalScript := &fleet.Script{}
 	team1Script := &fleet.Script{
-		TeamID: ptr.Uint(1),
+		TeamID: new(uint(1)),
 	}
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalScript, action: write, allow: false},
@@ -2983,7 +2998,7 @@ func TestAuthorizeScript(t *testing.T) {
 func TestJSONToInterfaceUser(t *testing.T) {
 	t.Parallel()
 
-	subject, err := jsonToInterface(&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)})
+	subject, err := jsonToInterface(&fleet.User{GlobalRole: new(fleet.RoleAdmin)})
 	require.NoError(t, err)
 	{
 		subject := subject.(map[string]interface{})
@@ -3012,7 +3027,7 @@ func TestJSONToInterfaceUser(t *testing.T) {
 func TestHostHealth(t *testing.T) {
 	t.Parallel()
 
-	hostHealth := &fleet.HostHealth{TeamID: ptr.Uint(1)}
+	hostHealth := &fleet.HostHealth{TeamID: new(uint(1))}
 	runTestCases(t, []authTestCase{
 		{user: nil, object: hostHealth, action: read, allow: false},
 		{user: test.UserGitOps, object: hostHealth, action: read, allow: false},


### PR DESCRIPTION
- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

<img width="2119" height="774" alt="Screenshot 2026-06-11 at 11 45 58 AM" src="https://github.com/user-attachments/assets/1b940649-e1fe-4162-bb22-d9eb73401f47" />

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now disables actions for users outside an admin’s full scope, showing tooltips; column config now respects the current user.
  * Added a permission helper to determine if one user can manage all teams of another.
  * Server-side authorization tightened to deny team-admin actions when coverage of the target’s teams is incomplete.

* **Tests**
  * Added comprehensive tests for multi-team and mixed-role permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->