### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.309.0",
+      "version": "7.319.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.309.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.319.1') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.309.0/Granola-7.309.0-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.319.1/Granola-7.319.1-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "3dd76897395f981f8f4bfef52b75bb88e09b7948d73a1e253dbd99713df86b0f",
+      "sha256": "9617754af892e481add2667481df3fa455d01d12af3b9dd8cdaf8854c7feb735",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.309.0",
+      "version": "7.319.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.309.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.319.1') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.309.0/Granola-7.309.0-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.319.1/Granola-7.319.1-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "6854bcd0fe746ff547f5ea5414ae84cb8c4a06d50bc037a81da6e81ac57e1200",
+      "sha256": "4cdeabf87e9b72d23ef7e59896087a4d67481f50e74b58eac9c25ec1b4a61942",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.1.25",
+      "version": "1.1.27",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.1.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.1.27') < 0);"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.1.25/Hive-1.1.25-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.1.27/Hive-1.1.27-arm64.dmg",
       "install_script_ref": "6b39e7ad",
       "uninstall_script_ref": "78bb4e43",
-      "sha256": "9fa7ede18e652c8f88b368ae45444968cd44aaab823a939b08223e94906c074c",
+      "sha256": "5749bfac1735b3c6167e2318bca2181503ff32521327e1f6b90a13f8a0fe9c08",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/pale-moon/darwin.json
+++ b/ee/maintained-apps/outputs/pale-moon/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "34.3.0",
+      "version": "34.3.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.pale moon';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.pale moon' AND version_compare(bundle_short_version, '34.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.pale moon' AND version_compare(bundle_short_version, '34.3.0.1') < 0);"
       },
-      "installer_url": "https://rm-us.palemoon.org/release/palemoon-34.3.0.arm64.dmg",
+      "installer_url": "https://rm-us.palemoon.org/release/palemoon-34.3.0.1.arm64.dmg",
       "install_script_ref": "79f730f7",
       "uninstall_script_ref": "6e68aa8a",
-      "sha256": "45b83582af9f86428aff0de374c9a742344d682f241f72123b5cc69f3b01f832",
+      "sha256": "382c3dc8a55c38e7ca4535551858f7fd1c8bd6d3a10f8088edab1c1c0a85dbbc",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/phoenix-slides/darwin.json
+++ b/ee/maintained-apps/outputs/phoenix-slides/darwin.json
@@ -11,7 +11,7 @@
       "uninstall_script_ref": "0f6d4b37",
       "sha256": "84c6165c37ad3f143bfbbab8e57a797b23d9524cbbc2c7349884f8ed5de4c694",
       "default_categories": [
-        "Developer tools"
+        "Productivity"
       ]
     }
   ],

--- a/ee/maintained-apps/outputs/proton-mail-bridge/darwin.json
+++ b/ee/maintained-apps/outputs/proton-mail-bridge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.24.2",
+      "version": "3.25.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.protonmail.bridge';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.protonmail.bridge' AND version_compare(bundle_short_version, '3.24.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.protonmail.bridge' AND version_compare(bundle_short_version, '3.25.0') < 0);"
       },
-      "installer_url": "https://github.com/ProtonMail/proton-bridge/releases/download/v3.24.2/Bridge-Installer.dmg",
+      "installer_url": "https://github.com/ProtonMail/proton-bridge/releases/download/v3.25.0/Bridge-Installer.dmg",
       "install_script_ref": "94046760",
       "uninstall_script_ref": "b9fdcb78",
-      "sha256": "46ca2f650836382ffb12a580d50dc3199252b89692f867d3082a1a233555bb6f",
+      "sha256": "fee7461131ab331f02106207a790044d356154f3c911e83746320d82f88be91a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/rightfont/darwin.json
+++ b/ee/maintained-apps/outputs/rightfont/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "10.0",
+      "version": "10.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.rightfontapp.RightFont5';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rightfontapp.RightFont5' AND version_compare(bundle_short_version, '10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rightfontapp.RightFont5' AND version_compare(bundle_short_version, '10.0.1') < 0);"
       },
       "installer_url": "https://rightfontapp.com/update/rightfont.zip",
       "install_script_ref": "40969d32",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app version metadata for Granola (7.319.1), Hive App (1.1.27), Pale Moon (34.3.0.1), Proton Mail Bridge (3.25.0), and RightFont (10.0.1) to reflect latest releases with corresponding installer checksums.
  * Updated Phoenix Slides categorization from Developer Tools to Productivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->