### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/camtasia/windows.json
+++ b/ee/maintained-apps/outputs/camtasia/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.2.16723",
+      "version": "26.1.3.17772",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation' AND version_compare(version, '26.1.2.16723') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Camtasia' AND publisher = 'TechSmith Corporation' AND version_compare(version, '26.1.3.17772') < 0);"
       },
-      "installer_url": "https://download.techsmith.com/camtasiastudio/releases/2612/camtasia.msi",
+      "installer_url": "https://download.techsmith.com/camtasiastudio/releases/2613/camtasia.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "1c05707a",
-      "sha256": "e0fc0054b3b51790f8155f7ad86696587b15615c86ec7a1ee9d9a13f9fd5fce7",
+      "sha256": "f1f155f6ff43428ec608d051889d8fc0d22dcc5a5e76c3d54791abc33584fb8a",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/pale-moon/darwin.json
+++ b/ee/maintained-apps/outputs/pale-moon/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "34.3.0",
+      "version": "34.3.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.pale moon';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.pale moon' AND version_compare(bundle_short_version, '34.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.pale moon' AND version_compare(bundle_short_version, '34.3.0.1') < 0);"
       },
-      "installer_url": "https://rm-us.palemoon.org/release/palemoon-34.3.0.arm64.dmg",
+      "installer_url": "https://rm-us.palemoon.org/release/palemoon-34.3.0.1.arm64.dmg",
       "install_script_ref": "79f730f7",
       "uninstall_script_ref": "6e68aa8a",
-      "sha256": "45b83582af9f86428aff0de374c9a742344d682f241f72123b5cc69f3b01f832",
+      "sha256": "382c3dc8a55c38e7ca4535551858f7fd1c8bd6d3a10f8088edab1c1c0a85dbbc",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/phoenix-slides/darwin.json
+++ b/ee/maintained-apps/outputs/phoenix-slides/darwin.json
@@ -11,7 +11,7 @@
       "uninstall_script_ref": "0f6d4b37",
       "sha256": "84c6165c37ad3f143bfbbab8e57a797b23d9524cbbc2c7349884f8ed5de4c694",
       "default_categories": [
-        "Developer tools"
+        "Productivity"
       ]
     }
   ],

--- a/ee/maintained-apps/outputs/proton-mail-bridge/darwin.json
+++ b/ee/maintained-apps/outputs/proton-mail-bridge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.24.2",
+      "version": "3.25.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.protonmail.bridge';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.protonmail.bridge' AND version_compare(bundle_short_version, '3.24.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.protonmail.bridge' AND version_compare(bundle_short_version, '3.25.0') < 0);"
       },
-      "installer_url": "https://github.com/ProtonMail/proton-bridge/releases/download/v3.24.2/Bridge-Installer.dmg",
+      "installer_url": "https://github.com/ProtonMail/proton-bridge/releases/download/v3.25.0/Bridge-Installer.dmg",
       "install_script_ref": "94046760",
       "uninstall_script_ref": "b9fdcb78",
-      "sha256": "46ca2f650836382ffb12a580d50dc3199252b89692f867d3082a1a233555bb6f",
+      "sha256": "fee7461131ab331f02106207a790044d356154f3c911e83746320d82f88be91a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.06.03.09.49.03",
+      "version": "0.2026.06.03.09.49.04",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.03.09.49.03') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.03.09.49.04') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.03.09.49.stable_03/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.03.09.49.stable_04/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.23.17",
+      "version": "26.23.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.23.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.23.19') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",

--- a/ee/maintained-apps/outputs/workflowy/darwin.json
+++ b/ee/maintained-apps/outputs/workflowy/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.2606091008",
+      "version": "4.3.2606111008",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop' AND version_compare(bundle_short_version, '4.3.2606091008') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop' AND version_compare(bundle_short_version, '4.3.2606111008') < 0);"
       },
-      "installer_url": "https://github.com/workflowy/desktop/releases/download/v4.3.2606091008/WorkFlowy.zip",
+      "installer_url": "https://github.com/workflowy/desktop/releases/download/v4.3.2606111008/WorkFlowy.zip",
       "install_script_ref": "467dafec",
       "uninstall_script_ref": "effe5345",
-      "sha256": "c645082b82195061a9591f7e12ab694fa2f7ad30b8ecafa76a48119cacea17cd",
+      "sha256": "2f01b38ad0e681a865e02be5320bc07d978a1cb1f530a3e7ce825c93a71fc668",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported application versions: Camtasia (26.1.3.17772), Pale Moon (34.3.0.1), Proton Mail Bridge (3.25.0), Warp (0.2026.06.03.09.49.04), WhatsApp (26.23.19), and Workflowy (4.3.2606111008)
  * Refined Phoenix Slides category classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->