### PR TITLE
Enable macOS EndpointSecurity and FDE profile

### DIFF
--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -52,6 +52,9 @@ agent_options:
     watchdog_utilization_limit: 130
     # --- macOS FIM ---
     enable_file_events: true
+    # --- macOS EndpointSecurity tables (requires Full Disk Access for osqueryd) ---
+    disable_endpointsecurity: false       # enables es_process_events
+    disable_endpointsecurity_fim: false   # enables es_process_file_events
     # --- Linux process + socket auditing via the audit framework ---
     disable_audit: false
     audit_allow_process_events: true
@@ -64,6 +67,10 @@ agent_options:
     orbit: edge
     desktop: edge
 controls:
+  apple_settings:
+    configuration_profiles:
+      # Required for osqueryd to inherit Full Disk Access (EndpointSecurity tables)
+      - path: ../lib/macos/configuration-profiles/full-disk-access-for-fleetd.mobileconfig
   setup_experience:
     macos_bootstrap_package: ""
     enable_end_user_authentication: true

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -62,6 +62,9 @@ agent_options:
     watchdog_utilization_limit: 130
     # --- macOS FIM ---
     enable_file_events: true
+    # --- macOS EndpointSecurity tables (requires Full Disk Access for osqueryd) ---
+    disable_endpointsecurity: false       # enables es_process_events
+    disable_endpointsecurity_fim: false   # enables es_process_file_events
     # --- Linux process + socket auditing via the audit framework ---
     disable_audit: false
     audit_allow_process_events: true


### PR DESCRIPTION
Enable EndpointSecurity-based process and FIM events in fleet configs and add the Full Disk Access profile for macOS. Adds disable_endpointsecurity: false and disable_endpointsecurity_fim: false to agent_options in testing-and-qa.yml and workstations.yml (enables es_process_events and es_process_file_events). Adds an apple_settings.configuration_profiles entry in testing-and-qa.yml pointing to full-disk-access-for-fleetd.mobileconfig so osqueryd can inherit Full Disk Access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS security monitoring by updating fleet configurations to enable endpoint security event tracking.
  * Added Full Disk Access configuration profile to support expanded security monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->