### PR TITLE
Update changelog for fleetd 1.56.3 release

### DIFF
--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.56.3 (Jun 11, 2026)
+
+* Added exponential backoff with jitter to Fleet Desktop's server polling. On error (401, 5xx, network failure), Desktop now doubles its retry interval (capped at 30 minutes) instead of retrying at a fixed rate. A single success resets to the normal interval. This prevents request storms that can overwhelm the database when many hosts have expired tokens.
+
+* Added support for on-demand Windows MDM sync. When the Fleet server requests it, fleetd now starts an OMA-DM management session so queued Windows MDM commands are delivered promptly even when the device's MDM poll schedule has been relaxed. This lets the server reduce the Windows MDM poll frequency without increasing command latency.
+
+* Fixed fleetd clearing pre-packaged/user-provided osquery flagfiles (`osquery.flags`) when `command_line_flags` is unset in the agent settings. Setting `command_line_flags` to an empty document (`{}` or `null`) still explicitly clears the flagfile.
+
+* Updated go to 1.26.4
+
+* Updated the Fleet Desktop disk encryption prompt on TPM-backed Linux hosts (e.g., Ubuntu 23.10+) to ask for the disk recovery key saved during installation, instead of a LUKS passphrase.
+
 ## 1.56.2 (Jun 04, 2026)
 
 * Added the `orbit.debug_logging_on_enroll_duration` agent option to allow enabling orbit debug logging for a specified time period after enrollment.

--- a/orbit/changes/43773-windows-mdm-on-demand-sync
+++ b/orbit/changes/43773-windows-mdm-on-demand-sync
@@ -1,1 +1,0 @@
-- Added support for on-demand Windows MDM sync. When the Fleet server requests it, fleetd now starts an OMA-DM management session so queued Windows MDM commands are delivered promptly even when the device's MDM poll schedule has been relaxed. This lets the server reduce the Windows MDM poll frequency without increasing command latency.

--- a/orbit/changes/45624-desktop-exponential-backoff
+++ b/orbit/changes/45624-desktop-exponential-backoff
@@ -1,1 +1,0 @@
-* Added exponential backoff with jitter to Fleet Desktop's server polling. On error (401, 5xx, network failure), Desktop now doubles its retry interval (capped at 30 minutes) instead of retrying at a fixed rate. A single success resets to the normal interval. This prevents request storms that can overwhelm the database when many hosts have expired tokens.

--- a/orbit/changes/46457-tpm-backed-luks-recovery-key-prompt
+++ b/orbit/changes/46457-tpm-backed-luks-recovery-key-prompt
@@ -1,1 +1,0 @@
-- Updated the Fleet Desktop disk encryption prompt on TPM-backed Linux hosts (e.g., Ubuntu 23.10+) to ask for the disk recovery key saved during installation, instead of a LUKS passphrase.

--- a/orbit/changes/47285-preserve-prepackaged-osquery-flags
+++ b/orbit/changes/47285-preserve-prepackaged-osquery-flags
@@ -1,1 +1,0 @@
-* Fixed fleetd clearing pre-packaged/user-provided osquery flagfiles (`osquery.flags`) when `command_line_flags` is unset in the agent settings. Setting `command_line_flags` to an empty document (`{}` or `null`) still explicitly clears the flagfile.

--- a/orbit/changes/update-go-1.26.4
+++ b/orbit/changes/update-go-1.26.4
@@ -1,1 +1,0 @@
-* Updated go to 1.26.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exponential backoff with jitter added to Fleet Desktop's server polling retry behavior, capping at 30 minutes and resetting on successful poll.

* **Bug Fixes**
  * Fixed fleetd's osquery flagfile handling to correctly clear pre-packaged flags when command line settings are unset or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->