### PR TITLE
Add changes for fleetd v1.56.3

### DIFF
--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.56.3 (Jun 11, 2026)
+
+* Fixed fleetd clearing pre-packaged/user-provided osquery flagfiles (`osquery.flags`) when `command_line_flags` is unset in the agent settings. Setting `command_line_flags` to an empty document (`{}` or `null`) still explicitly clears the flagfile.
+
 ## 1.56.2 (Jun 04, 2026)
 
 * Added the `orbit.debug_logging_on_enroll_duration` agent option to allow enabling orbit debug logging for a specified time period after enrollment.

--- a/orbit/changes/47285-preserve-prepackaged-osquery-flags
+++ b/orbit/changes/47285-preserve-prepackaged-osquery-flags
@@ -1,1 +1,0 @@
-* Fixed fleetd clearing pre-packaged/user-provided osquery flagfiles (`osquery.flags`) when `command_line_flags` is unset in the agent settings. Setting `command_line_flags` to an empty document (`{}` or `null`) still explicitly clears the flagfile.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent handling of osquery command line flags. The system now correctly preserves pre-packaged flagfiles when the flag setting is unset, while continuing to clear flags when explicitly set to empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->