### PR TITLE
Website: Update user routing in deliver-talk-to-us-submission action

### DIFF
--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -96,32 +96,72 @@ module.exports = {
 
 
 
-    // TODO: Send prompt to try to find this information in paralell.
-    let enrichmentInformation = await sails.helpers.iq.getEnriched.with({
-      emailAddress,
-    }).tolerate((err)=>{
-      sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
-      return {};
+    // Simultaneously run the enrichment helper and send a prompt to an LLM to try to guess the company's headquarters location (city/country/state) from the email domain.
+    // We use the information reutnred by the LLM as a fallback for the territory lookup below when the enrichment helper doesn't return location information.
+    let locationGuessSystemPrompt = 'You are a precise data-extraction function. Respond with a single raw JSON object and nothing else.';
+    let locationGuessPrompt =
+`Where is the company that owns the email domain "${emailDomain}" headquartered?
+
+Respond with a JSON object using these keys:
+- "city": the headquarters city name.
+- "country": the full country name in English (for example, "United States").
+- "state": the full state name. Only include this key when the country is the United States.
+
+Only include a key when you are confident of its value. Omit any key you are unsure of; do not guess, and do not use null or empty strings.`;
+
+    let { enrichmentInformation, locationGuessFromEmailDomain } = await sails.helpers.flow.simultaneously({
+      enrichmentInformation: async()=>{
+        return await sails.helpers.iq.getEnriched.with({
+          emailAddress,
+        }).tolerate((err)=>{
+          sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
+          return {};
+        });
+      },
+      locationGuessFromEmailDomain: async()=>{
+        return await sails.helpers.ai.prompt.with({
+          prompt: locationGuessPrompt,
+          baseModel: 'gpt-5-nano-2025-08-07',
+          expectJson: true,
+          systemPrompt: locationGuessSystemPrompt,
+        }).tolerate((err)=>{
+          sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while guessing their company's headquarters location from the email domain (${emailDomain}). Error from prompt helper: ${require('util').inspect(err)}`);
+          return {};
+        });
+      },
     });
 
-    // If we got a employer.numberOfEmployees value from the getEnriched helper, send the user to the "talk to us" calendly event if it is 700+.
-    if(enrichmentInformation.employer && enrichmentInformation.employer.numberOfEmployees && enrichmentInformation.employer.numberOfEmployees >= 700) {
+    let employeeCountFromEnrichmentHelper = (enrichmentInformation.employer || {}).numberOfEmployees;
+
+    // If we got a employer.numberOfEmployees value from the getEnriched helper, or the user entered more than 700 hosts, get the SF user who owns the territory that this user's company is in, and send them to a "Talk to us" calendly event.
+    if(numberOfHosts >= 700 || (employeeCountFromEnrichmentHelper && employeeCountFromEnrichmentHelper >= 700)) {
       contactInformation.contactSource = 'Website - Contact forms - Demo - ICP';
-      contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event because of the number of employees (${enrichmentInformation.employer.numberOfEmployees}) returned by Coresignal. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
+
+      if(employeeCountFromEnrichmentHelper && employeeCountFromEnrichmentHelper >= 700) {
+        contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event because of the number of employees (${employeeCountFromEnrichmentHelper}) returned by Coresignal. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
+      } else {
+        contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
+      }
+
       sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
         if(err) {
           sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}. Full Error: ${require('util').inspect(err)}`);
         }
-      });
-      console.log(enrichmentInformation);
+      });//_∏_
+      // Prefer the enrichment helper's location, but fall back to the email-domain location
+      // guess when enrichment didn't return a country (the field getTerritoryUserId requires).
+      let employerLocation = enrichmentInformation.employer || {};
+      let locationForTerritoryLookup = (employerLocation.country ? employerLocation : locationGuessFromEmailDomain) || {};// Default to an empty object if neither sources returned this information.
+
       let teritoryUserId = await sails.helpers.salesforce.getTerritoryUserId.with({
-        state: enrichmentInformation.employer.state,
-        country: enrichmentInformation.employer.country,
-        city: enrichmentInformation.employer.city
+        state: locationForTerritoryLookup.state,
+        country: locationForTerritoryLookup.country,
+        city: locationForTerritoryLookup.city
       }).tolerate((err)=>{
-        sails.log.warn(`When a user submitted the "Talk to us" form, Salesforce teritory information could not be found using the provided information. This user will be sent to the calendly link for the washingtonDc region. Full error: ${require('util').inspect(err)}`)
+        sails.log.warn(`When a user submitted the "Talk to us" form, Salesforce teritory information could not be found using the provided information. This user will be sent to the calendly link for the washingtonDc region. Full error: ${require('util').inspect(err)}`);
         return '0054x0000086sOlAAI';
       });
+
       let bookingUrlByUserId = {
         '005UG000006YYDVYA4': 'https://calendly.com/d/d3fs-28g-vdk/talk-to-us', //newYorkCity
         '0054x0000086sOlAAI': 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us', //washingtonDc
@@ -131,7 +171,11 @@ module.exports = {
       };
 
       let eventUrlForThisUsersTeritory = bookingUrlByUserId[teritoryUserId];
-
+      if(!eventUrlForThisUsersTeritory) {
+        // If the user ID returned by the helper is not one of the five expected values above, log a warning to alert us, and send the user to the washingtonDc calednly link.
+        sails.log.warn(`When looking up Salesforce territory information to route a user (email: ${emailAddress}) who submitted the "Talk to us" form to the correct meeting link, the user ID returned by the getTerritoryUserId helper (${teritoryUserId}) did not match the hardcoded user IDs in the bookingUrlByUserId dictionary. This user will be sent to the callendly link for the washingtonDc region.`)
+        eventUrlForThisUsersTeritory = 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us';
+      }
       return {
         icp: true,
         eventUrl: eventUrlForThisUsersTeritory,
@@ -144,7 +188,7 @@ module.exports = {
         if(err) {
           sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
         }
-      });
+      });//_∏_
       return {
         icp: false,
         eventUrl: `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -174,7 +174,7 @@ Only include a key when you are confident of its value. Omit any key you are uns
       let eventUrlForThisUsersTerritory = bookingUrlByUserId[territoryUserId];
       if(!eventUrlForThisUsersTerritory) {
         // If the user ID returned by the helper is not one of the five expected values above, log a warning to alert us, and send the user to the washingtonDc calednly link.
-        sails.log.warn(`When looking up Salesforce territory information to route a user (email: ${emailAddress}) who submitted the "Talk to us" form to the correct meeting link, the user ID returned by the getTerritoryUserId helper (${teritoryUserId}) did not match the hardcoded user IDs in the bookingUrlByUserId dictionary. This user will be sent to the callendly link for the washingtonDc region.`);
+        sails.log.warn(`When looking up Salesforce territory information to route a user (email: ${emailAddress}) who submitted the "Talk to us" form to the correct meeting link, the user ID returned by the getTerritoryUserId helper (${territoryUserId}) did not match the hardcoded user IDs in the bookingUrlByUserId dictionary. This user will be sent to the callendly link for the washingtonDc region.`);
         eventUrlForThisUsersTerritory = 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us';
       }
       return {

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -173,7 +173,7 @@ Only include a key when you are confident of its value. Omit any key you are uns
       let eventUrlForThisUsersTeritory = bookingUrlByUserId[teritoryUserId];
       if(!eventUrlForThisUsersTeritory) {
         // If the user ID returned by the helper is not one of the five expected values above, log a warning to alert us, and send the user to the washingtonDc calednly link.
-        sails.log.warn(`When looking up Salesforce territory information to route a user (email: ${emailAddress}) who submitted the "Talk to us" form to the correct meeting link, the user ID returned by the getTerritoryUserId helper (${teritoryUserId}) did not match the hardcoded user IDs in the bookingUrlByUserId dictionary. This user will be sent to the callendly link for the washingtonDc region.`)
+        sails.log.warn(`When looking up Salesforce territory information to route a user (email: ${emailAddress}) who submitted the "Talk to us" form to the correct meeting link, the user ID returned by the getTerritoryUserId helper (${teritoryUserId}) did not match the hardcoded user IDs in the bookingUrlByUserId dictionary. This user will be sent to the callendly link for the washingtonDc region.`);
         eventUrlForThisUsersTeritory = 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us';
       }
       return {

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -113,6 +113,7 @@ Only include a key when you are confident of its value. Omit any key you are uns
       enrichmentInformation: async()=>{
         return await sails.helpers.iq.getEnriched.with({
           emailAddress,
+          includeEmployerHeadquartersInformation: true,
         }).tolerate((err)=>{
           sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occurred while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
           return {};

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -94,58 +94,61 @@ module.exports = {
       marketingAttributionCookie: attributionCookieOrUndefined
     };
 
-    // If the user said they have 700+ hosts, Update/create a contact and account, and send them to the "Talk to us" Calendly event.
-    if(numberOfHosts >= 700){
+
+
+    // TODO: Send prompt to try to find this information in paralell.
+    let enrichmentInformation = await sails.helpers.iq.getEnriched.with({
+      emailAddress,
+    }).tolerate((err)=>{
+      sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
+      return {};
+    });
+
+    // If we got a employer.numberOfEmployees value from the getEnriched helper, send the user to the "talk to us" calendly event if it is 700+.
+    if(enrichmentInformation.employer && enrichmentInformation.employer.numberOfEmployees && enrichmentInformation.employer.numberOfEmployees >= 700) {
       contactInformation.contactSource = 'Website - Contact forms - Demo - ICP';
-      contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
+      contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event because of the number of employees (${enrichmentInformation.employer.numberOfEmployees}) returned by Coresignal. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
+      sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
+        if(err) {
+          sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}. Full Error: ${require('util').inspect(err)}`);
+        }
+      });
+      console.log(enrichmentInformation);
+      let teritoryUserId = await sails.helpers.salesforce.getTerritoryUserId.with({
+        state: enrichmentInformation.employer.state,
+        country: enrichmentInformation.employer.country,
+        city: enrichmentInformation.employer.city
+      }).tolerate((err)=>{
+        sails.log.warn(`When a user submitted the "Talk to us" form, Salesforce teritory information could not be found using the provided information. This user will be sent to the calendly link for the washingtonDc region. Full error: ${require('util').inspect(err)}`)
+        return '0054x0000086sOlAAI';
+      });
+      let bookingUrlByUserId = {
+        '005UG000006YYDVYA4': 'https://calendly.com/d/d3fs-28g-vdk/talk-to-us', //newYorkCity
+        '0054x0000086sOlAAI': 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us', //washingtonDc
+        '005UG000008y0wbYAA': 'https://calendly.com/d/ds9c-9vt-mz6/talk-to-us', //losAngeles
+        '0054x0000086wsGAAQ': 'https://calendly.com/d/dz4c-mjx-6xv/talk-to-us', //sanFrancisco
+        '005UG000009NnSfYAK': 'https://calendly.com/d/ds88-n2m-ddt/talk-to-us', //stockholm
+      };
+
+      let eventUrlForThisUsersTeritory = bookingUrlByUserId[teritoryUserId];
+
+      return {
+        icp: true,
+        eventUrl: eventUrlForThisUsersTeritory,
+      };
+    } else {
+      // If the enrichment helper didn't return a employer.numberOfEmployees value and this user has <700 hosts, send them to the "Let's get you set up!" Calendly event
+      contactInformation.contactSource = 'Website - Contact forms - Demo';
+      contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Let\'s get you set up!" event. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
       sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
         if(err) {
           sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
         }
       });
       return {
-        icp: true,
-        eventUrl: `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`
+        icp: false,
+        eventUrl: `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`
       };
-    } else {
-      // If the user has <700 hosts, use the get-enriched helper to try to find the number of employees at their organization.
-
-      let enrichmentInformation = await sails.helpers.iq.getEnriched.with({
-        emailAddress,
-        firstName,
-        lastName,
-      }).tolerate((err)=>{
-        sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
-        return {};
-      });
-
-      // If we got a employer.numberOfEmployees value from the getEnriched helper, send the user to the "talk to us" calendly event if it is 700+.
-      if(enrichmentInformation.employer && enrichmentInformation.employer.numberOfEmployees && enrichmentInformation.employer.numberOfEmployees >= 700) {
-        contactInformation.contactSource = 'Website - Contact forms - Demo - ICP';
-        contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event because of the number of employees (${enrichmentInformation.employer.numberOfEmployees}) returned by Coresignal. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
-        sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
-          if(err) {
-            sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
-          }
-        });
-        return {
-          icp: true,
-          eventUrl:`https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`
-        };
-      } else {
-        // If the enrichment helper didn't return a employer.numberOfEmployees value and this user has <700 hosts, send them to the "Let's get you set up!" Calendly event
-        contactInformation.contactSource = 'Website - Contact forms - Demo';
-        contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Let\'s get you set up!" event. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
-        sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
-          if(err) {
-            sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
-          }
-        });
-        return {
-          icp: false,
-          eventUrl: `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`
-        };
-      }
     }
   }
 

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -172,7 +172,7 @@ Only include a key when you are confident of its value. Omit any key you are uns
       };
 
       let eventUrlForThisUsersTerritory = bookingUrlByUserId[territoryUserId];
-      if(!eventUrlForThisUsersTerirtory) {
+      if(!eventUrlForThisUsersTerritory) {
         // If the user ID returned by the helper is not one of the five expected values above, log a warning to alert us, and send the user to the washingtonDc calednly link.
         sails.log.warn(`When looking up Salesforce territory information to route a user (email: ${emailAddress}) who submitted the "Talk to us" form to the correct meeting link, the user ID returned by the getTerritoryUserId helper (${teritoryUserId}) did not match the hardcoded user IDs in the bookingUrlByUserId dictionary. This user will be sent to the callendly link for the washingtonDc region.`);
         eventUrlForThisUsersTerritory = 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us';

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -97,7 +97,7 @@ module.exports = {
 
 
     // Simultaneously run the enrichment helper and send a prompt to an LLM to try to guess the company's headquarters location (city/country/state) from the email domain.
-    // We use the information reutnred by the LLM as a fallback for the territory lookup below when the enrichment helper doesn't return location information.
+    // We use the information returned by the LLM as a fallback for the territory lookup below when the enrichment helper doesn't return location information.
     let locationGuessSystemPrompt = 'You are a precise data-extraction function. Respond with a single raw JSON object and nothing else.';
     let locationGuessPrompt =
 `Where is the company that owns the email domain "${emailDomain}" headquartered?
@@ -114,7 +114,7 @@ Only include a key when you are confident of its value. Omit any key you are uns
         return await sails.helpers.iq.getEnriched.with({
           emailAddress,
         }).tolerate((err)=>{
-          sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
+          sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occurred while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
           return {};
         });
       },
@@ -125,7 +125,7 @@ Only include a key when you are confident of its value. Omit any key you are uns
           expectJson: true,
           systemPrompt: locationGuessSystemPrompt,
         }).tolerate((err)=>{
-          sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while guessing their company's headquarters location from the email domain (${emailDomain}). Error from prompt helper: ${require('util').inspect(err)}`);
+          sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occurred while guessing their company's headquarters location from the email domain (${emailDomain}). Error from prompt helper: ${require('util').inspect(err)}`);
           return {};
         });
       },
@@ -153,12 +153,12 @@ Only include a key when you are confident of its value. Omit any key you are uns
       let employerLocation = enrichmentInformation.employer || {};
       let locationForTerritoryLookup = (employerLocation.country ? employerLocation : locationGuessFromEmailDomain) || {};// Default to an empty object if neither sources returned this information.
 
-      let teritoryUserId = await sails.helpers.salesforce.getTerritoryUserId.with({
+      let territoryUserId = await sails.helpers.salesforce.getTerritoryUserId.with({
         state: locationForTerritoryLookup.state,
         country: locationForTerritoryLookup.country,
         city: locationForTerritoryLookup.city
       }).tolerate((err)=>{
-        sails.log.warn(`When a user submitted the "Talk to us" form, Salesforce teritory information could not be found using the provided information. This user will be sent to the calendly link for the washingtonDc region. Full error: ${require('util').inspect(err)}`);
+        sails.log.warn(`When a user submitted the "Talk to us" form, Salesforce territory information could not be found using the provided information. This user will be sent to the calendly link for the washingtonDc region. Full error: ${require('util').inspect(err)}`);
         return '0054x0000086sOlAAI';
       });
 
@@ -170,15 +170,15 @@ Only include a key when you are confident of its value. Omit any key you are uns
         '005UG000009NnSfYAK': 'https://calendly.com/d/ds88-n2m-ddt/talk-to-us', //stockholm
       };
 
-      let eventUrlForThisUsersTeritory = bookingUrlByUserId[teritoryUserId];
-      if(!eventUrlForThisUsersTeritory) {
+      let eventUrlForThisUsersTerritory = bookingUrlByUserId[territoryUserId];
+      if(!eventUrlForThisUsersTerirtory) {
         // If the user ID returned by the helper is not one of the five expected values above, log a warning to alert us, and send the user to the washingtonDc calednly link.
         sails.log.warn(`When looking up Salesforce territory information to route a user (email: ${emailAddress}) who submitted the "Talk to us" form to the correct meeting link, the user ID returned by the getTerritoryUserId helper (${teritoryUserId}) did not match the hardcoded user IDs in the bookingUrlByUserId dictionary. This user will be sent to the callendly link for the washingtonDc region.`);
-        eventUrlForThisUsersTeritory = 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us';
+        eventUrlForThisUsersTerritory = 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us';
       }
       return {
         icp: true,
-        eventUrl: eventUrlForThisUsersTeritory,
+        eventUrl: eventUrlForThisUsersTerritory +`?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`,
       };
     } else {
       // If the enrichment helper didn't return a employer.numberOfEmployees value and this user has <700 hosts, send them to the "Let's get you set up!" Calendly event

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -289,6 +289,35 @@ module.exports = {
         return undefined;
       });
       if (matchingCompanyPageInfo) {
+        console.log(_.omit(matchingCompanyPageInfo, ['company_featured_employees_collection', 'company_similar_collection', 'company_specialties_collection', 'company_updates_collection', 'company_also_viewed_collection', 'company_funding_rounds_collection', 'company_featured_investors_collection', 'company_affiliated_collection', 'company_crunchbase_info_collection']));
+        let companyHasActiveLocation = _.find(matchingCompanyPageInfo.company_locations_collection, (location)=>{
+          return location.is_primary === 1;
+        });
+        let locationInfo = {};
+        if(companyHasActiveLocation) {
+          let systemPromptForAddressInformation = 'You are a precise data-extraction function. Respond with a single raw JSON object and nothing else.';
+          let locationPrompt =
+          `Extract the location from the following company headquarters address.
+
+          Address: "${companyHasActiveLocation.location_address}"
+
+          Respond with a JSON object using these keys:
+          - "city": the city name.
+          - "country": the full country name in English (for example, "United States").
+          - "state": the full state name. Only include this key when the country is the United States.
+
+          Only include a key when its value is present in the address. Omit any key whose value you cannot determine; do not guess, and do not use null or empty strings.`;
+
+          locationInfo = await sails.helpers.ai.prompt.with({
+            prompt: locationPrompt,
+            baseModel: 'gpt-5-nano-2025-08-07',
+            expectJson: true,
+            systemPrompt: systemPromptForAddressInformation,
+          }).tolerate((err)=>{
+            sails.log.warn(`When parsing a company's headquarters address ("${companyHasActiveLocation.location_address}") into structured location data, the prompt helper responded with an error: `, err);
+            return {};
+          });
+        }
         let emailDomain;
         if(matchingCompanyPageInfo.website) {
           let parsedCompanyEmailDomain = require('url').parse(matchingCompanyPageInfo.website);
@@ -300,6 +329,9 @@ module.exports = {
           numberOfEmployees: matchingCompanyPageInfo.employees_count,
           emailDomain: emailDomain,
           linkedinCompanyPageUrl: matchingCompanyPageInfo.canonical_url.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS,''),
+          state: locationInfo.state,
+          country: locationInfo.country,
+          city: locationInfo.city,
         };
         if (organization && employer.organization && employer.organization !== organization) {
           sails.log.info(`Unexpected result when enriching: Matched organization name (${employer.organization}) does not equal the provided "organization" (${organization})`);

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -23,6 +23,8 @@ module.exports = {
     lastName: { type: 'string', defaultsTo: '', },
     organization: { type: 'string', defaultsTo: '', },
 
+
+    includeEmployerHeadquartersInformation: {type: 'boolean', defaultsTo: false}
   },
 
 
@@ -51,7 +53,7 @@ module.exports = {
   },
 
 
-  fn: async function ({emailAddress,linkedinUrl,firstName,lastName,organization}) {
+  fn: async function ({emailAddress,linkedinUrl,firstName,lastName,organization, includeEmployerHeadquartersInformation}) {
 
     require('assert')(sails.config.custom.iqSecret);// FUTURE: Rename this config
     require('assert')(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
@@ -290,34 +292,6 @@ module.exports = {
       });
       if (matchingCompanyPageInfo) {
 
-        let companyHasActiveLocation = _.find(matchingCompanyPageInfo.company_locations_collection, (location)=>{
-          return location.is_primary === 1;
-        });
-        let locationInfo = {};
-        if(companyHasActiveLocation) {
-          let systemPromptForAddressInformation = 'You are a precise data-extraction function. Respond with a single raw JSON object and nothing else.';
-          let locationPrompt =
-`Extract the location from the following company headquarters address.
-
-Address: "${companyHasActiveLocation.location_address}"
-
-Respond with a JSON object using these keys:
-- "city": the city name.
-- "country": the full country name in English (for example, "United States").
-- "state": the full state name. Only include this key when the country is the United States.
-
-Only include a key when its value is present in the address. Omit any key whose value you cannot determine; do not guess, and do not use null or empty strings.`;
-
-          locationInfo = await sails.helpers.ai.prompt.with({
-            prompt: locationPrompt,
-            baseModel: 'gpt-5-nano-2025-08-07',
-            expectJson: true,
-            systemPrompt: systemPromptForAddressInformation,
-          }).tolerate((err)=>{
-            sails.log.warn(`When parsing a company's headquarters address ("${companyHasActiveLocation.location_address}") into structured location data, the prompt helper responded with an error: `, err);
-            return {};
-          });
-        }
         let emailDomain;
         if(matchingCompanyPageInfo.website) {
           let parsedCompanyEmailDomain = require('url').parse(matchingCompanyPageInfo.website);
@@ -329,10 +303,45 @@ Only include a key when its value is present in the address. Omit any key whose 
           numberOfEmployees: matchingCompanyPageInfo.employees_count,
           emailDomain: emailDomain,
           linkedinCompanyPageUrl: matchingCompanyPageInfo.canonical_url.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS,''),
-          state: locationInfo.state,
-          country: locationInfo.country,
-          city: locationInfo.city,
         };
+
+        // If we're including location information, use the prompt helper to transform the location information returned by Coresignal into a JSON object.
+        if(includeEmployerHeadquartersInformation) {
+          let primaryLocation = _.find(matchingCompanyPageInfo.company_locations_collection, (location)=>{
+            return location.is_primary === 1;
+          });
+          let locationInfo = {};
+          if(primaryLocation) {
+            let systemPromptForAddressInformation = 'You are a precise data-extraction function. Respond with a single raw JSON object and nothing else.';
+            let locationPrompt =
+  `Extract the location from the following company headquarters address.
+
+  Address: "${primaryLocation.location_address}"
+
+  Respond with a JSON object using these keys:
+  - "city": the city name.
+  - "country": the full country name in English (for example, "United States").
+  - "state": the full state name. Only include this key when the country is the United States.
+
+  Only include a key when its value is present in the address. Omit any key whose value you cannot determine; do not guess, and do not use null or empty strings.`;
+
+            locationInfo = await sails.helpers.ai.prompt.with({
+              prompt: locationPrompt,
+              baseModel: 'gpt-5-nano-2025-08-07',
+              expectJson: true,
+              systemPrompt: systemPromptForAddressInformation,
+            }).tolerate((err)=>{
+              sails.log.warn(`When parsing a company's headquarters address ("${primaryLocation.location_address}") into structured location data, the prompt helper responded with an error: `, err);
+              return {};
+            });
+          }
+          employer.state = locationInfo.state;
+          employer.country = locationInfo.country;
+          employer.city = locationInfo.city;
+        }
+
+
+
         if (organization && employer.organization && employer.organization !== organization) {
           sails.log.info(`Unexpected result when enriching: Matched organization name (${employer.organization}) does not equal the provided "organization" (${organization})`);
         }//ﬁ

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -311,7 +311,7 @@ module.exports = {
             return location.is_primary === 1;
           });
           let locationInfo = {};
-          if(primaryLocation) {
+          if(primaryLocation && primaryLocation.location_address) {
             let systemPromptForAddressInformation = 'You are a precise data-extraction function. Respond with a single raw JSON object and nothing else.';
             let locationPrompt =
   `Extract the location from the following company headquarters address.

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -297,16 +297,16 @@ module.exports = {
         if(companyHasActiveLocation) {
           let systemPromptForAddressInformation = 'You are a precise data-extraction function. Respond with a single raw JSON object and nothing else.';
           let locationPrompt =
-          `Extract the location from the following company headquarters address.
+`Extract the location from the following company headquarters address.
 
-          Address: "${companyHasActiveLocation.location_address}"
+Address: "${companyHasActiveLocation.location_address}"
 
-          Respond with a JSON object using these keys:
-          - "city": the city name.
-          - "country": the full country name in English (for example, "United States").
-          - "state": the full state name. Only include this key when the country is the United States.
+Respond with a JSON object using these keys:
+- "city": the city name.
+- "country": the full country name in English (for example, "United States").
+- "state": the full state name. Only include this key when the country is the United States.
 
-          Only include a key when its value is present in the address. Omit any key whose value you cannot determine; do not guess, and do not use null or empty strings.`;
+Only include a key when its value is present in the address. Omit any key whose value you cannot determine; do not guess, and do not use null or empty strings.`;
 
           locationInfo = await sails.helpers.ai.prompt.with({
             prompt: locationPrompt,

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -289,7 +289,7 @@ module.exports = {
         return undefined;
       });
       if (matchingCompanyPageInfo) {
-        console.log(_.omit(matchingCompanyPageInfo, ['company_featured_employees_collection', 'company_similar_collection', 'company_specialties_collection', 'company_updates_collection', 'company_also_viewed_collection', 'company_funding_rounds_collection', 'company_featured_investors_collection', 'company_affiliated_collection', 'company_crunchbase_info_collection']));
+
         let companyHasActiveLocation = _.find(matchingCompanyPageInfo.company_locations_collection, (location)=>{
           return location.is_primary === 1;
         });

--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -37,7 +37,10 @@ module.exports = {
     if(state && state.toLowerCase() !== 'california') {
       city = undefined;
     }
-    let apexInputs = new URLSearchParams({state, country, city});
+    let apexInputs = new URLSearchParams();
+    if(state) { apexInputs.append('state', state); }
+    if(country) { apexInputs.append('country', country); }
+    if(city) { apexInputs.append('city', city); }
 
     let territoryInformation = await sails.helpers.flow.build(async ()=>{
       return await salesforceConnection.apex.get(`/territory-lookup?${apexInputs.toString()}`);

--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -33,16 +33,22 @@ module.exports = {
       loginUrl : 'https://fleetdm.my.salesforce.com'
     });
     await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
+    // If the state is not set to California, remove the city (This is the only state that is in two different territories.)
+    if(state && state.toLowerCase() !== 'california') {
+      city = undefined;
+    }
+    let apexInputs = new URLSearchParams({state, country, city});
 
-    let apexInputs = new URLSearchParams({state, city, country});
     let territoryInformation = await sails.helpers.flow.build(async ()=>{
       return await salesforceConnection.apex.get(`/territory-lookup?${apexInputs.toString()}`)
     }).intercept((err)=>{
-      throw new Error(`When sending a request to Salesforce to get lookup the territory ID for an address (${{state, city, country}}, an error occured. Full error: ${require('util').inspect(err)}`)
+      throw new Error(`When sending a request to Salesforce to lookup the territory ID for an address (${require('util').inspect({state, city, country})}) an error occured. Full error: ${require('util').inspect(err)}`)
     });
-
-    require('assert')(territoryInformation.users && _.isArray(territoryInformation.users));
-    require('assert')(territoryInformation.users[0] && territoryInformation.users[0].userId);
+    if(!territoryInformation.users || !_.isArray(territoryInformation.users)) {
+      throw new Error(`When looking up the territory ID for an address (${require('util').inspect({state, city, country})}), the information returned by Salesforce did not include a list of users. Territory information returned by Salesforce: ${require('util').inspect(territoryInformation)}`);
+    } else if(!territoryInformation.users[0] || !territoryInformation.users[0].userId) {
+      throw new Error(`When looking up the territory ID for an address (${require('util').inspect({state, city, country})}), the user information returned by Salesforce did not include the required information. Territory information returned by Salesforce: ${require('util').inspect(territoryInformation)}`);
+    }
 
     let userIdForThisTeritory = territoryInformation.users[0].userId;
     // Send back the result through the success exit.

--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -1,0 +1,55 @@
+module.exports = {
+
+
+  friendlyName: 'Get territory user ID' ,
+
+
+  description: 'Returns a Salesforce User ID who is associated with a location.',
+
+
+  inputs: {
+    state: { type: 'string' },
+    city: { type: 'string' },
+    country: { type: 'string', required: true},
+  },
+
+
+  exits: {
+
+    success: {
+      outputFriendlyName: 'territoryUserId',
+    },
+
+  },
+
+
+  fn: async function ({state, city, country}) {
+    //  ╦  ╔═╗╔═╗╦╔╗╔  ╔╦╗╔═╗  ╔═╗╔═╗╦  ╔═╗╔═╗╔═╗╔═╗╦═╗╔═╗╔═╗
+    //  ║  ║ ║║ ╦║║║║   ║ ║ ║  ╚═╗╠═╣║  ║╣ ╚═╗╠╣ ║ ║╠╦╝║  ║╣
+    //  ╩═╝╚═╝╚═╝╩╝╚╝   ╩ ╚═╝  ╚═╝╩ ╩╩═╝╚═╝╚═╝╚  ╚═╝╩╚═╚═╝╚═╝
+    // Log in to Salesforce.
+    let jsforce = require('jsforce');
+    let salesforceConnection = new jsforce.Connection({
+      loginUrl : 'https://fleetdm.my.salesforce.com'
+    });
+    await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
+
+    let apexInputs = new URLSearchParams({state, city, country});
+    let territoryInformation = await sails.helpers.flow.build(async ()=>{
+      return await salesforceConnection.apex.get(`/territory-lookup?${apexInputs.toString()}`)
+    }).intercept((err)=>{
+      throw new Error(`When sending a request to Salesforce to get lookup the territory ID for an address (${{state, city, country}}, an error occured. Full error: ${require('util').inspect(err)}`)
+    });
+
+    require('assert')(territoryInformation.users && _.isArray(territoryInformation.users));
+    require('assert')(territoryInformation.users[0] && territoryInformation.users[0].userId);
+
+    let userIdForThisTeritory = territoryInformation.users[0].userId;
+    // Send back the result through the success exit.
+    return userIdForThisTeritory;
+
+  }
+
+
+};
+

--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -45,7 +45,7 @@ module.exports = {
     let territoryInformation = await sails.helpers.flow.build(async ()=>{
       return await salesforceConnection.apex.get(`/territory-lookup?${apexInputs.toString()}`);
     }).intercept((err)=>{
-      throw new Error(`When sending a request to Salesforce to lookup the territory ID for an address (${require('util').inspect({state, city, country})}) an error occured. Full error: ${require('util').inspect(err)}`);
+      throw new Error(`When sending a request to Salesforce to lookup the territory ID for an address (${require('util').inspect({state, city, country})}) an error occurred. Full error: ${require('util').inspect(err)}`);
     });
     if(!territoryInformation.users || !_.isArray(territoryInformation.users)) {
       throw new Error(`When looking up the territory ID for an address (${require('util').inspect({state, city, country})}), the information returned by Salesforce did not include a list of users. Territory information returned by Salesforce: ${require('util').inspect(territoryInformation)}`);
@@ -53,9 +53,9 @@ module.exports = {
       throw new Error(`When looking up the territory ID for an address (${require('util').inspect({state, city, country})}), the user information returned by Salesforce did not include the required information. Territory information returned by Salesforce: ${require('util').inspect(territoryInformation)}`);
     }
 
-    let userIdForThisTeritory = territoryInformation.users[0].userId;
+    let userIdForThisTerritory = territoryInformation.users[0].userId;
     // Send back the result through the success exit.
-    return userIdForThisTeritory;
+    return userIdForThisTerritory;
 
   }
 

--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -40,9 +40,9 @@ module.exports = {
     let apexInputs = new URLSearchParams({state, country, city});
 
     let territoryInformation = await sails.helpers.flow.build(async ()=>{
-      return await salesforceConnection.apex.get(`/territory-lookup?${apexInputs.toString()}`)
+      return await salesforceConnection.apex.get(`/territory-lookup?${apexInputs.toString()}`);
     }).intercept((err)=>{
-      throw new Error(`When sending a request to Salesforce to lookup the territory ID for an address (${require('util').inspect({state, city, country})}) an error occured. Full error: ${require('util').inspect(err)}`)
+      throw new Error(`When sending a request to Salesforce to lookup the territory ID for an address (${require('util').inspect({state, city, country})}) an error occured. Full error: ${require('util').inspect(err)}`);
     });
     if(!territoryInformation.users || !_.isArray(territoryInformation.users)) {
       throw new Error(`When looking up the territory ID for an address (${require('util').inspect({state, city, country})}), the information returned by Salesforce did not include a list of users. Territory information returned by Salesforce: ${require('util').inspect(territoryInformation)}`);


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/16303

Changes:
- Added a new Salesforce helper: getTerritoryUserId, a helper that returns the ID of the Salesforce user associated with a provided location (state, country, city)
- Updated the deliver-talk-to-us-form-submission action to send ICP users to one of five different Calendly events based on their company's headquarters location.
- Updated the get-enriched helper to include company headquarters information when enriching a user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ICP detection for contact forms using submitted host counts or enriched employee counts.
  * Territory-aware scheduling routing with location-based assignment and a Washington DC fallback.
  * AI-assisted email-domain and headquarters location inference to improve routing decisions.
  * Improved contact upsert behavior for ICP vs non-ICP submissions with tailored descriptions and event URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->