### PR TITLE
Add query to list users with secure token for FileVault access on macOS

### DIFF
--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -5022,3 +5022,21 @@ spec:
   purpose: Detection
   tags: MITRE, ATT&CK, threat detection
   contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get users with secure token
+  platform: darwin
+  description: Lists local user accounts (UID 501 and above) and indicates whether each has a secure token, which is required for FileVault access on macOS.
+  query: |-
+    SELECT
+      u.uid,
+      u.username,
+      CASE WHEN fu.uuid IS NOT NULL THEN 1 ELSE 0 END AS has_secure_token
+    FROM users u
+    LEFT JOIN filevault_users fu ON fu.uuid = u.uuid
+    WHERE u.uid >= 501;
+  purpose: Informational
+  tags: filevault, users
+  contributors: kitzy,jakestenger


### PR DESCRIPTION
Introduce a query that lists local user accounts with a secure token, which is necessary for FileVault access on macOS. This enhancement provides visibility into user accounts that meet the criteria.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new inventory query for macOS users to identify those with secure token protection enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->