### PR TITLE
Website: Update error handler in http config

### DIFF
--- a/website/config/http.js
+++ b/website/config/http.js
@@ -62,6 +62,9 @@ module.exports.http = {
           // If an error occurs and this was a request going to a static asset, return a 403 response.
           } else if(req.url.match(sails.LOOKS_LIKE_ASSET_RX)) {
             return res.status(403).send();
+          } else if(err && _.isString(err.message) && err.message.startsWith('EUNFNTEX')) {
+          // If Skipper throws a EUNFNTEX error (A plaintext error thrown when a client never finishes streaming its request body), return a 408 (request timeout) response.
+            return res.status(408).send();
           } else {
             sails.log.error('Sending 500 ("Server Error") response: \n', err);
             return res.status(500).send();

--- a/website/config/http.js
+++ b/website/config/http.js
@@ -63,7 +63,7 @@ module.exports.http = {
           } else if(req.url.match(sails.LOOKS_LIKE_ASSET_RX)) {
             return res.status(403).send();
           } else if(err && _.isString(err.message) && err.message.startsWith('EUNFNTEX')) {
-          // If Skipper throws a EUNFNTEX error (A plaintext error thrown when a client never finishes streaming its request body), return a 408 (request timeout) response.
+          // If Skipper throws an EUNFNTEX error (a plaintext error thrown when a client never finishes streaming its request body), return a 408 (request timeout) response.
             return res.status(408).send();
           } else {
             sails.log.error('Sending 500 ("Server Error") response: \n', err);


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/47385


Changes:
- updated the `onBodyParserError` error handling function in the website's http config to return a 408 response when skipper throws a `EUNFNTEX` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for incomplete request bodies: clients now receive a 408 (Request Timeout) instead of a generic 500. This yields clearer, more accurate responses for stalled or malformed uploads and helps clients and intermediaries handle timeouts correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->