### PR TITLE
Bumping the loadtest/osquery-perf module version to utilize increased ulimits

### DIFF
--- a/infrastructure/loadtesting/terraform/osquery_perf/main.tf
+++ b/infrastructure/loadtesting/terraform/osquery_perf/main.tf
@@ -6,7 +6,7 @@ data "git_repository" "tf" {
 }
 
 module "osquery_perf" {
-  source                     = "github.com/fleetdm/fleet-terraform//addons/osquery-perf?ref=tf-mod-addon-osquery-perf-v1.2.1"
+  source                     = "github.com/fleetdm/fleet-terraform//addons/osquery-perf?ref=tf-mod-addon-osquery-perf-v1.2.2"
   customer_prefix            = local.customer
   ecs_cluster                = data.terraform_remote_state.infra.outputs.ecs_cluster
   loadtest_containers        = local.loadtest_containers


### PR DESCRIPTION
- Bump osquery-perf module version to v1.2.2
  - Increases ulimits from 9999 to 999999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance testing infrastructure dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->