### PR TITLE
Use JetBrains build numbers in FMA patch policies on Windows

### DIFF
--- a/ee/maintained-apps/inputs/winget/clion.json
+++ b/ee/maintained-apps/inputs/winget/clion.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.CLion",
   "unique_identifier": "CLion",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/clion_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/clion_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/datagrip.json
+++ b/ee/maintained-apps/inputs/winget/datagrip.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.DataGrip",
   "unique_identifier": "DataGrip",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/datagrip_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/datagrip_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/goland.json
+++ b/ee/maintained-apps/inputs/winget/goland.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.GoLand",
   "unique_identifier": "GoLand",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/goland_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/goland_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/intellij-idea-ce.json
+++ b/ee/maintained-apps/inputs/winget/intellij-idea-ce.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.IntelliJIDEA.Community",
   "unique_identifier": "IntelliJ IDEA Community Edition",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/intellij_idea_ce_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/intellij_idea_ce_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/intellij-idea.json
+++ b/ee/maintained-apps/inputs/winget/intellij-idea.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.IntelliJIDEA.Ultimate",
   "unique_identifier": "IntelliJ IDEA",
   "exists_query": "SELECT 1 FROM programs WHERE name LIKE 'IntelliJ IDEA %' AND name NOT LIKE 'IntelliJ IDEA Community%' AND name NOT LIKE 'IntelliJ IDEA Educational%' AND publisher = 'JetBrains s.r.o.';",
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/intellij_idea_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/intellij_idea_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/phpstorm.json
+++ b/ee/maintained-apps/inputs/winget/phpstorm.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.PhpStorm",
   "unique_identifier": "PhpStorm",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/phpstorm_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/phpstorm_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/pycharm-ce.json
+++ b/ee/maintained-apps/inputs/winget/pycharm-ce.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.PyCharm.Community",
   "unique_identifier": "PyCharm Community Edition",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/pycharm_ce_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/pycharm_ce_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/pycharm.json
+++ b/ee/maintained-apps/inputs/winget/pycharm.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.PyCharm.Professional",
   "unique_identifier": "PyCharm",
   "exists_query": "SELECT 1 FROM programs WHERE name LIKE 'PyCharm %' AND name NOT LIKE 'PyCharm Community Edition%' AND publisher = 'JetBrains s.r.o.';",
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/pycharm_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/pycharm_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/rider.json
+++ b/ee/maintained-apps/inputs/winget/rider.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.Rider",
   "unique_identifier": "JetBrains Rider",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/rider_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/rider_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/rubymine.json
+++ b/ee/maintained-apps/inputs/winget/rubymine.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.RubyMine",
   "unique_identifier": "RubyMine",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/rubymine_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/rubymine_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/rustrover.json
+++ b/ee/maintained-apps/inputs/winget/rustrover.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.RustRover",
   "unique_identifier": "RustRover",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/rustrover_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/rustrover_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/inputs/winget/webstorm.json
+++ b/ee/maintained-apps/inputs/winget/webstorm.json
@@ -4,6 +4,7 @@
   "package_identifier": "JetBrains.WebStorm",
   "unique_identifier": "WebStorm",
   "fuzzy_match_name": true,
+  "use_display_version_for_patch": true,
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/webstorm_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/webstorm_uninstall.ps1",
   "installer_arch": "x64",

--- a/ee/maintained-apps/outputs/clion/windows.json
+++ b/ee/maintained-apps/outputs/clion/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.137') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.3.exe",
       "install_script_ref": "f1faeca2",

--- a/ee/maintained-apps/outputs/datagrip/windows.json
+++ b/ee/maintained-apps/outputs/datagrip/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.24374.56') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.1.3.exe",
       "install_script_ref": "0897461e",

--- a/ee/maintained-apps/outputs/goland/windows.json
+++ b/ee/maintained-apps/outputs/goland/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'GoLand %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GoLand %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GoLand %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.147') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/go/goland-2026.1.3.exe",
       "install_script_ref": "6d754683",

--- a/ee/maintained-apps/outputs/intellij-idea-ce/windows.json
+++ b/ee/maintained-apps/outputs/intellij-idea-ce/windows.json
@@ -4,7 +4,7 @@
       "version": "2025.2.6.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IntelliJ IDEA Community Edition %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IntelliJ IDEA Community Edition %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2025.2.6.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IntelliJ IDEA Community Edition %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '252.28539.54') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/idea/ideaIC-2025.2.6.2.exe",
       "install_script_ref": "036a6387",

--- a/ee/maintained-apps/outputs/intellij-idea/windows.json
+++ b/ee/maintained-apps/outputs/intellij-idea/windows.json
@@ -4,7 +4,7 @@
       "version": "2025.2.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IntelliJ IDEA %' AND name NOT LIKE 'IntelliJ IDEA Community%' AND name NOT LIKE 'IntelliJ IDEA Educational%' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IntelliJ IDEA %' AND name NOT LIKE 'IntelliJ IDEA Community%' AND name NOT LIKE 'IntelliJ IDEA Educational%' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2025.2.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IntelliJ IDEA %' AND name NOT LIKE 'IntelliJ IDEA Community%' AND name NOT LIKE 'IntelliJ IDEA Educational%' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '252.28238.7') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/idea/ideaIU-2025.2.5.exe",
       "install_script_ref": "6284895d",

--- a/ee/maintained-apps/outputs/phpstorm/windows.json
+++ b/ee/maintained-apps/outputs/phpstorm/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'PhpStorm %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'PhpStorm %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'PhpStorm %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.104') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1.3.exe",
       "install_script_ref": "ea27a84f",

--- a/ee/maintained-apps/outputs/pycharm-ce/windows.json
+++ b/ee/maintained-apps/outputs/pycharm-ce/windows.json
@@ -4,7 +4,7 @@
       "version": "2025.2.6.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'PyCharm Community Edition %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'PyCharm Community Edition %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2025.2.6.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'PyCharm Community Edition %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '252.28539.58') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/python/pycharm-community-2025.2.6.1.exe",
       "install_script_ref": "94c332f4",

--- a/ee/maintained-apps/outputs/pycharm/windows.json
+++ b/ee/maintained-apps/outputs/pycharm/windows.json
@@ -4,7 +4,7 @@
       "version": "2024.3.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'PyCharm %' AND name NOT LIKE 'PyCharm Community Edition%' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'PyCharm %' AND name NOT LIKE 'PyCharm Community Edition%' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2024.3.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'PyCharm %' AND name NOT LIKE 'PyCharm Community Edition%' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '243.26053.29') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/python/pycharm-professional-2024.3.5.exe",
       "install_script_ref": "60d9c96b",

--- a/ee/maintained-apps/outputs/rider/windows.json
+++ b/ee/maintained-apps/outputs/rider/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'JetBrains Rider %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'JetBrains Rider %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'JetBrains Rider %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.24374.190') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.2.exe",
       "install_script_ref": "d65fe1de",

--- a/ee/maintained-apps/outputs/rubymine/windows.json
+++ b/ee/maintained-apps/outputs/rubymine/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'RubyMine %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'RubyMine %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'RubyMine %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.97') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1.3.exe",
       "install_script_ref": "a737b660",

--- a/ee/maintained-apps/outputs/rustrover/windows.json
+++ b/ee/maintained-apps/outputs/rustrover/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'RustRover %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'RustRover %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'RustRover %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.134') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/rustrover/RustRover-2026.1.3.exe",
       "install_script_ref": "02283015",

--- a/ee/maintained-apps/outputs/webstorm/windows.json
+++ b/ee/maintained-apps/outputs/webstorm/windows.json
@@ -4,7 +4,7 @@
       "version": "2026.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'WebStorm %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'WebStorm %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'WebStorm %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.101') < 0);"
       },
       "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3.exe",
       "install_script_ref": "68119c0c",


### PR DESCRIPTION
JetBrains NSIS installers write the build number (e.g. 252.28238.7) as the registry DisplayVersion, while the winget PackageVersion is the marketing version (e.g. 2025.2.5). The auto-generated patch policy compared osquery's programs.version (build number) against the marketing version, so up-to-date installs always failed the policy and queued unnecessary reinstalls.

Opt the 12 JetBrains IDE FMAs into use_display_version_for_patch so the patch policy compares against the build number published in the winget manifest's AppsAndFeaturesEntries. JetBrains Toolbox is excluded: its manifest has no DisplayVersion and it is not affected.

Fixes #47478



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated patch version detection and comparison thresholds for all supported JetBrains IDEs (CLion, DataGrip, GoLand, IntelliJ IDEA, PhpStorm, PyCharm, Rider, RubyMine, RustRover, WebStorm) to improve Windows package management accuracy.
  * Enhanced version handling configuration to properly identify patched installations across JetBrains product releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->