### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/android-studio/windows.json
+++ b/ee/maintained-apps/outputs/android-studio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.1.8",
+      "version": "2026.1.1.9",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC' AND version_compare(version, '2026.1.1.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC' AND version_compare(version, '2026.1.1.9') < 0);"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.8/android-studio-quail1-windows.exe",
+      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.9/android-studio-quail1-patch1-windows.exe",
       "install_script_ref": "36676cba",
       "uninstall_script_ref": "c48a6948",
-      "sha256": "df998400b6ad20a3e172ca3d3d1420230d2ff6e37c9bbaa830bb3a146ae2b6cf",
+      "sha256": "d738b85423c79f3320032907bf7a9684509cf119803d9705b15b93970473a58f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.11847.5",
+      "version": "1.12603.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.11847.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.12603.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.11847.5/Claude-9692f0b44ffa0158a501a91309e361c0d48ed8e4.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.12603.1/Claude-3df4fd263723119bc45f0af2d784afd5055e2ba9.msix",
       "install_script_ref": "218aa85b",
       "uninstall_script_ref": "03f72055",
-      "sha256": "f5fc745c1b08049cdba70920dbd228fbc9ba1439ed9e8de51da732c64ebccf99",
+      "sha256": "01777d6e38533e2b7a7454d21a65b23fb1264d8f5957613c6f44d5bc34b42f37",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firealpaca/darwin.json
+++ b/ee/maintained-apps/outputs/firealpaca/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.15.2",
+      "version": "2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.16.0') < 0);"
       },
       "installer_url": "https://firealpaca.com/download/mac",
       "install_script_ref": "f2cad371",

--- a/ee/maintained-apps/outputs/pritunl/darwin.json
+++ b/ee/maintained-apps/outputs/pritunl/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.3.4566.62",
+      "version": "1.3.4655.98",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4566.62') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4655.98') < 0);"
       },
-      "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4566.62/Pritunl.pkg.zip",
+      "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4655.98/Pritunl.pkg.zip",
       "install_script_ref": "50fa15ff",
       "uninstall_script_ref": "538e8310",
-      "sha256": "e81c91e654b6a6ddb5da67398b810255f80b624b955b32e0f1c074c3b702aa3a",
+      "sha256": "ecc85816b0646ef0f7ca51324065c56d44f5abcdc48dd6810cfef931e07066c7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/twingate/windows.json
+++ b/ee/maintained-apps/outputs/twingate/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "20.26.140.168",
+      "version": "20.26.155.647",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.140.168') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.' AND version_compare(version, '20.26.155.647') < 0);"
       },
-      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.140.168/TwingateWindowsInstaller.msi",
+      "installer_url": "https://binaries.twingate.com/client/windows/versions/2026.155.647/TwingateWindowsInstaller.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "880ef5c9",
-      "sha256": "a823aab7137f1889343ed1dfe2fe958cc993151fde8bd3862bc8f8eaf6b16aad",
+      "sha256": "ca901508231a632c7c933768bc745526aaec6d24ed6e81401792c41de1c23cf5",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.06.03.09.49.04",
+      "version": "0.2026.06.10.09.27.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.03.09.49.04') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.10.09.27.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.03.09.49.stable_04/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.10.09.27.stable_01/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata and installer information for multiple maintained applications: Android Studio (2026.1.1.9), Claude (1.12603.1), FireAlpaca (2.16.0), Pritunl (1.3.4655.98), Twingate (20.26.155.647), and Warp (0.2026.06.10.09.27.01).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->