### PR TITLE
log as error in apple reconciler for mixed label modes

### DIFF
--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -287,7 +287,9 @@ func (ds *Datastore) listAppleProfilesForReconcileTransaction(ctx context.Contex
 			// intent; exclude labels (if any) are preserved.
 			p.IncludeLabels = nil
 			p.IncludeMode = fleet.AppleProfileIncludeNone
-			ds.logger.WarnContext(ctx, "apple profile has mixed include label modes; ignoring include labels", "profile_uuid", uuid, "team_id", p.TeamID)
+			errMsg := "apple profile has mixed include label modes; ignoring include labels"
+			ds.logger.ErrorContext(ctx, errMsg, "profile_uuid", uuid, "team_id", p.TeamID)
+			ctxerr.Handle(ctx, errors.New(errMsg))
 			continue
 		}
 		p.IncludeMode = ia.mode

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -280,6 +280,10 @@ func (ds *Datastore) listAppleProfilesForReconcileTransaction(ctx context.Contex
 
 	for uuid, ia := range includeModes {
 		p := byUUID[uuid]
+		if p == nil {
+			// Should not happen, so not worth logging anything here.
+			continue
+		}
 		if ia.mixed {
 			// Defensive: include rows disagreed on require_all (should
 			// be impossible in production — the upsert path enforces a
@@ -288,11 +292,7 @@ func (ds *Datastore) listAppleProfilesForReconcileTransaction(ctx context.Contex
 			p.IncludeLabels = nil
 			p.IncludeMode = fleet.AppleProfileIncludeNone
 			errMsg := "apple profile has mixed include label modes; ignoring include labels"
-			logger := ds.logger
-			if p != nil {
-				logger = logger.With("team_id", p.TeamID)
-			}
-			ds.logger.ErrorContext(ctx, errMsg, "profile_uuid", uuid)
+			ds.logger.ErrorContext(ctx, errMsg, "profile_uuid", uuid, "team_id", p.TeamID)
 			ctxerr.Handle(ctx, ctxerr.New(ctx, errMsg))
 			continue
 		}
@@ -587,16 +587,16 @@ func (ds *Datastore) listAppleDeclarationsForReconcileTransaction(ctx context.Co
 
 	for uuid, ia := range includeModes {
 		d := byUUID[uuid]
+		if d == nil {
+			// Should never happen, so not worth logging anything here.
+			continue
+		}
 		if ia.mixed {
 			d.IncludeLabels = nil
 			d.IncludeMode = fleet.AppleProfileIncludeNone
 
 			errMsg := "apple declaration has mixed include label modes; ignoring include labels"
-			logger := ds.logger
-			if d != nil {
-				logger = logger.With("team_id", d.TeamID)
-			}
-			ds.logger.ErrorContext(ctx, errMsg, "declaration_uuid", uuid)
+			ds.logger.ErrorContext(ctx, errMsg, "declaration_uuid", uuid, "team_id", d.TeamID)
 			ctxerr.Handle(ctx, ctxerr.New(ctx, errMsg))
 			continue
 		}

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -288,8 +288,12 @@ func (ds *Datastore) listAppleProfilesForReconcileTransaction(ctx context.Contex
 			p.IncludeLabels = nil
 			p.IncludeMode = fleet.AppleProfileIncludeNone
 			errMsg := "apple profile has mixed include label modes; ignoring include labels"
-			ds.logger.ErrorContext(ctx, errMsg, "profile_uuid", uuid, "team_id", p.TeamID)
-			ctxerr.Handle(ctx, errors.New(errMsg))
+			logger := ds.logger
+			if p != nil {
+				logger = logger.With("team_id", p.TeamID)
+			}
+			ds.logger.ErrorContext(ctx, errMsg, "profile_uuid", uuid)
+			ctxerr.Handle(ctx, ctxerr.New(ctx, errMsg))
 			continue
 		}
 		p.IncludeMode = ia.mode
@@ -587,7 +591,13 @@ func (ds *Datastore) listAppleDeclarationsForReconcileTransaction(ctx context.Co
 			d.IncludeLabels = nil
 			d.IncludeMode = fleet.AppleProfileIncludeNone
 
-			ds.logger.WarnContext(ctx, "apple declaration has mixed include label modes; ignoring include labels", "declaration_uuid", uuid, "team_id", d.TeamID)
+			errMsg := "apple declaration has mixed include label modes; ignoring include labels"
+			logger := ds.logger
+			if d != nil {
+				logger = logger.With("team_id", d.TeamID)
+			}
+			ds.logger.ErrorContext(ctx, errMsg, "declaration_uuid", uuid)
+			ctxerr.Handle(ctx, ctxerr.New(ctx, errMsg))
 			continue
 		}
 		d.IncludeMode = ia.mode


### PR DESCRIPTION
Simple follow up based on the Windows work


- [] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple MDM reconciliation by detecting inconsistent include-label modes for both profiles and declarations.
  * These cases are now logged with contextual details (including team when available), handled gracefully, and the problematic include labels are discarded so reconciliation continues reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->