### PR TITLE
Always display Windows ESP error when software install fails

### DIFF
--- a/changes/45948-windows-esp-continue-anyway
+++ b/changes/45948-windows-esp-continue-anyway
@@ -1,0 +1,2 @@
+- Added an error on the Windows enrollment status page (ESP) when setup experience software fails to install during automatic
+  enrollment (Autopilot and other OOBE flows) and "Cancel setup if software fails" is turned off.

--- a/server/mdm/microsoft/esp_csp.go
+++ b/server/mdm/microsoft/esp_csp.go
@@ -2,6 +2,7 @@ package microsoft_mdm
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -18,18 +19,15 @@ const ESPTimeoutErrorText = "Setup is taking longer than expected. Please try ag
 const espContinuableErrorSuffix = "Reset your device to try again, or proceed and install missing software via self-service. " +
 	"If unavailable, contact your IT admin."
 
-// espMaxFailedNamesLen caps the rendered failed-software name list. The DMClient CSP does not document a maximum
-// length for CustomErrorText and the ESP renders it in a small area, so overly long lists are truncated to
-// "..., and N more".
-const espMaxFailedNamesLen = 400
+// espMaxFailedNamesShown caps how many software names the ESP failure message lists before summarizing the rest as
+// "N more". CustomErrorText renders in a small ESP area and the DMClient CSP documents no maximum length.
+const espMaxFailedNamesShown = 3
 
 // ESPSoftwareFailureContinuableErrorText returns the message shown on the Windows ESP failure screen when one or more
 // software installs failed but "Cancel setup if software fails" (require_all_software_windows) is off, so the end user
-// is allowed to continue to the desktop. The failed software is listed by name, e.g. "Slack, Zoom, and Docker failed
-// to install. Reset your device to try again, or proceed and install missing software via self-service. If
-// unavailable, contact your IT admin."
+// is allowed to continue to the desktop.
 func ESPSoftwareFailureContinuableErrorText(failedNames []string) string {
-	list := joinFailedNames(failedNames, espMaxFailedNamesLen)
+	list := joinFailedNames(failedNames)
 	if list == "" {
 		// Defensive: a failure was detected but no names were collected (e.g. rows with empty names).
 		return "Some software failed to install. " + espContinuableErrorSuffix
@@ -37,35 +35,16 @@ func ESPSoftwareFailureContinuableErrorText(failedNames []string) string {
 	return fmt.Sprintf("%s failed to install. %s", list, espContinuableErrorSuffix)
 }
 
-// joinFailedNames joins names into a human-readable list: "A", "A and B", "A, B, and C". If the joined list would
-// exceed maxLen, only the names that fit are listed and the remainder is summarized as "N more"; at least one name is
-// always included.
-func joinFailedNames(names []string, maxLen int) string {
-	nonEmpty := make([]string, 0, len(names))
-	for _, n := range names {
-		if n != "" {
-			nonEmpty = append(nonEmpty, n)
-		}
-	}
-	if len(nonEmpty) == 0 {
+// joinFailedNames renders names as a human-readable list: "A", "A and B", "A, B, and C". Empty names are dropped. When
+// more than espMaxFailedNamesShown names remain, only the first that many are listed and the rest is summarized, e.g.
+// "A, B, C, and 2 more". Returns "" when there are no non-empty names.
+func joinFailedNames(names []string) string {
+	items := slices.DeleteFunc(slices.Clone(names), func(s string) bool { return s == "" })
+	if len(items) == 0 {
 		return ""
 	}
-
-	// included counts how many names fit in maxLen. The running length approximates the final rendering (", " between
-	// items); exact "and"/Oxford-comma accounting isn't needed for a display cap.
-	included := 1
-	lenSoFar := len(nonEmpty[0])
-	for ; included < len(nonEmpty); included++ {
-		next := lenSoFar + 2 + len(nonEmpty[included])
-		if next > maxLen {
-			break
-		}
-		lenSoFar = next
-	}
-
-	items := nonEmpty[:included:included]
-	if rest := len(nonEmpty) - included; rest > 0 {
-		items = append(items, fmt.Sprintf("%d more", rest))
+	if extra := len(items) - espMaxFailedNamesShown; extra > 0 {
+		items = append(items[:espMaxFailedNamesShown:espMaxFailedNamesShown], fmt.Sprintf("%d more", extra))
 	}
 
 	switch len(items) {

--- a/server/mdm/microsoft/esp_csp.go
+++ b/server/mdm/microsoft/esp_csp.go
@@ -9,13 +9,14 @@ import (
 const ESPTimeoutSeconds = 3 * 60 * 60
 
 // ESPSoftwareFailureErrorText is the message shown on the Windows ESP failure screen when a critical software install fails.
-const ESPSoftwareFailureErrorText = "Critical software failed to install. Please try again. If this keeps happening, please contact your IT admin."
+const ESPSoftwareFailureErrorText = "Critical software failed to install. Reset your device to try again. If failures keep happening, please contact your IT admin."
 
 // ESPTimeoutErrorText is the message shown on the Windows ESP failure screen when the 3-hour ESP timeout expires before setup completes.
 const ESPTimeoutErrorText = "Setup is taking longer than expected. Please try again. If this keeps happening, please contact your IT admin."
 
 // espContinuableErrorSuffix follows the failed-software list when the end user is allowed to continue past the failure.
-const espContinuableErrorSuffix = "You can reset your device to start over or proceed and install missing software via self-service."
+const espContinuableErrorSuffix = "Reset your device to try again, or proceed and install missing software via self-service. " +
+	"If unavailable, contact your IT admin."
 
 // espMaxFailedNamesLen caps the rendered failed-software name list. The DMClient CSP does not document a maximum
 // length for CustomErrorText and the ESP renders it in a small area, so overly long lists are truncated to
@@ -25,7 +26,8 @@ const espMaxFailedNamesLen = 400
 // ESPSoftwareFailureContinuableErrorText returns the message shown on the Windows ESP failure screen when one or more
 // software installs failed but "Cancel setup if software fails" (require_all_software_windows) is off, so the end user
 // is allowed to continue to the desktop. The failed software is listed by name, e.g. "Slack, Zoom, and Docker failed
-// to install. You can reset your device to start over or proceed and install missing software via self-service."
+// to install. Reset your device to try again, or proceed and install missing software via self-service. If
+// unavailable, contact your IT admin."
 func ESPSoftwareFailureContinuableErrorText(failedNames []string) string {
 	list := joinFailedNames(failedNames, espMaxFailedNamesLen)
 	if list == "" {

--- a/server/mdm/microsoft/esp_csp.go
+++ b/server/mdm/microsoft/esp_csp.go
@@ -1,5 +1,10 @@
 package microsoft_mdm
 
+import (
+	"fmt"
+	"strings"
+)
+
 // ESPTimeoutSeconds is the default timeout for the Enrollment Status Page (3 hours).
 const ESPTimeoutSeconds = 3 * 60 * 60
 
@@ -8,3 +13,65 @@ const ESPSoftwareFailureErrorText = "Critical software failed to install. Please
 
 // ESPTimeoutErrorText is the message shown on the Windows ESP failure screen when the 3-hour ESP timeout expires before setup completes.
 const ESPTimeoutErrorText = "Setup is taking longer than expected. Please try again. If this keeps happening, please contact your IT admin."
+
+// espContinuableErrorSuffix follows the failed-software list when the end user is allowed to continue past the failure.
+const espContinuableErrorSuffix = "You can reset your device to start over or proceed and install missing software via self-service."
+
+// espMaxFailedNamesLen caps the rendered failed-software name list. The DMClient CSP does not document a maximum
+// length for CustomErrorText and the ESP renders it in a small area, so overly long lists are truncated to
+// "..., and N more".
+const espMaxFailedNamesLen = 400
+
+// ESPSoftwareFailureContinuableErrorText returns the message shown on the Windows ESP failure screen when one or more
+// software installs failed but "Cancel setup if software fails" (require_all_software_windows) is off, so the end user
+// is allowed to continue to the desktop. The failed software is listed by name, e.g. "Slack, Zoom, and Docker failed
+// to install. You can reset your device to start over or proceed and install missing software via self-service."
+func ESPSoftwareFailureContinuableErrorText(failedNames []string) string {
+	list := joinFailedNames(failedNames, espMaxFailedNamesLen)
+	if list == "" {
+		// Defensive: a failure was detected but no names were collected (e.g. rows with empty names).
+		return "Some software failed to install. " + espContinuableErrorSuffix
+	}
+	return fmt.Sprintf("%s failed to install. %s", list, espContinuableErrorSuffix)
+}
+
+// joinFailedNames joins names into a human-readable list: "A", "A and B", "A, B, and C". If the joined list would
+// exceed maxLen, only the names that fit are listed and the remainder is summarized as "N more"; at least one name is
+// always included.
+func joinFailedNames(names []string, maxLen int) string {
+	nonEmpty := make([]string, 0, len(names))
+	for _, n := range names {
+		if n != "" {
+			nonEmpty = append(nonEmpty, n)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return ""
+	}
+
+	// included counts how many names fit in maxLen. The running length approximates the final rendering (", " between
+	// items); exact "and"/Oxford-comma accounting isn't needed for a display cap.
+	included := 1
+	lenSoFar := len(nonEmpty[0])
+	for ; included < len(nonEmpty); included++ {
+		next := lenSoFar + 2 + len(nonEmpty[included])
+		if next > maxLen {
+			break
+		}
+		lenSoFar = next
+	}
+
+	items := nonEmpty[:included:included]
+	if rest := len(nonEmpty) - included; rest > 0 {
+		items = append(items, fmt.Sprintf("%d more", rest))
+	}
+
+	switch len(items) {
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " and " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + ", and " + items[len(items)-1]
+	}
+}

--- a/server/mdm/microsoft/esp_csp_test.go
+++ b/server/mdm/microsoft/esp_csp_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestESPSoftwareFailureContinuableErrorText(t *testing.T) {
-	const suffix = "Reset your device to try again, or proceed and install missing software via self-service. " +
-		"If unavailable, contact your IT admin."
-
 	tests := []struct {
 		name        string
 		failedNames []string
@@ -18,50 +15,50 @@ func TestESPSoftwareFailureContinuableErrorText(t *testing.T) {
 		{
 			name:        "no names falls back to generic text",
 			failedNames: nil,
-			want:        "Some software failed to install. " + suffix,
+			want:        "Some software failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			name:        "empty names are skipped",
 			failedNames: []string{"", ""},
-			want:        "Some software failed to install. " + suffix,
+			want:        "Some software failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			name:        "one name",
 			failedNames: []string{"Slack"},
-			want:        "Slack failed to install. " + suffix,
+			want:        "Slack failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			name:        "two names",
 			failedNames: []string{"Slack", "Zoom"},
-			want:        "Slack and Zoom failed to install. " + suffix,
+			want:        "Slack and Zoom failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			// The cap (espMaxFailedNamesShown) is 3, so three names list in full.
 			name:        "three names use Oxford comma",
 			failedNames: []string{"Slack", "Zoom", "Docker"},
-			want:        "Slack, Zoom, and Docker failed to install. " + suffix,
+			want:        "Slack, Zoom, and Docker failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			// Above the cap, the rest is summarized as "N more": four names -> first three plus "and 1 more".
 			name:        "four names list first three and one more",
 			failedNames: []string{"Slack", "Zoom", "Docker", "1Password"},
-			want:        "Slack, Zoom, Docker, and 1 more failed to install. " + suffix,
+			want:        "Slack, Zoom, Docker, and 1 more failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			name:        "six names list first three and three more",
 			failedNames: []string{"Slack", "Zoom", "Docker", "1Password", "Notion", "Chrome"},
-			want:        "Slack, Zoom, Docker, and 3 more failed to install. " + suffix,
+			want:        "Slack, Zoom, Docker, and 3 more failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			name:        "empty name mixed in is skipped",
 			failedNames: []string{"Slack", "", "Zoom"},
-			want:        "Slack and Zoom failed to install. " + suffix,
+			want:        "Slack and Zoom failed to install. " + espContinuableErrorSuffix,
 		},
 		{
 			// Empties are dropped before the cap is applied, so this counts as four names, not seven.
 			name:        "empties are dropped before the cap is counted",
 			failedNames: []string{"Slack", "", "Zoom", "", "Docker", "", "1Password"},
-			want:        "Slack, Zoom, Docker, and 1 more failed to install. " + suffix,
+			want:        "Slack, Zoom, Docker, and 1 more failed to install. " + espContinuableErrorSuffix,
 		},
 	}
 	for _, tc := range tests {

--- a/server/mdm/microsoft/esp_csp_test.go
+++ b/server/mdm/microsoft/esp_csp_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestESPSoftwareFailureContinuableErrorText(t *testing.T) {
-	const suffix = "You can reset your device to start over or proceed and install missing software via self-service."
+	const suffix = "Reset your device to try again, or proceed and install missing software via self-service. " +
+		"If unavailable, contact your IT admin."
 
 	tests := []struct {
 		name        string

--- a/server/mdm/microsoft/esp_csp_test.go
+++ b/server/mdm/microsoft/esp_csp_test.go
@@ -1,0 +1,80 @@
+package microsoft_mdm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestESPSoftwareFailureContinuableErrorText(t *testing.T) {
+	const suffix = "You can reset your device to start over or proceed and install missing software via self-service."
+
+	tests := []struct {
+		name        string
+		failedNames []string
+		want        string
+	}{
+		{
+			name:        "no names falls back to generic text",
+			failedNames: nil,
+			want:        "Some software failed to install. " + suffix,
+		},
+		{
+			name:        "empty names are skipped",
+			failedNames: []string{"", ""},
+			want:        "Some software failed to install. " + suffix,
+		},
+		{
+			name:        "one name",
+			failedNames: []string{"Slack"},
+			want:        "Slack failed to install. " + suffix,
+		},
+		{
+			name:        "two names",
+			failedNames: []string{"Slack", "Zoom"},
+			want:        "Slack and Zoom failed to install. " + suffix,
+		},
+		{
+			name:        "three names use Oxford comma",
+			failedNames: []string{"Slack", "Zoom", "Docker"},
+			want:        "Slack, Zoom, and Docker failed to install. " + suffix,
+		},
+		{
+			name:        "four names",
+			failedNames: []string{"Slack", "Zoom", "Docker", "1Password"},
+			want:        "Slack, Zoom, Docker, and 1Password failed to install. " + suffix,
+		},
+		{
+			name:        "empty name mixed in is skipped",
+			failedNames: []string{"Slack", "", "Zoom"},
+			want:        "Slack and Zoom failed to install. " + suffix,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ESPSoftwareFailureContinuableErrorText(tc.failedNames))
+		})
+	}
+
+	t.Run("long list is truncated to N more", func(t *testing.T) {
+		manyNames := make([]string, 50)
+		for i := range manyNames {
+			manyNames[i] = fmt.Sprintf("Application With A Fairly Long Name %02d", i)
+		}
+		got := ESPSoftwareFailureContinuableErrorText(manyNames)
+		assert.Contains(t, got, manyNames[0], "first name must always be included")
+		assert.Contains(t, got, "more failed to install. ", "truncated list must summarize the remainder as N more")
+		assert.NotContains(t, got, manyNames[len(manyNames)-1], "names past the cap must not be listed")
+		assert.True(t, strings.HasSuffix(got, suffix))
+		// The cap bounds the name list; the full message adds ", and N more failed to install. " plus the suffix.
+		assert.Less(t, len(got), espMaxFailedNamesLen+len(suffix)+50, "message must stay near the cap")
+	})
+
+	t.Run("single name longer than the cap is still included", func(t *testing.T) {
+		hugeName := strings.Repeat("x", espMaxFailedNamesLen+50)
+		got := ESPSoftwareFailureContinuableErrorText([]string{hugeName})
+		assert.Equal(t, hugeName+" failed to install. "+suffix, got)
+	})
+}

--- a/server/mdm/microsoft/esp_csp_test.go
+++ b/server/mdm/microsoft/esp_csp_test.go
@@ -1,8 +1,6 @@
 package microsoft_mdm
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,19 +36,32 @@ func TestESPSoftwareFailureContinuableErrorText(t *testing.T) {
 			want:        "Slack and Zoom failed to install. " + suffix,
 		},
 		{
+			// The cap (espMaxFailedNamesShown) is 3, so three names list in full.
 			name:        "three names use Oxford comma",
 			failedNames: []string{"Slack", "Zoom", "Docker"},
 			want:        "Slack, Zoom, and Docker failed to install. " + suffix,
 		},
 		{
-			name:        "four names",
+			// Above the cap, the rest is summarized as "N more": four names -> first three plus "and 1 more".
+			name:        "four names list first three and one more",
 			failedNames: []string{"Slack", "Zoom", "Docker", "1Password"},
-			want:        "Slack, Zoom, Docker, and 1Password failed to install. " + suffix,
+			want:        "Slack, Zoom, Docker, and 1 more failed to install. " + suffix,
+		},
+		{
+			name:        "six names list first three and three more",
+			failedNames: []string{"Slack", "Zoom", "Docker", "1Password", "Notion", "Chrome"},
+			want:        "Slack, Zoom, Docker, and 3 more failed to install. " + suffix,
 		},
 		{
 			name:        "empty name mixed in is skipped",
 			failedNames: []string{"Slack", "", "Zoom"},
 			want:        "Slack and Zoom failed to install. " + suffix,
+		},
+		{
+			// Empties are dropped before the cap is applied, so this counts as four names, not seven.
+			name:        "empties are dropped before the cap is counted",
+			failedNames: []string{"Slack", "", "Zoom", "", "Docker", "", "1Password"},
+			want:        "Slack, Zoom, Docker, and 1 more failed to install. " + suffix,
 		},
 	}
 	for _, tc := range tests {
@@ -58,24 +69,4 @@ func TestESPSoftwareFailureContinuableErrorText(t *testing.T) {
 			assert.Equal(t, tc.want, ESPSoftwareFailureContinuableErrorText(tc.failedNames))
 		})
 	}
-
-	t.Run("long list is truncated to N more", func(t *testing.T) {
-		manyNames := make([]string, 50)
-		for i := range manyNames {
-			manyNames[i] = fmt.Sprintf("Application With A Fairly Long Name %02d", i)
-		}
-		got := ESPSoftwareFailureContinuableErrorText(manyNames)
-		assert.Contains(t, got, manyNames[0], "first name must always be included")
-		assert.Contains(t, got, "more failed to install. ", "truncated list must summarize the remainder as N more")
-		assert.NotContains(t, got, manyNames[len(manyNames)-1], "names past the cap must not be listed")
-		assert.True(t, strings.HasSuffix(got, suffix))
-		// The cap bounds the name list; the full message adds ", and N more failed to install. " plus the suffix.
-		assert.Less(t, len(got), espMaxFailedNamesLen+len(suffix)+50, "message must stay near the cap")
-	})
-
-	t.Run("single name longer than the cap is still included", func(t *testing.T) {
-		hugeName := strings.Repeat("x", espMaxFailedNamesLen+50)
-		got := ESPSoftwareFailureContinuableErrorText([]string{hugeName})
-		assert.Equal(t, hugeName+" failed to install. "+suffix, got)
-	})
 }

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2328,12 +2328,14 @@ func (svc *Service) handleESPHoldOrTransition(ctx context.Context, device *fleet
 // handleESPRelease handles awaiting_configuration=Active. It waits for all profiles and setup experience items to reach
 // a terminal state, then finalizes the device down one of three paths:
 //
-//   - hard block: require_all_software_windows is true and any item failed, or the 3-hour timeout was hit. The ESP
-//     failure screen is shown with only the "Reset device" recovery option and remaining items are cancelled.
-//   - soft block: an item failed but require_all_software_windows is false. The ESP failure screen is shown listing
-//     the failed software by name, with a "Continue anyway" option so the user can proceed to the desktop and install
-//     the missing software via self-service. Nothing is cancelled (all items already reached a terminal state).
-//   - release: no failures (or pure timeout with require_all_software_windows false); the device proceeds to login.
+//   - hard block (require_all_software_windows=true and any item failed, or the 3-hour timeout was hit): the ESP
+//     failure screen is shown with only the "Reset device" recovery option, and remaining items are cancelled.
+//   - soft block (require_all_software_windows=false and an item failed, or the 3-hour timeout was hit): the ESP
+//     failure screen is shown with a "Continue anyway" option so the user can proceed to the desktop and install the
+//     missing software via self-service. It lists the failed software by name when any failed, otherwise (a timeout
+//     with nothing failed) shows the timeout message. Still-pending items are cancelled only on the timeout path; on
+//     the non-timeout path everything has already reached a terminal state, so there is nothing to cancel.
+//   - release (no failure and no timeout): the device proceeds to login.
 func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice) ([]*mdm_types.SyncMLCmd, error) {
 	if device.HostUUID == "" {
 		return nil, nil
@@ -3454,11 +3456,15 @@ func newSyncMLNoFormat(cmdVerb string, cmdTarget string) *mdm_types.SyncMLCmd {
 	return newSyncMLCmdWithItem(&cmdVerb, nil, item)
 }
 
-// newSyncMLCmdText creates a new SyncML command with text data
+// newSyncMLCmdText creates a new SyncML command with text data. The value is XML-escaped (matching
+// newSyncMLCmdXml/newSyncMLCmdBase64) because SyncML <Data> is serialized as innerxml (written raw); without
+// escaping, a value containing &, <, or > -- e.g. a software title like "AT&T" surfaced in CustomErrorText --
+// would produce malformed SyncML that the device rejects.
 func newSyncMLCmdText(cmdVerb string, cmdTarget string, cmdDataValue string) *mdm_types.SyncMLCmd {
 	cmdType := "text/plain"
 	cmdFormat := "chr"
-	item := newSyncMLItem(nil, &cmdTarget, &cmdType, &cmdFormat, &cmdDataValue)
+	escapedData := html.EscapeString(cmdDataValue)
+	item := newSyncMLItem(nil, &cmdTarget, &cmdType, &cmdFormat, &escapedData)
 	return newSyncMLCmdWithItem(&cmdVerb, nil, item)
 }
 

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2326,8 +2326,14 @@ func (svc *Service) handleESPHoldOrTransition(ctx context.Context, device *fleet
 }
 
 // handleESPRelease handles awaiting_configuration=Active. It waits for all profiles and setup experience items to reach
-// a terminal state, then either releases the device or, when require_all_software_windows is true and any item failed
-// (or the 3-hour timeout was hit), blocks the device on the ESP failure screen.
+// a terminal state, then finalizes the device down one of three paths:
+//
+//   - hard block: require_all_software_windows is true and any item failed, or the 3-hour timeout was hit. The ESP
+//     failure screen is shown with only the "Reset device" recovery option and remaining items are cancelled.
+//   - soft block: an item failed but require_all_software_windows is false. The ESP failure screen is shown listing
+//     the failed software by name, with a "Continue anyway" option so the user can proceed to the desktop and install
+//     the missing software via self-service. Nothing is cancelled (all items already reached a terminal state).
+//   - release: no failures (or pure timeout with require_all_software_windows false); the device proceeds to login.
 func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice) ([]*mdm_types.SyncMLCmd, error) {
 	if device.HostUUID == "" {
 		return nil, nil
@@ -2341,6 +2347,11 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 
 	// hasSoftwareFailure tracks setup-experience software failures only.
 	var hasSoftwareFailure bool
+
+	// failedSoftwareNames collects the names of the failed setup-experience items for the soft-block message. Only
+	// populated when Stage 3 runs; the timeout path skips Stage 3, so it stays empty there (the timeout text is used
+	// instead).
+	var failedSoftwareNames []string
 
 	// loadHost lazily fetches the host (writer-routed) and memoizes for the rest of this checkin. Writer routing guards
 	// two replica-lag races: (1) spurious notFound during the brief gap between orbit's host registration and the next
@@ -2500,6 +2511,9 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 			switch r.Status {
 			case fleet.SetupExperienceStatusFailure:
 				hasSoftwareFailure = true
+				if r.Name != "" {
+					failedSoftwareNames = append(failedSoftwareNames, r.Name)
+				}
 			case fleet.SetupExperienceStatusSuccess, fleet.SetupExperienceStatusCancelled:
 				// terminal, nothing to record
 			default:
@@ -2539,11 +2553,18 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 
 	failed := timedOut || hasSoftwareFailure
 	shouldBlock := failed && requireAll
+	// shouldWarn drives the soft block: software failed but "Cancel setup if software fails" is off. We still surface
+	// the ESP failure UI so the user learns which software failed, but with a "Continue anyway" option so they can
+	// proceed to the desktop and install the missing software via self-service (issue #45948). Pure timeout with
+	// require_all=false keeps releasing silently: the timeout path skips Stage 3, so there is no failed-software list
+	// to show.
+	shouldWarn := hasSoftwareFailure && !timedOut && !requireAll
 
 	// Build commands for the response.
 	provID := syncml.DocProvisioningAppProviderID
 	var cmds []*mdm_types.SyncMLCmd
-	if shouldBlock {
+	switch {
+	case shouldBlock:
 		// Pick the user-facing error text to surface on the failure UI. Software failure takes precedence over timeout
 		// because it's more actionable; pure timeout (no software failed) uses the timeout text so the user sees an
 		// accurate reason.
@@ -2551,8 +2572,11 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		if hasSoftwareFailure {
 			errorText = microsoft_mdm.ESPSoftwareFailureErrorText
 		}
-		cmds = buildESPBlockCommands(provID, errorText)
-	} else {
+		cmds = buildESPBlockCommands(provID, errorText, espBlockButtonsReset)
+	case shouldWarn:
+		cmds = buildESPBlockCommands(provID,
+			microsoft_mdm.ESPSoftwareFailureContinuableErrorText(failedSoftwareNames), espBlockButtonsResetAndContinue)
+	default:
 		// Release path: device proceeds to login. We do not send CustomErrorText here because the failure UI never renders
 		// on a release (no BlockInStatusPage, no forced timeout), so any error text would be dead state on the DMClient
 		// node.
@@ -2690,25 +2714,37 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		"timed_out", timedOut,
 		"has_software_failure", hasSoftwareFailure,
 		"require_all", requireAll,
-		"blocking", shouldBlock)
+		"blocking", shouldBlock,
+		"soft_blocking", shouldWarn)
 
 	return cmds, nil
 }
 
-// buildESPBlockCommands builds SyncML commands that put the device's ESP into a failed state with a "Reset device"
-// button and "Collect logs" button.
-func buildESPBlockCommands(provID, errorText string) []*mdm_types.SyncMLCmd {
+// BlockInStatusPage values per Microsoft DMClient CSP docs (bit flags): 1=Reset PC, 2=Try Again, 4=Continue Anyway.
+const (
+	// espBlockButtonsReset shows only the "Reset PC" button: used for the hard block (software failure with
+	// require_all_software_windows=true, or ESP timeout), where reset (Autopilot wipe + re-enrollment) is the only
+	// in-product recovery path.
+	espBlockButtonsReset = "1"
+	// espBlockButtonsResetAndContinue shows "Reset PC" and "Continue anyway" (1|4): used for the soft block when
+	// software failed but require_all_software_windows is false, so the user may proceed to the desktop and install
+	// the missing software via self-service.
+	espBlockButtonsResetAndContinue = "5"
+)
+
+// buildESPBlockCommands builds SyncML commands that put the device's ESP into a failed state showing errorText, a
+// "Collect logs" button, and the recovery buttons selected by blockButtons (one of the espBlockButtons* constants).
+func buildESPBlockCommands(provID, errorText, blockButtons string) []*mdm_types.SyncMLCmd {
 	cmds := []*mdm_types.SyncMLCmd{
 		// CustomErrorText: shown in the ESP failure UI as the failure reason.
 		newSyncMLCmdText(fleet.CmdReplace,
 			fmt.Sprintf("./Device/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/CustomErrorText", provID),
 			errorText),
-		// BlockInStatusPage=1: show the "Reset PC" button (per Microsoft DMClient CSP docs). Reset triggers an Autopilot
-		// wipe and re-enrollment, which is the only reliable in-product recovery path for a failed ESP. Documented values:
-		// 1=Reset PC, 2=Try Again, 4=Continue Anyway.
+		// BlockInStatusPage: which recovery buttons the failure UI offers. Reset triggers an Autopilot wipe and
+		// re-enrollment; Continue anyway (soft block only) lets the user proceed to the desktop.
 		newSyncMLCmdInt(fleet.CmdReplace,
 			fmt.Sprintf("./Device/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/BlockInStatusPage", provID),
-			"1"),
+			blockButtons),
 		// AllowCollectLogsButton: show the "Collect logs" button so IT can gather diagnostics from the failure screen.
 		newSyncMLCmdBool(fleet.CmdReplace,
 			fmt.Sprintf("./Device/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/AllowCollectLogsButton", provID),

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2348,10 +2348,24 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 	// hasSoftwareFailure tracks setup-experience software failures only.
 	var hasSoftwareFailure bool
 
-	// failedSoftwareNames collects the names of the failed setup-experience items for the soft-block message. Only
-	// populated when Stage 3 runs; the timeout path skips Stage 3, so it stays empty there (the timeout text is used
-	// instead).
+	// failedSoftwareNames collects the names of the failed setup-experience items for the soft-block message. It is
+	// populated by Stage 3 on the normal path and by the timeout-failure scan below (require_all=false only), so that
+	// the timeout finalize can list failed software instead of releasing silently.
 	var failedSoftwareNames []string
+
+	// recordSoftwareFailure marks a failed setup-experience item for the block/warn decision and the soft-block
+	// message, preferring the team-scoped custom display name (populated by ListSetupExperienceResultsByHostUUID) over
+	// the raw item name, matching how software titles render elsewhere in the product.
+	recordSoftwareFailure := func(r *fleet.SetupExperienceStatusResult) {
+		hasSoftwareFailure = true
+		name := r.Name
+		if r.DisplayName != "" {
+			name = r.DisplayName
+		}
+		if name != "" {
+			failedSoftwareNames = append(failedSoftwareNames, name)
+		}
+	}
 
 	// loadHost lazily fetches the host (writer-routed) and memoizes for the rest of this checkin. Writer routing guards
 	// two replica-lag races: (1) spurious notFound during the brief gap between orbit's host registration and the next
@@ -2464,13 +2478,22 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		// is enabled for the current OS/flags, which enqueues items into setup_experience_status_results.
 		//
 		// setup_experience_status_results.host_uuid is keyed by fleet.HostUUIDForSetupExperience; on Windows that's the
-		// host's OsqueryHostID. We pass teamID=0 because that parameter is only used for icon and display-name enrichment
-		// in the datastore call, not for filtering (the query filters only by host_uuid).
+		// host's OsqueryHostID. The teamID parameter only scopes the icon and display-name enrichment, not filtering
+		// (the query filters only by host_uuid), but the enrichment matters here: the soft-block error text renders
+		// these names to the end user, so they must reflect the host's team's custom display names.
 		seHostUUID, err := setupExperienceHostUUID()
 		if err != nil {
 			return nil, err
 		}
-		results, err := svc.ds.ListSetupExperienceResultsByHostUUID(ctx, seHostUUID, 0)
+		host, err := loadHost()
+		if err != nil {
+			return nil, err
+		}
+		var hostTeamID uint
+		if host.TeamID != nil {
+			hostTeamID = *host.TeamID
+		}
+		results, err := svc.ds.ListSetupExperienceResultsByHostUUID(ctx, seHostUUID, hostTeamID)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "list setup experience results for ESP release check")
 		}
@@ -2482,15 +2505,7 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		// the MDM enrollment independently of when it calls init, so on the first Active checkin after link we can hit
 		// this race. Disambiguate by checking whether items are configured for the host's team.
 		if len(results) == 0 {
-			host, err := loadHost()
-			if err != nil {
-				return nil, err
-			}
-			var teamIDForQuery uint
-			if host.TeamID != nil {
-				teamIDForQuery = *host.TeamID
-			}
-			hasItems, err := svc.ds.HasWindowsSetupExperienceItemsForTeam(ctx, teamIDForQuery)
+			hasItems, err := svc.ds.HasWindowsSetupExperienceItemsForTeam(ctx, hostTeamID)
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "check setup experience items configured for team")
 			}
@@ -2510,10 +2525,7 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		for _, r := range results {
 			switch r.Status {
 			case fleet.SetupExperienceStatusFailure:
-				hasSoftwareFailure = true
-				if r.Name != "" {
-					failedSoftwareNames = append(failedSoftwareNames, r.Name)
-				}
+				recordSoftwareFailure(r)
 			case fleet.SetupExperienceStatusSuccess, fleet.SetupExperienceStatusCancelled:
 				// terminal, nothing to record
 			default:
@@ -2551,14 +2563,42 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		return nil, err
 	}
 
-	failed := timedOut || hasSoftwareFailure
-	shouldBlock := failed && requireAll
-	// shouldWarn drives the soft block: software failed but "Cancel setup if software fails" is off. We still surface
-	// the ESP failure UI so the user learns which software failed, but with a "Continue anyway" option so they can
-	// proceed to the desktop and install the missing software via self-service (issue #45948). Pure timeout with
-	// require_all=false keeps releasing silently: the timeout path skips Stage 3, so there is no failed-software list
-	// to show.
-	shouldWarn := hasSoftwareFailure && !timedOut && !requireAll
+	// On a timeout with require_all=false, scan for software failures so the finalize surfaces them instead of
+	// releasing silently: the timeout path skipped Stage 3, so failures observed before the timeout are otherwise
+	// invisible. require_all=true keeps its existing behavior (hard block with timeout text) and is deliberately not
+	// re-scanned here -- a real failure under require_all=true would already have blocked on an earlier checkin via the
+	// Stage 3 in-flight short-circuit, before the 3-hour window elapsed.
+	if timedOut && !requireAll {
+		seHostUUID, err := setupExperienceHostUUID()
+		if err != nil {
+			return nil, err
+		}
+		host, err := loadHost()
+		if err != nil {
+			return nil, err
+		}
+		var hostTeamID uint
+		if host.TeamID != nil {
+			hostTeamID = *host.TeamID
+		}
+		results, err := svc.ds.ListSetupExperienceResultsByHostUUID(ctx, seHostUUID, hostTeamID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "list setup experience results for timeout finalize")
+		}
+		for _, r := range results {
+			if r.Status == fleet.SetupExperienceStatusFailure {
+				recordSoftwareFailure(r)
+			}
+		}
+	}
+
+	shouldBlock := (timedOut || hasSoftwareFailure) && requireAll
+	// shouldWarn drives the soft block (the ESP failure UI with a "Continue anyway" option) whenever "Cancel setup if
+	// software fails" is off and we have something to finalize on. It covers two cases: a software failure (list the
+	// failed software), and a timeout (give up after 3 hours). In both the user is shown what happened but allowed to
+	// proceed to the desktop and install missing software via self-service (issue #45948). require_all=true never
+	// warns -- it hard-blocks.
+	shouldWarn := !requireAll && (hasSoftwareFailure || timedOut)
 
 	// Build commands for the response.
 	provID := syncml.DocProvisioningAppProviderID
@@ -2574,8 +2614,13 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		}
 		cmds = buildESPBlockCommands(provID, errorText, espBlockButtonsReset)
 	case shouldWarn:
-		cmds = buildESPBlockCommands(provID,
-			microsoft_mdm.ESPSoftwareFailureContinuableErrorText(failedSoftwareNames), espBlockButtonsResetAndContinue)
+		// List the failed software when we have any; otherwise (require_all=false timeout with nothing failed) show the
+		// timeout text. Both keep the "Continue anyway" option so the user is never stuck.
+		errorText := microsoft_mdm.ESPTimeoutErrorText
+		if hasSoftwareFailure {
+			errorText = microsoft_mdm.ESPSoftwareFailureContinuableErrorText(failedSoftwareNames)
+		}
+		cmds = buildESPBlockCommands(provID, errorText, espBlockButtonsResetAndContinue)
 	default:
 		// Release path: device proceeds to login. We do not send CustomErrorText here because the failure UI never renders
 		// on a release (no BlockInStatusPage, no forced timeout), so any error text would be dead state on the DMClient
@@ -2647,15 +2692,18 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 			return nil, ctxerr.Wrap(ctx, err, "cancel pending setup experience steps")
 		}
 
-		// Emit the canceled_setup_experience activity for the timeout case. The software-failure-with-require_all=true
-		// case is already covered upstream by maybeCancelPendingSetupExperienceSteps (called from the software-install
-		// result reporter), which references the failed item; do not duplicate it here.
+		// Emit the canceled_setup_experience activity for every timeout finalize, since the timeout cancels whatever
+		// items were still pending. It references the first pending or running software item (the one that was in flight
+		// when the timeout fired); if none was queued (orbit's setup_experience/init never ran, or the timeout fired
+		// before any software was scheduled), the activity is still emitted with empty software fields so the host is
+		// represented in the activity feed.
 		//
-		// For timeout, pick the first pending or running software item (the one that was in flight when the timeout
-		// fired) as the activity reference. If none was queued (orbit's setup_experience/init never ran, or the timeout
-		// fired before any software was scheduled), the activity is still emitted but with empty software fields so the
-		// host is still represented in the activity feed.
-		if timedOut && !hasSoftwareFailure {
+		// This is gated on timedOut alone, not on the absence of a software failure: a require_all=false timeout can now
+		// also have hasSoftwareFailure set (from the timeout scan above), but its cancelled pending items still warrant
+		// the activity, and nothing emitted it upstream (the require_all=false software-install path does not cancel or
+		// emit). The require_all=true software-failure case is emitted upstream by maybeCancelPendingSetupExperienceSteps
+		// and never reaches a timeout finalize (it blocks on an earlier checkin), so there is no duplication.
+		if timedOut {
 			host, err := loadHost()
 			if err != nil {
 				return nil, err

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2329,12 +2329,11 @@ func (svc *Service) handleESPHoldOrTransition(ctx context.Context, device *fleet
 // a terminal state, then finalizes the device down one of three paths:
 //
 //   - hard block (require_all_software_windows=true and any item failed, or the 3-hour timeout was hit): the ESP
-//     failure screen is shown with only the "Reset device" recovery option, and remaining items are cancelled.
+//     failure screen is shown with only the "Reset device" recovery option, and remaining items are canceled.
 //   - soft block (require_all_software_windows=false and an item failed, or the 3-hour timeout was hit): the ESP
 //     failure screen is shown with a "Continue anyway" option so the user can proceed to the desktop and install the
 //     missing software via self-service. It lists the failed software by name when any failed, otherwise (a timeout
-//     with nothing failed) shows the timeout message. Still-pending items are cancelled only on the timeout path; on
-//     the non-timeout path everything has already reached a terminal state, so there is nothing to cancel.
+//     with nothing failed) shows the timeout message. Still-pending items are cancelled only on the timeout path.
 //   - release (no failure and no timeout): the device proceeds to login.
 func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice) ([]*mdm_types.SyncMLCmd, error) {
 	if device.HostUUID == "" {
@@ -2350,14 +2349,10 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 	// hasSoftwareFailure tracks setup-experience software failures only.
 	var hasSoftwareFailure bool
 
-	// failedSoftwareNames collects the names of the failed setup-experience items for the soft-block message. It is
-	// populated by Stage 3 on the normal path and by the timeout-failure scan below (require_all=false only), so that
-	// the timeout finalize can list failed software instead of releasing silently.
+	// failedSoftwareNames collects the names of the failed setup-experience items
 	var failedSoftwareNames []string
 
-	// recordSoftwareFailure marks a failed setup-experience item for the block/warn decision and the soft-block
-	// message, preferring the team-scoped custom display name (populated by ListSetupExperienceResultsByHostUUID) over
-	// the raw item name, matching how software titles render elsewhere in the product.
+	// recordSoftwareFailure marks a failed setup-experience item
 	recordSoftwareFailure := func(r *fleet.SetupExperienceStatusResult) {
 		hasSoftwareFailure = true
 		name := r.Name
@@ -2394,6 +2389,18 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		return host, nil
 	}
 
+	// hostTeamID resolves the host's team_id (0 for "no team / global"), used to scope setup-experience queries.
+	hostTeamID := func() (uint, error) {
+		host, err := loadHost()
+		if err != nil {
+			return 0, err
+		}
+		if host.TeamID != nil {
+			return *host.TeamID, nil
+		}
+		return 0, nil
+	}
+
 	// setupExperienceHostUUID returns the identifier used as setup_experience_status_results.host_uuid for this host.
 	// On Windows that's OsqueryHostID per fleet.HostUUIDForSetupExperience; if it's missing for some reason we fall back
 	// to the Fleet host UUID.
@@ -2406,6 +2413,25 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 			return *host.OsqueryHostID, nil
 		}
 		return device.HostUUID, nil
+	}
+
+	// listSetupExperienceResults fetches the host's setup-experience status rows. They are keyed by the Windows
+	// setup-experience host UUID (OsqueryHostID per fleet.HostUUIDForSetupExperience) and team-scoped so the rows carry
+	// the team's custom software display names (used in the soft-block message).
+	listSetupExperienceResults := func() ([]*fleet.SetupExperienceStatusResult, error) {
+		seHostUUID, err := setupExperienceHostUUID()
+		if err != nil {
+			return nil, err
+		}
+		teamID, err := hostTeamID()
+		if err != nil {
+			return nil, err
+		}
+		results, err := svc.ds.ListSetupExperienceResultsByHostUUID(ctx, seHostUUID, teamID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "list setup experience results for ESP")
+		}
+		return results, nil
 	}
 
 	// loadRequireAll memoizes the host -> team's require_all_software_windows lookup. It is consulted at most twice
@@ -2478,36 +2504,23 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 
 		// Stage 3: setup experience software/scripts still running. Orbit initiates setup experience during startup when it
 		// is enabled for the current OS/flags, which enqueues items into setup_experience_status_results.
-		//
-		// setup_experience_status_results.host_uuid is keyed by fleet.HostUUIDForSetupExperience; on Windows that's the
-		// host's OsqueryHostID. The teamID parameter only scopes the icon and display-name enrichment, not filtering
-		// (the query filters only by host_uuid), but the enrichment matters here: the soft-block error text renders
-		// these names to the end user, so they must reflect the host's team's custom display names.
-		seHostUUID, err := setupExperienceHostUUID()
+		results, err := listSetupExperienceResults()
 		if err != nil {
 			return nil, err
-		}
-		host, err := loadHost()
-		if err != nil {
-			return nil, err
-		}
-		var hostTeamID uint
-		if host.TeamID != nil {
-			hostTeamID = *host.TeamID
-		}
-		results, err := svc.ds.ListSetupExperienceResultsByHostUUID(ctx, seHostUUID, hostTeamID)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "list setup experience results for ESP release check")
 		}
 		svc.logger.DebugContext(ctx, "ESP: setup experience check",
-			"host_uuid", device.HostUUID, "se_host_uuid", seHostUUID, "results_count", len(results))
+			"host_uuid", device.HostUUID, "results_count", len(results))
 
 		// Empty results is ambiguous: it can mean "no setup experience is configured for this team" (safe to release) or
 		// "setup is configured but orbit hasn't called SetupExperienceInit yet" (must wait). Orbit links the host UUID to
 		// the MDM enrollment independently of when it calls init, so on the first Active checkin after link we can hit
 		// this race. Disambiguate by checking whether items are configured for the host's team.
 		if len(results) == 0 {
-			hasItems, err := svc.ds.HasWindowsSetupExperienceItemsForTeam(ctx, hostTeamID)
+			teamID, err := hostTeamID()
+			if err != nil {
+				return nil, err
+			}
+			hasItems, err := svc.ds.HasWindowsSetupExperienceItemsForTeam(ctx, teamID)
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "check setup experience items configured for team")
 			}
@@ -2571,21 +2584,9 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 	// re-scanned here -- a real failure under require_all=true would already have blocked on an earlier checkin via the
 	// Stage 3 in-flight short-circuit, before the 3-hour window elapsed.
 	if timedOut && !requireAll {
-		seHostUUID, err := setupExperienceHostUUID()
+		results, err := listSetupExperienceResults()
 		if err != nil {
 			return nil, err
-		}
-		host, err := loadHost()
-		if err != nil {
-			return nil, err
-		}
-		var hostTeamID uint
-		if host.TeamID != nil {
-			hostTeamID = *host.TeamID
-		}
-		results, err := svc.ds.ListSetupExperienceResultsByHostUUID(ctx, seHostUUID, hostTeamID)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "list setup experience results for timeout finalize")
 		}
 		for _, r := range results {
 			if r.Status == fleet.SetupExperienceStatusFailure {
@@ -2594,13 +2595,8 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		}
 	}
 
-	shouldBlock := (timedOut || hasSoftwareFailure) && requireAll
-	// shouldWarn drives the soft block (the ESP failure UI with a "Continue anyway" option) whenever "Cancel setup if
-	// software fails" is off and we have something to finalize on. It covers two cases: a software failure (list the
-	// failed software), and a timeout (give up after 3 hours). In both the user is shown what happened but allowed to
-	// proceed to the desktop and install missing software via self-service (issue #45948). require_all=true never
-	// warns -- it hard-blocks.
-	shouldWarn := !requireAll && (hasSoftwareFailure || timedOut)
+	shouldBlock := requireAll && (timedOut || hasSoftwareFailure)
+	shouldWarn := !requireAll && (timedOut || hasSoftwareFailure)
 
 	// Build commands for the response.
 	provID := syncml.DocProvisioningAppProviderID
@@ -2694,17 +2690,11 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 			return nil, ctxerr.Wrap(ctx, err, "cancel pending setup experience steps")
 		}
 
-		// Emit the canceled_setup_experience activity for every timeout finalize, since the timeout cancels whatever
-		// items were still pending. It references the first pending or running software item (the one that was in flight
-		// when the timeout fired); if none was queued (orbit's setup_experience/init never ran, or the timeout fired
-		// before any software was scheduled), the activity is still emitted with empty software fields so the host is
-		// represented in the activity feed.
-		//
-		// This is gated on timedOut alone, not on the absence of a software failure: a require_all=false timeout can now
-		// also have hasSoftwareFailure set (from the timeout scan above), but its cancelled pending items still warrant
-		// the activity, and nothing emitted it upstream (the require_all=false software-install path does not cancel or
-		// emit). The require_all=true software-failure case is emitted upstream by maybeCancelPendingSetupExperienceSteps
-		// and never reaches a timeout finalize (it blocks on an earlier checkin), so there is no duplication.
+		// Emit canceled_setup_experience for every timeout, which cancels whatever was still pending. It references the
+		// first pending/running software item (in flight when the timeout fired), or empty fields if none was queued.
+		// Gated on timedOut alone (not !hasSoftwareFailure): no duplication, since the require_all=true failure case
+		// emits upstream in maybeCancelPendingSetupExperienceSteps and blocks before any timeout, while the
+		// require_all=false failure case emits nowhere else.
 		if timedOut {
 			host, err := loadHost()
 			if err != nil {
@@ -2772,13 +2762,9 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 
 // BlockInStatusPage values per Microsoft DMClient CSP docs (bit flags): 1=Reset PC, 2=Try Again, 4=Continue Anyway.
 const (
-	// espBlockButtonsReset shows only the "Reset PC" button: used for the hard block (software failure with
-	// require_all_software_windows=true, or ESP timeout), where reset (Autopilot wipe + re-enrollment) is the only
-	// in-product recovery path.
+	// espBlockButtonsReset shows only the "Reset PC" button: used for the hard block
 	espBlockButtonsReset = "1"
-	// espBlockButtonsResetAndContinue shows "Reset PC" and "Continue anyway" (1|4): used for the soft block when
-	// software failed but require_all_software_windows is false, so the user may proceed to the desktop and install
-	// the missing software via self-service.
+	// espBlockButtonsResetAndContinue shows "Reset PC" and "Continue anyway" (1|4)
 	espBlockButtonsResetAndContinue = "5"
 )
 

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -17,16 +17,18 @@ import (
 	"pgregory.net/rapid"
 )
 
-// Property-based tests for handleESPRelease. They cover the wait-gate decision and the universal block/release
-// command-shape invariants in a single combined property check.
+// Property-based tests for handleESPRelease. They cover the wait-gate decision and the universal
+// block/warn/release command-shape invariants in a single combined property check.
 //
 // The spec function pbtESPSpec computes the expected (decision, observedHasFailure) from the inputs without
 // referencing the production code. We then run getESPCommands against a mock datastore and assert:
 //
-//   - Decision (wait/block/release) matches the spec.
+//   - Decision (wait/block/warn/release) matches the spec.
 //   - Wait → no side effects (no cancel, no persist, no CAS).
-//   - Block path command shape: BlockInStatusPage=1, AllowCollectLogsButton, TimeOutUntilSyncFailure=1,
-//     reason-specific CustomErrorText, NO ServerHasFinishedProvisioning, NO InstallationState.
+//   - Block-flavored command shape (hard block AND warn/soft block): AllowCollectLogsButton,
+//     TimeOutUntilSyncFailure=1, NO ServerHasFinishedProvisioning, NO InstallationState. They differ in
+//     BlockInStatusPage (block: 1 = Reset PC; warn: 5 = Reset PC + Continue Anyway) and CustomErrorText
+//     (block: reason-specific static text; warn: dynamic failed-software list).
 //   - Release path command shape: Device-scope AND User-scope ServerHasFinishedProvisioning plus
 //     PolicyProviders InstallationState=3; NO CustomErrorText, NO BlockInStatusPage. The user-scope
 //     Provider node is created during the hold phase via Add commands so the user-scope SHFP write
@@ -36,7 +38,8 @@ import (
 //     and the block flags across multiple TX boundaries).
 //   - Cancel block fires iff (timedOut || (observedHasFailure && requireAll)); when it fires,
 //     CancelHostUpcomingActivity is called once per Pending/Running row in input. Cancel-upcoming runs strictly
-//     before cancel-status; both run strictly before persist; persist runs strictly before CAS.
+//     before cancel-status; both run strictly before persist; persist runs strictly before CAS. The warn path
+//     never cancels: all items already reached a terminal state and the user may continue.
 //
 // Order independence is implicit: pbtESPSpec is a pure function of the multiset of statuses (no positional
 // dependency) and rapid samples many orderings, so any introduced order-dependence in production code
@@ -150,8 +153,11 @@ func newPBTESPSvc(
 type pbtESPDecision string
 
 const (
-	pbtESPWait    pbtESPDecision = "wait"
-	pbtESPBlock   pbtESPDecision = "block"
+	pbtESPWait pbtESPDecision = "wait"
+	// pbtESPBlock is the hard block: failure UI with Reset PC only, remaining items cancelled.
+	pbtESPBlock pbtESPDecision = "block"
+	// pbtESPWarn is the soft block: failure UI listing failed software with a Continue Anyway option, no cancellation.
+	pbtESPWarn    pbtESPDecision = "warn"
 	pbtESPRelease pbtESPDecision = "release"
 )
 
@@ -189,8 +195,13 @@ func pbtESPSpec(
 		}
 		return pbtESPBlock, inputHasFailure // short-circuit: failure + require_all + in-flight siblings -> block now
 	}
-	if inputHasFailure && requireAll {
-		return pbtESPBlock, inputHasFailure
+	if inputHasFailure {
+		if requireAll {
+			return pbtESPBlock, inputHasFailure
+		}
+		// Software failed but require_all=false: soft block. The user sees the failure UI listing the failed
+		// software but may continue to the desktop.
+		return pbtESPWarn, inputHasFailure
 	}
 	return pbtESPRelease, inputHasFailure
 }
@@ -220,6 +231,14 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 		requireAll := rapid.Bool().Draw(rt, "requireAll")
 
 		expected, observedHasFailure := pbtESPSpec(statuses, timedOut, requireAll)
+		// expectedFailedNames mirrors the mock fixture naming (row i is "item-i") for the Failure rows, in input
+		// order. Only the warn path consumes it (dynamic CustomErrorText).
+		var expectedFailedNames []string
+		for i, s := range statuses {
+			if s == fleet.SetupExperienceStatusFailure {
+				expectedFailedNames = append(expectedFailedNames, fmt.Sprintf("item-%d", i))
+			}
+		}
 		svc, device, trace := newPBTESPSvc(statuses, timedOut, requireAll)
 		cmds, err := svc.getESPCommands(t.Context(), device)
 		require.NoErrorf(rt, err, "statuses=%v timedOut=%v requireAll=%v", statuses, timedOut, requireAll)
@@ -254,47 +273,52 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 		require.Equalf(rt, 1, persistCount, "persist must be a single batched call; callOrder=%v", trace.callOrder)
 
 		switch expected {
-		case pbtESPBlock:
-			// Block path NEVER includes ServerHasFinishedProvisioning -- that command would tell Windows the
-			// ESP succeeded and proceed past the failure UI. Also NEVER InstallationState alone (VM testing
-			// confirmed setting it on the parent PolicyProviders node without per-tracker state from #43776
-			// does not escalate the failure UI).
+		case pbtESPBlock, pbtESPWarn:
+			// Block-flavored paths (hard block and warn/soft block) NEVER include ServerHasFinishedProvisioning --
+			// that command would tell Windows the ESP succeeded and proceed past the failure UI. Also NEVER
+			// InstallationState alone (VM testing confirmed setting it on the parent PolicyProviders node without
+			// per-tracker state from #43776 does not escalate the failure UI).
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
-				"block path must NOT include ServerHasFinishedProvisioning")
+				"%s path must NOT include ServerHasFinishedProvisioning", expected)
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "InstallationState"),
-				"block path uses the timeout-based trigger, not InstallationState")
+				"%s path uses the timeout-based trigger, not InstallationState", expected)
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "WasDeviceSuccessfullyProvisioned"),
-				"block path must NOT include WasDeviceSuccessfullyProvisioned (verified on Win11 26200: the "+
-					"documented path does not render failure UI on non-Sidecar MDM)")
+				"%s path must NOT include WasDeviceSuccessfullyProvisioned (verified on Win11 26200: the "+
+					"documented path does not render failure UI on non-Sidecar MDM)", expected)
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "IsSyncDone"),
-				"block path must NOT include IsSyncDone (verified on Win11 26200: the documented path does not "+
-					"render failure UI on non-Sidecar MDM)")
-			// Block path always includes BlockInStatusPage=1 (Reset PC), AllowCollectLogsButton, and
-			// TimeOutUntilSyncFailure=1 (one minute, forces failure UI).
+				"%s path must NOT include IsSyncDone (verified on Win11 26200: the documented path does not "+
+					"render failure UI on non-Sidecar MDM)", expected)
+			// Both flavors include BlockInStatusPage, AllowCollectLogsButton, and TimeOutUntilSyncFailure=1 (one
+			// minute, forces failure UI). The hard block offers Reset PC only (1); the warn path adds Continue
+			// Anyway (5 = 1|4). Hard-block errorText is software-failure text iff observedHasFailure (Stage 3 ran
+			// AND saw a Failure), else timeout text (the pure-timeout path lands there with
+			// observedHasFailure=false); warn errorText lists the failed software dynamically.
+			expectedButtons := "1"
+			expectedErrorText := microsoft_mdm.ESPTimeoutErrorText
+			switch {
+			case expected == pbtESPWarn:
+				expectedButtons = "5"
+				expectedErrorText = microsoft_mdm.ESPSoftwareFailureContinuableErrorText(expectedFailedNames)
+			case observedHasFailure:
+				expectedErrorText = microsoft_mdm.ESPSoftwareFailureErrorText
+			}
 			blockCmd := pbtFindCmdByLocURI(cmds, "BlockInStatusPage")
-			require.NotNilf(rt, blockCmd, "block path must include BlockInStatusPage")
+			require.NotNilf(rt, blockCmd, "%s path must include BlockInStatusPage", expected)
 			require.NotNilf(rt, blockCmd.Items[0].Data, "BlockInStatusPage must have data")
-			assert.Equalf(rt, "1", blockCmd.Items[0].Data.Content,
-				"BlockInStatusPage must be 1 (Reset PC) per DMClient CSP docs")
+			assert.Equalf(rt, expectedButtons, blockCmd.Items[0].Data.Content,
+				"BlockInStatusPage must match the %s flavor's recovery buttons per DMClient CSP bit flags", expected)
 			assert.NotNilf(rt, pbtFindCmdByLocURI(cmds, "AllowCollectLogsButton"),
-				"block path must include AllowCollectLogsButton")
+				"%s path must include AllowCollectLogsButton", expected)
 			timeoutCmd := pbtFindCmdByLocURI(cmds, "TimeOutUntilSyncFailure")
-			require.NotNilf(rt, timeoutCmd, "block path must include TimeOutUntilSyncFailure")
+			require.NotNilf(rt, timeoutCmd, "%s path must include TimeOutUntilSyncFailure", expected)
 			require.NotNilf(rt, timeoutCmd.Items[0].Data, "TimeOutUntilSyncFailure must have data")
 			assert.Equalf(rt, "1", timeoutCmd.Items[0].Data.Content,
 				"TimeOutUntilSyncFailure must be 1 minute (force quick failure)")
-			// errorText is software-failure text iff observedHasFailure (Stage 3 ran AND saw a Failure); else
-			// timeout text. The pure-timeout path lands here too with observedHasFailure=false.
 			errCmd := pbtFindCmdByLocURI(cmds, "CustomErrorText")
-			require.NotNilf(rt, errCmd, "block path must include CustomErrorText")
+			require.NotNilf(rt, errCmd, "%s path must include CustomErrorText", expected)
 			require.NotNilf(rt, errCmd.Items[0].Data, "CustomErrorText must have data")
-			if observedHasFailure {
-				assert.Equalf(rt, microsoft_mdm.ESPSoftwareFailureErrorText, errCmd.Items[0].Data.Content,
-					"block on software failure must use software-failure error text")
-			} else {
-				assert.Equalf(rt, microsoft_mdm.ESPTimeoutErrorText, errCmd.Items[0].Data.Content,
-					"block on pure timeout must use timeout error text")
-			}
+			assert.Equalf(rt, expectedErrorText, errCmd.Items[0].Data.Content,
+				"%s path must carry the expected error text", expected)
 		case pbtESPRelease:
 			// Release path NEVER includes CustomErrorText -- the failure UI never renders on a release, so
 			// any error text would be dead state on the DMClient node.

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -163,8 +163,9 @@ const (
 
 // pbtESPSpec computes the expected outcome from the inputs without referencing production code. It returns
 // the decision and the hasSoftwareFailure that production would observe. The latter differs from "results
-// contain Failure" when timedOut is true, because Stage 3 is skipped in that case so the production variable
-// stays at its zero value.
+// contain Failure" only on the require_all=true timeout branch: Stage 3 is skipped and that branch is not
+// re-scanned, so the production variable stays false there. The require_all=false timeout branch IS re-scanned,
+// so it reflects input failures.
 func pbtESPSpec(
 	statuses []fleet.SetupExperienceStatusResultStatus, timedOut, requireAll bool,
 ) (decision pbtESPDecision, observedHasFailure bool) {
@@ -178,12 +179,14 @@ func pbtESPSpec(
 		}
 	}
 	if timedOut {
-		// Wait gates skipped; finalize directly. observedHasFailure stays at its zero value because Stage 3
-		// never ran.
+		// Wait gates skipped; finalize directly. require_all=true is not re-scanned for failures (it would have
+		// hard-blocked earlier), so observedHasFailure stays false and it hard-blocks with the timeout text.
 		if requireAll {
 			return pbtESPBlock, false
 		}
-		return pbtESPRelease, false
+		// require_all=false is scanned: it soft-blocks either way (lists failures if any, else timeout text).
+		// observedHasFailure reflects whether the scan saw a Failure row.
+		return pbtESPWarn, inputHasFailure
 	}
 	// !timedOut: Stage 3 ran. observedHasFailure = inputHasFailure.
 	if inputAnyInFlight {
@@ -298,7 +301,11 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 			switch {
 			case expected == pbtESPWarn:
 				expectedButtons = "5"
-				expectedErrorText = microsoft_mdm.ESPSoftwareFailureContinuableErrorText(expectedFailedNames)
+				// Warn lists failed software when any failed; otherwise (require_all=false timeout, nothing failed) it
+				// shows the timeout text. Both keep Continue Anyway.
+				if observedHasFailure {
+					expectedErrorText = microsoft_mdm.ESPSoftwareFailureContinuableErrorText(expectedFailedNames)
+				}
 			case observedHasFailure:
 				expectedErrorText = microsoft_mdm.ESPSoftwareFailureErrorText
 			}

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -17,8 +17,8 @@ import (
 	"pgregory.net/rapid"
 )
 
-// Property-based tests for handleESPRelease. They cover the wait-gate decision and the universal
-// block/warn/release command-shape invariants in a single combined property check.
+// Property-based tests for handleESPRelease. They cover the wait-gate decision and the universal block/warn/release
+// command-shape invariants in a single combined property check.
 //
 // The spec function pbtESPSpec computes the expected (decision, observedHasFailure) from the inputs without
 // referencing the production code. We then run getESPCommands against a mock datastore and assert:
@@ -161,11 +161,14 @@ const (
 	pbtESPRelease pbtESPDecision = "release"
 )
 
-// pbtESPSpec computes the expected outcome from the inputs without referencing production code. It returns
-// the decision and the hasSoftwareFailure that production would observe. The latter differs from "results
-// contain Failure" only on the require_all=true timeout branch: Stage 3 is skipped and that branch is not
-// re-scanned, so the production variable stays false there. The require_all=false timeout branch IS re-scanned,
-// so it reflects input failures.
+// pbtESPSpec computes the expected outcome from the inputs without referencing production code. It returns the
+// decision and the hasSoftwareFailure that production would observe.
+//
+// observedHasFailure equals "the inputs contain a Failure row" on every path except one: a require_all=true timeout.
+// When the device times out, production finalizes immediately instead of examining each setup-experience result. The
+// require_all=false timeout path still examines the results so it can list the failed software, so observedHasFailure
+// reflects the inputs there. The require_all=true timeout path does not re-examine them (a real failure would already
+// have hard-blocked on an earlier check-in), so observedHasFailure stays false there even when a failure is present.
 func pbtESPSpec(
 	statuses []fleet.SetupExperienceStatusResultStatus, timedOut, requireAll bool,
 ) (decision pbtESPDecision, observedHasFailure bool) {
@@ -188,7 +191,7 @@ func pbtESPSpec(
 		// observedHasFailure reflects whether the scan saw a Failure row.
 		return pbtESPWarn, inputHasFailure
 	}
-	// !timedOut: Stage 3 ran. observedHasFailure = inputHasFailure.
+	// Not timed out: production examined every setup-experience result, so observedHasFailure = inputHasFailure.
 	if inputAnyInFlight {
 		if !inputHasFailure {
 			return pbtESPWait, inputHasFailure
@@ -291,11 +294,7 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "IsSyncDone"),
 				"%s path must NOT include IsSyncDone (verified on Win11 26200: the documented path does not "+
 					"render failure UI on non-Sidecar MDM)", expected)
-			// Both flavors include BlockInStatusPage, AllowCollectLogsButton, and TimeOutUntilSyncFailure=1 (one
-			// minute, forces failure UI). The hard block offers Reset PC only (1); the warn path adds Continue
-			// Anyway (5 = 1|4). Hard-block errorText is software-failure text iff observedHasFailure (Stage 3 ran
-			// AND saw a Failure), else timeout text (the pure-timeout path lands there with
-			// observedHasFailure=false); warn errorText lists the failed software dynamically.
+			// The hard block offers Reset PC only (1); the warn path adds Continue Anyway (5 = 1|4).
 			expectedButtons := "1"
 			expectedErrorText := microsoft_mdm.ESPTimeoutErrorText
 			switch {

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1891,10 +1891,25 @@ func TestGetESPCommands(t *testing.T) {
 		// UI listing the failed software by name, with a "Continue anyway" option so the user can proceed to the
 		// desktop and install the missing software via self-service. Nothing is cancelled and no
 		// canceled_setup_experience activity is emitted: setup was not cancelled, the user is merely warned.
+		//
+		// The host is placed on a team to also pin the user-facing-name plumbing: the list call must receive the
+		// host's team ID (it scopes the custom display-name enrichment) and the message must prefer DisplayName over
+		// the raw item name when present.
 		ds, svc := newSvc(t)
+		hostTeamID := uint(9)
+		osqueryHostID := "osquery-" + hostUUID
+		ds.HostLiteByIdentifierFunc = func(ctx context.Context, identifier string) (*fleet.HostLite, error) {
+			return &fleet.HostLite{ID: 1, UUID: identifier, OsqueryHostID: &osqueryHostID, TeamID: &hostTeamID}, nil
+		}
+		// require_all_software_windows stays false via the team path (zero-value team config).
+		ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+			return &fleet.TeamLite{ID: tid}, nil
+		}
 		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+			require.Equal(t, hostTeamID, teamID,
+				"list call must pass the host's team ID so display-name enrichment is team-scoped")
 			return []*fleet.SetupExperienceStatusResult{
-				{Name: "Slack", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
+				{Name: "slack-installer", DisplayName: "Slack", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
 				{Name: "Zoom", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(2))},
 				{Name: "Notepad++", Status: fleet.SetupExperienceStatusSuccess, SoftwareInstallerID: new(uint(3))},
 				{Name: "Docker", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(4))},
@@ -1918,9 +1933,10 @@ func TestGetESPCommands(t *testing.T) {
 		require.NotNil(t, errCmd.Items[0].Data)
 		assert.Equal(t,
 			"Slack, Zoom, and Docker failed to install. "+
-				"You can reset your device to start over or proceed and install missing software via self-service.",
+				"Reset your device to try again, or proceed and install missing software via self-service. "+
+				"If unavailable, contact your IT admin.",
 			errCmd.Items[0].Data.Content,
-			"soft block must list only the failed software by name, in result order")
+			"soft block must list only the failed software, in result order, preferring custom display names")
 
 		assert.Nil(t, findCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
 			"soft block must NOT signal ESP success")
@@ -1952,10 +1968,18 @@ func TestGetESPCommands(t *testing.T) {
 			"must not finalize while items are in flight")
 	})
 
-	t.Run("timeout with require_all=false releases without error text", func(t *testing.T) {
-		// The soft block applies to observed software failures only. A pure timeout with require_all=false keeps the
-		// existing silent-release behavior (the timeout path skips Stage 3, so there is no failed-software list).
-		_, svc := newSvc(t)
+	t.Run("timeout with require_all=false and no failures soft blocks with timeout text", func(t *testing.T) {
+		// A pure timeout (nothing failed, items just stuck past the 3-hour window) with require_all=false surfaces the
+		// timeout text on the ESP failure UI but keeps the "Continue anyway" option so the user is never stuck. This
+		// replaces the old silent-release behavior: setup didn't finish, so we tell the user rather than dropping them
+		// onto the desktop with no explanation.
+		ds, svc := newSvc(t)
+		// One item still pending at the timeout (no failures) -- it gets cancelled by the timeout finalize.
+		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+			return []*fleet.SetupExperienceStatusResult{
+				{Name: "Slow App", Status: fleet.SetupExperienceStatusPending, SoftwareInstallerID: new(uint(1)), HostSoftwareInstallsExecutionID: new("exec-slow")},
+			}, nil
+		}
 		past := time.Now().Add(-4 * time.Hour)
 		device := newActiveDevice()
 		device.AwaitingConfigurationAt = &past
@@ -1963,12 +1987,84 @@ func TestGetESPCommands(t *testing.T) {
 		cmds, err := svc.getESPCommands(t.Context(), device)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds)
-		assert.NotNil(t, findCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
-			"pure timeout with require_all=false must release the device")
-		assert.Nil(t, findCmdByLocURI(cmds, "BlockInStatusPage"),
-			"pure timeout with require_all=false must not surface the failure UI")
-		assert.Nil(t, findCmdByLocURI(cmds, "CustomErrorText"),
-			"release path must not carry error text")
+
+		blockCmd := findCmdByLocURI(cmds, "BlockInStatusPage")
+		require.NotNil(t, blockCmd, "timeout with require_all=false must surface the ESP failure UI")
+		assert.Equal(t, "5", blockCmd.Items[0].Data.Content,
+			"timeout soft block must offer Reset PC and Continue Anyway")
+		errCmd := findCmdByLocURI(cmds, "CustomErrorText")
+		require.NotNil(t, errCmd)
+		assert.Equal(t, microsoft_mdm.ESPTimeoutErrorText, errCmd.Items[0].Data.Content,
+			"timeout with no failures must show the timeout text")
+		assert.Nil(t, findCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
+			"timeout soft block must NOT signal ESP success")
+		assert.True(t, ds.CancelPendingSetupExperienceStepsFuncInvoked,
+			"timeout must cancel the still-pending items")
+	})
+
+	t.Run("timeout with require_all=false and a failure soft blocks listing failed software", func(t *testing.T) {
+		// A failure that occurred before the 3-hour timeout (with a sibling still stuck) must still be surfaced: the
+		// timeout path scans for failures so it lists the failed software rather than releasing silently. This is the
+		// case CodeRabbit flagged and the reason the PR is titled "always display ... when software install fails".
+		ds, svc := newSvc(t)
+		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+			return []*fleet.SetupExperienceStatusResult{
+				{Name: "Slack", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
+				{Name: "Stuck App", Status: fleet.SetupExperienceStatusPending, SoftwareInstallerID: new(uint(2)), HostSoftwareInstallsExecutionID: new("exec-stuck")},
+			}, nil
+		}
+		past := time.Now().Add(-4 * time.Hour)
+		device := newActiveDevice()
+		device.AwaitingConfigurationAt = &past
+
+		cmds, err := svc.getESPCommands(t.Context(), device)
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+
+		blockCmd := findCmdByLocURI(cmds, "BlockInStatusPage")
+		require.NotNil(t, blockCmd, "timeout with a failure must surface the ESP failure UI")
+		assert.Equal(t, "5", blockCmd.Items[0].Data.Content,
+			"timeout soft block must offer Reset PC and Continue Anyway")
+		errCmd := findCmdByLocURI(cmds, "CustomErrorText")
+		require.NotNil(t, errCmd)
+		assert.Equal(t,
+			"Slack failed to install. "+
+				"Reset your device to try again, or proceed and install missing software via self-service. "+
+				"If unavailable, contact your IT admin.",
+			errCmd.Items[0].Data.Content,
+			"timeout with a failure must list the failed software, not the timeout text")
+		assert.Nil(t, findCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
+			"timeout soft block must NOT signal ESP success")
+		assert.True(t, ds.CancelPendingSetupExperienceStepsFuncInvoked,
+			"timeout must cancel the still-pending sibling")
+	})
+
+	t.Run("timeout with require_all=true keeps hard block with timeout text", func(t *testing.T) {
+		// require_all=true is explicitly unchanged: the timeout path is NOT scanned for failures (a real failure would
+		// have hard-blocked on an earlier checkin), so the device hard-blocks with the timeout text and Reset only.
+		ds, svc := newSvc(t)
+		setRequireAll(ds, true)
+		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+			return []*fleet.SetupExperienceStatusResult{
+				{Name: "Whatever", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
+			}, nil
+		}
+		past := time.Now().Add(-4 * time.Hour)
+		device := newActiveDevice()
+		device.AwaitingConfigurationAt = &past
+
+		cmds, err := svc.getESPCommands(t.Context(), device)
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+
+		blockCmd := findCmdByLocURI(cmds, "BlockInStatusPage")
+		require.NotNil(t, blockCmd)
+		assert.Equal(t, "1", blockCmd.Items[0].Data.Content,
+			"require_all=true timeout must hard block with Reset only")
+		errCmd := findCmdByLocURI(cmds, "CustomErrorText")
+		require.NotNil(t, errCmd)
+		assert.Equal(t, microsoft_mdm.ESPTimeoutErrorText, errCmd.Items[0].Data.Content,
+			"require_all=true timeout keeps the timeout text (not re-scanned for failures)")
 	})
 
 	t.Run("timeout cancel tolerates upcoming activity already gone", func(t *testing.T) {

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -385,6 +385,23 @@ func TestValidSyncMLCmdText(t *testing.T) {
 	require.Contains(t, payload, "<Format xmlns=\"syncml:metinf\">chr</Format>")
 }
 
+func TestSyncMLCmdTextEscapesXMLMetacharacters(t *testing.T) {
+	// Text data is written into SyncML <Data> as innerxml (raw), so a value with XML metacharacters must be escaped
+	// or it produces malformed SyncML the device rejects. This matters for CustomErrorText, which lists software
+	// titles that can contain "&" (e.g. "AT&T") or other metacharacters.
+	cmdMsg := newSyncMLCmdText(fleet.CmdReplace, "testuri", `AT&T <Reader>`)
+	outXML, err := xml.MarshalIndent(cmdMsg, "", "  ")
+	require.NoError(t, err)
+	payload := string(outXML)
+
+	// The marshaled XML must be well-formed (parseable) and carry escaped entities, not raw metacharacters. A raw
+	// "&"/"<" here would make xml.Unmarshal fail, which is exactly the device-side rejection we are preventing.
+	require.NoError(t, xml.Unmarshal(outXML, new(fleet.SyncMLCmd)), "escaped command must be well-formed XML")
+	require.Contains(t, payload, "AT&amp;T")
+	require.Contains(t, payload, "&lt;Reader&gt;")
+	require.NotContains(t, payload, "AT&T", "raw ampersand must not appear unescaped")
+}
+
 func TestValidSyncMLCmdXml(t *testing.T) {
 	testOmaURI := "testuri"
 	testData := "testdata"

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1886,6 +1886,91 @@ func TestGetESPCommands(t *testing.T) {
 			"software failure error text takes precedence over profile/timeout text")
 	})
 
+	t.Run("software failure with require_all=false soft blocks with continue anyway", func(t *testing.T) {
+		// When software fails but "Cancel setup if software fails" is off, the device still surfaces the ESP failure
+		// UI listing the failed software by name, with a "Continue anyway" option so the user can proceed to the
+		// desktop and install the missing software via self-service. Nothing is cancelled and no
+		// canceled_setup_experience activity is emitted: setup was not cancelled, the user is merely warned.
+		ds, svc := newSvc(t)
+		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+			return []*fleet.SetupExperienceStatusResult{
+				{Name: "Slack", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
+				{Name: "Zoom", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(2))},
+				{Name: "Notepad++", Status: fleet.SetupExperienceStatusSuccess, SoftwareInstallerID: new(uint(3))},
+				{Name: "Docker", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(4))},
+			}, nil
+		}
+		activitySvc := &mock.MockActivityService{}
+		svc.SetActivityService(activitySvc)
+
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+
+		blockCmd := findCmdByLocURI(cmds, "BlockInStatusPage")
+		require.NotNil(t, blockCmd, "soft block must surface the ESP failure UI")
+		require.NotNil(t, blockCmd.Items[0].Data)
+		assert.Equal(t, "5", blockCmd.Items[0].Data.Content,
+			"soft block must offer Reset PC and Continue Anyway (1|4) per DMClient CSP bit flags")
+
+		errCmd := findCmdByLocURI(cmds, "CustomErrorText")
+		require.NotNil(t, errCmd)
+		require.NotNil(t, errCmd.Items[0].Data)
+		assert.Equal(t,
+			"Slack, Zoom, and Docker failed to install. "+
+				"You can reset your device to start over or proceed and install missing software via self-service.",
+			errCmd.Items[0].Data.Content,
+			"soft block must list only the failed software by name, in result order")
+
+		assert.Nil(t, findCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
+			"soft block must NOT signal ESP success")
+		assert.False(t, ds.CancelPendingSetupExperienceStepsFuncInvoked,
+			"soft block must not cancel setup experience steps")
+		assert.False(t, ds.CancelHostUpcomingActivityFuncInvoked,
+			"soft block must not cancel upcoming activities")
+		assert.False(t, activitySvc.NewActivityFuncInvoked,
+			"soft block must not emit canceled_setup_experience: setup was not cancelled")
+		assert.True(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
+			"soft block finalizes: awaiting_configuration must transition out of Active")
+	})
+
+	t.Run("software failure with require_all=false waits for in-flight items", func(t *testing.T) {
+		// A failure observed while other items are still installing must not finalize early: the soft block is
+		// surfaced once everything reaches a terminal state, so it aggregates ALL failures in one message.
+		ds, svc := newSvc(t)
+		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+			return []*fleet.SetupExperienceStatusResult{
+				{Name: "Slack", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
+				{Name: "Zoom", Status: fleet.SetupExperienceStatusRunning, SoftwareInstallerID: new(uint(2))},
+			}, nil
+		}
+
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		require.NoError(t, err)
+		assert.Nil(t, cmds, "must wait for remaining installs before surfacing the soft block")
+		assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
+			"must not finalize while items are in flight")
+	})
+
+	t.Run("timeout with require_all=false releases without error text", func(t *testing.T) {
+		// The soft block applies to observed software failures only. A pure timeout with require_all=false keeps the
+		// existing silent-release behavior (the timeout path skips Stage 3, so there is no failed-software list).
+		_, svc := newSvc(t)
+		past := time.Now().Add(-4 * time.Hour)
+		device := newActiveDevice()
+		device.AwaitingConfigurationAt = &past
+
+		cmds, err := svc.getESPCommands(t.Context(), device)
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+		assert.NotNil(t, findCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
+			"pure timeout with require_all=false must release the device")
+		assert.Nil(t, findCmdByLocURI(cmds, "BlockInStatusPage"),
+			"pure timeout with require_all=false must not surface the failure UI")
+		assert.Nil(t, findCmdByLocURI(cmds, "CustomErrorText"),
+			"release path must not carry error text")
+	})
+
 	t.Run("timeout cancel tolerates upcoming activity already gone", func(t *testing.T) {
 		// CancelHostUpcomingActivity returns notFound when the row is already absent (e.g., a previous finalize
 		// attempt cancelled the queue row and crashed before the status table update; the retry sees status

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -386,9 +386,7 @@ func TestValidSyncMLCmdText(t *testing.T) {
 }
 
 func TestSyncMLCmdTextEscapesXMLMetacharacters(t *testing.T) {
-	// Text data is written into SyncML <Data> as innerxml (raw), so a value with XML metacharacters must be escaped
-	// or it produces malformed SyncML the device rejects. This matters for CustomErrorText, which lists software
-	// titles that can contain "&" (e.g. "AT&T") or other metacharacters.
+	t.Parallel()
 	cmdMsg := newSyncMLCmdText(fleet.CmdReplace, "testuri", `AT&T <Reader>`)
 	outXML, err := xml.MarshalIndent(cmdMsg, "", "  ")
 	require.NoError(t, err)
@@ -1906,12 +1904,7 @@ func TestGetESPCommands(t *testing.T) {
 	t.Run("software failure with require_all=false soft blocks with continue anyway", func(t *testing.T) {
 		// When software fails but "Cancel setup if software fails" is off, the device still surfaces the ESP failure
 		// UI listing the failed software by name, with a "Continue anyway" option so the user can proceed to the
-		// desktop and install the missing software via self-service. Nothing is cancelled and no
-		// canceled_setup_experience activity is emitted: setup was not cancelled, the user is merely warned.
-		//
-		// The host is placed on a team to also pin the user-facing-name plumbing: the list call must receive the
-		// host's team ID (it scopes the custom display-name enrichment) and the message must prefer DisplayName over
-		// the raw item name when present.
+		// desktop and install the missing software via self-service.
 		ds, svc := newSvc(t)
 		hostTeamID := uint(9)
 		osqueryHostID := "osquery-" + hostUUID
@@ -1967,62 +1960,9 @@ func TestGetESPCommands(t *testing.T) {
 			"soft block finalizes: awaiting_configuration must transition out of Active")
 	})
 
-	t.Run("software failure with require_all=false waits for in-flight items", func(t *testing.T) {
-		// A failure observed while other items are still installing must not finalize early: the soft block is
-		// surfaced once everything reaches a terminal state, so it aggregates ALL failures in one message.
-		ds, svc := newSvc(t)
-		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
-			return []*fleet.SetupExperienceStatusResult{
-				{Name: "Slack", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
-				{Name: "Zoom", Status: fleet.SetupExperienceStatusRunning, SoftwareInstallerID: new(uint(2))},
-			}, nil
-		}
-
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
-		require.NoError(t, err)
-		assert.Nil(t, cmds, "must wait for remaining installs before surfacing the soft block")
-		assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
-			"must not finalize while items are in flight")
-	})
-
-	t.Run("timeout with require_all=false and no failures soft blocks with timeout text", func(t *testing.T) {
-		// A pure timeout (nothing failed, items just stuck past the 3-hour window) with require_all=false surfaces the
-		// timeout text on the ESP failure UI but keeps the "Continue anyway" option so the user is never stuck. This
-		// replaces the old silent-release behavior: setup didn't finish, so we tell the user rather than dropping them
-		// onto the desktop with no explanation.
-		ds, svc := newSvc(t)
-		// One item still pending at the timeout (no failures) -- it gets cancelled by the timeout finalize.
-		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
-			return []*fleet.SetupExperienceStatusResult{
-				{Name: "Slow App", Status: fleet.SetupExperienceStatusPending, SoftwareInstallerID: new(uint(1)), HostSoftwareInstallsExecutionID: new("exec-slow")},
-			}, nil
-		}
-		past := time.Now().Add(-4 * time.Hour)
-		device := newActiveDevice()
-		device.AwaitingConfigurationAt = &past
-
-		cmds, err := svc.getESPCommands(t.Context(), device)
-		require.NoError(t, err)
-		require.NotEmpty(t, cmds)
-
-		blockCmd := findCmdByLocURI(cmds, "BlockInStatusPage")
-		require.NotNil(t, blockCmd, "timeout with require_all=false must surface the ESP failure UI")
-		assert.Equal(t, "5", blockCmd.Items[0].Data.Content,
-			"timeout soft block must offer Reset PC and Continue Anyway")
-		errCmd := findCmdByLocURI(cmds, "CustomErrorText")
-		require.NotNil(t, errCmd)
-		assert.Equal(t, microsoft_mdm.ESPTimeoutErrorText, errCmd.Items[0].Data.Content,
-			"timeout with no failures must show the timeout text")
-		assert.Nil(t, findCmdByLocURI(cmds, "ServerHasFinishedProvisioning"),
-			"timeout soft block must NOT signal ESP success")
-		assert.True(t, ds.CancelPendingSetupExperienceStepsFuncInvoked,
-			"timeout must cancel the still-pending items")
-	})
-
 	t.Run("timeout with require_all=false and a failure soft blocks listing failed software", func(t *testing.T) {
 		// A failure that occurred before the 3-hour timeout (with a sibling still stuck) must still be surfaced: the
-		// timeout path scans for failures so it lists the failed software rather than releasing silently. This is the
-		// case CodeRabbit flagged and the reason the PR is titled "always display ... when software install fails".
+		// timeout path scans for failures so it lists the failed software rather than releasing silently.
 		ds, svc := newSvc(t)
 		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
 			return []*fleet.SetupExperienceStatusResult{
@@ -2054,34 +1994,6 @@ func TestGetESPCommands(t *testing.T) {
 			"timeout soft block must NOT signal ESP success")
 		assert.True(t, ds.CancelPendingSetupExperienceStepsFuncInvoked,
 			"timeout must cancel the still-pending sibling")
-	})
-
-	t.Run("timeout with require_all=true keeps hard block with timeout text", func(t *testing.T) {
-		// require_all=true is explicitly unchanged: the timeout path is NOT scanned for failures (a real failure would
-		// have hard-blocked on an earlier checkin), so the device hard-blocks with the timeout text and Reset only.
-		ds, svc := newSvc(t)
-		setRequireAll(ds, true)
-		ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
-			return []*fleet.SetupExperienceStatusResult{
-				{Name: "Whatever", Status: fleet.SetupExperienceStatusFailure, SoftwareInstallerID: new(uint(1))},
-			}, nil
-		}
-		past := time.Now().Add(-4 * time.Hour)
-		device := newActiveDevice()
-		device.AwaitingConfigurationAt = &past
-
-		cmds, err := svc.getESPCommands(t.Context(), device)
-		require.NoError(t, err)
-		require.NotEmpty(t, cmds)
-
-		blockCmd := findCmdByLocURI(cmds, "BlockInStatusPage")
-		require.NotNil(t, blockCmd)
-		assert.Equal(t, "1", blockCmd.Items[0].Data.Content,
-			"require_all=true timeout must hard block with Reset only")
-		errCmd := findCmdByLocURI(cmds, "CustomErrorText")
-		require.NotNil(t, errCmd)
-		assert.Equal(t, microsoft_mdm.ESPTimeoutErrorText, errCmd.Items[0].Data.Content,
-			"require_all=true timeout keeps the timeout text (not re-scanned for failures)")
 	})
 
 	t.Run("timeout cancel tolerates upcoming activity already gone", func(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45948

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Updated Windows ESP failure copy with clearer “Reset your device to try again…” wording.
  * When not all apps are required, added a **“Reset PC and Continue Anyway”** soft-block option and continuable error text that lists failed app names with truncation (“N more”).
* **Bug Fixes**
  * Improved SyncML generation by escaping XML-sensitive characters in embedded text.
* **Tests**
  * Added/expanded unit and property-based tests covering continuable error formatting, soft-block behavior, and SyncML XML escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->