### PR TITLE
Remove DRI for `api_endpoints.yml` from website config

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -129,7 +129,6 @@ module.exports.custom = {
     // 'docs/Contributing/reference/api-for-contributors.md': '', // « Covered in CODEOWNERS (2023-07-22)
     'schema': 'rachaelshaw',                               // Data tables (osquery/fleetd schema) documentation
     'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': 'rachaelshaw', //« Built-in queries
-    'server/api_endpoints/api_endpoints.yml': 'rachaelshaw', //« API endpoint display names in the Fleet UI (API-only users)
     'docs/get-started/faq': 'zayhanlon',
     'docs/Contributing/rituals': 'lukeheath',
     'ee/cis': 'sharon-fdm',//« Fleet Premium only: built-in queries  (built-in policies for CIS benchmarks)  -- FYI: On 2023-07-15, we changed this so that Sharon, Lucas, and Rachel are all maintainers, but where there is a single DRI who is automatically requested approval from.


### PR DESCRIPTION
This didn't override the need for a @go codeowner review since they own the directory it's in, so moved it to CODEOWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->