### PR TITLE
Website: update error handling in Github webhook

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -912,9 +912,14 @@ module.exports = {
           'Accept': 'application/vnd.github.v4+json',
           'User-Agent': 'Fleet-Engineering-Metrics'
         }
-      );
+      )
+      .tolerate((err)=>{
+        // If there is an error sending a request to the GitHub API, log a warning and return undefined.
+        sails.log.warn(`When the receive-from-github webhook sent a request to the GitHub API to look up an issue, an error occurred. Full error: ${require('util').inspect(err)}`);
+        return undefined;
+      });
 
-      if (!graphqlQueryResponse.data || !graphqlQueryResponse.data.node) {
+      if (!graphqlQueryResponse || !graphqlQueryResponse.data || !graphqlQueryResponse.data.node) {
         return;
       }
 


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/47391

Changes:
- Updated the receive-from-github webhook to log a warning and return a 200 response when a request to the GitHub GraphQL API to find issue details fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook stability by adding error handling for GitHub API requests. Failed requests now log warnings and gracefully continue processing instead of causing the webhook handler to stop abruptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->