### PR TITLE
Fleet UI: Fix dark mode switch flicker on data tables

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -19,9 +19,9 @@ $shadow-transition-width: 16px;
       /* Shadows */ linear-gradient(
           to right,
           $core-fleet-white,
-          $transparent
+          $core-fleet-white-transparent
         ),
-        linear-gradient(to left, $core-fleet-white, $transparent),
+        linear-gradient(to left, $core-fleet-white, $core-fleet-white-transparent),
         /* Shadow covers */
           linear-gradient(
             to right,

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -34,13 +34,15 @@ body {
   body.theme-transition *::after {
     transition: background-color 300ms ease, color 300ms ease,
       border-color 300ms ease, box-shadow 300ms ease, fill 300ms ease,
-      stroke 300ms ease !important;
+      stroke 300ms ease, background-image 300ms ease !important;
   }
 
-  // Hide the gradient image during theme switch so background-color
-  // can transition smoothly without the gradient snapping.
-  body.theme-transition .core-wrapper,
-  body.theme-transition .data-table__wrapper {
+  // The core-wrapper's hero gradient doesn't interpolate cleanly between
+  // themes (different shape/stops), so hide it during the transition and
+  // let background-color carry the fade. The data-table wrapper keeps its
+  // gradient — it has the same shape in both themes, so background-image
+  // interpolates smoothly along with background-color.
+  body.theme-transition .core-wrapper {
     background-image: none !important;
   }
 }

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -39,7 +39,8 @@ body {
 
   // Hide the gradient image during theme switch so background-color
   // can transition smoothly without the gradient snapping.
-  body.theme-transition .core-wrapper {
+  body.theme-transition .core-wrapper,
+  body.theme-transition .data-table__wrapper {
     background-image: none !important;
   }
 }
@@ -283,6 +284,26 @@ body.dark-mode thead {
 body.dark-mode .data-table-block tbody tr,
 body.dark-mode tbody tr {
   background-color: $dark-mode-table-row;
+}
+
+// Data table rows stay transparent in dark mode so the wrapper's scroll
+// shadow can show through when the table is horizontally scrollable —
+// matches the light-mode pattern where `tr` has no background and the
+// wrapper shows through.
+body.dark-mode .data-table-block tbody tr {
+  background-color: transparent;
+}
+
+// $ui-off-white-opaque is a near-transparent rgba tuned for light mode;
+// against the dark wrapper it's perceptually invisible. A translucent
+// black overlay darkens the row beneath the wrapper color cleanly — the
+// interpolation from `transparent` (rgba(0,0,0,0)) to rgba(0,0,0,0.2)
+// stays in monotonically darkening tints, so no flicker. Selector
+// includes `.data-table` to beat the component rule's `.single-row:hover`
+// specificity (0,4,2).
+body.dark-mode .data-table-block .data-table tbody tr:hover,
+body.dark-mode .data-table-block .data-table tbody .single-row:hover {
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 body.dark-mode .site-nav-item:not(.dup-org-logo):hover {

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -12,6 +12,11 @@
   --core-fleet-black: #192147;
   --core-fleet-green: #009a7d;
   --core-fleet-white: #ffffff;
+  // Same RGB as --core-fleet-white with zero alpha. Use as the fade-out
+  // endpoint in gradients that need to disappear into the wrapper background
+  // cleanly. The generic `$transparent` is rgba(255, 255, 255, 0) regardless
+  // of theme, which leaks white into dark-mode gradients.
+  --core-fleet-white-transparent: rgba(255, 255, 255, 0);
   --ui-fleet-black-75: #515774;
   --ui-fleet-black-50: #8b8fa2;
   --ui-fleet-black-33: #b3b6c1;
@@ -118,6 +123,7 @@ body.dark-mode {
   --core-fleet-black: #e2e4ea;
   --core-fleet-green: #00c28b;
   --core-fleet-white: #1a1c21;
+  --core-fleet-white-transparent: rgba(26, 28, 33, 0);
   --ui-fleet-black-75: #bebebf;
   --ui-fleet-black-50: #87888b;
   --ui-fleet-black-33: #636777;
@@ -147,7 +153,7 @@ body.dark-mode {
   --ui-gray: #32363e;
   --ui-light-grey: #1e2128;
   --ui-off-white: #1e2128;
-  --ui-shadow: #000000;
+  --ui-shadow: #2a2e36;
   --ui-vibrant-blue-50: rgba(123, 121, 255, 0.3);
   --ui-vibrant-blue-25: #282736;
   --ui-vibrant-blue-10: #2d2e4d;
@@ -219,6 +225,7 @@ body.dark-mode {
 $core-fleet-black: var(--core-fleet-black);
 $core-fleet-green: var(--core-fleet-green);
 $core-fleet-white: var(--core-fleet-white);
+$core-fleet-white-transparent: var(--core-fleet-white-transparent);
 $ui-fleet-black-75: var(--ui-fleet-black-75);
 $ui-fleet-black-50: var(--ui-fleet-black-50);
 $ui-fleet-black-33: var(--ui-fleet-black-33);


### PR DESCRIPTION
## Issue
Closes #47330 

## Description
Fixes flicker when switching between light and dark mode on pages with data tables.

- Add background-image to the global theme-transition property list so the data-table scroll-shadow gradient interpolates its colors over 300ms alongside background-color, instead of snapping to the new theme instantly. .core-wrapper keeps the existing background-image: none workaround since its gradient shape differs between themes and can't be interpolated.
- Add a theme-aware $core-fleet-white-transparent token for gradient fade-outs that match the wrapper color in both modes. The generic $transparent is rgba(255, 255, 255, 0) regardless of theme and leaks white into dark-mode gradients.
- Dark-mode table tweaks: rows are now background-color: transparent so the wrapper's scroll-shadow shows through when the table is horizontally scrollable (matches the light-mode pattern); row hover uses a translucent black overlay, since the light-mode $ui-off-white-opaque is perceptually invisible against the dark wrapper.
- Lighten --ui-shadow in dark mode from `#000000` to `#2a2e36` so the scroll-shadow indicator isn't blown out against the dark wrapper.

## Screenrecording

https://github.com/user-attachments/assets/8327e394-cb20-44a5-a2de-33c53ac4b799

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Adjusted data table wrapper “shadow” gradients to fade using a new transparent-white theme color
  * Improved dark mode styling for data table rows, including clearer hover overlays and transparent default row backgrounds
  * Updated global theme color variables to support refined gradient/interpolation and shadow tones across light and dark modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->