### PR TITLE
Show Fleet Premium message when viewing install details modal on Fleet Free

### DIFF
--- a/changes/44617-install-activity-premium-error
+++ b/changes/44617-install-activity-premium-error
@@ -1,0 +1,1 @@
+- Fixed a generic error in the software install activity modal when using Fleet Free to show a Fleet Premium message instead.

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -9,6 +9,7 @@ import {
   getSoftwareInstallHandlerOnlyInstallOutput,
   getSoftwareInstallHandlerWithPreInstall,
   getSoftwareInstallHandlerOnlyPreInstallOutput,
+  getSoftwareInstallResultHandlerPremiumRequired,
 } from "test/handlers/software-handlers";
 import mockServer from "test/mock-server";
 import { noop } from "lodash";
@@ -381,6 +382,36 @@ describe("SoftwareInstallDetailsModal", () => {
           name: /Details/i,
         })
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("API error states", () => {
+    afterEach(() => {
+      mockServer.resetHandlers();
+    });
+
+    it("renders the Fleet Premium upsell when the results request returns 402", async () => {
+      mockServer.use(getSoftwareInstallResultHandlerPremiumRequired);
+      const renderWithServer = createCustomRenderer({ withBackendMock: true });
+
+      renderWithServer(
+        <SoftwareInstallDetailsModal
+          details={baseDetails}
+          hostSoftware={baseHostSoftware}
+          onCancel={noop}
+        />
+      );
+
+      expect(
+        await screen.findByText("Couldn't get install details.")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/This feature is included in Fleet Premium/i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /Learn more/i })).toHaveAttribute(
+        "href",
+        "https://fleetdm.com/upgrade"
+      );
     });
   });
 });

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -34,6 +34,7 @@ import DeviceUserError from "components/DeviceUserError";
 import Spinner from "components/Spinner/Spinner";
 import RevealButton from "components/buttons/RevealButton";
 import CustomLink from "components/CustomLink";
+import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 
 import {
   INSTALL_DETAILS_STATUS_ICONS,
@@ -402,6 +403,17 @@ export const SoftwareInstallDetailsModal = ({
             <DeviceUserError />
           ) : (
             <DataError description="Close this modal and try again." />
+          );
+        }
+
+        if (error?.status === 402) {
+          return deviceAuthToken ? (
+            <DeviceUserError />
+          ) : (
+            <>
+              <p>Couldn&apos;t get install details.</p>
+              <PremiumFeatureMessage />
+            </>
           );
         }
       }

--- a/frontend/test/handlers/software-handlers.ts
+++ b/frontend/test/handlers/software-handlers.ts
@@ -64,6 +64,17 @@ export const getSoftwareInstallResultHandler = http.get(
   }
 );
 
+// Requires Fleet Premium license (server returns 402)
+export const getSoftwareInstallResultHandlerPremiumRequired = http.get(
+  baseUrl("/software/install/:install_uuid/results"),
+  () => {
+    return HttpResponse.json(
+      { message: "Requires Fleet Premium license" },
+      { status: 402 }
+    );
+  }
+);
+
 // ---- Pre install query output ----
 
 // Installed, outputs for pre-install, install, and post-install


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44617
Screenshot:
<img width="1318" height="528" alt="image" src="https://github.com/user-attachments/assets/4ec4bd85-8efb-4729-86ad-ea3059439b60" />

Note that the uninstall details modal is viewable without any errors on Fleet Free, so maybe we should address that at some point.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When accessing software install details without a Fleet Premium license, the activity modal now displays a Fleet Premium upsell message with a "Learn more" link instead of a generic error, providing clearer guidance to upgrade.

* **Tests**
  * Added test coverage for the Fleet Premium license requirement scenario in the install details modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->