### PR TITLE
Add 12 Windows FMAs

### DIFF
--- a/ee/maintained-apps/inputs/winget/bitwig-studio.json
+++ b/ee/maintained-apps/inputs/winget/bitwig-studio.json
@@ -1,0 +1,11 @@
+{
+  "name": "Bitwig Studio",
+  "slug": "bitwig-studio/windows",
+  "package_identifier": "bitwig.bitwig",
+  "unique_identifier": "Bitwig Studio",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "fuzzy_match_name": true,
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/clockify.json
+++ b/ee/maintained-apps/inputs/winget/clockify.json
@@ -1,0 +1,11 @@
+{
+  "name": "Clockify Desktop",
+  "slug": "clockify/windows",
+  "package_identifier": "Clockify.Clockify",
+  "unique_identifier": "Clockify",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "program_publisher": "CAKE.com Inc.",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/cmake-app.json
+++ b/ee/maintained-apps/inputs/winget/cmake-app.json
@@ -1,0 +1,10 @@
+{
+  "name": "CMake",
+  "slug": "cmake-app/windows",
+  "package_identifier": "Kitware.CMake",
+  "unique_identifier": "CMake",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/cmake.json
+++ b/ee/maintained-apps/inputs/winget/cmake.json
@@ -1,0 +1,10 @@
+{
+  "name": "CMake",
+  "slug": "cmake/windows",
+  "package_identifier": "Kitware.CMake",
+  "unique_identifier": "CMake",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/emclient.json
+++ b/ee/maintained-apps/inputs/winget/emclient.json
@@ -1,0 +1,11 @@
+{
+  "name": "eM Client",
+  "slug": "emclient/windows",
+  "package_identifier": "eMClient.eMClient",
+  "unique_identifier": "eM Client",
+  "installer_arch": "x86",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "program_publisher": "eM Client s.r.o.",
+  "default_categories": ["Communication"]
+}

--- a/ee/maintained-apps/inputs/winget/epic-games.json
+++ b/ee/maintained-apps/inputs/winget/epic-games.json
@@ -1,0 +1,10 @@
+{
+  "name": "Epic Games Launcher",
+  "slug": "epic-games/windows",
+  "package_identifier": "EpicGames.EpicGamesLauncher",
+  "unique_identifier": "Epic Games Launcher",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/mixxx.json
+++ b/ee/maintained-apps/inputs/winget/mixxx.json
@@ -1,0 +1,10 @@
+{
+  "name": "Mixxx",
+  "slug": "mixxx/windows",
+  "package_identifier": "Mixxx.Mixxx",
+  "unique_identifier": "Mixxx",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/naps2.json
+++ b/ee/maintained-apps/inputs/winget/naps2.json
@@ -1,0 +1,10 @@
+{
+  "name": "NAPS2",
+  "slug": "naps2/windows",
+  "package_identifier": "Cyanfish.NAPS2",
+  "unique_identifier": "NAPS2",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/pdfsam-basic.json
+++ b/ee/maintained-apps/inputs/winget/pdfsam-basic.json
@@ -1,0 +1,10 @@
+{
+  "name": "PDFsam Basic",
+  "slug": "pdfsam-basic/windows",
+  "package_identifier": "PDFsam.PDFsam",
+  "unique_identifier": "PDFsam Basic",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/topaz-gigapixel-ai.json
+++ b/ee/maintained-apps/inputs/winget/topaz-gigapixel-ai.json
@@ -1,0 +1,10 @@
+{
+  "name": "Topaz Gigapixel AI",
+  "slug": "topaz-gigapixel-ai/windows",
+  "package_identifier": "TopazLabs.TopazGigapixelAI",
+  "unique_identifier": "Topaz Gigapixel AI",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/topaz-photo-ai.json
+++ b/ee/maintained-apps/inputs/winget/topaz-photo-ai.json
@@ -1,0 +1,10 @@
+{
+  "name": "Topaz Photo AI",
+  "slug": "topaz-photo-ai/windows",
+  "package_identifier": "TopazLabs.TopazPhotoAI",
+  "unique_identifier": "Topaz Photo AI",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/transmission.json
+++ b/ee/maintained-apps/inputs/winget/transmission.json
@@ -1,0 +1,11 @@
+{
+  "name": "Transmission",
+  "slug": "transmission/windows",
+  "package_identifier": "Transmission.Transmission",
+  "unique_identifier": "Transmission",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "fuzzy_match_name": true,
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/zulip.json
+++ b/ee/maintained-apps/inputs/winget/zulip.json
@@ -1,0 +1,10 @@
+{
+  "name": "Zulip",
+  "slug": "zulip/windows",
+  "package_identifier": "Zulip.Zulip",
+  "unique_identifier": "Zulip",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Communication"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -954,6 +954,13 @@
       "description": "Bitwig Studio is a digital audio workstation."
     },
     {
+      "name": "Bitwig Studio",
+      "slug": "bitwig-studio/windows",
+      "platform": "windows",
+      "unique_identifier": "Bitwig Studio",
+      "description": "Bitwig Studio is a digital audio workstation."
+    },
+    {
       "name": "Blender",
       "slug": "blender/darwin",
       "platform": "darwin",
@@ -1500,6 +1507,13 @@
       "description": "Clockify Desktop is a time tracking tool for agencies and freelancers."
     },
     {
+      "name": "Clockify Desktop",
+      "slug": "clockify/windows",
+      "platform": "windows",
+      "unique_identifier": "Clockify",
+      "description": "Clockify Desktop is a time tracking tool for agencies and freelancers."
+    },
+    {
       "name": "Clop",
       "slug": "clop/darwin",
       "platform": "darwin",
@@ -1532,6 +1546,13 @@
       "slug": "cmake-app/darwin",
       "platform": "darwin",
       "unique_identifier": "org.cmake.cmake",
+      "description": "CMake is a family of tools to build, test and package software."
+    },
+    {
+      "name": "CMake",
+      "slug": "cmake/windows",
+      "platform": "windows",
+      "unique_identifier": "CMake",
       "description": "CMake is a family of tools to build, test and package software."
     },
     {
@@ -2438,6 +2459,13 @@
       "description": "eM Client is an email client."
     },
     {
+      "name": "eM Client",
+      "slug": "emclient/windows",
+      "platform": "windows",
+      "unique_identifier": "eM Client",
+      "description": "eM Client is an email client."
+    },
+    {
       "name": "Enpass",
       "slug": "enpass/darwin",
       "platform": "darwin",
@@ -2456,6 +2484,13 @@
       "slug": "epic-games/darwin",
       "platform": "darwin",
       "unique_identifier": "com.epicgames.EpicGamesLauncher",
+      "description": "Epic Games Launcher is a launcher for *Epic Games* games."
+    },
+    {
+      "name": "Epic Games Launcher",
+      "slug": "epic-games/windows",
+      "platform": "windows",
+      "unique_identifier": "Epic Games Launcher",
       "description": "Epic Games Launcher is a launcher for *Epic Games* games."
     },
     {
@@ -4503,6 +4538,13 @@
       "description": "Mixxx is an open-source DJ software."
     },
     {
+      "name": "Mixxx",
+      "slug": "mixxx/windows",
+      "platform": "windows",
+      "unique_identifier": "Mixxx",
+      "description": "Mixxx is an open-source DJ software."
+    },
+    {
       "name": "Mobirise",
       "slug": "mobirise/darwin",
       "platform": "darwin",
@@ -4668,6 +4710,13 @@
       "slug": "naps2/darwin",
       "platform": "darwin",
       "unique_identifier": "com.naps2.desktop",
+      "description": "NAPS2 is a document scanning application."
+    },
+    {
+      "name": "NAPS2",
+      "slug": "naps2/windows",
+      "platform": "windows",
+      "unique_identifier": "NAPS2",
       "description": "NAPS2 is a document scanning application."
     },
     {
@@ -5285,6 +5334,13 @@
       "platform": "darwin",
       "unique_identifier": "org.pdfsam.modules",
       "description": "PDFsam Basic is an extracts pages, splits, merges, mixes and rotates PDF files."
+    },
+    {
+      "name": "PDFsam Basic",
+      "slug": "pdfsam-basic/windows",
+      "platform": "windows",
+      "unique_identifier": "PDFsam Basic",
+      "description": "PDFsam Basic extracts pages, splits, merges, mixes and rotates PDF files."
     },
     {
       "name": "Pearcleaner",
@@ -7177,10 +7233,24 @@
       "description": "Topaz Gigapixel AI is an AI image upscaler."
     },
     {
+      "name": "Topaz Gigapixel AI",
+      "slug": "topaz-gigapixel-ai/windows",
+      "platform": "windows",
+      "unique_identifier": "Topaz Gigapixel AI",
+      "description": "Topaz Gigapixel AI is an AI image upscaler."
+    },
+    {
       "name": "Topaz Photo AI",
       "slug": "topaz-photo-ai/darwin",
       "platform": "darwin",
       "unique_identifier": "com.topazlabs.TopazPhotoAI",
+      "description": "Topaz Photo AI is an AI image enhancer."
+    },
+    {
+      "name": "Topaz Photo AI",
+      "slug": "topaz-photo-ai/windows",
+      "platform": "windows",
+      "unique_identifier": "Topaz Photo AI",
       "description": "Topaz Photo AI is an AI image enhancer."
     },
     {
@@ -7244,6 +7314,13 @@
       "slug": "transmission/darwin",
       "platform": "darwin",
       "unique_identifier": "org.m0k.transmission.LSSharedFileList",
+      "description": "Transmission is an open-source BitTorrent client."
+    },
+    {
+      "name": "Transmission",
+      "slug": "transmission/windows",
+      "platform": "windows",
+      "unique_identifier": "Transmission",
       "description": "Transmission is an open-source BitTorrent client."
     },
     {
@@ -8105,6 +8182,13 @@
       "slug": "zulip/darwin",
       "platform": "darwin",
       "unique_identifier": "org.zulip.zulip-electron",
+      "description": "Zulip is a desktop client for the Zulip team chat platform."
+    },
+    {
+      "name": "Zulip",
+      "slug": "zulip/windows",
+      "platform": "windows",
+      "unique_identifier": "Zulip",
       "description": "Zulip is a desktop client for the Zulip team chat platform."
     },
     {

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -954,6 +954,13 @@
       "description": "Bitwig Studio is a digital audio workstation."
     },
     {
+      "name": "Bitwig Studio",
+      "slug": "bitwig-studio/windows",
+      "platform": "windows",
+      "unique_identifier": "Bitwig Studio",
+      "description": "Bitwig Studio is a digital audio workstation."
+    },
+    {
       "name": "Blender",
       "slug": "blender/darwin",
       "platform": "darwin",
@@ -1500,6 +1507,13 @@
       "description": "Clockify Desktop is a time tracking tool for agencies and freelancers."
     },
     {
+      "name": "Clockify Desktop",
+      "slug": "clockify/windows",
+      "platform": "windows",
+      "unique_identifier": "Clockify",
+      "description": "Clockify Desktop is a time tracking tool for agencies and freelancers."
+    },
+    {
       "name": "Clop",
       "slug": "clop/darwin",
       "platform": "darwin",
@@ -1532,6 +1546,13 @@
       "slug": "cmake-app/darwin",
       "platform": "darwin",
       "unique_identifier": "org.cmake.cmake",
+      "description": "CMake is a family of tools to build, test and package software."
+    },
+    {
+      "name": "CMake",
+      "slug": "cmake-app/windows",
+      "platform": "windows",
+      "unique_identifier": "CMake",
       "description": "CMake is a family of tools to build, test and package software."
     },
     {
@@ -2438,6 +2459,13 @@
       "description": "eM Client is an email client."
     },
     {
+      "name": "eM Client",
+      "slug": "emclient/windows",
+      "platform": "windows",
+      "unique_identifier": "eM Client",
+      "description": "eM Client is an email client."
+    },
+    {
       "name": "Enpass",
       "slug": "enpass/darwin",
       "platform": "darwin",
@@ -2456,6 +2484,13 @@
       "slug": "epic-games/darwin",
       "platform": "darwin",
       "unique_identifier": "com.epicgames.EpicGamesLauncher",
+      "description": "Epic Games Launcher is a launcher for *Epic Games* games."
+    },
+    {
+      "name": "Epic Games Launcher",
+      "slug": "epic-games/windows",
+      "platform": "windows",
+      "unique_identifier": "Epic Games Launcher",
       "description": "Epic Games Launcher is a launcher for *Epic Games* games."
     },
     {
@@ -4503,6 +4538,13 @@
       "description": "Mixxx is an open-source DJ software."
     },
     {
+      "name": "Mixxx",
+      "slug": "mixxx/windows",
+      "platform": "windows",
+      "unique_identifier": "Mixxx",
+      "description": "Mixxx is an open-source DJ software."
+    },
+    {
       "name": "Mobirise",
       "slug": "mobirise/darwin",
       "platform": "darwin",
@@ -4668,6 +4710,13 @@
       "slug": "naps2/darwin",
       "platform": "darwin",
       "unique_identifier": "com.naps2.desktop",
+      "description": "NAPS2 is a document scanning application."
+    },
+    {
+      "name": "NAPS2",
+      "slug": "naps2/windows",
+      "platform": "windows",
+      "unique_identifier": "NAPS2",
       "description": "NAPS2 is a document scanning application."
     },
     {
@@ -5285,6 +5334,13 @@
       "platform": "darwin",
       "unique_identifier": "org.pdfsam.modules",
       "description": "PDFsam Basic is an extracts pages, splits, merges, mixes and rotates PDF files."
+    },
+    {
+      "name": "PDFsam Basic",
+      "slug": "pdfsam-basic/windows",
+      "platform": "windows",
+      "unique_identifier": "PDFsam Basic",
+      "description": "PDFsam Basic extracts pages, splits, merges, mixes and rotates PDF files."
     },
     {
       "name": "Pearcleaner",
@@ -7177,10 +7233,24 @@
       "description": "Topaz Gigapixel AI is an AI image upscaler."
     },
     {
+      "name": "Topaz Gigapixel AI",
+      "slug": "topaz-gigapixel-ai/windows",
+      "platform": "windows",
+      "unique_identifier": "Topaz Gigapixel AI",
+      "description": "Topaz Gigapixel AI is an AI image upscaler."
+    },
+    {
       "name": "Topaz Photo AI",
       "slug": "topaz-photo-ai/darwin",
       "platform": "darwin",
       "unique_identifier": "com.topazlabs.TopazPhotoAI",
+      "description": "Topaz Photo AI is an AI image enhancer."
+    },
+    {
+      "name": "Topaz Photo AI",
+      "slug": "topaz-photo-ai/windows",
+      "platform": "windows",
+      "unique_identifier": "Topaz Photo AI",
       "description": "Topaz Photo AI is an AI image enhancer."
     },
     {
@@ -7244,6 +7314,13 @@
       "slug": "transmission/darwin",
       "platform": "darwin",
       "unique_identifier": "org.m0k.transmission.LSSharedFileList",
+      "description": "Transmission is an open-source BitTorrent client."
+    },
+    {
+      "name": "Transmission",
+      "slug": "transmission/windows",
+      "platform": "windows",
+      "unique_identifier": "Transmission",
       "description": "Transmission is an open-source BitTorrent client."
     },
     {
@@ -8105,6 +8182,13 @@
       "slug": "zulip/darwin",
       "platform": "darwin",
       "unique_identifier": "org.zulip.zulip-electron",
+      "description": "Zulip is a desktop client for the Zulip team chat platform."
+    },
+    {
+      "name": "Zulip",
+      "slug": "zulip/windows",
+      "platform": "windows",
+      "unique_identifier": "Zulip",
       "description": "Zulip is a desktop client for the Zulip team chat platform."
     },
     {

--- a/ee/maintained-apps/outputs/bitwig-studio/windows.json
+++ b/ee/maintained-apps/outputs/bitwig-studio/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "6.0.6",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name LIKE 'Bitwig Studio %' AND publisher = 'Bitwig GmbH';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Bitwig Studio %' AND publisher = 'Bitwig GmbH' AND version_compare(version, '6.0.6') < 0);"
+      },
+      "installer_url": "https://www.bitwig.com/dl/Bitwig%20Studio/6.0.6/installer_windows/",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "9b9fc2cf",
+      "sha256": "8b44bf8bd420e3a1938166293dbcae3c9752c88601c6407e9cc904a09528eb6b",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "9b9fc2cf": "$product_code = '{8AFA291D-C7A6-4461-9A6A-A5B38120BAF0}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/clockify/windows.json
+++ b/ee/maintained-apps/outputs/clockify/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "2.2.0",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.' AND version_compare(version, '2.2.0') < 0);"
+      },
+      "installer_url": "https://clockify.me/downloads/clockify-setup.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "f7f14087",
+      "sha256": "420f7dddcaa69a3275c01057687783b69495cdaf86e191dbb94ed58ef6f770d5",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{A17CEE88-470D-49D0-A58D-40D503A0BEBF}"
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "f7f14087": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{A17CEE88-470D-49D0-A58D-40D503A0BEBF}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+  }
+}

--- a/ee/maintained-apps/outputs/cmake-app/windows.json
+++ b/ee/maintained-apps/outputs/cmake-app/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "4.3.3",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware' AND version_compare(version, '4.3.3') < 0);"
+      },
+      "installer_url": "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-windows-x86_64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "6ac3efbc",
+      "sha256": "b6c50584847f02fe7f11d94ad1d99d592b5b371c476e2de3770ae3ee823b2638",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}"
+    }
+  ],
+  "refs": {
+    "6ac3efbc": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/cmake/windows.json
+++ b/ee/maintained-apps/outputs/cmake/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "4.3.3",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware' AND version_compare(version, '4.3.3') < 0);"
+      },
+      "installer_url": "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-windows-x86_64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "6ac3efbc",
+      "sha256": "b6c50584847f02fe7f11d94ad1d99d592b5b371c476e2de3770ae3ee823b2638",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}"
+    }
+  ],
+  "refs": {
+    "6ac3efbc": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/emclient/windows.json
+++ b/ee/maintained-apps/outputs/emclient/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "10.4.5326.0",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'eM Client' AND publisher = 'eM Client s.r.o.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'eM Client' AND publisher = 'eM Client s.r.o.' AND version_compare(version, '10.4.5326.0') < 0);"
+      },
+      "installer_url": "https://cdn-dist.emclient.com/dist/v10.4.5326/setup.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "04c930bd",
+      "sha256": "2699adae5607438fbe6eacfab2b60baa5086d8280a8f797778c5c52dde7ac1e0",
+      "default_categories": [
+        "Communication"
+      ],
+      "upgrade_code": "{D8A1DC6C-8EDA-4135-8E82-6F4EEA116B2F}"
+    }
+  ],
+  "refs": {
+    "04c930bd": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{D8A1DC6C-8EDA-4135-8E82-6F4EEA116B2F}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/epic-games/windows.json
+++ b/ee/maintained-apps/outputs/epic-games/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "1.3.176.0",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Epic Games Launcher' AND publisher = 'Epic Games, Inc.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Epic Games Launcher' AND publisher = 'Epic Games, Inc.' AND version_compare(version, '1.3.176.0') < 0);"
+      },
+      "installer_url": "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Windows/EpicInstaller-19.2.3.msi?launcherfilename=EpicInstaller-19.2.3.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "f3ea6878",
+      "sha256": "04b984cad5af063749bcf14ba5eb751314a9fd091c07169eaa156c15088146da",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{D0769F44-D459-450F-B084-CAE38062C75B}"
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "f3ea6878": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{D0769F44-D459-450F-B084-CAE38062C75B}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+  }
+}

--- a/ee/maintained-apps/outputs/mixxx/windows.json
+++ b/ee/maintained-apps/outputs/mixxx/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "2.5.6",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Mixxx' AND publisher = 'Mixxx Project';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mixxx' AND publisher = 'Mixxx Project' AND version_compare(version, '2.5.6') < 0);"
+      },
+      "installer_url": "https://downloads.mixxx.org/releases/2.5.6/mixxx-2.5.6-win64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "3c905cb2",
+      "sha256": "0d1f01a1f5c2e4d4180cd462e60365d0230b405808e7bd2b6625b62a53a29c72",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{921DC99C-4DCF-478D-B950-50685CB9E6BE}"
+    }
+  ],
+  "refs": {
+    "3c905cb2": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{921DC99C-4DCF-478D-B950-50685CB9E6BE}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/naps2/windows.json
+++ b/ee/maintained-apps/outputs/naps2/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "8.2.1",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'NAPS2' AND publisher = 'NAPS2 Software';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'NAPS2' AND publisher = 'NAPS2 Software' AND version_compare(version, '8.2.1') < 0);"
+      },
+      "installer_url": "https://github.com/cyanfish/naps2/releases/download/v8.2.1/naps2-8.2.1-win-x64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "6e7bd63d",
+      "sha256": "84fdf4747f7c0dd0bdfd081073684c6dc1924ec08283939b3ffa7893c2131aec",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{FEB82971-B3E6-4F19-9684-1D543E644D73}"
+    }
+  ],
+  "refs": {
+    "6e7bd63d": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{FEB82971-B3E6-4F19-9684-1D543E644D73}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/pdfsam-basic/windows.json
+++ b/ee/maintained-apps/outputs/pdfsam-basic/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "6.0.1.0",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'PDFsam Basic' AND publisher = 'Sober Lemur S.r.l.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PDFsam Basic' AND publisher = 'Sober Lemur S.r.l.' AND version_compare(version, '6.0.1.0') < 0);"
+      },
+      "installer_url": "https://github.com/torakiki/pdfsam/releases/download/v6.0.1/pdfsam-basic-6.0.1-windows-x64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "e9918859",
+      "sha256": "03ff98e2a920e55543bf8957523f57ee8aaaffa220364df8f0480d299c07de60",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{DB40FA48-1629-11E2-9401-2F676188709B}"
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "e9918859": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{DB40FA48-1629-11E2-9401-2F676188709B}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+  }
+}

--- a/ee/maintained-apps/outputs/topaz-gigapixel-ai/windows.json
+++ b/ee/maintained-apps/outputs/topaz-gigapixel-ai/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "8.4.4",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Topaz Gigapixel AI' AND publisher = 'Topaz Labs LLC';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Topaz Gigapixel AI' AND publisher = 'Topaz Labs LLC' AND version_compare(version, '8.4.4') < 0);"
+      },
+      "installer_url": "https://downloads.topazlabs.com/deploy/TopazGigapixelAI/8.4.4/TopazGigapixelAI-8.4.4.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "33a59ac9",
+      "sha256": "9458fb4f0ec7847729e82e48e97d2276cce8f76fd9409949fc94b9743673ff20",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{F1897D84-BE83-4F46-825F-007CD58D6218}"
+    }
+  ],
+  "refs": {
+    "33a59ac9": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{F1897D84-BE83-4F46-825F-007CD58D6218}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/topaz-photo-ai/windows.json
+++ b/ee/maintained-apps/outputs/topaz-photo-ai/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "4.0.4",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Topaz Photo AI' AND publisher = 'Topaz Labs LLC';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Topaz Photo AI' AND publisher = 'Topaz Labs LLC' AND version_compare(version, '4.0.4') < 0);"
+      },
+      "installer_url": "https://downloads.topazlabs.com/deploy/TopazPhotoAI/4.0.4/TopazPhotoAI-4.0.4.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "cfa1dc06",
+      "sha256": "5d9463485957c65b2b247535c43b5e11cc78ad094b03e11dd6e85ea36c6e339c",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{EDBFCDC7-6D1B-498E-A7AB-C84CF4E8ADA2}"
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "cfa1dc06": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{EDBFCDC7-6D1B-498E-A7AB-C84CF4E8ADA2}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+  }
+}

--- a/ee/maintained-apps/outputs/transmission/windows.json
+++ b/ee/maintained-apps/outputs/transmission/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "4.1.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name LIKE 'Transmission %' AND publisher = 'Transmission Project';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Transmission %' AND publisher = 'Transmission Project' AND version_compare(version, '4.1.2') < 0);"
+      },
+      "installer_url": "https://github.com/transmission/transmission/releases/download/4.1.2/transmission-4.1.2-x64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "22a80967",
+      "sha256": "f36fd9c245f3c298597ac238b319c86f00eacfd1984881aa8eca3a0943f53008",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{1FB3C295-9BD4-4248-8C8B-B85CD11FE7C4}"
+    }
+  ],
+  "refs": {
+    "22a80967": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{1FB3C295-9BD4-4248-8C8B-B85CD11FE7C4}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/zulip/windows.json
+++ b/ee/maintained-apps/outputs/zulip/windows.json
@@ -1,0 +1,23 @@
+{
+  "versions": [
+    {
+      "version": "5.12.3",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Zulip' AND publisher = 'Kandra Labs, Inc.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zulip' AND publisher = 'Kandra Labs, Inc.' AND version_compare(version, '5.12.3') < 0);"
+      },
+      "installer_url": "https://github.com/zulip/zulip-desktop/releases/download/v5.12.3/Zulip-5.12.3-x64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "5237b38e",
+      "sha256": "12bc49fde2758a81e4cd12d8c8f1ab13862af26608f3aefc37f9c1aaa5011972",
+      "default_categories": [
+        "Communication"
+      ],
+      "upgrade_code": "{E19E3054-C647-509A-A863-1C21A98215A7}"
+    }
+  ],
+  "refs": {
+    "5237b38e": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{E19E3054-C647-509A-A863-1C21A98215A7}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
Adds Windows Fleet-maintained apps for apps that already exist as macOS FMAs and ship in winget as a machine-scope MSI/WiX installer:

Bitwig Studio, Clockify, CMake, eM Client, Epic Games Launcher, Mixxx, NAPS2, PDFsam Basic, Topaz Gigapixel AI, Topaz Photo AI, Transmission, Zulip.

Identity fields verified against the real MSI (msiinfo) per new-fma rules:
- fuzzy_match_name for version-bearing DisplayNames (Bitwig, Transmission)
- program_publisher overrides where registry Publisher != winget locale (Clockify -> CAKE.com Inc., eM Client -> eM Client s.r.o.)
- eM Client is x86-only (no x64 in winget)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 12 new applications to the Windows package catalog: Bitwig Studio, Clockify, CMake, eM Client, Epic Games Launcher, Mixxx, NAPS2, PDFsam Basic, Topaz Gigapixel AI, Topaz Photo AI, Transmission, and Zulip.
  * Configured Windows installer metadata and automated installation/uninstallation support for each application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->