### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/android-studio/windows.json
+++ b/ee/maintained-apps/outputs/android-studio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.1.8",
+      "version": "2026.1.1.9",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC' AND version_compare(version, '2026.1.1.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC' AND version_compare(version, '2026.1.1.9') < 0);"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.8/android-studio-quail1-windows.exe",
+      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.9/android-studio-quail1-patch1-windows.exe",
       "install_script_ref": "36676cba",
       "uninstall_script_ref": "c48a6948",
-      "sha256": "df998400b6ad20a3e172ca3d3d1420230d2ff6e37c9bbaa830bb3a146ae2b6cf",
+      "sha256": "d738b85423c79f3320032907bf7a9684509cf119803d9705b15b93970473a58f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/audacity/windows.json
+++ b/ee/maintained-apps/outputs/audacity/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.7.7",
+      "version": "3.7.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Audacity %' AND publisher = 'Audacity Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Audacity %' AND publisher = 'Audacity Team' AND version_compare(version, '3.7.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Audacity %' AND publisher = 'Audacity Team' AND version_compare(version, '3.7.8') < 0);"
       },
-      "installer_url": "https://github.com/audacity/audacity/releases/download/Audacity-3.7.7/audacity-win-3.7.7-64bit.exe",
+      "installer_url": "https://github.com/audacity/audacity/releases/download/Audacity-3.7.8/audacity-win-3.7.8-64bit.exe",
       "install_script_ref": "33137473",
       "uninstall_script_ref": "3cfe5900",
-      "sha256": "a96f41f21efcdfec1d2f7f332544f8a8fb00a6c411e3bee2aa0031b691dd91a7",
+      "sha256": "4a6d77f023c0209a396fcf2f3c7c04e240b6ba9897b3231a6ed18e14c10caa16",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.35.3",
+      "version": "2.35.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.4') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.3.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.4.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "51872df2cd874e7232cfdd6e1b8944c1084d965c3c38c0e501db855233329946",
+      "sha256": "0785d8af3ef6f31a5f407287a1edf879fe94d19b24e7616e0d0894f38c79932c",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/bezel/darwin.json
+++ b/ee/maintained-apps/outputs/bezel/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.0",
+      "version": "4.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct' AND version_compare(bundle_short_version, '4.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct' AND version_compare(bundle_short_version, '4.4.0') < 0);"
       },
-      "installer_url": "https://download.nonstrict.eu/bezel/Bezel-4.3.0.zip",
+      "installer_url": "https://download.nonstrict.eu/bezel/Bezel-4.4.0.zip",
       "install_script_ref": "6ddd4f59",
       "uninstall_script_ref": "539e1578",
-      "sha256": "e154e929f4247f5fa45c518d0b973ce0f0f10fe045763d88aae67439d3e2d0b5",
+      "sha256": "25c984d26873ccd2318e549a4c54467cea8349241e27bc7ffdd70d1e91f58ba7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/coconutbattery/darwin.json
+++ b/ee/maintained-apps/outputs/coconutbattery/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.2",
+      "version": "4.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.coconut-flavour.coconutBattery-Menu';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coconut-flavour.coconutBattery-Menu' AND version_compare(bundle_short_version, '4.3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coconut-flavour.coconutBattery-Menu' AND version_compare(bundle_short_version, '4.3.3') < 0);"
       },
-      "installer_url": "https://www.coconut-flavour.com/downloads/coconutBattery_432_213.zip",
+      "installer_url": "https://www.coconut-flavour.com/downloads/coconutBattery_433_218.zip",
       "install_script_ref": "0d0c8ca7",
       "uninstall_script_ref": "8d4d4d78",
-      "sha256": "8a03378cb6fc8c1bc7959e2dae61f204f3f3994264b810e8cdd229894664ce7d",
+      "sha256": "d2aea31aaf95a1a178743c41b40c5c1b93d3d4106576aa644e8918a54fde130e",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/codex-app/darwin.json
+++ b/ee/maintained-apps/outputs/codex-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.609.30741",
+      "version": "26.609.41114",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.609.30741') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.609.41114') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.609.30741.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.609.41114.zip",
       "install_script_ref": "5e3efa57",
       "uninstall_script_ref": "a2b5ee81",
-      "sha256": "24cd7b226c70aefb9143571cdcfb2d39fb38794a98ba3935d406d89e7202bf7e",
+      "sha256": "6f69d0de7800bc7f48cda0f87810068f109fe6ecf839df8dec0d093cb23ad362",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.7.27",
+      "version": "3.7.36",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.27') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.36') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/e48ee6102a199492b0c9964699bf011886708ba3/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/776d1f9d76df50a4e0aeca61819a88e7c1b861e2/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "3ec727cbf471a40b03f564b4f67fd26a39a78b14418ba0c718fb7d69b35fbc16",
+      "sha256": "881e4a19db1bdd678425dda0ffce237045da81c44fe7af4befe80245d34b4b86",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dropbox/windows.json
+++ b/ee/maintained-apps/outputs/dropbox/windows.json
@@ -1,22 +1,22 @@
 {
   "versions": [
     {
-      "version": "258.3.3629",
+      "version": "258.3.3645",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Dropbox' AND publisher = 'Dropbox, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dropbox' AND publisher = 'Dropbox, Inc.' AND version_compare(version, '258.3.3629') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dropbox' AND publisher = 'Dropbox, Inc.' AND version_compare(version, '258.3.3645') < 0);"
       },
-      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20258.3.3629%20Enterprise%20Installer.x64.msi",
+      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20258.3.3645%20Enterprise%20Installer.x64.msi",
       "install_script_ref": "8959087b",
-      "uninstall_script_ref": "1035e43a",
-      "sha256": "6039fe80aaacb4cdae935bd0b5b91cc585cfa64e479dc0112802feefa96e2d27",
+      "uninstall_script_ref": "f9913fdb",
+      "sha256": "997a6fc7d61abba872c6ebcabebe59ee6ce432758fee14e46949cbef606f8739",
       "default_categories": [
         "Productivity"
       ]
     }
   ],
   "refs": {
-    "1035e43a": "$product_code = '{C1BD7420-DAD0-58F1-BAD3-C58354BEE1AB}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n",
-    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "f9913fdb": "$product_code = '{6D846646-9AD7-5D6C-8BB0-04B336C8EC3A}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n"
   }
 }

--- a/ee/maintained-apps/outputs/firealpaca/darwin.json
+++ b/ee/maintained-apps/outputs/firealpaca/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.15.2",
+      "version": "2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.16.0') < 0);"
       },
       "installer_url": "https://firealpaca.com/download/mac",
       "install_script_ref": "f2cad371",

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.33",
+      "version": "3.0.34",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.0.33') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.0.34') < 0);"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.0.33.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.0.34.zip",
       "install_script_ref": "c6782863",
       "uninstall_script_ref": "9e4b9fca",
-      "sha256": "7ad81fad5118720414ad560629207155347e85fb1e8697da1e8a3fec089639a4",
+      "sha256": "38dc60f018efe52d203a95a463896c3f394ae05a527de0191e97473e7a7f9e3c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.62",
+      "version": "149.0.4022.69",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '149.0.4022.62') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '149.0.4022.69') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/be446108-f4a5-446d-9738-a3eb4fc475f6/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/1620c248-1a72-4421-966f-1404bb5ccc34/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "e6fbeb15752f91b526f228526dae65030b719d7dca210c72edb98a7e4f05a18e",
+      "sha256": "11c34dbd3891744a459746e270dd02897a2c6260f14390bc4389312ebd243785",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/nextcloud-talk/darwin.json
+++ b/ee/maintained-apps/outputs/nextcloud-talk/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.1.2",
+      "version": "2.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac' AND version_compare(bundle_short_version, '2.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac' AND version_compare(bundle_short_version, '2.2.0') < 0);"
       },
-      "installer_url": "https://github.com/nextcloud-releases/talk-desktop/releases/download/v2.1.2/Nextcloud.Talk-macos-universal.dmg",
+      "installer_url": "https://github.com/nextcloud-releases/talk-desktop/releases/download/v2.2.0/Nextcloud.Talk-macos-universal.dmg",
       "install_script_ref": "597512da",
       "uninstall_script_ref": "baa87dcf",
-      "sha256": "9a3362ef9757e01fe8bfecc49a22434d5fb6a369d59f5cef39c0f992e709767a",
+      "sha256": "4d631867ebeb243033dc950aefbd3b2938fe81d08bd93f3377ef45da91c14900",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notesnook/darwin.json
+++ b/ee/maintained-apps/outputs/notesnook/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.3.22",
+      "version": "3.3.23",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook' AND version_compare(bundle_short_version, '3.3.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook' AND version_compare(bundle_short_version, '3.3.23') < 0);"
       },
-      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.3.22/notesnook_mac_arm64.dmg",
+      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.3.23/notesnook_mac_arm64.dmg",
       "install_script_ref": "458f8fba",
       "uninstall_script_ref": "181a288a",
-      "sha256": "78c7bfcc2d0895fc5be23d6d13f9818b7c3de3db1ce5161ea6c8ce9bc192212d",
+      "sha256": "89302d43a6509bc651bf08a39f651f1dd72dd2a1ee9908a2f06d4deb6f619943",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
+++ b/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.0.85.133",
+      "version": "2.0.85.135",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.85.133') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.85.135') < 0);"
       },
       "installer_url": "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg",
       "install_script_ref": "a9979922",

--- a/ee/maintained-apps/outputs/soundanchor/darwin.json
+++ b/ee/maintained-apps/outputs/soundanchor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.7.0",
+      "version": "1.8.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'me.kopiro.soundanchor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'me.kopiro.soundanchor' AND version_compare(bundle_short_version, '1.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'me.kopiro.soundanchor' AND version_compare(bundle_short_version, '1.8.1') < 0);"
       },
-      "installer_url": "https://cdn.kopiro.me/soundanchor/soundanchor-1.7.0.dmg",
+      "installer_url": "https://cdn.kopiro.me/soundanchor/soundanchor-1.8.1.dmg",
       "install_script_ref": "b057933e",
       "uninstall_script_ref": "924d2c8c",
-      "sha256": "c0231b8ce768813469c00acd073dad0d768371fff841e83baf734df856c3d34c",
+      "sha256": "c91ff3f761e2d50648f8a1327c115cc2790f604cf789156faf5834619c47a64b",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/spotify/windows.json
+++ b/ee/maintained-apps/outputs/spotify/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.90.451.gb094aab0",
+      "version": "1.2.92.147.g5b8f9367",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB' AND version_compare(version, '1.2.90.451.gb094aab0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB' AND version_compare(version, '1.2.92.147.g5b8f9367') < 0);"
       },
       "installer_url": "https://download.scdn.co/SpotifyFullSetupX64.exe",
       "install_script_ref": "7e4727ac",
       "uninstall_script_ref": "48d55e3d",
-      "sha256": "7701d124417f9c93b2861f5a4904674ab8d49667dc1587f5468f79c25bffd43e",
+      "sha256": "0f34edb3c51dfb48957b0137290111cef06308fd645004a2a7aa0fc4f71ec573",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/syncovery/darwin.json
+++ b/ee/maintained-apps/outputs/syncovery/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.15.8",
+      "version": "11.15.14",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '11.15.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '11.15.14') < 0);"
       },
-      "installer_url": "https://www.syncovery.com/release/SyncoveryMac11.15.8-Apple.dmg",
+      "installer_url": "https://www.syncovery.com/release/SyncoveryMac11.15.14-Apple.dmg",
       "install_script_ref": "618d4067",
       "uninstall_script_ref": "04c1cc55",
-      "sha256": "090ec82d7c82ac16b65b0cbf47bf3235b0aaa5edd048c9a6e3a1cdfec66a4257",
+      "sha256": "45ffff57cc7e5619ebd8cd67dd6ad3e492bc81a6fa0060c7bf4e4cac8c7638ad",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/telegram/windows.json
+++ b/ee/maintained-apps/outputs/telegram/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.9.2",
+      "version": "6.9.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC' AND version_compare(version, '6.9.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC' AND version_compare(version, '6.9.3') < 0);"
       },
-      "installer_url": "https://github.com/telegramdesktop/tdesktop/releases/download/v6.9.2/tsetup-x64.6.9.2.exe",
+      "installer_url": "https://github.com/telegramdesktop/tdesktop/releases/download/v6.9.3/tsetup-x64.6.9.3.exe",
       "install_script_ref": "0b88a95e",
       "uninstall_script_ref": "42311f1b",
-      "sha256": "d23053e6ae2d2c8c917e3e7b730cb42afc6bdfebf05bc68aa9e54ba3fe687ae7",
+      "sha256": "45aa94a591763118c5d3ba9481d3f97c0b95b5e56dc33c9b39311f7c46ee72c9",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -6,7 +6,7 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.13.7') < 0);"
       },
-      "installer_url": "https://download.typora.io/mac/Typora-1.13.7.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.13.7.dmg",
       "install_script_ref": "46cc7e99",
       "uninstall_script_ref": "a8ba94c9",
       "sha256": "756e4f64818958b5d9d291c467f7a9dddef90a7df9d0e9ead70ba3f746f4aa9b",

--- a/ee/maintained-apps/outputs/vuescan/darwin.json
+++ b/ee/maintained-apps/outputs/vuescan/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "9.8.54",
+      "version": "9.8.55",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hamrick.vuescan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hamrick.vuescan' AND version_compare(bundle_short_version, '9.8.54') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hamrick.vuescan' AND version_compare(bundle_short_version, '9.8.55') < 0);"
       },
       "installer_url": "https://www.hamrick.com/files/vuea6498.dmg",
       "install_script_ref": "efea8e55",

--- a/ee/maintained-apps/outputs/zen/darwin.json
+++ b/ee/maintained-apps/outputs/zen/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.21b",
+      "version": "1.21.1b",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.21b') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.21.1b') < 0);"
       },
-      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.21b/zen.macos-universal.dmg",
+      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.21.1b/zen.macos-universal.dmg",
       "install_script_ref": "fd25a9c8",
       "uninstall_script_ref": "6fa48a6f",
-      "sha256": "fb16e63d772771e39a6435fc97900448d4b3e16d591b36cf3081699fb019ace0",
+      "sha256": "5d362d21a685cf3ffa591705813ef9ddb0912454c72c2ec071ab4627bac83d50",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for 21 applications to support latest available versions across Windows and macOS. Includes updates for Android Studio, Audacity, AWS CLI, Bezel, CoconutBattery, Codex App, Cursor, Dropbox, FireAlpaca, Marked App, Microsoft Edge, Nextcloud Talk, Notesnook, NVIDIA GeForce Now, SoundAnchor, Spotify, Syncovery, Telegram, Typora, VueScan, and Zen Browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->