### PR TITLE
Clear idp cookie after succesful SSO

### DIFF
--- a/changes/47343-idp-cookie
+++ b/changes/47343-idp-cookie
@@ -1,0 +1,1 @@
+* Clear SSO authentication cookie after successful authentication.

--- a/changes/47343-idp-cookie
+++ b/changes/47343-idp-cookie
@@ -1,1 +1,1 @@
-* Clear SSO authentication cookie after successful authentication.
+* Clear SSO authentication cookie after successful authentication for fully-managed Android enrollment.

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -488,6 +488,7 @@
       const ANDROID_MDM_ENABLED = "{{.AndroidMDMEnabled}}" === "true";
       const MAC_MDM_ENABLED = "{{.MacMDMEnabled}}" == "true";
       const ERROR_MESSAGE = "{{.ErrorMessage}}";
+      const IDP_UUID = "{{.IdpUUID}}";
       const isFullyManaged = new URLSearchParams(window.location.search).has(
         "fully_managed",
         true
@@ -679,6 +680,12 @@
 
         if (fullyManaged) {
           url = url.concat("&fully_managed=true");
+        }
+
+        if (IDP_UUID) {
+          url = url.concat(
+            `&idp_uuid=${encodeURIComponent(IDP_UUID)}`
+          );
         }
 
         const response = await fetch(url, {

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -7,8 +7,6 @@ import (
 	"google.golang.org/api/androidmanagement/v1"
 )
 
-const byodIdpCookieName = "__Host-FLEETBYODIDP"
-
 type Service interface {
 	EnterpriseSignup(ctx context.Context) (*SignupDetails, error)
 	EnterpriseSignupCallback(ctx context.Context, signupToken string, enterpriseToken string) error
@@ -101,22 +99,4 @@ type EnterpriseSignupResponse struct {
 type EnrollmentTokenResponse struct {
 	*EnrollmentToken
 	DefaultResponse
-}
-
-// SetCookies clears the BYOD IdP cookie after an enrollment token is
-// successfully created so that subsequent enrollments require a fresh SSO
-// authentication instead of reusing a stale identity.
-func (r EnrollmentTokenResponse) SetCookies(_ context.Context, w http.ResponseWriter) {
-	if r.Err != nil {
-		return
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     byodIdpCookieName,
-		Value:    "",
-		Path:     "/",
-		MaxAge:   -1,
-		Secure:   true,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
 }

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -7,6 +7,8 @@ import (
 	"google.golang.org/api/androidmanagement/v1"
 )
 
+const byodIdpCookieName = "__Host-FLEETBYODIDP"
+
 type Service interface {
 	EnterpriseSignup(ctx context.Context) (*SignupDetails, error)
 	EnterpriseSignupCallback(ctx context.Context, signupToken string, enterpriseToken string) error
@@ -99,4 +101,22 @@ type EnterpriseSignupResponse struct {
 type EnrollmentTokenResponse struct {
 	*EnrollmentToken
 	DefaultResponse
+}
+
+// SetCookies clears the BYOD IdP cookie after an enrollment token is
+// successfully created so that subsequent enrollments require a fresh SSO
+// authentication instead of reusing a stale identity.
+func (r EnrollmentTokenResponse) SetCookies(_ context.Context, w http.ResponseWriter) {
+	if r.Err != nil {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     byodIdpCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -491,13 +491,21 @@ func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request
 		}
 	}
 
-	byodIdpCookie, err := r.Cookie(mdm.BYODIdpCookieName)
-
 	fullyManaged := false
 	fullyManagedParam := r.URL.Query().Get("fully_managed")
 	if fullyManagedParam == "true" || fullyManagedParam == "1" {
 		fullyManaged = true
 	}
+
+	if idpUUID := r.URL.Query().Get("idp_uuid"); idpUUID != "" {
+		return &enrollmentTokenRequest{
+			EnrollSecret: enrollSecret,
+			IdpUUID:      idpUUID,
+			FullyManaged: fullyManaged,
+		}, nil
+	}
+
+	byodIdpCookie, err := r.Cookie(mdm.BYODIdpCookieName)
 
 	if err == http.ErrNoCookie {
 		// We do not fail here if no cookie is found, we validate later down the line if it's required

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -174,14 +174,15 @@ func ServeEndUserEnrollOTA(
 
 		// Clear the BYOD IdP cookie now that we are about to render the enrollment page.
 		var idpUUID string
-		if authRequired {
+		fullyManaged := r.URL.Query().Get("fully_managed")
+		if authRequired && fullyManaged == "true" {
 			idpUUID = r.URL.Query().Get("enrollment_reference")
 			http.SetCookie(w, &http.Cookie{
 				Name:     shared_mdm.BYODIdpCookieName,
 				Value:    "",
 				Path:     "/",
 				MaxAge:   -1,
-				Secure:   true,
+				Secure:   cookieSecure,
 				HttpOnly: true,
 				SameSite: http.SameSiteLaxMode,
 			})

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -175,7 +175,7 @@ func ServeEndUserEnrollOTA(
 		// Clear the BYOD IdP cookie now that we are about to render the enrollment page.
 		var idpUUID string
 		fullyManaged := r.URL.Query().Get("fully_managed")
-		if authRequired && fullyManaged == "true" {
+		if authRequired && (fullyManaged == "true" || fullyManaged == "1") {
 			idpUUID = r.URL.Query().Get("enrollment_reference")
 			http.SetCookie(w, &http.Cookie{
 				Name:     shared_mdm.BYODIdpCookieName,

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -120,7 +120,7 @@ func ServeEndUserEnrollOTA(
 
 		errorMsg := r.URL.Query().Get("error")
 		if errorMsg != "" {
-			if err := renderEnrollPage(w, appCfg, urlPrefix, "", errorMsg, nonce); err != nil {
+			if err := renderEnrollPage(w, appCfg, urlPrefix, "", errorMsg, nonce, ""); err != nil {
 				herr(ctx, w, err.Error())
 			}
 			return
@@ -128,7 +128,7 @@ func ServeEndUserEnrollOTA(
 
 		enrollSecret := r.URL.Query().Get("enroll_secret")
 		if enrollSecret == "" {
-			if err := renderEnrollPage(w, appCfg, urlPrefix, "", "This URL is invalid. : Enroll secret is invalid. Please contact your IT admin.", nonce); err != nil {
+			if err := renderEnrollPage(w, appCfg, urlPrefix, "", "This URL is invalid. : Enroll secret is invalid. Please contact your IT admin.", nonce, ""); err != nil {
 				herr(ctx, w, err.Error())
 			}
 			return
@@ -171,7 +171,23 @@ func ServeEndUserEnrollOTA(
 		// if we get here, IdP SSO authentication is either not required, or has
 		// been successfully completed (we have a cookie with the IdP account
 		// reference).
-		if err := renderEnrollPage(w, appCfg, urlPrefix, enrollSecret, "", nonce); err != nil {
+
+		// Clear the BYOD IdP cookie now that we are about to render the enrollment page.
+		var idpUUID string
+		if authRequired {
+			idpUUID = r.URL.Query().Get("enrollment_reference")
+			http.SetCookie(w, &http.Cookie{
+				Name:     shared_mdm.BYODIdpCookieName,
+				Value:    "",
+				Path:     "/",
+				MaxAge:   -1,
+				Secure:   true,
+				HttpOnly: true,
+				SameSite: http.SameSiteLaxMode,
+			})
+		}
+
+		if err := renderEnrollPage(w, appCfg, urlPrefix, enrollSecret, "", nonce, idpUUID); err != nil {
 			herr(ctx, w, err.Error())
 			return
 		}
@@ -195,7 +211,7 @@ func generateEnrollOTAURL(fleetURL string, enrollSecret string) (string, error) 
 	return enrollURL.String(), nil
 }
 
-func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSecret, errorMessage, nonce string) error {
+func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSecret, errorMessage, nonce, idpUUID string) error {
 	fs := newBinaryFileSystem("/frontend")
 	file, err := fs.Open("templates/enroll-ota.html")
 	if err != nil {
@@ -224,6 +240,7 @@ func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSec
 		MacMDMEnabled         bool
 		AndroidFeatureEnabled bool
 		CSPNonce              string
+		IdpUUID               string
 	}{
 		URLPrefix:             urlPrefix,
 		EnrollURL:             enrollURL,
@@ -232,6 +249,7 @@ func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSec
 		MacMDMEnabled:         appCfg.MDM.EnabledAndConfigured,
 		AndroidFeatureEnabled: true,
 		CSPNonce:              nonce,
+		IdpUUID:               idpUUID,
 	}); err != nil {
 		return fmt.Errorf("execute react template: %w", err)
 	}

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"testing"
 
-	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/assert"

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 )
 
 func TestServeFrontend(t *testing.T) {
@@ -104,4 +106,88 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 			require.Contains(t, bodyString, fmt.Sprintf(`const MAC_MDM_ENABLED = "%t" == "true";`, enabled))
 		})
 	}
+}
+
+func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
+	if !hasBuildTag("full") {
+		t.Skip("This test requires running with -tags full")
+	}
+
+	ds := new(mock.DataStore)
+	ds.HasUsersFunc = func(ctx context.Context) (bool, error) {
+		return true, nil
+	}
+	teamID := uint(1)
+	ds.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+		return &fleet.EnrollSecret{Secret: secret, TeamID: &teamID}, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{
+			ID: id,
+			Config: fleet.TeamConfigLite{
+				MDM: fleet.TeamMDM{
+					MacOSSetup: fleet.MacOSSetup{
+						EnableEndUserAuthentication: true,
+					},
+				},
+			},
+		}, nil
+	}
+	appCfg := &fleet.AppConfig{
+		MDM: fleet.MDM{
+			EnabledAndConfigured:        true,
+			AndroidEnabledAndConfigured: true,
+		},
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return appCfg, nil
+	}
+
+	svc, _ := newTestService(t, ds, nil, nil)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	h := ServeEndUserEnrollOTA(svc, "", ds, logger, false)
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+	})
+
+	idpUUID := "test-idp-uuid-1234"
+
+	// Simulate a request with a valid BYOD cookie + matching enrollment_reference
+	// for a fully-managed Android enrollment.
+	req, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&fully_managed=true&enrollment_reference="+idpUUID, nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{
+		Name:  shared_mdm.BYODIdpCookieName,
+		Value: idpUUID,
+	})
+
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse // don't follow redirects
+	}}
+	response, err := client.Do(req)
+	require.NoError(t, err)
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	// Assert that Set-Cookie header is present and clears the BYOD cookie.
+	setCookieHeaders := response.Header.Values("Set-Cookie")
+	var foundClear bool
+	for _, sc := range setCookieHeaders {
+		if assert.ObjectsAreEqual(true, true) &&
+			len(sc) > 0 &&
+			bytes.Contains([]byte(sc), []byte(shared_mdm.BYODIdpCookieName)) &&
+			bytes.Contains([]byte(sc), []byte("Max-Age=0")) {
+			foundClear = true
+			break
+		}
+	}
+	require.True(t, foundClear, "expected Set-Cookie header to clear %s, got: %v", shared_mdm.BYODIdpCookieName, setCookieHeaders)
+
+	// Assert that the rendered HTML contains the IdP UUID for JS to use.
+	bodyBytes, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	bodyString := string(bodyBytes)
+	require.Contains(t, bodyString, fmt.Sprintf(`const IDP_UUID = "%s";`, idpUUID))
 }

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -173,9 +173,7 @@ func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 	setCookieHeaders := response.Header.Values("Set-Cookie")
 	var foundClear bool
 	for _, sc := range setCookieHeaders {
-		if assert.ObjectsAreEqual(true, true) &&
-			len(sc) > 0 &&
-			bytes.Contains([]byte(sc), []byte(shared_mdm.BYODIdpCookieName)) &&
+		if bytes.Contains([]byte(sc), []byte(shared_mdm.BYODIdpCookieName)) &&
 			bytes.Contains([]byte(sc), []byte("Max-Age=0")) {
 			foundClear = true
 			break
@@ -188,4 +186,32 @@ func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 	require.NoError(t, err)
 	bodyString := string(bodyBytes)
 	require.Contains(t, bodyString, fmt.Sprintf(`const IDP_UUID = "%s";`, idpUUID))
+
+	// BYOD (non-fully-managed) requests should NOT clear the cookie
+	req2, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&enrollment_reference="+idpUUID, nil)
+	require.NoError(t, err)
+	req2.AddCookie(&http.Cookie{
+		Name:  shared_mdm.BYODIdpCookieName,
+		Value: idpUUID,
+	})
+
+	response2, err := client.Do(req2)
+	require.NoError(t, err)
+	defer response2.Body.Close()
+
+	require.Equal(t, http.StatusOK, response2.StatusCode)
+
+	setCookieHeaders2 := response2.Header.Values("Set-Cookie")
+	for _, sc := range setCookieHeaders2 {
+		require.False(t,
+			bytes.Contains([]byte(sc), []byte(shared_mdm.BYODIdpCookieName)) &&
+				bytes.Contains([]byte(sc), []byte("Max-Age=0")),
+			"BYOD request should not clear %s, got: %v", shared_mdm.BYODIdpCookieName, setCookieHeaders2,
+		)
+	}
+
+	// Assert that BYOD rendered HTML has an empty IdP UUID (not passed through template).
+	bodyBytes2, err := io.ReadAll(response2.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(bodyBytes2), `const IDP_UUID = "";`)
 }

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -11,12 +11,12 @@ import (
 	"os"
 	"testing"
 
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 )
 
 func TestServeFrontend(t *testing.T) {
@@ -162,9 +162,7 @@ func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 		Value: idpUUID,
 	})
 
-	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse // don't follow redirects
-	}}
+	client := fleethttp.NewClient(fleethttp.WithFollowRedir(false))
 	response, err := client.Do(req)
 	require.NoError(t, err)
 	defer response.Body.Close()

--- a/server/service/integrationtest/android/android_test.go
+++ b/server/service/integrationtest/android/android_test.go
@@ -266,6 +266,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true&idp_uuid=%s", globalSecret, idpAccount.UUID),
 				nil, http.StatusOK, nil,
 			)
+			defer resp.Body.Close()
 
 			bodyBytes, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
@@ -322,6 +323,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 					"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, cookieAccount.UUID),
 				},
 			)
+			defer resp.Body.Close()
 
 			bodyBytes, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)

--- a/server/service/integrationtest/android/android_test.go
+++ b/server/service/integrationtest/android/android_test.go
@@ -247,6 +247,106 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			})
 		})
 
+		t.Run("when idp_uuid is passed as query param", func(t *testing.T) {
+			enableAndroidMDM()
+			createTeamAndSecret(globalSecret, globalSecret, true)
+			setupAndroidEnterprise()
+			idpEmail := "queryparam@local.com"
+			err := s.DS.InsertMDMIdPAccount(t.Context(), &fleet.MDMIdPAccount{
+				Username: "queryparam",
+				Email:    idpEmail,
+			})
+			require.NoError(t, err)
+			idpAccount, err := s.DS.GetMDMIdPAccountByEmail(t.Context(), idpEmail)
+			require.NoError(t, err)
+
+			// Pass idp_uuid as query parameter (no cookie). This is the path
+			// used after the BYOD cookie is cleared for fully-managed Android.
+			resp := s.DoRawWithHeaders(t, "GET",
+				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true&idp_uuid=%s", globalSecret, idpAccount.UUID),
+				nil, http.StatusOK, nil,
+			)
+
+			bodyBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			var etr android.EnrollmentTokenResponse
+			err = json.Unmarshal(bodyBytes, &etr)
+			require.NoError(t, err)
+
+			decoded, err := base64.StdEncoding.DecodeString(etr.EnrollmentToken.EnrollmentToken)
+			require.NoError(t, err)
+			var et androidmanagement.EnrollmentToken
+			err = json.Unmarshal(decoded, &et)
+			require.NoError(t, err)
+
+			require.Equal(t, "PERSONAL_USAGE_DISALLOWED", et.AllowPersonalUsage)
+
+			var enrollmentRequest enrollmentTokenRequest
+			err = json.Unmarshal([]byte(et.AdditionalData), &enrollmentRequest)
+			require.NoError(t, err)
+
+			require.Equal(t, globalSecret, enrollmentRequest.EnrollSecret)
+			require.Equal(t, idpAccount.UUID, enrollmentRequest.IdpUUID)
+
+			t.Cleanup(func() {
+				mysqltest.TruncateTables(t, s.DS)
+			})
+		})
+
+		t.Run("when idp_uuid query param takes precedence over cookie", func(t *testing.T) {
+			enableAndroidMDM()
+			createTeamAndSecret(globalSecret, globalSecret, true)
+			setupAndroidEnterprise()
+
+			// Create two IdP accounts
+			err := s.DS.InsertMDMIdPAccount(t.Context(), &fleet.MDMIdPAccount{
+				Username: "cookie-user",
+				Email:    "cookie@local.com",
+			})
+			require.NoError(t, err)
+			cookieAccount, err := s.DS.GetMDMIdPAccountByEmail(t.Context(), "cookie@local.com")
+			require.NoError(t, err)
+
+			err = s.DS.InsertMDMIdPAccount(t.Context(), &fleet.MDMIdPAccount{
+				Username: "param-user",
+				Email:    "param@local.com",
+			})
+			require.NoError(t, err)
+			paramAccount, err := s.DS.GetMDMIdPAccountByEmail(t.Context(), "param@local.com")
+			require.NoError(t, err)
+
+			// Send both cookie and query param with different UUIDs
+			resp := s.DoRawWithHeaders(t, "GET",
+				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true&idp_uuid=%s", globalSecret, paramAccount.UUID),
+				nil, http.StatusOK, map[string]string{
+					"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, cookieAccount.UUID),
+				},
+			)
+
+			bodyBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			var etr android.EnrollmentTokenResponse
+			err = json.Unmarshal(bodyBytes, &etr)
+			require.NoError(t, err)
+
+			decoded, err := base64.StdEncoding.DecodeString(etr.EnrollmentToken.EnrollmentToken)
+			require.NoError(t, err)
+			var et androidmanagement.EnrollmentToken
+			err = json.Unmarshal(decoded, &et)
+			require.NoError(t, err)
+
+			var enrollmentRequest enrollmentTokenRequest
+			err = json.Unmarshal([]byte(et.AdditionalData), &enrollmentRequest)
+			require.NoError(t, err)
+
+			// Query param UUID should win over cookie UUID
+			require.Equal(t, paramAccount.UUID, enrollmentRequest.IdpUUID)
+
+			t.Cleanup(func() {
+				mysqltest.TruncateTables(t, s.DS)
+			})
+		})
+
 		t.Run("when fully_managed is true", func(t *testing.T) {
 			enableAndroidMDM()
 			createTeamAndSecret(globalSecret, globalSecret, false)


### PR DESCRIPTION
**Related issue:** Resolves #47343

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing an identity provider (IdP) UUID in enrollment-token requests via an `idp_uuid` query parameter, affecting both fully-managed and non-fully-managed flows.
  * Enrollment OTA now carries the IdP UUID into the enrollment flow and token request, with server-rendered pages exposing the selected IdP when applicable.

* **Bug Fixes**
  * For fully-managed enrollments, the IdP/SSO cookie is cleared after successful authentication to avoid stale IdP selection.

* **Tests**
  * Extended coverage for `idp_uuid` precedence over the IdP cookie and for cookie-clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->