### PR TITLE
Filter OTEL by environment

### DIFF
--- a/changes/47573-signoz-dashboards-deployment-environment
+++ b/changes/47573-signoz-dashboards-deployment-environment
@@ -1,0 +1,1 @@
+* Updated the SigNoz OTEL dashboards under `tools/signoz/` to template and filter on the `deployment.environment` resource attribute, with the environment variable defaulting to `default`, so multiple Fleet environments reporting to the same SigNoz backend can be scoped per environment.

--- a/cmd/fleet/otel.go
+++ b/cmd/fleet/otel.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/platform/tracing"
 	"github.com/fleetdm/fleet/v4/server/version"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -36,12 +37,16 @@ func initOTELProviders(cfg config.FleetConfig, traceRegistry *tracing.Registry, 
 	}
 
 	// Create shared resource with service identification attributes. OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES env vars
-	// can override the defaults below.
+	// can override the defaults below. resource.WithFromEnv() runs after WithAttributes, so env-provided values win on conflict.
+	// We always emit a deployment.environment so the attribute key exists in every SigNoz instance Fleet reports to. This lets
+	// dashboards use a dynamic environment selector.
 	res, err := resource.New(context.Background(),
 		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(
 			semconv.ServiceName("fleet"),
 			semconv.ServiceVersion(version.Version().Version),
+			semconv.DeploymentEnvironmentName("default"),
+			attribute.String("deployment.environment", "default"), // 2026-06-14: deprecated attribute still used by SigNoz
 		),
 		resource.WithFromEnv(),
 		resource.WithTelemetrySDK(),

--- a/tools/signoz/README.md
+++ b/tools/signoz/README.md
@@ -91,3 +91,6 @@ JSON exports of Fleet-specific SigNoz dashboards live alongside this README. Imp
 
 - `database_custom_dashboard.json` — MySQL query metrics (RPS, latency, slow queries) derived from `db.sql.*` instrumentation.
 - `host_cache_dashboard.json` — Redis-backed host lookup cache (`LoadHostByNodeKey` / `LoadHostByOrbitNodeKey`). Shows hit rate over time, lookups/sec by result, errors/sec by op, and invalidations/sec by write-path reason. Requires `FLEET_REDIS_HOST_CACHE_ENABLED=true` (default on).
+- `http_errors_dashboard.json` — Fleet HTTP errors (the "Errors" signal of the RED method / Google SRE Golden Signals). Shows 4XX client errors and 5XX server errors from `fleet.http.client_errors` / `fleet.http.server_errors`, broken down by `error.type`.
+
+Each dashboard includes an `environment` selector (a dynamic dashboard variable on the `deployment.environment` resource attribute) so you can scope panels to a single deployment or view all. It defaults to ALL. Fleet always emits `deployment.environment` (default value `default`, overridable via `OTEL_RESOURCE_ATTRIBUTES`), so the selector populates on any instance Fleet reports to.

--- a/tools/signoz/database_custom_dashboard.json
+++ b/tools/signoz/database_custom_dashboard.json
@@ -1,1742 +1,1593 @@
 {
-    "layout": [
+  "title": "DB & Connection Observability",
+  "description": "MySQL client observability from db.sql.* instrumentation: query rate, latency, error rate, and connection-pool health.",
+  "tags": [
+    "mysql",
+    "database"
+  ],
+  "variables": {
+    "environment": {
+      "id": "environment",
+      "name": "environment",
+      "description": "Deployment environment to view, auto-discovered from the deployment.environment resource attribute. Fleet always emits deployment.environment (default value 'default', overridable via OTEL_RESOURCE_ATTRIBUTES) so this key exists in every SigNoz instance Fleet reports to, which makes the dynamic lookup safe. Defaults to ALL so all environments show.",
+      "type": "DYNAMIC",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "customValue": "",
+      "queryValue": "",
+      "textboxValue": "",
+      "multiSelect": true,
+      "showALLOption": true,
+      "sort": "ASC",
+      "selectedValue": "__all__",
+      "allSelected": true,
+      "order": 0
+    }
+  },
+  "layout": [
+    {
+      "i": "rps",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "avg-dur",
+      "x": 6,
+      "y": 0,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "83588a79-739c-4842-89ec-63c74e1e0125",
+      "x": 0,
+      "y": 6,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "5316909f-3d26-4649-81d4-7d4db19a31f9",
+      "x": 6,
+      "y": 6,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "bba90ad8-179b-434e-b09e-86f024f1611e",
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "2bccc3f8-da0b-40ac-9115-d26c09356033",
+      "x": 6,
+      "y": 12,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "f881f862-6665-40be-81d6-1af5084d29d2",
+      "x": 0,
+      "y": 18,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "afe9e692-fcba-414a-812d-bf7826085a5e",
+      "x": 6,
+      "y": 18,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "3211ae8b-f9b2-4c1e-86b3-b214013065de",
+      "x": 0,
+      "y": 24,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "342b3cf0-b6bc-4ca7-86b3-dc11806a8d88",
+      "x": 6,
+      "y": 24,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "cc2a2fea-09eb-4736-868a-9316eeb3820d",
+      "x": 0,
+      "y": 30,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "404b92ed-c805-4b1b-b2c3-37f98ff25cb3",
+      "x": 6,
+      "y": 30,
+      "w": 6,
+      "h": 6
+    }
+  ],
+  "widgets": [
+    {
+      "id": "rps",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "queryName": "A"
+            }
+          ]
+        },
+        "queryType": "builder"
+      },
+      "title": "Database Calls RPS"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "avg-dur",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.sum",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B",
+              "legend": "Avg Duration",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "dc3e9384-6d94-4bb5-99cb-cc027f8b3737",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Average Query Duration",
+      "yAxisUnit": "ms"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "83588a79-739c-4842-89ec-63c74e1e0125",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "histogram_quantile(0.99)",
+              "legend": "",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5eefa7f4-1096-4bae-aaf0-4ee5f974987f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
         {
-            "h": 6,
-            "i": "rps",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 0,
-            "y": 0
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
         },
         {
-            "h": 6,
-            "i": "avg-dur",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 6,
-            "y": 0
-        },
-        {
-            "h": 6,
-            "i": "83588a79-739c-4842-89ec-63c74e1e0125",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 0,
-            "y": 6
-        },
-        {
-            "h": 6,
-            "i": "5316909f-3d26-4649-81d4-7d4db19a31f9",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 6,
-            "y": 6
-        },
-        {
-            "h": 6,
-            "i": "bba90ad8-179b-434e-b09e-86f024f1611e",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 0,
-            "y": 12
-        },
-        {
-            "h": 6,
-            "i": "2bccc3f8-da0b-40ac-9115-d26c09356033",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 6,
-            "y": 12
-        },
-        {
-            "h": 6,
-            "i": "f881f862-6665-40be-81d6-1af5084d29d2",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 0,
-            "y": 18
-        },
-        {
-            "h": 6,
-            "i": "afe9e692-fcba-414a-812d-bf7826085a5e",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 6,
-            "y": 18
-        },
-        {
-            "h": 6,
-            "i": "3211ae8b-f9b2-4c1e-86b3-b214013065de",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 0,
-            "y": 24
-        },
-        {
-            "h": 6,
-            "i": "342b3cf0-b6bc-4ca7-86b3-dc11806a8d88",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 6,
-            "y": 24
-        },
-        {
-            "h": 6,
-            "i": "cc2a2fea-09eb-4736-868a-9316eeb3820d",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 0,
-            "y": 30
-        },
-        {
-            "h": 6,
-            "i": "404b92ed-c805-4b1b-b2c3-37f98ff25cb3",
-            "moved": false,
-            "static": false,
-            "w": 6,
-            "x": 6,
-            "y": 30
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
         }
-    ],
-    "panelMap": {},
-    "title": "DB & Connection Observability",
-    "uploadedGrafana": false,
-    "version": "v5",
-    "widgets": [
+      ],
+      "selectedTracesFields": [
         {
-            "id": "rps",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.count",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "sum",
-                                    "timeAggregation": "rate"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "queryName": "A"
-                        }
-                    ]
-                },
-                "queryType": "builder"
-            },
-            "title": "Database Calls RPS",
-            "type": "timeseries"
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
         },
         {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "avg-dur",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.sum",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "sum",
-                                    "timeAggregation": "rate"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": true,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        },
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.count",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "sum",
-                                    "timeAggregation": "rate"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": true,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "B",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [
-                        {
-                            "disabled": false,
-                            "expression": "A / B",
-                            "legend": "Avg Duration",
-                            "queryName": "F1"
-                        }
-                    ]
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "dc3e9384-6d94-4bb5-99cb-cc027f8b3737",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [],
-            "selectedTracesFields": [],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Average Query Duration",
-            "type": "timeseries",
-            "yAxisUnit": "ms"
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
         },
         {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "83588a79-739c-4842-89ec-63c74e1e0125",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.bucket",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        },
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.bucket",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "B",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "B",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [
-                        {
-                            "disabled": false,
-                            "expression": "histogram_quantile(0.99)",
-                            "legend": "",
-                            "queryName": "F1"
-                        }
-                    ],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "5eefa7f4-1096-4bae-aaf0-4ee5f974987f",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "P99 Latency",
-            "yAxisUnit": "ms"
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
         },
         {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "bba90ad8-179b-434e-b09e-86f024f1611e",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.count",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "sum",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [
-                                {
-                                    "dataType": "",
-                                    "id": "state----",
-                                    "key": "state",
-                                    "type": ""
-                                }
-                            ],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "2be716da-5e6f-4675-a056-9d6ad723821e",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Conn Occupancy",
-            "yAxisUnit": ""
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
         },
         {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "5316909f-3d26-4649-81d4-7d4db19a31f9",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "value",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.count",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        },
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.max",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "B",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "B",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [
-                        {
-                            "disabled": false,
-                            "expression": "(A / B) * 100",
-                            "legend": "percent",
-                            "queryName": "F1"
-                        }
-                    ],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "f375d73d-193b-4010-aaee-5226328feb66",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Pool Saturation %",
-            "yAxisUnit": "none"
-        },
-        {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "f881f862-6665-40be-81d6-1af5084d29d2",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.wait_time",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "17d784a3-1019-4e5f-aea0-6f372cf9d7d6",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Avg Connection Wait Time",
-            "yAxisUnit": "ms"
-        },
-        {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "2bccc3f8-da0b-40ac-9115-d26c09356033",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.wait_count",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "a3012b77-e868-45dc-88e1-adea1355ff7b",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Pending Requests (Queue)",
-            "yAxisUnit": ""
-        },
-        {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "3211ae8b-f9b2-4c1e-86b3-b214013065de",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.count",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": "status IN (\"idle\") "
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "5949afcc-96c2-40cf-b09f-dc350294d082",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Connection Churn Rate",
-            "yAxisUnit": "none"
-        },
-        {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "afe9e692-fcba-414a-812d-bf7826085a5e",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.wait_time",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        },
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.sum",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "B",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "B",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [
-                        {
-                            "disabled": false,
-                            "expression": "A / B",
-                            "legend": "",
-                            "queryName": "F1"
-                        }
-                    ],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "71685f66-f214-4e8d-bf26-07861d5057c5",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Wait-to-Work Ratio",
-            "yAxisUnit": "ms"
-        },
-        {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "342b3cf0-b6bc-4ca7-86b3-dc11806a8d88",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.closed.max_idle",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        },
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.client.connection.closed.max_idle_time",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "B",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "B",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [
-                        {
-                            "disabled": false,
-                            "expression": "A+B",
-                            "legend": "",
-                            "queryName": "F1"
-                        }
-                    ],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "79737dbb-50a6-4558-af3a-134984415420",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Idle Limit Evictions",
-            "yAxisUnit": "none"
-        },
-        {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "cc2a2fea-09eb-4736-868a-9316eeb3820d",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.max",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "8e3d11a7-5122-40a0-a59f-72b60520c771",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Max Queue Latency",
-            "yAxisUnit": "ms"
-        },
-        {
-            "bucketCount": 30,
-            "bucketWidth": 0,
-            "columnUnits": {},
-            "contextLinks": {
-                "linksData": []
-            },
-            "customLegendColors": {},
-            "decimalPrecision": 2,
-            "description": "",
-            "fillSpans": false,
-            "id": "404b92ed-c805-4b1b-b2c3-37f98ff25cb3",
-            "isLogScale": false,
-            "legendPosition": "bottom",
-            "mergeAllActiveQueries": false,
-            "nullZeroValues": "zero",
-            "opacity": "1",
-            "panelTypes": "graph",
-            "query": {
-                "builder": {
-                    "queryData": [
-                        {
-                            "aggregations": [
-                                {
-                                    "metricName": "db.sql.latency.min",
-                                    "reduceTo": "avg",
-                                    "spaceAggregation": "avg",
-                                    "temporality": "",
-                                    "timeAggregation": "avg"
-                                }
-                            ],
-                            "dataSource": "metrics",
-                            "disabled": false,
-                            "expression": "A",
-                            "filter": {
-                                "expression": ""
-                            },
-                            "functions": [],
-                            "groupBy": [],
-                            "having": {
-                                "expression": ""
-                            },
-                            "legend": "",
-                            "limit": null,
-                            "orderBy": [],
-                            "queryName": "A",
-                            "source": "",
-                            "stepInterval": null
-                        }
-                    ],
-                    "queryFormulas": [],
-                    "queryTraceOperator": []
-                },
-                "clickhouse_sql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "id": "64ba4c3f-dc9f-41dc-9963-b7c545cb29a7",
-                "promql": [
-                    {
-                        "disabled": false,
-                        "legend": "",
-                        "name": "A",
-                        "query": ""
-                    }
-                ],
-                "queryType": "builder",
-                "unit": ""
-            },
-            "selectedLogFields": [
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "timestamp",
-                    "signal": "logs",
-                    "type": "log"
-                },
-                {
-                    "dataType": "",
-                    "fieldContext": "log",
-                    "fieldDataType": "",
-                    "isIndexed": false,
-                    "name": "body",
-                    "signal": "logs",
-                    "type": "log"
-                }
-            ],
-            "selectedTracesFields": [
-                {
-                    "fieldContext": "resource",
-                    "fieldDataType": "string",
-                    "name": "service.name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "string",
-                    "name": "name",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "duration_nano",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "http_method",
-                    "signal": "traces"
-                },
-                {
-                    "fieldContext": "span",
-                    "fieldDataType": "",
-                    "name": "response_status_code",
-                    "signal": "traces"
-                }
-            ],
-            "softMax": 0,
-            "softMin": 0,
-            "stackedBarChart": false,
-            "thresholds": [],
-            "timePreferance": "GLOBAL_TIME",
-            "title": "Min queue latency",
-            "yAxisUnit": "ms"
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
         }
-    ],
-    "uuid": "019d0766-4fc4-73e0-b272-dd7cdbe5f67b"
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "P99 Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "bba90ad8-179b-434e-b09e-86f024f1611e",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "",
+                  "id": "state----",
+                  "key": "state",
+                  "type": ""
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2be716da-5e6f-4675-a056-9d6ad723821e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Conn Occupancy",
+      "yAxisUnit": ""
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "5316909f-3d26-4649-81d4-7d4db19a31f9",
+      "legendPosition": "bottom",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.max",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "(A / B) * 100",
+              "legend": "percent",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f375d73d-193b-4010-aaee-5226328feb66",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Pool Saturation %",
+      "yAxisUnit": "none"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "f881f862-6665-40be-81d6-1af5084d29d2",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.wait_time",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "17d784a3-1019-4e5f-aea0-6f372cf9d7d6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Avg Connection Wait Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "2bccc3f8-da0b-40ac-9115-d26c09356033",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.wait_count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a3012b77-e868-45dc-88e1-adea1355ff7b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Pending Requests (Queue)",
+      "yAxisUnit": ""
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "3211ae8b-f9b2-4c1e-86b3-b214013065de",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "status IN (\"idle\") AND deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5949afcc-96c2-40cf-b09f-dc350294d082",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Connection Churn Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "afe9e692-fcba-414a-812d-bf7826085a5e",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.wait_time",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.sum",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B",
+              "legend": "",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "71685f66-f214-4e8d-bf26-07861d5057c5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Wait-to-Work Ratio",
+      "yAxisUnit": "ms"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "342b3cf0-b6bc-4ca7-86b3-dc11806a8d88",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.closed.max_idle",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.client.connection.closed.max_idle_time",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A+B",
+              "legend": "",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "79737dbb-50a6-4558-af3a-134984415420",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Idle Limit Evictions",
+      "yAxisUnit": "none"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "cc2a2fea-09eb-4736-868a-9316eeb3820d",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.max",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8e3d11a7-5122-40a0-a59f-72b60520c771",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Max Queue Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "404b92ed-c805-4b1b-b2c3-37f98ff25cb3",
+      "legendPosition": "bottom",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "db.sql.latency.min",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "64ba4c3f-dc9f-41dc-9963-b7c545cb29a7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Min queue latency",
+      "yAxisUnit": "ms"
+    }
+  ]
 }

--- a/tools/signoz/database_custom_dashboard.json
+++ b/tools/signoz/database_custom_dashboard.json
@@ -258,9 +258,9 @@
                 {
                   "metricName": "db.sql.latency.bucket",
                   "reduceTo": "avg",
-                  "spaceAggregation": "avg",
-                  "temporality": "",
-                  "timeAggregation": "avg"
+                  "spaceAggregation": "p99",
+                  "temporality": "cumulative",
+                  "timeAggregation": ""
                 }
               ],
               "dataSource": "metrics",
@@ -274,50 +274,15 @@
               "having": {
                 "expression": ""
               },
-              "legend": "",
+              "legend": "p99",
               "limit": null,
               "orderBy": [],
               "queryName": "A",
               "source": "",
               "stepInterval": null
-            },
-            {
-              "aggregations": [
-                {
-                  "metricName": "db.sql.latency.bucket",
-                  "reduceTo": "avg",
-                  "spaceAggregation": "avg",
-                  "temporality": "",
-                  "timeAggregation": "avg"
-                }
-              ],
-              "dataSource": "metrics",
-              "disabled": false,
-              "expression": "B",
-              "filter": {
-                "expression": "deployment.environment IN $environment"
-              },
-              "functions": [],
-              "groupBy": [],
-              "having": {
-                "expression": ""
-              },
-              "legend": "",
-              "limit": null,
-              "orderBy": [],
-              "queryName": "B",
-              "source": "",
-              "stepInterval": null
             }
           ],
-          "queryFormulas": [
-            {
-              "disabled": false,
-              "expression": "histogram_quantile(0.99)",
-              "legend": "",
-              "queryName": "F1"
-            }
-          ],
+          "queryFormulas": [],
           "queryTraceOperator": []
         },
         "clickhouse_sql": [

--- a/tools/signoz/database_custom_dashboard.json
+++ b/tools/signoz/database_custom_dashboard.json
@@ -1,10 +1,7 @@
 {
-  "title": "DB & Connection Observability",
+  "title": "Fleet DB & Connection Observability",
   "description": "MySQL client observability from db.sql.* instrumentation: query rate, latency, error rate, and connection-pool health.",
-  "tags": [
-    "mysql",
-    "database"
-  ],
+  "tags": ["mysql", "database"],
   "variables": {
     "environment": {
       "id": "environment",
@@ -128,7 +125,7 @@
               ],
               "dataSource": "metrics",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -164,7 +161,7 @@
               "disabled": true,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -191,7 +188,7 @@
               "disabled": true,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -267,7 +264,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -387,7 +384,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [
@@ -514,7 +511,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -542,7 +539,7 @@
               "disabled": false,
               "expression": "B",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -669,7 +666,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -789,7 +786,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -909,7 +906,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "status IN (\"idle\") AND deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND status IN (\"idle\") AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -1029,7 +1026,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -1057,7 +1054,7 @@
               "disabled": false,
               "expression": "B",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -1184,7 +1181,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -1212,7 +1209,7 @@
               "disabled": false,
               "expression": "B",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -1339,7 +1336,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],
@@ -1459,7 +1456,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [],

--- a/tools/signoz/host_cache_dashboard.json
+++ b/tools/signoz/host_cache_dashboard.json
@@ -66,7 +66,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "result IN ['hit', 'negative_hit'] AND deployment.environment IN $environment" },
+              "filter": { "expression": "service.name = 'fleet' AND result IN ['hit', 'negative_hit'] AND deployment.environment IN $environment" },
               "groupBy": [],
               "orderBy": [],
               "selectColumns": [],
@@ -86,7 +86,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "deployment.environment IN $environment" },
+              "filter": { "expression": "service.name = 'fleet' AND deployment.environment IN $environment" },
               "groupBy": [],
               "orderBy": [],
               "selectColumns": [],
@@ -136,7 +136,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "deployment.environment IN $environment" },
+              "filter": { "expression": "service.name = 'fleet' AND deployment.environment IN $environment" },
               "groupBy": [
                 { "key": "result", "dataType": "string", "type": "tag" }
               ],
@@ -180,7 +180,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "deployment.environment IN $environment" },
+              "filter": { "expression": "service.name = 'fleet' AND deployment.environment IN $environment" },
               "groupBy": [
                 { "key": "op", "dataType": "string", "type": "tag" }
               ],
@@ -225,7 +225,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "deployment.environment IN $environment" },
+              "filter": { "expression": "service.name = 'fleet' AND deployment.environment IN $environment" },
               "groupBy": [
                 { "key": "reason", "dataType": "string", "type": "tag" }
               ],

--- a/tools/signoz/host_cache_dashboard.json
+++ b/tools/signoz/host_cache_dashboard.json
@@ -2,6 +2,25 @@
   "title": "Fleet host cache",
   "description": "Observability for the Redis-backed host lookup cache fronting LoadHostByNodeKey and LoadHostByOrbitNodeKey. Shows hit rate, lookup volume by result, error volume by operation, and invalidation volume by write-path reason.",
   "tags": ["redis", "cache", "host-cache"],
+  "variables": {
+    "environment": {
+      "id": "environment",
+      "name": "environment",
+      "description": "Deployment environment to view, auto-discovered from the deployment.environment resource attribute. Fleet always emits deployment.environment (default value 'default', overridable via OTEL_RESOURCE_ATTRIBUTES) so this key exists in every SigNoz instance Fleet reports to, which is what makes the dynamic lookup safe. Defaults to ALL so all environments show.",
+      "type": "DYNAMIC",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "customValue": "",
+      "queryValue": "",
+      "textboxValue": "",
+      "multiSelect": true,
+      "showALLOption": true,
+      "sort": "ASC",
+      "selectedValue": "__all__",
+      "allSelected": true,
+      "order": 0
+    }
+  },
   "layout": [
     { "i": "row-overview",  "x": 0, "y": 0, "w": 12, "h": 1 },
     { "i": "hit-rate",      "x": 0, "y": 1, "w": 4,  "h": 4 },
@@ -24,7 +43,7 @@
       "id": "hit-rate",
       "panelTypes": "graph",
       "title": "Hit rate",
-      "description": "A/B where A = rate of hits + negative_hits (both Redis-served, both avoid MySQL), B = rate of all lookups. Target: >= 80% at steady state once the cache warms. Watch for drops during invalidation storms (mass team transfers, re-enrollments).",
+      "description": "A/B where A = rate of hits + negative_hits (both Redis-served, both avoid MySQL), B = rate of all lookups. Target: >= 90% at steady state once the cache warms. Watch for drops during invalidation storms (mass team transfers, re-enrollments).",
       "yAxisUnit": "percentunit",
       "legendPosition": "bottom",
       "query": {
@@ -47,7 +66,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "result IN ['hit', 'negative_hit']" },
+              "filter": { "expression": "result IN ['hit', 'negative_hit'] AND deployment.environment IN $environment" },
               "groupBy": [],
               "orderBy": [],
               "selectColumns": [],
@@ -67,7 +86,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "" },
+              "filter": { "expression": "deployment.environment IN $environment" },
               "groupBy": [],
               "orderBy": [],
               "selectColumns": [],
@@ -84,7 +103,7 @@
         }
       },
       "thresholds": [
-        { "index": "1", "keyIndex": 0, "thresholdColor": "Orange", "thresholdFormat": "Line", "thresholdOperator": "<", "thresholdUnit": "percentunit", "thresholdValue": 0.8 }
+        { "index": "1", "keyIndex": 0, "thresholdColor": "Orange", "thresholdFormat": "Line", "thresholdOperator": "<", "thresholdUnit": "percentunit", "thresholdValue": 0.9 }
       ],
       "selectedLogFields": [],
       "selectedTracesFields": [],
@@ -117,7 +136,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "" },
+              "filter": { "expression": "deployment.environment IN $environment" },
               "groupBy": [
                 { "key": "result", "dataType": "string", "type": "tag" }
               ],
@@ -161,7 +180,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "" },
+              "filter": { "expression": "deployment.environment IN $environment" },
               "groupBy": [
                 { "key": "op", "dataType": "string", "type": "tag" }
               ],
@@ -206,7 +225,7 @@
                   "spaceAggregation": "sum"
                 }
               ],
-              "filter": { "expression": "" },
+              "filter": { "expression": "deployment.environment IN $environment" },
               "groupBy": [
                 { "key": "reason", "dataType": "string", "type": "tag" }
               ],

--- a/tools/signoz/http_errors_dashboard.json
+++ b/tools/signoz/http_errors_dashboard.json
@@ -63,7 +63,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [
@@ -192,7 +192,7 @@
               "disabled": false,
               "expression": "A",
               "filter": {
-                "expression": "deployment.environment IN $environment"
+                "expression": "service.name = 'fleet' AND deployment.environment IN $environment"
               },
               "functions": [],
               "groupBy": [

--- a/tools/signoz/http_errors_dashboard.json
+++ b/tools/signoz/http_errors_dashboard.json
@@ -1,0 +1,300 @@
+{
+  "title": "Fleet HTTP errors",
+  "description": "HTTP error volume split by class: 4XX client errors and 5XX server errors, broken down by error.type. This is the 'Errors' signal of the RED method / Google SRE Golden Signals for the Fleet API.",
+  "tags": [],
+  "variables": {
+    "environment": {
+      "id": "environment",
+      "name": "environment",
+      "description": "Deployment environment to view, auto-discovered from the deployment.environment resource attribute. Fleet always emits deployment.environment (default value 'default', overridable via OTEL_RESOURCE_ATTRIBUTES) so this key exists in every SigNoz instance Fleet reports to, which makes the dynamic lookup safe. Defaults to ALL so all environments show.",
+      "type": "DYNAMIC",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "customValue": "",
+      "queryValue": "",
+      "textboxValue": "",
+      "multiSelect": true,
+      "showALLOption": true,
+      "sort": "ASC",
+      "selectedValue": "__all__",
+      "allSelected": true,
+      "order": 0
+    }
+  },
+  "layout": [
+    {
+      "i": "e597beb2-2c9f-4332-8a59-14d0700cd173",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "03714789-45d4-4f69-818e-664739417be4",
+      "x": 6,
+      "y": 0,
+      "w": 6,
+      "h": 6
+    }
+  ],
+  "widgets": [
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "e597beb2-2c9f-4332-8a59-14d0700cd173",
+      "legendPosition": "bottom",
+      "panelTypes": "bar",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "fleet.http.client_errors",
+                  "reduceTo": "sum",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "increase"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "error.type--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "error.type",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "770c0dbd-bf06-4228-8cd5-406716dda036",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": true,
+      "thresholds": [],
+      "title": "Client errors (4XX)",
+      "yAxisUnit": "{count}"
+    },
+    {
+      "contextLinks": {
+        "linksData": []
+      },
+      "description": "",
+      "id": "03714789-45d4-4f69-818e-664739417be4",
+      "legendPosition": "bottom",
+      "panelTypes": "bar",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "fleet.http.server_errors",
+                  "reduceTo": "sum",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "increase"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "deployment.environment IN $environment"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "error.type--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "error.type",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0477ae6c-0cd9-498e-86c9-50183cf05607",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "stackedBarChart": true,
+      "thresholds": [],
+      "title": "Server errors",
+      "yAxisUnit": "{count}"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47573

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Fleet HTTP errors” dashboard to monitor client (4XX) and server errors with environment-based filtering.
* **Improvements**
  * OTEL telemetry now reliably includes `deployment.environment`, defaulting to `default`.
  * Updated SigNoz dashboards to support dynamic environment selection for relevant queries.
  * Improved host cache dashboard hit-rate target and applied environment filtering across key panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->