### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/boltai/darwin.json
+++ b/ee/maintained-apps/outputs/boltai/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.13.3",
+      "version": "2.13.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.13.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.13.4') < 0);"
       },
-      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.13.3.dmg",
+      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.13.4.dmg",
       "install_script_ref": "fbb1d678",
       "uninstall_script_ref": "8c3f3ae8",
-      "sha256": "70d0256157ab1568c7bd85ac9227acc33bfb07abdbcb80ffe3f62112ebaa66c4",
+      "sha256": "5465bead0350daee7e5d9e3ed4ddd7c8f4eae51cd9b0e96908d9d44f1528c85a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.34.0",
+      "version": "0.35.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.34.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.35.0') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.34.0/CodexBar-macos-universal-0.34.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.35.0/CodexBar-macos-universal-0.35.0.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "f30ee3edef1629c99eb7e583dd2139d05a3127ec8a0e213701172fedf91fea39",
+      "sha256": "961525fe7b86e379a1b048fc5113f757867435d4ad6749494ef6fe9fa672c266",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.7.27",
+      "version": "3.7.36",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.7.27') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.7.36') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/e48ee6102a199492b0c9964699bf011886708ba3/win32/x64/system-setup/CursorSetup-x64-3.7.27.exe",
+      "installer_url": "https://downloads.cursor.com/production/776d1f9d76df50a4e0aeca61819a88e7c1b861e2/win32/x64/system-setup/CursorSetup-x64-3.7.36.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "9ed8f75379baf84b75a6539cb1296e5c7c3386c41f7f50fee8fe310b6e5ebe7d",
+      "sha256": "0e96adee52fb6ecc693a461984ff51db3a43705f653e950b38c86bbaa05ecb49",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dockside/darwin.json
+++ b/ee/maintained-apps/outputs/dockside/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.9.8",
+      "version": "2.9.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.10') < 0);"
       },
-      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.8/Dockside.dmg",
+      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.10/Dockside.dmg",
       "install_script_ref": "11c3511b",
       "uninstall_script_ref": "262fd2cc",
-      "sha256": "5e27090c0c8a8d0cf0a72d22aa124eef7675bd8fbb42653d933248d19dffd893",
+      "sha256": "78ac0c119bd8e263517c7c596b9150e8c47ace707b5f80a2c1d77063e4edb1d7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dropshare/darwin.json
+++ b/ee/maintained-apps/outputs/dropshare/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.12",
+      "version": "6.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.mkswap.Dropshare6';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.mkswap.Dropshare6' AND version_compare(bundle_short_version, '6.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.mkswap.Dropshare6' AND version_compare(bundle_short_version, '6.13') < 0);"
       },
-      "installer_url": "https://d2wvuuix8c9e48.cloudfront.net/Dropshare6-6227.app.zip",
+      "installer_url": "https://d2wvuuix8c9e48.cloudfront.net/Dropshare6-6249.app.zip",
       "install_script_ref": "4ff3b255",
       "uninstall_script_ref": "ea78fa85",
-      "sha256": "6f36425693093ad3fb1536051f761f152fca373198e0befaa5d8579ae7a73c7f",
+      "sha256": "456f08c30c00a1ac9e52b7d251561337c674e419b6758e739aec16fd4aacb989",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firealpaca/darwin.json
+++ b/ee/maintained-apps/outputs/firealpaca/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.15.2",
+      "version": "2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.16.0') < 0);"
       },
       "installer_url": "https://firealpaca.com/download/mac",
       "install_script_ref": "f2cad371",

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.1.27",
+      "version": "1.1.28",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.1.27') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.1.28') < 0);"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.1.27/Hive-1.1.27-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.1.28/Hive-1.1.28-arm64.dmg",
       "install_script_ref": "6b39e7ad",
       "uninstall_script_ref": "78bb4e43",
-      "sha256": "5749bfac1735b3c6167e2318bca2181503ff32521327e1f6b90a13f8a0fe9c08",
+      "sha256": "3da4172711c47e847d8fccbaa4a84d1460912148eedeaa37b0ccd01dbada4d67",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/melodics/darwin.json
+++ b/ee/maintained-apps/outputs/melodics/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.0.627",
+      "version": "5.0.639",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics' AND version_compare(bundle_short_version, '5.0.627') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics' AND version_compare(bundle_short_version, '5.0.639') < 0);"
       },
-      "installer_url": "https://web-cdn.melodics.com/download/AED19966-0D0E-4A4E-A29B-1C2D1688B662.zip",
+      "installer_url": "https://web-cdn.melodics.com/download/78BF0BF3-7D3C-4F20-9A1B-0E64B6D5B738.zip",
       "install_script_ref": "3d315b05",
       "uninstall_script_ref": "4abaa93b",
-      "sha256": "01a933f648481338914bd5c2e6995a9468f86af2c248fc49e618cd42ee20674e",
+      "sha256": "419ea11b539f3e4f8118b705628dd7361da675d3d1e85a696f3e739aadf2f112",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
+++ b/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.0.85.133",
+      "version": "2.0.85.135",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.85.133') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.85.135') < 0);"
       },
       "installer_url": "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg",
       "install_script_ref": "a9979922",

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17.5",
+      "version": "1.17.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.7') < 0);"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.5/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "727dc41e",
       "uninstall_script_ref": "ad62b190",
-      "sha256": "8805df39e6d7023f7d67c6d789024eee21fb47b47ab0077010fece693c934374",
+      "sha256": "aec61baf85b8983716f9b2e0718c143d6e7b562c03ae9e3030f9e28ccf4e91e7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.14.5",
+      "version": "12.15.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.14.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.15.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.14.5/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.15.0/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "497b1a4d4adc5d4a079e13620cf16de21501327596c2167a7e63b6921c082baa",
+      "sha256": "4c1db727762b1a03643c0d07d22bfa382bf5a933091a5c72702cce558145235b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.1",
+      "version": "3.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.3') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.1/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.3/Stats.dmg",
       "install_script_ref": "de9e4d0c",
       "uninstall_script_ref": "7e8d1240",
-      "sha256": "02366ebec9fed6d1ae3e3b968d63f72f0b7feb6d79cdc0acc8801ae800bae006",
+      "sha256": "1c4e4694d8d86537b672595c46c85020cb71525be9d16932e81c25e25a87e856",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/syncovery/darwin.json
+++ b/ee/maintained-apps/outputs/syncovery/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.15.14",
+      "version": "11.15.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '11.15.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '11.15.15') < 0);"
       },
-      "installer_url": "https://www.syncovery.com/release/SyncoveryMac11.15.14-Apple.dmg",
+      "installer_url": "https://www.syncovery.com/release/SyncoveryMac11.15.15-Apple.dmg",
       "install_script_ref": "618d4067",
       "uninstall_script_ref": "04c1cc55",
-      "sha256": "45ffff57cc7e5619ebd8cd67dd6ad3e492bc81a6fa0060c7bf4e4cac8c7638ad",
+      "sha256": "d4ef0b5947dbe4545fdc8f65beb9e09b68b41e63f83e9c0f8761becfef5cfcbb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tableplus/darwin.json
+++ b/ee/maintained-apps/outputs/tableplus/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.1.8",
+      "version": "7.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus' AND version_compare(bundle_short_version, '7.1.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus' AND version_compare(bundle_short_version, '7.2.0') < 0);"
       },
-      "installer_url": "https://files.tableplus.com/macos/718/TablePlus.dmg",
+      "installer_url": "https://files.tableplus.com/macos/720/TablePlus.dmg",
       "install_script_ref": "4c748894",
       "uninstall_script_ref": "20e49d94",
-      "sha256": "e342cdda6dc1cbae3add429843c2c92d4c056e66b3121aac632f37cc54775e24",
+      "sha256": "2ccbcf3d8e1f7b76cf6cbdba3977a0589ea57784a2c7cfdc685c0ec8e974866c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.7",
+      "version": "1.13.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.13.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.13.8') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/mac/Typora-1.13.7.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.13.8.dmg",
       "install_script_ref": "46cc7e99",
       "uninstall_script_ref": "a8ba94c9",
-      "sha256": "756e4f64818958b5d9d291c467f7a9dddef90a7df9d0e9ead70ba3f746f4aa9b",
+      "sha256": "bea6c1d7c8ab138634674e4c96c077e7a0db140da725d9b8294e446789d81ac7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zettlr/darwin.json
+++ b/ee/maintained-apps/outputs/zettlr/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.5.0",
+      "version": "4.6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.zettlr.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.zettlr.app' AND version_compare(bundle_short_version, '4.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.zettlr.app' AND version_compare(bundle_short_version, '4.6.0') < 0);"
       },
-      "installer_url": "https://github.com/Zettlr/Zettlr/releases/download/v4.5.0/Zettlr-4.5.0-arm64.dmg",
+      "installer_url": "https://github.com/Zettlr/Zettlr/releases/download/v4.6.0/Zettlr-4.6.0-arm64.dmg",
       "install_script_ref": "fc21f2d9",
       "uninstall_script_ref": "a3051277",
-      "sha256": "fd1e964378f4130703754ceee48ad99db57a5917e7d961af0e83ddf52d392a4b",
+      "sha256": "c0ff76d9e869eee312d7c131764fe73322344f85127ed2e5fada1076cb88cf32",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version metadata for 16 software packages across macOS and Windows platforms, including version bumps for BoltAI, Cursor, CodexBar, Dockside, Dropshare, FireAlpaca, Hive App, Melodics, GeForce NOW, OpenCode Desktop, Postman, Stats, Syncovery, TablePlus, Typora, and Zettlr.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->