### PR TITLE
Ignore openssl CVEs in fleetdm/bomutils and fleetdm/wix

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -691,6 +691,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-20 11:42:37
 
+### [CVE-2026-45447](https://nvd.nist.gov/vuln/detail/CVE-2026-45447)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use OpenSSL (e.g. PKCS7_verify) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-06-15 08:42:45
+
 ### [CVE-2026-42011](https://nvd.nist.gov/vuln/detail/CVE-2026-42011)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -924,6 +932,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `bomutils`,`pkg:deb/debian/libcap2`,`pkg:deb/debian/libcap2-bin`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:25:00
+
+### [CVE-2026-45447](https://nvd.nist.gov/vuln/detail/CVE-2026-45447)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use OpenSSL (e.g. PKCS7_verify) when using fleetdm/bomutils to generate PKG packages.
+- **Products:** `bomutils`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-06-15 08:42:45
 
 ### [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789)
 - **Author:** @lucasmrod

--- a/security/vex/bomutils/CVE-2026-45447.vex.json
+++ b/security/vex/bomutils/CVE-2026-45447.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f0f45c7d0e686268da270d87328b89f5fb45ea455800872a6eecaa3232d98f30",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45447"
+      },
+      "products": [
+        {
+          "@id": "bomutils"
+        },
+        {
+          "@id": "pkg:deb/debian/libssl3t64"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl-provider-legacy"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use OpenSSL (e.g. PKCS7_verify) when using fleetdm/bomutils to generate PKG packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-06-15T08:42:45.486177Z"
+    }
+  ],
+  "timestamp": "2026-06-15T08:42:45Z"
+}

--- a/security/vex/wix/CVE-2026-45447.vex.json
+++ b/security/vex/wix/CVE-2026-45447.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-d9383cf7b0c5530cf59d92e31a6ffe7fb246ba945dd0fc9be6018b05edce5933",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45447"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssl3t64"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl-provider-legacy"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use OpenSSL (e.g. PKCS7_verify) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-06-15T08:42:45.464341Z"
+    }
+  ],
+  "timestamp": "2026-06-15T08:42:45Z"
+}


### PR DESCRIPTION
Fixes: 
- https://github.com/fleetdm/fleet/actions/runs/27533019044
- https://github.com/fleetdm/fleet/actions/runs/27531598289

Runs:
- https://github.com/fleetdm/fleet/actions/runs/27534679935
- https://github.com/fleetdm/fleet/actions/runs/27534673753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added VEX (Vulnerability Exploitability eXchange) security declarations for CVE-2026-45447 across multiple products, marking the vulnerability as not affecting specified versions with justification that vulnerable code is not in the execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->