### PR TITLE
For R.C. - Fleet UI: preserve raw software name for icon matching when display name overrides are set (#47355)

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -83,8 +83,13 @@ Use helpers from `frontend/utilities/strings/stringUtils.ts`:
 - `stripQuotes(str)`, `strToBool(str)` — input parsing
 - `enforceFleetSentenceCasing(str)` — respects Fleet stylization rules
 
-## Software titles — display name
+## Software titles
+
+### Display name
 Render software title names via `getDisplayedSoftwareName(name, display_name)` from `pages/SoftwarePage/helpers.tsx` — never raw `t.name` or open-coded `display_name || name`. See `frontend/docs/patterns.md`.
+
+### Icons
+`<SoftwareIcon name={...}>` uses `name` for fallback icon matching when `icon_url` is null (Fleet-maintained apps depend entirely on this). Pass the **raw** `name`, never `getDisplayedSoftwareName(...)` or `display_name`, or admin renames will break the icon match. When a flattened row carries only one name field, add a sibling `iconName` (raw) field and feed THAT to `<SoftwareIcon>`. See `frontend/docs/patterns.md` and #47123.
 
 ## Styling (SCSS + BEM)
 - Define `const baseClass = "component-name"` at the top of the component

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareProcessCell/SetupSoftwareProcessCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareProcessCell/SetupSoftwareProcessCell.tsx
@@ -5,13 +5,21 @@ const baseClass = "setup-software-process-cell";
 
 interface ISetupSoftwareProcessCell {
   name: string;
+  /** Raw software name used for SoftwareIcon fallback matching when url is null.
+   * Display-name overrides won't match the known-icon lookup (e.g. FMAs without
+   * a custom icon_url), so pass the raw title name here. Defaults to `name`. */
+  iconName?: string;
   url?: string | null;
 }
 
-const SetupSoftwareProcessCell = ({ name, url }: ISetupSoftwareProcessCell) => {
+const SetupSoftwareProcessCell = ({
+  name,
+  iconName,
+  url,
+}: ISetupSoftwareProcessCell) => {
   return (
     <span className={baseClass}>
-      <SoftwareIcon name={name || ""} size="small" url={url} />
+      <SoftwareIcon name={iconName ?? name ?? ""} size="small" url={url} />
       <div>
         Install <b>{name || "Unknown software"}</b>
       </div>

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -146,12 +146,17 @@ export default {
 }
 ```
 
-### Display names for software titles
+### Software titles
 
 Software titles have two fields that look like a name:
 
 - `name` — the raw title from the installer/package metadata (e.g. `Microsoft.CompanyPortal`)
 - `display_name` — an optional custom name set per fleet by an admin
+
+Render the label from the resolved display name, but pass the **raw** `name` to
+`<SoftwareIcon>` — the icon matcher only knows raw, well-known names.
+
+#### Display name
 
 **Never render `name` directly in the UI.** Always route software names through
 `getDisplayedSoftwareName(name, display_name)` from `pages/SoftwarePage/helpers.tsx`.
@@ -176,6 +181,41 @@ The same rule applies to any object shape that carries both fields
 `IPolicySoftwareToInstall`, etc.). The `ISoftwareTitle.name` JSDoc states the
 expectation: "All software names displayed by UI is ran through
 getDisplayedSoftwareName."
+
+#### Icons
+
+`<SoftwareIcon name={...}>` uses the `name` prop for **fallback icon matching**
+via `getMatchedSoftwareIcon({ name, source })` when `icon_url` is null. That
+matcher only knows the raw, well-known names (`notion`, `microsoft.companyportal`,
+etc.). If you pass it a resolved display name like `getDisplayedSoftwareName(...)`
+or `display_name || name`, an admin who renames the title to anything not in the
+match table will lose the icon to a generic fallback. Fleet-maintained apps are
+the highest-risk surface because they have no `icon_url` — they depend
+entirely on name matching. See #47123.
+
+When you have both fields, pass the raw `name` to the icon and the resolved
+name to the label:
+
+```tsx
+// good — icon matches against raw name, label shows resolved display name
+const displayName = getDisplayedSoftwareName(title.name, title.display_name);
+<>
+  <SoftwareIcon name={title.name} source={title.source} url={title.icon_url} />
+  {displayName}
+</>
+
+// bad — admin renames break the icon match for FMAs and other matched titles
+<SoftwareIcon name={displayName} ... />
+```
+
+When the data has been flattened into a single `name` field upstream (e.g. for a
+row object or table-cell renderer), carry the raw name alongside it as a
+separate field (`iconName`, `rawName`, etc.) and feed THAT to `<SoftwareIcon>`.
+See `frontend/pages/policies/ManagePoliciesPage/helpers.tsx`'s
+`ISoftwareAutomationData.iconName` for the established pattern.
+
+`SoftwareNameCell` already does this internally — when you can use it, prefer
+it over hand-rolling icon + label rendering.
 
 ## Components
 

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
@@ -24,6 +24,7 @@ const generateColumnConfigs = (): ISetupStatusTableConfig[] => [
         return (
           <SetupSoftwareProcessCell
             name={getDisplayedSoftwareName(name, display_name)}
+            iconName={name ?? ""}
             url={icon_url}
           />
         );

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -69,11 +69,11 @@ interface IDataColumn {
 
 const AUTOMATION_ICON_RENDERERS: Record<
   IAutomationData["type"],
-  (args: { name: string; iconUrl?: string }) => JSX.Element
+  (args: { name: string; iconName?: string; iconUrl?: string }) => JSX.Element
 > = {
-  software: ({ name, iconUrl }) => (
+  software: ({ name, iconName, iconUrl }) => (
     <span className="automations__software-icon">
-      <SoftwareIcon name={name} url={iconUrl} size="small" />
+      <SoftwareIcon name={iconName ?? name} url={iconUrl} size="small" />
     </span>
   ),
   script: ({ name }) => (
@@ -142,10 +142,12 @@ const AutomationsCell = ({
 
   const handleEdit = () => onOpenManageAutomationsModal?.(policy);
 
-  const renderAutomationIcon = ({ type, name, iconUrl }: IAutomationData) => {
-    return AUTOMATION_ICON_RENDERERS[type]({
-      name,
-      iconUrl: iconUrl ?? undefined,
+  const renderAutomationIcon = (automation: IAutomationData) => {
+    return AUTOMATION_ICON_RENDERERS[automation.type]({
+      name: automation.name,
+      iconName:
+        automation.type === "software" ? automation.iconName : undefined,
+      iconUrl: automation.iconUrl ?? undefined,
     });
   };
 

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
@@ -345,6 +345,22 @@ describe("getAutomationsForPolicy", () => {
     expect(result[0].name).toBe("Company Portal");
   });
 
+  it("preserves the raw install_software.name as iconName for fallback icon matching (regression: #47123)", () => {
+    const result = getAutomationsForPolicy({
+      ...basePolicy,
+      install_software: {
+        name: "Zoom",
+        display_name: "Custom Renamed App",
+        software_title_id: 42,
+      },
+    });
+    expect(result[0]).toMatchObject({
+      type: "software",
+      name: "Custom Renamed App",
+      iconName: "Zoom",
+    });
+  });
+
   it("returns script automation with file name", () => {
     const result = getAutomationsForPolicy({
       ...basePolicy,

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
@@ -16,6 +16,10 @@ export type AutomationDisplayType =
 interface ISoftwareAutomationData {
   type: "software";
   name: string;
+  /** Raw software name passed to SoftwareIcon for name-based fallback matching.
+   * Display-name overrides won't match the known-icon lookup (e.g. FMAs without
+   * a custom icon_url), so we keep the raw name available alongside `name`. */
+  iconName: string;
   softwareTitleId: number;
   iconUrl?: string | null;
 }
@@ -23,6 +27,7 @@ interface ISoftwareAutomationData {
 interface INonSoftwareAutomationData {
   type: Exclude<AutomationDisplayType, "software">;
   name: string;
+  iconName?: never;
   softwareTitleId?: never;
   iconUrl?: never;
 }
@@ -52,6 +57,7 @@ export const getAutomationsForPolicy = (
         policy.install_software.name,
         policy.install_software.display_name
       ),
+      iconName: policy.install_software.name,
       softwareTitleId: policy.install_software.software_title_id,
       iconUrl: policy.install_software.icon_url,
     });

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tests.tsx
@@ -6,11 +6,16 @@ import ENDPOINTS from "utilities/endpoints";
 
 import PolicyAutomationsList from "./PolicyAutomationsList";
 
-// Stub SoftwareIcon to avoid asset resolution in tests; surface the url prop so
-// we can assert the custom icon path is forwarded.
+// Stub SoftwareIcon to avoid asset resolution in tests; surface the url and
+// name props so we can assert the raw software name (used for fallback icon
+// matching) and the custom icon path are forwarded.
 jest.mock("pages/SoftwarePage/components/icons/SoftwareIcon", () => {
-  return ({ url }: { url?: string | null }) => (
-    <span data-testid="software-icon" data-url={url ?? ""} />
+  return ({ name, url }: { name?: string; url?: string | null }) => (
+    <span
+      data-testid="software-icon"
+      data-name={name ?? ""}
+      data-url={url ?? ""}
+    />
   );
 });
 
@@ -133,6 +138,31 @@ describe("PolicyAutomationsList", () => {
         "data-url",
         ""
       );
+    });
+
+    it("passes the raw install_software.name to SoftwareIcon even when a display_name override is set (regression: #47123)", () => {
+      // The display name is what users see, but SoftwareIcon's fallback
+      // matcher needs the raw name to find FMA / well-known icons; otherwise
+      // a custom display name causes it to fall through to the generic icon.
+      render(
+        <PolicyAutomationsList
+          storedPolicy={createMockPolicy({
+            install_software: {
+              name: "Zoom",
+              display_name: "Custom Renamed App",
+              software_title_id: 42,
+            },
+          })}
+          currentAutomatedPolicies={[]}
+        />
+      );
+
+      expect(screen.getByTestId("software-icon")).toHaveAttribute(
+        "data-name",
+        "Zoom"
+      );
+      // sanity check: label still uses the display name override
+      expect(screen.getByText("Custom Renamed App")).toBeInTheDocument();
     });
 
     it("shows script automation row", () => {

--- a/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsList/PolicyAutomationsList.tsx
@@ -19,6 +19,9 @@ const OTHER_AUTOMATION_NAMES: Record<OtherAutomationType, string> = {
 
 interface IAutomationDisplayRow {
   name: string;
+  /** Raw software name forwarded to SoftwareIcon for name-based fallback
+   * matching; display-name overrides break the known-icon lookup. */
+  iconName?: string;
   type: string;
   graphicName?: GraphicNames;
   isSoftware?: boolean;
@@ -51,6 +54,7 @@ const PolicyAutomationsList = ({
     );
     automationRows.push({
       name: displayedName,
+      iconName: storedPolicy.install_software.name,
       type: "Software",
       isSoftware: true,
       iconUrl: storedPolicy.install_software.icon_url,
@@ -128,7 +132,7 @@ const PolicyAutomationsList = ({
               <div className={`${baseClass}__row-name`}>
                 {row.isSoftware ? (
                   <SoftwareIcon
-                    name={row.name}
+                    name={row.iconName ?? row.name}
                     url={row.iconUrl}
                     size="small"
                   />


### PR DESCRIPTION
## Issue
Closes #47123


## Description 
- Previously merged into `main` with #47355
- This is for the 4.87.0 R.C. 
