### PR TITLE
For R.C. - Fleet UI: Unreleased bug fixes to command palette (unsupported screen size, hide fleet picker fleets based on page, add fleet picker empty state) (#47345)

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -11,7 +11,10 @@ import { Command } from "cmdk";
 import { browserHistory } from "react-router";
 
 import { AppContext } from "context/app";
-import { APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
+import {
+  APP_CONTEXT_ALL_TEAMS_ID,
+  APP_CONTEXT_NO_TEAM_ID,
+} from "interfaces/team";
 import Icon from "components/Icon";
 import { isDarkMode, setThemeMode } from "utilities/theme";
 import paths from "router/paths";
@@ -23,6 +26,8 @@ import {
   buildPaletteItems,
   buildFleetSwitchUrl,
   computeBestMatch,
+  pathSupportsAllFleets,
+  pathSupportsUnassigned,
 } from "./helpers";
 import FleetPicker from "./components/FleetPicker";
 import HostPicker from "./components/HostPicker";
@@ -836,7 +841,28 @@ const CommandPalette = (): JSX.Element | null => {
         {page === "root" && renderRootPage()}
         {page === "switch-fleet" && (
           <FleetPicker
-            availableTeams={availableTeams}
+            // Drop "All fleets" and "Unassigned" on pages whose useTeamIdParam
+            // config rejects them (e.g. Dashboard hides Unassigned; the Fleet
+            // → Users/Options/Settings admin pages hide All). Otherwise the
+            // option appears valid but selecting it triggers a redirect-to-
+            // default and silently reverts. Read pathname at render — the
+            // palette can't be navigated away from without closing, so the
+            // value is stable per session.
+            availableTeams={availableTeams?.filter((t) => {
+              if (
+                t.id === APP_CONTEXT_NO_TEAM_ID &&
+                !pathSupportsUnassigned(window.location.pathname)
+              ) {
+                return false;
+              }
+              if (
+                t.id === APP_CONTEXT_ALL_TEAMS_ID &&
+                !pathSupportsAllFleets(window.location.pathname)
+              ) {
+                return false;
+              }
+              return true;
+            })}
             currentTeam={currentTeam}
             search={search}
             onSelect={handleSwitchFleet}

--- a/frontend/components/CommandPalette/_styles.scss
+++ b/frontend/components/CommandPalette/_styles.scss
@@ -32,6 +32,17 @@
     overflow: hidden;
   }
 
+  // Below the supported breakpoint the UnsupportedScreenSize layout takes
+  // over the viewport. Hide the palette (overlay + content) without closing
+  // it so internal state, focus intent, and the current picker page survive
+  // a resize back up.
+  @media (max-width: ($break-xs - 1px)) {
+    &__overlay,
+    &__content {
+      display: none;
+    }
+  }
+
   &__input-wrapper {
     position: relative;
     display: flex;

--- a/frontend/components/CommandPalette/components/FleetPicker.tests.tsx
+++ b/frontend/components/CommandPalette/components/FleetPicker.tests.tsx
@@ -14,6 +14,20 @@ const renderPicker = (
 ): ReturnType<typeof renderInCommand> =>
   renderInCommand(<Command>{component}</Command>);
 
+// cmdk drives filtering off its own internal search state (mutated via
+// Command.Input). Rendering a Command.Input here lets a test type into
+// cmdk and exercise Command.Empty / row visibility the way the real
+// palette does.
+const renderPickerWithInput = (
+  component: React.ReactElement
+): ReturnType<typeof renderInCommand> =>
+  renderInCommand(
+    <Command>
+      <Command.Input aria-label="search" />
+      {component}
+    </Command>
+  );
+
 describe("FleetPicker", () => {
   const availableTeams = [
     { id: -1, name: "All fleets" },
@@ -73,5 +87,31 @@ describe("FleetPicker", () => {
   it("renders empty (no items) when availableTeams is undefined", () => {
     renderPicker(<FleetPicker search="" onSelect={jest.fn()} />);
     expect(screen.queryByText("Engineering")).not.toBeInTheDocument();
+  });
+
+  it("shows the contextual empty state when search matches no fleet", async () => {
+    const { user } = renderPickerWithInput(
+      <FleetPicker
+        availableTeams={availableTeams}
+        currentTeam={availableTeams[2]}
+        search="zzz-nope"
+        onSelect={jest.fn()}
+      />
+    );
+
+    // cmdk filters off its own input value. Typing here mirrors what the
+    // real palette does when the user types into Command.Input.
+    await user.type(screen.getByLabelText("search"), "zzz-nope");
+
+    expect(screen.getByText('No fleets match "zzz-nope".')).toBeInTheDocument();
+    expect(screen.queryByText("Engineering")).not.toBeInTheDocument();
+  });
+
+  it("shows the no-search empty copy when availableTeams is empty", () => {
+    renderPicker(
+      <FleetPicker availableTeams={[]} search="" onSelect={jest.fn()} />
+    );
+
+    expect(screen.getByText("No fleets found.")).toBeInTheDocument();
   });
 });

--- a/frontend/components/CommandPalette/components/FleetPicker.tsx
+++ b/frontend/components/CommandPalette/components/FleetPicker.tsx
@@ -21,27 +21,36 @@ const FleetPicker = ({
   onSelect,
 }: IFleetPickerProps): JSX.Element => {
   return (
-    <Command.Group className={`${baseClass}__group`}>
-      {availableTeams?.map((fleet) => {
-        const isSelected = fleet.id === currentTeam?.id;
-        return (
-          <Command.Item
-            key={`fleet-${fleet.id}`}
-            value={fleet.name}
-            onSelect={() => onSelect(fleet.id)}
-            className={`${baseClass}__item`}
-          >
-            <span
-              className={`${baseClass}__item-label${
-                isSelected ? ` ${baseClass}__item-label--selected` : ""
-              }`}
+    <>
+      {/* cmdk's Command.Empty auto-renders when every Item is filtered out.
+          Mirrors the root palette's "No results found." so the picker doesn't
+          go blank on a typo. CommandPalette suppresses its own Command.Empty
+          on picker pages — pickers own their empty copy. */}
+      <Command.Empty className={`${baseClass}__empty`}>
+        {search ? `No fleets match "${search}".` : "No fleets found."}
+      </Command.Empty>
+      <Command.Group className={`${baseClass}__group`}>
+        {availableTeams?.map((fleet) => {
+          const isSelected = fleet.id === currentTeam?.id;
+          return (
+            <Command.Item
+              key={`fleet-${fleet.id}`}
+              value={fleet.name}
+              onSelect={() => onSelect(fleet.id)}
+              className={`${baseClass}__item`}
             >
-              <HighlightedLabel text={fleet.name} query={search} />
-            </span>
-          </Command.Item>
-        );
-      })}
-    </Command.Group>
+              <span
+                className={`${baseClass}__item-label${
+                  isSelected ? ` ${baseClass}__item-label--selected` : ""
+                }`}
+              >
+                <HighlightedLabel text={fleet.name} query={search} />
+              </span>
+            </Command.Item>
+          );
+        })}
+      </Command.Group>
+    </>
   );
 };
 

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -9,6 +9,8 @@ import {
   highlightMatches,
   ICommandItem,
   ICommandPaletteContext,
+  pathSupportsAllFleets,
+  pathSupportsUnassigned,
   scoreMatch,
   SCORE_KEYWORD_EXACT,
   SCORE_KEYWORD_PREFIX,
@@ -731,14 +733,39 @@ describe("CommandPalette helpers", () => {
         ).toBe(paths.MANAGE_HOSTS);
       });
 
-      it("keeps fleet_id=0 on the fallback URL when switching to Unassigned", () => {
+      it("keeps fleet_id=0 on the fallback URL when switching to Unassigned from a page that doesn't support it", () => {
+        // NEW_REPORT uses includeNoTeam: false — Unassigned must bounce.
         expect(
+          buildFleetSwitchUrl({
+            pathname: paths.NEW_REPORT,
+            currentSearch: "?fleet_id=1",
+            fleetId: 0,
+          })
+        ).toBe(`${paths.MANAGE_HOSTS}?fleet_id=0`);
+      });
+
+      it("stays on Controls when switching to Unassigned (Controls supports includeNoTeam)", () => {
+        const url = parse(
+          buildFleetSwitchUrl({
+            pathname: paths.CONTROLS,
+            currentSearch: "?fleet_id=1",
+            fleetId: 0,
+          })
+        );
+        expect(url.pathname).toBe(paths.CONTROLS);
+        expect(url.searchParams.get("fleet_id")).toBe("0");
+      });
+
+      it("stays on Software Library when switching to Unassigned (Library supports includeNoTeam)", () => {
+        const url = parse(
           buildFleetSwitchUrl({
             pathname: paths.SOFTWARE_LIBRARY,
             currentSearch: "?fleet_id=1&self_service=1",
             fleetId: 0,
           })
-        ).toBe(`${paths.MANAGE_HOSTS}?fleet_id=0`);
+        );
+        expect(url.pathname).toBe(paths.SOFTWARE_LIBRARY);
+        expect(url.searchParams.get("fleet_id")).toBe("0");
       });
 
       it("does not trigger the fallback on a non-team-required page", () => {
@@ -859,6 +886,70 @@ describe("CommandPalette helpers", () => {
           })
         ).toBe(paths.MANAGE_HOSTS);
       });
+    });
+  });
+
+  describe("pathSupportsUnassigned", () => {
+    it("returns true for hosts pages (manage and details)", () => {
+      expect(pathSupportsUnassigned(paths.MANAGE_HOSTS)).toBe(true);
+      expect(pathSupportsUnassigned(paths.HOST_DETAILS(42))).toBe(true);
+    });
+
+    it("returns true for software pages", () => {
+      expect(pathSupportsUnassigned(paths.SOFTWARE)).toBe(true);
+      expect(pathSupportsUnassigned(paths.SOFTWARE_TITLE_DETAILS("3"))).toBe(
+        true
+      );
+    });
+
+    it("returns true for controls pages", () => {
+      expect(pathSupportsUnassigned(paths.CONTROLS)).toBe(true);
+      expect(pathSupportsUnassigned(paths.CONTROLS_SCRIPTS)).toBe(true);
+    });
+
+    it("returns true for policies pages", () => {
+      expect(pathSupportsUnassigned(paths.MANAGE_POLICIES)).toBe(true);
+      expect(pathSupportsUnassigned(paths.POLICY_DETAILS(7))).toBe(true);
+      expect(pathSupportsUnassigned(paths.EDIT_POLICY(7))).toBe(true);
+      expect(pathSupportsUnassigned(paths.NEW_POLICY)).toBe(true);
+    });
+
+    it("returns false for Dashboard", () => {
+      expect(pathSupportsUnassigned(paths.DASHBOARD)).toBe(false);
+    });
+
+    it("returns false for Reports pages", () => {
+      expect(pathSupportsUnassigned(paths.MANAGE_REPORTS)).toBe(false);
+      expect(pathSupportsUnassigned(paths.NEW_REPORT)).toBe(false);
+    });
+
+    it("returns false for admin/settings pages", () => {
+      expect(pathSupportsUnassigned("/settings/teams/1")).toBe(false);
+    });
+  });
+
+  describe("pathSupportsAllFleets", () => {
+    it("returns true for top-level team-aware pages", () => {
+      expect(pathSupportsAllFleets(paths.DASHBOARD)).toBe(true);
+      expect(pathSupportsAllFleets(paths.MANAGE_HOSTS)).toBe(true);
+      expect(pathSupportsAllFleets(paths.SOFTWARE)).toBe(true);
+      expect(pathSupportsAllFleets(paths.MANAGE_POLICIES)).toBe(true);
+      expect(pathSupportsAllFleets(paths.MANAGE_REPORTS)).toBe(true);
+    });
+
+    it("returns false for fleet admin detail pages (Users/Options/Settings)", () => {
+      expect(pathSupportsAllFleets(paths.FLEET_DETAILS_USERS(1))).toBe(false);
+      expect(pathSupportsAllFleets(paths.FLEET_DETAILS_OPTIONS(1))).toBe(false);
+      expect(pathSupportsAllFleets(paths.FLEET_DETAILS_SETTINGS(1))).toBe(
+        false
+      );
+    });
+
+    it("still returns true for the /settings/fleets list page", () => {
+      // The list view itself has no fleet scope (no useTeamIdParam), so
+      // switching from the palette there is fine. Only the detail sub-pages
+      // (which require a specific fleet_id) hide All.
+      expect(pathSupportsAllFleets(paths.ADMIN_FLEETS)).toBe(true);
     });
   });
 

--- a/frontend/components/CommandPalette/helpers.ts
+++ b/frontend/components/CommandPalette/helpers.ts
@@ -423,14 +423,85 @@ export const buildPaletteItems = (
   ];
 };
 
-// Pages that require a specific fleet — they can't render "All fleets" or
-// (with some overlap) "Unassigned". When switching to either of those from
-// one of these pages, fall back to Hosts which supports both.
-const TEAM_REQUIRED_PREFIXES = [
-  paths.CONTROLS,
-  paths.SOFTWARE_LIBRARY,
-  paths.NEW_REPORT,
+// Per-page fleet picker behavior. One row per path prefix; each row
+// declares overrides off the common defaults:
+//
+//   default all:        "native"  — page renders All fleets inline
+//   default unassigned: "hidden"  — picker omits Unassigned
+//
+// Overrides:
+//   all = "redirect" — keep in the picker as a shortcut, but selecting it
+//                      sends the user to /hosts/manage (which supports All).
+//                      Mirrors `useTeamIdParam({ includeAllTeams: false })`
+//                      or, for SOFTWARE_LIBRARY, the explicit redirect in
+//                      SoftwarePage when All is selected on the Library tab.
+//   all = "hidden"   — omit from picker. Reserved for admin views where
+//                      "all fleets" is conceptually meaningless (no global
+//                      view of fleet-level user/option/settings config).
+//   unassigned = "native" — page renders Unassigned (id 0) inline. Mirrors
+//                      `useTeamIdParam({ includeNoTeam: true })`.
+//
+// Multiple rows may match a path; the longest-matching prefix wins per
+// dimension (e.g. /software/library inherits unassigned:"native" from
+// /software while overriding all to "redirect" via its own row).
+//
+// Scope: Premium, non-Primo only. The fleet picker doesn't exist on Fleet
+// Free or in Primo mode — both entry points (Cmd+Shift+F and the
+// fleet-switcher button) are gated behind `canSwitchFleet`, which requires
+// `isPremiumTier && !isPrimoMode`. This table and its resolver describe
+// the picker's behavior within that gated surface; do not consult them
+// from Free or Primo code paths.
+
+type AllOverride = "redirect" | "hidden";
+type UnassignedOverride = "native";
+
+interface PageFleetRule {
+  prefix: string;
+  all?: AllOverride;
+  unassigned?: UnassignedOverride;
+}
+
+const PAGE_FLEET_RULES: ReadonlyArray<PageFleetRule> = [
+  { prefix: paths.CONTROLS, all: "redirect", unassigned: "native" },
+  { prefix: paths.SOFTWARE_LIBRARY, all: "redirect" },
+  { prefix: paths.SOFTWARE, unassigned: "native" },
+  { prefix: paths.NEW_REPORT, all: "redirect" },
+  { prefix: `${paths.ROOT}hosts`, unassigned: "native" },
+  { prefix: `${paths.ROOT}policies`, unassigned: "native" },
+  { prefix: `${paths.ROOT}settings/fleets/users`, all: "hidden" },
+  { prefix: `${paths.ROOT}settings/fleets/options`, all: "hidden" },
+  { prefix: `${paths.ROOT}settings/fleets/settings`, all: "hidden" },
 ];
+
+interface ResolvedFleetSupport {
+  all: "native" | AllOverride;
+  unassigned: "native" | "hidden";
+}
+
+const resolvePageFleetSupport = (pathname: string): ResolvedFleetSupport => {
+  let all: ResolvedFleetSupport["all"] = "native";
+  let unassigned: ResolvedFleetSupport["unassigned"] = "hidden";
+  let allPrefixLen = -1;
+  let unassignedPrefixLen = -1;
+  PAGE_FLEET_RULES.forEach((rule) => {
+    if (!pathname.startsWith(rule.prefix)) return;
+    if (rule.all && rule.prefix.length > allPrefixLen) {
+      all = rule.all;
+      allPrefixLen = rule.prefix.length;
+    }
+    if (rule.unassigned && rule.prefix.length > unassignedPrefixLen) {
+      unassigned = rule.unassigned;
+      unassignedPrefixLen = rule.prefix.length;
+    }
+  });
+  return { all, unassigned };
+};
+
+export const pathSupportsUnassigned = (pathname: string): boolean =>
+  resolvePageFleetSupport(pathname).unassigned === "native";
+
+export const pathSupportsAllFleets = (pathname: string): boolean =>
+  resolvePageFleetSupport(pathname).all !== "hidden";
 
 /**
  * Build the next URL for a fleet switch initiated from the command palette.
@@ -451,17 +522,19 @@ export const buildFleetSwitchUrl = ({
 }): string => {
   const isAll = fleetId === APP_CONTEXT_ALL_TEAMS_ID;
   const isUnassignedTarget = fleetId === 0;
-  const isOnTeamRequiredPage = TEAM_REQUIRED_PREFIXES.some((p) =>
-    pathname.startsWith(p)
-  );
+  const support = resolvePageFleetSupport(pathname);
 
-  if ((isAll || isUnassignedTarget) && isOnTeamRequiredPage) {
-    // For Unassigned, keep fleet_id=0 on the fallback URL.
-    // useTeamIdParam coerces a missing param back to All fleets (-1),
-    // which would silently undo the setCurrentTeam({id:0}) caller.
-    return isUnassignedTarget
-      ? `${paths.MANAGE_HOSTS}?fleet_id=0`
-      : paths.MANAGE_HOSTS;
+  // All fleets: page can't render it but the picker keeps the option as a
+  // shortcut. Redirect to Hosts (which supports All).
+  if (isAll && support.all === "redirect") {
+    return paths.MANAGE_HOSTS;
+  }
+  // Unassigned: page can't render it. Keep fleet_id=0 on the fallback URL
+  // — useTeamIdParam coerces a missing param back to All fleets (-1),
+  // which would silently undo the switch. This branch is defensive; the
+  // picker already filters unsupported Unassigned via pathSupportsUnassigned.
+  if (isUnassignedTarget && support.unassigned !== "native") {
+    return `${paths.MANAGE_HOSTS}?fleet_id=0`;
   }
 
   const params = new URLSearchParams(currentSearch);


### PR DESCRIPTION
## Issue
Closes #47295 
Closes #47310 
Closes #47311 

## Description
- Previously merged into `main` with #47345
- This is for the 4.87.0 R.C. 