### PR TITLE
For R.C. - Fleet UI: fix labels unreleased double scroll bug (#47313)

### DIFF
--- a/frontend/pages/labels/ManageLabelsPage/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/_styles.scss
@@ -1,4 +1,9 @@
 .manage-labels-page {
+  // Opt out of MainContent's `overflow: auto` so the actions dropdown menu
+  // can spill below the page without triggering a second scrollbar on
+  // MainContent. Matches the pattern used by `.admin-wrapper`.
+  overflow: visible;
+
   @include vertical-page-layout;
 
   &__header-wrap {


### PR DESCRIPTION
## Issue
Closes #46812 

## Description 
- Previously merged into `main` with #47313 
- This is for the 4.87.0 RC branch