### PR TITLE
Run Windows FMA test workflows on ARM64 runner

### DIFF
--- a/.github/workflows/test-fma-windows-pr-only.yml
+++ b/.github/workflows/test-fma-windows-pr-only.yml
@@ -30,7 +30,9 @@ jobs:
   test-fma-pr-only:
     env:
       LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
-    runs-on: windows-latest
+    # ARM64 runner so we can validate ARM-native FMAs. x86/x64 FMAs continue to
+    # install and run here via Windows 11 on ARM's Prism emulation.
+    runs-on: windows-11-arm
 
     steps:
       - name: Harden Runner
@@ -187,7 +189,16 @@ jobs:
         if: steps.check-windows-apps.outputs.has_windows_apps == 'true'
         run: |
           Write-Host "Runner architecture: $env:PROCESSOR_ARCHITECTURE"
-          curl -L -o osquery.zip "https://github.com/osquery/osquery/releases/download/5.18.1/osquery-5.18.1.windows_x86_64.zip"
+          # Use the native osquery build for the runner architecture. On
+          # windows-11-arm this picks the arm64 zip so osqueryi runs natively
+          # rather than under Prism emulation; x86_64 runners keep the x64 zip.
+          if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+            $osqueryAsset = "osquery-5.18.1.windows_arm64.zip"
+          } else {
+            $osqueryAsset = "osquery-5.18.1.windows_x86_64.zip"
+          }
+          Write-Host "Downloading osquery asset: $osqueryAsset"
+          curl -L -o osquery.zip "https://github.com/osquery/osquery/releases/download/5.18.1/$osqueryAsset"
           Expand-Archive -Path osquery.zip -DestinationPath osquery
           Get-ChildItem -Recurse osquery | Where-Object { $_.Name -like "*osquery*" -and $_.Extension -eq ".exe" }
           $osqueryPath = (Get-ChildItem -Recurse osquery | Where-Object { $_.Name -eq "osqueryi.exe" }).Directory.FullName

--- a/.github/workflows/test-fma-windows.yml
+++ b/.github/workflows/test-fma-windows.yml
@@ -26,7 +26,9 @@ jobs:
   test-fma:
     env:
       LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
-    runs-on: windows-latest
+    # ARM64 runner so we can validate ARM-native FMAs. x86/x64 FMAs continue to
+    # install and run here via Windows 11 on ARM's Prism emulation.
+    runs-on: windows-11-arm
 
     steps:
       - name: Harden Runner
@@ -51,7 +53,16 @@ jobs:
       - name: Install osquery windows
         run: |
           Write-Host "Runner architecture: $env:PROCESSOR_ARCHITECTURE"
-          curl -L -o osquery.zip "https://github.com/osquery/osquery/releases/download/5.18.1/osquery-5.18.1.windows_x86_64.zip"
+          # Use the native osquery build for the runner architecture. On
+          # windows-11-arm this picks the arm64 zip so osqueryi runs natively
+          # rather than under Prism emulation; x86_64 runners keep the x64 zip.
+          if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+            $osqueryAsset = "osquery-5.18.1.windows_arm64.zip"
+          } else {
+            $osqueryAsset = "osquery-5.18.1.windows_x86_64.zip"
+          }
+          Write-Host "Downloading osquery asset: $osqueryAsset"
+          curl -L -o osquery.zip "https://github.com/osquery/osquery/releases/download/5.18.1/$osqueryAsset"
           Expand-Archive -Path osquery.zip -DestinationPath osquery
           Get-ChildItem -Recurse osquery | Where-Object { $_.Name -like "*osquery*" -and $_.Extension -eq ".exe" }
           $osqueryPath = (Get-ChildItem -Recurse osquery | Where-Object { $_.Name -eq "osqueryi.exe" }).Directory.FullName


### PR DESCRIPTION
Switch the Windows Fleet-maintained app test workflows from windows-latest to windows-11-arm so ARM-native FMAs can be validated. Existing x86/x64 FMAs continue to install and run via Windows 11 on ARM's Prism emulation, and detection is registry-based so it stays architecture-agnostic.

Also make the osquery download architecture-aware: pick the native arm64 build on ARM64 runners and fall back to x86_64 otherwise, so osqueryi runs natively rather than under emulation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to include Windows 11 ARM64 architecture. The application is now validated on ARM-based systems in addition to traditional x86_64 platforms.
  * Updated test infrastructure to automatically detect system architecture and download corresponding dependencies, ensuring proper validation across both ARM64 and x86_64 Windows configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->