### PR TITLE
Fleet UI: Fix radix missing title/description logs

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -8,6 +8,10 @@ import React, {
   useRef,
 } from "react";
 import { Command } from "cmdk";
+import {
+  Title as DialogTitle,
+  Description as DialogDescription,
+} from "@radix-ui/react-dialog";
 import { browserHistory } from "react-router";
 
 import { AppContext } from "context/app";
@@ -768,6 +772,14 @@ const CommandPalette = (): JSX.Element | null => {
         return 0;
       }}
     >
+      {/* cmdk's Dialog wraps Radix Dialog.Content, which requires a Title and
+          a Description for screen reader accessibility — without these, Radix
+          logs a console error/warning on every open. Both are rendered
+          visually hidden so the palette UI stays unchanged. */}
+      <DialogTitle className="sr-only">Command palette</DialogTitle>
+      <DialogDescription className="sr-only">
+        Search for a page, command, or resource across Fleet.
+      </DialogDescription>
       <div className={`${baseClass}__input-wrapper`}>
         {page !== "root" && (
           // tabIndex=-1 so Radix's open-autofocus skips the back button


### PR DESCRIPTION
## Issue
Closes #47491 

## Description
- Unreleased bug fix to not have errors in the console when command palette/fleet picker are open and closed

## Screenrecording

- Video showing no console errors pop up while navigating to/through the command palette

https://github.com/user-attachments/assets/048e50e6-be31-4def-859e-6464033cc33f

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated console warnings that appeared when opening the command palette while preserving all existing functionality and visual design.

* **Chores**
  * Improved screen reader and assistive technology support for the command palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->