### PR TITLE
Fix scrollbar showing up when not needed in report/policy results tables

### DIFF
--- a/changes/44272-fix-scrollbar-always-showing
+++ b/changes/44272-fix-scrollbar-always-showing
@@ -1,0 +1,1 @@
+- Fixed horizontal scrollbar showing up when there is nothing to scroll in report and policy results tables.

--- a/frontend/pages/hosts/details/HostQueryReport/HQRTable/_styles.scss
+++ b/frontend/pages/hosts/details/HostQueryReport/HQRTable/_styles.scss
@@ -39,7 +39,7 @@
   }
 
   .data-table {
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   .empty-table__container {

--- a/frontend/pages/policies/edit/components/PolicyResults/_styles.scss
+++ b/frontend/pages/policies/edit/components/PolicyResults/_styles.scss
@@ -4,7 +4,7 @@
   }
 
   .data-table__wrapper {
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   .data-table-block .data-table thead th {

--- a/frontend/pages/queries/details/components/QueryReport/_styles.scss
+++ b/frontend/pages/queries/details/components/QueryReport/_styles.scss
@@ -15,7 +15,7 @@
     }
 
     .data-table__wrapper {
-      overflow-x: scroll;
+      overflow-x: auto;
     }
   }
 

--- a/frontend/pages/queries/edit/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/edit/components/QueryResults/_styles.scss
@@ -9,7 +9,7 @@
   }
 
   .data-table__wrapper {
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   .data-table-block .data-table thead th {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44272 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
Pages  tested:
```
https://<fleet_url>/hosts/<host_id>/reports/<id>
https://<fleet_url>/reports/<id>?fleet_id=<fleet_id>
https://<fleet_url>/reports/<id>/live?fleet_id=<fleet_id>
https://<fleet_url>/policies/<id>/live?fleet_id=<fleet_id>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary horizontal scrollbars appearing in report and policy results tables. Scrollbars now display only when content requires horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->