### PR TITLE
Fix IdP re-enrollment of devices with different email

### DIFF
--- a/changes/47626-fix-idp-enrollment
+++ b/changes/47626-fix-idp-enrollment
@@ -1,0 +1,1 @@
+* Fixed error in SSO re-enrollment for devices when using a different e-mail than the previous SSO enroll.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3159,6 +3159,7 @@ func (ds *Datastore) InsertMDMIdPAccount(ctx context.Context, account *fleet.MDM
       VALUES
         (COALESCE(NULLIF(TRIM(?), ''), UUID()), ?, ?, ?)
       ON DUPLICATE KEY UPDATE
+        email      = VALUES(email),
         username   = VALUES(username),
         fullname   = VALUES(fullname)`
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -2866,6 +2866,52 @@ func testMDMAppleIdPAccount(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.NotNil(t, idpAccount)
 	require.Equal(t, *acc1, *idpAccount)
+
+	// Re-enrollment with the same device UUID but a different IdP email.
+	//
+	// The account UUID is the host UUID, which is the table's primary key. On a
+	// previous enrollment the device registered with "before@example.com"; on a
+	// later enrollment the user signed in with a different IdP account. The
+	// INSERT collides on the primary key (uuid), so it falls into ON DUPLICATE
+	// KEY UPDATE. If the upsert doesn't update the email column, the row keeps
+	// the old email and the subsequent lookup by the new email returns
+	// not-found, which surfaced as "retrieving new account data from IdP".
+	const reEnrollUUID = "reenroll-device-uuid"
+	beforeAcc := &fleet.MDMIdPAccount{
+		UUID:     reEnrollUUID,
+		Username: "before@example.com",
+		Email:    "before@example.com",
+		Fullname: "Before User",
+	}
+	require.NoError(t, ds.InsertMDMIdPAccount(ctx, beforeAcc))
+
+	out, err = ds.GetMDMIdPAccountByEmail(ctx, beforeAcc.Email)
+	require.NoError(t, err)
+	require.Equal(t, beforeAcc, out)
+
+	afterAcc := &fleet.MDMIdPAccount{
+		UUID:     reEnrollUUID,
+		Username: "after@example.com",
+		Email:    "after@example.com",
+		Fullname: "After User",
+	}
+	require.NoError(t, ds.InsertMDMIdPAccount(ctx, afterAcc))
+
+	// The new email must be retrievable (this is the read-back that previously
+	// failed with not-found).
+	out, err = ds.GetMDMIdPAccountByEmail(ctx, afterAcc.Email)
+	require.NoError(t, err)
+	require.Equal(t, afterAcc, out)
+
+	// It must be the same row (same UUID), with email/username/fullname updated.
+	out, err = ds.GetMDMIdPAccountByUUID(ctx, reEnrollUUID)
+	require.NoError(t, err)
+	require.Equal(t, afterAcc, out)
+
+	// The old email no longer maps to any account.
+	out, err = ds.GetMDMIdPAccountByEmail(ctx, beforeAcc.Email)
+	require.ErrorAs(t, err, &nfe)
+	require.Nil(t, out)
 }
 
 func testDoNotIgnoreMDMClientError(t *testing.T, ds *Datastore) {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -6837,6 +6837,76 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	require.True(t, q.Has("error"))
 }
 
+// TestMDMSSOReenrollWithDifferentIdPEmail reproduces the case where a device
+// that was already registered with one IdP email re-enrolls and signs in with a
+// different IdP account. In the Orbit setup-experience flow the device's host
+// UUID is the primary key of the mdm_idp_accounts row, so the second login
+// upserts on the same row. If that upsert doesn't refresh the email column, the
+// row keeps the stale email and the read-back by the new email fails with
+// "retrieving new account data from IdP", surfacing to the device as a failed
+// SSO login (the callback redirects with error=true).
+func (s *integrationMDMTestSuite) TestMDMSSOReenrollWithDifferentIdPEmail() {
+	t := s.T()
+	s.setSkipWorkerJobs(t)
+
+	lastSubmittedProfile := &godep.Profile{}
+	s.setUpEndUserAuthentication(t, lastSubmittedProfile, false)
+
+	// The host UUID stays stable across enrollments; it becomes the IdP account
+	// primary key for the setup-experience flow. It's stored in the
+	// host_mdm_idp_accounts.account_uuid column, which is VARCHAR(36), so use a
+	// plain UUID.
+	hostUUID := uuid.NewString()
+
+	// First enrollment: the device's end user signs in as sso_user.
+	res := s.LoginMDMSSOUserSetupExperience("sso_user", "user123#", hostUUID)
+	require.NotEmpty(t, res.Header.Get("Location"))
+	require.Equal(t, http.StatusSeeOther, res.StatusCode)
+
+	u, err := url.Parse(res.Header.Get("Location"))
+	require.NoError(t, err)
+	q := u.Query()
+	require.False(t, q.Has("error"))
+	require.True(t, q.Has("enrollment_reference"))
+	// the enrollment reference is the account UUID, which is the host UUID.
+	require.Equal(t, hostUUID, q.Get("enrollment_reference"))
+
+	// IdP account and the host association reflect sso_user.
+	s.checkStoredIdPInfo(t, hostUUID, "sso_user", "SSO User 1", "sso_user@example.com")
+	acc, err := s.ds.GetMDMIdPAccountByHostUUID(context.Background(), hostUUID)
+	require.NoError(t, err)
+	require.NotNil(t, acc)
+	require.Equal(t, "sso_user@example.com", acc.Email)
+
+	// Re-enrollment: the same device signs in as a different IdP user, sso_user2.
+	// This upserts the mdm_idp_accounts row keyed on the host UUID with a new
+	// email. Before the fix, the read-back by sso_user2@example.com failed and
+	// the callback redirected with error=true.
+	res = s.LoginMDMSSOUserSetupExperience("sso_user2", "user123#", hostUUID)
+	require.Equal(t, http.StatusSeeOther, res.StatusCode)
+
+	u, err = url.Parse(res.Header.Get("Location"))
+	require.NoError(t, err)
+	q = u.Query()
+	require.False(t, q.Has("error"), "re-enrollment with a different IdP email should not fail")
+	require.True(t, q.Has("enrollment_reference"))
+	// same host, so the account UUID (and enrollment reference) is unchanged.
+	require.Equal(t, hostUUID, q.Get("enrollment_reference"))
+
+	// The IdP account and host association now reflect sso_user2.
+	s.checkStoredIdPInfo(t, hostUUID, "sso_user2", "SSO User 2", "sso_user2@example.com")
+	acc, err = s.ds.GetMDMIdPAccountByHostUUID(context.Background(), hostUUID)
+	require.NoError(t, err)
+	require.NotNil(t, acc)
+	require.Equal(t, "sso_user2@example.com", acc.Email)
+
+	// The new email is resolvable, and the old one no longer maps to an account.
+	_, err = s.ds.GetMDMIdPAccountByEmail(context.Background(), "sso_user2@example.com")
+	require.NoError(t, err)
+	_, err = s.ds.GetMDMIdPAccountByEmail(context.Background(), "sso_user@example.com")
+	require.True(t, fleet.IsNotFound(err))
+}
+
 func (s *integrationMDMTestSuite) checkStoredIdPInfo(t *testing.T, uuid, username, fullname, email string) {
 	acc, err := s.ds.GetMDMIdPAccountByUUID(context.Background(), uuid)
 	require.NoError(t, err)

--- a/server/service/testing_client_test.go
+++ b/server/service/testing_client_test.go
@@ -476,6 +476,20 @@ func (ts *withServer) LoginMDMSSOUser(username, password string) *http.Response 
 	return res
 }
 
+// LoginMDMSSOUserSetupExperience initiates the MDM SSO flow as Orbit's setup
+// experience would, passing a fixed host UUID. The host UUID becomes the IdP
+// account's primary key (see InsertMDMIdPAccount), so re-running this for the
+// same host with a different IdP user exercises the re-enrollment upsert path.
+func (ts *withServer) LoginMDMSSOUserSetupExperience(username, password, hostUUID string) *http.Response {
+	body, err := json.Marshal(initiateMDMSSORequest{
+		Initiator: fleet.SSOInitiatorOrbitSetupExperience,
+		HostUUID:  hostUUID,
+	})
+	require.NoError(ts.s.T(), err)
+	res := ts.loginSSOUserWithBody(username, password, "/api/v1/fleet/mdm/sso", http.StatusSeeOther, body)
+	return res
+}
+
 // LoginOTAEnrollSSOUser initiates the OTA enrollment SSO flow by hitting
 // /enroll?enroll_secret=... (as an Android or BYOD device would), follows the
 // SAML login at the IdP, and posts the SAMLResponse back to the MDM SSO


### PR DESCRIPTION
Resolves #47626.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where SSO re-enrollment would fail for devices when users re-enroll using a different email address than their previous enrollment. The system now properly handles email updates during SSO re-enrollment, allowing for seamless transitions when user credentials change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->