### PR TITLE
Website: Update get-territory-user-id helper

### DIFF
--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -10,7 +10,7 @@ module.exports = {
   inputs: {
     state: { type: 'string' },
     city: { type: 'string' },
-    country: { type: 'string', required: true},
+    country: { type: 'string'},
   },
 
 
@@ -24,6 +24,11 @@ module.exports = {
 
 
   fn: async function ({state, city, country}) {
+
+    if(!country) {
+      // IF a country is not provided, throw an error and log the provided inputs to help us debug the issue.
+      throw new Error(`Cannot determine Salesforce territory without a country. Provided inputs: country: ${country}, state: ${state}, city: ${city}`)
+    }
     //  ╦  ╔═╗╔═╗╦╔╗╔  ╔╦╗╔═╗  ╔═╗╔═╗╦  ╔═╗╔═╗╔═╗╔═╗╦═╗╔═╗╔═╗
     //  ║  ║ ║║ ╦║║║║   ║ ║ ║  ╚═╗╠═╣║  ║╣ ╚═╗╠╣ ║ ║╠╦╝║  ║╣
     //  ╩═╝╚═╝╚═╝╩╝╚╝   ╩ ╚═╝  ╚═╝╩ ╩╩═╝╚═╝╚═╝╚  ╚═╝╩╚═╚═╝╚═╝

--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -27,7 +27,7 @@ module.exports = {
 
     if(!country) {
       // IF a country is not provided, throw an error and log the provided inputs to help us debug the issue.
-      throw new Error(`Cannot determine Salesforce territory without a country. Provided inputs: country: ${country}, state: ${state}, city: ${city}`)
+      throw new Error(`Cannot determine Salesforce territory without a country. Provided inputs: country: ${country}, state: ${state}, city: ${city}`);
     }
     //  ╦  ╔═╗╔═╗╦╔╗╔  ╔╦╗╔═╗  ╔═╗╔═╗╦  ╔═╗╔═╗╔═╗╔═╗╦═╗╔═╗╔═╗
     //  ║  ║ ║║ ╦║║║║   ║ ║ ║  ╚═╗╠═╣║  ║╣ ╚═╗╠╣ ║ ║╠╦╝║  ║╣


### PR DESCRIPTION
Changes:
- Updated the get-territory-user-id helper to not require a country input, but to throw an error if one is not provided. This is done to replace the default usageError that is thrown by helpers with an error that provides more information about the provided inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated territory lookup input validation so `country` is no longer required.
  * When `country` is missing or empty, the lookup now fails fast with a clearer, explicit runtime error that includes the provided `state`, `city`, and `country` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->