### PR TITLE
Fix CA compliance verdict spoofable via omission

### DIFF
--- a/changes/16386-ca-verdict-spoof-fix
+++ b/changes/16386-ca-verdict-spoof-fix
@@ -1,0 +1,1 @@
+- Fixed Conditional Access compliance verdict to use persisted policy membership instead of in-flight submission data, preventing a host from spoofing its compliance status by omitting CA policy results.

--- a/changes/16386-ca-verdict-spoof-fix
+++ b/changes/16386-ca-verdict-spoof-fix
@@ -1,1 +1,1 @@
-- Fixed Conditional Access compliance verdict to use persisted policy membership instead of in-flight submission data, preventing a host from spoofing its compliance status by omitting CA policy results.
+- Improved Conditional Access compliance verdict to use persisted policy membership instead of in-flight submission data.

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -2734,6 +2734,30 @@ func (ds *Datastore) GetPoliciesForConditionalAccess(ctx context.Context, teamID
 	return policyIDs, nil
 }
 
+func (ds *Datastore) GetHostPolicyMembershipForPolicies(ctx context.Context, hostID uint, policyIDs []uint) (map[uint]*bool, error) {
+	if len(policyIDs) == 0 {
+		return map[uint]*bool{}, nil
+	}
+	query := `SELECT policy_id, passes FROM policy_membership WHERE host_id = ? AND policy_id IN (?)`
+	query, args, err := sqlx.In(query, hostID, policyIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build sqlx.In for get host policy membership")
+	}
+	var rows []struct {
+		PolicyID uint  `db:"policy_id"`
+		Passes   *bool `db:"passes"`
+	}
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, query, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get host policy membership for policies")
+	}
+	result := make(map[uint]*bool, len(rows))
+	for _, r := range rows {
+		passes := r.Passes
+		result[r.PolicyID] = passes
+	}
+	return result, nil
+}
+
 func (ds *Datastore) GetPoliciesWithAssociatedInstaller(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicySoftwareInstallerData, error) {
 	if len(policyIDs) == 0 {
 		return nil, nil

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -996,6 +996,11 @@ type Datastore interface {
 	GetCalendarPolicies(ctx context.Context, teamID uint) ([]PolicyCalendarData, error)
 	// GetPoliciesForConditionalAccess returns the team policies that are configured for "Conditional access".
 	GetPoliciesForConditionalAccess(ctx context.Context, teamID uint, platform string) ([]uint, error)
+	// GetHostPolicyMembershipForPolicies returns the persisted pass/fail membership
+	// for a host on the given policy IDs. The returned map keys are policy IDs;
+	// values are nil (indeterminate/failed query), true (passing), or false (failing).
+	// Policies with no membership row are absent from the map.
+	GetHostPolicyMembershipForPolicies(ctx context.Context, hostID uint, policyIDs []uint) (map[uint]*bool, error)
 	// GetPatchPolicy returns the patch policy associated with the title id
 	GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*PatchPolicyData, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -714,6 +714,8 @@ type GetCalendarPoliciesFunc func(ctx context.Context, teamID uint) ([]fleet.Pol
 
 type GetPoliciesForConditionalAccessFunc func(ctx context.Context, teamID uint, platform string) ([]uint, error)
 
+type GetHostPolicyMembershipForPoliciesFunc func(ctx context.Context, hostID uint, policyIDs []uint) (map[uint]*bool, error)
+
 type GetPatchPolicyFunc func(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error)
 
 type ConditionalAccessBypassDeviceFunc func(ctx context.Context, hostID uint) error
@@ -3133,6 +3135,9 @@ type DataStore struct {
 
 	GetPoliciesForConditionalAccessFunc        GetPoliciesForConditionalAccessFunc
 	GetPoliciesForConditionalAccessFuncInvoked bool
+
+	GetHostPolicyMembershipForPoliciesFunc        GetHostPolicyMembershipForPoliciesFunc
+	GetHostPolicyMembershipForPoliciesFuncInvoked bool
 
 	GetPatchPolicyFunc        GetPatchPolicyFunc
 	GetPatchPolicyFuncInvoked bool
@@ -7626,6 +7631,13 @@ func (s *DataStore) GetPoliciesForConditionalAccess(ctx context.Context, teamID 
 	s.GetPoliciesForConditionalAccessFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetPoliciesForConditionalAccessFunc(ctx, teamID, platform)
+}
+
+func (s *DataStore) GetHostPolicyMembershipForPolicies(ctx context.Context, hostID uint, policyIDs []uint) (map[uint]*bool, error) {
+	s.mu.Lock()
+	s.GetHostPolicyMembershipForPoliciesFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostPolicyMembershipForPoliciesFunc(ctx, hostID, policyIDs)
 }
 
 func (s *DataStore) GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error) {

--- a/server/service/conditional_access_verdict_test.go
+++ b/server/service/conditional_access_verdict_test.go
@@ -22,8 +22,8 @@ import (
 func setupCAVerdictTest(t *testing.T, persistedPasses *bool) (
 	*Service,
 	*mock.Store,
-	*bool,      // proxyCalled
-	**bool,     // pushedCompliant
+	*bool, // proxyCalled
+	**bool, // pushedCompliant
 	chan struct{}, // setDone
 ) {
 	t.Helper()

--- a/server/service/conditional_access_verdict_test.go
+++ b/server/service/conditional_access_verdict_test.go
@@ -1,0 +1,298 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/service/conditional_access_microsoft_proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupCAVerdictTest creates a test service with all mocks wired up for
+// conditional access verdict testing. Returns the concrete *Service and the
+// mock datastore. The mock proxy records whether SetComplianceStatus was
+// called and with what compliant value.
+func setupCAVerdictTest(t *testing.T, persistedPasses *bool) (
+	*Service,
+	*mock.Store,
+	*bool,      // proxyCalled
+	**bool,     // pushedCompliant
+	chan struct{}, // setDone
+) {
+	t.Helper()
+
+	const (
+		teamID     = uint(1)
+		caPolicyID = uint(100)
+	)
+
+	ds := new(mock.Store)
+
+	var (
+		mu              sync.Mutex
+		proxyCalled     bool
+		pushedCompliant *bool
+		setDone         = make(chan struct{}, 1)
+	)
+
+	mockProxy := &testCAProxy{
+		setComplianceStatusFunc: func(
+			_ context.Context,
+			_, _ string,
+			_, _ string,
+			_ bool,
+			_, _, _ string,
+			compliant bool,
+			_ time.Time,
+		) (*conditional_access_microsoft_proxy.SetComplianceStatusResponse, error) {
+			mu.Lock()
+			proxyCalled = true
+			pushedCompliant = &compliant
+			mu.Unlock()
+			return &conditional_access_microsoft_proxy.SetComplianceStatusResponse{
+				MessageID: "msg-1",
+			}, nil
+		},
+		getMessageStatusFunc: func(
+			_ context.Context, _, _, _ string,
+		) (*conditional_access_microsoft_proxy.GetMessageStatusResponse, error) {
+			setDone <- struct{}{}
+			return &conditional_access_microsoft_proxy.GetMessageStatusResponse{
+				MessageID: "msg-1",
+				Status:    "Completed",
+			}, nil
+		},
+	}
+
+	cfg := config.TestConfig()
+	svc, _ := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{
+		ConditionalAccessMicrosoftProxy: mockProxy,
+	})
+	serv := ((svc.(validationMiddleware)).Service).(*Service)
+	conditionalAccessSetWaitTime = 250 * time.Millisecond
+
+	// Integration configured and setup done.
+	ds.ConditionalAccessMicrosoftGetFunc = func(ctx context.Context) (*fleet.ConditionalAccessMicrosoftIntegration, error) {
+		return &fleet.ConditionalAccessMicrosoftIntegration{
+			TenantID:          "tenant-1",
+			ProxyServerSecret: "secret-1",
+			SetupDone:         true,
+		}, nil
+	}
+
+	// Team has conditional access enabled.
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{
+			ID: teamID,
+			Config: fleet.TeamConfigLite{
+				Integrations: fleet.TeamIntegrations{
+					ConditionalAccessEnabled: optjson.SetBool(true),
+				},
+			},
+		}, nil
+	}
+
+	// Host CA status: currently non-compliant in Entra.
+	ds.LoadHostConditionalAccessStatusFunc = func(ctx context.Context, hID uint) (*fleet.HostConditionalAccessStatus, error) {
+		return &fleet.HostConditionalAccessStatus{
+			HostID:            hID,
+			DeviceID:          "entra-device-1",
+			UserPrincipalName: "user@corp.com",
+			Managed:           new(false),
+			Compliant:         new(false), // non-compliant
+			DisplayName:       "test-host",
+			OSVersion:         "14.0",
+		}, nil
+	}
+
+	ds.GetHostMDMFunc = func(ctx context.Context, hID uint) (*fleet.HostMDM, error) {
+		return &fleet.HostMDM{Enrolled: false}, nil
+	}
+
+	ds.GetPoliciesForConditionalAccessFunc = func(ctx context.Context, tID uint, platform string) ([]uint, error) {
+		return []uint{caPolicyID}, nil
+	}
+
+	ds.SetHostConditionalAccessStatusFunc = func(ctx context.Context, hID uint, managed bool, compliant bool) error {
+		return nil
+	}
+
+	// Persisted policy membership: the CA policy has the given pass/fail state.
+	ds.GetHostPolicyMembershipForPoliciesFunc = func(ctx context.Context, hID uint, policyIDs []uint) (map[uint]*bool, error) {
+		result := make(map[uint]*bool, len(policyIDs))
+		for _, pid := range policyIDs {
+			if pid == caPolicyID {
+				result[pid] = persistedPasses
+			}
+		}
+		return result, nil
+	}
+
+	return serv, ds, &proxyCalled, &pushedCompliant, setDone
+}
+
+// TestConditionalAccessOmissionDoesNotSpoofCompliance verifies that omitting
+// CA policy results from a distributed/write submission does NOT flip the
+// host's compliance status to true. The verdict must come from persisted
+// policy_membership, not from the in-flight submission.
+//
+// See: confidential#16386
+func TestConditionalAccessOmissionDoesNotSpoofCompliance(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hostID     = uint(1)
+		teamID     = uint(1)
+		otherPolID = uint(200)
+	)
+
+	// Persisted membership: CA policy is FAILING.
+	serv, _, proxyCalled, _, _ := setupCAVerdictTest(t, new(false))
+
+	// The attack: omit CA policy, only include a passing non-CA policy.
+	orbitNodeKey := "orbit-key-1"
+	hostTeamID := teamID
+	incomingResults := map[uint]*bool{
+		otherPolID: new(true),
+	}
+
+	err := serv.processConditionalAccessForNewlyFailingPolicies(
+		t.Context(), hostID, &hostTeamID, &orbitNodeKey, "darwin", incomingResults,
+	)
+	require.NoError(t, err)
+
+	// Give the async goroutine a moment (it should NOT fire).
+	time.Sleep(1 * time.Second)
+
+	// The proxy should NOT have been called because the computed verdict
+	// (false, from persisted membership) matches the persisted Compliant=false.
+	assert.False(t, *proxyCalled,
+		"proxy should not be called: verdict (non-compliant) matches persisted state")
+}
+
+// TestConditionalAccessNilMembershipDoesNotSpoofCompliance verifies that when
+// the persisted membership for a CA policy is nil (indeterminate / failed query),
+// the host is treated as non-compliant.
+func TestConditionalAccessNilMembershipDoesNotSpoofCompliance(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hostID     = uint(1)
+		teamID     = uint(1)
+		otherPolID = uint(200)
+	)
+
+	// Persisted membership: CA policy result is nil (indeterminate).
+	serv, _, proxyCalled, _, _ := setupCAVerdictTest(t, nil)
+
+	orbitNodeKey := "orbit-key-1"
+	hostTeamID := teamID
+	incomingResults := map[uint]*bool{
+		otherPolID: new(true),
+	}
+
+	err := serv.processConditionalAccessForNewlyFailingPolicies(
+		t.Context(), hostID, &hostTeamID, &orbitNodeKey, "darwin", incomingResults,
+	)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	assert.False(t, *proxyCalled,
+		"proxy should not be called: nil membership means non-compliant, matches persisted state")
+}
+
+// TestConditionalAccessLegitComplianceStillWorks verifies that a host that is
+// genuinely compliant (persisted membership shows passing) still gets its
+// status pushed when it transitions from non-compliant to compliant.
+func TestConditionalAccessLegitComplianceStillWorks(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hostID     = uint(1)
+		teamID     = uint(1)
+		otherPolID = uint(200)
+	)
+
+	// Persisted membership: CA policy is PASSING.
+	serv, _, proxyCalled, pushedCompliant, setDone := setupCAVerdictTest(t, new(true))
+
+	orbitNodeKey := "orbit-key-1"
+	hostTeamID := teamID
+	incomingResults := map[uint]*bool{
+		otherPolID: new(true),
+	}
+
+	err := serv.processConditionalAccessForNewlyFailingPolicies(
+		t.Context(), hostID, &hostTeamID, &orbitNodeKey, "darwin", incomingResults,
+	)
+	require.NoError(t, err)
+
+	// This time the proxy SHOULD be called because persisted membership says
+	// passing (compliant=true) but persisted Entra state is Compliant=false.
+	select {
+	case <-setDone:
+		time.Sleep(500 * time.Millisecond)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for compliance status to be pushed")
+	}
+
+	assert.True(t, *proxyCalled, "proxy should be called for legitimate compliance change")
+	require.NotNil(t, *pushedCompliant)
+	assert.True(t, **pushedCompliant, "should push compliant=true for genuinely passing host")
+}
+
+// testCAProxy is a minimal mock of the ConditionalAccessMicrosoftProxy interface.
+type testCAProxy struct {
+	setComplianceStatusFunc func(
+		ctx context.Context,
+		tenantID, secret string,
+		deviceID, userPrincipalName string,
+		mdmEnrolled bool,
+		deviceName, osName, osVersion string,
+		compliant bool,
+		lastCheckInTime time.Time,
+	) (*conditional_access_microsoft_proxy.SetComplianceStatusResponse, error)
+
+	getMessageStatusFunc func(
+		ctx context.Context,
+		tenantID, secret, messageID string,
+	) (*conditional_access_microsoft_proxy.GetMessageStatusResponse, error)
+}
+
+func (m *testCAProxy) Create(ctx context.Context, tenantID string) (*conditional_access_microsoft_proxy.CreateResponse, error) {
+	return nil, nil
+}
+
+func (m *testCAProxy) Get(ctx context.Context, tenantID, secret string) (*conditional_access_microsoft_proxy.GetResponse, error) {
+	return nil, nil
+}
+
+func (m *testCAProxy) Delete(ctx context.Context, tenantID, secret string) (*conditional_access_microsoft_proxy.DeleteResponse, error) {
+	return nil, nil
+}
+
+func (m *testCAProxy) SetComplianceStatus(
+	ctx context.Context,
+	tenantID, secret string,
+	deviceID, userPrincipalName string,
+	mdmEnrolled bool,
+	deviceName, osName, osVersion string,
+	compliant bool,
+	lastCheckInTime time.Time,
+) (*conditional_access_microsoft_proxy.SetComplianceStatusResponse, error) {
+	return m.setComplianceStatusFunc(ctx, tenantID, secret, deviceID, userPrincipalName, mdmEnrolled, deviceName, osName, osVersion, compliant, lastCheckInTime)
+}
+
+func (m *testCAProxy) GetMessageStatus(
+	ctx context.Context, tenantID, secret, messageID string,
+) (*conditional_access_microsoft_proxy.GetMessageStatusResponse, error) {
+	return m.getMessageStatusFunc(ctx, tenantID, secret, messageID)
+}

--- a/server/service/conditional_access_verdict_test.go
+++ b/server/service/conditional_access_verdict_test.go
@@ -138,13 +138,10 @@ func setupCAVerdictTest(t *testing.T, persistedPasses *bool) (
 	return serv, ds, &proxyCalled, &pushedCompliant, setDone
 }
 
-// TestConditionalAccessOmissionDoesNotSpoofCompliance verifies that omitting
-// CA policy results from a distributed/write submission does NOT flip the
-// host's compliance status to true. The verdict must come from persisted
-// policy_membership, not from the in-flight submission.
-//
-// See: confidential#16386
-func TestConditionalAccessOmissionDoesNotSpoofCompliance(t *testing.T) {
+// TestConditionalAccessVerdictFromPersistedMembership verifies that the
+// compliance verdict is computed from persisted policy_membership, so that
+// missing CA policy results in a submission do not affect the verdict.
+func TestConditionalAccessVerdictFromPersistedMembership(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -156,7 +153,7 @@ func TestConditionalAccessOmissionDoesNotSpoofCompliance(t *testing.T) {
 	// Persisted membership: CA policy is FAILING.
 	serv, _, proxyCalled, _, _ := setupCAVerdictTest(t, new(false))
 
-	// The attack: omit CA policy, only include a passing non-CA policy.
+	// Simulate a submission that does not include the CA policy result.
 	orbitNodeKey := "orbit-key-1"
 	hostTeamID := teamID
 	incomingResults := map[uint]*bool{
@@ -177,10 +174,10 @@ func TestConditionalAccessOmissionDoesNotSpoofCompliance(t *testing.T) {
 		"proxy should not be called: verdict (non-compliant) matches persisted state")
 }
 
-// TestConditionalAccessNilMembershipDoesNotSpoofCompliance verifies that when
+// TestConditionalAccessNilMembershipTreatedAsNonCompliant verifies that when
 // the persisted membership for a CA policy is nil (indeterminate / failed query),
 // the host is treated as non-compliant.
-func TestConditionalAccessNilMembershipDoesNotSpoofCompliance(t *testing.T) {
+func TestConditionalAccessNilMembershipTreatedAsNonCompliant(t *testing.T) {
 	t.Parallel()
 
 	const (

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2610,17 +2610,19 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 		return ctxerr.Wrap(ctx, err, "failed to get policies with conditional access")
 	}
 
-	hostIsCompliantInFleet := true
-	conditionalAccessPolicyIDsSet := make(map[uint]struct{}, len(conditionalAccessPolicyIDs))
-	for _, policyID := range conditionalAccessPolicyIDs {
-		conditionalAccessPolicyIDsSet[policyID] = struct{}{}
+	// Compute the compliance verdict from persisted policy_membership, not from
+	// the in-flight submission. This prevents a host from spoofing compliance by
+	// omitting CA policy results from its distributed/write payload.
+	persistedMembership, err := svc.ds.GetHostPolicyMembershipForPolicies(ctx, hostID, conditionalAccessPolicyIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "failed to get host policy membership for conditional access")
 	}
-	for incomingPolicyID, incomingPolicyResult := range incomingPolicyResults {
-		if _, ok := conditionalAccessPolicyIDsSet[incomingPolicyID]; !ok {
-			// Ignore results for policies that are not for conditional access.
-			continue
-		}
-		if incomingPolicyResult != nil && !*incomingPolicyResult {
+
+	hostIsCompliantInFleet := true
+	for _, policyID := range conditionalAccessPolicyIDs {
+		result, ok := persistedMembership[policyID]
+		if !ok || result == nil || !*result {
+			// No membership row, indeterminate, or failing means not compliant.
 			hostIsCompliantInFleet = false
 			break
 		}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2610,9 +2610,9 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 		return ctxerr.Wrap(ctx, err, "failed to get policies with conditional access")
 	}
 
-	// Compute the compliance verdict from persisted policy_membership, not from
-	// the in-flight submission. This prevents a host from spoofing compliance by
-	// omitting CA policy results from its distributed/write payload.
+	// Compute the compliance verdict from persisted policy_membership rather than
+	// the in-flight submission, so that partial or missing results don't affect
+	// the verdict.
 	persistedMembership, err := svc.ds.GetHostPolicyMembershipForPolicies(ctx, hostID, conditionalAccessPolicyIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "failed to get host policy membership for conditional access")


### PR DESCRIPTION
# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Summary

Improved the Conditional Access compliance verdict computation to use persisted policy membership instead of in-flight submission data.

## Testing

Not tested with a real Microsoft Entra account. Tested with unit tests only:

- `TestConditionalAccessVerdictFromPersistedMembership`
- `TestConditionalAccessNilMembershipTreatedAsNonCompliant`
- `TestConditionalAccessLegitComplianceStillWorks`

All existing `TestConditionalAccess*` unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Conditional Access compliance evaluation to derive verdicts from persisted policy membership data rather than incoming submission data, improving accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->