### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.35.4",
+      "version": "2.35.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.5') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.4.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.5.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "0785d8af3ef6f31a5f407287a1edf879fe94d19b24e7616e0d0894f38c79932c",
+      "sha256": "648b9854ffc71147223d98fbea53d82612e724c56c98531ad66c9df668ce14a9",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/codex-app/darwin.json
+++ b/ee/maintained-apps/outputs/codex-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.609.41114",
+      "version": "26.609.71450",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.609.41114') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.609.71450') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.609.41114.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.609.71450.zip",
       "install_script_ref": "5e3efa57",
       "uninstall_script_ref": "a2b5ee81",
-      "sha256": "6f69d0de7800bc7f48cda0f87810068f109fe6ecf839df8dec0d093cb23ad362",
+      "sha256": "e773c824d5ad0d8567bbabb1d39f32ce730dd4699e4a9de5b838ea6955e268b7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.35.0",
+      "version": "0.36.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.35.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.36.0') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.35.0/CodexBar-macos-universal-0.35.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.36.0/CodexBar-macos-universal-0.36.0.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "961525fe7b86e379a1b048fc5113f757867435d4ad6749494ef6fe9fa672c266",
+      "sha256": "c30fcd2ccf2bed482b57a6c010d77085ced359fe593e64daca3402b153e5f347",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/discord/windows.json
+++ b/ee/maintained-apps/outputs/discord/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.9241",
+      "version": "1.0.9242",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9241') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9242') < 0);"
       },
-      "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9241/DiscordSetup.exe",
+      "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9242/DiscordSetup.exe",
       "install_script_ref": "fd04e860",
       "uninstall_script_ref": "73fc6eff",
-      "sha256": "99909799082c39500bd6abe13ec7752fbe13ee659a75ddab585ff727d1d8b2bb",
+      "sha256": "3ee7967fc974f0f0d3c829d196f6c9846331815d3ab1c3b61b972306b60e1e71",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/loom/windows.json
+++ b/ee/maintained-apps/outputs/loom/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.353.3",
+      "version": "0.354.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.353.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.354.0') < 0);"
       },
-      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.353.3.exe",
+      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.354.0.exe",
       "install_script_ref": "77327cbf",
       "uninstall_script_ref": "b012f1e7",
-      "sha256": "db4b68d78b06fae97442c9ca36a00581632ed6945f4ea867b83ba8ccc63996fa",
+      "sha256": "65df0c885a41eda53d694440c36392ce31b40520531cf4b4b0d189df66b8c81d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/milanote/darwin.json
+++ b/ee/maintained-apps/outputs/milanote/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.18.107",
+      "version": "3.18.108",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.milanote.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.milanote.app' AND version_compare(bundle_short_version, '3.18.107') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.milanote.app' AND version_compare(bundle_short_version, '3.18.108') < 0);"
       },
-      "installer_url": "https://milanote-app-releases.s3.amazonaws.com/Milanote-3.18.107.dmg",
+      "installer_url": "https://milanote-app-releases.s3.amazonaws.com/Milanote-3.18.108.dmg",
       "install_script_ref": "ed82e649",
       "uninstall_script_ref": "19269206",
-      "sha256": "603c13e5fc91217f9f3527c69dc698ea6c5e7582b438eae872998a9a902e1f26",
+      "sha256": "4e7dc5229c22fe78baa8ee9171e5976251ef44dc816b8b5a0114a7cca2eb1fbe",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/slack/windows.json
+++ b/ee/maintained-apps/outputs/slack/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.50.136",
+      "version": "4.50.140",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.' AND version_compare(version, '4.50.136') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.' AND version_compare(version, '4.50.140') < 0);"
       },
-      "installer_url": "https://downloads.slack-edge.com/desktop-releases/windows/x64/4.50.136/Slack.msix",
+      "installer_url": "https://downloads.slack-edge.com/desktop-releases/windows/x64/4.50.140/Slack.msix",
       "install_script_ref": "8b41f934",
       "uninstall_script_ref": "034eae14",
-      "sha256": "da15dc60c979b4c278278ac0b00e754716fc2163d2b1144a1a570dd82bb7b13d",
+      "sha256": "c2a04477eeb19dced44462b605ef87a929af75425d0dac3ee8c179a31b75c0b7",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application metadata for AWS CLI (Windows 2.35.5), Codex (macOS 26.609.71450), CodexBar (macOS 0.36.0), Discord (Windows 1.0.9242), Loom (Windows 0.354.0), Milanote (macOS 3.18.108), and Slack (Windows 4.50.140).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->