### PR TITLE
Orbit re-enroll improvements

### DIFF
--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -39,6 +39,18 @@ type OrbitClient struct {
 	enrolledMu sync.Mutex
 	enrolled   bool
 
+	// reenrollMu guards the 401 debounce state below.
+	reenrollMu sync.Mutex
+	// unauthenticatedSince is when authenticated requests first started failing with a 401 in the
+	// current streak. Zero means the most recent authenticated request succeeded (or none have
+	// failed). Used to debounce re-enrollment so a transient/spurious 401 does not throw away an
+	// otherwise-valid node key.
+	unauthenticatedSince time.Time
+	// forceReenroll is armed once 401s have persisted past unauthenticatedReenrollGracePeriod. When
+	// set, getNodeKeyOrEnroll re-enrolls (overwriting the existing key) even though a node key file
+	// is present.
+	forceReenroll bool
+
 	lastRecordedErrMu sync.Mutex
 	lastRecordedErr   error
 
@@ -87,6 +99,13 @@ const configCacheTTL = 3 * time.Second
 // If the user closes the SSO browser window before completing authentication,
 // the window will be re-opened after this interval.
 const ssoWindowReopenInterval = 5 * time.Minute
+
+// unauthenticatedReenrollGracePeriod is how long authenticated requests must keep failing with a
+// 401 before orbit re-enrolls. Deleting/replacing the node key is a heavyweight action (it forces a
+// re-enroll, which can require end-user SSO), so we ride out transient or spurious 401s first (e.g.
+// brief read-replica lag or a short-lived server-side negative cache) rather than reacting to a
+// single one. It is a var (not a const) so tests can shorten it.
+var unauthenticatedReenrollGracePeriod = 60 * time.Second
 
 type configCache struct {
 	mu          sync.Mutex
@@ -552,14 +571,29 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 	defer enrollLock.Unlock()
 
 	orbitNodeKey, err := os.ReadFile(oc.nodeKeyFilePath)
-	switch {
-	case err == nil:
-		return string(orbitNodeKey), nil
-	case errors.Is(err, fs.ErrNotExist):
-		// OK, if there's no orbit node key, proceed to enroll.
-	default:
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("read orbit node key file: %w", err)
 	}
+	// A present, non-empty key is reused unless the server has been rejecting it (forceReenroll,
+	// armed by repeated 401s in authenticatedRequest). Read it once so the reuse check and the log
+	// message below agree even if a concurrent 401 flips it.
+	forced := oc.reenrollForced()
+	if err == nil && len(bytes.TrimSpace(orbitNodeKey)) > 0 && !forced {
+		return string(orbitNodeKey), nil
+	}
+
+	switch {
+	case forced:
+		// The node key on disk was repeatedly rejected with a 401; re-enroll to obtain a fresh one.
+		log.Info().Str("server", oc.BaseURL.String()).Msg("orbit node key was rejected by the server, re-enrolling")
+	case err == nil:
+		// The file exists but is empty (e.g. a prior write was interrupted). Enroll instead of
+		// sending an empty key that the server would reject with a 401.
+		log.Info().Str("server", oc.BaseURL.String()).Msg("orbit node key file is empty, enrolling")
+	default:
+		log.Info().Str("server", oc.BaseURL.String()).Msg("orbit node key file not found, enrolling")
+	}
+
 	var orbitNodeKey_ string
 	if err := retry.Do(
 		func() error {
@@ -612,6 +646,8 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 		}
 		return "", fmt.Errorf("orbit node key enroll failed, attempts=%d", constant.OrbitEnrollMaxRetries)
 	}
+	// Enrollment succeeded and the new key has been written, so clear any armed re-enroll / 401 streak.
+	oc.clearReenrollState()
 	return orbitNodeKey_, nil
 }
 
@@ -630,21 +666,55 @@ func (oc *OrbitClient) enrollAndWriteNodeKeyFile() (string, error) {
 		return "", fmt.Errorf("enroll request: %w", err)
 	}
 
-	if runtime.GOOS == "windows" {
-		// creating the secret file with empty content
-		if err := os.WriteFile(oc.nodeKeyFilePath, nil, constant.DefaultFileMode); err != nil {
-			return "", fmt.Errorf("create orbit node key file: %w", err)
+	// Write the new node key atomically: write+restrict a temp file in the same directory, then
+	// rename it over the destination. This guarantees we never truncate or remove an existing,
+	// still-valid node key until the new key is fully on disk, so a crash mid-write (or an enroll
+	// that is ultimately rejected) cannot leave the host with an empty or missing node key file.
+	tmp, err := os.CreateTemp(filepath.Dir(oc.nodeKeyFilePath), ".orbit-node-key-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp orbit node key file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	renamed := false
+	closed := false
+	closeTmp := func() error {
+		if closed {
+			return nil
 		}
-		// restricting file access
-		if err := platform.ChmodRestrictFile(oc.nodeKeyFilePath); err != nil {
+		closed = true
+		return tmp.Close()
+	}
+	defer func() {
+		if !renamed {
+			_ = closeTmp()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if runtime.GOOS == "windows" {
+		// Restrict file access before the key material is written so the secret is never on disk
+		// with default (inherited) permissions.
+		if err := platform.ChmodRestrictFile(tmpPath); err != nil {
 			return "", fmt.Errorf("apply ACLs: %w", err)
 		}
 	}
-
-	// writing raw key material to the acl-ready secret file
-	if err := os.WriteFile(oc.nodeKeyFilePath, []byte(orbitNodeKey), constant.DefaultFileMode); err != nil {
-		return "", fmt.Errorf("write orbit node key file: %w", err)
+	if _, err := tmp.WriteString(orbitNodeKey); err != nil {
+		return "", fmt.Errorf("write temp orbit node key file: %w", err)
 	}
+	if err := tmp.Sync(); err != nil {
+		return "", fmt.Errorf("sync temp orbit node key file: %w", err)
+	}
+	if err := closeTmp(); err != nil {
+		return "", fmt.Errorf("close temp orbit node key file: %w", err)
+	}
+	// os.Rename replaces the destination atomically. On Windows this can fail with a sharing
+	// violation if another process (e.g. antivirus/EDR) holds the destination open at this instant;
+	// in that case the existing key is left intact and we retry on the next enroll, which is the
+	// desired fallback.
+	if err := os.Rename(tmpPath, oc.nodeKeyFilePath); err != nil {
+		return "", fmt.Errorf("replace orbit node key file: %w", err)
+	}
+	renamed = true
 
 	return orbitNodeKey, nil
 }
@@ -662,12 +732,28 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params any
 	switch {
 	case err == nil:
 		oc.setEnrolled(true)
+		// A successful authenticated request means the node key is valid; clear any 401 streak.
+		oc.clearReenrollState()
 		return nil
 	case errors.Is(err, ErrUnauthenticated):
-		if err := os.Remove(oc.nodeKeyFilePath); err != nil {
-			log.Info().Err(err).Msg("remove orbit node key")
-		}
+		// A 401 on an authenticated request means the server rejected the orbit node key (e.g. the host
+		// was deleted, the key was rotated, or the --fleet-url changed). Rather than reacting to a single
+		// 401 (which can be transient/spurious and would needlessly destroy a valid key and force a
+		// re-enroll), we wait until 401s have persisted for unauthenticatedReenrollGracePeriod. We never
+		// delete the key here: getNodeKeyOrEnroll re-enrolls and overwrites it only once a new key is
+		// obtained (acquire-then-replace), so a re-enroll blocked by end-user auth keeps the current key.
+		// Logged at INFO (not debug) because this is the event that triggers an unexpected re-enrollment,
+		// and the request path identifies which endpoint saw the 401 (e.g. the orbit config endpoint).
 		oc.setEnrolled(false)
+		reenroll, waited := oc.noteUnauthenticated()
+		if reenroll {
+			log.Info().Str("path", path).Dur("after", waited).
+				Msg("orbit node key repeatedly rejected with 401, will re-enroll on next request")
+		} else {
+			log.Info().Str("path", path).Dur("after", waited).
+				Msg("orbit received 401 unauthenticated, retrying with existing node key before re-enrolling")
+			return err
+		}
 
 		if oc.hostIdentityCertPath != "" {
 			if err := os.Remove(oc.hostIdentityCertPath); err != nil {
@@ -680,6 +766,41 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params any
 	default:
 		return err
 	}
+}
+
+// noteUnauthenticated records a 401 on an authenticated request and reports whether 401s have
+// persisted long enough (unauthenticatedReenrollGracePeriod) to warrant a re-enroll, along with how
+// long the current 401 streak has lasted. When it returns true it arms forceReenroll, which
+// getNodeKeyOrEnroll acts on (overwriting the existing key) on the next call.
+func (oc *OrbitClient) noteUnauthenticated() (reenroll bool, waited time.Duration) {
+	oc.reenrollMu.Lock()
+	defer oc.reenrollMu.Unlock()
+	now := time.Now()
+	if oc.unauthenticatedSince.IsZero() {
+		oc.unauthenticatedSince = now
+	}
+	waited = now.Sub(oc.unauthenticatedSince)
+	if waited >= unauthenticatedReenrollGracePeriod {
+		oc.forceReenroll = true
+		return true, waited
+	}
+	return false, waited
+}
+
+// reenrollForced reports whether a re-enroll has been armed by repeated 401s.
+func (oc *OrbitClient) reenrollForced() bool {
+	oc.reenrollMu.Lock()
+	defer oc.reenrollMu.Unlock()
+	return oc.forceReenroll
+}
+
+// clearReenrollState resets the 401 streak and any armed re-enroll, called after a successful
+// authenticated request or a successful (re-)enroll.
+func (oc *OrbitClient) clearReenrollState() {
+	oc.reenrollMu.Lock()
+	defer oc.reenrollMu.Unlock()
+	oc.unauthenticatedSince = time.Time{}
+	oc.forceReenroll = false
 }
 
 func (oc *OrbitClient) Enrolled() bool {

--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -41,14 +41,12 @@ type OrbitClient struct {
 
 	// reenrollMu guards the 401 debounce state below.
 	reenrollMu sync.Mutex
-	// unauthenticatedSince is when authenticated requests first started failing with a 401 in the
-	// current streak. Zero means the most recent authenticated request succeeded (or none have
-	// failed). Used to debounce re-enrollment so a transient/spurious 401 does not throw away an
-	// otherwise-valid node key.
+	// unauthenticatedSince is when authenticated requests first started failing with a 401 in the current streak. Zero means the most
+	// recent authenticated request succeeded (or none have failed). Used to debounce re-enrollment so a transient/spurious 401 does
+	// not throw away an otherwise-valid node key.
 	unauthenticatedSince time.Time
-	// forceReenroll is armed once 401s have persisted past unauthenticatedReenrollGracePeriod. When
-	// set, getNodeKeyOrEnroll re-enrolls (overwriting the existing key) even though a node key file
-	// is present.
+	// forceReenroll is armed once 401s have persisted past unauthenticatedReenrollGracePeriod. When set, getNodeKeyOrEnroll
+	// re-enrolls (overwriting the existing key).
 	forceReenroll bool
 
 	lastRecordedErrMu sync.Mutex
@@ -79,10 +77,8 @@ type OrbitClient struct {
 
 	// hostIdentityCertPath is the file path to the host identity certificate issued using SCEP.
 	//
-	// If set, it is deleted once HTTP 401 errors from Fleet have persisted past
-	// unauthenticatedReenrollGracePeriod (see authenticatedRequest), which also causes
-	// ExecuteConfigReceivers to terminate and trigger a restart. Transient 401s within the grace
-	// period leave it in place.
+	// If set, it is deleted once HTTP 401 errors from Fleet have persisted past unauthenticatedReenrollGracePeriod (see
+	// authenticatedRequest), which also causes ExecuteConfigReceivers to terminate and trigger a restart.
 	hostIdentityCertPath string
 
 	// lastSSOWindowOpen tracks when the SSO browser window was last opened.
@@ -102,15 +98,8 @@ const configCacheTTL = 3 * time.Second
 // the window will be re-opened after this interval.
 const ssoWindowReopenInterval = 5 * time.Minute
 
-// unauthenticatedReenrollGracePeriod is how long authenticated requests must keep failing with a
-// 401 before orbit re-enrolls. Re-enrolling is a heavyweight action (it can trigger an end-user SSO
-// prompt), so we ride out transient or spurious 401s first (e.g. brief read-replica lag or a
-// short-lived server-side negative cache) rather than reacting to a single one. The only conditions
-// that 401 a valid key are those caches/lag of a few seconds; server faults return 5xx, which we
-// already ignore here. 45s comfortably outlasts them while still recovering a genuinely
-// invalidated key within ~1 minute, and is deliberately not a multiple of the ~30s config poll
-// interval so the re-enroll decision doesn't land on a poll boundary. It is a var (not a const) so
-// tests can shorten it.
+// unauthenticatedReenrollGracePeriod is how long authenticated requests must keep failing with a 401 before orbit re-enrolls.
+// It is a var (not a const) so tests can shorten it.
 var unauthenticatedReenrollGracePeriod = 45 * time.Second
 
 type configCache struct {
@@ -580,9 +569,8 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("read orbit node key file: %w", err)
 	}
-	// A present, non-empty key is reused unless the server has been rejecting it (forceReenroll,
-	// armed by repeated 401s in authenticatedRequest). Read it once so the reuse check and the log
-	// message below agree even if a concurrent 401 flips it.
+	// A present, non-empty key is reused unless the server has been rejecting it (forceReenroll). Read it once so the reuse check and
+	// the log message below agree even if a concurrent 401 flips it.
 	forced := oc.reenrollForced()
 	if err == nil && len(bytes.TrimSpace(orbitNodeKey)) > 0 && !forced {
 		return string(orbitNodeKey), nil
@@ -672,10 +660,9 @@ func (oc *OrbitClient) enrollAndWriteNodeKeyFile() (string, error) {
 		return "", fmt.Errorf("enroll request: %w", err)
 	}
 
-	// Write the new node key atomically: write+restrict a temp file in the same directory, then
-	// rename it over the destination. This guarantees we never truncate or remove an existing,
-	// still-valid node key until the new key is fully on disk, so a crash mid-write (or an enroll
-	// that is ultimately rejected) cannot leave the host with an empty or missing node key file.
+	// Write the new node key atomically: write+restrict a temp file in the same directory, then rename it over the destination. This
+	// guarantees we never truncate or remove an existing, still-valid node key until the new key is fully on disk, so a crash
+	// mid-write (or an enroll that is ultimately rejected) cannot leave the host with an empty or missing node key file.
 	tmp, err := os.CreateTemp(filepath.Dir(oc.nodeKeyFilePath), ".orbit-node-key-*")
 	if err != nil {
 		return "", fmt.Errorf("create temp orbit node key file: %w", err)
@@ -713,10 +700,11 @@ func (oc *OrbitClient) enrollAndWriteNodeKeyFile() (string, error) {
 	if err := closeTmp(); err != nil {
 		return "", fmt.Errorf("close temp orbit node key file: %w", err)
 	}
-	// os.Rename replaces the destination atomically. On Windows this can fail with a sharing
-	// violation if another process (e.g. antivirus/EDR) holds the destination open at this instant;
-	// in that case the existing key is left intact and we retry on the next enroll, which is the
-	// desired fallback.
+	// os.Rename atomically replaces the destination; this matches orbit's existing atomic-write pattern (e.g. pkg/update). On Windows
+	// a rename can fail with a sharing violation if another process (e.g. antivirus/EDR) holds the destination open at this instant
+	// (orbit already contends with Windows file-in-use locking elsewhere, see orbit/pkg/platform). On failure we don't leave an empty
+	// or partial file: the prior key stays on disk. enroll() has already rotated the server-side key by this point, so that on-disk
+	// key is now stale and the host will 401 and re-enroll via the debounce path on a later attempt (self-healing).
 	if err := os.Rename(tmpPath, oc.nodeKeyFilePath); err != nil {
 		return "", fmt.Errorf("replace orbit node key file: %w", err)
 	}
@@ -742,14 +730,7 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params any
 		oc.clearReenrollState()
 		return nil
 	case errors.Is(err, ErrUnauthenticated):
-		// A 401 on an authenticated request means the server rejected the orbit node key (e.g. the host
-		// was deleted, the key was rotated, or the --fleet-url changed). Rather than reacting to a single
-		// 401 (which can be transient/spurious and would needlessly destroy a valid key and force a
-		// re-enroll), we wait until 401s have persisted for unauthenticatedReenrollGracePeriod. We never
-		// delete the key here: getNodeKeyOrEnroll re-enrolls and overwrites it only once a new key is
-		// obtained (acquire-then-replace), so a re-enroll blocked by end-user auth keeps the current key.
-		// Logged at INFO (not debug) because this is the event that triggers an unexpected re-enrollment,
-		// and the request path identifies which endpoint saw the 401 (e.g. the orbit config endpoint).
+		// A 401 on an authenticated request means the server rejected the orbit node key. Rather than reacting to a single 401, we wait until 401s have persisted for unauthenticatedReenrollGracePeriod.
 		oc.setEnrolled(false)
 		reenroll, waited := oc.noteUnauthenticated()
 		if reenroll {
@@ -774,10 +755,9 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params any
 	}
 }
 
-// noteUnauthenticated records a 401 on an authenticated request and reports whether 401s have
-// persisted long enough (unauthenticatedReenrollGracePeriod) to warrant a re-enroll, along with how
-// long the current 401 streak has lasted. When it returns true it arms forceReenroll, which
-// getNodeKeyOrEnroll acts on (overwriting the existing key) on the next call.
+// noteUnauthenticated records a 401 on an authenticated request and reports whether 401s have persisted long enough
+// (unauthenticatedReenrollGracePeriod) to warrant a re-enroll, along with how long the current 401 streak has lasted. When it
+// returns true it arms forceReenroll, which getNodeKeyOrEnroll acts on (overwriting the existing key) on the next call.
 func (oc *OrbitClient) noteUnauthenticated() (reenroll bool, waited time.Duration) {
 	oc.reenrollMu.Lock()
 	defer oc.reenrollMu.Unlock()

--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -79,8 +79,10 @@ type OrbitClient struct {
 
 	// hostIdentityCertPath is the file path to the host identity certificate issued using SCEP.
 	//
-	// If set then it will be deleted on HTTP 401 errors from Fleet and it will cause ExecuteConfigReceivers
-	// to terminate to trigger a restart.
+	// If set, it is deleted once HTTP 401 errors from Fleet have persisted past
+	// unauthenticatedReenrollGracePeriod (see authenticatedRequest), which also causes
+	// ExecuteConfigReceivers to terminate and trigger a restart. Transient 401s within the grace
+	// period leave it in place.
 	hostIdentityCertPath string
 
 	// lastSSOWindowOpen tracks when the SSO browser window was last opened.

--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -103,11 +103,15 @@ const configCacheTTL = 3 * time.Second
 const ssoWindowReopenInterval = 5 * time.Minute
 
 // unauthenticatedReenrollGracePeriod is how long authenticated requests must keep failing with a
-// 401 before orbit re-enrolls. Deleting/replacing the node key is a heavyweight action (it forces a
-// re-enroll, which can require end-user SSO), so we ride out transient or spurious 401s first (e.g.
-// brief read-replica lag or a short-lived server-side negative cache) rather than reacting to a
-// single one. It is a var (not a const) so tests can shorten it.
-var unauthenticatedReenrollGracePeriod = 60 * time.Second
+// 401 before orbit re-enrolls. Re-enrolling is a heavyweight action (it can trigger an end-user SSO
+// prompt), so we ride out transient or spurious 401s first (e.g. brief read-replica lag or a
+// short-lived server-side negative cache) rather than reacting to a single one. The only conditions
+// that 401 a valid key are those caches/lag of a few seconds; server faults return 5xx, which we
+// already ignore here. 45s comfortably outlasts them while still recovering a genuinely
+// invalidated key within ~1 minute, and is deliberately not a multiple of the ~30s config poll
+// interval so the re-enroll decision doesn't land on a poll boundary. It is a var (not a const) so
+// tests can shorten it.
+var unauthenticatedReenrollGracePeriod = 45 * time.Second
 
 type configCache struct {
 	mu          sync.Mutex
@@ -749,10 +753,10 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params any
 		oc.setEnrolled(false)
 		reenroll, waited := oc.noteUnauthenticated()
 		if reenroll {
-			log.Info().Str("path", path).Dur("after", waited).
+			log.Info().Str("path", path).Str("after", waited.Round(time.Second).String()).
 				Msg("orbit node key repeatedly rejected with 401, will re-enroll on next request")
 		} else {
-			log.Info().Str("path", path).Dur("after", waited).
+			log.Info().Str("path", path).Str("after", waited.Round(time.Second).String()).
 				Msg("orbit received 401 unauthenticated, retrying with existing node key before re-enrolling")
 			return err
 		}

--- a/client/orbit_client_reenroll_test.go
+++ b/client/orbit_client_reenroll_test.go
@@ -28,8 +28,9 @@ func newReenrollTestClient(t *testing.T, serverURL, nodeKeyPath string) *OrbitCl
 	}
 }
 
-// setReenrollGracePeriod temporarily overrides the package-level grace period and returns a restore
-// func. The grace period is package state, so tests using it must not run in parallel.
+// setReenrollGracePeriod temporarily overrides the package-level grace period for the duration of
+// the test, restoring it via t.Cleanup. The grace period is package state, so tests using it must
+// not run in parallel.
 func setReenrollGracePeriod(t *testing.T, d time.Duration) {
 	t.Helper()
 	orig := unauthenticatedReenrollGracePeriod
@@ -208,7 +209,10 @@ func TestAuthenticatedRequest401Debounce(t *testing.T) {
 		// and the request then succeeds.
 		err = oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
 		require.NoError(t, err)
-		require.GreaterOrEqual(t, enrollCalls, 1)
+		mu.Lock()
+		gotEnrollCalls := enrollCalls
+		mu.Unlock()
+		require.GreaterOrEqual(t, gotEnrollCalls, 1)
 		require.False(t, oc.reenrollForced(), "re-enroll state should be cleared after success")
 
 		contents, err = os.ReadFile(nodeKeyPath)

--- a/client/orbit_client_reenroll_test.go
+++ b/client/orbit_client_reenroll_test.go
@@ -1,0 +1,251 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newReenrollTestClient(t *testing.T, serverURL, nodeKeyPath string) *OrbitClient {
+	t.Helper()
+	bc, err := NewBaseClient(serverURL, true, "", "", nil, fleet.CapabilityMap{}, nil)
+	require.NoError(t, err)
+	return &OrbitClient{
+		BaseClient:      bc,
+		nodeKeyFilePath: nodeKeyPath,
+		enrollSecret:    "secret",
+		hostInfo:        fleet.OrbitHostInfo{HardwareUUID: "uuid-1", Platform: "linux"},
+	}
+}
+
+// setReenrollGracePeriod temporarily overrides the package-level grace period and returns a restore
+// func. The grace period is package state, so tests using it must not run in parallel.
+func setReenrollGracePeriod(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := unauthenticatedReenrollGracePeriod
+	unauthenticatedReenrollGracePeriod = d
+	t.Cleanup(func() { unauthenticatedReenrollGracePeriod = orig })
+}
+
+func TestGetNodeKeyOrEnrollEmptyFileEnrolls(t *testing.T) {
+	dir := t.TempDir()
+	nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
+	// An empty/whitespace-only file must be treated like a missing one and trigger enrollment,
+	// rather than returning "" which the server would reject with a 401.
+	require.NoError(t, os.WriteFile(nodeKeyPath, []byte("  \n"), 0o600))
+
+	var enrollCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/orbit/enroll") {
+			enrollCalls++
+			assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "new-key"}))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+	key, err := oc.getNodeKeyOrEnroll()
+	require.NoError(t, err)
+	require.Equal(t, "new-key", key)
+	require.Equal(t, 1, enrollCalls)
+
+	contents, err := os.ReadFile(nodeKeyPath)
+	require.NoError(t, err)
+	require.Equal(t, "new-key", string(contents))
+}
+
+func TestGetNodeKeyOrEnrollValidFileReturnsKeyWithoutEnrolling(t *testing.T) {
+	dir := t.TempDir()
+	nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
+	require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server must not be called when a valid node key exists, got %s", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+	key, err := oc.getNodeKeyOrEnroll()
+	require.NoError(t, err)
+	require.Equal(t, "existing-key", key)
+}
+
+func TestEnrollAndWriteNodeKeyFileAtomicReplace(t *testing.T) {
+	t.Run("success overwrites existing key and leaves no temp file", func(t *testing.T) {
+		dir := t.TempDir()
+		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
+		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("old-key"), 0o600))
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "fresh-key"}))
+		}))
+		defer srv.Close()
+
+		oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+		key, err := oc.enrollAndWriteNodeKeyFile()
+		require.NoError(t, err)
+		require.Equal(t, "fresh-key", key)
+
+		contents, err := os.ReadFile(nodeKeyPath)
+		require.NoError(t, err)
+		require.Equal(t, "fresh-key", string(contents))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1, "temp file should have been renamed into place, not left behind")
+	})
+
+	t.Run("failed enroll preserves existing key and leaves no temp file", func(t *testing.T) {
+		dir := t.TempDir()
+		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
+		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("old-key"), 0o600))
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+		_, err := oc.enrollAndWriteNodeKeyFile()
+		require.Error(t, err)
+
+		// acquire-then-replace: the existing key must survive a failed enroll.
+		contents, err := os.ReadFile(nodeKeyPath)
+		require.NoError(t, err)
+		require.Equal(t, "old-key", string(contents))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1, "temp file should have been cleaned up on failure")
+	})
+}
+
+func TestAuthenticatedRequest401Debounce(t *testing.T) {
+	t.Run("single 401 within grace does not delete key or re-enroll", func(t *testing.T) {
+		setReenrollGracePeriod(t, time.Hour)
+
+		dir := t.TempDir()
+		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
+		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+
+		var enrollCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/orbit/enroll") {
+				enrollCalls++
+				assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "new-key"}))
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+		err := oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
+		require.ErrorIs(t, err, ErrUnauthenticated)
+		require.False(t, oc.reenrollForced(), "a single 401 within the grace period should not arm re-enroll")
+		require.Equal(t, 0, enrollCalls)
+
+		contents, err := os.ReadFile(nodeKeyPath)
+		require.NoError(t, err)
+		require.Equal(t, "existing-key", string(contents), "the node key must not be deleted on a transient 401")
+	})
+
+	t.Run("sustained 401 arms re-enroll and next request replaces the key", func(t *testing.T) {
+		setReenrollGracePeriod(t, 0) // any 401 immediately exceeds the grace period
+
+		dir := t.TempDir()
+		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
+		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+
+		var mu sync.Mutex
+		rejectAuthed := true
+		var enrollCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			if strings.HasSuffix(r.URL.Path, "/orbit/enroll") {
+				enrollCalls++
+				assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "new-key"}))
+				return
+			}
+			if rejectAuthed {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			assert.NoError(t, json.NewEncoder(w).Encode(fleet.OrbitConfig{}))
+		}))
+		defer srv.Close()
+
+		oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+
+		// First request: 401 -> re-enroll armed, but the existing key is NOT deleted yet.
+		err := oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
+		require.ErrorIs(t, err, ErrUnauthenticated)
+		require.True(t, oc.reenrollForced())
+		contents, err := os.ReadFile(nodeKeyPath)
+		require.NoError(t, err)
+		require.Equal(t, "existing-key", string(contents))
+
+		// Stop rejecting the authenticated endpoint so the post-enroll request succeeds.
+		mu.Lock()
+		rejectAuthed = false
+		mu.Unlock()
+
+		// Second request: getNodeKeyOrEnroll sees the armed re-enroll, enrolls, overwrites the key,
+		// and the request then succeeds.
+		err = oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, enrollCalls, 1)
+		require.False(t, oc.reenrollForced(), "re-enroll state should be cleared after success")
+
+		contents, err = os.ReadFile(nodeKeyPath)
+		require.NoError(t, err)
+		require.Equal(t, "new-key", string(contents))
+	})
+
+	t.Run("host identity cert is removed only after the grace period, not on the first 401", func(t *testing.T) {
+		setReenrollGracePeriod(t, time.Hour)
+
+		dir := t.TempDir()
+		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
+		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+		certPath := filepath.Join(dir, "host-identity.crt")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert"), 0o600))
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		oc := newReenrollTestClient(t, srv.URL, nodeKeyPath)
+		oc.hostIdentityCertPath = certPath
+		var restartCalls int
+		oc.receiverUpdateCancelFunc = func() { restartCalls++ }
+
+		err := oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
+		require.ErrorIs(t, err, ErrUnauthenticated)
+		// Within the grace period the cert must be preserved and no restart triggered.
+		require.FileExists(t, certPath)
+		require.Equal(t, 0, restartCalls)
+
+		// Once 401s have persisted past the grace period, the cert is removed and a restart fires.
+		setReenrollGracePeriod(t, 0)
+		err = oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
+		require.ErrorIs(t, err, ErrUnauthenticated)
+		require.NoFileExists(t, certPath)
+		require.Equal(t, 1, restartCalls)
+	})
+}

--- a/client/orbit_client_reenroll_test.go
+++ b/client/orbit_client_reenroll_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -28,6 +29,29 @@ func newReenrollTestClient(t *testing.T, serverURL, nodeKeyPath string) *OrbitCl
 	}
 }
 
+// newNodeKeyFile creates a temp dir containing a node key file with the given contents and returns
+// both. The dir is returned so tests can assert no stray temp files are left behind.
+func newNodeKeyFile(t *testing.T, contents string) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, "secret-orbit-node-key.txt")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return dir, path
+}
+
+func requireNodeKey(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
+}
+
+// writeEnrollResponse writes a successful enroll response handing back nodeKey.
+func writeEnrollResponse(t *testing.T, w http.ResponseWriter, nodeKey string) {
+	t.Helper()
+	assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: nodeKey}))
+}
+
 // setReenrollGracePeriod temporarily overrides the package-level grace period for the duration of
 // the test, restoring it via t.Cleanup. The grace period is package state, so tests using it must
 // not run in parallel.
@@ -39,17 +63,15 @@ func setReenrollGracePeriod(t *testing.T, d time.Duration) {
 }
 
 func TestGetNodeKeyOrEnrollEmptyFileEnrolls(t *testing.T) {
-	dir := t.TempDir()
-	nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
 	// An empty/whitespace-only file must be treated like a missing one and trigger enrollment,
 	// rather than returning "" which the server would reject with a 401.
-	require.NoError(t, os.WriteFile(nodeKeyPath, []byte("  \n"), 0o600))
+	_, nodeKeyPath := newNodeKeyFile(t, "  \n")
 
 	var enrollCalls int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/orbit/enroll") {
 			enrollCalls++
-			assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "new-key"}))
+			writeEnrollResponse(t, w, "new-key")
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -61,16 +83,11 @@ func TestGetNodeKeyOrEnrollEmptyFileEnrolls(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "new-key", key)
 	require.Equal(t, 1, enrollCalls)
-
-	contents, err := os.ReadFile(nodeKeyPath)
-	require.NoError(t, err)
-	require.Equal(t, "new-key", string(contents))
+	requireNodeKey(t, nodeKeyPath, "new-key")
 }
 
 func TestGetNodeKeyOrEnrollValidFileReturnsKeyWithoutEnrolling(t *testing.T) {
-	dir := t.TempDir()
-	nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
-	require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+	_, nodeKeyPath := newNodeKeyFile(t, "existing-key")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("server must not be called when a valid node key exists, got %s", r.URL.Path)
@@ -86,12 +103,10 @@ func TestGetNodeKeyOrEnrollValidFileReturnsKeyWithoutEnrolling(t *testing.T) {
 
 func TestEnrollAndWriteNodeKeyFileAtomicReplace(t *testing.T) {
 	t.Run("success overwrites existing key and leaves no temp file", func(t *testing.T) {
-		dir := t.TempDir()
-		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
-		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("old-key"), 0o600))
+		dir, nodeKeyPath := newNodeKeyFile(t, "old-key")
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "fresh-key"}))
+			writeEnrollResponse(t, w, "fresh-key")
 		}))
 		defer srv.Close()
 
@@ -99,10 +114,7 @@ func TestEnrollAndWriteNodeKeyFileAtomicReplace(t *testing.T) {
 		key, err := oc.enrollAndWriteNodeKeyFile()
 		require.NoError(t, err)
 		require.Equal(t, "fresh-key", key)
-
-		contents, err := os.ReadFile(nodeKeyPath)
-		require.NoError(t, err)
-		require.Equal(t, "fresh-key", string(contents))
+		requireNodeKey(t, nodeKeyPath, "fresh-key")
 
 		entries, err := os.ReadDir(dir)
 		require.NoError(t, err)
@@ -110,9 +122,7 @@ func TestEnrollAndWriteNodeKeyFileAtomicReplace(t *testing.T) {
 	})
 
 	t.Run("failed enroll preserves existing key and leaves no temp file", func(t *testing.T) {
-		dir := t.TempDir()
-		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
-		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("old-key"), 0o600))
+		dir, nodeKeyPath := newNodeKeyFile(t, "old-key")
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -124,9 +134,7 @@ func TestEnrollAndWriteNodeKeyFileAtomicReplace(t *testing.T) {
 		require.Error(t, err)
 
 		// acquire-then-replace: the existing key must survive a failed enroll.
-		contents, err := os.ReadFile(nodeKeyPath)
-		require.NoError(t, err)
-		require.Equal(t, "old-key", string(contents))
+		requireNodeKey(t, nodeKeyPath, "old-key")
 
 		entries, err := os.ReadDir(dir)
 		require.NoError(t, err)
@@ -134,19 +142,51 @@ func TestEnrollAndWriteNodeKeyFileAtomicReplace(t *testing.T) {
 	})
 }
 
+// TestNoteUnauthenticated covers the 401 debounce state machine directly. It runs in a
+// testing/synctest bubble so the elapsed-time logic is driven by a fake clock that fast-forwards
+// time.Sleep (no real waiting), exercising the actual now.Sub(since) computation rather than
+// poking internal state. It verifies that a streak must accumulate past the grace period before
+// re-enroll is armed, and that a success resets an in-progress streak so a transient 401 followed
+// by a success never re-enrolls.
+func TestNoteUnauthenticated(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		setReenrollGracePeriod(t, 30*time.Second)
+		oc := &OrbitClient{}
+
+		// First 401 starts the streak with zero elapsed time.
+		reenroll, waited := oc.noteUnauthenticated()
+		require.False(t, reenroll)
+		require.Zero(t, waited)
+		require.False(t, oc.reenrollForced())
+
+		// A success resets the streak (the transient 401 recovered).
+		oc.clearReenrollState()
+		require.True(t, oc.unauthenticatedSince.IsZero())
+
+		// A fresh 401 after the reset starts a new streak from zero, not from the earlier one.
+		reenroll, waited = oc.noteUnauthenticated()
+		require.False(t, reenroll)
+		require.Zero(t, waited)
+
+		// Advance the fake clock past the grace period; the next 401 then arms re-enroll.
+		time.Sleep(31 * time.Second)
+		reenroll, waited = oc.noteUnauthenticated()
+		require.True(t, reenroll, "a 401 streak older than the grace period should arm re-enroll")
+		require.Equal(t, 31*time.Second, waited)
+		require.True(t, oc.reenrollForced())
+	})
+}
+
 func TestAuthenticatedRequest401Debounce(t *testing.T) {
 	t.Run("single 401 within grace does not delete key or re-enroll", func(t *testing.T) {
 		setReenrollGracePeriod(t, time.Hour)
-
-		dir := t.TempDir()
-		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
-		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+		_, nodeKeyPath := newNodeKeyFile(t, "existing-key")
 
 		var enrollCalls int
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if strings.HasSuffix(r.URL.Path, "/orbit/enroll") {
 				enrollCalls++
-				assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "new-key"}))
+				writeEnrollResponse(t, w, "new-key")
 				return
 			}
 			w.WriteHeader(http.StatusUnauthorized)
@@ -158,18 +198,13 @@ func TestAuthenticatedRequest401Debounce(t *testing.T) {
 		require.ErrorIs(t, err, ErrUnauthenticated)
 		require.False(t, oc.reenrollForced(), "a single 401 within the grace period should not arm re-enroll")
 		require.Equal(t, 0, enrollCalls)
-
-		contents, err := os.ReadFile(nodeKeyPath)
-		require.NoError(t, err)
-		require.Equal(t, "existing-key", string(contents), "the node key must not be deleted on a transient 401")
+		requireNodeKey(t, nodeKeyPath, "existing-key") // not deleted on a transient 401
 	})
 
 	t.Run("sustained 401 arms re-enroll and next request replaces the key", func(t *testing.T) {
 		setReenrollGracePeriod(t, 0) // any 401 immediately exceeds the grace period
 
-		dir := t.TempDir()
-		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
-		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+		_, nodeKeyPath := newNodeKeyFile(t, "existing-key")
 
 		var mu sync.Mutex
 		rejectAuthed := true
@@ -179,7 +214,7 @@ func TestAuthenticatedRequest401Debounce(t *testing.T) {
 			defer mu.Unlock()
 			if strings.HasSuffix(r.URL.Path, "/orbit/enroll") {
 				enrollCalls++
-				assert.NoError(t, json.NewEncoder(w).Encode(fleet.EnrollOrbitResponse{OrbitNodeKey: "new-key"}))
+				writeEnrollResponse(t, w, "new-key")
 				return
 			}
 			if rejectAuthed {
@@ -196,9 +231,7 @@ func TestAuthenticatedRequest401Debounce(t *testing.T) {
 		err := oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
 		require.ErrorIs(t, err, ErrUnauthenticated)
 		require.True(t, oc.reenrollForced())
-		contents, err := os.ReadFile(nodeKeyPath)
-		require.NoError(t, err)
-		require.Equal(t, "existing-key", string(contents))
+		requireNodeKey(t, nodeKeyPath, "existing-key")
 
 		// Stop rejecting the authenticated endpoint so the post-enroll request succeeds.
 		mu.Lock()
@@ -214,18 +247,12 @@ func TestAuthenticatedRequest401Debounce(t *testing.T) {
 		mu.Unlock()
 		require.GreaterOrEqual(t, gotEnrollCalls, 1)
 		require.False(t, oc.reenrollForced(), "re-enroll state should be cleared after success")
-
-		contents, err = os.ReadFile(nodeKeyPath)
-		require.NoError(t, err)
-		require.Equal(t, "new-key", string(contents))
+		requireNodeKey(t, nodeKeyPath, "new-key")
 	})
 
 	t.Run("host identity cert is removed only after the grace period, not on the first 401", func(t *testing.T) {
 		setReenrollGracePeriod(t, time.Hour)
-
-		dir := t.TempDir()
-		nodeKeyPath := filepath.Join(dir, "secret-orbit-node-key.txt")
-		require.NoError(t, os.WriteFile(nodeKeyPath, []byte("existing-key"), 0o600))
+		dir, nodeKeyPath := newNodeKeyFile(t, "existing-key")
 		certPath := filepath.Join(dir, "host-identity.crt")
 		require.NoError(t, os.WriteFile(certPath, []byte("cert"), 0o600))
 

--- a/client/orbit_client_reenroll_test.go
+++ b/client/orbit_client_reenroll_test.go
@@ -63,8 +63,7 @@ func setReenrollGracePeriod(t *testing.T, d time.Duration) {
 }
 
 func TestGetNodeKeyOrEnrollEmptyFileEnrolls(t *testing.T) {
-	// An empty/whitespace-only file must be treated like a missing one and trigger enrollment,
-	// rather than returning "" which the server would reject with a 401.
+	// An empty/whitespace-only file must be treated like a missing one and trigger enrollment
 	_, nodeKeyPath := newNodeKeyFile(t, "  \n")
 
 	var enrollCalls int
@@ -142,12 +141,7 @@ func TestEnrollAndWriteNodeKeyFileAtomicReplace(t *testing.T) {
 	})
 }
 
-// TestNoteUnauthenticated covers the 401 debounce state machine directly. It runs in a
-// testing/synctest bubble so the elapsed-time logic is driven by a fake clock that fast-forwards
-// time.Sleep (no real waiting), exercising the actual now.Sub(since) computation rather than
-// poking internal state. It verifies that a streak must accumulate past the grace period before
-// re-enroll is armed, and that a success resets an in-progress streak so a transient 401 followed
-// by a success never re-enrolls.
+// TestNoteUnauthenticated covers the 401 debounce state machine directly.
 func TestNoteUnauthenticated(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		setReenrollGracePeriod(t, 30*time.Second)
@@ -238,8 +232,7 @@ func TestAuthenticatedRequest401Debounce(t *testing.T) {
 		rejectAuthed = false
 		mu.Unlock()
 
-		// Second request: getNodeKeyOrEnroll sees the armed re-enroll, enrolls, overwrites the key,
-		// and the request then succeeds.
+		// Second request: getNodeKeyOrEnroll sees the armed re-enroll, enrolls, overwrites the key, and the request then succeeds.
 		err = oc.authenticatedRequest("POST", "/api/fleet/orbit/config", &fleet.OrbitGetConfigRequest{}, &fleet.OrbitConfig{})
 		require.NoError(t, err)
 		mu.Lock()

--- a/orbit/changes/47650-orbit-reenroll-visibility-and-401-hardening.md
+++ b/orbit/changes/47650-orbit-reenroll-visibility-and-401-hardening.md
@@ -1,0 +1,2 @@
+- Added INFO-level orbit logging that records why a host (re-)enrolls: when the node key file is missing or empty, when the server rejects the node key with a 401 (including the request path), and which server is being enrolled against.
+- Hardened orbit against unexpected re-enrollments: a transient or spurious 401 no longer immediately discards a valid node key. Orbit now waits until 401s have persisted for a grace period before re-enrolling, and writes the new node key atomically so an existing key is never deleted or truncated until a replacement has been obtained.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47650 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication resilience by debouncing repeated unauthorized responses and only triggering recovery after a grace period.
  * Updated node-key handling to avoid treating empty key files as valid and to prevent accidental deletion during short failures.
  * Ensured node-key storage is written atomically to avoid partial or empty credential files.

* **Tests**
  * Added comprehensive test coverage for node re-enrollment behavior, authentication grace-period timing, and atomic file write guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->