### PR TITLE
POC: DDM assets

### DIFF
--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1462,7 +1462,7 @@ func (svc *Service) mdmAppleEditedAppleOSUpdates(ctx context.Context, teamID *ui
 	}
 }`, softwareUpdateIdentifier, apple_mdm.DeclarationTypeSoftwareUpdate, updates.MinimumVersion.Value, updates.Deadline.Value))
 
-	d := fleet.NewMDMAppleDeclaration(rawDecl, teamID, osUpdatesProfileName, apple_mdm.DeclarationTypeSoftwareUpdate, softwareUpdateIdentifier)
+	d := fleet.NewMDMAppleDeclaration(rawDecl, teamID, osUpdatesProfileName, apple_mdm.DeclarationTypeSoftwareUpdate, softwareUpdateIdentifier, fleet.PayloadScopeSystem)
 
 	// Associate the profile with the built-in label to ensure that the profile is applied to the targeted devices.
 	lblIDs, err := svc.ds.LabelIDsByName(ctx, []string{labelName}, fleet.TeamFilter{}) // built-in labels are global

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -4824,9 +4824,10 @@ INSERT INTO mdm_apple_declarations (
 	identifier,
 	name,
 	raw_json,
+	scope,
 	secrets_updated_at,
 	uploaded_at)
-(SELECT ?,?,?,?,?,?,CURRENT_TIMESTAMP() FROM DUAL WHERE
+(SELECT ?,?,?,?,?,?,?,CURRENT_TIMESTAMP() FROM DUAL WHERE
 	NOT EXISTS (
  		SELECT 1 FROM mdm_windows_configuration_profiles WHERE name = ? AND team_id = ?
  	) AND NOT EXISTS (
@@ -4846,6 +4847,57 @@ INSERT INTO mdm_apple_declarations (
 	return ds.insertOrUpsertMDMAppleDeclaration(ctx, stmt, declaration, usesFleetVars, isSoftwareUpdate)
 }
 
+func (ds *Datastore) NewMDMAppleDeclarationAsset(ctx context.Context, asset *fleet.MDMAppleDeclarationAsset) (*fleet.MDMAppleDeclarationAsset, error) {
+	// TODO: Support fleet vars
+	assetUUID := uuid.NewString() // This does not need the platform prefix.
+	const stmt = `
+	INSERT INTO mdm_apple_declaration_assets (
+		asset_uuid,
+		identifier,
+		name,
+		raw_json,
+		uploaded_at	
+	) VALUES (
+		?, ?, ?, ?, NOW(6)	
+	)`
+
+	marshalled, err := asset.RawJSON.MarshalJSON()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "marshalling asset raw json")
+	}
+	encrypted, err := encrypt(marshalled, ds.serverPrivateKey)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "encrypting asset raw json")
+	}
+	_, err = ds.writer(ctx).ExecContext(ctx, stmt, assetUUID, asset.Identifier, asset.Name, encrypted)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "inserting new apple mdm declaration asset")
+	}
+
+	asset.AssetUUID = assetUUID
+	return asset, nil
+}
+
+func (ds *Datastore) MDMAppleDDMDeclarationItemsAssets(ctx context.Context) ([]fleet.MDMAppleDDMDeclarationAssetItem, error) {
+	const stmt = `SELECT asset_uuid, identifier, HEX(token) as token, uploaded_at, raw_json FROM mdm_apple_declaration_assets`
+	var assets []fleet.MDMAppleDDMDeclarationAssetItem
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &assets, stmt); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "loading apple mdm declaration assets")
+	}
+
+	// Unencrypt the raw json for returning
+	for i, asset := range assets {
+		decrypted, err := decrypt([]byte(*asset.RawJSON), ds.serverPrivateKey)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "decrypting asset raw json")
+		}
+		rawJSON := json.RawMessage(decrypted)
+		assets[i].RawJSON = &rawJSON
+	}
+
+	return assets, nil
+}
+
 func (ds *Datastore) SetOrUpdateMDMAppleDeclaration(ctx context.Context, declaration *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
 	const stmt = `
 INSERT INTO mdm_apple_declarations (
@@ -4854,9 +4906,10 @@ INSERT INTO mdm_apple_declarations (
 	identifier,
 	name,
 	raw_json,
+	scope,
 	secrets_updated_at,
 	uploaded_at)
-(SELECT ?,?,?,?,?,?,NOW(6) FROM DUAL WHERE
+(SELECT ?,?,?,?,?,?,?,NOW(6) FROM DUAL WHERE
 	NOT EXISTS (
  		SELECT 1 FROM mdm_windows_configuration_profiles WHERE name = ? AND team_id = ?
  	) AND NOT EXISTS (
@@ -4886,7 +4939,7 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 	err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		res, err := tx.ExecContext(ctx, insOrUpsertStmt,
 			declUUID, tmID, declaration.Identifier, declaration.Name, declaration.RawJSON,
-			declaration.SecretsUpdatedAt,
+			declaration.Scope, declaration.SecretsUpdatedAt,
 			declaration.Name, tmID, declaration.Name, tmID, declaration.Name, tmID)
 		if err != nil {
 			switch {

--- a/server/datastore/mysql/migrations/tables/20260615102351_DDMPoC.go
+++ b/server/datastore/mysql/migrations/tables/20260615102351_DDMPoC.go
@@ -1,0 +1,30 @@
+package tables
+
+import (
+	"database/sql"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20260615102351, Down_20260615102351)
+}
+
+func Up_20260615102351(tx *sql.Tx) error {
+	_, err := tx.Exec(`CREATE TABLE mdm_apple_declaration_assets (
+	asset_uuid VARCHAR(36) NOT NULL PRIMARY KEY,
+	name VARCHAR(255) NOT NULL,
+	identifier VARCHAR(255) NOT NULL,
+	raw_json MEDIUMBLOB NOT NULL, -- We encrypt the payload since it's often credentials
+	created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+	uploaded_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+	token BINARY(16) GENERATED ALWAYS AS (unhex(md5(raw_json))) STORED, -- Add secrets_updated_at if we want to support that like the DDM token
+	auto_increment BIGINT NOT NULL AUTO_INCREMENT UNIQUE,
+	UNIQUE KEY unique_identifier (identifier)
+	)`)
+
+	// TODO: Should we introduce this into the mdm_configuration_profile_variables, or keep it locally to this table?
+	return err
+}
+
+func Down_20260615102351(tx *sql.Tx) error {
+	return nil
+}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -861,6 +861,8 @@ type MDMAppleDeclaration struct {
 	// Fleet requires that Name must be unique in combination with the Identifier and TeamID.
 	Name string `db:"name" json:"name"`
 
+	Scope PayloadScope `db:"scope" json:"scope"`
+
 	// RawJSON is the raw JSON content of the declaration
 	RawJSON json.RawMessage `db:"raw_json" json:"-"`
 
@@ -877,6 +879,19 @@ type MDMAppleDeclaration struct {
 	UploadedAt         time.Time  `db:"uploaded_at" json:"uploaded_at"`
 	SecretsUpdatedAt   *time.Time `db:"secrets_updated_at" json:"-"`
 	VariablesUpdatedAt *time.Time `db:"variables_updated_at" json:"-"`
+}
+
+type MDMAppleDeclarationAsset struct {
+	AssetUUID string `db:"asset_uuid" json:"asset_uuid"`
+
+	Identifier string          `db:"identifier" json:"identifier"`
+	Name       string          `db:"name" json:"name"`
+	RawJSON    json.RawMessage `db:"raw_json" json:"-"`
+	// Token is used to identify if declaration needs to be re-applied.
+	// It contains the checksum of the JSON contents and secrets updated timestamp (if secret variables are present).
+	Token      string    `db:"token" json:"-"`
+	CreatedAt  time.Time `db:"created_at" json:"created_at"`
+	UploadedAt time.Time `db:"uploaded_at" json:"uploaded_at"`
 }
 
 // EffectiveDDMToken computes the per-declaration token that incorporates both
@@ -903,18 +918,7 @@ type MDMAppleRawDeclaration struct {
 // ForbiddenDeclTypes is a set of declaration types that are not allowed to be
 // added by users into Fleet.
 var ForbiddenDeclTypes = map[string]struct{}{
-	"com.apple.configuration.account.caldav":               {},
-	"com.apple.configuration.account.carddav":              {},
-	"com.apple.configuration.account.exchange":             {},
-	"com.apple.configuration.account.google":               {},
-	"com.apple.configuration.account.ldap":                 {},
-	"com.apple.configuration.account.mail":                 {},
-	"com.apple.configuration.screensharing.connection":     {},
-	"com.apple.configuration.security.certificate":         {},
-	"com.apple.configuration.security.identity":            {},
-	"com.apple.configuration.security.passkey.attestation": {},
-	"com.apple.configuration.services.configuration-files": {},
-	"com.apple.configuration.watch.enrollment":             {},
+	"com.apple.configuration.watch.enrollment": {},
 }
 
 func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
@@ -928,8 +932,13 @@ func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 		return NewInvalidArgumentError(r.Type, "Declaration profile can’t include status subscription type. To get host’s vitals, please use queries and policies.")
 	}
 
-	if !strings.HasPrefix(r.Type, "com.apple.configuration.") {
-		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) are supported.")
+	// TODO: Are we missing a block here for software management?
+	if r.Type == "com.apple.configuration.app.managed" || r.Type == "com.apple.configuration.package" {
+		return NewInvalidArgumentError(r.Type, "Declaration profile can’t include software management types. To manage software, please use the Software tab.")
+	}
+
+	if !strings.HasPrefix(r.Type, "com.apple.configuration.") && !strings.HasPrefix(r.Type, "com.apple.asset.") {
+		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) and asset declarations (com.apple.asset.) are supported.")
 	}
 
 	return err
@@ -999,13 +1008,14 @@ func (p MDMAppleHostDeclaration) Equal(other MDMAppleHostDeclaration) bool {
 		varsEqual
 }
 
-func NewMDMAppleDeclaration(raw []byte, teamID *uint, name string, declType, ident string) *MDMAppleDeclaration {
+func NewMDMAppleDeclaration(raw []byte, teamID *uint, name string, declType, ident string, scope PayloadScope) *MDMAppleDeclaration {
 	var decl MDMAppleDeclaration
 
 	decl.Identifier = ident
 	decl.Name = name
 	decl.RawJSON = raw
 	decl.TeamID = teamID
+	decl.Scope = scope
 
 	return &decl
 }
@@ -1072,6 +1082,16 @@ type MDMAppleDDMDeclarationItem struct {
 	// variables (variables_updated_at IS NOT NULL and operation_type = 'install')
 	// so that handleDeclarationItems can check variable resolution without an
 	// extra query.
+	RawJSON *json.RawMessage `db:"raw_json"`
+}
+
+type MDMAppleDDMDeclarationAssetItem struct {
+	AssetUUID   string    `db:"asset_uuid"`
+	Identifier  string    `db:"identifier"`
+	ServerToken string    `db:"token"`
+	UploadedAt  time.Time `db:"uploaded_at"`
+
+	// This is the unencrypted content
 	RawJSON *json.RawMessage `db:"raw_json"`
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1968,6 +1968,7 @@ type Datastore interface {
 	MDMAppleDDMDeclarationsToken(ctx context.Context, hostUUID string) (*MDMAppleDDMDeclarationsToken, error)
 	// MDMAppleDDMDeclarationItems returns the declaration items for the specified host UUID.
 	MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID string) ([]MDMAppleDDMDeclarationItem, error)
+	MDMAppleDDMDeclarationItemsAssets(ctx context.Context) ([]MDMAppleDDMDeclarationAssetItem, error)
 	// MDMAppleDDMDeclarationPayload returns the declaration payload for the specified identifier and team.
 	MDMAppleDDMDeclarationsResponse(ctx context.Context, identifier string, hostUUID string) (*MDMAppleDeclaration, error)
 
@@ -2457,6 +2458,8 @@ type Datastore interface {
 	// An OS-update (software update) declaration is tracked as the team's OS-update
 	// profile within the same transaction, failing if one already exists.
 	NewMDMAppleDeclaration(ctx context.Context, declaration *MDMAppleDeclaration, usesFleetVars []FleetVarName) (*MDMAppleDeclaration, error)
+
+	NewMDMAppleDeclarationAsset(ctx context.Context, asset *MDMAppleDeclarationAsset) (*MDMAppleDeclarationAsset, error)
 
 	// SetOrUpdateMDMAppleDeclaration upserts the MDM Apple declaration.
 	SetOrUpdateMDMAppleDeclaration(ctx context.Context, declaration *MDMAppleDeclaration, usesFleetVars []FleetVarName) (*MDMAppleDeclaration, error)

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -927,7 +927,7 @@ type Service interface {
 	// NewMDMAppleConfigProfile creates a new configuration profile for the specified team.
 	NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string) (*MDMAppleConfigProfile, error)
 	// NewMDMAppleConfigProfileWithPayload creates a new declaration for the specified team.
-	NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string) (*MDMAppleDeclaration, error)
+	NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string, scope PayloadScope) (*MDMAppleDeclaration, error)
 
 	// GetMDMAppleConfigProfileByDeprecatedID retrieves the specified Apple
 	// configuration profile via its numeric ID. This method is deprecated and

--- a/server/mdm/apple/util.go
+++ b/server/mdm/apple/util.go
@@ -157,7 +157,11 @@ func IsAppAlreadyInstalledError(chain []mdm.ErrorChain) bool {
 func FmtDDMError(reasons []fleet.MDMAppleDDMStatusErrorReason) string {
 	var errMsg strings.Builder
 	for _, r := range reasons {
-		errMsg.WriteString(fmt.Sprintf("%s: %s %+v\n", r.Code, r.Description, r.Details))
+		baseString := fmt.Sprintf("%s: %s", r.Code, r.Description)
+		if len(r.Details) > 0 {
+			baseString = fmt.Sprintf("%s %+v", baseString, r.Details)
+		}
+		errMsg.WriteString(fmt.Sprintf("%s\n", baseString))
 	}
 	return errMsg.String()
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1238,6 +1238,8 @@ type MDMAppleDDMDeclarationsTokenFunc func(ctx context.Context, hostUUID string)
 
 type MDMAppleDDMDeclarationItemsFunc func(ctx context.Context, hostUUID string) ([]fleet.MDMAppleDDMDeclarationItem, error)
 
+type MDMAppleDDMDeclarationItemsAssetsFunc func(ctx context.Context) ([]fleet.MDMAppleDDMDeclarationAssetItem, error)
+
 type MDMAppleDDMDeclarationsResponseFunc func(ctx context.Context, identifier string, hostUUID string) (*fleet.MDMAppleDeclaration, error)
 
 type MDMAppleHostDeclarationsGetAndClearResyncFunc func(ctx context.Context) (hostUUIDs []string, err error)
@@ -1455,6 +1457,8 @@ type SetOrUpdateMDMWindowsConfigProfileFunc func(ctx context.Context, cp fleet.M
 type BatchSetMDMProfilesFunc func(ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile, macDeclarations []*fleet.MDMAppleDeclaration, androidProfiles []*fleet.MDMAndroidConfigProfile, profilesVariables []fleet.MDMProfileIdentifierFleetVariables) (updates fleet.MDMProfilesUpdates, err error)
 
 type NewMDMAppleDeclarationFunc func(ctx context.Context, declaration *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error)
+
+type NewMDMAppleDeclarationAssetFunc func(ctx context.Context, asset *fleet.MDMAppleDeclarationAsset) (*fleet.MDMAppleDeclarationAsset, error)
 
 type SetOrUpdateMDMAppleDeclarationFunc func(ctx context.Context, declaration *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error)
 
@@ -3920,6 +3924,9 @@ type DataStore struct {
 	MDMAppleDDMDeclarationItemsFunc        MDMAppleDDMDeclarationItemsFunc
 	MDMAppleDDMDeclarationItemsFuncInvoked bool
 
+	MDMAppleDDMDeclarationItemsAssetsFunc        MDMAppleDDMDeclarationItemsAssetsFunc
+	MDMAppleDDMDeclarationItemsAssetsFuncInvoked bool
+
 	MDMAppleDDMDeclarationsResponseFunc        MDMAppleDDMDeclarationsResponseFunc
 	MDMAppleDDMDeclarationsResponseFuncInvoked bool
 
@@ -4246,6 +4253,9 @@ type DataStore struct {
 
 	NewMDMAppleDeclarationFunc        NewMDMAppleDeclarationFunc
 	NewMDMAppleDeclarationFuncInvoked bool
+
+	NewMDMAppleDeclarationAssetFunc        NewMDMAppleDeclarationAssetFunc
+	NewMDMAppleDeclarationAssetFuncInvoked bool
 
 	SetOrUpdateMDMAppleDeclarationFunc        SetOrUpdateMDMAppleDeclarationFunc
 	SetOrUpdateMDMAppleDeclarationFuncInvoked bool
@@ -9462,6 +9472,13 @@ func (s *DataStore) MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID st
 	return s.MDMAppleDDMDeclarationItemsFunc(ctx, hostUUID)
 }
 
+func (s *DataStore) MDMAppleDDMDeclarationItemsAssets(ctx context.Context) ([]fleet.MDMAppleDDMDeclarationAssetItem, error) {
+	s.mu.Lock()
+	s.MDMAppleDDMDeclarationItemsAssetsFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMAppleDDMDeclarationItemsAssetsFunc(ctx)
+}
+
 func (s *DataStore) MDMAppleDDMDeclarationsResponse(ctx context.Context, identifier string, hostUUID string) (*fleet.MDMAppleDeclaration, error) {
 	s.mu.Lock()
 	s.MDMAppleDDMDeclarationsResponseFuncInvoked = true
@@ -10223,6 +10240,13 @@ func (s *DataStore) NewMDMAppleDeclaration(ctx context.Context, declaration *fle
 	s.NewMDMAppleDeclarationFuncInvoked = true
 	s.mu.Unlock()
 	return s.NewMDMAppleDeclarationFunc(ctx, declaration, usesFleetVars)
+}
+
+func (s *DataStore) NewMDMAppleDeclarationAsset(ctx context.Context, asset *fleet.MDMAppleDeclarationAsset) (*fleet.MDMAppleDeclarationAsset, error) {
+	s.mu.Lock()
+	s.NewMDMAppleDeclarationAssetFuncInvoked = true
+	s.mu.Unlock()
+	return s.NewMDMAppleDeclarationAssetFunc(ctx, asset)
 }
 
 func (s *DataStore) SetOrUpdateMDMAppleDeclaration(ctx context.Context, declaration *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -578,7 +578,7 @@ type GetHostDEPAssignmentDetailsFunc func(ctx context.Context, hostID uint) (*fl
 
 type NewMDMAppleConfigProfileFunc func(ctx context.Context, teamID uint, data []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleConfigProfile, error)
 
-type NewMDMAppleDeclarationFunc func(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleDeclaration, error)
+type NewMDMAppleDeclarationFunc func(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, scope fleet.PayloadScope) (*fleet.MDMAppleDeclaration, error)
 
 type GetMDMAppleConfigProfileByDeprecatedIDFunc func(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error)
 
@@ -4277,11 +4277,11 @@ func (s *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, dat
 	return s.NewMDMAppleConfigProfileFunc(ctx, teamID, data, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 }
 
-func (s *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleDeclaration, error) {
+func (s *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, scope fleet.PayloadScope) (*fleet.MDMAppleDeclaration, error) {
 	s.mu.Lock()
 	s.NewMDMAppleDeclarationFuncInvoked = true
 	s.mu.Unlock()
-	return s.NewMDMAppleDeclarationFunc(ctx, teamID, data, labelsInclude, name, labelsMembershipMode, labelsExcludeAny)
+	return s.NewMDMAppleDeclarationFunc(ctx, teamID, data, labelsInclude, name, labelsMembershipMode, labelsExcludeAny, scope)
 }
 
 func (s *Service) GetMDMAppleConfigProfileByDeprecatedID(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -858,7 +858,7 @@ func additionalNDESValidation(contents string, ndesVars *NDESVarsFound) error {
 	return nil
 }
 
-func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleDeclaration, error) {
+func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, scope fleet.PayloadScope) (*fleet.MDMAppleDeclaration, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: &teamID}, fleet.ActionWrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
@@ -937,8 +937,29 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 		}
 	}
 
-	d := fleet.NewMDMAppleDeclaration(data, &teamID, name, rawDecl.Type, rawDecl.Identifier)
+	// TODO Move this out to better handle across calls
+	if strings.HasPrefix(rawDecl.Type, "com.apple.asset.") {
+		asset := &fleet.MDMAppleDeclarationAsset{
+			Identifier: rawDecl.Identifier,
+			Name:       name,
+			RawJSON:    data,
+		}
+		asset, err := svc.ds.NewMDMAppleDeclarationAsset(ctx, asset)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "creating new apple mdm declaration asset")
+		}
+
+		// TODO: Temporary to satisfy type constraints, but warrents we might have a new method called higher up.
+		return &fleet.MDMAppleDeclaration{
+			DeclarationUUID: asset.AssetUUID,
+		}, nil
+	}
+
+	d := fleet.NewMDMAppleDeclaration(data, &teamID, name, rawDecl.Type, rawDecl.Identifier, scope)
 	d.SecretsUpdatedAt = secretsUpdatedAt
+
+	// TODO: Should we validate incoming asset references? It's a bit of extra work, and could be fragile as we will
+	// TODO: partial match on strings, but gives better instant feedback.
 
 	switch labelsMembershipMode {
 	case fleet.LabelsIncludeAny:
@@ -6038,6 +6059,21 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 		return nil, ctxerr.Wrap(ctx, err, "getting synchronization tokens")
 	}
 
+	// TODO: For now I send all assets to all hosts, but this should be correlated with the individual declarations.
+	// TODO: And be removed once it's no longer referenced.
+	assets, err := svc.ds.MDMAppleDDMDeclarationItemsAssets(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting declaration items assets")
+	}
+
+	manifestAssets := []fleet.MDMAppleDDMManifest{}
+	for _, asset := range assets {
+		manifestAssets = append(manifestAssets, fleet.MDMAppleDDMManifest{
+			Identifier:  asset.Identifier,
+			ServerToken: asset.ServerToken,
+		})
+	}
+
 	activations := []fleet.MDMAppleDDMManifest{}
 	configurations := []fleet.MDMAppleDDMManifest{}
 	var removeDeclarationUUIDsToUpdateToPending []string
@@ -6131,7 +6167,7 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 		Declarations: fleet.MDMAppleDDMManifestItems{
 			Activations:    activations,
 			Configurations: configurations,
-			Assets:         []fleet.MDMAppleDDMManifest{},
+			Assets:         manifestAssets,
 			Management:     []fleet.MDMAppleDDMManifest{},
 		},
 		DeclarationsToken: token,
@@ -6165,9 +6201,43 @@ func (svc *MDMAppleDDMService) handleDeclarationsResponse(ctx context.Context, e
 		return svc.handleActivationDeclaration(ctx, parts, hostUUID)
 	case "configuration":
 		return svc.handleConfigurationDeclaration(ctx, parts, hostUUID)
+	case "asset":
+		return svc.handleAssetDeclaration(ctx, parts, hostUUID)
 	default:
 		return nil, nano_service.NewHTTPStatusError(http.StatusNotFound, ctxerr.Errorf(ctx, "declaration type not supported: %s", parts[1]))
 	}
+}
+
+func (svc *MDMAppleDDMService) handleAssetDeclaration(ctx context.Context, parts []string, hostUUID string) ([]byte, error) {
+	// TODO: Lookup based on identifier
+	assets, err := svc.ds.MDMAppleDDMDeclarationItemsAssets(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting declaration items assets")
+	}
+
+	var foundAsset *fleet.MDMAppleDDMDeclarationAssetItem
+	for _, asset := range assets {
+		if asset.Identifier == parts[2] {
+			foundAsset = &asset
+			break
+		}
+	}
+
+	if foundAsset == nil {
+		return nil, nano_service.NewHTTPStatusError(http.StatusNotFound, ctxerr.Errorf(ctx, "asset not found: %s", parts[2]))
+	}
+
+	var tempd map[string]any
+	if err := json.Unmarshal([]byte(*foundAsset.RawJSON), &tempd); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "unmarshaling stored asset")
+	}
+	tempd["ServerToken"] = foundAsset.ServerToken
+
+	b, err := json.Marshal(tempd)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "marshaling declaration")
+	}
+	return b, nil
 }
 
 func (svc *MDMAppleDDMService) handleActivationDeclaration(ctx context.Context, parts []string, hostUUID string) ([]byte, error) {

--- a/server/service/apple_mdm_declarations_batched.go
+++ b/server/service/apple_mdm_declarations_batched.go
@@ -102,6 +102,9 @@ func ReconcileAppleDeclarationsBatched(
 		hosts, hostLabels, currentByHost, declsByTeam, declsWithBrokenLabel,
 	)
 
+	// TODO: Split declRowsToWrite and filter out user-scoped and do similar check to profile reconciler with user-channel available.
+	// TODO: Vice-versa could we check and fail-fast on system-scoped for ADUE?
+
 	logger.DebugContext(ctx, "ddm batched reconcile: computed deltas",
 		"changed_hosts", len(changedHostUUIDs), "host_decl_rows_to_write", len(declRowsToWrite))
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1641,6 +1641,8 @@ type newMDMConfigProfileRequest struct {
 	LabelsIncludeAll []string
 	LabelsIncludeAny []string
 	LabelsExcludeAny []string
+	// This is only checked and used for DDM profiles.
+	ProfileScope fleet.PayloadScope
 }
 
 func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
@@ -1705,6 +1707,20 @@ func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Req
 		return nil, &fleet.BadRequestError{Message: fmt.Sprintf(`Label %q cannot appear in both include and exclude lists.`, overlap)}
 	}
 
+	ddmPayloadScope, existsDDMPayloadScope := r.MultipartForm.Value["scope"]
+	ddmScope := fleet.PayloadScopeSystem // Default to system
+	if existsDDMPayloadScope {
+		switch ddmPayloadScope[0] {
+		case "system":
+			ddmScope = fleet.PayloadScopeSystem
+		case "user":
+			ddmScope = fleet.PayloadScopeUser
+		default:
+			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("invalid scope: %s", ddmPayloadScope[0])}
+		}
+	}
+	decoded.ProfileScope = ddmScope
+
 	return &decoded, nil
 }
 
@@ -1768,7 +1784,7 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 	if isMobileConfig || isAppleDeclarationJSON {
 		// Then it's an Apple configuration file
 		if isJSON {
-			decl, err := svc.NewMDMAppleDeclaration(ctx, req.TeamID, data, labels, profileName, labelsMode, req.LabelsExcludeAny)
+			decl, err := svc.NewMDMAppleDeclaration(ctx, req.TeamID, data, labels, profileName, labelsMode, req.LabelsExcludeAny, req.ProfileScope)
 			if err != nil {
 				errStr := err.Error()
 				if strings.Contains(errStr, "MDMAppleDeclaration.Name") && strings.Contains(errStr, "already exists") {
@@ -2533,7 +2549,7 @@ func getAppleProfiles(
 				}
 			}
 
-			mdmDecl := fleet.NewMDMAppleDeclaration(prof.Contents, tmID, prof.Name, rawDecl.Type, rawDecl.Identifier)
+			mdmDecl := fleet.NewMDMAppleDeclaration(prof.Contents, tmID, prof.Name, rawDecl.Type, rawDecl.Identifier, fleet.PayloadScopeSystem) // TODO: Parse scope from HTTP request
 			mdmDecl.SecretsUpdatedAt = prof.SecretsUpdatedAt
 			for _, labelName := range prof.LabelsIncludeAll {
 				if lbl, ok := labelMap[labelName]; ok {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
