### PR TITLE
Reap sudo child processes in execuser on Linux to prevent zombies

### DIFF
--- a/orbit/changes/41796-orbit-sudo-zombies
+++ b/orbit/changes/41796-orbit-sudo-zombies
@@ -1,0 +1,1 @@
+- Fixed fleetd leaving thousands of zombie `sudo` processes on Linux when Fleet Desktop repeatedly failed to start.

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -83,6 +83,17 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 	if err := cmd.Start(); err != nil {
 		return "", fmt.Errorf("open path %q: %w", path, err)
 	}
+	// Reap the child process in a background goroutine. Orbit runs as root and
+	// only calls Start here (it monitors the desktop process separately, so this
+	// function must return after starting it). Without a corresponding Wait, every
+	// `sudo`/`timeout` child that exits becomes a zombie. When the desktop fails to
+	// start and Orbit respawns it in a loop, these zombies accumulate by the
+	// thousands. See https://github.com/fleetdm/fleet/issues/41796.
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			log.Debug().Err(err).Msg("run cmd wait")
+		}
+	}()
 	return "", nil
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41796

Root cause: run() in orbit/pkg/execuser/execuser_linux.go called cmd.Start() but never cmd.Wait(). On Linux a child that exits stays a zombie until the parent reaps it, so every sudo … fleet-desktop invocation leaked a zombie. When Fleet Desktop fails to start, orbit respawns it in a loop (desktopRunner.Execute), so the zombies pile up.
 
Fix: reap the child in a background goroutine after Start(). run() still returns immediately (orbit monitors the desktop process separately), so behavior is unchanged otherwise.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

#### Reproduction steps

1. Start TUF server and create .deb package
```sh
SYSTEMS="linux-arm64" \
DEB_FLEET_URL=https://nicolasulmete.xyz \  # personal ngrok tunnel serving Fleet
DEB_TUF_URL=http://nicotuf.ngrok.io \            # personal ngrok tunnel serving TUF
GENERATE_DEB_ARM64=1 \
ENROLL_SECRET=<enroll-secret> \
FLEET_DESKTOP=1 \
TUF_PATH=$FLEET_REPO_DIR/test_tuf \
./tools/tuf/test/main.sh
```

2. Install .deb on a Ubuntu 25.10 ARM64 VM.
3. Push a failing fleet-desktop stub to trigger the respawn loop that produces zombie processes:

```sh
export TUF_PATH=$FLEET_REPO_DIR/test_tuf
export FLEET_TARGETS_PASSPHRASE=p4ssphr4s3 FLEET_SNAPSHOT_PASSPHRASE=p4ssphr4s3 FLEET_TIMESTAMP_PASSPHRASE=p4ssphr4s3
source ./tools/tuf/test/load_orbit_version_vars.sh
STUB=$(mktemp -d)
mkdir -p "$STUB/fleet-desktop"
printf '#!/bin/sh\n[ "$1" = "--help" ] && exit 0\nexit 1\n' > "$STUB/fleet-desktop/fleet-desktop"
chmod +x "$STUB/fleet-desktop/fleet-desktop"
tar czf "$STUB/desktop.tar.gz" -C "$STUB" fleet-desktop
./build/fleetctl updates add --path "$TUF_PATH" --target "$STUB/desktop.tar.gz" --platform linux-arm64 --name desktop --version "$ORBIT_VERSION" -t "$ORBIT_MAJOR.$ORBIT_MINOR" -t "$ORBIT_MAJOR" -t stable
rm -rf "$STUB"
```

4. Watch zombie processes on the VM:

```sh
 watch -n5 'ORB=$(pgrep -x orbit); \
    echo "zombie sudo children: $(ps -eo ppid,stat,comm | awk -v o="$ORB" "\$1==o && \$2 ~ /Z/ && \$3==\"sudo\"" | wc -l)"; \
    echo "total sudo lines:     $(ps aux | grep -c "[s]udo")"'
```

https://github.com/user-attachments/assets/dfa4d766-3c8e-4eb0-9104-7219c421538f

#### Test fix

1. Switch to this branch, rebuild and push the new orbit binary (note that we still have the stub fleet-desktop that always exits).

```sh
make build
export TUF_PATH=$FLEET_REPO_DIR/test_tuf
bash $FLEET_REPO_DIR/push-orbit-arm64.sh
```

Contents of `push-orbit-arm64.sh` is:

```sh
#!/bin/bash
set -e

source ./tools/tuf/test/load_orbit_version_vars.sh

GOOS=linux GOARCH=arm64 go build \
    -o orbit-linux-arm64 \
    -ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=$ORBIT_COMMIT" \
    ./orbit/cmd/orbit

./tools/tuf/test/push_target.sh linux-arm64 orbit orbit-linux-arm64 "$ORBIT_VERSION"
```

2. Verify on the VM that the update is detected and applied. Also, run step 4's cmd from the reproduction steps and see the zombies being 0, even though fleet-desktop is still continuously exiting.

https://github.com/user-attachments/assets/d0f96d85-5e94-4878-b413-67031add3c1e

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Linux where repeated Fleet Desktop startup failures could result in thousands of orphaned processes accumulating in the background, degrading system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->