### PR TITLE
Add more filtering to Vulnerability Exposure chart (frontend)

### DIFF
--- a/changes/44746-more-filtering-in-vulns-chart
+++ b/changes/44746-more-filtering-in-vulns-chart
@@ -1,0 +1,1 @@
+- Added more filtering options for the Vulnerability Exposure chart.

--- a/frontend/interfaces/charts.ts
+++ b/frontend/interfaces/charts.ts
@@ -14,6 +14,40 @@ export interface IDataSet {
   relativeScale?: boolean;
 }
 
+// CVE chart software categories. Values must match the backend api.CVECategory*
+// keys. The "os" category covers operating-system vulnerabilities and the Linux
+// kernel. Descriptions mirror the Figma sub-labels.
+export const CVE_SOFTWARE_CATEGORIES = [
+  {
+    value: "os",
+    label: "Operating system (OS)",
+    tooltipLabel: "OS",
+    description: "",
+  },
+  {
+    value: "browsers",
+    label: "Browsers",
+    tooltipLabel: "browsers",
+    description: "Google Chrome, Safari, Mozilla Firefox, Brave, and Opera",
+  },
+  {
+    value: "office",
+    label: "Microsoft Office",
+    tooltipLabel: "Microsoft Office",
+    description: "Word, Excel, PowerPoint, and Outlook",
+  },
+  {
+    value: "adobe",
+    label: "Adobe",
+    tooltipLabel: "Adobe",
+    description: "Acrobat, Flash, and Shockwave Player",
+  },
+] as const;
+
+export const ALL_CVE_SOFTWARE_CATEGORY_VALUES = CVE_SOFTWARE_CATEGORIES.map(
+  (c) => c.value as string
+);
+
 export interface IFormattedDataPoint {
   timestamp: string;
   label: string;

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -25,11 +25,17 @@ import {
   DATASET_CONFIG_KEY,
   DATASET_LABEL,
   HistoricalDataConfigKey,
+  CVE_SOFTWARE_CATEGORIES,
+  ALL_CVE_SOFTWARE_CATEGORY_VALUES,
 } from "interfaces/charts";
 
 import { AppContext } from "context/app";
 
-import ChartFilterModal, { IChartFilterState } from "./ChartFilterModal";
+import ChartFilterModal, {
+  IChartFilterState,
+  ChartFilterTab,
+} from "./ChartFilterModal";
+import { isEpssActive } from "./ChartFilterModal/SoftwareFilters/helpers";
 import LineChartViz from "./LineChartViz";
 import CheckerboardViz from "./CheckerboardViz";
 import DataCollectionDisabledState from "./DataCollectionDisabledState";
@@ -40,11 +46,84 @@ const baseClass = "chart-card";
 // configurable ranges we'll add UI and request-param plumbing for this.
 const CHART_DAYS = 30;
 
-const hasActiveFilters = (filters: IChartFilterState): boolean => {
+const DEFAULT_CHART_FILTERS: IChartFilterState = {
+  labelIDs: [],
+  platforms: [],
+  hostFilterMode: "none",
+  selectedHosts: [],
+  softwareCategories: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
+  knownExploit: false,
+  epssMin: "",
+  epssMax: "",
+  excludeCVEs: [],
+};
+
+const hasActiveHostFilters = (filters: IChartFilterState): boolean => {
   const hasHostFilter =
     filters.hostFilterMode !== "none" && filters.selectedHosts.length > 0;
   return (
     filters.labelIDs.length > 0 || filters.platforms.length > 0 || hasHostFilter
+  );
+};
+
+const hasActiveSoftwareFilters = (filters: IChartFilterState): boolean =>
+  filters.softwareCategories.length !==
+    ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
+  filters.knownExploit ||
+  isEpssActive(filters.epssMin, filters.epssMax) ||
+  filters.excludeCVEs.length > 0;
+
+// Human-readable "a, b, and c".
+const formatList = (items: string[]): string => {
+  if (items.length <= 1) return items.join("");
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+};
+
+const softwareFilterTooltip = (filters: IChartFilterState): JSX.Element => {
+  const lines: string[] = [];
+  const cats = CVE_SOFTWARE_CATEGORIES.filter((c) =>
+    filters.softwareCategories.includes(c.value)
+  ).map((c) => c.tooltipLabel);
+  if (cats.length) lines.push(formatList(cats));
+  if (filters.knownExploit) lines.push("Known exploits only");
+  if (
+    isEpssActive(filters.epssMin, filters.epssMax) ||
+    filters.excludeCVEs.length > 0
+  ) {
+    lines.push("Advanced filters");
+  }
+  return (
+    <>
+      {lines.map((line) => (
+        <div key={line}>{line}</div>
+      ))}
+    </>
+  );
+};
+
+const hostFilterTooltip = (filters: IChartFilterState): JSX.Element => {
+  const lines: string[] = [];
+  if (filters.labelIDs.length > 0) lines.push("Labels");
+  if (filters.platforms.length > 0) lines.push("Platforms");
+  if (
+    filters.hostFilterMode === "include" &&
+    filters.selectedHosts.length > 0
+  ) {
+    lines.push("Specific hosts");
+  }
+  if (
+    filters.hostFilterMode === "exclude" &&
+    filters.selectedHosts.length > 0
+  ) {
+    lines.push("Excluded hosts");
+  }
+  return (
+    <>
+      {lines.map((line) => (
+        <div key={line}>{line}</div>
+      ))}
+    </>
   );
 };
 
@@ -59,12 +138,15 @@ const ChartCard = ({
 }: IChartCardProps): JSX.Element => {
   const [selectedMetric, setSelectedMetric] = useState("uptime");
   const [showFilterModal, setShowFilterModal] = useState(false);
-  const [chartFilters, setChartFilters] = useState<IChartFilterState>({
-    labelIDs: [],
-    platforms: [],
-    hostFilterMode: "none",
-    selectedHosts: [],
-  });
+  const [initialTab, setInitialTab] = useState<ChartFilterTab>("hosts");
+  const [chartFilters, setChartFilters] = useState<IChartFilterState>(
+    DEFAULT_CHART_FILTERS
+  );
+
+  const openFilterModal = (tab: ChartFilterTab = "hosts") => {
+    setInitialTab(tab);
+    setShowFilterModal(true);
+  };
 
   const { isPremiumTier } = useContext(AppContext);
 
@@ -98,22 +180,15 @@ const ChartCard = ({
       defaultChartType: "checkerboard",
       description: (
         <>
-          The number of hosts with critical vulnerabilities detected in browsers
-          and{" "}
-          <CustomLink
-            newTab
-            text="other common software "
-            variant="tooltip-link"
-            url="https://fleetdm.com/learn-more-about/vulnerability-exposure-cves"
-          />
+          All critical vulnerabilities.
           <br />
           <br />
-          Want more control? Comprehensive vulnerability filtering is{" "}
+          Want more control? Severity (CVSS) filter is{" "}
           <CustomLink
             newTab
             text="coming soon "
             variant="tooltip-link"
-            url="https://github.com/fleetdm/fleet/issues/44746"
+            url="https://github.com/fleetdm/fleet/issues/47326"
           />
         </>
       ),
@@ -132,12 +207,7 @@ const ChartCard = ({
   // Labels and selected hosts are team-scoped, so clear filters when the
   // active fleet changes to avoid submitting stale IDs under the new scope.
   useEffect(() => {
-    setChartFilters({
-      labelIDs: [],
-      platforms: [],
-      hostFilterMode: "none",
-      selectedHosts: [],
-    });
+    setChartFilters(DEFAULT_CHART_FILTERS);
   }, [currentTeamId]);
 
   const currentDataset = getDataset(selectedMetric);
@@ -151,6 +221,21 @@ const ChartCard = ({
       : historicalDataEnabled?.[datasetConfigKey] ?? true;
 
   const queryParams: IChartApiParams = useMemo(() => {
+    const isCVE = selectedMetric === "cve";
+    // Only narrow categories when not all are selected; EPSS only narrows when
+    // min > 0 or max < 100. The Software tab enters EPSS as 0–100 %, but the
+    // API takes 0.0–1.0, so divide before sending.
+    const narrowsCategories =
+      isCVE &&
+      chartFilters.softwareCategories.length !==
+        ALL_CVE_SOFTWARE_CATEGORY_VALUES.length;
+    const epssMinActive =
+      isCVE && chartFilters.epssMin !== "" && Number(chartFilters.epssMin) > 0;
+    const epssMaxActive =
+      isCVE &&
+      chartFilters.epssMax !== "" &&
+      Number(chartFilters.epssMax) < 100;
+
     return {
       // Add an extra day to ensure we get the full # of calendar days
       // represented in the chart, regardless of timezone.
@@ -173,8 +258,18 @@ const ChartCard = ({
         chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
+      software_categories: narrowsCategories
+        ? chartFilters.softwareCategories.join(",")
+        : undefined,
+      known_exploit: isCVE && chartFilters.knownExploit ? true : undefined,
+      epss_min: epssMinActive ? Number(chartFilters.epssMin) / 100 : undefined,
+      epss_max: epssMaxActive ? Number(chartFilters.epssMax) / 100 : undefined,
+      exclude_cves:
+        isCVE && chartFilters.excludeCVEs.length
+          ? chartFilters.excludeCVEs.join(",")
+          : undefined,
     };
-  }, [chartFilters, currentTeamId]);
+  }, [chartFilters, currentTeamId, selectedMetric]);
 
   const { data: chartData, isLoading, error } = useQuery<
     IChartResponse,
@@ -280,8 +375,40 @@ const ChartCard = ({
               <Icon name="info-outline" />
             </TooltipWrapper>
           )}
-          {hasActiveFilters(chartFilters) && (
-            <span className={`${baseClass}__filtered-badge`}>Filtered</span>
+          {currentDataset.name === "cve" &&
+            hasActiveSoftwareFilters(chartFilters) && (
+              <TooltipWrapper
+                tipContent={softwareFilterTooltip(chartFilters)}
+                position="top"
+                underline={false}
+                showArrow
+                tipOffset={8}
+              >
+                <button
+                  type="button"
+                  className={`${baseClass}__filter-pill`}
+                  onClick={() => openFilterModal("software")}
+                >
+                  Software filtered
+                </button>
+              </TooltipWrapper>
+            )}
+          {hasActiveHostFilters(chartFilters) && (
+            <TooltipWrapper
+              tipContent={hostFilterTooltip(chartFilters)}
+              position="top"
+              underline={false}
+              showArrow
+              tipOffset={8}
+            >
+              <button
+                type="button"
+                className={`${baseClass}__filter-pill`}
+                onClick={() => openFilterModal("hosts")}
+              >
+                Hosts filtered
+              </button>
+            </TooltipWrapper>
           )}
         </div>
         <div className={`${baseClass}__header-right`}>
@@ -290,7 +417,7 @@ const ChartCard = ({
             variant="inverse"
             className={`${baseClass}__settings-btn`}
             ariaLabel="Configure chart filters"
-            onClick={() => setShowFilterModal(true)}
+            onClick={() => openFilterModal()}
           >
             <Icon name="settings" />
           </Button>
@@ -301,6 +428,8 @@ const ChartCard = ({
         <ChartFilterModal
           filters={chartFilters}
           currentTeamId={currentTeamId}
+          metric={selectedMetric}
+          initialTab={initialTab}
           onApply={(newFilters) => {
             setChartFilters(newFilters);
             setShowFilterModal(false);

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -9,6 +9,7 @@ import chartsAPI, {
   IChartQueryKey,
 } from "services/entities/charts";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import stringUtils from "utilities/strings/stringUtils";
 
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
@@ -74,6 +75,7 @@ const hasActiveSoftwareFilters = (filters: IChartFilterState): boolean =>
 
 // Human-readable "a, b, and c".
 const formatList = (items: string[]): string => {
+  items = items.map(stringUtils.capitalize);
   if (items.length <= 1) return items.join("");
   if (items.length === 2) return `${items[0]} and ${items[1]}`;
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -258,13 +258,13 @@ const ChartCard = ({
         chartFilters.selectedHosts.length
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
-      software_categories: narrowsCategories
+      software_filters: narrowsCategories
         ? chartFilters.softwareCategories.join(",")
         : undefined,
-      known_exploit: isCVE && chartFilters.knownExploit ? true : undefined,
+      has_known_exploit: isCVE && chartFilters.knownExploit ? true : undefined,
       epss_min: epssMinActive ? Number(chartFilters.epssMin) / 100 : undefined,
       epss_max: epssMaxActive ? Number(chartFilters.epssMax) / 100 : undefined,
-      exclude_cves:
+      exclude_vulnerabilities:
         isCVE && chartFilters.excludeCVEs.length
           ? chartFilters.excludeCVEs.join(",")
           : undefined,

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -79,32 +79,22 @@ const formatList = (items: string[]): string => {
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 };
 
-const softwareFilterTooltip = (filters: IChartFilterState): JSX.Element => {
-  const lines: string[] = [];
-  const cats = CVE_SOFTWARE_CATEGORIES.filter((c) =>
-    filters.softwareFilters.includes(c.value)
-  ).map((c) => c.tooltipLabel);
-  if (cats.length) lines.push(formatList(cats));
-  if (filters.knownExploit) lines.push("Known exploits only");
-  if (
-    isEpssActive(filters.epssMin, filters.epssMax) ||
-    filters.excludeCVEs.length > 0
-  ) {
-    lines.push("Advanced filters");
-  }
-  return (
-    <>
-      {lines.map((line) => (
-        <div key={line}>{line}</div>
-      ))}
-    </>
-  );
+// Maps platform filter values to their display names for the tooltip.
+const PLATFORM_LABELS: Record<string, string> = {
+  darwin: "macOS",
+  windows: "Windows",
+  linux: "Linux",
+  chrome: "ChromeOS",
 };
 
-const hostFilterTooltip = (filters: IChartFilterState): JSX.Element => {
+const hostFilterLines = (filters: IChartFilterState): string[] => {
   const lines: string[] = [];
+  if (filters.platforms.length > 0) {
+    lines.push(
+      formatList(filters.platforms.map((p) => PLATFORM_LABELS[p] ?? p))
+    );
+  }
   if (filters.labelIDs.length > 0) lines.push("Labels");
-  if (filters.platforms.length > 0) lines.push("Platforms");
   if (
     filters.hostFilterMode === "include" &&
     filters.selectedHosts.length > 0
@@ -117,11 +107,49 @@ const hostFilterTooltip = (filters: IChartFilterState): JSX.Element => {
   ) {
     lines.push("Excluded hosts");
   }
+  return lines;
+};
+
+const softwareFilterLines = (filters: IChartFilterState): string[] => {
+  const lines: string[] = [];
+  const cats = CVE_SOFTWARE_CATEGORIES.filter((c) =>
+    filters.softwareFilters.includes(c.value)
+  ).map((c) => c.tooltipLabel);
+  if (cats.length) lines.push(formatList(cats));
+  if (filters.knownExploit) lines.push("Known exploits only");
+  if (
+    isEpssActive(filters.epssMin, filters.epssMax) ||
+    filters.excludeCVEs.length > 0
+  ) {
+    lines.push("Advanced filters");
+  }
+  return lines;
+};
+
+// A single consolidated tooltip summarizing every active filter, grouped into
+// "Hosts" and "Software" sections. Each section is omitted when it has no
+// active filters; software filters only apply to the cve dataset.
+const filterTooltip = (
+  filters: IChartFilterState,
+  isCVE: boolean
+): JSX.Element => {
+  const hostLines = hostFilterLines(filters);
+  const softwareLines = isCVE ? softwareFilterLines(filters) : [];
+  const renderSection = (header: string, lines: string[]) =>
+    lines.length > 0 ? (
+      <div className={`${baseClass}__tooltip-section`}>
+        <div className={`${baseClass}__tooltip-section-header`}>{header}</div>
+        {lines.map((line) => (
+          <div key={line} className={`${baseClass}__tooltip-section-line`}>
+            {line}
+          </div>
+        ))}
+      </div>
+    ) : null;
   return (
     <>
-      {lines.map((line) => (
-        <div key={line}>{line}</div>
-      ))}
+      {renderSection("Hosts", hostLines)}
+      {renderSection("Software", softwareLines)}
     </>
   );
 };
@@ -211,6 +239,11 @@ const ChartCard = ({
 
   const currentDataset = getDataset(selectedMetric);
 
+  const isCVE = currentDataset.name === "cve";
+  const hostFiltersActive = hasActiveHostFilters(chartFilters);
+  const softwareFiltersActive = isCVE && hasActiveSoftwareFilters(chartFilters);
+  const anyFiltersActive = hostFiltersActive || softwareFiltersActive;
+
   const datasetConfigKey = DATASET_CONFIG_KEY[currentDataset.name];
   // If a dataset has no config-key mapping (future addition), treat it as
   // enabled — collection toggles only apply to known config keys.
@@ -220,7 +253,6 @@ const ChartCard = ({
       : historicalDataEnabled?.[datasetConfigKey] ?? true;
 
   const queryParams: IChartApiParams = useMemo(() => {
-    const isCVE = selectedMetric === "cve";
     // Only narrow categories when not all are selected; EPSS only narrows when
     // min > 0 or max < 100. The Software tab enters EPSS as 0–100 %, but the
     // API takes 0.0–1.0, so divide before sending.
@@ -268,7 +300,7 @@ const ChartCard = ({
           ? chartFilters.excludeCVEs.join(",")
           : undefined,
     };
-  }, [chartFilters, currentTeamId, selectedMetric]);
+  }, [chartFilters, currentTeamId, isCVE]);
 
   const { data: chartData, isLoading, error } = useQuery<
     IChartResponse,
@@ -374,27 +406,9 @@ const ChartCard = ({
               <Icon name="info-outline" />
             </TooltipWrapper>
           )}
-          {currentDataset.name === "cve" &&
-            hasActiveSoftwareFilters(chartFilters) && (
-              <TooltipWrapper
-                tipContent={softwareFilterTooltip(chartFilters)}
-                position="top"
-                underline={false}
-                showArrow
-                tipOffset={8}
-              >
-                <button
-                  type="button"
-                  className={`${baseClass}__filter-pill`}
-                  onClick={() => openFilterModal("software")}
-                >
-                  Software filtered
-                </button>
-              </TooltipWrapper>
-            )}
-          {hasActiveHostFilters(chartFilters) && (
+          {anyFiltersActive && (
             <TooltipWrapper
-              tipContent={hostFilterTooltip(chartFilters)}
+              tipContent={filterTooltip(chartFilters, isCVE)}
               position="top"
               underline={false}
               showArrow
@@ -403,9 +417,11 @@ const ChartCard = ({
               <button
                 type="button"
                 className={`${baseClass}__filter-pill`}
-                onClick={() => openFilterModal("hosts")}
+                onClick={() =>
+                  openFilterModal(hostFiltersActive ? "hosts" : "software")
+                }
               >
-                Hosts filtered
+                Filtered
               </button>
             </TooltipWrapper>
           )}

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -114,10 +114,17 @@ const hostFilterLines = (filters: IChartFilterState): string[] => {
 
 const softwareFilterLines = (filters: IChartFilterState): string[] => {
   const lines: string[] = [];
+  // Only surface category text when the user has actually narrowed the
+  // selection — all categories are selected by default, so an unnarrowed
+  // selection isn't an active filter and shouldn't show a Software section.
+  const categoriesNarrowed =
+    filters.softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length;
   const cats = CVE_SOFTWARE_CATEGORIES.filter((c) =>
     filters.softwareFilters.includes(c.value)
   ).map((c) => c.tooltipLabel);
-  if (cats.length) lines.push(formatList(cats));
+  if (categoriesNarrowed) {
+    lines.push(cats.length ? formatList(cats) : "No software categories");
+  }
   if (filters.knownExploit) lines.push("Known exploits only");
   if (
     isEpssActive(filters.epssMin, filters.epssMax) ||

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -51,7 +51,7 @@ const DEFAULT_CHART_FILTERS: IChartFilterState = {
   platforms: [],
   hostFilterMode: "none",
   selectedHosts: [],
-  softwareCategories: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
+  softwareFilters: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
   knownExploit: false,
   epssMin: "",
   epssMax: "",
@@ -67,8 +67,7 @@ const hasActiveHostFilters = (filters: IChartFilterState): boolean => {
 };
 
 const hasActiveSoftwareFilters = (filters: IChartFilterState): boolean =>
-  filters.softwareCategories.length !==
-    ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
+  filters.softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
   filters.knownExploit ||
   isEpssActive(filters.epssMin, filters.epssMax) ||
   filters.excludeCVEs.length > 0;
@@ -83,7 +82,7 @@ const formatList = (items: string[]): string => {
 const softwareFilterTooltip = (filters: IChartFilterState): JSX.Element => {
   const lines: string[] = [];
   const cats = CVE_SOFTWARE_CATEGORIES.filter((c) =>
-    filters.softwareCategories.includes(c.value)
+    filters.softwareFilters.includes(c.value)
   ).map((c) => c.tooltipLabel);
   if (cats.length) lines.push(formatList(cats));
   if (filters.knownExploit) lines.push("Known exploits only");
@@ -227,7 +226,7 @@ const ChartCard = ({
     // API takes 0.0–1.0, so divide before sending.
     const narrowsCategories =
       isCVE &&
-      chartFilters.softwareCategories.length !==
+      chartFilters.softwareFilters.length !==
         ALL_CVE_SOFTWARE_CATEGORY_VALUES.length;
     const epssMinActive =
       isCVE && chartFilters.epssMin !== "" && Number(chartFilters.epssMin) > 0;
@@ -259,7 +258,7 @@ const ChartCard = ({
           ? chartFilters.selectedHosts.map((h) => h.id).join(",")
           : undefined,
       software_filters: narrowsCategories
-        ? chartFilters.softwareCategories.join(",")
+        ? chartFilters.softwareFilters.join(",")
         : undefined,
       has_known_exploit: isCVE && chartFilters.knownExploit ? true : undefined,
       epss_min: epssMinActive ? Number(chartFilters.epssMin) / 100 : undefined,

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
@@ -5,12 +5,14 @@ import { useDebouncedCallback } from "use-debounce";
 
 import { IHost } from "interfaces/host";
 import { ILabelSummary } from "interfaces/label";
+import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
 import hostsAPI, { ILoadHostsResponse } from "services/entities/hosts";
 import labelsAPI from "services/entities/labels";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
+import TooltipWrapper from "components/TooltipWrapper";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -19,7 +21,17 @@ import SearchField from "components/forms/fields/SearchField";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 
+import SoftwareFilters from "./SoftwareFilters";
+import {
+  EPSS_RANGE_INVALID_MSG,
+  hasEpssErrors,
+  isEpssActive,
+  isEpssRangeInvalid,
+} from "./SoftwareFilters/helpers";
+
 const baseClass = "chart-filter-modal";
+
+export type ChartFilterTab = "hosts" | "software";
 
 const PLATFORM_OPTIONS = [
   { label: "macOS", value: "darwin" },
@@ -35,11 +47,22 @@ export interface IChartFilterState {
   platforms: string[];
   hostFilterMode: HostFilterMode;
   selectedHosts: IHost[];
+  // Software (cve) filters. softwareCategories holds the checked category
+  // values (defaults to all). epssMin/epssMax are raw 0–100 % strings ("" =
+  // unset); the card converts them to the 0.0–1.0 API value.
+  softwareCategories: string[];
+  knownExploit: boolean;
+  epssMin: string;
+  epssMax: string;
+  excludeCVEs: string[];
 }
 
 interface IChartFilterModalProps {
   filters: IChartFilterState;
   currentTeamId?: number;
+  // metric drives whether the Software tab is shown (cve only).
+  metric: string;
+  initialTab?: ChartFilterTab;
   onApply: (filters: IChartFilterState) => void;
   onCancel: () => void;
 }
@@ -50,9 +73,25 @@ const SEARCH_DEBOUNCE_MS = 300;
 const ChartFilterModal = ({
   filters,
   currentTeamId,
+  metric,
+  initialTab = "hosts",
   onApply,
   onCancel,
 }: IChartFilterModalProps): JSX.Element => {
+  const isCVE = metric === "cve";
+  const [activeTab, setActiveTab] = useState(initialTab === "software" ? 1 : 0);
+
+  // Software (cve) filter state.
+  const [softwareCategories, setSoftwareCategories] = useState<string[]>(
+    filters.softwareCategories
+  );
+  const [knownExploit, setKnownExploit] = useState<boolean>(
+    filters.knownExploit
+  );
+  const [epssMin, setEpssMin] = useState<string>(filters.epssMin);
+  const [epssMax, setEpssMax] = useState<string>(filters.epssMax);
+  const [excludeCVEs, setExcludeCVEs] = useState<string[]>(filters.excludeCVEs);
+
   const [selectedLabelIDs, setSelectedLabelIDs] = useState<number[]>(
     filters.labelIDs
   );
@@ -156,6 +195,11 @@ const ChartFilterModal = ({
       platforms: selectedPlatforms,
       hostFilterMode,
       selectedHosts,
+      softwareCategories,
+      knownExploit,
+      epssMin,
+      epssMax,
+      excludeCVEs,
     });
   };
 
@@ -169,6 +213,12 @@ const ChartFilterModal = ({
     setPageCount(1);
     setSearchFieldKey((k) => k + 1);
     debouncedSetSearchQuery.cancel();
+    // Reset software filters to their defaults (all categories selected).
+    setSoftwareCategories([...ALL_CVE_SOFTWARE_CATEGORY_VALUES]);
+    setKnownExploit(false);
+    setEpssMin("");
+    setEpssMax("");
+    setExcludeCVEs([]);
   };
 
   const handleTabChange = (index: number) => {
@@ -188,12 +238,27 @@ const ChartFilterModal = ({
     setSelectedHosts((prev) => prev.filter((h) => h.id !== hostId));
   };
 
+  const softwareFiltersActive =
+    isCVE &&
+    (softwareCategories.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
+      knownExploit ||
+      isEpssActive(epssMin, epssMax) ||
+      excludeCVEs.length > 0);
+
   const hasFilters =
     selectedLabelIDs.length > 0 ||
     selectedPlatforms.length > 0 ||
-    selectedHosts.length > 0;
+    selectedHosts.length > 0 ||
+    softwareFiltersActive;
 
+  // Inner host include/exclude tab.
   const tabIndex = hostFilterMode === "include" ? 1 : 0;
+
+  // Block Apply on invalid EPSS input; surface the reason as a tooltip.
+  const applyDisabled = isCVE && hasEpssErrors(epssMin, epssMax);
+  const applyTooltip = isEpssRangeInvalid(epssMin, epssMax)
+    ? EPSS_RANGE_INVALID_MSG
+    : "Enter EPSS values from 0 to 100.";
 
   const renderHostSearch = () => (
     <div className={`${baseClass}__host-search`}>
@@ -251,60 +316,95 @@ const ChartFilterModal = ({
     </div>
   );
 
+  const renderHostFilters = () => (
+    <div className={`${baseClass}__form`}>
+      <Dropdown
+        label="Labels"
+        name="labels"
+        options={labelOptions}
+        value={selectedLabelIDs.join(",")}
+        onChange={(value: string | null) => {
+          if (!value) {
+            setSelectedLabelIDs([]);
+          } else {
+            setSelectedLabelIDs(value.split(",").map(Number));
+          }
+        }}
+        multi
+        placeholder="All labels"
+        searchable
+        clearable
+      />
+      <Dropdown
+        label="Platforms"
+        name="platforms"
+        options={PLATFORM_OPTIONS}
+        value={selectedPlatforms.join(",")}
+        onChange={(value: string | null) => {
+          if (!value) {
+            setSelectedPlatforms([]);
+          } else {
+            setSelectedPlatforms(value.split(","));
+          }
+        }}
+        multi
+        placeholder="All platforms"
+        searchable={false}
+        clearable
+      />
+      <TabNav secondary>
+        <Tabs selectedIndex={tabIndex} onSelect={handleTabChange}>
+          <TabList>
+            <Tab>
+              <TabText>Exclude hosts</TabText>
+            </Tab>
+            <Tab>
+              <TabText>Specific hosts</TabText>
+            </Tab>
+          </TabList>
+          {/* Only render the active tab to avoid two parallel host lists
+              fighting over the shared listRef and duplicating API requests. */}
+          <TabPanel>{tabIndex === 0 && renderHostSearch()}</TabPanel>
+          <TabPanel>{tabIndex === 1 && renderHostSearch()}</TabPanel>
+        </Tabs>
+      </TabNav>
+    </div>
+  );
+
   return (
     <Modal title="Settings" onExit={onCancel} className={baseClass}>
-      <div className={`${baseClass}__form`}>
-        <Dropdown
-          label="Labels"
-          name="labels"
-          options={labelOptions}
-          value={selectedLabelIDs.join(",")}
-          onChange={(value: string | null) => {
-            if (!value) {
-              setSelectedLabelIDs([]);
-            } else {
-              setSelectedLabelIDs(value.split(",").map(Number));
-            }
-          }}
-          multi
-          placeholder="All labels"
-          searchable
-          clearable
-        />
-        <Dropdown
-          label="Platforms"
-          name="platforms"
-          options={PLATFORM_OPTIONS}
-          value={selectedPlatforms.join(",")}
-          onChange={(value: string | null) => {
-            if (!value) {
-              setSelectedPlatforms([]);
-            } else {
-              setSelectedPlatforms(value.split(","));
-            }
-          }}
-          multi
-          placeholder="All platforms"
-          searchable={false}
-          clearable
-        />
-        <TabNav secondary>
-          <Tabs selectedIndex={tabIndex} onSelect={handleTabChange}>
+      {isCVE ? (
+        <TabNav>
+          <Tabs selectedIndex={activeTab} onSelect={setActiveTab}>
             <TabList>
               <Tab>
-                <TabText>Exclude hosts</TabText>
+                <TabText>Hosts</TabText>
               </Tab>
               <Tab>
-                <TabText>Specific hosts</TabText>
+                <TabText>Software</TabText>
               </Tab>
             </TabList>
-            {/* Only render the active tab to avoid two parallel host lists
-                fighting over the shared listRef and duplicating API requests. */}
-            <TabPanel>{tabIndex === 0 && renderHostSearch()}</TabPanel>
-            <TabPanel>{tabIndex === 1 && renderHostSearch()}</TabPanel>
+            <TabPanel>{renderHostFilters()}</TabPanel>
+            <TabPanel>
+              <SoftwareFilters
+                currentTeamId={currentTeamId}
+                categories={softwareCategories}
+                knownExploit={knownExploit}
+                epssMin={epssMin}
+                epssMax={epssMax}
+                excludeCVEs={excludeCVEs}
+                setCategories={setSoftwareCategories}
+                setKnownExploit={setKnownExploit}
+                setEpssMin={setEpssMin}
+                setEpssMax={setEpssMax}
+                setExcludeCVEs={setExcludeCVEs}
+              />
+            </TabPanel>
           </Tabs>
         </TabNav>
-      </div>
+      ) : (
+        renderHostFilters()
+      )}
       <div className={`${baseClass}__btn-wrap`}>
         {hasFilters && (
           <Button variant="inverse" onClick={handleClear}>
@@ -315,9 +415,17 @@ const ChartFilterModal = ({
           <Button variant="inverse" onClick={onCancel}>
             Cancel
           </Button>
-          <Button variant="default" onClick={handleApply}>
-            Apply
-          </Button>
+          {applyDisabled ? (
+            <TooltipWrapper tipContent={applyTooltip} underline={false}>
+              <Button variant="default" disabled>
+                Apply
+              </Button>
+            </TooltipWrapper>
+          ) : (
+            <Button variant="default" onClick={handleApply}>
+              Apply
+            </Button>
+          )}
         </div>
       </div>
     </Modal>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
@@ -47,10 +47,10 @@ export interface IChartFilterState {
   platforms: string[];
   hostFilterMode: HostFilterMode;
   selectedHosts: IHost[];
-  // Software (cve) filters. softwareCategories holds the checked category
+  // Software (cve) filters. softwareFilters holds the checked category
   // values (defaults to all). epssMin/epssMax are raw 0–100 % strings ("" =
   // unset); the card converts them to the 0.0–1.0 API value.
-  softwareCategories: string[];
+  softwareFilters: string[];
   knownExploit: boolean;
   epssMin: string;
   epssMax: string;
@@ -82,8 +82,8 @@ const ChartFilterModal = ({
   const [activeTab, setActiveTab] = useState(initialTab === "software" ? 1 : 0);
 
   // Software (cve) filter state.
-  const [softwareCategories, setSoftwareCategories] = useState<string[]>(
-    filters.softwareCategories
+  const [softwareFilters, setSoftwareFilters] = useState<string[]>(
+    filters.softwareFilters
   );
   const [knownExploit, setKnownExploit] = useState<boolean>(
     filters.knownExploit
@@ -195,7 +195,7 @@ const ChartFilterModal = ({
       platforms: selectedPlatforms,
       hostFilterMode,
       selectedHosts,
-      softwareCategories,
+      softwareFilters,
       knownExploit,
       epssMin,
       epssMax,
@@ -214,7 +214,7 @@ const ChartFilterModal = ({
     setSearchFieldKey((k) => k + 1);
     debouncedSetSearchQuery.cancel();
     // Reset software filters to their defaults (all categories selected).
-    setSoftwareCategories([...ALL_CVE_SOFTWARE_CATEGORY_VALUES]);
+    setSoftwareFilters([...ALL_CVE_SOFTWARE_CATEGORY_VALUES]);
     setKnownExploit(false);
     setEpssMin("");
     setEpssMax("");
@@ -240,7 +240,7 @@ const ChartFilterModal = ({
 
   const softwareFiltersActive =
     isCVE &&
-    (softwareCategories.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
+    (softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
       knownExploit ||
       isEpssActive(epssMin, epssMax) ||
       excludeCVEs.length > 0);
@@ -388,12 +388,12 @@ const ChartFilterModal = ({
             <TabPanel>
               <SoftwareFilters
                 currentTeamId={currentTeamId}
-                categories={softwareCategories}
+                categories={softwareFilters}
                 knownExploit={knownExploit}
                 epssMin={epssMin}
                 epssMax={epssMax}
                 excludeCVEs={excludeCVEs}
-                setCategories={setSoftwareCategories}
+                setCategories={setSoftwareFilters}
                 setKnownExploit={setKnownExploit}
                 setEpssMin={setEpssMin}
                 setEpssMax={setEpssMax}

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
@@ -23,10 +23,8 @@ import Dropdown from "components/forms/fields/Dropdown";
 
 import SoftwareFilters from "./SoftwareFilters";
 import {
-  EPSS_RANGE_INVALID_MSG,
-  hasEpssErrors,
+  getSoftwareFilterApplyError,
   isEpssActive,
-  isEpssRangeInvalid,
 } from "./SoftwareFilters/helpers";
 
 const baseClass = "chart-filter-modal";
@@ -254,11 +252,13 @@ const ChartFilterModal = ({
   // Inner host include/exclude tab.
   const tabIndex = hostFilterMode === "include" ? 1 : 0;
 
-  // Block Apply on invalid EPSS input; surface the reason as a tooltip.
-  const applyDisabled = isCVE && hasEpssErrors(epssMin, epssMax);
-  const applyTooltip = isEpssRangeInvalid(epssMin, epssMax)
-    ? EPSS_RANGE_INVALID_MSG
-    : "Enter EPSS values from 0 to 100.";
+  // Block Apply when the Software tab is invalid — no category selected or bad
+  // EPSS input — and surface the reason as a tooltip.
+  const applyError = isCVE
+    ? getSoftwareFilterApplyError(softwareFilters, epssMin, epssMax)
+    : null;
+  const applyDisabled = applyError !== null;
+  const applyTooltip = applyError ?? "";
 
   const renderHostSearch = () => (
     <div className={`${baseClass}__host-search`}>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
@@ -386,19 +386,23 @@ const ChartFilterModal = ({
             </TabList>
             <TabPanel>{renderHostFilters()}</TabPanel>
             <TabPanel>
-              <SoftwareFilters
-                currentTeamId={currentTeamId}
-                categories={softwareFilters}
-                knownExploit={knownExploit}
-                epssMin={epssMin}
-                epssMax={epssMax}
-                excludeCVEs={excludeCVEs}
-                setCategories={setSoftwareFilters}
-                setKnownExploit={setKnownExploit}
-                setEpssMin={setEpssMin}
-                setEpssMax={setEpssMax}
-                setExcludeCVEs={setExcludeCVEs}
-              />
+              {/* Wrap in __form so the Software tab gets the same bottom
+                  spacing before the action buttons as the Hosts tab. */}
+              <div className={`${baseClass}__form`}>
+                <SoftwareFilters
+                  currentTeamId={currentTeamId}
+                  categories={softwareFilters}
+                  knownExploit={knownExploit}
+                  epssMin={epssMin}
+                  epssMax={epssMax}
+                  excludeCVEs={excludeCVEs}
+                  setCategories={setSoftwareFilters}
+                  setKnownExploit={setKnownExploit}
+                  setEpssMin={setEpssMin}
+                  setEpssMax={setEpssMax}
+                  setExcludeCVEs={setExcludeCVEs}
+                />
+              </div>
             </TabPanel>
           </Tabs>
         </TabNav>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tests.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import { createCustomRenderer, baseUrl } from "test/test-utils";
+import mockServer from "test/mock-server";
+import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
+
+import SoftwareFilters from "./SoftwareFilters";
+
+const emptyVulnsHandler = http.get(baseUrl("/vulnerabilities"), () =>
+  HttpResponse.json({
+    count: 0,
+    counts_updated_at: "",
+    vulnerabilities: [],
+    meta: { has_next_results: false, has_previous_results: false },
+  })
+);
+
+const baseProps = {
+  categories: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
+  knownExploit: false,
+  epssMin: "",
+  epssMax: "",
+  excludeCVEs: [],
+  setCategories: jest.fn(),
+  setKnownExploit: jest.fn(),
+  setEpssMin: jest.fn(),
+  setEpssMax: jest.fn(),
+  setExcludeCVEs: jest.fn(),
+};
+
+const render = createCustomRenderer({ withBackendMock: true });
+
+describe("SoftwareFilters", () => {
+  beforeEach(() => mockServer.use(emptyVulnsHandler));
+
+  it("shows all software categories checked by default and KEV unchecked", () => {
+    render(<SoftwareFilters {...baseProps} />);
+
+    // The visible checkbox is a div[role=checkbox] whose accessible name is the
+    // `name` prop (e.g. "category-os"); its checked state is aria-checked.
+    expect(screen.getByRole("checkbox", { name: "category-os" })).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "category-browsers" })
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "category-office" })
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "category-adobe" })
+    ).toBeChecked();
+
+    // Human-readable labels are rendered too.
+    expect(screen.getByText("Operating system (OS)")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("checkbox", { name: "known-exploit" })
+    ).not.toBeChecked();
+  });
+
+  it("removes a category from the set when unchecked", async () => {
+    const setCategories = jest.fn();
+    const { user } = render(
+      <SoftwareFilters {...baseProps} setCategories={setCategories} />
+    );
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "category-browsers" })
+    );
+
+    expect(setCategories).toHaveBeenCalledWith(
+      ALL_CVE_SOFTWARE_CATEGORY_VALUES.filter((c) => c !== "browsers")
+    );
+  });
+
+  it("keeps Advanced options collapsed until toggled", async () => {
+    const { user } = render(<SoftwareFilters {...baseProps} />);
+
+    expect(
+      screen.queryByText("Probability of exploit")
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Advanced options/i }));
+
+    expect(screen.getByText("Probability of exploit")).toBeInTheDocument();
+    expect(
+      screen.getByText("Exclude vulnerabilities (CVEs)")
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces an EPSS range error for out-of-range input", async () => {
+    const { user } = render(<SoftwareFilters {...baseProps} epssMin="-1" />);
+
+    await user.click(screen.getByRole("button", { name: /Advanced options/i }));
+
+    expect(screen.getByText("Must be from 0 to 100")).toBeInTheDocument();
+  });
+
+  it("renders excluded CVEs as removable pills", async () => {
+    const setExcludeCVEs = jest.fn();
+    const { user } = render(
+      <SoftwareFilters
+        {...baseProps}
+        excludeCVEs={["CVE-2025-0001"]}
+        setExcludeCVEs={setExcludeCVEs}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Advanced options/i }));
+
+    const pill = screen.getByRole("button", { name: /CVE-2025-0001/i });
+    expect(pill).toBeInTheDocument();
+
+    await user.click(pill);
+    expect(setExcludeCVEs).toHaveBeenCalledWith([]);
+  });
+});

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tests.tsx
@@ -74,6 +74,22 @@ describe("SoftwareFilters", () => {
     );
   });
 
+  it("shows a validation error when no category is selected", () => {
+    render(<SoftwareFilters {...baseProps} categories={[]} />);
+
+    expect(
+      screen.getByText("Select at least one software category.")
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the category error when a category is selected", () => {
+    render(<SoftwareFilters {...baseProps} categories={["os"]} />);
+
+    expect(
+      screen.queryByText("Select at least one software category.")
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps Advanced options collapsed until toggled", async () => {
     const { user } = render(<SoftwareFilters {...baseProps} />);
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
@@ -16,6 +16,7 @@ import SearchField from "components/forms/fields/SearchField";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 
+import TooltipWrapper from "components/TooltipWrapper/TooltipWrapper";
 import { getEpssError, NO_CATEGORIES_MSG } from "./helpers";
 
 const baseClass = "software-filters";
@@ -172,7 +173,18 @@ const SoftwareFilters = ({
         <div className={`${baseClass}__advanced`}>
           <div className={`${baseClass}__epss`}>
             <h3 className={`${baseClass}__section-title`}>
-              Probability of exploit
+              <TooltipWrapper
+                tooltipClass={`${baseClass}__tooltip-text`}
+                tipContent={
+                  <>
+                    The probability that this vulnerability will be exploited in
+                    the next 30 days (EPSS probability). <br />
+                    This data is reported by FIRST.org.
+                  </>
+                }
+              >
+                Probability of exploit
+              </TooltipWrapper>
             </h3>
             <p className={`${baseClass}__section-help`}>
               EPSS probabilities range from 0 to 100%.

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
@@ -16,7 +16,7 @@ import SearchField from "components/forms/fields/SearchField";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 
-import { getEpssError } from "./helpers";
+import { getEpssError, NO_CATEGORIES_MSG } from "./helpers";
 
 const baseClass = "software-filters";
 
@@ -139,6 +139,11 @@ const SoftwareFilters = ({
             {cat.label}
           </Checkbox>
         ))}
+        {categories.length === 0 && (
+          <div className={`${baseClass}__categories-error`} role="alert">
+            {NO_CATEGORIES_MSG}
+          </div>
+        )}
       </div>
 
       <div className={`${baseClass}__kev`}>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
@@ -85,7 +85,9 @@ const SoftwareFilters = ({
         per_page: pageCount * PAGE_SIZE,
         query: searchQuery || undefined,
       }),
-    { keepPreviousData: true, staleTime: 30000 }
+    // The CVE search UI lives entirely inside the Advanced section, so don't
+    // fetch until the user opens it.
+    { keepPreviousData: true, staleTime: 30000, enabled: showAdvanced }
   );
 
   const cves: IVulnerability[] = vulnData?.vulnerabilities ?? [];

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
@@ -1,0 +1,256 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery } from "react-query";
+import { useDebouncedCallback } from "use-debounce";
+
+import { IVulnerability } from "interfaces/vulnerability";
+import { CVE_SOFTWARE_CATEGORIES } from "interfaces/charts";
+import {
+  getVulnerabilities,
+  IVulnerabilitiesResponse,
+} from "services/entities/vulnerabilities";
+
+import Checkbox from "components/forms/fields/Checkbox";
+import Icon from "components/Icon";
+import RevealButton from "components/buttons/RevealButton";
+import SearchField from "components/forms/fields/SearchField";
+// @ts-ignore
+import InputField from "components/forms/fields/InputField";
+
+import { getEpssError } from "./helpers";
+
+const baseClass = "software-filters";
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface ISoftwareFiltersProps {
+  currentTeamId?: number;
+  categories: string[];
+  knownExploit: boolean;
+  epssMin: string;
+  epssMax: string;
+  excludeCVEs: string[];
+  setCategories: (categories: string[]) => void;
+  setKnownExploit: (value: boolean) => void;
+  setEpssMin: (value: string) => void;
+  setEpssMax: (value: string) => void;
+  setExcludeCVEs: (cves: string[]) => void;
+}
+
+const SoftwareFilters = ({
+  currentTeamId,
+  categories,
+  knownExploit,
+  epssMin,
+  epssMax,
+  excludeCVEs,
+  setCategories,
+  setKnownExploit,
+  setEpssMin,
+  setEpssMax,
+  setExcludeCVEs,
+}: ISoftwareFiltersProps): JSX.Element => {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [searchInput, setSearchInput] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [pageCount, setPageCount] = useState(1);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const excludedSet = new Set(excludeCVEs);
+
+  const debouncedSetSearchQuery = useDebouncedCallback((value: string) => {
+    setSearchQuery(value);
+    setPageCount(1);
+    if (listRef.current) {
+      listRef.current.scrollTop = 0;
+    }
+  }, SEARCH_DEBOUNCE_MS);
+
+  useEffect(() => {
+    return () => debouncedSetSearchQuery.cancel();
+  }, [debouncedSetSearchQuery]);
+
+  // Search all CVEs (not just the curated set) so a user can exclude anything.
+  // Mirrors the host search: keep prior pages cached and grow per_page on scroll.
+  const {
+    data: vulnData,
+    isLoading: isLoadingVulns,
+    error: vulnsError,
+  } = useQuery<IVulnerabilitiesResponse, Error>(
+    ["chartFilterCVEs", currentTeamId, searchQuery, pageCount],
+    () =>
+      getVulnerabilities({
+        teamId: currentTeamId,
+        page: 0,
+        per_page: pageCount * PAGE_SIZE,
+        query: searchQuery || undefined,
+      }),
+    { keepPreviousData: true, staleTime: 30000 }
+  );
+
+  const cves: IVulnerability[] = vulnData?.vulnerabilities ?? [];
+  const hasMore = vulnData?.meta?.has_next_results ?? false;
+
+  const handleScroll = useCallback(() => {
+    const el = listRef.current;
+    if (!el || !hasMore || isLoadingVulns) return;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 40) {
+      setPageCount((prev) => prev + 1);
+    }
+  }, [hasMore, isLoadingVulns]);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchInput(value);
+      debouncedSetSearchQuery(value);
+    },
+    [debouncedSetSearchQuery]
+  );
+
+  const toggleCategory = (value: string) => {
+    if (categories.includes(value)) {
+      setCategories(categories.filter((c) => c !== value));
+    } else {
+      setCategories([...categories, value]);
+    }
+  };
+
+  const toggleCVE = (cve: string) => {
+    if (excludedSet.has(cve)) {
+      setExcludeCVEs(excludeCVEs.filter((c) => c !== cve));
+    } else {
+      setExcludeCVEs([...excludeCVEs, cve]);
+    }
+  };
+
+  return (
+    <div className={baseClass}>
+      <div className={`${baseClass}__categories`}>
+        {CVE_SOFTWARE_CATEGORIES.map((cat) => (
+          <Checkbox
+            key={cat.value}
+            name={`category-${cat.value}`}
+            value={categories.includes(cat.value)}
+            onChange={() => toggleCategory(cat.value)}
+            helpText={cat.description || undefined}
+          >
+            {cat.label}
+          </Checkbox>
+        ))}
+      </div>
+
+      <div className={`${baseClass}__kev`}>
+        <h3 className={`${baseClass}__section-title`}>
+          CISA known exploit (KEV)
+        </h3>
+        <Checkbox
+          name="known-exploit"
+          value={knownExploit}
+          onChange={() => setKnownExploit(!knownExploit)}
+          helpText="Software has vulnerabilities that have been actively exploited in the wild."
+        >
+          Has known exploit
+        </Checkbox>
+      </div>
+
+      <RevealButton
+        isShowing={showAdvanced}
+        showText="Advanced options"
+        hideText="Advanced options"
+        caretPosition="after"
+        onClick={() => setShowAdvanced((prev) => !prev)}
+      />
+
+      {showAdvanced && (
+        <div className={`${baseClass}__advanced`}>
+          <div className={`${baseClass}__epss`}>
+            <h3 className={`${baseClass}__section-title`}>
+              Probability of exploit
+            </h3>
+            <p className={`${baseClass}__section-help`}>
+              EPSS probabilities range from 0 to 100%.
+            </p>
+            <div className={`${baseClass}__epss-inputs`}>
+              <InputField
+                label="Min"
+                name="epss-min"
+                type="number"
+                value={epssMin}
+                placeholder="0"
+                error={getEpssError(epssMin)}
+                onChange={setEpssMin}
+              />
+              <InputField
+                label="Max"
+                name="epss-max"
+                type="number"
+                value={epssMax}
+                placeholder="100"
+                error={getEpssError(epssMax)}
+                onChange={setEpssMax}
+              />
+            </div>
+          </div>
+
+          <div className={`${baseClass}__exclude-cves`}>
+            <h3 className={`${baseClass}__section-title`}>
+              Exclude vulnerabilities (CVEs)
+            </h3>
+            <SearchField
+              placeholder="Search CVEs"
+              defaultValue={searchInput}
+              onChange={handleSearchChange}
+            />
+            {excludeCVEs.length > 0 && (
+              <div className={`${baseClass}__pills`}>
+                {excludeCVEs.map((cve) => (
+                  <button
+                    key={cve}
+                    type="button"
+                    className={`${baseClass}__pill`}
+                    onClick={() => toggleCVE(cve)}
+                  >
+                    {cve}
+                    <Icon name="close" />
+                  </button>
+                ))}
+              </div>
+            )}
+            <div
+              className={`${baseClass}__results-list`}
+              ref={listRef}
+              onScroll={handleScroll}
+            >
+              {cves.map((vuln) => (
+                <div key={vuln.cve} className={`${baseClass}__results-row`}>
+                  <Checkbox
+                    name={`cve-${vuln.cve}`}
+                    value={excludedSet.has(vuln.cve)}
+                    onChange={() => toggleCVE(vuln.cve)}
+                  >
+                    {vuln.cve}
+                  </Checkbox>
+                </div>
+              ))}
+              {vulnsError && (
+                <div className={`${baseClass}__results-status`} role="alert">
+                  Couldn&apos;t load CVEs. Please try again.
+                </div>
+              )}
+              {!vulnsError && isLoadingVulns && (
+                <div className={`${baseClass}__results-status`}>Loading...</div>
+              )}
+              {!vulnsError && !isLoadingVulns && cves.length === 0 && (
+                <div className={`${baseClass}__results-status`}>
+                  No matching CVEs.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SoftwareFilters;

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
@@ -114,4 +114,8 @@
     font-size: $x-small;
     color: $ui-fleet-black-50;
   }
+
+  &__tooltip-text {
+    text-align: center;
+  }
 }

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
@@ -1,0 +1,112 @@
+.software-filters {
+  display: flex;
+  flex-direction: column;
+  gap: $pad-large;
+
+  &__categories {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
+  }
+
+  &__section-title {
+    margin: 0;
+    font-size: $x-small;
+    font-weight: $bold;
+    color: $core-fleet-black;
+  }
+
+  &__section-help {
+    margin: 0;
+    font-size: $xx-small;
+    color: $ui-fleet-black-50;
+  }
+
+  &__kev {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
+  }
+
+  &__advanced {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-large;
+  }
+
+  &__epss {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
+  }
+
+  &__epss-inputs {
+    display: flex;
+    gap: $pad-medium;
+
+    .form-field {
+      flex: 1;
+    }
+  }
+
+  &__exclude-cves {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
+  }
+
+  &__pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $pad-xsmall;
+  }
+
+  &__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: $pad-xsmall;
+    padding: 4px $pad-small;
+    border: 1px solid $ui-fleet-black-25;
+    border-radius: $border-radius;
+    background: $core-fleet-white;
+    font-size: $xx-small;
+    color: $core-fleet-black;
+    cursor: pointer;
+
+    &:hover {
+      border-color: $ui-fleet-black-50;
+    }
+
+    .fleeticon {
+      font-size: 10px;
+      color: $ui-fleet-black-50;
+    }
+  }
+
+  &__results-list {
+    max-height: 280px;
+    overflow-y: auto;
+    border: 1px solid $ui-fleet-black-10;
+    border-radius: $border-radius;
+  }
+
+  &__results-row {
+    padding: $pad-small $pad-medium;
+    border-bottom: 1px solid $ui-fleet-black-10;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    .fleet-checkbox {
+      margin: 0;
+    }
+  }
+
+  &__results-status {
+    padding: $pad-medium;
+    text-align: center;
+    font-size: $x-small;
+    color: $ui-fleet-black-50;
+  }
+}

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
@@ -9,6 +9,11 @@
     gap: $pad-medium;
   }
 
+  &__categories-error {
+    font-size: $xx-small;
+    color: $core-vibrant-red;
+  }
+
   &__section-title {
     margin: 0;
     font-size: $x-small;

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.tests.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.tests.ts
@@ -1,9 +1,13 @@
 import {
   EPSS_RANGE_HELP,
+  EPSS_RANGE_HELP_MSG,
+  EPSS_RANGE_INVALID_MSG,
   getEpssError,
+  getSoftwareFilterApplyError,
   hasEpssErrors,
   isEpssActive,
   isEpssRangeInvalid,
+  NO_CATEGORIES_MSG,
 } from "./helpers";
 
 describe("SoftwareFilters helpers", () => {
@@ -61,6 +65,32 @@ describe("SoftwareFilters helpers", () => {
     it("is active when min > 0 or max < 100", () => {
       expect(isEpssActive("1", "100")).toBe(true);
       expect(isEpssActive("0", "99")).toBe(true);
+    });
+  });
+
+  describe("getSoftwareFilterApplyError", () => {
+    it("blocks Apply when no category is selected", () => {
+      expect(getSoftwareFilterApplyError([], "", "")).toBe(NO_CATEGORIES_MSG);
+      // The category error takes precedence over EPSS errors.
+      expect(getSoftwareFilterApplyError([], "10", "5")).toBe(
+        NO_CATEGORIES_MSG
+      );
+    });
+
+    it("returns null when at least one category is selected and EPSS is valid", () => {
+      expect(getSoftwareFilterApplyError(["os"], "", "")).toBeNull();
+      expect(
+        getSoftwareFilterApplyError(["os", "adobe"], "5", "90")
+      ).toBeNull();
+    });
+
+    it("surfaces EPSS errors once a category is selected", () => {
+      expect(getSoftwareFilterApplyError(["os"], "10", "5")).toBe(
+        EPSS_RANGE_INVALID_MSG
+      );
+      expect(getSoftwareFilterApplyError(["os"], "-1", "")).toBe(
+        EPSS_RANGE_HELP_MSG
+      );
     });
   });
 });

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.tests.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.tests.ts
@@ -1,0 +1,66 @@
+import {
+  EPSS_RANGE_HELP,
+  getEpssError,
+  hasEpssErrors,
+  isEpssActive,
+  isEpssRangeInvalid,
+} from "./helpers";
+
+describe("SoftwareFilters helpers", () => {
+  describe("getEpssError", () => {
+    it("treats empty input as valid (unset)", () => {
+      expect(getEpssError("")).toBeNull();
+      expect(getEpssError("   ")).toBeNull();
+    });
+
+    it("accepts values within 0–100", () => {
+      expect(getEpssError("0")).toBeNull();
+      expect(getEpssError("50")).toBeNull();
+      expect(getEpssError("100")).toBeNull();
+    });
+
+    it("rejects out-of-range and non-numeric values", () => {
+      expect(getEpssError("-1")).toBe(EPSS_RANGE_HELP);
+      expect(getEpssError("101")).toBe(EPSS_RANGE_HELP);
+      expect(getEpssError("abc")).toBe(EPSS_RANGE_HELP);
+    });
+  });
+
+  describe("isEpssRangeInvalid", () => {
+    it("is false unless both bounds are present, valid, and min > max", () => {
+      expect(isEpssRangeInvalid("", "")).toBe(false);
+      expect(isEpssRangeInvalid("", "5")).toBe(false);
+      expect(isEpssRangeInvalid("5", "10")).toBe(false);
+      expect(isEpssRangeInvalid("abc", "5")).toBe(false); // per-field error instead
+    });
+
+    it("is true when min > max", () => {
+      expect(isEpssRangeInvalid("10", "5")).toBe(true);
+    });
+  });
+
+  describe("hasEpssErrors", () => {
+    it("is true for any field error or inverted range", () => {
+      expect(hasEpssErrors("-1", "")).toBe(true);
+      expect(hasEpssErrors("", "200")).toBe(true);
+      expect(hasEpssErrors("10", "5")).toBe(true);
+    });
+
+    it("is false for valid/empty input", () => {
+      expect(hasEpssErrors("", "")).toBe(false);
+      expect(hasEpssErrors("5", "90")).toBe(false);
+    });
+  });
+
+  describe("isEpssActive", () => {
+    it("treats empty or the full 0–100 range as inactive", () => {
+      expect(isEpssActive("", "")).toBe(false);
+      expect(isEpssActive("0", "100")).toBe(false);
+    });
+
+    it("is active when min > 0 or max < 100", () => {
+      expect(isEpssActive("1", "100")).toBe(true);
+      expect(isEpssActive("0", "99")).toBe(true);
+    });
+  });
+});

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.ts
@@ -1,0 +1,45 @@
+// EPSS inputs are entered as a 0–100 percentage; the chart API takes 0.0–1.0.
+export const EPSS_MIN_PCT = 0;
+export const EPSS_MAX_PCT = 100;
+
+export const EPSS_RANGE_HELP = `Must be from ${EPSS_MIN_PCT} to ${EPSS_MAX_PCT}`;
+export const EPSS_RANGE_INVALID_MSG =
+  "Minimum EPSS probability cannot be greater than the maximum EPSS probability.";
+
+// Returns an error string when the raw value is out of the 0–100 range, or null
+// when it's empty (unset) or valid.
+export const getEpssError = (raw: string): string | null => {
+  if (raw.trim() === "") {
+    return null;
+  }
+  const n = Number(raw);
+  if (Number.isNaN(n) || n < EPSS_MIN_PCT || n > EPSS_MAX_PCT) {
+    return EPSS_RANGE_HELP;
+  }
+  return null;
+};
+
+// True when both bounds are present, individually valid, and min > max.
+export const isEpssRangeInvalid = (min: string, max: string): boolean => {
+  if (min.trim() === "" || max.trim() === "") {
+    return false;
+  }
+  if (getEpssError(min) || getEpssError(max)) {
+    return false; // individual range errors are surfaced per-field instead
+  }
+  return Number(min) > Number(max);
+};
+
+// The Software filters are invalid (Apply blocked) when any EPSS field is out of
+// range or the min/max are inverted.
+export const hasEpssErrors = (min: string, max: string): boolean =>
+  getEpssError(min) !== null ||
+  getEpssError(max) !== null ||
+  isEpssRangeInvalid(min, max);
+
+// An EPSS bound only narrows when min > 0 or max < 100; empty or 0–100 is "all".
+export const isEpssActive = (min: string, max: string): boolean => {
+  const minActive = min.trim() !== "" && Number(min) > EPSS_MIN_PCT;
+  const maxActive = max.trim() !== "" && Number(max) < EPSS_MAX_PCT;
+  return minActive || maxActive;
+};

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.ts
@@ -6,6 +6,12 @@ export const EPSS_RANGE_HELP = `Must be from ${EPSS_MIN_PCT} to ${EPSS_MAX_PCT}`
 export const EPSS_RANGE_INVALID_MSG =
   "Minimum EPSS probability cannot be greater than the maximum EPSS probability.";
 
+// At least one software category must stay selected: an empty set is
+// indistinguishable from "no filter" on the wire, so the chart would show every
+// category instead of none. Block Apply and surface this message instead.
+export const NO_CATEGORIES_MSG = "Select at least one software category.";
+export const EPSS_RANGE_HELP_MSG = "Enter EPSS values from 0 to 100.";
+
 // Returns an error string when the raw value is out of the 0–100 range, or null
 // when it's empty (unset) or valid.
 export const getEpssError = (raw: string): string | null => {
@@ -42,4 +48,25 @@ export const isEpssActive = (min: string, max: string): boolean => {
   const minActive = min.trim() !== "" && Number(min) > EPSS_MIN_PCT;
   const maxActive = max.trim() !== "" && Number(max) < EPSS_MAX_PCT;
   return minActive || maxActive;
+};
+
+// Returns the reason Apply should be blocked for the Software tab, or null when
+// the filters are valid. Used both to disable the Apply button and as its
+// tooltip text. Categories are checked first since an empty set is the more
+// fundamental error.
+export const getSoftwareFilterApplyError = (
+  categories: string[],
+  epssMin: string,
+  epssMax: string
+): string | null => {
+  if (categories.length === 0) {
+    return NO_CATEGORIES_MSG;
+  }
+  if (isEpssRangeInvalid(epssMin, epssMax)) {
+    return EPSS_RANGE_INVALID_MSG;
+  }
+  if (hasEpssErrors(epssMin, epssMax)) {
+    return EPSS_RANGE_HELP_MSG;
+  }
+  return null;
 };

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/index.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SoftwareFilters";

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/index.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./ChartFilterModal";
-export type { IChartFilterState } from "./ChartFilterModal";
+export type { IChartFilterState, ChartFilterTab } from "./ChartFilterModal";

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -95,21 +95,8 @@
     }
   }
 
-  &__filtered-badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 2px 10px;
-    font-size: $xx-small;
-    font-weight: $bold;
-    color: $ui-fleet-black-75;
-    border: 1px solid $ui-fleet-black-10;
-    border-radius: 12px;
-    background: $core-fleet-white;
-    white-space: nowrap;
-  }
-
-  // Clickable variant of the filtered badge — opens the Settings modal to the
-  // matching tab. Shares the badge's pill appearance.
+  // Clickable filtered badge — opens the Settings modal to the first tab with
+  // active filters.
   &__filter-pill {
     display: inline-flex;
     align-items: center;
@@ -171,6 +158,25 @@
   }
 
   &__tooltip-value {
+    font-weight: $bold;
+  }
+
+  // Consolidated filter tooltip: "Hosts" / "Software" sections, each with a
+  // muted header above its active-filter value lines.
+  &__tooltip-section {
+    text-align: left;
+
+    & + & {
+      margin-top: $pad-small;
+    }
+  }
+
+  &__tooltip-section-header {
+    font-weight: $regular;
+    opacity: 0.8;
+  }
+
+  &__tooltip-section-line {
     font-weight: $bold;
   }
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -108,6 +108,26 @@
     white-space: nowrap;
   }
 
+  // Clickable variant of the filtered badge — opens the Settings modal to the
+  // matching tab. Shares the badge's pill appearance.
+  &__filter-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 10px;
+    font-size: $xx-small;
+    font-weight: $bold;
+    color: $ui-fleet-black-75;
+    border: 1px solid $ui-fleet-black-10;
+    border-radius: 12px;
+    background: $core-fleet-white;
+    white-space: nowrap;
+    cursor: pointer;
+
+    &:hover {
+      border-color: $ui-fleet-black-25;
+    }
+  }
+
   &__settings-btn {
     // Button variant="inverse" applies a 36px height that would make the
     // chart-card header taller than HostsEnrolledCard's bare h2 next door.

--- a/frontend/services/entities/charts.ts
+++ b/frontend/services/entities/charts.ts
@@ -12,6 +12,15 @@ export interface IChartFilters {
   platforms?: string[];
   include_host_ids?: number[];
   exclude_host_ids?: number[];
+
+  // CVE entity filters (cve metric only). Echoed back from the API.
+  software_categories?: string[];
+  known_exploit?: boolean;
+  epss_min?: number;
+  epss_max?: number;
+  severity_min?: number;
+  severity_max?: number;
+  exclude_cves?: string[];
 }
 
 export interface IChartResponse {
@@ -33,6 +42,16 @@ export interface IChartApiParams {
   platforms?: string;
   include_host_ids?: string;
   exclude_host_ids?: string;
+
+  // CVE entity filters (cve metric only). Lists are comma-separated; EPSS is
+  // 0.0–1.0 (the Software tab converts from its 0–100 % input before sending).
+  software_categories?: string;
+  known_exploit?: boolean;
+  epss_min?: number;
+  epss_max?: number;
+  severity_min?: number;
+  severity_max?: number;
+  exclude_cves?: string;
 }
 
 export interface IChartQueryKey {

--- a/frontend/services/entities/charts.ts
+++ b/frontend/services/entities/charts.ts
@@ -14,13 +14,13 @@ export interface IChartFilters {
   exclude_host_ids?: number[];
 
   // CVE entity filters (cve metric only). Echoed back from the API.
-  software_categories?: string[];
-  known_exploit?: boolean;
+  software_filters?: string[];
+  has_known_exploit?: boolean;
   epss_min?: number;
   epss_max?: number;
   severity_min?: number;
   severity_max?: number;
-  exclude_cves?: string[];
+  exclude_vulnerabilities?: string[];
 }
 
 export interface IChartResponse {
@@ -45,13 +45,13 @@ export interface IChartApiParams {
 
   // CVE entity filters (cve metric only). Lists are comma-separated; EPSS is
   // 0.0–1.0 (the Software tab converts from its 0–100 % input before sending).
-  software_categories?: string;
-  known_exploit?: boolean;
+  software_filters?: string;
+  has_known_exploit?: boolean;
   epss_min?: number;
   epss_max?: number;
   severity_min?: number;
   severity_max?: number;
-  exclude_cves?: string;
+  exclude_vulnerabilities?: string;
 }
 
 export interface IChartQueryKey {

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -268,9 +269,7 @@ func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.C
 	// Software-side: skip entirely when no matcher falls in the selected
 	// categories (e.g. only the OS category is selected).
 	if swClause, swArgs, ok := softwareMatcherClause(cats); ok {
-		args := make([]any, 0, len(swArgs)+len(metaArgs))
-		args = append(args, swArgs...)
-		args = append(args, metaArgs...)
+		args := slices.Concat(swArgs, metaArgs)
 		swQuery := `
 			SELECT DISTINCT sc.cve
 			FROM software_cve sc


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For #44746 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  - [x] Changing the filters in the UI causes the related API params to be set
  - [x] Changing the software filters causes the "filtered" tooltip to show up and include info about software filters
  - [x] Changing the host filters causes the "filtered" tooltip to show up and include info about host filters
  - [x] Changing both host and software filters causes the "filtered" tooltip to show up and include info about both filters
  - [x] CVE search works and utilizes infinite scroll



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added software category filtering options to vulnerability charts.
  * Added EPSS range filtering with validation to refine results.
  * Added known exploit toggle and CVE exclusion capabilities.
  * Improved filter status display with tabbed interface.

* **Tests**
  * Added comprehensive test coverage for software filtering and validation logic.

* **Style**
  * Enhanced filter UI styling and interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->