### PR TITLE
Fleet UI: My account theme radios stay in sync, fix gradient flash on no-op theme picks

### DIFF
--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -55,6 +55,21 @@ const AccountSidePanel = ({
     getVersionData();
   }, []);
 
+  // Keep the radio selection in sync when the theme is changed elsewhere
+  // (command palette "Toggle dark mode", OS media query when on system).
+  // utilities/theme dispatches `fleet-theme-change` on every applied
+  // change — re-read the mode rather than trusting `detail.dark`, since
+  // dark/light alone can't disambiguate "Dark" from "System (dark)".
+  useEffect(() => {
+    const onThemeChange = () => {
+      setThemeModeState(getThemeMode());
+    };
+    window.addEventListener("fleet-theme-change", onThemeChange);
+    return () => {
+      window.removeEventListener("fleet-theme-change", onThemeChange);
+    };
+  }, []);
+
   const {
     global_role: globalRole,
     updated_at: updatedAt,

--- a/frontend/utilities/theme.tests.ts
+++ b/frontend/utilities/theme.tests.ts
@@ -1,0 +1,66 @@
+import { setThemeMode } from "./theme";
+
+describe("theme - setThemeMode", () => {
+  beforeEach(() => {
+    document.body.className = "";
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not add theme-transition when picking a mode that resolves to the current state", () => {
+    // Body starts without `dark-mode`, i.e. currently light. Picking
+    // Light shouldn't trigger the transition class — the App's hero
+    // gradient flickers when `transition: background-image` re-runs
+    // even between two visually identical gradients.
+    setThemeMode("light");
+
+    expect(document.body.classList.contains("theme-transition")).toBe(false);
+  });
+
+  it("adds theme-transition when the resolved dark state actually flips", () => {
+    // Body starts light → picking Dark is a real transition.
+    setThemeMode("dark");
+
+    expect(document.body.classList.contains("theme-transition")).toBe(true);
+    expect(document.body.classList.contains("dark-mode")).toBe(true);
+  });
+
+  it("removes theme-transition after the 300ms transition window", () => {
+    setThemeMode("dark");
+    expect(document.body.classList.contains("theme-transition")).toBe(true);
+
+    jest.advanceTimersByTime(300);
+
+    expect(document.body.classList.contains("theme-transition")).toBe(false);
+  });
+
+  it("dispatches fleet-theme-change on every applied mode change", () => {
+    // Both the animated path (real flip) and the no-op path (System →
+    // Light when System resolves to Light) must dispatch the event, so
+    // subscribers like AccountSidePanel can re-read getThemeMode() and
+    // keep the radio in sync with the picked mode.
+    const handler = jest.fn();
+    window.addEventListener("fleet-theme-change", handler);
+
+    setThemeMode("dark");
+    setThemeMode("light");
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[0][0].detail).toEqual({ dark: true });
+    expect(handler.mock.calls[1][0].detail).toEqual({ dark: false });
+
+    window.removeEventListener("fleet-theme-change", handler);
+  });
+
+  it("persists explicit modes to localStorage and clears the key for system", () => {
+    setThemeMode("dark");
+    expect(localStorage.getItem("fleet-theme")).toBe("dark");
+
+    setThemeMode("system");
+    expect(localStorage.getItem("fleet-theme")).toBeNull();
+  });
+});

--- a/frontend/utilities/theme.tests.ts
+++ b/frontend/utilities/theme.tests.ts
@@ -38,20 +38,23 @@ describe("theme - setThemeMode", () => {
     expect(document.body.classList.contains("theme-transition")).toBe(false);
   });
 
-  it("dispatches fleet-theme-change on every applied mode change", () => {
-    // Both the animated path (real flip) and the no-op path (System →
-    // Light when System resolves to Light) must dispatch the event, so
-    // subscribers like AccountSidePanel can re-read getThemeMode() and
-    // keep the radio in sync with the picked mode.
+  it("dispatches fleet-theme-change on every applied mode change, including no-op picks", () => {
+    // Both the animated path (real flip) and the no-op path (picking
+    // a mode that resolves to the current dark state) must dispatch
+    // the event, so subscribers like AccountSidePanel can re-read
+    // getThemeMode() and keep the radio in sync with the picked mode
+    // even when nothing visual changes.
     const handler = jest.fn();
     window.addEventListener("fleet-theme-change", handler);
 
-    setThemeMode("dark");
-    setThemeMode("light");
+    setThemeMode("light"); // no-op: body starts without dark-mode
+    setThemeMode("dark"); // real flip
+    setThemeMode("light"); // real flip back
 
-    expect(handler).toHaveBeenCalledTimes(2);
-    expect(handler.mock.calls[0][0].detail).toEqual({ dark: true });
-    expect(handler.mock.calls[1][0].detail).toEqual({ dark: false });
+    expect(handler).toHaveBeenCalledTimes(3);
+    expect(handler.mock.calls[0][0].detail).toEqual({ dark: false });
+    expect(handler.mock.calls[1][0].detail).toEqual({ dark: true });
+    expect(handler.mock.calls[2][0].detail).toEqual({ dark: false });
 
     window.removeEventListener("fleet-theme-change", handler);
   });

--- a/frontend/utilities/theme.ts
+++ b/frontend/utilities/theme.ts
@@ -55,7 +55,15 @@ export const setThemeMode = (mode: ThemeMode): void => {
     // localStorage can throw in restricted environments; the DOM still
     // gets the updated theme below, the choice just won't persist.
   }
-  applyDarkMode(resolveDark(mode), true);
+  // Only animate when the resolved dark state actually changes. Picking
+  // System when System already resolves to the current mode (or picking
+  // the explicit mode that matches it) doesn't change anything visually,
+  // but `transition: background-image` still re-runs across the app and
+  // makes gradients (e.g. the App hero gradient) flicker because the
+  // browser can't smoothly interpolate between two identical gradients.
+  const nextDark = resolveDark(mode);
+  const currentDark = document.body.classList.contains("dark-mode");
+  applyDarkMode(nextDark, nextDark !== currentDark);
 };
 
 export const initTheme = (): void => {


### PR DESCRIPTION
## Issue
Closes #47667

## Description
- **Radio sync**: `AccountSidePanel` now subscribes to the `fleet-theme-change` window event (the same one `utilities/theme.ts` already dispatches on every applied change). When the theme is toggled from anywhere else — the command palette's "Toggle dark mode" command, or the OS media query while on "System" — the radio re-reads `getThemeMode()` and updates so the selection always reflects the current mode. Re-reading the mode is intentional: trusting the event's `detail.dark` boolean alone can't disambiguate explicit "Dark" from "System (dark)".
- **No-op transition flash**: `setThemeMode` now only adds the `theme-transition` class when the resolved dark state actually changes. Picking System ↔ Light (both light) was running the 300ms `transition: background-image` across the app for nothing, and the App's hero gradient flickered because the browser can't smoothly interpolate between two identical gradients. Real flips (Light ↔ Dark, System ↔ Dark, etc.) still animate. The OS media-query path that follows system changes is unaffected.
- **Tests**: new `frontend/utilities/theme.tests.ts` covers the no-op-doesn't-animate case (regression test for the gradient flash — confirmed to fail without the fix), animation on a real flip, the 300ms cleanup, `fleet-theme-change` dispatch on both the animated and skipped-animation paths, and localStorage persistence.

## Screenrecording of fixes


https://github.com/user-attachments/assets/1a96e33c-4e20-41f5-b246-00a9b00743f7



## Testing
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Kept the account theme selector in sync when the theme changes elsewhere in the app.
* **Performance**
  * Avoided unnecessary `theme-transition` animations when switching between modes that resolve to the same visual theme.
* **Tests**
  * Added Jest coverage for theme switching, transition timing, dispatched `fleet-theme-change` events, and localStorage persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->