### PR TITLE
Website: update get-enriched helper

### DIFF
--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -308,7 +308,7 @@ module.exports = {
         // If we're including location information, use the prompt helper to transform the location information returned by Coresignal into a JSON object.
         if(includeEmployerHeadquartersInformation) {
           let primaryLocation = _.find(matchingCompanyPageInfo.company_locations_collection, (location)=>{
-            return location.is_primary === 1;
+            return location.is_primary === 1 && location.deleted === 0;
           });
           let locationInfo = {};
           if(primaryLocation && primaryLocation.location_address) {


### PR DESCRIPTION
Changes:
- Updated the get-enriched helper to not use deleted locations returned from Coresignal when including information about a company's headquarters. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed company headquarters location extraction to properly exclude deleted locations alongside selecting only primary headquarters, improving data accuracy when employer information is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->