### PR TITLE
For R.C. - Fleet UI: My account theme radios stay in sync, fix gradient flash on no-op theme picks (#47687)

### DIFF
--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -55,6 +55,21 @@ const AccountSidePanel = ({
     getVersionData();
   }, []);
 
+  // Keep the radio selection in sync when the theme is changed elsewhere
+  // (command palette "Toggle dark mode", OS media query when on system).
+  // utilities/theme dispatches `fleet-theme-change` on every applied
+  // change — re-read the mode rather than trusting `detail.dark`, since
+  // dark/light alone can't disambiguate "Dark" from "System (dark)".
+  useEffect(() => {
+    const onThemeChange = () => {
+      setThemeModeState(getThemeMode());
+    };
+    window.addEventListener("fleet-theme-change", onThemeChange);
+    return () => {
+      window.removeEventListener("fleet-theme-change", onThemeChange);
+    };
+  }, []);
+
   const {
     global_role: globalRole,
     updated_at: updatedAt,

--- a/frontend/utilities/theme.tests.ts
+++ b/frontend/utilities/theme.tests.ts
@@ -1,0 +1,69 @@
+import { setThemeMode } from "./theme";
+
+describe("theme - setThemeMode", () => {
+  beforeEach(() => {
+    document.body.className = "";
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not add theme-transition when picking a mode that resolves to the current state", () => {
+    // Body starts without `dark-mode`, i.e. currently light. Picking
+    // Light shouldn't trigger the transition class — the App's hero
+    // gradient flickers when `transition: background-image` re-runs
+    // even between two visually identical gradients.
+    setThemeMode("light");
+
+    expect(document.body.classList.contains("theme-transition")).toBe(false);
+  });
+
+  it("adds theme-transition when the resolved dark state actually flips", () => {
+    // Body starts light → picking Dark is a real transition.
+    setThemeMode("dark");
+
+    expect(document.body.classList.contains("theme-transition")).toBe(true);
+    expect(document.body.classList.contains("dark-mode")).toBe(true);
+  });
+
+  it("removes theme-transition after the 300ms transition window", () => {
+    setThemeMode("dark");
+    expect(document.body.classList.contains("theme-transition")).toBe(true);
+
+    jest.advanceTimersByTime(300);
+
+    expect(document.body.classList.contains("theme-transition")).toBe(false);
+  });
+
+  it("dispatches fleet-theme-change on every applied mode change, including no-op picks", () => {
+    // Both the animated path (real flip) and the no-op path (picking
+    // a mode that resolves to the current dark state) must dispatch
+    // the event, so subscribers like AccountSidePanel can re-read
+    // getThemeMode() and keep the radio in sync with the picked mode
+    // even when nothing visual changes.
+    const handler = jest.fn();
+    window.addEventListener("fleet-theme-change", handler);
+
+    setThemeMode("light"); // no-op: body starts without dark-mode
+    setThemeMode("dark"); // real flip
+    setThemeMode("light"); // real flip back
+
+    expect(handler).toHaveBeenCalledTimes(3);
+    expect(handler.mock.calls[0][0].detail).toEqual({ dark: false });
+    expect(handler.mock.calls[1][0].detail).toEqual({ dark: true });
+    expect(handler.mock.calls[2][0].detail).toEqual({ dark: false });
+
+    window.removeEventListener("fleet-theme-change", handler);
+  });
+
+  it("persists explicit modes to localStorage and clears the key for system", () => {
+    setThemeMode("dark");
+    expect(localStorage.getItem("fleet-theme")).toBe("dark");
+
+    setThemeMode("system");
+    expect(localStorage.getItem("fleet-theme")).toBeNull();
+  });
+});

--- a/frontend/utilities/theme.ts
+++ b/frontend/utilities/theme.ts
@@ -55,7 +55,15 @@ export const setThemeMode = (mode: ThemeMode): void => {
     // localStorage can throw in restricted environments; the DOM still
     // gets the updated theme below, the choice just won't persist.
   }
-  applyDarkMode(resolveDark(mode), true);
+  // Only animate when the resolved dark state actually changes. Picking
+  // System when System already resolves to the current mode (or picking
+  // the explicit mode that matches it) doesn't change anything visually,
+  // but `transition: background-image` still re-runs across the app and
+  // makes gradients (e.g. the App hero gradient) flicker because the
+  // browser can't smoothly interpolate between two identical gradients.
+  const nextDark = resolveDark(mode);
+  const currentDark = document.body.classList.contains("dark-mode");
+  applyDarkMode(nextDark, nextDark !== currentDark);
 };
 
 export const initTheme = (): void => {


### PR DESCRIPTION
## Issue
Closes #47667

## Description
- Previously merged into `main` with #47687
- This is for the 4.87.0 R.C.