### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/1password/darwin.json
+++ b/ee/maintained-apps/outputs/1password/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "8.12.22",
+      "version": "8.12.24",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.24') < 0);"
       },
       "installer_url": "https://downloads.1password.com/mac/1Password.pkg",
       "install_script_ref": "ef2a17ff",

--- a/ee/maintained-apps/outputs/android-studio/darwin.json
+++ b/ee/maintained-apps/outputs/android-studio/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio' AND version_compare(bundle_short_version, '2026.1') < 0);"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.9/android-studio-quail1-patch1-mac_arm.dmg",
+      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.10/android-studio-quail1-patch2-mac_arm.dmg",
       "install_script_ref": "d9306d86",
       "uninstall_script_ref": "aa386b1a",
-      "sha256": "07145348f0b7bce6336eb362addd773093a84c40a4780f436beb6795a48b1270",
+      "sha256": "69a13f8b7430f91919ff8b958c941d69953c13095e29fafa51e77d32417521a2",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/bambu-studio/darwin.json
+++ b/ee/maintained-apps/outputs/bambu-studio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "02.07.01.57",
+      "version": "02.07.01.62",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bambulab.bambu-studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bambulab.bambu-studio' AND version_compare(bundle_short_version, '02.07.01.57') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bambulab.bambu-studio' AND version_compare(bundle_short_version, '02.07.01.62') < 0);"
       },
-      "installer_url": "https://github.com/bambulab/BambuStudio/releases/download/v02.07.01.57/Bambu_Studio_mac-v02.07.01.57-20260601165745.dmg",
+      "installer_url": "https://github.com/bambulab/BambuStudio/releases/download/v02.07.01.62/Bambu_Studio_mac-v02.07.01.62-20260616174358.dmg",
       "install_script_ref": "57b12f2b",
       "uninstall_script_ref": "012866aa",
-      "sha256": "ef7d2b4b693fae95fef6caee40787d86ca90081251882a55c367b85c6dfc00a9",
+      "sha256": "1e54c25aefc5249d56b63711cf773bed56f14430aafcc34340cd4894aef15896",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.12603.1",
+      "version": "1.13576.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.12603.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.13576.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.12603.1/Claude-3df4fd263723119bc45f0af2d784afd5055e2ba9.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.13576.0/Claude-1290fc2ef5fd27a3883b74505e0ff917413d6832.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "a3f2b7988f46c3c6469e946eee562d038a6737140097e435ce395755be595815",
+      "sha256": "ef222b5ac55f3ec0a187c862ccbdb5c9a9e255c9dd8f96707d3735152e5cfd93",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.7.36",
+      "version": "3.7.42",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.36') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.42') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/776d1f9d76df50a4e0aeca61819a88e7c1b861e2/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/5702c9cfca656d8710fad58402fe37f14345e3ac/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "881e4a19db1bdd678425dda0ffce237045da81c44fe7af4befe80245d34b4b86",
+      "sha256": "432967de71cfa589e98b1ca26a0d68638111931c6bd904006fb91bd882c64a4b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0.4",
+      "version": "152.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '152.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.4/mac/en-US/Firefox%20151.0.4.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/152.0/mac/en-US/Firefox%20152.0.dmg",
       "install_script_ref": "b5e4c76e",
       "uninstall_script_ref": "b85c0267",
-      "sha256": "bc2e72f6abf31aa854b30a3e2841d3f2b8b8e153eaa0a5c3ab285728b7f9b160",
+      "sha256": "b8a46188850d2fb32f16ad3c0829b08cd689bc714b8ee18fd9b09bb60629004d",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@esr/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@esr/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "140.11.0",
+      "version": "140.12.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.11.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.12.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.11.0esr/mac/en-US/Firefox%20140.11.0esr.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.12.0esr/mac/en-US/Firefox%20140.12.0esr.dmg",
       "install_script_ref": "b5e4c76e",
       "uninstall_script_ref": "cc27bc9d",
-      "sha256": "ac2aac7314f9cacf441e047ae9ec30e27b56b32838561b4dfdab4e17ec7928ce",
+      "sha256": "7d868edcee33d55d904303add39803b9b1ad91921d7a0c129d2a313db0c9f70c",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/forklift/darwin.json
+++ b/ee/maintained-apps/outputs/forklift/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.3",
+      "version": "4.6.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.binarynights.ForkLift-4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.binarynights.ForkLift-4' AND version_compare(bundle_short_version, '4.6.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.binarynights.ForkLift-4' AND version_compare(bundle_short_version, '4.6.4') < 0);"
       },
-      "installer_url": "https://download.binarynights.com/ForkLift/ForkLift4.6.3.zip",
+      "installer_url": "https://download.binarynights.com/ForkLift/ForkLift4.6.4.zip",
       "install_script_ref": "050b6846",
       "uninstall_script_ref": "99e7648d",
-      "sha256": "17bbf7669c72cf42f928e21ffbc8bbfdf0267b4992994594f1d8fa0c2e99f084",
+      "sha256": "df0da8ae4e9818739f56a226c1e9174785dea58c7a1ac62659c9dd7e9ac6bb0d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/framer/darwin.json
+++ b/ee/maintained-apps/outputs/framer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.23.3",
+      "version": "2026.23.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.framer.electron';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.framer.electron' AND version_compare(bundle_short_version, '2026.23.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.framer.electron' AND version_compare(bundle_short_version, '2026.23.5') < 0);"
       },
-      "installer_url": "https://updates.framer.com/electron/darwin/arm64/Framer-2026.23.3.zip",
+      "installer_url": "https://updates.framer.com/electron/darwin/arm64/Framer-2026.23.5.zip",
       "install_script_ref": "7c743e16",
       "uninstall_script_ref": "4775195c",
-      "sha256": "fc0755e53901b9beb4f960ce5d724721a6bf393a01b49dd64af79b08243ac14a",
+      "sha256": "581a93d414c6a497ca531d66e87872d8c01817d2dc6734f241112fd0ce16f863",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/gitkraken/darwin.json
+++ b/ee/maintained-apps/outputs/gitkraken/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.2.0",
+      "version": "12.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken' AND version_compare(bundle_short_version, '12.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken' AND version_compare(bundle_short_version, '12.2.1') < 0);"
       },
-      "installer_url": "https://api.gitkraken.dev/releases/production/darwin/arm64/12.2.0/GitKraken-v12.2.0.zip",
+      "installer_url": "https://api.gitkraken.dev/releases/production/darwin/arm64/12.2.1/GitKraken-v12.2.1.zip",
       "install_script_ref": "f20ab23e",
       "uninstall_script_ref": "da9e6343",
-      "sha256": "02c72a630065f5144ae6f80fd01892581fc286bec7c397d90574cae2d80e3396",
+      "sha256": "a9b9ffe38f9eb0f14bbbfdfd0b450c8447adee1500c38eb89acac2569599b641",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.319.1",
+      "version": "7.324.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.319.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.324.2') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.319.1/Granola-7.319.1-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.324.2/Granola-7.324.2-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "9617754af892e481add2667481df3fa455d01d12af3b9dd8cdaf8854c7feb735",
+      "sha256": "b7cb621811a15ba908486df78dbc0b9aa5e1126109bbb477251ab00210c9da68",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/insomnia/darwin.json
+++ b/ee/maintained-apps/outputs/insomnia/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.6.0",
+      "version": "13.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '12.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '13.0.0') < 0);"
       },
-      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4012.6.0/Insomnia.Core-12.6.0.dmg",
+      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4013.0.0/Insomnia.Core-13.0.0.dmg",
       "install_script_ref": "80491bd1",
       "uninstall_script_ref": "093d2a58",
-      "sha256": "a922a54282f063da82775826389c05c751f74e3259a9f69b8eaa2bf252531fef",
+      "sha256": "b0f97b2970bc675dcb159bf1b8a834da20dbb6b0b19fffd8aebf0038e7f7543e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/kiro-cli/darwin.json
+++ b/ee/maintained-apps/outputs/kiro-cli/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.7.1') < 0);"
       },
-      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.7.0/Kiro%20CLI.dmg",
+      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.7.1/Kiro%20CLI.dmg",
       "install_script_ref": "7bf3d706",
       "uninstall_script_ref": "31b59062",
-      "sha256": "524c2b7212e375b4376961d81be0dc3246ed43228211b1bac1d35f3a9bb8d936",
+      "sha256": "499cd6d99d66d627ee9671a737c7d05e203de4053469c22054cb8a454ff4724f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.15.0",
+      "version": "12.15.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.15.4') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.15.0/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.15.4/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "8f557b9a53943c852de13c0d86e8c27588a81aba16be9c172aa3589bdb2bb99b",
+      "sha256": "d688fc02fb852b00644012cab07e8db9e80c07417b24485d1050fb2bfd44b378",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.15.0",
+      "version": "12.15.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.15.4') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.15.0/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.15.4/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "4c1db727762b1a03643c0d07d22bfa382bf5a933091a5c72702cce558145235b",
+      "sha256": "7933be166b2e08fd5bc94d140997c1363917e72a767f72afc27e9d63f1733561",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/thunderbird/darwin.json
+++ b/ee/maintained-apps/outputs/thunderbird/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0.1",
+      "version": "152.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '151.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '152.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/151.0.1/mac/en-US/Thunderbird%20151.0.1.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/152.0/mac/en-US/Thunderbird%20152.0.dmg",
       "install_script_ref": "7cfa15ee",
       "uninstall_script_ref": "88749f85",
-      "sha256": "161efae828f7cb85acc7e7490c88042a22c0867f3c6bb616b73319bea834a378",
+      "sha256": "42ac9a908831d8fb32c85dbd484a8d31106dd9fee950be5b43565dcf8303ea7f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/virtualbox/darwin.json
+++ b/ee/maintained-apps/outputs/virtualbox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.2.8",
+      "version": "7.2.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox' AND version_compare(bundle_short_version, '7.2.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox' AND version_compare(bundle_short_version, '7.2.10') < 0);"
       },
-      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-macOSArm64.dmg",
+      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.10/VirtualBox-7.2.10-174163-macOSArm64.dmg",
       "install_script_ref": "18eac9a0",
       "uninstall_script_ref": "e04a5c15",
-      "sha256": "60d164cc5afc059e44591bcc70f63c7ad3378495f19564cecd1ad9a4461dd935",
+      "sha256": "95bc371769ad9afa7defbff15f2fbc07f641a0a4fcb0cf3cc8116101ff741060",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webcatalog/darwin.json
+++ b/ee/maintained-apps/outputs/webcatalog/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "75.2.0",
+      "version": "76.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '75.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '76.0.1') < 0);"
       },
-      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-75.2.0-universal.dmg",
+      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-76.0.1-universal.dmg",
       "install_script_ref": "f04928dc",
       "uninstall_script_ref": "d196a4c8",
-      "sha256": "81e5e87fdf195ac2b16099f5483c4948527da6e2a4383866f646a26544cbae3b",
+      "sha256": "da4380121f3b25d07639d06f1bb11ce685f80438d5c2b989ad113a3fedf1dd77",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "46.5.0.35006",
+      "version": "46.6.0.35178",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.5.0.35006') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.0.35178') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "d105863f",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version information and metadata for macOS and Windows across 18 applications including Firefox, Thunderbird, Postman, VirtualBox, 1Password, GitKraken, Claude, Cursor, Android Studio, Insomnia, ForkLift, Framer, WebCatalog, Webex, Bambu Studio, Granola, Kiro CLI, and Firefox ESR to their latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->