### PR TITLE
Add GCS presigned URL support for software installer downloads

### DIFF
--- a/changes/gcs-software-installers-signed-url
+++ b/changes/gcs-software-installers-signed-url
@@ -1,0 +1,1 @@
+- Added the `s3_software_installers_signed_url` configuration option to serve software installer and in-house app downloads via GCS presigned URLs (the GCS counterpart to CloudFront URL signing), so clients download directly from object storage instead of streaming through the Fleet server.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -511,6 +511,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			}
 			// Extract the CloudFront URL signer before creating the S3 stores.
 			config.S3.ValidateCloudFrontURL(initFatal)
+			config.S3.ValidateSoftwareInstallersSignedURL(initFatal)
 			if config.S3.SoftwareInstallersCloudFrontURLSigningPrivateKey != "" {
 				// Strip newlines from private key
 				signingPrivateKey := strings.ReplaceAll(config.S3.SoftwareInstallersCloudFrontURLSigningPrivateKey, "\\n", "\n")

--- a/ee/server/service/in_house_apps.go
+++ b/ee/server/service/in_house_apps.go
@@ -212,7 +212,7 @@ func (svc *Service) GetInHouseAppManifest(ctx context.Context, titleID uint, tok
 		signedURL, err := svc.softwareInstallStore.Sign(ctx, meta.StorageID, fleet.InHouseAppSignedURLExpiry)
 		if err != nil {
 			// We log the error and continue to send the Fleet server URL for the in-house app
-			svc.logger.ErrorContext(ctx, "error signing in-house app URL; check CloudFront configuration", "err", err)
+			svc.logger.ErrorContext(ctx, "error signing in-house app URL; check signed URL configuration", "err", err)
 		} else {
 			downloadURL = signedURL
 		}

--- a/ee/server/service/in_house_apps.go
+++ b/ee/server/service/in_house_apps.go
@@ -208,7 +208,7 @@ func (svc *Service) GetInHouseAppManifest(ctx context.Context, titleID uint, tok
 		appConfig.ServerSettings.ServerURL, titleID, token,
 	)
 
-	if svc.config.S3.SoftwareInstallersCloudFrontSigner != nil {
+	if svc.config.S3.SoftwareInstallersCloudFrontSigner != nil || svc.config.S3.SoftwareInstallersSignedURL {
 		signedURL, err := svc.softwareInstallStore.Sign(ctx, meta.StorageID, fleet.InHouseAppSignedURLExpiry)
 		if err != nil {
 			// We log the error and continue to send the Fleet server URL for the in-house app

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1146,7 +1146,7 @@ func (svc *Service) GetSoftwareInstallDetails(ctx context.Context, installUUID s
 	}
 
 	// SoftwareInstallersCloudFrontSigner can only be set if license.IsPremium()
-	if svc.config.S3.SoftwareInstallersCloudFrontSigner != nil {
+	if svc.config.S3.SoftwareInstallersCloudFrontSigner != nil || svc.config.S3.SoftwareInstallersSignedURL {
 		// Sign the URL for the installer
 		installerURL, err := svc.getSoftwareInstallURL(ctx, details.InstallerID)
 		if err != nil {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1152,7 +1152,7 @@ func (svc *Service) GetSoftwareInstallDetails(ctx context.Context, installUUID s
 		if err != nil {
 			// We log the error but continue to return the details without the signed URL because orbit can still
 			// try to download the installer via Fleet server.
-			svc.logger.ErrorContext(ctx, "error getting software installer URL; check CloudFront configuration", "err", err)
+			svc.logger.ErrorContext(ctx, "error getting software installer URL; check signed URL configuration", "err", err)
 		} else {
 			details.SoftwareInstallerURL = installerURL
 		}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -499,6 +499,12 @@ type S3Config struct {
 	SoftwareInstallersCloudFrontURLSigningPublicKeyID string        `yaml:"software_installers_cloudfront_url_signing_public_key_id"`
 	SoftwareInstallersCloudFrontURLSigningPrivateKey  string        `yaml:"software_installers_cloudfront_url_signing_private_key"`
 	SoftwareInstallersCloudFrontSigner                crypto.Signer `yaml:"-"`
+	// SoftwareInstallersSignedURL, when true, makes Fleet hand out a presigned
+	// GET URL (instead of proxying the bytes) for software installer, in-house
+	// app and bootstrap package downloads, so clients fetch directly from the
+	// object store. Only supported against a GCS (storage.googleapis.com)
+	// endpoint. This is the GCS counterpart to the CloudFront signing config.
+	SoftwareInstallersSignedURL bool `yaml:"software_installers_signed_url"`
 }
 
 func (s S3Config) ValidateCloudFrontURL(initFatal func(err error, msg string)) {
@@ -530,6 +536,20 @@ func (s S3Config) ValidateCloudFrontURL(initFatal func(err error, msg string)) {
 	}
 }
 
+// ValidateSoftwareInstallersSignedURL validates the GCS presigned-URL download
+// option. Presigned downloads are only supported against a GCS endpoint, so we
+// fail fast on any other endpoint to avoid silently proxying large files.
+func (s S3Config) ValidateSoftwareInstallersSignedURL(initFatal func(err error, msg string)) {
+	if !s.SoftwareInstallersSignedURL {
+		return
+	}
+	if !strings.Contains(s.SoftwareInstallersEndpointURL, "storage.googleapis.com") {
+		initFatal(errors.New("Couldn't configure. `s3_software_installers_signed_url` requires `s3_software_installers_endpoint_url` to point at a GCS endpoint (storage.googleapis.com)."),
+			"S3 software installers signed URL")
+		return
+	}
+}
+
 func (s S3Config) BucketsAndPrefixesMatch() bool {
 	cb := s.CarvesBucket
 	if cb == "" {
@@ -557,6 +577,7 @@ func (s S3Config) SoftwareInstallersToInternalCfg() S3ConfigInternal {
 		DisableSSL:       s.SoftwareInstallersDisableSSL,
 		ForceS3PathStyle: s.SoftwareInstallersForceS3PathStyle,
 		GCSIAMAuth:       s.SoftwareInstallersGCSIAMAuth,
+		SignedURL:        s.SoftwareInstallersSignedURL,
 	}
 	if s.SoftwareInstallersCloudFrontSigner != nil {
 		configInternal.CloudFrontConfig = &S3CloudFrontConfig{
@@ -632,6 +653,7 @@ type S3ConfigInternal struct {
 	ForceS3PathStyle bool
 	GCSIAMAuth       bool
 	CloudFrontConfig *S3CloudFrontConfig
+	SignedURL        bool
 }
 
 type S3CloudFrontConfig struct {
@@ -1613,6 +1635,7 @@ func (man Manager) addConfigs() {
 	man.addConfigString("s3.software_installers_cloudfront_url", "", "CloudFront URL for software installers")
 	man.addConfigString("s3.software_installers_cloudfront_url_signing_public_key_id", "", "CloudFront public key ID for URL signing")
 	man.addConfigString("s3.software_installers_cloudfront_url_signing_private_key", "", "CloudFront private key for URL signing")
+	man.addConfigBool("s3.software_installers_signed_url", false, "Hand out presigned GCS URLs for installer/in-house app/bootstrap downloads instead of proxying bytes (requires a storage.googleapis.com endpoint)")
 
 	// PubSub
 	man.addConfigString("pubsub.project", "", "Google Cloud Project to use")
@@ -2167,6 +2190,7 @@ func (man Manager) loadS3Config() S3Config {
 		SoftwareInstallersCloudFrontURL:                   man.getConfigString("s3.software_installers_cloudfront_url"),
 		SoftwareInstallersCloudFrontURLSigningPublicKeyID: man.getConfigString("s3.software_installers_cloudfront_url_signing_public_key_id"),
 		SoftwareInstallersCloudFrontURLSigningPrivateKey:  man.getConfigString("s3.software_installers_cloudfront_url_signing_private_key"),
+		SoftwareInstallersSignedURL:                       man.getConfigBool("s3.software_installers_signed_url"),
 	}
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -543,7 +543,23 @@ func (s S3Config) ValidateSoftwareInstallersSignedURL(initFatal func(err error, 
 	if !s.SoftwareInstallersSignedURL {
 		return
 	}
-	if !strings.Contains(s.SoftwareInstallersEndpointURL, "storage.googleapis.com") {
+	// Validate against the parsed hostname rather than a substring match, so a
+	// URL that merely contains "storage.googleapis.com" elsewhere (e.g. a
+	// look-alike host or a path) is rejected.
+	endpoint := s.SoftwareInstallersEndpointURL
+	if !strings.Contains(endpoint, "://") {
+		// url.Parse needs a scheme to populate Hostname(); the endpoint may be
+		// configured without one (e.g. "storage.googleapis.com").
+		endpoint = "https://" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		initFatal(fmt.Errorf("invalid s3_software_installers_endpoint_url: %w", err),
+			"S3 software installers signed URL")
+		return
+	}
+	host := strings.ToLower(u.Hostname())
+	if host != "storage.googleapis.com" && !strings.HasSuffix(host, ".storage.googleapis.com") {
 		initFatal(errors.New("Couldn't configure. `s3_software_installers_signed_url` requires `s3_software_installers_endpoint_url` to point at a GCS endpoint (storage.googleapis.com)."),
 			"S3 software installers signed URL")
 		return

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -775,6 +775,40 @@ func TestValidateCloudfrontURL(t *testing.T) {
 	}
 }
 
+func TestValidateSoftwareInstallersSignedURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		enabled   bool
+		endpoint  string
+		wantFatal bool
+	}{
+		{"disabled skips validation", false, "https://s3.amazonaws.com", false},
+		{"gcs host", true, "https://storage.googleapis.com", false},
+		{"gcs host without scheme", true, "storage.googleapis.com", false},
+		{"gcs bucket virtual host", true, "https://my-bucket.storage.googleapis.com", false},
+		{"look-alike host rejected", true, "https://storage.googleapis.com.evil.com", true},
+		{"substring in path rejected", true, "https://evil.com/storage.googleapis.com", true},
+		{"non-gcs host rejected", true, "https://s3.amazonaws.com", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s3 := S3Config{
+				SoftwareInstallersSignedURL:   c.enabled,
+				SoftwareInstallersEndpointURL: c.endpoint,
+			}
+			var gotFatal bool
+			initFatal := func(err error, msg string) {
+				gotFatal = true
+				require.Error(t, err)
+			}
+			s3.ValidateSoftwareInstallersSignedURL(initFatal)
+			require.Equal(t, c.wantFatal, gotFatal)
+		})
+	}
+}
+
 func TestAndroidAgentConfigValidate(t *testing.T) {
 	t.Parallel()
 

--- a/server/datastore/s3/common_file_store.go
+++ b/server/datastore/s3/common_file_store.go
@@ -190,19 +190,46 @@ func (s *commonFileStore) Cleanup(ctx context.Context, usedFileIDs []string, rem
 }
 
 func (s *commonFileStore) Sign(ctx context.Context, fileID string, expiresIn time.Duration) (string, error) {
-	if s.cloudFrontConfig == nil {
-		return "", ctxerr.Wrapf(ctx, fleet.ErrNotConfigured, "signing %s URL in S3 store", s.fileLabel)
+	// Preferred: CloudFront signed URL (AWS), when configured.
+	if s.cloudFrontConfig != nil {
+		urlToAccess, err := url.JoinPath(s.cloudFrontConfig.BaseURL, s.keyForFile(fileID))
+		if err != nil {
+			return "", ctxerr.Wrapf(ctx, err, "building URL for %s  with ID %s in S3 store", s.fileLabel, fileID)
+		}
+		signer := sign.NewURLSigner(s.cloudFrontConfig.SigningPublicKeyID, s.cloudFrontConfig.Signer)
+		signedURL, err := signer.Sign(urlToAccess, time.Now().Add(expiresIn))
+		if err != nil {
+			return "", ctxerr.Wrapf(ctx, err, "signing %s URL %s in S3 store", s.fileLabel, urlToAccess)
+		}
+		return signedURL, nil
 	}
-	urlToAccess, err := url.JoinPath(s.cloudFrontConfig.BaseURL, s.keyForFile(fileID))
-	if err != nil {
-		return "", ctxerr.Wrapf(ctx, err, "building URL for %s  with ID %s in S3 store", s.fileLabel, fileID)
+
+	// GCS (or other S3-compatible store): hand out a presigned GET URL generated
+	// with this store's own client/credentials, so clients download directly
+	// from the bucket instead of proxying the bytes through Fleet.
+	if s.signedURL {
+		key := s.keyForFile(fileID)
+		// Drop the inherited APIOptions for presigning: the GCS request
+		// workarounds (ignoreSigningHeaders/disableTrailingChecksum) insert
+		// middleware relative to the "Signing" step, which doesn't exist in the
+		// presign stack, and they only matter for actual upload/download
+		// requests, not for computing a presigned GET URL.
+		presignClient := s3.NewPresignClient(s.s3Client, func(po *s3.PresignOptions) {
+			po.ClientOptions = append(po.ClientOptions, func(o *s3.Options) {
+				o.APIOptions = nil
+			})
+		})
+		req, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+			Bucket: &s.bucket,
+			Key:    &key,
+		}, s3.WithPresignExpires(expiresIn))
+		if err != nil {
+			return "", ctxerr.Wrapf(ctx, err, "presigning %s URL in S3 store", s.fileLabel)
+		}
+		return req.URL, nil
 	}
-	signer := sign.NewURLSigner(s.cloudFrontConfig.SigningPublicKeyID, s.cloudFrontConfig.Signer)
-	signedURL, err := signer.Sign(urlToAccess, time.Now().Add(expiresIn))
-	if err != nil {
-		return "", ctxerr.Wrapf(ctx, err, "signing %s URL %s in S3 store", s.fileLabel, urlToAccess)
-	}
-	return signedURL, nil
+
+	return "", ctxerr.Wrapf(ctx, fleet.ErrNotConfigured, "signing %s URL in S3 store", s.fileLabel)
 }
 
 // keyForFile builds an S3 key to identify the file.

--- a/server/datastore/s3/s3.go
+++ b/server/datastore/s3/s3.go
@@ -39,6 +39,11 @@ type s3store struct {
 	prefix           string
 	cloudFrontConfig *config.S3CloudFrontConfig
 	gcs              bool
+	// signedURL, when true, makes Sign() return a presigned GET URL generated
+	// with this store's client/credentials (used for GCS, where there is no
+	// CloudFront-style signer). Gated by config and validated to require a GCS
+	// endpoint.
+	signedURL bool
 }
 
 type installerNotFoundError struct{}
@@ -176,6 +181,7 @@ func newS3Store(cfg config.S3ConfigInternal) (*s3store, error) {
 		prefix:           cfg.Prefix,
 		cloudFrontConfig: cfg.CloudFrontConfig,
 		gcs:              gcsEndpoint,
+		signedURL:        cfg.SignedURL,
 	}, nil
 }
 

--- a/server/datastore/s3/s3.go
+++ b/server/datastore/s3/s3.go
@@ -63,6 +63,15 @@ func newS3Store(cfg config.S3ConfigInternal) (*s3store, error) {
 	var opts []func(*aws_config.LoadOptions) error
 	gcsEndpoint := cfg.EndpointURL != "" && isGCS(cfg.EndpointURL)
 
+	// SignedURL presigns with SigV4 HMAC credentials, but GCSIAMAuth swaps those
+	// for placeholder static credentials plus bearer-token middleware that
+	// presigning drops (APIOptions is cleared when presigning). The two together
+	// would produce presigned URLs that can't authenticate, so reject the
+	// combination up front.
+	if cfg.SignedURL && cfg.GCSIAMAuth {
+		return nil, errors.New("software installers signed URL cannot be combined with gcs iam auth; configure HMAC credentials (access key/secret) for presigning")
+	}
+
 	if cfg.GCSIAMAuth {
 		switch {
 		case cfg.EndpointURL == "":

--- a/server/datastore/s3/signed_url_test.go
+++ b/server/datastore/s3/signed_url_test.go
@@ -50,4 +50,15 @@ func TestSignGCSPresignedURL(t *testing.T) {
 		_, err = store.Sign(context.Background(), "abc123", 15*time.Minute)
 		require.True(t, errors.Is(err, fleet.ErrNotConfigured), "expected ErrNotConfigured, got %v", err)
 	})
+
+	t.Run("signed url with gcs iam auth is rejected", func(t *testing.T) {
+		// GCS IAM (bearer) auth is incompatible with SigV4 presigning, so store
+		// initialization must fail rather than hand out unusable signed URLs.
+		cfg := baseCfg()
+		cfg.SoftwareInstallersSignedURL = true
+		cfg.SoftwareInstallersGCSIAMAuth = true
+
+		_, err := NewSoftwareInstallerStore(cfg)
+		require.Error(t, err)
+	})
 }

--- a/server/datastore/s3/signed_url_test.go
+++ b/server/datastore/s3/signed_url_test.go
@@ -1,0 +1,53 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignGCSPresignedURL verifies the GCS presigned-URL download path added on
+// top of the upstream CloudFront-only Sign(). It runs fully offline:
+// PresignGetObject computes the URL locally without contacting the bucket, and
+// a non-empty region avoids the GetBucketRegion network lookup in newS3Store.
+func TestSignGCSPresignedURL(t *testing.T) {
+	baseCfg := func() config.S3Config {
+		return config.S3Config{
+			SoftwareInstallersBucket:           "test-bucket",
+			SoftwareInstallersRegion:           "auto",
+			SoftwareInstallersEndpointURL:      "https://storage.googleapis.com",
+			SoftwareInstallersAccessKeyID:      "GOOG-test",
+			SoftwareInstallersSecretAccessKey:  "secret",
+			SoftwareInstallersForceS3PathStyle: true,
+		}
+	}
+
+	t.Run("signed url enabled returns GCS presigned URL", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.SoftwareInstallersSignedURL = true
+		store, err := NewSoftwareInstallerStore(cfg)
+		require.NoError(t, err)
+
+		signed, err := store.Sign(context.Background(), "abc123", 15*time.Minute)
+		require.NoError(t, err)
+		require.Contains(t, signed, "storage.googleapis.com")
+		require.Contains(t, signed, "test-bucket")
+		require.True(t,
+			strings.Contains(signed, "X-Amz-Signature") || strings.Contains(signed, "X-Goog-Signature"),
+			"expected a presigned signature query param, got %s", signed)
+	})
+
+	t.Run("signed url disabled and no cloudfront returns ErrNotConfigured", func(t *testing.T) {
+		store, err := NewSoftwareInstallerStore(baseCfg())
+		require.NoError(t, err)
+
+		_, err = store.Sign(context.Background(), "abc123", 15*time.Minute)
+		require.True(t, errors.Is(err, fleet.ErrNotConfigured), "expected ErrNotConfigured, got %v", err)
+	})
+}


### PR DESCRIPTION
Fleet can already hand out signed download URLs so clients fetch software installer and in-house app packages directly from object storage instead of streaming the bytes through the Fleet server. That path was AWS-only: it relied on CloudFront URL signing, which has no Google Cloud Storage equivalent. On a GCS-backed deployment, downloads always proxied through Fleet.

This adds a GCS counterpart. When the new `s3_software_installers_signed_url` option is enabled, the S3 store returns a SigV4 presigned GET URL generated locally from its own credentials (no call to the bucket), pointing directly at the GCS endpoint. The signing logic prefers an existing CloudFront signer when configured and otherwise falls back to presigning; behavior is unchanged for deployments using neither.

This additionally provides a workaround for the issue described in https://github.com/fleetdm/fleet/issues/37352 where in GCP CloudRun deployments, one can either chose HTTP1, which breaks large file up/downloads or HTTP2, which breaks live query functionality. By using GCS presigned URLs, you can at least use HTTP1 and unbreak live querying functionality while still keeping large file downloads working. 

The option is gated and validated at startup to require a GCS (storage.googleapis.com) endpoint, so it fails fast rather than silently proxying large files on an unsupported backend.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GCS presigned URLs to enable direct downloads of software installers and in-house app assets from Google Cloud Storage, bypassing the Fleet server. Enable via the new `s3_software_installers_signed_url` configuration option.
* **Bug Fixes / Behavior Changes**
  * When signed URLs are enabled, download links are generated from signed-URL configuration; if signing fails, links fall back to the original server URL.
* **Validation**
  * Added upfront configuration validation to ensure signed URLs are only enabled with appropriate GCS endpoint settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->