### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/1password/darwin.json
+++ b/ee/maintained-apps/outputs/1password/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "8.12.22",
+      "version": "8.12.24",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.24') < 0);"
       },
       "installer_url": "https://downloads.1password.com/mac/1Password.pkg",
       "install_script_ref": "ef2a17ff",

--- a/ee/maintained-apps/outputs/1password/windows.json
+++ b/ee/maintained-apps/outputs/1password/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.12.21",
+      "version": "8.12.24",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.' AND version_compare(version, '8.12.21') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.' AND version_compare(version, '8.12.24') < 0);"
       },
-      "installer_url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-8.12.21.msi",
+      "installer_url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-8.12.24.msi",
       "install_script_ref": "8959087b",
-      "uninstall_script_ref": "9f49925c",
-      "sha256": "031bf791587635090ad59f999004766f11fcb9188e3e3d1fb016358e16213e09",
+      "uninstall_script_ref": "eeb3b3d3",
+      "sha256": "d685551fc9769b68ae5ad68365abf609124f232fe4b313d87288fe89f3bb6813",
       "default_categories": [
         "Productivity"
       ]
@@ -17,6 +17,6 @@
   ],
   "refs": {
     "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
-    "9f49925c": "# 1Password Uninstall Script\n# Closes running processes before uninstalling to prevent hangs\n\n$product_code = '{2385DFA4-343E-42DE-9E7A-D41189885BD7}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Close any running 1Password processes\nGet-Process -Name \"1Password*\" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue\nStart-Sleep -Seconds 2\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_INSTALL_FAILURE\n}\n\n# Check exit code and output result\nif ($process.ExitCode -eq 0) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n\n"
+    "eeb3b3d3": "# 1Password Uninstall Script\n# Closes running processes before uninstalling to prevent hangs\n\n$product_code = '{D56E499A-302F-403E-A362-450BCE7AD94F}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Close any running 1Password processes\nGet-Process -Name \"1Password*\" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue\nStart-Sleep -Seconds 2\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_INSTALL_FAILURE\n}\n\n# Check exit code and output result\nif ($process.ExitCode -eq 0) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n\n"
   }
 }

--- a/ee/maintained-apps/outputs/alcove/darwin.json
+++ b/ee/maintained-apps/outputs/alcove/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.7.2",
+      "version": "1.7.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.henrikruscon.Alcove';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.henrikruscon.Alcove' AND version_compare(bundle_short_version, '1.7.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.henrikruscon.Alcove' AND version_compare(bundle_short_version, '1.7.3') < 0);"
       },
-      "installer_url": "https://github.com/henrikruscon/alcove-releases/releases/download/1.7.2/Alcove.zip",
+      "installer_url": "https://download.tryalcove.com/Alcove.dmg",
       "install_script_ref": "bdb62bd2",
       "uninstall_script_ref": "61446eae",
-      "sha256": "83357f05d2edd1c978f7470f1cf2b943a4b81d168723f7b8cdc39d9ccf8c5588",
+      "sha256": "no_check",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/android-studio/darwin.json
+++ b/ee/maintained-apps/outputs/android-studio/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio' AND version_compare(bundle_short_version, '2026.1') < 0);"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.9/android-studio-quail1-patch1-mac_arm.dmg",
+      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.1.10/android-studio-quail1-patch2-mac_arm.dmg",
       "install_script_ref": "d9306d86",
       "uninstall_script_ref": "aa386b1a",
-      "sha256": "07145348f0b7bce6336eb362addd773093a84c40a4780f436beb6795a48b1270",
+      "sha256": "69a13f8b7430f91919ff8b958c941d69953c13095e29fafa51e77d32417521a2",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/bambu-studio/darwin.json
+++ b/ee/maintained-apps/outputs/bambu-studio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "02.07.01.57",
+      "version": "02.07.01.62",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bambulab.bambu-studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bambulab.bambu-studio' AND version_compare(bundle_short_version, '02.07.01.57') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bambulab.bambu-studio' AND version_compare(bundle_short_version, '02.07.01.62') < 0);"
       },
-      "installer_url": "https://github.com/bambulab/BambuStudio/releases/download/v02.07.01.57/Bambu_Studio_mac-v02.07.01.57-20260601165745.dmg",
+      "installer_url": "https://github.com/bambulab/BambuStudio/releases/download/v02.07.01.62/Bambu_Studio_mac-v02.07.01.62-20260616174358.dmg",
       "install_script_ref": "57b12f2b",
       "uninstall_script_ref": "012866aa",
-      "sha256": "ef7d2b4b693fae95fef6caee40787d86ca90081251882a55c367b85c6dfc00a9",
+      "sha256": "1e54c25aefc5249d56b63711cf773bed56f14430aafcc34340cd4894aef15896",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.2.923",
+      "version": "4.2.936",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.2.923') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.2.936') < 0);"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.2.923-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.2.936-arm64-mac.zip",
       "install_script_ref": "a73050ea",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "657e64a49ca7f81d6e65fa1f0f6de1e31cbc857ca7f70b3932a2cd49334e5ef1",
+      "sha256": "b08df9cb9fce335a97cc60cfd02b78e30d8acf8f827e566d9c6f4b1a3d6cc58d",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.12603.1",
+      "version": "1.13576.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.12603.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.13576.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.12603.1/Claude-3df4fd263723119bc45f0af2d784afd5055e2ba9.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.13576.0/Claude-1290fc2ef5fd27a3883b74505e0ff917413d6832.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "a3f2b7988f46c3c6469e946eee562d038a6737140097e435ce395755be595815",
+      "sha256": "ef222b5ac55f3ec0a187c862ccbdb5c9a9e255c9dd8f96707d3735152e5cfd93",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/codex-app/darwin.json
+++ b/ee/maintained-apps/outputs/codex-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.609.71450",
+      "version": "26.611.61049",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.609.71450') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.611.61049') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.609.71450.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.611.61049.zip",
       "install_script_ref": "5e3efa57",
       "uninstall_script_ref": "a2b5ee81",
-      "sha256": "e773c824d5ad0d8567bbabb1d39f32ce730dd4699e4a9de5b838ea6955e268b7",
+      "sha256": "2a96fe47d4bec9cb667ec58cd480e06b4b7cda5c88bb8d6466b6a16d4191fa66",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.7.36",
+      "version": "3.7.42",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.36') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.7.42') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/776d1f9d76df50a4e0aeca61819a88e7c1b861e2/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/5702c9cfca656d8710fad58402fe37f14345e3ac/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "881e4a19db1bdd678425dda0ffce237045da81c44fe7af4befe80245d34b4b86",
+      "sha256": "432967de71cfa589e98b1ca26a0d68638111931c6bd904006fb91bd882c64a4b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.7.36",
+      "version": "3.7.42",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.7.36') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.7.42') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/776d1f9d76df50a4e0aeca61819a88e7c1b861e2/win32/x64/system-setup/CursorSetup-x64-3.7.36.exe",
+      "installer_url": "https://downloads.cursor.com/production/5702c9cfca656d8710fad58402fe37f14345e3ac/win32/x64/system-setup/CursorSetup-x64-3.7.42.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "0e96adee52fb6ecc693a461984ff51db3a43705f653e950b38c86bbaa05ecb49",
+      "sha256": "0984150cda0c6d3ec7d563ebf6bdccdbc9fb0fa8563bea5f96c4dcc276c35f93",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dockside/darwin.json
+++ b/ee/maintained-apps/outputs/dockside/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.9.10",
+      "version": "2.9.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.11') < 0);"
       },
-      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.10/Dockside.dmg",
+      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.11/Dockside.dmg",
       "install_script_ref": "11c3511b",
       "uninstall_script_ref": "262fd2cc",
-      "sha256": "78ac0c119bd8e263517c7c596b9150e8c47ace707b5f80a2c1d77063e4edb1d7",
+      "sha256": "caff9a06b116d99ee0a163c57555939e698d9d3ea199617cd26240515b0d7f76",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0.4",
+      "version": "152.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '151.0.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '152.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/151.0.4/mac/en-US/Firefox%20151.0.4.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/152.0/mac/en-US/Firefox%20152.0.dmg",
       "install_script_ref": "b5e4c76e",
       "uninstall_script_ref": "b85c0267",
-      "sha256": "bc2e72f6abf31aa854b30a3e2841d3f2b8b8e153eaa0a5c3ab285728b7f9b160",
+      "sha256": "b8a46188850d2fb32f16ad3c0829b08cd689bc714b8ee18fd9b09bb60629004d",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@esr/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@esr/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "140.11.0",
+      "version": "140.12.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.11.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.12.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.11.0esr/mac/en-US/Firefox%20140.11.0esr.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.12.0esr/mac/en-US/Firefox%20140.12.0esr.dmg",
       "install_script_ref": "b5e4c76e",
       "uninstall_script_ref": "cc27bc9d",
-      "sha256": "ac2aac7314f9cacf441e047ae9ec30e27b56b32838561b4dfdab4e17ec7928ce",
+      "sha256": "7d868edcee33d55d904303add39803b9b1ad91921d7a0c129d2a313db0c9f70c",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/forklift/darwin.json
+++ b/ee/maintained-apps/outputs/forklift/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.3",
+      "version": "4.6.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.binarynights.ForkLift-4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.binarynights.ForkLift-4' AND version_compare(bundle_short_version, '4.6.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.binarynights.ForkLift-4' AND version_compare(bundle_short_version, '4.6.4') < 0);"
       },
-      "installer_url": "https://download.binarynights.com/ForkLift/ForkLift4.6.3.zip",
+      "installer_url": "https://download.binarynights.com/ForkLift/ForkLift4.6.4.zip",
       "install_script_ref": "050b6846",
       "uninstall_script_ref": "99e7648d",
-      "sha256": "17bbf7669c72cf42f928e21ffbc8bbfdf0267b4992994594f1d8fa0c2e99f084",
+      "sha256": "df0da8ae4e9818739f56a226c1e9174785dea58c7a1ac62659c9dd7e9ac6bb0d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/framer/darwin.json
+++ b/ee/maintained-apps/outputs/framer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.23.3",
+      "version": "2026.23.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.framer.electron';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.framer.electron' AND version_compare(bundle_short_version, '2026.23.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.framer.electron' AND version_compare(bundle_short_version, '2026.23.5') < 0);"
       },
-      "installer_url": "https://updates.framer.com/electron/darwin/arm64/Framer-2026.23.3.zip",
+      "installer_url": "https://updates.framer.com/electron/darwin/arm64/Framer-2026.23.5.zip",
       "install_script_ref": "7c743e16",
       "uninstall_script_ref": "4775195c",
-      "sha256": "fc0755e53901b9beb4f960ce5d724721a6bf393a01b49dd64af79b08243ac14a",
+      "sha256": "581a93d414c6a497ca531d66e87872d8c01817d2dc6734f241112fd0ce16f863",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/gitkraken/darwin.json
+++ b/ee/maintained-apps/outputs/gitkraken/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.2.0",
+      "version": "12.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken' AND version_compare(bundle_short_version, '12.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken' AND version_compare(bundle_short_version, '12.2.1') < 0);"
       },
-      "installer_url": "https://api.gitkraken.dev/releases/production/darwin/arm64/12.2.0/GitKraken-v12.2.0.zip",
+      "installer_url": "https://api.gitkraken.dev/releases/production/darwin/arm64/12.2.1/GitKraken-v12.2.1.zip",
       "install_script_ref": "f20ab23e",
       "uninstall_script_ref": "da9e6343",
-      "sha256": "02c72a630065f5144ae6f80fd01892581fc286bec7c397d90574cae2d80e3396",
+      "sha256": "a9b9ffe38f9eb0f14bbbfdfd0b450c8447adee1500c38eb89acac2569599b641",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/google-chrome/darwin.json
+++ b/ee/maintained-apps/outputs/google-chrome/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "149.0.7827.115",
+      "version": "149.0.7827.156",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '149.0.7827.115') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '149.0.7827.156') < 0);"
       },
       "installer_url": "https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg",
       "install_script_ref": "6981ff84",

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.319.1",
+      "version": "7.324.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.319.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.324.2') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.319.1/Granola-7.319.1-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.324.2/Granola-7.324.2-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "9617754af892e481add2667481df3fa455d01d12af3b9dd8cdaf8854c7feb735",
+      "sha256": "b7cb621811a15ba908486df78dbc0b9aa5e1126109bbb477251ab00210c9da68",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/insomnia/darwin.json
+++ b/ee/maintained-apps/outputs/insomnia/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.6.0",
+      "version": "13.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '12.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '13.0.0') < 0);"
       },
-      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4012.6.0/Insomnia.Core-12.6.0.dmg",
+      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4013.0.0/Insomnia.Core-13.0.0.dmg",
       "install_script_ref": "80491bd1",
       "uninstall_script_ref": "093d2a58",
-      "sha256": "a922a54282f063da82775826389c05c751f74e3259a9f69b8eaa2bf252531fef",
+      "sha256": "b0f97b2970bc675dcb159bf1b8a834da20dbb6b0b19fffd8aebf0038e7f7543e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/kiro-cli/darwin.json
+++ b/ee/maintained-apps/outputs/kiro-cli/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.7.1') < 0);"
       },
-      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.7.0/Kiro%20CLI.dmg",
+      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.7.1/Kiro%20CLI.dmg",
       "install_script_ref": "7bf3d706",
       "uninstall_script_ref": "31b59062",
-      "sha256": "524c2b7212e375b4376961d81be0dc3246ed43228211b1bac1d35f3a9bb8d936",
+      "sha256": "499cd6d99d66d627ee9671a737c7d05e203de4053469c22054cb8a454ff4724f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notion/darwin.json
+++ b/ee/maintained-apps/outputs/notion/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.21.0",
+      "version": "7.22.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'notion.id';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'notion.id' AND version_compare(bundle_short_version, '7.21.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'notion.id' AND version_compare(bundle_short_version, '7.22.0') < 0);"
       },
-      "installer_url": "https://desktop-release.notion-static.com/Notion-7.21.0-arm64.dmg",
+      "installer_url": "https://desktop-release.notion-static.com/Notion-7.22.0-arm64.dmg",
       "install_script_ref": "20b617ec",
       "uninstall_script_ref": "5400135a",
-      "sha256": "efafe9dd532fb155e15d64eb06670f66828b8a97bb2f47a1c3d87e6ee7154f41",
+      "sha256": "cc10093c96fce64ea29b5a82228ca0fb1577d4b438f9fdfbe55f816600fac2dd",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.30.8",
+      "version": "0.30.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.9') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.8/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.9/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "bf40e2d5",
-      "sha256": "62a68eacb27dde8d61560fd3bf4c5669c141f5482c5668ce7328420e871088e6",
+      "sha256": "96b0a66463b156a5ea4fca0b41a413bcd58192dcb7405fb58fa05dcb08b0655b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/onedrive/windows.json
+++ b/ee/maintained-apps/outputs/onedrive/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.088.0510.0004",
+      "version": "26.095.0519.0003",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation' AND version_compare(version, '26.088.0510.0004') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation' AND version_compare(version, '26.095.0519.0003') < 0);"
       },
-      "installer_url": "https://oneclient.sfx.ms/Win/Installers/26.088.0510.0004/amd64/OneDriveSetup.exe",
+      "installer_url": "https://oneclient.sfx.ms/Win/Installers/26.095.0519.0003/amd64/OneDriveSetup.exe",
       "install_script_ref": "ab0b56ab",
       "uninstall_script_ref": "374be511",
-      "sha256": "0e175c6e4484196f3dc388e764b5674bbb08aef6fbefef9484c885fde36306b1",
+      "sha256": "0d74a3220233b14208426c08657cb4c531684b7d3c5f64e9f87550cad38b97d2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.15.0",
+      "version": "12.15.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.15.4') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.15.0/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.15.4/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "8f557b9a53943c852de13c0d86e8c27588a81aba16be9c172aa3589bdb2bb99b",
+      "sha256": "d688fc02fb852b00644012cab07e8db9e80c07417b24485d1050fb2bfd44b378",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.15.0",
+      "version": "12.15.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.15.4') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.15.0/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.15.4/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "4c1db727762b1a03643c0d07d22bfa382bf5a933091a5c72702cce558145235b",
+      "sha256": "7933be166b2e08fd5bc94d140997c1363917e72a767f72afc27e9d63f1733561",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/power-bi/windows.json
+++ b/ee/maintained-apps/outputs/power-bi/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.154.1260.0",
+      "version": "2.155.756.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Power BI Desktop (x64)' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Power BI Desktop (x64)' AND publisher = 'Microsoft Corporation' AND version_compare(version, '2.154.1260.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Power BI Desktop (x64)' AND publisher = 'Microsoft Corporation' AND version_compare(version, '2.155.756.0') < 0);"
       },
-      "installer_url": "https://download.microsoft.com/download/8/8/0/880BCA75-79DD-466A-927D-1ABF1F5454B0/PBIDesktopSetup-2026-05_x64.exe",
+      "installer_url": "https://download.microsoft.com/download/8/8/0/880BCA75-79DD-466A-927D-1ABF1F5454B0/PBIDesktopSetup-2026-06_x64.exe",
       "install_script_ref": "cc478c11",
       "uninstall_script_ref": "abc3b459",
-      "sha256": "8ac9965a8c845326e58fe44df9a6fcc8462da21262e09b829d926a3a76c87422",
+      "sha256": "d73aaadbb3e22095057be5eae8d3b8ac96b33be17d18d41e58c4c39493e3d185",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/qlab/darwin.json
+++ b/ee/maintained-apps/outputs/qlab/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.5.10",
+      "version": "5.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.figure53.QLab.5';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figure53.QLab.5' AND version_compare(bundle_short_version, '5.5.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figure53.QLab.5' AND version_compare(bundle_short_version, '5.6') < 0);"
       },
-      "installer_url": "https://qlab.app/downloads/archive/QLab-5.5.10.zip",
+      "installer_url": "https://qlab.app/downloads/archive/QLab-5.6.zip",
       "install_script_ref": "00ad3e5d",
       "uninstall_script_ref": "a60a2320",
-      "sha256": "b1f2a81789a4901cc4ac4be0b0c4ae1465418dc87924ccb56bf3ec17c25c24b6",
+      "sha256": "ef35e5243cf6931157fbba9a1022d487beed8c61dfdeb7f2524d9916d648eec1",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rive/darwin.json
+++ b/ee/maintained-apps/outputs/rive/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.8.5037",
+      "version": "0.8.5068",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5037') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5068') < 0);"
       },
-      "installer_url": "https://releases.rive.app/macos/0.8.5037/Rive.dmg",
+      "installer_url": "https://releases.rive.app/macos/0.8.5068/Rive.dmg",
       "install_script_ref": "2bbfee4e",
       "uninstall_script_ref": "8f862785",
-      "sha256": "3361eacbf1624134d14a2263b2efd2d06be10b9134d24555703dc9dda51f3347",
+      "sha256": "a9a8af8b00348e8a2afcf1421dfa2798115f8210502d70678ba992531ff4d4a9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/sql-server-management-studio/windows.json
+++ b/ee/maintained-apps/outputs/sql-server-management-studio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "22.7.0",
+      "version": "22.7.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'SQL Server Management Studio 22';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'SQL Server Management Studio 22' AND version_compare(version, '22.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'SQL Server Management Studio 22' AND version_compare(version, '22.7.1') < 0);"
       },
-      "installer_url": "https://download.visualstudio.microsoft.com/download/pr/105ab965-3bff-41cb-a75d-b4020a784328/1b424980a39e6408fec3a24977c6f0aa69bdac9bbf937cef2eadbcce86bb17e9/vs_SSMS.exe",
+      "installer_url": "https://download.visualstudio.microsoft.com/download/pr/a95b7880-2074-4c46-bdbf-e1b8c547ac60/bc34d75d5b325e2cc9c804019442a7ef2599ab33eda2011a9aec23745239d048/vs_SSMS.exe",
       "install_script_ref": "660f158a",
       "uninstall_script_ref": "13740770",
-      "sha256": "1b424980a39e6408fec3a24977c6f0aa69bdac9bbf937cef2eadbcce86bb17e9",
+      "sha256": "bc34d75d5b325e2cc9c804019442a7ef2599ab33eda2011a9aec23745239d048",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/sqlpro-for-mssql/darwin.json
+++ b/ee/maintained-apps/outputs/sqlpro-for-mssql/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.85",
+      "version": "2026.171",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankinsoft.osx.tinysqlstudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankinsoft.osx.tinysqlstudio' AND version_compare(bundle_short_version, '2026.85') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankinsoft.osx.tinysqlstudio' AND version_compare(bundle_short_version, '2026.171') < 0);"
       },
-      "installer_url": "https://d3fwkemdw8spx3.cloudfront.net/mssql/SQLProMSSQL.2026.85.app.zip",
+      "installer_url": "https://d3fwkemdw8spx3.cloudfront.net/mssql/SQLProMSSQL.2026.171.app.zip",
       "install_script_ref": "422d1a8e",
       "uninstall_script_ref": "7448321f",
-      "sha256": "b376e23004dce21684a83aefdde986d004fa33c8ae039963e08ed7effd9cbac4",
+      "sha256": "8d056775987fa2ddb01c683e6e410e08f8f841231b22fc8009dd4799e77c368d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/superwhisper/darwin.json
+++ b/ee/maintained-apps/outputs/superwhisper/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.16.0",
+      "version": "2.16.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superduper.superwhisper';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superduper.superwhisper' AND version_compare(bundle_short_version, '2.16.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superduper.superwhisper' AND version_compare(bundle_short_version, '2.16.1') < 0);"
       },
-      "installer_url": "https://builds.superwhisper.com/v2.16.0/superwhisper.zip",
+      "installer_url": "https://builds.superwhisper.com/v2.16.1/superwhisper.zip",
       "install_script_ref": "06338cb4",
       "uninstall_script_ref": "27ca9133",
-      "sha256": "c3274edba6d595f1419ecd1eedb2d135c818e569a9f7ba1913b7e3acab9fe6e9",
+      "sha256": "ff2b1852826cd8e8222c1bb3e97436b565d95dbf3c1c00959cdb33a90570bcd3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/thunderbird/darwin.json
+++ b/ee/maintained-apps/outputs/thunderbird/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "151.0.1",
+      "version": "152.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '151.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '152.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/151.0.1/mac/en-US/Thunderbird%20151.0.1.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/152.0/mac/en-US/Thunderbird%20152.0.dmg",
       "install_script_ref": "7cfa15ee",
       "uninstall_script_ref": "88749f85",
-      "sha256": "161efae828f7cb85acc7e7490c88042a22c0867f3c6bb616b73319bea834a378",
+      "sha256": "42ac9a908831d8fb32c85dbd484a8d31106dd9fee950be5b43565dcf8303ea7f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/unity-hub/darwin.json
+++ b/ee/maintained-apps/outputs/unity-hub/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.18.2",
+      "version": "3.18.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.18.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.18.3') < 0);"
       },
       "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-arm64.dmg",
       "install_script_ref": "c26804cb",

--- a/ee/maintained-apps/outputs/virtualbox/darwin.json
+++ b/ee/maintained-apps/outputs/virtualbox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.2.8",
+      "version": "7.2.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox' AND version_compare(bundle_short_version, '7.2.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox' AND version_compare(bundle_short_version, '7.2.10') < 0);"
       },
-      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-macOSArm64.dmg",
+      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.10/VirtualBox-7.2.10-174163-macOSArm64.dmg",
       "install_script_ref": "18eac9a0",
       "uninstall_script_ref": "e04a5c15",
-      "sha256": "60d164cc5afc059e44591bcc70f63c7ad3378495f19564cecd1ad9a4461dd935",
+      "sha256": "95bc371769ad9afa7defbff15f2fbc07f641a0a4fcb0cf3cc8116101ff741060",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/virtualbox/windows.json
+++ b/ee/maintained-apps/outputs/virtualbox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.2.8",
+      "version": "7.2.10",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates' AND version_compare(version, '7.2.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates' AND version_compare(version, '7.2.10') < 0);"
       },
-      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-Win.exe",
+      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.10/VirtualBox-7.2.10-174163-Win.exe",
       "install_script_ref": "556130e3",
       "uninstall_script_ref": "fb3c3d4d",
-      "sha256": "ae5415cc968c0e8acddd99358c21d267a2c31ac4ff5182861aab9e6931001606",
+      "sha256": "f4750f6f64c44df03ee2921de77e63c30e84e03a3aad07fd00f292265ff164c7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webcatalog/darwin.json
+++ b/ee/maintained-apps/outputs/webcatalog/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "75.2.0",
+      "version": "76.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '75.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '76.0.1') < 0);"
       },
-      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-75.2.0-universal.dmg",
+      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-76.0.1-universal.dmg",
       "install_script_ref": "f04928dc",
       "uninstall_script_ref": "d196a4c8",
-      "sha256": "81e5e87fdf195ac2b16099f5483c4948527da6e2a4383866f646a26544cbae3b",
+      "sha256": "da4380121f3b25d07639d06f1bb11ce685f80438d5c2b989ad113a3fedf1dd77",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "46.5.0.35006",
+      "version": "46.6.0.35178",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.5.0.35006') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.0.35178') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "d105863f",

--- a/ee/maintained-apps/outputs/windows-app/windows.json
+++ b/ee/maintained-apps/outputs/windows-app/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.0.1129.0",
+      "version": "2.0.1186.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Windows App' AND publisher = 'Microsoft Corp.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Windows App' AND publisher = 'Microsoft Corp.' AND version_compare(version, '2.0.1129.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Windows App' AND publisher = 'Microsoft Corp.' AND version_compare(version, '2.0.1186.0') < 0);"
       },
-      "installer_url": "https://res.cdn.office.net/remote-desktop-windows-client/0a11b53f-95d7-4ea7-a283-00f8162fabdf/WindowsApp_x64_Release_2.0.1129.0.msix",
+      "installer_url": "https://res.cdn.office.net/remote-desktop-windows-client/f10b58f7-bb1d-4781-81de-1df8e4d08acf/WindowsApp_x64_Release_2.0.1186.0.msix",
       "install_script_ref": "f3fab53b",
       "uninstall_script_ref": "3518ea18",
-      "sha256": "d62958ee2a332778a015e8766c8b5771565c7cd3490715277eb022c92d6f84b8",
+      "sha256": "6c27b5d8e01b59bf2cca68467e9852a1b451358e7177066d35d1458bab5e8fc3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wispr-flow/darwin.json
+++ b/ee/maintained-apps/outputs/wispr-flow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.789",
+      "version": "1.5.848",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.5.789') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.5.848') < 0);"
       },
-      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.5.789.dmg",
+      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.5.848.dmg",
       "install_script_ref": "3a49fcfd",
       "uninstall_script_ref": "e0cf2e96",
-      "sha256": "f581b9e9101ad5d9ce891f1898483a0075cd385c23f913678371f32b2081680b",
+      "sha256": "ff9e1434fa2528e0c2907d2111c80dde64176f075856a394aa988c1dfd105f9c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/yubico-authenticator/darwin.json
+++ b/ee/maintained-apps/outputs/yubico-authenticator/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.3.3",
+      "version": "7.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.yubioath';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.yubioath' AND version_compare(bundle_short_version, '7.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.yubico.yubioath' AND version_compare(bundle_short_version, '7.4.0') < 0);"
       },
-      "installer_url": "https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-7.3.3-mac.dmg",
+      "installer_url": "https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-7.4.0-mac.dmg",
       "install_script_ref": "7dc459ff",
       "uninstall_script_ref": "47160642",
-      "sha256": "afda30861d6f899ed1905018fe234ee68c0ed0c3d04e0789e1538d02227aadc4",
+      "sha256": "fd776bea250dfddac6f4fa1bc2f24d27c3a1a11fba2bbeeafc5b9f1446f0701b",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated metadata and checksums for 35+ maintained applications across macOS and Windows platforms, including 1Password, Firefox, Postman, VirtualBox, Claude, Cursor, and others, to reflect their latest available versions and corresponding installation artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->