### PR TITLE
Fix out-of-order Windows MDM fleetd install commands (#47683)

### DIFF
--- a/changes/47683-windows-mdm-fleetd-install-ordering
+++ b/changes/47683-windows-mdm-fleetd-install-ordering
@@ -1,0 +1,1 @@
+* Fixed an issue where fleetd could intermittently fail to install during Windows MDM enrollment, which could cause the Windows Autopilot Enrollment Status Page to hang.

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1591,7 +1591,10 @@ func (svc *Service) enqueueInstallFleetdCommand(ctx context.Context, deviceID st
 	}
 	fleetURL := appCfg.ServerSettings.ServerURL
 	globalEnrollSecret := secrets[0].Secret
-	addCommandUUID := uuid.NewString()
+	// Fleet-internal CmdID: the Add is injected inline and is never its own tracked queue command (only the Exec
+	// UUID is the queue/command_uuid), so a stray Add-only device response cannot trigger an "unmatched Windows MDM
+	// commands" warning in MDMWindowsSaveResponse.
+	addCommandUUID := fleet.FleetInternalCmdIDPrefix + "fleetd-install-add"
 	execCommandUUID := uuid.NewString()
 
 	euaTokenArg := ""
@@ -1653,9 +1656,9 @@ func (svc *Service) enqueueInstallFleetdCommand(ctx context.Context, deviceID st
 	// back-to-back), so the Exec can be delivered before the Add. The device then runs DownloadInstall on a node
 	// that doesn't exist yet, returns 404, and the install is created-but-never-run (stuck at "Ready") -- an
 	// intermittent fleetd-install failure, most visibly a hung Autopilot ESP. One raw_command guarantees order.
-	// The command_uuid is the Exec's so the install result (the meaningful status) is the one tracked and the
-	// one that acks the queue; the Add's CmdID is harmlessly unmatched (no "unmatched" warning, since the Exec matches).
-	rawCombinedCmd := []byte(string(rawAddCmd) + string(rawExecCmd))
+	// The command_uuid is the Exec's, so the install result (the meaningful status) is the one tracked and the
+	// one that acks the queue. The Add uses a Fleet-internal CmdID (see above) so it is not tracked separately.
+	rawCombinedCmd := slices.Concat(rawAddCmd, rawExecCmd)
 	fleetdInstallCmd := &fleet.MDMWindowsCommand{
 		CommandUUID:  execCommandUUID,
 		RawCommand:   rawCombinedCmd,

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1591,9 +1591,8 @@ func (svc *Service) enqueueInstallFleetdCommand(ctx context.Context, deviceID st
 	}
 	fleetURL := appCfg.ServerSettings.ServerURL
 	globalEnrollSecret := secrets[0].Secret
-	// Fleet-internal CmdID: the Add is injected inline and is never its own tracked queue command (only the Exec
-	// UUID is the queue/command_uuid), so a stray Add-only device response cannot trigger an "unmatched Windows MDM
-	// commands" warning in MDMWindowsSaveResponse.
+	// Fleet-internal CmdID: the Add is injected inline and is never its own tracked queue command. The Exec command is
+	// the important one, and we only track that.
 	addCommandUUID := fleet.FleetInternalCmdIDPrefix + "fleetd-install-add"
 	execCommandUUID := uuid.NewString()
 

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1647,23 +1647,22 @@ func (svc *Service) enqueueInstallFleetdCommand(ctx context.Context, deviceID st
 </Exec>
 `)
 
-	// TODO: add ability to batch-enqueue multiple commands at the same time
-	addFleetdCmd := &fleet.MDMWindowsCommand{
-		CommandUUID:  addCommandUUID,
-		RawCommand:   rawAddCmd,
-		TargetLocURI: syncml.FleetdWindowsInstallerGUID,
-	}
-	if err := svc.ds.MDMWindowsInsertCommandForHosts(ctx, []string{deviceID}, addFleetdCmd); err != nil {
-		return ctxerr.Wrap(ctx, err, "insert add command to install fleetd")
-	}
-
-	execFleetCmd := &fleet.MDMWindowsCommand{
+	// Deliver the Add and Exec as a SINGLE command so they ride in one SyncML body with Add textually before
+	// Exec. As two separate queued commands they can be reordered: MDMWindowsGetPendingCommands orders only by
+	// created_at, which ties at the 1-second granularity of the `timestamp` column (the pair is inserted
+	// back-to-back), so the Exec can be delivered before the Add. The device then runs DownloadInstall on a node
+	// that doesn't exist yet, returns 404, and the install is created-but-never-run (stuck at "Ready") -- an
+	// intermittent fleetd-install failure, most visibly a hung Autopilot ESP. One raw_command guarantees order.
+	// The command_uuid is the Exec's so the install result (the meaningful status) is the one tracked and the
+	// one that acks the queue; the Add's CmdID is harmlessly unmatched (no "unmatched" warning, since the Exec matches).
+	rawCombinedCmd := []byte(string(rawAddCmd) + string(rawExecCmd))
+	fleetdInstallCmd := &fleet.MDMWindowsCommand{
 		CommandUUID:  execCommandUUID,
-		RawCommand:   rawExecCmd,
+		RawCommand:   rawCombinedCmd,
 		TargetLocURI: syncml.FleetdWindowsInstallerGUID,
 	}
-	if err := svc.ds.MDMWindowsInsertCommandForHosts(ctx, []string{deviceID}, execFleetCmd); err != nil {
-		return ctxerr.Wrap(ctx, err, "insert exec command to install fleetd")
+	if err := svc.ds.MDMWindowsInsertCommandForHosts(ctx, []string{deviceID}, fleetdInstallCmd); err != nil {
+		return ctxerr.Wrap(ctx, err, "insert command to install fleetd")
 	}
 
 	return nil

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1650,14 +1650,9 @@ func (svc *Service) enqueueInstallFleetdCommand(ctx context.Context, deviceID st
 </Exec>
 `)
 
-	// Deliver the Add and Exec as a SINGLE command so they ride in one SyncML body with Add textually before
-	// Exec. As two separate queued commands they can be reordered: MDMWindowsGetPendingCommands orders only by
-	// created_at, which ties at the 1-second granularity of the `timestamp` column (the pair is inserted
-	// back-to-back), so the Exec can be delivered before the Add. The device then runs DownloadInstall on a node
-	// that doesn't exist yet, returns 404, and the install is created-but-never-run (stuck at "Ready") -- an
-	// intermittent fleetd-install failure, most visibly a hung Autopilot ESP. One raw_command guarantees order.
-	// The command_uuid is the Exec's, so the install result (the meaningful status) is the one tracked and the
-	// one that acks the queue. The Add uses a Fleet-internal CmdID (see above) so it is not tracked separately.
+	// Deliver the Add and Exec as a SINGLE command so they ride in one SyncML body with Add textually before Exec. As
+	// two separate queued commands they can be reordered when they are applied in the same second, we must manually
+	// guarantee the ordering.
 	rawCombinedCmd := slices.Concat(rawAddCmd, rawExecCmd)
 	fleetdInstallCmd := &fleet.MDMWindowsCommand{
 		CommandUUID:  execCommandUUID,


### PR DESCRIPTION
The fleetd install Add and Exec were enqueued as two separate Windows MDM commands ordered only by created_at (1-second granularity), so they could be delivered Exec-before-Add. The device then ran DownloadInstall on a not-yet-created node, returned 404, and fleetd never installed, which could hang the Windows Autopilot Enrollment Status Page. Enqueue them as a single command so Add always precedes Exec.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47683 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent fleetd installation failures during Windows MDM enrollment that could cause the Windows Autopilot Enrollment Status Page to hang.

* **Documentation**
  * Updated Windows MDM fleetd installation documentation to reflect the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->