### PR TITLE
Don't require end user auth on orbit re-enrollment (#46300)

### DIFF
--- a/changes/46300-orbit-reenroll-eua
+++ b/changes/46300-orbit-reenroll-eua
@@ -1,0 +1,1 @@
+- Fixed an issue where Windows and Linux hosts that had already enrolled were prompted for end user authentication (an SSO browser tab) when fleetd re-enrolled after a service restart. Re-enrollment of an already-enrolled host no longer requires end user authentication; only genuinely new devices are prompted.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2518,6 +2518,37 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 	return &host, nil
 }
 
+// HostPreviouslyOrbitEnrolled reports whether a host matching the given orbit enrollment identifiers already exists in Fleet
+// and was previously orbit-enrolled (i.e. it has an orbit node key). It mirrors the host matching done by EnrollOrbit so that
+// "a host already exists here" means the same row EnrollOrbit would take over. See https://github.com/fleetdm/fleet/issues/46300.
+func (ds *Datastore) HostPreviouslyOrbitEnrolled(ctx context.Context, hostInfo fleet.OrbitHostInfo, isMDMEnabled bool) (bool, error) {
+	if hostInfo.HardwareUUID == "" {
+		return false, ctxerr.New(ctx, "hardware uuid is empty")
+	}
+
+	serialToMatch := hostInfo.HardwareSerial
+	if hostInfo.Platform == "windows" {
+		// For Windows, don't match by serial number, matching EnrollOrbit's behavior.
+		serialToMatch = ""
+	}
+
+	// reader honors RequirePrimary, which EnrollOrbit's service handler sets, so this stays consistent with the subsequent
+	// enroll within the same request.
+	matched, err := matchHostDuringEnrollment(ctx, ds.reader(ctx), orbitEnroll, isMDMEnabled, hostInfo.OsqueryIdentifier,
+		hostInfo.HardwareUUID, serialToMatch, hostInfo.Platform)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		// No host matches these identifiers: this is a new device (or one moving to a different Fleet server), not a re-enroll.
+		return false, nil
+	case err != nil:
+		return false, ctxerr.Wrap(ctx, err, "match host for orbit re-enrollment check")
+	default:
+		// Require a previously-set orbit node key so a never-orbit-enrolled row (e.g. a DEP-pre-created host) does not exempt
+		// enrollment from end user authentication.
+		return matched.NodeKeySet, nil
+	}
+}
+
 // EnrollOsquery enrolls the osquery agent to Fleet.
 func (ds *Datastore) EnrollOsquery(ctx context.Context, opts ...fleet.DatastoreEnrollOsqueryOption) (*fleet.Host, error) {
 	enrollConfig := &fleet.DatastoreEnrollOsqueryConfig{}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2518,9 +2518,9 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 	return &host, nil
 }
 
-// HostPreviouslyOrbitEnrolled reports whether a host matching the given orbit enrollment identifiers already exists in Fleet
-// and was previously orbit-enrolled (i.e. it has an orbit node key). It mirrors the host matching done by EnrollOrbit so that
-// "a host already exists here" means the same row EnrollOrbit would take over. See https://github.com/fleetdm/fleet/issues/46300.
+// HostPreviouslyOrbitEnrolled reports whether a host matching the given orbit enrollment identifiers already exists in Fleet and
+// was previously orbit-enrolled (i.e. it has an orbit node key). It mirrors the host matching done by EnrollOrbit so that "a host
+// already exists here" means the same row EnrollOrbit would take over.
 func (ds *Datastore) HostPreviouslyOrbitEnrolled(ctx context.Context, hostInfo fleet.OrbitHostInfo, isMDMEnabled bool) (bool, error) {
 	if hostInfo.HardwareUUID == "" {
 		return false, ctxerr.New(ctx, "hardware uuid is empty")
@@ -2532,8 +2532,6 @@ func (ds *Datastore) HostPreviouslyOrbitEnrolled(ctx context.Context, hostInfo f
 		serialToMatch = ""
 	}
 
-	// reader honors RequirePrimary, which EnrollOrbit's service handler sets, so this stays consistent with the subsequent
-	// enroll within the same request.
 	matched, err := matchHostDuringEnrollment(ctx, ds.reader(ctx), orbitEnroll, isMDMEnabled, hostInfo.OsqueryIdentifier,
 		hostInfo.HardwareUUID, serialToMatch, hostInfo.Platform)
 	switch {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -177,6 +177,7 @@ func TestHosts(t *testing.T) {
 		{"GetUnverifiedDiskEncryptionKeys", testHostsGetUnverifiedDiskEncryptionKeys},
 		{"LUKS", testLUKSDatastoreFunctions},
 		{"EnrollOrbit", testHostsEnrollOrbit},
+		{"HostPreviouslyOrbitEnrolled", testHostPreviouslyOrbitEnrolled},
 		{"HostsEnrollOrbitWithPlatformLike", testHostsEnrollOrbitWithPlatformLike},
 		{"EnrollUpdatesMissingInfo", testHostsEnrollUpdatesMissingInfo},
 		{"EncryptionKeyRawDecryption", testHostsEncryptionKeyRawDecryption},
@@ -11471,6 +11472,62 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 			})
 		}
 	}
+}
+
+func testHostPreviouslyOrbitEnrolled(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	// A host that orbit-enrolled (has an orbit node key) is reported as previously enrolled, matching by hardware UUID
+	// (Windows path) and by osquery identifier.
+	t.Run("windows host previously orbit-enrolled", func(t *testing.T) {
+		hostUUID := uuid.New().String()
+		_, err := ds.EnrollOrbit(ctx,
+			fleet.WithEnrollOrbitMDMEnabled(false),
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+				HardwareUUID: hostUUID,
+				Platform:     "windows",
+			}),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		)
+		require.NoError(t, err)
+
+		got, err := ds.HostPreviouslyOrbitEnrolled(ctx, fleet.OrbitHostInfo{HardwareUUID: hostUUID, Platform: "windows"}, false)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+
+	// An unknown device (no matching row) is not reported as previously enrolled: it is a new enrollment, or a host moving to
+	// a different Fleet server.
+	t.Run("unknown host", func(t *testing.T) {
+		got, err := ds.HostPreviouslyOrbitEnrolled(ctx, fleet.OrbitHostInfo{HardwareUUID: uuid.New().String(), Platform: "windows"}, false)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	// A host row that exists but never orbit-enrolled (no orbit node key, e.g. a DEP-pre-created or osquery-only row) must not
+	// be reported as previously orbit-enrolled.
+	t.Run("host exists but never orbit-enrolled", func(t *testing.T) {
+		dbZeroTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+		osqueryID := uuid.New().String()
+		_, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:        "no-orbit",
+			Platform:        "ubuntu",
+			LastEnrolledAt:  dbZeroTime,
+			DetailUpdatedAt: dbZeroTime,
+			OsqueryHostID:   &osqueryID,
+		})
+		require.NoError(t, err)
+
+		got, err := ds.HostPreviouslyOrbitEnrolled(ctx, fleet.OrbitHostInfo{HardwareUUID: osqueryID, Platform: "ubuntu"}, false)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	// An empty hardware UUID is an error (orbit always sends one).
+	t.Run("empty hardware uuid", func(t *testing.T) {
+		_, err := ds.HostPreviouslyOrbitEnrolled(ctx, fleet.OrbitHostInfo{Platform: "windows"}, false)
+		require.Error(t, err)
+	})
 }
 
 func testHostsEnrollOrbitWithPlatformLike(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -11475,10 +11475,9 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 }
 
 func testHostPreviouslyOrbitEnrolled(t *testing.T, ds *Datastore) {
-	ctx := context.Background()
+	ctx := t.Context()
 
-	// A host that orbit-enrolled (has an orbit node key) is reported as previously enrolled, matching by hardware UUID
-	// (Windows path) and by osquery identifier.
+	// A Windows host that orbit-enrolled (has an orbit node key) is reported as previously enrolled, matched by its hardware UUID.
 	t.Run("windows host previously orbit-enrolled", func(t *testing.T) {
 		hostUUID := uuid.New().String()
 		_, err := ds.EnrollOrbit(ctx,
@@ -11507,18 +11506,33 @@ func testHostPreviouslyOrbitEnrolled(t *testing.T, ds *Datastore) {
 	// A host row that exists but never orbit-enrolled (no orbit node key, e.g. a DEP-pre-created or osquery-only row) must not
 	// be reported as previously orbit-enrolled.
 	t.Run("host exists but never orbit-enrolled", func(t *testing.T) {
-		dbZeroTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-		osqueryID := uuid.New().String()
-		_, err := ds.NewHost(ctx, &fleet.Host{
-			Hostname:        "no-orbit",
-			Platform:        "ubuntu",
-			LastEnrolledAt:  dbZeroTime,
-			DetailUpdatedAt: dbZeroTime,
-			OsqueryHostID:   &osqueryID,
-		})
+		h := test.NewHost(t, ds, "no-orbit", "", "no-orbit-key", uuid.New().String(), time.Now())
+
+		got, err := ds.HostPreviouslyOrbitEnrolled(ctx, fleet.OrbitHostInfo{HardwareUUID: *h.OsqueryHostID, Platform: "ubuntu"}, false)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	// A Windows enrollment must not be matched to an Apple host that shares a hardware serial: HostPreviouslyOrbitEnrolled
+	// forces serial matching off for Windows. Serial matching is enabled here (isMDMEnabled=true) so the skip is provably due
+	// to the Windows guard, not a disabled serial path.
+	t.Run("windows enroll does not match an apple host by serial", func(t *testing.T) {
+		serial := uuid.New().String()
+		// An Apple host previously orbit-enrolled with this serial (and an orbit node key).
+		_, err := ds.EnrollOrbit(ctx,
+			fleet.WithEnrollOrbitMDMEnabled(true),
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+				HardwareUUID:   uuid.New().String(),
+				HardwareSerial: serial,
+				Platform:       "darwin",
+			}),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		)
 		require.NoError(t, err)
 
-		got, err := ds.HostPreviouslyOrbitEnrolled(ctx, fleet.OrbitHostInfo{HardwareUUID: osqueryID, Platform: "ubuntu"}, false)
+		// Same serial, different (unmatched) UUID, Windows platform: the serial must be ignored, so no match.
+		got, err := ds.HostPreviouslyOrbitEnrolled(ctx,
+			fleet.OrbitHostInfo{HardwareUUID: uuid.New().String(), HardwareSerial: serial, Platform: "windows"}, true)
 		require.NoError(t, err)
 		require.False(t, got)
 	})

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1331,9 +1331,7 @@ type Datastore interface {
 	EnrollOrbit(ctx context.Context, opts ...DatastoreEnrollOrbitOption) (*Host, error)
 
 	// HostPreviouslyOrbitEnrolled reports whether a host matching the given orbit enrollment identifiers already exists in
-	// Fleet and was previously orbit-enrolled (i.e. it has an orbit node key). It uses the same host matching semantics as
-	// EnrollOrbit. It is used to decide whether an orbit re-enrollment (e.g. after a service restart or node key loss) should
-	// be exempt from end user authentication. See https://github.com/fleetdm/fleet/issues/46300.
+	// Fleet and was previously orbit-enrolled (i.e. it has an orbit node key).
 	HostPreviouslyOrbitEnrolled(ctx context.Context, hostInfo OrbitHostInfo, isMDMEnabled bool) (bool, error)
 
 	SerialUpdateHost(ctx context.Context, host *Host) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1330,6 +1330,12 @@ type Datastore interface {
 	//	- If an entry for the host doesn't exist (osquery enrolls later) then it will create a new entry in the hosts table.
 	EnrollOrbit(ctx context.Context, opts ...DatastoreEnrollOrbitOption) (*Host, error)
 
+	// HostPreviouslyOrbitEnrolled reports whether a host matching the given orbit enrollment identifiers already exists in
+	// Fleet and was previously orbit-enrolled (i.e. it has an orbit node key). It uses the same host matching semantics as
+	// EnrollOrbit. It is used to decide whether an orbit re-enrollment (e.g. after a service restart or node key loss) should
+	// be exempt from end user authentication. See https://github.com/fleetdm/fleet/issues/46300.
+	HostPreviouslyOrbitEnrolled(ctx context.Context, hostInfo OrbitHostInfo, isMDMEnabled bool) (bool, error)
+
 	SerialUpdateHost(ctx context.Context, host *Host) error
 
 	///////////////////////////////////////////////////////////////////////////////

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -926,6 +926,8 @@ type EnrollOsqueryFunc func(ctx context.Context, opts ...fleet.DatastoreEnrollOs
 
 type EnrollOrbitFunc func(ctx context.Context, opts ...fleet.DatastoreEnrollOrbitOption) (*fleet.Host, error)
 
+type HostPreviouslyOrbitEnrolledFunc func(ctx context.Context, hostInfo fleet.OrbitHostInfo, isMDMEnabled bool) (bool, error)
+
 type SerialUpdateHostFunc func(ctx context.Context, host *fleet.Host) error
 
 type NewJobFunc func(ctx context.Context, job *fleet.Job) (*fleet.Job, error)
@@ -3451,6 +3453,9 @@ type DataStore struct {
 
 	EnrollOrbitFunc        EnrollOrbitFunc
 	EnrollOrbitFuncInvoked bool
+
+	HostPreviouslyOrbitEnrolledFunc        HostPreviouslyOrbitEnrolledFunc
+	HostPreviouslyOrbitEnrolledFuncInvoked bool
 
 	SerialUpdateHostFunc        SerialUpdateHostFunc
 	SerialUpdateHostFuncInvoked bool
@@ -8368,6 +8373,13 @@ func (s *DataStore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnro
 	s.EnrollOrbitFuncInvoked = true
 	s.mu.Unlock()
 	return s.EnrollOrbitFunc(ctx, opts...)
+}
+
+func (s *DataStore) HostPreviouslyOrbitEnrolled(ctx context.Context, hostInfo fleet.OrbitHostInfo, isMDMEnabled bool) (bool, error) {
+	s.mu.Lock()
+	s.HostPreviouslyOrbitEnrolledFuncInvoked = true
+	s.mu.Unlock()
+	return s.HostPreviouslyOrbitEnrolledFunc(ctx, hostInfo, isMDMEnabled)
 }
 
 func (s *DataStore) SerialUpdateHost(ctx context.Context, host *fleet.Host) error {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -31677,11 +31677,10 @@ func (s *integrationEnterpriseTestSuite) TestOrbitEnrollWithIdPPopulatesDeviceMa
 	})
 }
 
-// TestOrbitReEnrollSkipsEndUserAuth covers issue #46300: once a host has orbit-enrolled, a subsequent re-enrollment (e.g.
-// after a service restart, node key file loss, or osquery DB rebuild) must not prompt for end user authentication again,
-// even if End User Authentication is enabled on the host's team and the host has no IdP association. This grandfathers hosts
-// that enrolled before EUA was enabled. A genuinely new device is still gated (covered by
-// TestOrbitEnrollWithIdPPopulatesDeviceMapping).
+// TestOrbitReEnrollSkipsEndUserAuth covers issue #46300: once a host has orbit-enrolled, a subsequent re-enrollment (e.g. after a
+// service restart, node key file loss, or osquery DB rebuild) must not prompt for end user authentication again, even if End User
+// Authentication is enabled on the host's team and the host has no IdP association. This grandfathers hosts that enrolled before
+// EUA was enabled. A genuinely new device is still gated (covered by TestOrbitEnrollWithIdPPopulatesDeviceMapping).
 func (s *integrationEnterpriseTestSuite) TestOrbitReEnrollSkipsEndUserAuth() {
 	t := s.T()
 	ctx := t.Context()
@@ -31741,6 +31740,11 @@ func (s *integrationEnterpriseTestSuite) TestOrbitReEnrollSkipsEndUserAuth() {
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&orbitResp))
 		res.Body.Close()
 		require.NotEmpty(t, orbitResp.OrbitNodeKey, "re-enrollment of an already-enrolled host must not be gated by EUA")
+
+		// The re-enrollment must reuse the existing host row, not create a duplicate.
+		reEnrolledHost, err := s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.NoError(t, err)
+		require.Equal(t, hostLite.ID, reEnrolledHost.ID, "re-enrollment must reuse the existing host row, not create a duplicate")
 
 		// Reset team EUA for the next subtest's first enrollment.
 		team.Config.MDM.MacOSSetup.EnableEndUserAuthentication = false

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -31677,6 +31677,86 @@ func (s *integrationEnterpriseTestSuite) TestOrbitEnrollWithIdPPopulatesDeviceMa
 	})
 }
 
+// TestOrbitReEnrollSkipsEndUserAuth covers issue #46300: once a host has orbit-enrolled, a subsequent re-enrollment (e.g.
+// after a service restart, node key file loss, or osquery DB rebuild) must not prompt for end user authentication again,
+// even if End User Authentication is enabled on the host's team and the host has no IdP association. This grandfathers hosts
+// that enrolled before EUA was enabled. A genuinely new device is still gated (covered by
+// TestOrbitEnrollWithIdPPopulatesDeviceMapping).
+func (s *integrationEnterpriseTestSuite) TestOrbitReEnrollSkipsEndUserAuth() {
+	t := s.T()
+	ctx := t.Context()
+
+	// Create a team with End User Authentication DISABLED, so the first enrollment succeeds without an SSO prompt and the
+	// host gets an orbit node key (the "previously enrolled" state).
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{
+		Name:        t.Name(),
+		Description: t.Name(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, s.ds.DeleteTeam(context.Background(), team.ID))
+	})
+
+	enrollSecret := t.Name() + "-secret"
+	require.NoError(t, s.ds.ApplyEnrollSecrets(ctx, &team.ID, []*fleet.EnrollSecret{{Secret: enrollSecret}}))
+
+	var caps fleet.CapabilityMap
+	caps.PopulateFromString(string(fleet.CapabilityEndUserAuth))
+	capsHeaders := map[string]string{fleet.CapabilitiesHeader: caps.String()}
+
+	runFlow := func(t *testing.T, platform, platformLike string) {
+		hostUUID := uuid.New().String()
+		enrollBody, err := json.Marshal(fleet.EnrollOrbitRequest{
+			EnrollSecret:   enrollSecret,
+			HardwareUUID:   hostUUID,
+			HardwareSerial: uuid.New().String(),
+			Hostname:       strings.ReplaceAll(t.Name(), "/", "-") + ".local",
+			Platform:       platform,
+			PlatformLike:   platformLike,
+			HardwareModel:  "TestModel",
+		})
+		require.NoError(t, err)
+
+		// First enrollment with EUA disabled: succeeds and stores an orbit node key.
+		res := s.DoRawWithHeaders("POST", "/api/fleet/orbit/enroll", enrollBody, http.StatusOK, capsHeaders)
+		var orbitResp enrollOrbitResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&orbitResp))
+		res.Body.Close()
+		require.NotEmpty(t, orbitResp.OrbitNodeKey)
+
+		hostLite, err := s.ds.HostLiteByIdentifier(ctx, hostUUID)
+		require.NoError(t, err)
+		require.NotZero(t, hostLite.ID)
+
+		// Now enable End User Authentication on the team. EnrollOrbit reads team config via TeamLite (not in the cached
+		// layer), so this direct write is visible to the running server immediately.
+		team.Config.MDM.MacOSSetup.EnableEndUserAuthentication = true
+		_, err = s.ds.SaveTeam(ctx, team)
+		require.NoError(t, err)
+
+		// Re-enroll the same host. There is no IdP association, so before the fix this returned END_USER_AUTH_REQUIRED. The
+		// host is already orbit-enrolled, so enrollment must now succeed without prompting.
+		res = s.DoRawWithHeaders("POST", "/api/fleet/orbit/enroll", enrollBody, http.StatusOK, capsHeaders)
+		orbitResp = enrollOrbitResponse{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&orbitResp))
+		res.Body.Close()
+		require.NotEmpty(t, orbitResp.OrbitNodeKey, "re-enrollment of an already-enrolled host must not be gated by EUA")
+
+		// Reset team EUA for the next subtest's first enrollment.
+		team.Config.MDM.MacOSSetup.EnableEndUserAuthentication = false
+		_, err = s.ds.SaveTeam(ctx, team)
+		require.NoError(t, err)
+	}
+
+	t.Run("linux", func(t *testing.T) {
+		runFlow(t, "ubuntu", "debian")
+	})
+
+	t.Run("windows", func(t *testing.T) {
+		runFlow(t, "windows", "")
+	})
+}
+
 // TestOrbitEnrollWithEUAToken covers the Windows MSI EUA-token branch in
 // EnrollOrbit (the `case platform == "windows" && euaToken != ""` arm of the
 // End User Auth switch in server/service/orbit.go). This is the flow Fleet

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -270,8 +270,27 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 					euaIdpAcctUUID = idpAcctUUID
 					// Continue enrollment — do not return END_USER_AUTH_REQUIRED.
 				default:
-					// Otherwise report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
-					return "", fleet.NewOrbitIDPAuthRequiredError()
+					// A host that already exists in Fleet and was previously orbit-enrolled is re-enrolling (e.g. after a
+					// service restart, node key file loss, or osquery DB rebuild), not enrolling for the first time. We must not
+					// prompt for end user authentication again: it would interrupt the user on every restart, and it also
+					// grandfathers hosts that enrolled before end user authentication was enabled (those have no
+					// host_mdm_idp_accounts row). A genuinely new device, or one moved to a different Fleet server (where it
+					// won't be found here), is not matched and is still gated. See https://github.com/fleetdm/fleet/issues/46300.
+					//
+					// Security note: matching by hardware UUID is not a strong identity check, but this does not introduce a new
+					// attack vector. EnrollOrbit already takes over an existing host row on a duplicate-UUID enrollment
+					// regardless of this gate, and hosts that already have an IdP account skip it. Requiring the matched host to
+					// have previously held an orbit node key keeps the exemption to hosts that genuinely enrolled before.
+					previouslyEnrolled, err := svc.ds.HostPreviouslyOrbitEnrolled(ctx, hostInfo, appConfig.MDM.EnabledAndConfigured)
+					if err != nil {
+						return "", fleet.OrbitError{Message: "failed to check for prior orbit enrollment: " + err.Error()}
+					}
+					if !previouslyEnrolled {
+						// Otherwise report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
+						return "", fleet.NewOrbitIDPAuthRequiredError()
+					}
+					svc.logger.InfoContext(ctx, "allowing re-enrollment without end-user authentication: host previously orbit-enrolled",
+						"host_uuid", hostInfo.HardwareUUID)
 				}
 			}
 		}

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -289,7 +289,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 						// Otherwise report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
 						return "", fleet.NewOrbitIDPAuthRequiredError()
 					}
-					svc.logger.InfoContext(ctx, "allowing re-enrollment without end-user authentication: host previously orbit-enrolled",
+					svc.logger.DebugContext(ctx, "allowing re-enrollment without end-user authentication: host previously orbit-enrolled",
 						"host_uuid", hostInfo.HardwareUUID)
 				}
 			}

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -272,15 +272,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 				default:
 					// A host that already exists in Fleet and was previously orbit-enrolled is re-enrolling (e.g. after a
 					// service restart, node key file loss, or osquery DB rebuild), not enrolling for the first time. We must not
-					// prompt for end user authentication again: it would interrupt the user on every restart, and it also
-					// grandfathers hosts that enrolled before end user authentication was enabled (those have no
-					// host_mdm_idp_accounts row). A genuinely new device, or one moved to a different Fleet server (where it
-					// won't be found here), is not matched and is still gated. See https://github.com/fleetdm/fleet/issues/46300.
-					//
-					// Security note: matching by hardware UUID is not a strong identity check, but this does not introduce a new
-					// attack vector. EnrollOrbit already takes over an existing host row on a duplicate-UUID enrollment
-					// regardless of this gate, and hosts that already have an IdP account skip it. Requiring the matched host to
-					// have previously held an orbit node key keeps the exemption to hosts that genuinely enrolled before.
+					// prompt for end user authentication again. See https://github.com/fleetdm/fleet/issues/46300.
 					previouslyEnrolled, err := svc.ds.HostPreviouslyOrbitEnrolled(ctx, hostInfo, appConfig.MDM.EnabledAndConfigured)
 					if err != nil {
 						return "", fleet.OrbitError{Message: "failed to check for prior orbit enrollment: " + err.Error()}
@@ -289,7 +281,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 						// Otherwise report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
 						return "", fleet.NewOrbitIDPAuthRequiredError()
 					}
-					svc.logger.DebugContext(ctx, "allowing re-enrollment without end-user authentication: host previously orbit-enrolled",
+					svc.logger.InfoContext(ctx, "allowing re-enrollment without end-user authentication: host previously orbit-enrolled",
 						"host_uuid", hostInfo.HardwareUUID)
 				}
 			}


### PR DESCRIPTION
Windows and Linux hosts that had already orbit-enrolled were prompted for end user authentication (an SSO browser tab) when fleetd re-enrolled after a service restart, node key file loss, or osquery DB rebuild. Hosts enrolled before EUA was enabled have no host_mdm_idp_accounts row, so the service-layer EUA gate treated every re-enroll like a brand-new device.

Before returning END_USER_AUTH_REQUIRED, EnrollOrbit now checks whether a host matching the enrollment identifiers already exists and previously held an orbit node key (HostPreviouslyOrbitEnrolled, reusing matchHostDuringEnrollment's semantics). If so, the re-enroll proceeds without prompting. Genuinely new devices, and hosts moved to a different Fleet server, are still gated.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46300 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

**Bug Fixes**
* Fixed unnecessary end-user authentication prompts for Windows and Linux hosts during fleetd re-enrollment after a service restart. Previously enrolled devices can now re-enroll without being prompted for SSO authentication, while new devices still require the appropriate authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->