### PR TITLE
filter OS versions platforms

### DIFF
--- a/changes/46322-filter-os-versions-correctly
+++ b/changes/46322-filter-os-versions-correctly
@@ -1,0 +1,1 @@
+* Fixed an issue where more than 8 entries for OS versions would not be paginated.

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
@@ -70,7 +70,12 @@ const CurrentVersionSection = ({
     AxiosError
   >(
     ["os_versions", currentTeamId, queryParams],
-    () => getOSVersions({ teamId: currentTeamId, ...queryParams }),
+    () =>
+      getOSVersions({
+        teamId: currentTeamId,
+        ...queryParams,
+        query: "windows,darwin,ios,ipados", // We only want to show windows mac, ios, ipados versions atm.
+      }),
     {
       retry: false,
       refetchOnWindowFocus: false,
@@ -119,20 +124,10 @@ const CurrentVersionSection = ({
       return <OSVersionsEmptyState />;
     }
 
-    // We only want to show windows mac, ios, ipados versions atm.
-    const filteredOSVersionData = data.os_versions.filter((osVersion) => {
-      return (
-        osVersion.platform === "windows" ||
-        osVersion.platform === "darwin" ||
-        osVersion.platform === "ios" ||
-        osVersion.platform === "ipados"
-      );
-    }) as IFilteredOperatingSystemVersion[];
-
     return (
       <OSVersionTable
         router={router}
-        osVersionData={filteredOSVersionData}
+        osVersionData={data.os_versions as IFilteredOperatingSystemVersion[]}
         currentTeamId={currentTeamId}
         isLoading={isLoadingOsVersions}
         queryParams={queryParams}

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -25,6 +25,7 @@ export interface IGetOSVersionsQueryParams {
   page?: number;
   per_page?: number;
   max_vulnerabilities?: number;
+  query?: string; // filters the platform column
 }
 
 export interface IGetOSVersionsQueryKey extends IGetOSVersionsQueryParams {
@@ -70,6 +71,7 @@ export const getOSVersions = ({
   page,
   per_page,
   max_vulnerabilities = 0,
+  query = "",
 }: IGetOSVersionsQueryParams = {}): Promise<IOSVersionsResponse> => {
   const { OS_VERSIONS } = endpoints;
   let path = OS_VERSIONS;
@@ -84,6 +86,7 @@ export const getOSVersions = ({
     page,
     per_page,
     max_vulnerabilities,
+    query,
   };
 
   const queryString = buildQueryStringFromParams(params);

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -3252,10 +3252,10 @@ func (svc *Service) OSVersions(
 		})
 	}
 
-	// Total count BEFORE pagination
-	count = len(osVersions.OSVersions)
-
 	filtered := filterOSVersions(osVersions.OSVersions, opts)
+
+	// Total count BEFORE pagination but AFTER filtering.
+	count = len(filtered)
 
 	// Paginate first
 	paged, meta := paginateOSVersions(filtered, opts)

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -3255,8 +3255,10 @@ func (svc *Service) OSVersions(
 	// Total count BEFORE pagination
 	count = len(osVersions.OSVersions)
 
+	filtered := filterOSVersions(osVersions.OSVersions, opts)
+
 	// Paginate first
-	paged, meta := paginateOSVersions(osVersions.OSVersions, opts)
+	paged, meta := paginateOSVersions(filtered, opts)
 
 	// Pull vulnerabilities ONLY for the paginated slice, as the full list slows
 	// response times down significantly with many CVEs.
@@ -3299,6 +3301,22 @@ func (svc *Service) OSVersions(
 		CountsUpdatedAt: osVersions.CountsUpdatedAt,
 		OSVersions:      paged,
 	}, count, meta, nil
+}
+
+// filterOSVersions checks the MatchQuery and filters on the platform name.
+// MatchQuery can be a comma-separated list of platform names.
+func filterOSVersions(slice []fleet.OSVersion, opts fleet.ListOptions) []fleet.OSVersion {
+	if opts.MatchQuery == "" {
+		return slice
+	}
+
+	var filtered []fleet.OSVersion
+	for _, osVersion := range slice {
+		if strings.Contains(strings.ToLower(opts.MatchQuery), strings.ToLower(osVersion.Platform)) {
+			filtered = append(filtered, osVersion)
+		}
+	}
+	return filtered
 }
 
 func paginateOSVersions(slice []fleet.OSVersion, opts fleet.ListOptions) ([]fleet.OSVersion, *fleet.PaginationMetadata) {

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -2728,6 +2728,15 @@ func TestOSVersionsListOptions(t *testing.T) {
 	assert.Equal(t, "Ubuntu 21.04", vers.OSVersions[5].NameOnly)
 	assert.Equal(t, now, vers.CountsUpdatedAt)
 
+	// platform filtering
+	opts = fleet.ListOptions{MatchQuery: "darwin"}
+	vers, _, _, err = svc.OSVersions(test.UserContext(ctx, test.UserAdmin), nil, new("darwin"), nil, nil, opts, false, nil)
+	require.NoError(t, err)
+	assert.Len(t, vers.OSVersions, 2)
+	assert.Equal(t, "macOS 12.2", vers.OSVersions[0].NameOnly)
+	assert.Equal(t, "macOS 12.1", vers.OSVersions[1].NameOnly)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
+
 	// pagination
 	opts = fleet.ListOptions{Page: 0, PerPage: 2}
 	vers, _, _, err = svc.OSVersions(test.UserContext(ctx, test.UserAdmin), nil, nil, nil, nil, opts, false, nil)

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -2730,9 +2730,10 @@ func TestOSVersionsListOptions(t *testing.T) {
 
 	// platform filtering
 	opts = fleet.ListOptions{MatchQuery: "darwin"}
-	vers, _, _, err = svc.OSVersions(test.UserContext(ctx, test.UserAdmin), nil, new("darwin"), nil, nil, opts, false, nil)
+	vers, count, _, err := svc.OSVersions(test.UserContext(ctx, test.UserAdmin), nil, new("darwin"), nil, nil, opts, false, nil)
 	require.NoError(t, err)
 	assert.Len(t, vers.OSVersions, 2)
+	assert.Equal(t, 2, count)
 	assert.Equal(t, "macOS 12.2", vers.OSVersions[0].NameOnly)
 	assert.Equal(t, "macOS 12.1", vers.OSVersions[1].NameOnly)
 	assert.Equal(t, now, vers.CountsUpdatedAt)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46322

I'm not sure why, but it already had pagination? I suspect the frontend filtering was breaking it, so I moved the platform filtering to the backend via the `MatchQuery` query param.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pagination for OS version lists containing more than 8 entries.
  * Improved OS version filtering so platform queries are applied consistently before pagination, yielding correct results and counts.
  * Enhanced OS version list coverage with a new test validating platform-specific filtering and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->