### PR TITLE
Fix fleetd keychain error logs during first ABM enrollment

### DIFF
--- a/orbit/changes/41338-fleetd-keychain-error-logs
+++ b/orbit/changes/41338-fleetd-keychain-error-logs
@@ -1,0 +1,1 @@
+- Fixed confusing keychain error logs (`secret cannot be empty` and `failed to retrieve enroll secret from default keychain: %!w(<nil>)`) emitted by fleetd during ABM enrollment of packages built with `--use-system-configuration`. Such packages no longer ship an empty `/opt/orbit/secret.txt`.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -282,6 +282,117 @@ func main() {
 	}
 }
 
+// enrollSecretKeystore abstracts orbit/pkg/keystore so the enroll secret
+// loading logic can be unit tested.
+type enrollSecretKeystore interface {
+	Supported() bool
+	Name() string
+	GetSecret() (string, error)
+	AddSecret(secret string) error
+	UpdateSecret(secret string) error
+}
+
+// realKeystore delegates to the orbit/pkg/keystore package.
+type realKeystore struct{}
+
+func (realKeystore) Supported() bool                  { return keystore.Supported() }
+func (realKeystore) Name() string                     { return keystore.Name() }
+func (realKeystore) GetSecret() (string, error)       { return keystore.GetSecret() }
+func (realKeystore) AddSecret(secret string) error    { return keystore.AddSecret(secret) }
+func (realKeystore) UpdateSecret(secret string) error { return keystore.UpdateSecret(secret) }
+
+// readEnrollSecretFromFile reads the enroll secret from enrollSecretPath. If the
+// secret is found and the keystore is enabled, it writes/overwrites the secret
+// in the keystore and deletes the file. An empty (or missing) secret file is a
+// no-op: there's nothing to load, so the keystore is not touched.
+func readEnrollSecretFromFile(enrollSecretPath string, ks enrollSecretKeystore, disableKeystore bool, setSecret func(string) error) error {
+	b, err := os.ReadFile(enrollSecretPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) || !ks.Supported() || disableKeystore {
+			return fmt.Errorf("read enroll secret file: %w", err)
+		}
+		return nil
+	}
+	secret := strings.TrimSpace(string(b))
+	// An empty secret file means there's nothing to load. Don't set the secret
+	// or attempt to add it to the keystore (otherwise the keystore rejects it
+	// with "secret cannot be empty"). This happens during ABM enrollment of a
+	// package built with --use-system-configuration, before the configuration
+	// profile is available.
+	if secret == "" {
+		return nil
+	}
+	if err = setSecret(secret); err != nil {
+		return fmt.Errorf("set enroll secret from file: %w", err)
+	}
+	if !ks.Supported() || disableKeystore {
+		return nil
+	}
+	// Check if secret is already in the keystore.
+	secretFromKeystore, err := ks.GetSecret()
+	if err != nil { //nolint:gocritic // ignore ifElseChain
+		log.Warn().Err(err).Msgf("failed to retrieve enroll secret from %v", ks.Name())
+	} else if secretFromKeystore == "" {
+		// Keystore secret not found, so we will add it to the keystore.
+		if err = ks.AddSecret(secret); err != nil {
+			log.Warn().Err(err).Msgf("failed to add enroll secret to %v", ks.Name())
+		} else {
+			// Sanity check that the secret was added to the keystore.
+			checkSecret, err := ks.GetSecret()
+			if err != nil { //nolint:gocritic // ignore ifElseChain
+				log.Warn().Err(err).Msgf("failed to check that enroll secret was saved in %v", ks.Name())
+			} else if checkSecret != secret {
+				log.Warn().Msgf("enroll secret was not saved correctly in %v", ks.Name())
+			} else {
+				log.Info().Msgf("added enroll secret to keystore: %v", ks.Name())
+				deleteSecretPathIfExists(enrollSecretPath)
+			}
+		}
+	} else if secretFromKeystore != secret {
+		// Keystore secret found, but needs to be updated.
+		if err = ks.UpdateSecret(secret); err != nil {
+			log.Warn().Err(err).Msgf("failed to update enroll secret in %v", ks.Name())
+		} else {
+			// Sanity check that the secret was updated in the keystore.
+			checkSecret, err := ks.GetSecret()
+			if err != nil { //nolint:gocritic // ignore ifElseChain
+				log.Warn().Err(err).Msgf("failed to check that enroll secret was updated in %v", ks.Name())
+			} else if checkSecret != secret {
+				log.Warn().Msgf("enroll secret was not updated correctly in %v", ks.Name())
+			} else {
+				log.Info().Msgf("updated enroll secret in keystore: %v", ks.Name())
+				deleteSecretPathIfExists(enrollSecretPath)
+			}
+		}
+	} else {
+		// Keystore secret found, and it matches the secret from the file.
+		deleteSecretPathIfExists(enrollSecretPath)
+	}
+	return nil
+}
+
+// tryReadEnrollSecretFromKeystore loads the enroll secret from the keystore via
+// setSecret when one isn't already set and the keystore is enabled. A keystore
+// that holds no secret yet is not an error: there's simply nothing to load.
+func tryReadEnrollSecretFromKeystore(currentSecret string, ks enrollSecretKeystore, disableKeystore bool, setSecret func(string) error) error {
+	if currentSecret != "" || !ks.Supported() || disableKeystore {
+		return nil
+	}
+	secret, err := ks.GetSecret()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve enroll secret from %v: %w", ks.Name(), err)
+	}
+	if secret == "" {
+		// No secret stored in the keystore yet; nothing to load.
+		return nil
+	}
+	log.Info().Msgf("found enroll secret in keystore: %v", ks.Name())
+	if err = setSecret(secret); err != nil {
+		return fmt.Errorf("set enroll secret from keystore: %w", err)
+	}
+	return nil
+}
+
 // orbitAction is a named function so that NilAway can analyze it for nil-safety.
 func orbitAction(c *cli.Context) error {
 	if c.Bool("version") {
@@ -349,87 +460,19 @@ func orbitAction(c *cli.Context) error {
 		return fmt.Errorf("the osquery database must be an absolute path: %q", odb)
 	}
 
-	readEnrollSecretFromFile := func(enrollSecretPath string) error {
-		// Read secret from file. If secret is found and keystore enabled, write/overwrite the secret to the keystore and delete the file.
-		b, err := os.ReadFile(enrollSecretPath)
-		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) || !keystore.Supported() || c.Bool("disable-keystore") {
-				return fmt.Errorf("read enroll secret file: %w", err)
-			}
-		} else {
-			secret := strings.TrimSpace(string(b))
-			if err = c.Set("enroll-secret", secret); err != nil {
-				return fmt.Errorf("set enroll secret from file: %w", err)
-			}
-			if keystore.Supported() && !c.Bool("disable-keystore") {
-				// Check if secret is already in the keystore.
-				secretFromKeystore, err := keystore.GetSecret()
-				if err != nil { //nolint:gocritic // ignore ifElseChain
-					log.Warn().Err(err).Msgf("failed to retrieve enroll secret from %v", keystore.Name())
-				} else if secretFromKeystore == "" {
-					// Keystore secret not found, so we will add it to the keystore.
-					if err = keystore.AddSecret(secret); err != nil {
-						log.Warn().Err(err).Msgf("failed to add enroll secret to %v", keystore.Name())
-					} else {
-						// Sanity check that the secret was added to the keystore.
-						checkSecret, err := keystore.GetSecret()
-						if err != nil { //nolint:gocritic // ignore ifElseChain
-							log.Warn().Err(err).Msgf("failed to check that enroll secret was saved in %v", keystore.Name())
-						} else if checkSecret != secret {
-							log.Warn().Msgf("enroll secret was not saved correctly in %v", keystore.Name())
-						} else {
-							log.Info().Msgf("added enroll secret to keystore: %v", keystore.Name())
-							deleteSecretPathIfExists(enrollSecretPath)
-						}
-					}
-				} else if secretFromKeystore != secret {
-					// Keystore secret found, but needs to be updated.
-					if err = keystore.UpdateSecret(secret); err != nil {
-						log.Warn().Err(err).Msgf("failed to update enroll secret in %v", keystore.Name())
-					} else {
-						// Sanity check that the secret was updated in the keystore.
-						checkSecret, err := keystore.GetSecret()
-						if err != nil { //nolint:gocritic // ignore ifElseChain
-							log.Warn().Err(err).Msgf("failed to check that enroll secret was updated in %v", keystore.Name())
-						} else if checkSecret != secret {
-							log.Warn().Msgf("enroll secret was not updated correctly in %v", keystore.Name())
-						} else {
-							log.Info().Msgf("updated enroll secret in keystore: %v", keystore.Name())
-							deleteSecretPathIfExists(enrollSecretPath)
-						}
-					}
-				} else {
-					// Keystore secret found, and it matches the secret from the file.
-					deleteSecretPathIfExists(enrollSecretPath)
-				}
-			}
-		}
-		return nil
-	}
+	setEnrollSecret := func(secret string) error { return c.Set("enroll-secret", secret) }
+	disableKeystore := c.Bool("disable-keystore")
 	enrollSecretPath := c.String("enroll-secret-path")
 	if enrollSecretPath != "" {
 		if c.String("enroll-secret") != "" {
 			return errors.New("enroll-secret and enroll-secret-path may not be specified together")
 		}
-		if err := readEnrollSecretFromFile(enrollSecretPath); err != nil {
+		if err := readEnrollSecretFromFile(enrollSecretPath, realKeystore{}, disableKeystore, setEnrollSecret); err != nil {
 			return err
 		}
 	}
-	tryReadEnrollSecretFromKeystore := func() error {
-		if c.String("enroll-secret") == "" && keystore.Supported() && !c.Bool("disable-keystore") {
-			secret, err := keystore.GetSecret()
-			if err != nil || secret == "" {
-				return fmt.Errorf("failed to retrieve enroll secret from %v: %w", keystore.Name(), err)
-			}
-			log.Info().Msgf("found enroll secret in keystore: %v", keystore.Name())
-			if err = c.Set("enroll-secret", secret); err != nil {
-				return fmt.Errorf("set enroll secret from keystore: %w", err)
-			}
-		}
-		return nil
-	}
 	if !(runtime.GOOS == "darwin" && c.Bool("use-system-configuration")) {
-		if err := tryReadEnrollSecretFromKeystore(); err != nil {
+		if err := tryReadEnrollSecretFromKeystore(c.String("enroll-secret"), realKeystore{}, disableKeystore, setEnrollSecret); err != nil {
 			return err
 		}
 	}
@@ -495,13 +538,19 @@ func orbitAction(c *cli.Context) error {
 					return fmt.Errorf("set fleet URL from file: %w", err)
 				}
 			}
-			// Now, get enroll secret
-			if err := readEnrollSecretFromFile(path.Join(c.String("root-dir"), constant.OsqueryEnrollSecretFileName)); err != nil {
-				return err
+			// Now, get enroll secret. During initial ABM/profile bootstrap the local
+			// secret file is expected to be absent (it's written once the configuration
+			// profile is read). When the keystore is disabled, readEnrollSecretFromFile
+			// reports a missing file as an error; ignore that here so the loop keeps
+			// polling for the configuration profile instead of exiting.
+			if err := readEnrollSecretFromFile(path.Join(c.String("root-dir"), constant.OsqueryEnrollSecretFileName), realKeystore{}, disableKeystore, setEnrollSecret); err != nil {
+				if !(disableKeystore && errors.Is(err, os.ErrNotExist)) {
+					return err
+				}
 			}
 			// Since the normal enroll secret flow supports keychain, we can use it here as well.
 			// The story to remove the enroll secret from macOS MDM profile is: https://github.com/fleetdm/fleet/issues/16118
-			if err := tryReadEnrollSecretFromKeystore(); err != nil {
+			if err := tryReadEnrollSecretFromKeystore(c.String("enroll-secret"), realKeystore{}, disableKeystore, setEnrollSecret); err != nil {
 				// Log the error but don't return it, as we want to keep trying to read the configuration
 				// from the system profile.
 				log.Error().Err(err).Msg("failed to read enroll secret from keystore")

--- a/orbit/cmd/orbit/orbit_test.go
+++ b/orbit/cmd/orbit/orbit_test.go
@@ -1,12 +1,238 @@
 package main
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeKeystore is a test double for enrollSecretKeystore.
+type fakeKeystore struct {
+	supported bool
+	secret    string
+	getErr    error
+	addErr    error
+	updateErr error
+
+	getCalls    int
+	addCalls    int
+	updateCalls int
+}
+
+func (f *fakeKeystore) Supported() bool { return f.supported }
+func (f *fakeKeystore) Name() string    { return "fake keystore" }
+
+func (f *fakeKeystore) GetSecret() (string, error) {
+	f.getCalls++
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	return f.secret, nil
+}
+
+func (f *fakeKeystore) AddSecret(secret string) error {
+	f.addCalls++
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.secret = secret
+	return nil
+}
+
+func (f *fakeKeystore) UpdateSecret(secret string) error {
+	f.updateCalls++
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	f.secret = secret
+	return nil
+}
+
+func TestReadEnrollSecretFromFile(t *testing.T) {
+	t.Run("empty file does not touch keystore or set the secret", func(t *testing.T) {
+		// Reproduces the --use-system-configuration ABM scenario: an empty
+		// secret.txt must not trigger keystore.AddSecret (which rejects empty
+		// secrets with "secret cannot be empty").
+		path := filepath.Join(t.TempDir(), "secret.txt")
+		require.NoError(t, os.WriteFile(path, []byte("   \n"), 0o600))
+
+		ks := &fakeKeystore{supported: true}
+		var setCalled bool
+		err := readEnrollSecretFromFile(path, ks, false, func(string) error {
+			setCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		require.False(t, setCalled, "enroll secret should not be set from an empty file")
+		require.Zero(t, ks.addCalls, "AddSecret must not be attempted with an empty secret")
+		require.Zero(t, ks.getCalls)
+		require.FileExists(t, path, "empty file should be left untouched")
+	})
+
+	t.Run("empty file does not touch an existing keystore secret", func(t *testing.T) {
+		// With a populated keystore, the old code reached the update branch and
+		// logged a spurious "failed to update enroll secret" warning (UpdateSecret
+		// rejects the empty secret). The early return must skip the keystore
+		// entirely and leave the stored secret intact.
+		path := filepath.Join(t.TempDir(), "secret.txt")
+		require.NoError(t, os.WriteFile(path, []byte("\n  \n"), 0o600))
+
+		ks := &fakeKeystore{supported: true, secret: "existing"}
+		err := readEnrollSecretFromFile(path, ks, false, func(string) error {
+			t.Fatal("setSecret must not be called for an empty file")
+			return nil
+		})
+		require.NoError(t, err)
+		require.Zero(t, ks.getCalls, "keystore must not be queried for an empty file")
+		require.Zero(t, ks.addCalls)
+		require.Zero(t, ks.updateCalls)
+		require.Equal(t, "existing", ks.secret, "existing keystore secret must be preserved")
+	})
+
+	t.Run("missing file is a no-op when keystore is supported", func(t *testing.T) {
+		ks := &fakeKeystore{supported: true}
+		err := readEnrollSecretFromFile(filepath.Join(t.TempDir(), "missing.txt"), ks, false, func(string) error {
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("missing file errors when keystore is unsupported", func(t *testing.T) {
+		ks := &fakeKeystore{supported: false}
+		err := readEnrollSecretFromFile(filepath.Join(t.TempDir(), "missing.txt"), ks, false, func(string) error {
+			return nil
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("missing file errors as ErrNotExist when keystore is disabled", func(t *testing.T) {
+		// The --use-system-configuration loop relies on errors.Is(err, os.ErrNotExist)
+		// matching through the wrap to keep polling when the local secret file is
+		// absent during bootstrap.
+		ks := &fakeKeystore{supported: true}
+		err := readEnrollSecretFromFile(filepath.Join(t.TempDir(), "missing.txt"), ks, true, func(string) error {
+			return nil
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("adds secret to empty keystore and deletes file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "secret.txt")
+		require.NoError(t, os.WriteFile(path, []byte(" mysecret \n"), 0o600))
+
+		ks := &fakeKeystore{supported: true}
+		var got string
+		err := readEnrollSecretFromFile(path, ks, false, func(s string) error {
+			got = s
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "mysecret", got)
+		require.Equal(t, 1, ks.addCalls)
+		require.Equal(t, "mysecret", ks.secret)
+		require.NoFileExists(t, path, "file should be deleted once stored in keystore")
+	})
+
+	t.Run("disabled keystore sets secret but does not store or delete", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "secret.txt")
+		require.NoError(t, os.WriteFile(path, []byte("mysecret"), 0o600))
+
+		ks := &fakeKeystore{supported: true}
+		var got string
+		err := readEnrollSecretFromFile(path, ks, true, func(s string) error {
+			got = s
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "mysecret", got)
+		require.Zero(t, ks.addCalls)
+		require.FileExists(t, path)
+	})
+
+	t.Run("matching keystore secret deletes file without writing", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "secret.txt")
+		require.NoError(t, os.WriteFile(path, []byte("mysecret"), 0o600))
+
+		ks := &fakeKeystore{supported: true, secret: "mysecret"}
+		err := readEnrollSecretFromFile(path, ks, false, func(string) error { return nil })
+		require.NoError(t, err)
+		require.Zero(t, ks.addCalls)
+		require.Zero(t, ks.updateCalls)
+		require.NoFileExists(t, path)
+	})
+
+	t.Run("different keystore secret is updated", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "secret.txt")
+		require.NoError(t, os.WriteFile(path, []byte("newsecret"), 0o600))
+
+		ks := &fakeKeystore{supported: true, secret: "oldsecret"}
+		err := readEnrollSecretFromFile(path, ks, false, func(string) error { return nil })
+		require.NoError(t, err)
+		require.Equal(t, 1, ks.updateCalls)
+		require.Equal(t, "newsecret", ks.secret)
+		require.NoFileExists(t, path)
+	})
+}
+
+func TestTryReadEnrollSecretFromKeystore(t *testing.T) {
+	t.Run("empty keystore is not an error", func(t *testing.T) {
+		// Regression for the malformed `%!w(<nil>)` log: an empty keystore must
+		// return nil (nothing to load), not a wrapped nil error.
+		ks := &fakeKeystore{supported: true, secret: ""}
+		var setCalled bool
+		err := tryReadEnrollSecretFromKeystore("", ks, false, func(string) error {
+			setCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		require.False(t, setCalled)
+	})
+
+	t.Run("propagates keystore read error", func(t *testing.T) {
+		ks := &fakeKeystore{supported: true, getErr: errors.New("boom")}
+		err := tryReadEnrollSecretFromKeystore("", ks, false, func(string) error { return nil })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("loads secret from keystore", func(t *testing.T) {
+		ks := &fakeKeystore{supported: true, secret: "fromkeystore"}
+		var got string
+		err := tryReadEnrollSecretFromKeystore("", ks, false, func(s string) error {
+			got = s
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "fromkeystore", got)
+	})
+
+	t.Run("no-op when secret already set", func(t *testing.T) {
+		ks := &fakeKeystore{supported: true, secret: "fromkeystore"}
+		err := tryReadEnrollSecretFromKeystore("already-set", ks, false, func(string) error { return nil })
+		require.NoError(t, err)
+		require.Zero(t, ks.getCalls)
+	})
+
+	t.Run("no-op when keystore unsupported", func(t *testing.T) {
+		ks := &fakeKeystore{supported: false}
+		err := tryReadEnrollSecretFromKeystore("", ks, false, func(string) error { return nil })
+		require.NoError(t, err)
+		require.Zero(t, ks.getCalls)
+	})
+
+	t.Run("no-op when keystore disabled", func(t *testing.T) {
+		ks := &fakeKeystore{supported: true, secret: "fromkeystore"}
+		err := tryReadEnrollSecretFromKeystore("", ks, true, func(string) error { return nil })
+		require.NoError(t, err)
+		require.Zero(t, ks.getCalls)
+	})
+}
 
 func TestCfgsDiffer(t *testing.T) {
 	for _, tc := range []struct {

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -106,7 +106,7 @@ func BuildPkg(opt Options) (string, error) {
 	if err := writeScripts(opt, tmpDir); err != nil {
 		return "", fmt.Errorf("write postinstall: %w", err)
 	}
-	if err := writeSecret(opt, orbitRoot); err != nil {
+	if err := writeMacOSSecret(opt, orbitRoot); err != nil {
 		return "", fmt.Errorf("write enroll secret: %w", err)
 	}
 	if err := writeOsqueryFlagfile(opt, orbitRoot); err != nil {

--- a/orbit/pkg/packaging/macos_test.go
+++ b/orbit/pkg/packaging/macos_test.go
@@ -1,0 +1,30 @@
+package packaging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteMacOSSecret(t *testing.T) {
+	t.Run("skips writing when enroll secret is empty", func(t *testing.T) {
+		// With --use-system-configuration the enroll secret is empty and is
+		// resolved at runtime; writing an empty secret.txt produces confusing
+		// keystore errors during ABM enrollment.
+		orbitRoot := t.TempDir()
+		require.NoError(t, writeMacOSSecret(Options{EnrollSecret: ""}, orbitRoot))
+		require.NoFileExists(t, filepath.Join(orbitRoot, constant.OsqueryEnrollSecretFileName))
+	})
+
+	t.Run("writes the secret when present", func(t *testing.T) {
+		orbitRoot := t.TempDir()
+		require.NoError(t, writeMacOSSecret(Options{EnrollSecret: "mysecret"}, orbitRoot))
+		path := filepath.Join(orbitRoot, constant.OsqueryEnrollSecretFileName)
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, "mysecret", string(contents))
+	})
+}

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -346,6 +346,18 @@ func writeSecret(opt Options, orbitRoot string) error {
 	return nil
 }
 
+// writeMacOSSecret writes the enroll secret file unless the secret is empty.
+// An empty secret happens with --use-system-configuration, where the secret is
+// resolved at runtime from a configuration profile or the keystore. Writing an
+// empty secret.txt causes it to be read on the device as an empty enroll secret,
+// producing confusing keystore errors during ABM enrollment.
+func writeMacOSSecret(opt Options, orbitRoot string) error {
+	if opt.EnrollSecret == "" {
+		return nil
+	}
+	return writeSecret(opt, orbitRoot)
+}
+
 func writeOsqueryFlagfile(opt Options, orbitRoot string) error {
 	path := filepath.Join(orbitRoot, "osquery.flags")
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41338

A fleetd-base.pkg built with `fleetctl package --use-system-configuration` shipped an empty /opt/orbit/secret.txt. During ABM enrollment, before the configuration profile was available, orbit read that empty file as an empty enroll secret, producing confusing logs.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed confusing fleetd keychain error messages during ABM enrollment when building packages with `--use-system-configuration`.
  * Ensured empty enrollment secret files are no longer produced and no longer trigger misleading messages.

* **New Features**
  * Improved enroll-secret loading behavior by correctly handling whitespace-only/missing secrets and keystore-enabled scenarios.

* **Tests**
  * Added comprehensive test coverage for enrollment secret handling, keystore operations, and macOS enroll secret writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->