### PR TITLE
Fix self-service update button flashing

### DIFF
--- a/changes/44645-self-service-update-button
+++ b/changes/44645-self-service-update-button
@@ -1,0 +1,1 @@
+- Fixed the **My device > Self-service** page briefly showing the "Update" button again on apps that had just finished updating, instead of holding the "Updated" state while the software inventory refreshes.

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -1,14 +1,23 @@
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen, within, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
 
 import { noop } from "lodash";
-import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import {
+  createCustomRenderer,
+  createMockRouter,
+  baseUrl,
+} from "test/test-utils";
 import mockServer from "test/mock-server";
 import { customDeviceSoftwareHandler } from "test/handlers/device-handler";
-import { createMockDeviceSoftware } from "__mocks__/deviceUserMock";
+import {
+  createMockDeviceSoftware,
+  createMockDeviceSoftwareResponse,
+} from "__mocks__/deviceUserMock";
 import {
   DEFAULT_INSTALLED_VERSION,
   DEFAULT_HOST_HOSTNAME,
+  createMockHostSoftwarePackage,
 } from "__mocks__/hostMock";
 
 import SelfService, { ISoftwareSelfServiceProps } from "./SelfService";
@@ -304,6 +313,104 @@ describe("SelfService", () => {
     expect(await screen.findByText("user-enrolled-app")).toBeInTheDocument();
     expect(
       screen.queryByText(/Self-service isn't supported/i)
+    ).not.toBeInTheDocument();
+  });
+
+  // After a (bulk) update finishes, the host-details refetch surfaces the app as
+  // installed while its software inventory is still stale (installer version is
+  // still newer than installed_versions). The "Updated" state should hold
+  // throughout that refetch window — the "Update" button must not reappear.
+  it("keeps the 'Updated' state (not the 'Update' button) while inventory refetch is pending after an update", async () => {
+    const LAST_INSTALL_AT = "2022-01-01T12:00:00Z";
+    // Host software inventory timestamp is newer than the last install, so the
+    // stale-inventory app would otherwise resolve to "update_available".
+    const HOST_SOFTWARE_UPDATED_AT = "2022-06-01T12:00:00Z";
+
+    const makeUpdatableSoftware = (status: "installed" | "pending_install") =>
+      createMockDeviceSoftware({
+        id: 1,
+        name: "test-update",
+        status,
+        // Installed version (1.0.0) is older than the packaged installer (2.0.0).
+        installed_versions: [
+          { ...DEFAULT_INSTALLED_VERSION, version: "1.0.0" },
+        ],
+        software_package: createMockHostSoftwarePackage({
+          version: "2.0.0",
+          last_install: {
+            install_uuid: "abc-123",
+            installed_at: LAST_INSTALL_AT,
+          },
+        }),
+      });
+
+    const softwareByPhase = {
+      available: makeUpdatableSoftware("installed"),
+      pending: makeUpdatableSoftware("pending_install"),
+      // Update finished, but inventory still reports the old version.
+      completed: makeUpdatableSoftware("installed"),
+    };
+    let phase: keyof typeof softwareByPhase = "available";
+
+    mockServer.use(
+      http.get(baseUrl("/device/:token/software"), () =>
+        HttpResponse.json(
+          createMockDeviceSoftwareResponse({
+            software: [softwareByPhase[phase]],
+            count: 1,
+          })
+        )
+      ),
+      http.post(baseUrl("/device/:token/software/install/:id"), () =>
+        HttpResponse.json({})
+      )
+    );
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { user, rerender } = render(
+      <SelfService
+        {...TEST_PROPS}
+        hostSoftwareUpdatedAt={HOST_SOFTWARE_UPDATED_AT}
+      />
+    );
+
+    // Initial state: an update is available, so the Updates card shows "Update".
+    const getUpdatesCard = () =>
+      screen.getByText("Updates").closest(".updates-card") as HTMLElement;
+    await screen.findByText("Updates");
+    expect(
+      within(getUpdatesCard()).getByRole("button", { name: /^Update$/ })
+    ).toBeEnabled();
+
+    // User triggers the update; the dedicated poll observes it go pending.
+    phase = "pending";
+    await user.click(screen.getByRole("button", { name: "Update all" }));
+    await within(getUpdatesCard()).findByText(/Updating/);
+
+    // Host-details polling completes (the automatic refetch in the bug report),
+    // which refetches self-service data and surfaces the completed-but-stale app.
+    phase = "completed";
+    rerender(
+      <SelfService
+        {...TEST_PROPS}
+        hostSoftwareUpdatedAt={HOST_SOFTWARE_UPDATED_AT}
+        isHostDetailsPolling
+      />
+    );
+    rerender(
+      <SelfService
+        {...TEST_PROPS}
+        hostSoftwareUpdatedAt={HOST_SOFTWARE_UPDATED_AT}
+        isHostDetailsPolling={false}
+      />
+    );
+
+    // The card must show "Updated" and must NOT fall back to an "Update" button.
+    await waitFor(() => {
+      expect(within(getUpdatesCard()).getByText("Updated")).toBeInTheDocument();
+    });
+    expect(
+      within(getUpdatesCard()).queryByRole("button", { name: /^Update$/ })
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -157,6 +157,14 @@ const SoftwareSelfService = ({
   const recentlyUpdatedTimeouts = useRef<{ [key: number]: NodeJS.Timeout }>({});
   /** Stores the set of pending install/uninstall software IDs for polling */
   const pendingSoftwareIdsRef = useRef<Set<string>>(new Set());
+  /**
+   * Tracks the set of pending IDs observed on the previous `selfServiceData`
+   * snapshot, independent of the polling query. Lets us promote a user-initiated
+   * action to "recently updated" the moment ANY data path (main query,
+   * host-details refetch) surfaces its completion, not only the dedicated poll —
+   * otherwise the "Update" button briefly reappears during the refetch.
+   */
+  const lastObservedPendingIdsRef = useRef<Set<string>>(new Set());
   /** Stores polling timeout for regularly checking API */
   const pollingTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
   /** Detects parent/host polling completion status to trigger self-update sync */
@@ -249,6 +257,48 @@ const SoftwareSelfService = ({
       ),
     }));
   }, [selfServiceData, recentlyUpdatedSoftwareIds, hostSoftwareUpdatedAt]);
+
+  // Promote completed user-initiated actions to "recently updated" on every
+  // `selfServiceData` change, regardless of which path produced it (main query,
+  // host-details refetch, or the pending poll). This guarantees the flag is set
+  // in the same render that first surfaces a completed-but-inventory-stale app,
+  // so its card never falls back to the "Update" button mid-refetch.
+  useEffect(() => {
+    if (!selfServiceData) return;
+
+    const currentlyPendingIds = new Set(
+      selfServiceData.software
+        .filter(
+          (software) =>
+            software.status === "pending_install" ||
+            software.status === "pending_uninstall"
+        )
+        .map((software) => String(software.id))
+    );
+
+    // IDs we previously saw as pending that are no longer pending → completed.
+    const completedAppIds = [...lastObservedPendingIdsRef.current].filter(
+      (id) => !currentlyPendingIds.has(id)
+    );
+
+    if (completedAppIds.length > 0) {
+      setRecentlyUpdatedSoftwareIds((prev) => {
+        const next = new Set(prev);
+        completedAppIds.forEach((idStr) => {
+          const id = Number(idStr);
+          if (userActionIdsRef.current.has(id)) {
+            next.add(id);
+            userActionIdsRef.current.delete(id);
+            // (Re)arm the 2-minute expiry timeout for the "recently updated" badge.
+            registerUserSoftwareAction(id);
+          }
+        });
+        return next;
+      });
+    }
+
+    lastObservedPendingIdsRef.current = currentlyPendingIds;
+  }, [selfServiceData, registerUserSoftwareAction]);
 
   const selectedSoftwareForUninstall = useRef<{
     softwareId: number;

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -224,9 +224,8 @@ const SoftwareSelfService = ({
     };
   }, []);
 
-  /** Registers a software ID as user-initiated action */
-  const registerUserSoftwareAction = useCallback((id: number) => {
-    userActionIdsRef.current.add(id);
+  /** (Re)arms the timeout that clears a software ID's "recently updated" badge. */
+  const scheduleRecentlyUpdatedExpiry = useCallback((id: number) => {
     // Prevent double timeouts
     if (recentlyUpdatedTimeouts.current[id]) {
       clearTimeout(recentlyUpdatedTimeouts.current[id]);
@@ -244,6 +243,15 @@ const SoftwareSelfService = ({
       delete recentlyUpdatedTimeouts.current[id];
     }, 120000); // 2 minutes
   }, []);
+
+  /** Registers a software ID as a user-initiated action and arms its expiry. */
+  const registerUserSoftwareAction = useCallback(
+    (id: number) => {
+      userActionIdsRef.current.add(id);
+      scheduleRecentlyUpdatedExpiry(id);
+    },
+    [scheduleRecentlyUpdatedExpiry]
+  );
 
   const enhancedSoftware: IDeviceSoftwareWithUiStatus[] = useMemo(() => {
     if (!selfServiceData) return [];
@@ -288,9 +296,11 @@ const SoftwareSelfService = ({
           const id = Number(idStr);
           if (userActionIdsRef.current.has(id)) {
             next.add(id);
+            // Consume the user-action flag so a later non-user-initiated
+            // completion for the same app isn't misclassified as recently updated.
             userActionIdsRef.current.delete(id);
             // (Re)arm the 2-minute expiry timeout for the "recently updated" badge.
-            registerUserSoftwareAction(id);
+            scheduleRecentlyUpdatedExpiry(id);
           }
         });
         return next;
@@ -298,7 +308,7 @@ const SoftwareSelfService = ({
     }
 
     lastObservedPendingIdsRef.current = currentlyPendingIds;
-  }, [selfServiceData, registerUserSoftwareAction]);
+  }, [selfServiceData, scheduleRecentlyUpdatedExpiry]);
 
   const selectedSoftwareForUninstall = useRef<{
     softwareId: number;
@@ -392,9 +402,11 @@ const SoftwareSelfService = ({
               const id = Number(idStr);
               if (userActionIdsRef.current.has(id)) {
                 next.add(id);
+                // Consume the user-action flag so a later non-user-initiated
+                // completion for the same app isn't misclassified as recently updated.
                 userActionIdsRef.current.delete(id);
-                // Register a timeout for this id (for cleanup and removal)
-                registerUserSoftwareAction(id);
+                // Re-arm the expiry timeout for the "recently updated" badge.
+                scheduleRecentlyUpdatedExpiry(id);
               }
             });
             return next;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44645

# Summary

On the My device > Self-service page, apps that just finished updating briefly flashed the "Update" button again during the inventory refetch. The "recently updated" flag was only set by the pending-poll, so other refetch paths could surface a completed-but-stale app before it was flagged. Now a `selfServiceData`-keyed effect flags completed user actions on every data change, so the card holds "Updated" through the refetch instead of reverting.

  # Checklist for submitter

  - [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or
  `ee/fleetd-chrome/changes`. See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/c9a6ee13-c1f9-4ba0-a704-a578552a5dcd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue on the **My device > Self-service** page where the **“Update”** button could briefly reappear after app updates, even though the card should remain in the **“Updated”** state until the software inventory refresh completes.
* **Tests**
  * Added coverage to ensure the **“Updated”** UI state persists while inventory refetch is pending, and that the **“Update”** button does not render during that window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->