### PR TITLE
For R.C. - Fleet UI: Empty state full-width fix, self-service row truncation (#47746)

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -99,6 +99,14 @@ Render software title names via `getDisplayedSoftwareName(name, display_name)` f
 - Style files use underscore prefix: `_styles.scss`
 - Prefer `gap` over `margin` for spacing between sibling elements when the parent is `display: flex`/`grid`. Use the layout mixins from `frontend/styles/var/mixins.scss`: `vertical-card-layout`, `vertical-form-layout`, `vertical-modal-layout`, `vertical-page-layout`, `vertical-page-tab-panel-layout`, `vertical-data-set-layout`
 
+## Lists & rows
+User-typed free-text fields (`name`, `title`, `label`, `description`) inside an `UploadList` `ListItemComponent`, a `__row` flex container with sibling actions/badges, or a `TableContainer` open-text cell — wrap the value in `<TooltipTruncatedText value={...} />` and give the immediate parent `flex: 1; min-width: 0`.
+
+Anti-pattern:
+```tsx
+<span className={`${baseClass}__row-name`}>{item.name}</span>
+```
+
 ## Interfaces & Types
 - Interface files live in `frontend/interfaces/` with `I` prefix: `IHost`, `IUser`, `IPack`
 - Legacy pattern: some files export both PropTypes (default export) and TypeScript interfaces (named export)

--- a/frontend/components/EmptyState/_styles.scss
+++ b/frontend/components/EmptyState/_styles.scss
@@ -14,6 +14,13 @@ $ghost-cell-padding-x: $pad-large; // 24px, matches Figma
 
 .empty-state {
   position: relative;
+  // Span the full width of the parent regardless of its align-items setting.
+  // Without this, parents using `align-items: flex-start` (or any non-stretch
+  // value) collapse the empty state to its intrinsic content width — see #46370.
+  // box-sizing: border-box so width: 100% + the 1px border doesn't overflow
+  // the parent by 2px in content-box mode (Fleet has no global box-sizing reset).
+  box-sizing: border-box;
+  width: 100%;
   border: 1px solid $ui-fleet-black-10;
   border-radius: 8px;
   overflow: hidden;

--- a/frontend/components/UploadList/UploadList.tsx
+++ b/frontend/components/UploadList/UploadList.tsx
@@ -10,6 +10,9 @@ interface IUploadListProps<T = any> {
   keyAttribute?: keyof T;
   listItems: T[];
   HeadingComponent?: (props: any) => JSX.Element;
+  /** If the row renders user-typed text (name/title/label/description),
+   * wrap it in <TooltipTruncatedText /> with `flex: 1; min-width: 0` on the
+   * container — see "Lists & rows" in .claude/rules/fleet-frontend.md. */
   ListItemComponent: (props: { listItem: T }) => JSX.Element;
   className?: string;
 }

--- a/frontend/components/UploadList/_styles.scss
+++ b/frontend/components/UploadList/_styles.scss
@@ -1,12 +1,14 @@
 .upload-list {
   border: 1px solid $ui-fleet-black-10;
-  border-radius: 4px;
+  border-radius: $border-radius;
 
   &__header {
     padding: $pad-medium $pad-large;
     font-size: $x-small;
     border-bottom: 1px solid $ui-fleet-black-10;
     background-color: $ui-off-white;
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
   }
 
   &__list {

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -23,6 +23,7 @@ import PageDescription from "components/PageDescription";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import Spinner from "components/Spinner";
 import TeamsDropdown from "components/TeamsDropdown";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 import UploadList from "components/UploadList";
 
 import AddCategoryModal from "./AddCategoryModal";
@@ -228,7 +229,9 @@ const SelfServiceCategoriesPage = ({
         )}
         ListItemComponent={({ listItem }) => (
           <div className={`${baseClass}__row`}>
-            <span className={`${baseClass}__row-name`}>{listItem.name}</span>
+            <div className={`${baseClass}__row-name`}>
+              <TooltipTruncatedText value={listItem.name} />
+            </div>
             {canManage && (
               <div className={`${baseClass}__row-actions`}>
                 <Button

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
@@ -52,6 +52,11 @@
   }
 
   &__row-name {
+    // flex: 1 + min-width: 0 lets the child TooltipTruncatedText shrink and
+    // ellipsize. Without min-width: 0, flex items refuse to go below their
+    // content's intrinsic size, defeating overflow: hidden.
+    flex: 1;
+    min-width: 0;
     font-size: $x-small;
     color: $core-fleet-black;
   }


### PR DESCRIPTION
## Issue
Closes #47724
Closes #47720

## Description
- Previously merged into `main` with #47746
- This is for the 4.87.0 R.C.