### PR TITLE
Fleet UI: Self-service — install all 'Recently installed' badge, deletion ID leak, update button flash

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -560,6 +560,15 @@ const SoftwareSelfService = ({
     [deviceToken, registerUserSoftwareAction, onInstallOrUninstall, renderFlash]
   );
 
+  // install_all's response doesn't carry per-app IDs, so snapshot them at click
+  // time to keep the "Recently installed" badge through the refetch window.
+  const onInstallAllSubmit = useCallback(
+    (ids: number[]) => {
+      ids.forEach((id) => registerUserSoftwareAction(id));
+    },
+    [registerUserSoftwareAction]
+  );
+
   const onClickUpdateAll = useCallback(async () => {
     const updateAvailableSoftware = enhancedSoftware.filter(
       (software) =>
@@ -747,6 +756,7 @@ const SoftwareSelfService = ({
         pathname={pathname}
         isMobileView={isMobileView}
         onClickInstallAction={onClickInstallAction}
+        onInstallAllSubmit={onInstallAllSubmit}
         onInstallAllSuccess={onInstallOrUninstall}
       />
     );
@@ -775,6 +785,7 @@ const SoftwareSelfService = ({
         router={router}
         pathname={pathname}
         onClickInstallAction={onClickInstallAction}
+        onInstallAllSubmit={onInstallAllSubmit}
         onInstallAllSuccess={onInstallOrUninstall}
       />
       {showUninstallSoftwareModal && selectedSoftwareForUninstall.current && (

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -23,6 +23,7 @@ import SelfServiceTiles from "../components/SelfServiceTiles";
 import {
   countUninstalledForInstallAll,
   filterSoftwareByCustomCategory,
+  getEligibleInstallAllIds,
   hasInProgressInstallAllItems,
 } from "../helpers";
 
@@ -52,6 +53,9 @@ export interface ISelfServiceCardProps {
   pathname: string;
   isMobileView?: boolean;
   onClickInstallAction: (softwareId: number, isScriptPackage?: boolean) => void;
+  /** Fires at click time with the eligible IDs so the parent can track the
+   * "Recently installed" badge — install_all's response doesn't carry them. */
+  onInstallAllSubmit?: (ids: number[]) => void;
   onInstallAllSuccess?: () => void;
 }
 
@@ -70,6 +74,7 @@ const SelfServiceCard = ({
   pathname,
   isMobileView,
   onClickInstallAction,
+  onInstallAllSubmit,
   onInstallAllSuccess,
 }: ISelfServiceCardProps) => {
   const initialSortHeader = queryParams.order_key || "name";
@@ -244,6 +249,11 @@ const SelfServiceCard = ({
       hasInProgressInCategory={hasInProgress}
       deviceToken={deviceToken}
       categoryId={queryParams.category_id}
+      onSubmit={() =>
+        onInstallAllSubmit?.(
+          getEligibleInstallAllIds(softwareInSelectedCategory)
+        )
+      }
       onSuccess={() => onInstallAllSuccess?.()}
     />
   ) : null;

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
@@ -21,6 +21,9 @@ export interface IInstallAllInCategoryButtonProps {
    * — the service omits the `category_id` query param and the BE installs
    * every uninstalled item the device user is entitled to. */
   categoryId?: number;
+  /** Fires synchronously before the install_all request so the parent can
+   * snapshot eligible IDs (powers the "Recently installed" badge). */
+  onSubmit?: () => void;
   /** Called after the install_all request resolves successfully. */
   onSuccess: () => void;
 }
@@ -30,6 +33,7 @@ const InstallAllInCategoryButton = ({
   hasInProgressInCategory,
   deviceToken,
   categoryId,
+  onSubmit,
   onSuccess,
 }: IInstallAllInCategoryButtonProps) => {
   const { renderFlash } = useContext(NotificationContext);
@@ -38,6 +42,7 @@ const InstallAllInCategoryButton = ({
 
   const handleConfirm = useCallback(async () => {
     setIsSubmitting(true);
+    onSubmit?.();
     try {
       await deviceUserAPI.installAllSelfServiceSoftwareInCategory(
         deviceToken,
@@ -50,7 +55,7 @@ const InstallAllInCategoryButton = ({
     } finally {
       setIsSubmitting(false);
     }
-  }, [deviceToken, categoryId, onSuccess, renderFlash]);
+  }, [deviceToken, categoryId, onSubmit, onSuccess, renderFlash]);
 
   const isDisabled = hasInProgressInCategory || uninstalledCount === 0;
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
@@ -96,6 +96,15 @@ export const countUninstalledForInstallAll = (
     (item) => !INSTALLED_OR_IN_FLIGHT_UI_STATUSES.has(item.ui_status)
   ).length;
 
+/** IDs of items eligible to be queued by install_all (mirrors
+ * `countUninstalledForInstallAll`). */
+export const getEligibleInstallAllIds = (
+  software: IDeviceSoftwareWithUiStatus[]
+): number[] =>
+  software
+    .filter((item) => !INSTALLED_OR_IN_FLIGHT_UI_STATUSES.has(item.ui_status))
+    .map((item) => item.id);
+
 /** True if any item in the list is currently in-progress (install_all should
  * be disabled until they all leave that state). */
 export const hasInProgressInstallAllItems = (


### PR DESCRIPTION
## Issue
Closes #47773

## Description
- Bug fix (root cause): `installAllSelfServiceSoftwareInCategory`'s response doesn't carry per-app IDs (the BE derives them from `category_id`), so the FE had no payload to flag for the "Recently installed" tracker and the badge fell through immediately. Snapshot eligible IDs at click time via a new `getEligibleInstallAllIds` helper and register each via `registerUserSoftwareAction` so the badge holds through the inventory-refetch window.

## Screenrecording
- Install all in a category → "Recently installed" badge holds across the refetch window



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually