### PR TITLE
For R.C: Prevent in-flight carves from being wrongly expired by S3 cleanup

### DIFF
--- a/server/datastore/s3/carves.go
+++ b/server/datastore/s3/carves.go
@@ -156,6 +156,14 @@ func (c *CarveStore) CleanupCarves(ctx context.Context, now time.Time) (int, err
 	cleanCount := 0
 	var retErr error
 	for _, carve := range nonExpiredCarves {
+		// A carve whose multipart upload has not completed yet has no listable
+		// object in S3 (ListObjectsV2 does not return in-progress multipart
+		// uploads), so skip it to avoid expiring a carve that is still
+		// uploading. Such a carve would otherwise become permanently
+		// undownloadable.
+		if !carve.BlocksComplete() {
+			continue
+		}
 		if _, ok := carveKeys[c.generateS3Key(carve)]; !ok {
 			carve.Expired = true
 			if uerr := c.UpdateCarve(ctx, carve); uerr != nil {

--- a/server/datastore/s3/carves_test.go
+++ b/server/datastore/s3/carves_test.go
@@ -69,11 +69,11 @@ func TestCleanupCarvesMarksS3AbsentCarvesExpired(t *testing.T) {
 	const bucket = "carves-cleanup-test"
 	const prefix = "carvetest/"
 
-	// Two carves ordered by created_at ascending (matching the OrderKey fix).
+	// Two carves whose uploads have completed (MaxBlock == BlockCount-1).
 	// carve1 will have a corresponding S3 object; carve2 will not.
 	baseTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
-	carve1 := &fleet.CarveMetadata{ID: 1, Name: "session-with-s3", CreatedAt: baseTime}
-	carve2 := &fleet.CarveMetadata{ID: 2, Name: "session-without-s3", CreatedAt: baseTime.Add(30 * time.Minute)}
+	carve1 := &fleet.CarveMetadata{ID: 1, Name: "session-with-s3", CreatedAt: baseTime, BlockCount: 1, MaxBlock: 0}
+	carve2 := &fleet.CarveMetadata{ID: 2, Name: "session-without-s3", CreatedAt: baseTime.Add(30 * time.Minute), BlockCount: 1, MaxBlock: 0}
 
 	stub := &stubCarveMetadataStore{carves: []*fleet.CarveMetadata{carve1, carve2}}
 
@@ -111,4 +111,54 @@ func TestCleanupCarvesMarksS3AbsentCarvesExpired(t *testing.T) {
 
 	require.False(t, carve1.Expired, "carve1 has an S3 object and must not be marked expired")
 	require.True(t, carve2.Expired, "carve2 has no S3 object and must be marked expired")
+}
+
+// TestCleanupCarvesSkipsInFlightCarves verifies that carves whose multipart
+// upload has not yet completed are not marked expired. An in-flight carve has
+// no completed S3 object yet (ListObjectsV2 does not return in-progress
+// multipart uploads), so without a completion guard it would be wrongly
+// expired and become permanently undownloadable.
+//
+// Requires a running S3-compatible endpoint (set S3_STORAGE_TEST env var).
+func TestCleanupCarvesSkipsInFlightCarves(t *testing.T) {
+	checkTestEnv(t)
+	ctx := t.Context()
+
+	const bucket = "carves-inflight-test"
+	const prefix = "carvetest/"
+
+	baseTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	// completed: upload finished (MaxBlock == BlockCount-1), object absent from S3.
+	completed := &fleet.CarveMetadata{ID: 1, Name: "completed-absent", CreatedAt: baseTime, BlockCount: 1, MaxBlock: 0}
+	// inFlight: upload still in progress (MaxBlock < BlockCount-1), object not yet listable.
+	inFlight := &fleet.CarveMetadata{ID: 2, Name: "in-flight", CreatedAt: baseTime.Add(30 * time.Minute), BlockCount: 3, MaxBlock: 0}
+
+	stub := &stubCarveMetadataStore{carves: []*fleet.CarveMetadata{completed, inFlight}}
+
+	store, err := NewCarveStore(config.S3Config{
+		CarvesBucket:           bucket,
+		CarvesPrefix:           prefix,
+		CarvesRegion:           "localhost",
+		CarvesEndpointURL:      testEndpoint,
+		CarvesAccessKeyID:      testAccessKeyID,
+		CarvesSecretAccessKey:  testSecretAccessKey,
+		CarvesForceS3PathStyle: true,
+		CarvesDisableSSL:       true,
+	}, stub)
+	require.NoError(t, err)
+
+	require.NoError(t, store.CreateTestBucket(ctx, bucket))
+	t.Cleanup(func() {
+		if err := store.CleanupTestBucket(context.Background()); err != nil {
+			t.Errorf("cleanup s3 bucket %q: %v", bucket, err)
+		}
+	})
+
+	// Neither carve has a completed object in S3.
+	cleaned, err := store.CleanupCarves(ctx, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 1, cleaned, "only the completed carve absent from S3 should be expired")
+
+	require.True(t, completed.Expired, "completed carve absent from S3 must be marked expired")
+	require.False(t, inFlight.Expired, "in-flight carve must not be marked expired")
 }


### PR DESCRIPTION
Cherrypick: https://github.com/fleetdm/fleet/pull/47741