### PR TITLE
Self-service categories: bug fixes on empty state, fleet-free layout, dropped fleet_id

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -66,6 +66,7 @@ Use the `useTeamIdParam` hook for team-scoped pages:
 Use react-router, not `window.location` / `window.history`. Direct window mutation desyncs react-router's location state.
 - Read query params from `location.query`, not `URLSearchParams(window.location.search)`.
 - Mutate the URL with `router.replace`/`router.push` or `browserHistory.replace`/`.push`, not `window.history.replaceState`.
+- Internal `<CustomLink>` (and any `router.push` / `<Link>`) to a fleet-scoped route MUST preserve the current fleet via `getPathWithQueryParams(PATHS.X, { fleet_id: teamId })`. Linking to the bare path drops fleet context and lands the user on the wrong fleet. Applies to any path that reads `fleet_id` from the query string (most `/software`, `/hosts`, `/policies`, `/queries`, `/controls` routes). `getPathWithQueryParams` filters undefined/null, so pass `teamId` directly — `fleet_id=0` (No team) is a valid, intentional value and must be preserved.
 
 ## Notifications
 - Use `renderFlash(alertType, message)` from `NotificationContext`

--- a/changes/47712-self-service-categories-empty-array
+++ b/changes/47712-self-service-categories-empty-array
@@ -1,1 +1,0 @@
-* Fixed self-service Categories picker showing an error instead of the empty state when editing software on a team with zero categories. `GET /api/latest/fleet/software/self_service_categories` now returns `[]` rather than `null` for teams with no categories.

--- a/changes/47712-self-service-categories-empty-array
+++ b/changes/47712-self-service-categories-empty-array
@@ -1,0 +1,1 @@
+* Fixed self-service Categories picker showing an error instead of the empty state when editing software on a team with zero categories. `GET /api/latest/fleet/software/self_service_categories` now returns `[]` rather than `null` for teams with no categories.

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
@@ -77,10 +77,18 @@ describe("SelfServiceCategoriesPage", () => {
       },
     });
 
-    render(<SelfServiceCategoriesPage {...baseProps} />);
+    const { container } = render(<SelfServiceCategoriesPage {...baseProps} />);
 
     expect(
       screen.getByText("This feature is included in Fleet Premium.")
+    ).toBeInTheDocument();
+    // Fleet Free has no concept of teams — the dropdown must be hidden, and
+    // a static page title takes its place.
+    expect(
+      container.querySelector(".team-dropdown-wrapper")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Self-service categories" })
     ).toBeInTheDocument();
   });
 

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -142,7 +142,7 @@ const SelfServiceCategoriesPage = ({
   const renderHeader = () => (
     <>
       <BackButton text="Back to software library" path={backToLibraryPath} />
-      {!isPrimoMode && (
+      {isPremiumTier && !isPrimoMode ? (
         <div className={`${baseClass}__fleet-row`}>
           <TeamsDropdown
             currentUserTeams={userTeams ?? []}
@@ -152,6 +152,8 @@ const SelfServiceCategoriesPage = ({
             includeNoTeams
           />
         </div>
+      ) : (
+        <h1>Self-service categories</h1>
       )}
       <PageDescription
         content={

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
@@ -11,6 +11,7 @@
   }
 
   &__premium-card {
+    align-self: stretch;
     background-color: $ui-off-white;
     border: 1px solid $ui-fleet-black-10;
     border-radius: $border-radius;

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -119,8 +119,23 @@ describe("SoftwareOptionsSelector", () => {
       renderComponent(selfServiceEditingProps);
 
       const link = await screen.findByRole("link", { name: /add category/i });
-      expect(link).toHaveAttribute("href", "/software/library/categories");
+      expect(link).toHaveAttribute(
+        "href",
+        "/software/library/categories?fleet_id=1"
+      );
       expect(screen.getByText("to assign software to it.")).toBeInTheDocument();
+    });
+
+    it("includes fleet_id=0 in the Add category link when on no team", async () => {
+      mockServer.use(emptySelfServiceCategoriesHandler);
+
+      renderComponent({ ...selfServiceEditingProps, teamId: 0 });
+
+      const link = await screen.findByRole("link", { name: /add category/i });
+      expect(link).toHaveAttribute(
+        "href",
+        "/software/library/categories?fleet_id=0"
+      );
     });
 
     it("does not render the empty state while categories are loading", () => {

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -9,6 +9,7 @@ import DataError from "components/DataError";
 import Spinner from "components/Spinner";
 
 import paths from "router/paths";
+import { getPathWithQueryParams } from "utilities/url";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { getSelfServiceTooltip } from "pages/SoftwarePage/helpers";
 import { ISoftwareVppFormData } from "pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm";
@@ -117,7 +118,9 @@ const CategoriesSelector = ({
       return (
         <div className={`${baseClass}__categories-empty`}>
           <CustomLink
-            url={paths.SOFTWARE_LIBRARY_CATEGORIES}
+            url={getPathWithQueryParams(paths.SOFTWARE_LIBRARY_CATEGORIES, {
+              fleet_id: teamId,
+            })}
             text="Add category"
           />
           <span>to assign software to it.</span>

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -6953,7 +6953,9 @@ FROM software_categories
 WHERE team_id = ?
 ORDER BY name
 `
-	var categories []fleet.SoftwareCategory
+	// Non-nil so the JSON response serializes as `[]` rather than `null` when a
+	// team has no categories.
+	categories := []fleet.SoftwareCategory{}
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &categories, stmt, teamID); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list software categories")
 	}

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -12867,6 +12867,26 @@ func testSoftwareCategoryCRUD(t *testing.T, ds *Datastore) {
 	err = ds.DeleteSoftwareCategory(ctx, 9999999)
 	require.Error(t, err)
 	require.True(t, fleet.IsNotFound(err))
+
+	// A team with zero categories returns a non-nil empty slice so the JSON
+	// response serializes as `[]` rather than `null`. See issue #47712.
+	emptyTeam, err := ds.NewTeam(ctx, &fleet.Team{Name: "empty" + t.Name()})
+	require.NoError(t, err)
+	seeded, err := ds.ListSoftwareCategories(ctx, emptyTeam.ID)
+	require.NoError(t, err)
+	for _, c := range seeded {
+		require.NoError(t, ds.DeleteSoftwareCategory(ctx, c.ID))
+	}
+	emptyCats, err := ds.ListSoftwareCategories(ctx, emptyTeam.ID)
+	require.NoError(t, err)
+	require.NotNil(t, emptyCats)
+	require.Empty(t, emptyCats)
+
+	// An unknown team_id also returns a non-nil empty slice.
+	unknownCats, err := ds.ListSoftwareCategories(ctx, 9999999)
+	require.NoError(t, err)
+	require.NotNil(t, unknownCats)
+	require.Empty(t, unknownCats)
 }
 
 func testGetDisplayNamesByTeamAndTitleIdsBatching(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
## Issue
Closes #47712
Closes #47758
Closes #47763

## Description
- **#47712 BE** — `ListSoftwareCategories` (`server/datastore/mysql/software.go`) returned a nil slice when no rows matched, so the endpoint JSON-serialized `{"self_service_categories": null}` for a team with zero categories. The Categories picker called `.map` on the value and errored out instead of falling through to the "Add category" empty state. Initialized the slice as `[]fleet.SoftwareCategory{}` so the response is always `[]`. Added datastore assertions for an emptied team and an unknown `team_id`.
- **#47712 FE** — `SoftwareOptionsSelector` empty-state link pointed at the bare `/software/library/categories` route, which dropped fleet context and landed users on the wrong fleet. Switched to `getPathWithQueryParams(PATHS.SOFTWARE_LIBRARY_CATEGORIES, { fleet_id: teamId })` so the link round-trips the current fleet (including `fleet_id=0` for No team). Added a test for the `teamId: 0` case and tightened the existing assertion.
- **#47758 layout** — `__premium-card` collapsed to ~472px because the parent flex container uses `align-items: flex-start`. Added `align-self: stretch` so the card fills the content width like its `__fleet-row` / `__list` siblings.
- **#47763 + #47758 dropdown** — `TeamsDropdown` was gated only on `!isPrimoMode`, so Fleet Free showed an "Unassigned" fleet dropdown above the premium gate. Now gated on `isPremiumTier && !isPrimoMode`. Falls back to a static `<h1>Self-service categories</h1>` so the page keeps an identity anchor on Free and in Primo. Matches the pattern already in `SoftwarePage.tsx`.
- **Rules** — codified the link-preserves-fleet_id rule under "Routing & URL state" in `.claude/rules/fleet-frontend.md` so future internal links don't drop fleet context.

## Screenrecording


https://github.com/user-attachments/assets/7009997f-9573-49aa-b635-295510373623

<img width="1444" height="451" alt="Screenshot 2026-06-17 at 2 14 57 PM" src="https://github.com/user-attachments/assets/e1f15a30-8cda-4e92-8841-6bd83523425e" />


## Testing
- [x] Added/updated automated tests — `testSoftwareCategoryCRUD` (mysql) asserts non-nil empty slice for emptied team + unknown `team_id`; `SoftwareOptionsSelector.tests.tsx` asserts `fleet_id` is in the Add category link for both a real team and `teamId: 0`; `SelfServiceCategoriesPage.tests.tsx` Fleet Free case asserts the dropdown is hidden and the `<h1>` shows.
- [x] QA'd all new/changed functionality manually