### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/4k-youtube-to-mp3/darwin.json
+++ b/ee/maintained-apps/outputs/4k-youtube-to-mp3/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.4",
+      "version": "26.1.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openmedia.4kyoutubetomp3';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openmedia.4kyoutubetomp3' AND version_compare(bundle_short_version, '26.1.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openmedia.4kyoutubetomp3' AND version_compare(bundle_short_version, '26.1.5') < 0);"
       },
-      "installer_url": "https://dl.4kdownload.com/app/4kyoutubetomp3_26.1.4_arm64.dmg",
+      "installer_url": "https://dl.4kdownload.com/app/4kyoutubetomp3_26.1.5_arm64.dmg",
       "install_script_ref": "32bb3c2c",
       "uninstall_script_ref": "f51f85f1",
-      "sha256": "aed76bcc4566220d9af40934700379c72e96763e9523aea010b1f512f12fd3a2",
+      "sha256": "c96299d6795caaaf867fc2a580a8061d92a02a735495a51893a7176f778b595b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13576.0",
+      "version": "1.13576.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.13576.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.13576.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.13576.0/Claude-1290fc2ef5fd27a3883b74505e0ff917413d6832.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.13576.1/Claude-772d01ffc175c3795a49154acdecf043d634b5d1.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "ef222b5ac55f3ec0a187c862ccbdb5c9a9e255c9dd8f96707d3735152e5cfd93",
+      "sha256": "2832279d84f54b471e8543e5a6740e774a95dde991567b21af85e25c1aa52d4f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cmake-app/darwin.json
+++ b/ee/maintained-apps/outputs/cmake-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.3",
+      "version": "4.3.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake' AND version_compare(bundle_short_version, '4.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake' AND version_compare(bundle_short_version, '4.3.4') < 0);"
       },
-      "installer_url": "https://cmake.org/files/v4.3/cmake-4.3.3-macos-universal.dmg",
+      "installer_url": "https://cmake.org/files/v4.3/cmake-4.3.4-macos-universal.dmg",
       "install_script_ref": "e8baa8ae",
       "uninstall_script_ref": "87ce57a8",
-      "sha256": "d56979bd250c90e373c0d20dfbd0fc8472f7e9faee904fcef72ab1b7a8d53e6a",
+      "sha256": "2aacd32eaaca88e2edcb29a892ff3d34db3f93ac09d9751aebef38e9ac80dd69",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/codex-app/darwin.json
+++ b/ee/maintained-apps/outputs/codex-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.611.61753",
+      "version": "26.611.62324",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.611.61753') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.611.62324') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.611.61753.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.611.62324.zip",
       "install_script_ref": "5e3efa57",
       "uninstall_script_ref": "a2b5ee81",
-      "sha256": "2423fa8cc7a837c24f6000ba0f60354ff45b3c6b7a9d1a93448e82d91a49e81c",
+      "sha256": "aa5ffa86f0f629e8b02a7ae08f43cdaa87fca7e176b5b9b7e672c1c21a9c1963",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.354.0",
+      "version": "0.354.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.354.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.354.2') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.354.0-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.354.2-arm64.dmg",
       "install_script_ref": "bd0f7905",
       "uninstall_script_ref": "f408ec47",
-      "sha256": "c23fca0fd19c3ac6815ce17fbde453f640c972f7d4feb5296206af12ebfe251d",
+      "sha256": "e284d3589f334639d08ca0b326ef3f6971a4419f94a24e9cbe6fcf8263112554",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS application versions: 4k-YouTube-to-MP3 (26.1.5), Claude for Desktop (1.13576.1), CMake (4.3.4), Codex (26.611.62324), and Loom (0.354.2).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->