### PR TITLE
Extend update software installer API to support FMA version pinning 

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -645,12 +645,10 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	if payload.RollbackVersion != nil {
 		if existingInstaller.FleetMaintainedAppID == nil {
 			return nil, &fleet.BadRequestError{
-				Message: `Couldn't update. "version" can be specified for a software title that have a Fleet-maintained app.`,
+				Message: `Couldn't update. "version" can be only specified for a software title that has a Fleet-maintained app.`,
 			}
 		}
 
-		// The pinned-version flow only changes the active version; reject any other field edits in the same request.
-		// dirty is fully populated above, so a non-empty map here means another field was also changed.
 		if len(dirty) > 0 {
 			return nil, &fleet.BadRequestError{
 				Message: `Couldn't update. "version" can't be changed at the same time as other fields.`,
@@ -672,7 +670,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			return nil, ctxerr.New(ctx, "no cached versions for Fleet-maintained app")
 		}
 
-		// versions are sorted by version descending, so the first match is the newest.
 		switch {
 		case requestedVersion == "": // Latest
 			activeInstallerID = versions[0].ID
@@ -688,8 +685,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				}
 			}
 			if activeInstallerID == 0 {
-				// A caret allows any version up to that major, so when nothing in the major is cached we keep the
-				// newest cached version instead of erroring. The GitOps path does the same.
 				activeInstallerID = versions[0].ID
 			}
 		default: // literal version
@@ -2551,9 +2546,8 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 		return ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
 	}
 
-	// Leave payload.RollbackVersion as the user typed it so the pin expression, including a "^major" caret, is
-	// persisted downstream; callers that match it against a cached version must handle the caret form. For a caret,
-	// hydrate with an empty version so the latest manifest is fetched instead of a specific cached version.
+	// use a temporary string for calling hydrate, so we download the latest manifest but keep the
+	// version in the db later for the auto update cron job
 	hydrateVersion := payload.RollbackVersion
 	if usesCaret {
 		hydrateVersion = ""
@@ -2580,9 +2574,6 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 			if err != nil {
 				return fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
 			}
-			// Intentionally use the newest cached version (versions[0]) when the pinned major has no cached
-			// installer (e.g. "^8" while only 7.x is cached): keeping the newest cached version is preferred over
-			// erroring or pinning to an older/previously-active one.
 
 			// This is a bit inefficient as we are duplicating strings for categories and install/uninstall scripts,
 			// but it can be optimized in softwareBatchUpload if it accepted only passing category and script content IDs.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -655,8 +655,8 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			}
 		}
 
-		requestedVersion := *payload.PinnedVersion
-		majorVersionString, usesCaret, err := parsePinnedVersion(ctx, requestedVersion)
+		*payload.PinnedVersion = strings.TrimSpace(*payload.PinnedVersion)
+		majorVersionString, usesCaret, err := parsePinnedVersion(ctx, *payload.PinnedVersion)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
 		}
@@ -670,7 +670,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 
 		switch {
-		case requestedVersion == "": // Latest
+		case *payload.PinnedVersion == "": // Latest
 			activeInstallerID = versions[0].ID
 		case usesCaret:
 			for _, v := range versions {
@@ -688,7 +688,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			}
 		default: // literal version
 			for _, v := range versions {
-				if v.Version == requestedVersion {
+				if v.Version == *payload.PinnedVersion {
 					activeInstallerID = v.ID
 					break
 				}
@@ -2517,6 +2517,7 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 		return err
 	}
 
+	payload.RollbackVersion = strings.TrimSpace(payload.RollbackVersion)
 	majorVersionString, usesCaret, err := parsePinnedVersion(ctx, payload.RollbackVersion)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -715,31 +715,11 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	var shouldDoSideEffects bool
 	// persist changes starting here, now that we've done all the validation/diffing we can
 	if len(dirty) > 0 {
-		switch {
-		case len(dirty) == 1 && dirty["SelfService"]: // only self-service changed; use lighter update function
+		if len(dirty) == 1 && dirty["SelfService"] { // only self-service changed; use lighter update function
 			if err := svc.ds.UpdateInstallerSelfServiceFlag(ctx, *payload.SelfService, existingInstaller.InstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "updating installer self service flag")
 			}
-		case len(dirty) == 1 && dirty["PinnedVersion"]:
-			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
-			}
-
-			if *payload.PinnedVersion == "" {
-				if err := svc.ds.DeletePinnedVersion(ctx, payload.TeamID, payload.TitleID); err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
-				}
-			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.PinnedVersion); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
-			}
-
-			// Do side effects to avoid installs of the inactive version
-			if activeInstallerID != existingInstaller.InstallerID {
-				if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, true, false); err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "processing side effects for version pin")
-				}
-			}
-		default:
+		} else {
 			if payloadForNewInstallerFile != nil {
 				if err := svc.storeSoftware(ctx, payloadForNewInstallerFile); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "storing software installer")
@@ -805,12 +785,31 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				}
 			}
 
+			// a version pin flips the active installer below, so cancel pending installs of the version we pinned away from
+			if dirty["PinnedVersion"] && activeInstallerID != existingInstaller.InstallerID {
+				shouldDoSideEffects = true
+			}
+
 			// if we're updating anything other than self-service, we cancel pending installs/uninstalls,
 			// and if we're updating the package we reset counts. This is run in its own transaction internally
 			// for consistency, but independent of the installer update query as the main update should stick
 			// even if side effects fail.
 			if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, shouldDoSideEffects, dirty["Package"]); err != nil {
 				return nil, err
+			}
+		}
+
+		if dirty["PinnedVersion"] {
+			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
+			}
+
+			if *payload.PinnedVersion == "" {
+				if err := svc.ds.DeletePinnedVersion(ctx, payload.TeamID, payload.TitleID); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
+				}
+			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.PinnedVersion); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
 			}
 		}
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -720,15 +720,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				return nil, ctxerr.Wrap(ctx, err, "updating installer self service flag")
 			}
 		case len(dirty) == 1 && dirty["PinnedVersion"]: // only the pinned version changed; flip the active installer rather than rewriting it
-			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
-			}
-
-			if *payload.PinnedVersion == "" {
-				if err := svc.ds.DeletePinnedVersion(ctx, payload.TeamID, payload.TitleID); err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
-				}
-			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.PinnedVersion); err != nil {
+			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload, activeInstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
 			}
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -640,6 +640,92 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
+	var activeInstallerID uint
+	if payload.RollbackVersion != nil {
+
+		// TODO(JK): we need to think about the overall architecture of this
+		// we will have an hourly cron job that updates fleet maintained apps
+
+		// one thing it has to know about is which version is active, which is already done
+		// and it can overwrite the inactive version and cache the new downloaded one on top
+		// BUT, what if someone wants to pin to major version? that is not kept anywhere
+
+		// Is the current idea that the new cron job will pick up versions from GET /software/titles/:id
+		// and then update installers based on that (which is where softwareInstallerPayloadFromSlug will be reused)?
+
+		if existingInstaller.FleetMaintainedAppID == nil {
+			return nil, &fleet.BadRequestError{
+				Message: `Couldn't update. "version" can be specified for a software title that have a Fleet-maintained app.`,
+			}
+		}
+
+		// The pinned-version flow only changes the active version; reject any other field edits in the same request.
+		// dirty is fully populated above, so a non-empty map here means another field was also changed.
+		if len(dirty) > 0 {
+			return nil, &fleet.BadRequestError{
+				Message: `Couldn't update. "version" can't be changed at the same time as other fields.`,
+			}
+		}
+
+		// Mirrors the trim+validate phase of softwareInstallerPayloadFromSlug, but never hydrates: every selectable
+		// version is already cached, so we only decide which installer becomes active.
+		requestedVersion := *payload.RollbackVersion
+		majorVersionString, usesCaret := strings.CutPrefix(requestedVersion, "^")
+		if usesCaret {
+			if len(majorVersionString) == 0 {
+				return nil, ctxerr.Wrap(ctx, errors.New("no version number provided"), "reading Fleet-maintained app pinned version")
+			}
+			if parts := strings.Split(requestedVersion, "."); len(parts) > 1 {
+				return nil, fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)
+			}
+		}
+
+		versions, err := svc.ds.GetFleetMaintainedVersionsByTitleID(ctx, payload.TeamID, payload.TitleID, true)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting Fleet-maintained app versions")
+		}
+		if len(versions) == 0 {
+			return nil, ctxerr.New(ctx, "no cached versions for Fleet-maintained app")
+		}
+
+		// versions are sorted by version descending, so the first match is the newest.
+		switch {
+		case requestedVersion == "": // Latest
+			activeInstallerID = versions[0].ID
+		case usesCaret:
+			major, err := fleet.VersionToSemverVersion(majorVersionString)
+			if err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "parsing pinned major version")
+			}
+			for _, v := range versions {
+				cached, err := fleet.VersionToSemverVersion(v.Version)
+				if err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "parsing cached version")
+				}
+				if cached.Major() == major.Major() {
+					activeInstallerID = v.ID
+					break
+				}
+			}
+			if activeInstallerID == 0 {
+				return nil, fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
+			}
+		default: // literal version
+			for _, v := range versions {
+				if v.Version == requestedVersion {
+					activeInstallerID = v.ID
+					break
+				}
+			}
+			if activeInstallerID == 0 {
+				return nil, fleet.NewUserMessageError(errVersionNotFound, http.StatusNotFound)
+			}
+		}
+
+		// The active-installer flip is applied in the dirty section below.
+		dirty["RollbackVersion"] = true
+	}
+
 	fieldsShouldSideEffect := map[string]struct{}{
 		"InstallerFile":     {},
 		"InstallScript":     {},
@@ -728,6 +814,12 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			// even if side effects fail.
 			if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, shouldDoSideEffects, dirty["Package"]); err != nil {
 				return nil, err
+			}
+		}
+
+		if dirty["RollbackVersion"] {
+			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
 			}
 		}
 
@@ -2410,6 +2502,7 @@ func (svc *Service) BatchSetSoftwareInstallers(
 var (
 	errNonMajorVersion      = errors.New("only the major version can be specified with a caret (^), without including minor and patch versions. For example, \"^32\".")
 	errMajorVersionNotFound = errors.New("specified major version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.")
+	errVersionNotFound      = errors.New("specified version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.")
 )
 
 func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payload *fleet.SoftwareInstallerPayload, teamID *uint) error {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -688,10 +688,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				}
 			}
 			if activeInstallerID == 0 {
-				// No cached installer in the pinned major. The Versions modal only offers cached majors, so the
-				// update endpoint rejects this rather than silently pinning a different major. (GitOps instead keeps
-				// the newest cached version — see softwareInstallerPayloadFromSlug.)
-				return nil, fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
+				// A caret allows any version up to that major, so when nothing in the major is cached we keep the
+				// newest cached version instead of erroring. The GitOps path does the same.
+				activeInstallerID = versions[0].ID
 			}
 		default: // literal version
 			for _, v := range versions {
@@ -738,7 +737,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			}
 			// If the active version actually changed, cancel in-flight installs/uninstalls of the previously-active
 			// version so hosts don't keep installing what we just pinned away from. No new package file was uploaded,
-			// so existing install stats are kept (wasPackageUpdated=false).
+			// so existing install stats are kept.
 			if activeInstallerID != existingInstaller.InstallerID {
 				if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, true, false); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "processing side effects for version pin")
@@ -834,10 +833,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 		if payload.DisplayName != nil {
 			activity.SoftwareDisplayName = *payload.DisplayName
-		}
-		// An empty RollbackVersion means "Latest" (no pin), recorded as null; a literal or "^major" string is the pin.
-		if dirty["RollbackVersion"] && *payload.RollbackVersion != "" {
-			activity.PinnedVersion = payload.RollbackVersion
 		}
 		if err := svc.NewActivity(ctx, vc.User, activity); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "creating activity for edited software")
@@ -2556,12 +2551,9 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 		return ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
 	}
 
-	// TODO(JK): remove long comment
-	// Leave payload.RollbackVersion untouched so it carries the verbatim pin expression downstream (persisted to
-	// software_title_team_pins by BatchSetSoftwareInstallers). NOTE: it may be a "^major" caret, not just a literal
-	// version — callers that exact-match on RollbackVersion must skip the caret form (today only
-	// BatchSetSoftwareInstallers). Hydrate gets a local "" for caret so it fetches the latest manifest rather than a
-	// specific cached version.
+	// Leave payload.RollbackVersion as the user typed it so the pin expression, including a "^major" caret, is
+	// persisted downstream; callers that match it against a cached version must handle the caret form. For a caret,
+	// hydrate with an empty version so the latest manifest is fetched instead of a specific cached version.
 	hydrateVersion := payload.RollbackVersion
 	if usesCaret {
 		hydrateVersion = ""

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -688,7 +688,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				}
 			}
 			if activeInstallerID == 0 {
-				return nil, fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
+				// "^N" allows versions up to N.x; when no cached version is in that major, use the newest cached
+				// version (sorted descending) instead of erroring — matching the GitOps batch behavior.
+				activeInstallerID = versions[0].ID
 			}
 		default: // literal version
 			for _, v := range versions {
@@ -723,9 +725,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				return nil, ctxerr.Wrap(ctx, err, "updating installer self service flag")
 			}
 		} else if len(dirty) == 1 && dirty["RollbackVersion"] {
-			// TODO(pin): this light branch flips the active installer but does not run
-			// ProcessInstallerUpdateSideEffects, so in-flight host installs of the previously active version are
-			// not cancelled when the pin changes. Decide whether a version pin should cancel them.
 			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
 			}
@@ -735,6 +734,14 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				}
 			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.RollbackVersion); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
+			}
+			// If the active version actually changed, cancel in-flight installs/uninstalls of the previously-active
+			// version so hosts don't keep installing what we just pinned away from. No new package file was uploaded,
+			// so existing install stats are kept (wasPackageUpdated=false).
+			if activeInstallerID != existingInstaller.InstallerID {
+				if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, true, false); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "processing side effects for version pin")
+				}
 			}
 		} else {
 			if payloadForNewInstallerFile != nil {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -655,7 +655,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			}
 		}
 
-		// Never hydrates: every selectable version is already cached, so we only resolve which installer is active.
 		requestedVersion := *payload.PinnedVersion
 		majorVersionString, usesCaret, err := parsePinnedVersion(ctx, requestedVersion)
 		if err != nil {
@@ -715,11 +714,31 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	var shouldDoSideEffects bool
 	// persist changes starting here, now that we've done all the validation/diffing we can
 	if len(dirty) > 0 {
-		if len(dirty) == 1 && dirty["SelfService"] { // only self-service changed; use lighter update function
+		switch {
+		case len(dirty) == 1 && dirty["SelfService"]: // only self-service changed; use lighter update function
 			if err := svc.ds.UpdateInstallerSelfServiceFlag(ctx, *payload.SelfService, existingInstaller.InstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "updating installer self service flag")
 			}
-		} else {
+		case len(dirty) == 1 && dirty["PinnedVersion"]: // only the pinned version changed; flip the active installer rather than rewriting it
+			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
+			}
+
+			if *payload.PinnedVersion == "" {
+				if err := svc.ds.DeletePinnedVersion(ctx, payload.TeamID, payload.TitleID); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
+				}
+			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.PinnedVersion); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
+			}
+
+			// cancel pending installs of the version we pinned away from
+			if activeInstallerID != existingInstaller.InstallerID {
+				if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, true, false); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "processing side effects for version pin")
+				}
+			}
+		default:
 			if payloadForNewInstallerFile != nil {
 				if err := svc.storeSoftware(ctx, payloadForNewInstallerFile); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "storing software installer")
@@ -785,31 +804,12 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				}
 			}
 
-			// a version pin flips the active installer below, so cancel pending installs of the version we pinned away from
-			if dirty["PinnedVersion"] && activeInstallerID != existingInstaller.InstallerID {
-				shouldDoSideEffects = true
-			}
-
 			// if we're updating anything other than self-service, we cancel pending installs/uninstalls,
 			// and if we're updating the package we reset counts. This is run in its own transaction internally
 			// for consistency, but independent of the installer update query as the main update should stick
 			// even if side effects fail.
 			if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, shouldDoSideEffects, dirty["Package"]); err != nil {
 				return nil, err
-			}
-		}
-
-		if dirty["PinnedVersion"] {
-			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
-			}
-
-			if *payload.PinnedVersion == "" {
-				if err := svc.ds.DeletePinnedVersion(ctx, payload.TeamID, payload.TitleID); err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
-				}
-			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.PinnedVersion); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
 			}
 		}
 
@@ -2490,6 +2490,7 @@ func (svc *Service) BatchSetSoftwareInstallers(
 }
 
 var (
+	errEmptyCaretVersion    = errors.New("a major version must be specified after the caret (^). For example, \"^32\".")
 	errNonMajorVersion      = errors.New("only the major version can be specified with a caret (^), without including minor and patch versions. For example, \"^32\".")
 	errMajorVersionNotFound = errors.New("specified major version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.")
 	errVersionNotFound      = errors.New("specified version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.")
@@ -3993,7 +3994,7 @@ func parsePinnedVersion(ctx context.Context, version string) (majorVersion strin
 	majorVersion, usesCaret = strings.CutPrefix(version, "^")
 	if usesCaret {
 		if len(majorVersion) == 0 {
-			return "", false, ctxerr.New(ctx, "no version number provided")
+			return "", false, fleet.NewUserMessageError(errEmptyCaretVersion, http.StatusBadRequest)
 		}
 		if parts := strings.Split(version, "."); len(parts) > 1 {
 			return "", false, fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -688,9 +688,10 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				}
 			}
 			if activeInstallerID == 0 {
-				// "^N" allows versions up to N.x; when no cached version is in that major, use the newest cached
-				// version (sorted descending) instead of erroring — matching the GitOps batch behavior.
-				activeInstallerID = versions[0].ID
+				// No cached installer in the pinned major. The Versions modal only offers cached majors, so the
+				// update endpoint rejects this rather than silently pinning a different major. (GitOps instead keeps
+				// the newest cached version — see softwareInstallerPayloadFromSlug.)
+				return nil, fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
 			}
 		default: // literal version
 			for _, v := range versions {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -723,8 +723,18 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 				return nil, ctxerr.Wrap(ctx, err, "updating installer self service flag")
 			}
 		} else if len(dirty) == 1 && dirty["RollbackVersion"] {
+			// TODO(pin): this light branch flips the active installer but does not run
+			// ProcessInstallerUpdateSideEffects, so in-flight host installs of the previously active version are
+			// not cancelled when the pin changes. Decide whether a version pin should cancel them.
 			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
+			}
+			if *payload.RollbackVersion == "" {
+				if err := svc.ds.DeletePinnedVersion(ctx, payload.TeamID, payload.TitleID); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
+				}
+			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.RollbackVersion); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
 			}
 		} else {
 			if payloadForNewInstallerFile != nil {
@@ -2537,12 +2547,19 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
 	}
+
+	// TODO(JK): long comment
+	// Leave payload.RollbackVersion untouched so it carries the verbatim pin expression downstream (persisted to
+	// software_title_team_pins by BatchSetSoftwareInstallers). NOTE: it may be a "^major" caret, not just a literal
+	// version — callers that exact-match on RollbackVersion must skip the caret form (today only
+	// BatchSetSoftwareInstallers). Hydrate gets a local "" for caret so it fetches the latest manifest rather than a
+	// specific cached version.
+	hydrateVersion := payload.RollbackVersion
 	if usesCaret {
-		// unset rollback version to avoid getting a cached installer
-		payload.RollbackVersion = ""
+		hydrateVersion = ""
 	}
 
-	_, err = maintained_apps.Hydrate(ctx, app, payload.RollbackVersion, teamID, svc.ds)
+	_, err = maintained_apps.Hydrate(ctx, app, hydrateVersion, teamID, svc.ds)
 	if err != nil {
 		return err
 	}
@@ -2563,6 +2580,9 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 			if err != nil {
 				return fleet.NewUserMessageError(errMajorVersionNotFound, http.StatusNotFound)
 			}
+			// Intentionally use the newest cached version (versions[0]) when the pinned major has no cached
+			// installer (e.g. "^8" while only 7.x is cached): keeping the newest cached version is preferred over
+			// erroring or pinning to an older/previously-active one.
 
 			// This is a bit inefficient as we are duplicating strings for categories and install/uninstall scripts,
 			// but it can be optimized in softwareBatchUpload if it accepted only passing category and script content IDs.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -640,9 +640,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
-	// switch active installer to one that matches the rollback version
+	// switch active installer to one that matches the pinned version
 	var activeInstallerID uint
-	if payload.RollbackVersion != nil {
+	if payload.PinnedVersion != nil {
 		if existingInstaller.FleetMaintainedAppID == nil {
 			return nil, &fleet.BadRequestError{
 				Message: `Couldn't update. "version" can be only specified for a software title that has a Fleet-maintained app.`,
@@ -656,7 +656,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 
 		// Never hydrates: every selectable version is already cached, so we only resolve which installer is active.
-		requestedVersion := *payload.RollbackVersion
+		requestedVersion := *payload.PinnedVersion
 		majorVersionString, usesCaret, err := parsePinnedVersion(ctx, requestedVersion)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
@@ -700,7 +700,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 
 		// The active-installer flip is applied in the dirty section below.
-		dirty["RollbackVersion"] = true
+		dirty["PinnedVersion"] = true
 	}
 
 	fieldsShouldSideEffect := map[string]struct{}{
@@ -715,30 +715,31 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	var shouldDoSideEffects bool
 	// persist changes starting here, now that we've done all the validation/diffing we can
 	if len(dirty) > 0 {
-		if len(dirty) == 1 && dirty["SelfService"] { // only self-service changed; use lighter update function
+		switch {
+		case len(dirty) == 1 && dirty["SelfService"]: // only self-service changed; use lighter update function
 			if err := svc.ds.UpdateInstallerSelfServiceFlag(ctx, *payload.SelfService, existingInstaller.InstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "updating installer self service flag")
 			}
-		} else if len(dirty) == 1 && dirty["RollbackVersion"] {
+		case len(dirty) == 1 && dirty["PinnedVersion"]:
 			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
 			}
-			if *payload.RollbackVersion == "" {
+
+			if *payload.PinnedVersion == "" {
 				if err := svc.ds.DeletePinnedVersion(ctx, payload.TeamID, payload.TitleID); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
 				}
-			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.RollbackVersion); err != nil {
+			} else if err := svc.ds.SetPinnedVersion(ctx, payload.TeamID, payload.TitleID, *payload.PinnedVersion); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
 			}
-			// If the active version actually changed, cancel in-flight installs/uninstalls of the previously-active
-			// version so hosts don't keep installing what we just pinned away from. No new package file was uploaded,
-			// so existing install stats are kept.
+
+			// Do side effects to avoid installs of the inactive version
 			if activeInstallerID != existingInstaller.InstallerID {
 				if err := svc.ds.ProcessInstallerUpdateSideEffects(ctx, existingInstaller.InstallerID, true, false); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "processing side effects for version pin")
 				}
 			}
-		} else {
+		default:
 			if payloadForNewInstallerFile != nil {
 				if err := svc.storeSoftware(ctx, payloadForNewInstallerFile); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "storing software installer")
@@ -2495,31 +2496,6 @@ var (
 	errVersionNotFound      = errors.New("specified version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.")
 )
 
-func parsePinnedVersion(ctx context.Context, version string) (majorVersion string, usesCaret bool, err error) {
-	majorVersion, usesCaret = strings.CutPrefix(version, "^")
-	if usesCaret {
-		if len(majorVersion) == 0 {
-			return "", false, ctxerr.New(ctx, "no version number provided")
-		}
-		if parts := strings.Split(version, "."); len(parts) > 1 {
-			return "", false, fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)
-		}
-	}
-	return majorVersion, usesCaret, nil
-}
-
-func versionMatchesMajor(version string, majorVersion string) (bool, error) {
-	v, err := fleet.VersionToSemverVersion(version)
-	if err != nil {
-		return false, err
-	}
-	major, err := fleet.VersionToSemverVersion(majorVersion)
-	if err != nil {
-		return false, err
-	}
-	return v.Major() == major.Major(), nil
-}
-
 func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payload *fleet.SoftwareInstallerPayload, teamID *uint) error {
 	slug := payload.Slug
 	if slug == nil || *slug == "" {
@@ -4012,4 +3988,29 @@ func (svc *Service) batchAddSelfServiceCategories(ctx context.Context, teamID *u
 		return nil, ctxerr.Wrap(ctx, err, "creating self-service categories")
 	}
 	return allCategories, nil
+}
+
+func parsePinnedVersion(ctx context.Context, version string) (majorVersion string, usesCaret bool, err error) {
+	majorVersion, usesCaret = strings.CutPrefix(version, "^")
+	if usesCaret {
+		if len(majorVersion) == 0 {
+			return "", false, ctxerr.New(ctx, "no version number provided")
+		}
+		if parts := strings.Split(version, "."); len(parts) > 1 {
+			return "", false, fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)
+		}
+	}
+	return majorVersion, usesCaret, nil
+}
+
+func versionMatchesMajor(version string, majorVersion string) (bool, error) {
+	v, err := fleet.VersionToSemverVersion(version)
+	if err != nil {
+		return false, err
+	}
+	major, err := fleet.VersionToSemverVersion(majorVersion)
+	if err != nil {
+		return false, err
+	}
+	return v.Major() == major.Major(), nil
 }

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2555,7 +2555,7 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 		return ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
 	}
 
-	// TODO(JK): long comment
+	// TODO(JK): remove long comment
 	// Leave payload.RollbackVersion untouched so it carries the verbatim pin expression downstream (persisted to
 	// software_title_team_pins by BatchSetSoftwareInstallers). NOTE: it may be a "^major" caret, not just a literal
 	// version — callers that exact-match on RollbackVersion must skip the caret form (today only

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -640,19 +640,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
+	// switch active installer to one that matches the rollback version
 	var activeInstallerID uint
 	if payload.RollbackVersion != nil {
-
-		// TODO(JK): we need to think about the overall architecture of this
-		// we will have an hourly cron job that updates fleet maintained apps
-
-		// one thing it has to know about is which version is active, which is already done
-		// and it can overwrite the inactive version and cache the new downloaded one on top
-		// BUT, what if someone wants to pin to major version? that is not kept anywhere
-
-		// Is the current idea that the new cron job will pick up versions from GET /software/titles/:id
-		// and then update installers based on that (which is where softwareInstallerPayloadFromSlug will be reused)?
-
 		if existingInstaller.FleetMaintainedAppID == nil {
 			return nil, &fleet.BadRequestError{
 				Message: `Couldn't update. "version" can be specified for a software title that have a Fleet-maintained app.`,
@@ -667,17 +657,11 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			}
 		}
 
-		// Mirrors the trim+validate phase of softwareInstallerPayloadFromSlug, but never hydrates: every selectable
-		// version is already cached, so we only decide which installer becomes active.
+		// Never hydrates: every selectable version is already cached, so we only resolve which installer is active.
 		requestedVersion := *payload.RollbackVersion
-		majorVersionString, usesCaret := strings.CutPrefix(requestedVersion, "^")
-		if usesCaret {
-			if len(majorVersionString) == 0 {
-				return nil, ctxerr.Wrap(ctx, errors.New("no version number provided"), "reading Fleet-maintained app pinned version")
-			}
-			if parts := strings.Split(requestedVersion, "."); len(parts) > 1 {
-				return nil, fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)
-			}
+		majorVersionString, usesCaret, err := parsePinnedVersion(ctx, requestedVersion)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
 		}
 
 		versions, err := svc.ds.GetFleetMaintainedVersionsByTitleID(ctx, payload.TeamID, payload.TitleID, true)
@@ -693,16 +677,12 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		case requestedVersion == "": // Latest
 			activeInstallerID = versions[0].ID
 		case usesCaret:
-			major, err := fleet.VersionToSemverVersion(majorVersionString)
-			if err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "parsing pinned major version")
-			}
 			for _, v := range versions {
-				cached, err := fleet.VersionToSemverVersion(v.Version)
+				matches, err := versionMatchesMajor(v.Version, majorVersionString)
 				if err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "parsing cached version")
+					return nil, ctxerr.Wrap(ctx, err, "comparing Fleet-maintained app major version")
 				}
-				if cached.Major() == major.Major() {
+				if matches {
 					activeInstallerID = v.ID
 					break
 				}
@@ -741,6 +721,10 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		if len(dirty) == 1 && dirty["SelfService"] { // only self-service changed; use lighter update function
 			if err := svc.ds.UpdateInstallerSelfServiceFlag(ctx, *payload.SelfService, existingInstaller.InstallerID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "updating installer self service flag")
+			}
+		} else if len(dirty) == 1 && dirty["RollbackVersion"] {
+			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
 			}
 		} else {
 			if payloadForNewInstallerFile != nil {
@@ -817,12 +801,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			}
 		}
 
-		if dirty["RollbackVersion"] {
-			if err := svc.ds.SetFleetMaintainedAppActiveInstaller(ctx, payload.TeamID, payload.TitleID, *existingInstaller.FleetMaintainedAppID, activeInstallerID); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "setting active Fleet-maintained app installer")
-			}
-		}
-
 		// now that the payload has been updated with any patches, we can set the
 		// final fields of the activity
 		actLabelsInclAny, actLabelsExclAny, actLabelsInclAll := activitySoftwareLabelsFromSoftwareScopeLabels(
@@ -838,6 +816,10 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 		if payload.DisplayName != nil {
 			activity.SoftwareDisplayName = *payload.DisplayName
+		}
+		// An empty RollbackVersion means "Latest" (no pin), recorded as null; a literal or "^major" string is the pin.
+		if dirty["RollbackVersion"] && *payload.RollbackVersion != "" {
+			activity.PinnedVersion = payload.RollbackVersion
 		}
 		if err := svc.NewActivity(ctx, vc.User, activity); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "creating activity for edited software")
@@ -2505,6 +2487,31 @@ var (
 	errVersionNotFound      = errors.New("specified version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.")
 )
 
+func parsePinnedVersion(ctx context.Context, version string) (majorVersion string, usesCaret bool, err error) {
+	majorVersion, usesCaret = strings.CutPrefix(version, "^")
+	if usesCaret {
+		if len(majorVersion) == 0 {
+			return "", false, ctxerr.New(ctx, "no version number provided")
+		}
+		if parts := strings.Split(version, "."); len(parts) > 1 {
+			return "", false, fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)
+		}
+	}
+	return majorVersion, usesCaret, nil
+}
+
+func versionMatchesMajor(version string, majorVersion string) (bool, error) {
+	v, err := fleet.VersionToSemverVersion(version)
+	if err != nil {
+		return false, err
+	}
+	major, err := fleet.VersionToSemverVersion(majorVersion)
+	if err != nil {
+		return false, err
+	}
+	return v.Major() == major.Major(), nil
+}
+
 func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payload *fleet.SoftwareInstallerPayload, teamID *uint) error {
 	slug := payload.Slug
 	if slug == nil || *slug == "" {
@@ -2526,14 +2533,11 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 		return err
 	}
 
-	majorVersionString, usesCaret := strings.CutPrefix(payload.RollbackVersion, "^")
+	majorVersionString, usesCaret, err := parsePinnedVersion(ctx, payload.RollbackVersion)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "reading Fleet-maintained app pinned version")
+	}
 	if usesCaret {
-		if len(majorVersionString) == 0 {
-			return ctxerr.Wrap(ctx, errors.New("no version number provided"), "reading Fleet-maintained app pinned version")
-		}
-		if parts := strings.Split(payload.RollbackVersion, "."); len(parts) > 1 {
-			return fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)
-		}
 		// unset rollback version to avoid getting a cached installer
 		payload.RollbackVersion = ""
 	}
@@ -2544,17 +2548,12 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 	}
 
 	if usesCaret {
-		downloadedSemVer, err := fleet.VersionToSemverVersion(app.Version)
+		matches, err := versionMatchesMajor(app.Version, majorVersionString)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "extracting semver version")
+			return ctxerr.Wrap(ctx, err, "comparing Fleet-maintained app major version")
 		}
 
-		majorVersion, err := fleet.VersionToSemverVersion(majorVersionString)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "extracting pinnged major version")
-		}
-
-		if downloadedSemVer.Major() != majorVersion.Major() {
+		if !matches {
 			// We cannot use the FMA we just got the manifest for since it is on a different major
 			// version, so we try to find the latest cached version and use that instead.
 			if app.TitleID == nil {

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -530,7 +530,7 @@ func TestSoftwareInstallerPayloadFromSlug(t *testing.T) {
 		{
 			name:    "no version",
 			version: "^",
-			wantErr: "no version number provided",
+			wantErr: errEmptyCaretVersion.Error(),
 		},
 		{
 			name:    "invalid version",

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -548,6 +548,9 @@ func TestSoftwareInstallerPayloadFromSlug(t *testing.T) {
 				require.ErrorContains(t, err, vt.wantErr)
 			} else {
 				require.NoError(t, err)
+				// RollbackVersion must be left verbatim (not erased for caret) so the verbatim pin expression
+				// survives downstream to BatchSetSoftwareInstallers, which persists it to software_title_team_pins.
+				require.Equal(t, vt.version, payload.RollbackVersion)
 			}
 		})
 	}

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -548,8 +548,8 @@ func TestSoftwareInstallerPayloadFromSlug(t *testing.T) {
 				require.ErrorContains(t, err, vt.wantErr)
 			} else {
 				require.NoError(t, err)
-				// RollbackVersion must be left verbatim (not erased for caret) so the verbatim pin expression
-				// survives downstream to BatchSetSoftwareInstallers, which persists it to software_title_team_pins.
+				// RollbackVersion must be left as the user typed it, including a caret, so the pin expression
+				// survives downstream and is persisted to software_title_team_pins.
 				require.Equal(t, vt.version, payload.RollbackVersion)
 			}
 		})

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3078,8 +3078,7 @@ WHERE
 					return ctxerr.Wrapf(ctx, err, "setting active installer for %q", installer.Filename)
 				}
 
-				// GitOps writes the pin here but never reads it back: the YAML is the source of truth for
-				// GitOps-managed titles, so this only keeps the table consistent for the API and the cron.
+				// Write the pinned version so the auto update cron job keeps this information
 				if installer.RollbackVersion != "" {
 					if err := setPinnedVersionDB(ctx, tx, globalOrTeamID, titleID, installer.RollbackVersion); err != nil {
 						return ctxerr.Wrapf(ctx, err, "pinning version for %q", installer.Filename)
@@ -3088,9 +3087,7 @@ WHERE
 					return ctxerr.Wrapf(ctx, err, "clearing pin for %q", installer.Filename)
 				}
 
-				// Re-point this title's policies to the active FMA installer. This covers a replaced custom package
-				// and any other cached FMA version that was previously active, so a policy never points at an inactive
-				// installer. The update endpoint does the same re-pointing.
+				// Re-point this title's policies to the active FMA installer.
 				if _, err := tx.ExecContext(ctx, `
 					UPDATE policies SET software_installer_id = ?
 					WHERE software_installer_id IN (
@@ -4004,4 +4001,45 @@ func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *f
 	}
 
 	return toInstall, categoryName, nil
+}
+
+func (ds *Datastore) GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error) {
+	var version string
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &version, `
+		SELECT pinned_version FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
+	`, ptr.ValOrZero(teamID), titleID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get pinned version")
+	}
+	return &version, nil
+}
+
+func (ds *Datastore) SetPinnedVersion(ctx context.Context, teamID *uint, titleID uint, version string) error {
+	if err := setPinnedVersionDB(ctx, ds.writer(ctx), ptr.ValOrZero(teamID), titleID, version); err != nil {
+		return ctxerr.Wrap(ctx, err, "set pinned version")
+	}
+	return nil
+}
+
+func (ds *Datastore) DeletePinnedVersion(ctx context.Context, teamID *uint, titleID uint) error {
+	if err := deletePinnedVersionDB(ctx, ds.writer(ctx), ptr.ValOrZero(teamID), titleID); err != nil {
+		return ctxerr.Wrap(ctx, err, "delete pinned version")
+	}
+	return nil
+}
+
+func setPinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint, version string) error {
+	_, err := ex.ExecContext(ctx, `
+		INSERT INTO software_title_team_pins (global_or_team_id, title_id, pinned_version)
+		VALUES (?, ?, ?)
+		ON DUPLICATE KEY UPDATE pinned_version = VALUES(pinned_version)
+	`, globalOrTeamID, titleID, version)
+	return err
+}
+
+func deletePinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint) error {
+	_, err := ex.ExecContext(ctx, `
+		DELETE FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
+	`, globalOrTeamID, titleID)
+	return err
 }

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -673,15 +673,18 @@ func (ds *Datastore) UpdateInstallerSelfServiceFlag(ctx context.Context, selfSer
 	return nil
 }
 
-func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error {
-	globalOrTeamID := ptr.ValOrZero(teamID)
+func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
+	if payload.PinnedVersion == nil {
+		return ctxerr.New(ctx, "pinned version is required to set the active Fleet-maintained app installer")
+	}
+	tmID := ptr.ValOrZero(payload.TeamID)
 
 	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		if _, err := tx.ExecContext(ctx, `
 			UPDATE software_installers
 			SET is_active = (id = ?)
-			WHERE global_or_team_id = ? AND fleet_maintained_app_id = ?
-		`, installerID, globalOrTeamID, fmaID); err != nil {
+			WHERE global_or_team_id = ? AND title_id = ?
+		`, activeInstallerID, tmID, payload.TitleID); err != nil {
 			return ctxerr.Wrap(ctx, err, "setting active fleet-maintained app installer")
 		}
 
@@ -691,8 +694,17 @@ func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, t
 				SELECT id FROM software_installers
 				WHERE global_or_team_id = ? AND title_id = ? AND id != ?
 			)
-		`, installerID, globalOrTeamID, titleID, installerID); err != nil {
+		`, activeInstallerID, tmID, payload.TitleID, activeInstallerID); err != nil {
 			return ctxerr.Wrap(ctx, err, "re-pointing policies to active fleet-maintained app installer")
+		}
+
+		// record the pin in the same transaction; an empty version clears it (Latest)
+		if *payload.PinnedVersion == "" {
+			if err := deletePinnedVersionDB(ctx, tx, tmID, payload.TitleID); err != nil {
+				return ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")
+			}
+		} else if err := setPinnedVersionDB(ctx, tx, tmID, payload.TitleID, *payload.PinnedVersion); err != nil {
+			return ctxerr.Wrap(ctx, err, "pinning Fleet-maintained app version")
 		}
 
 		return nil

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -674,10 +674,7 @@ func (ds *Datastore) UpdateInstallerSelfServiceFlag(ctx context.Context, selfSer
 }
 
 func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error {
-	var globalOrTeamID uint
-	if teamID != nil {
-		globalOrTeamID = *teamID
-	}
+	globalOrTeamID := ptr.ValOrZero(teamID)
 
 	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		if _, err := tx.ExecContext(ctx, `
@@ -3000,10 +2997,9 @@ WHERE
 			// For FMA installers: determine the active version, then evict old versions
 			// (protecting the active one from eviction).
 			if installer.FleetMaintainedAppID != nil {
-				// Determine which installer should be "active" for this FMA+team.
-				// A literal RollbackVersion pins that exact cached version; a "^major" caret (or empty) falls through
-				// to the newest just inserted/updated — for caret, softwareInstallerPayloadFromSlug already resolved
-				// and inserted the correct version, so we must not exact-match the caret string here.
+				// Determine which installer should be "active" for this FMA and team. A literal RollbackVersion pins
+				// that exact cached version; a "^major" caret or an empty value falls through to the newest just
+				// inserted version, which the slug resolver already chose, so the caret string must not be matched here.
 				activeInstallerID := installerID
 				if installer.RollbackVersion != "" && !strings.HasPrefix(installer.RollbackVersion, "^") {
 					var pinnedID uint
@@ -3093,8 +3089,8 @@ WHERE
 				}
 
 				// Re-point this title's policies to the active FMA installer. This covers a replaced custom package
-				// and any other cached FMA version that was previously active (e.g. after a version flip), matching
-				// the PATCH path (SetFleetMaintainedAppActiveInstaller) so a policy never points at an inactive installer.
+				// and any other cached FMA version that was previously active, so a policy never points at an inactive
+				// installer. The update endpoint does the same re-pointing.
 				if _, err := tx.ExecContext(ctx, `
 					UPDATE policies SET software_installer_id = ?
 					WHERE software_installer_id IN (

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3092,19 +3092,17 @@ WHERE
 					return ctxerr.Wrapf(ctx, err, "clearing pin for %q", installer.Filename)
 				}
 
-				// Re-point policies from any non-FMA installers for this title to the active FMA installer.
-				// TODO(pin): this does not re-point policies that point at another *cached FMA version* when the
-				// active version flips (e.g. after a version pin), so an install policy can be left pointing at an
-				// inactive installer. The PATCH path (SetFleetMaintainedAppActiveInstaller) re-points all of the
-				// title's installers; this should be made consistent.
+				// Re-point this title's policies to the active FMA installer. This covers a replaced custom package
+				// and any other cached FMA version that was previously active (e.g. after a version flip), matching
+				// the PATCH path (SetFleetMaintainedAppActiveInstaller) so a policy never points at an inactive installer.
 				if _, err := tx.ExecContext(ctx, `
 					UPDATE policies SET software_installer_id = ?
 					WHERE software_installer_id IN (
 						SELECT id FROM software_installers
-						WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+						WHERE global_or_team_id = ? AND title_id = ? AND id != ?
 					)
-				`, activeInstallerID, globalOrTeamID, titleID); err != nil {
-					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
+				`, activeInstallerID, globalOrTeamID, titleID, activeInstallerID); err != nil {
+					return ctxerr.Wrapf(ctx, err, "re-point policies to active FMA installer %q", installer.Filename)
 				}
 				// Mark previous custom package installers for this title for deletion.
 				for _, e := range existing {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3001,10 +3001,11 @@ WHERE
 			// (protecting the active one from eviction).
 			if installer.FleetMaintainedAppID != nil {
 				// Determine which installer should be "active" for this FMA+team.
-				// If RollbackVersion is specified, find the cached installer with that version;
-				// otherwise default to the newest (just inserted/updated).
+				// A literal RollbackVersion pins that exact cached version; a "^major" caret (or empty) falls through
+				// to the newest just inserted/updated — for caret, softwareInstallerPayloadFromSlug already resolved
+				// and inserted the correct version, so we must not exact-match the caret string here.
 				activeInstallerID := installerID
-				if installer.RollbackVersion != "" {
+				if installer.RollbackVersion != "" && !strings.HasPrefix(installer.RollbackVersion, "^") {
 					var pinnedID uint
 					err := sqlx.GetContext(ctx, tx, &pinnedID, `
 						SELECT id FROM software_installers
@@ -3081,7 +3082,21 @@ WHERE
 					return ctxerr.Wrapf(ctx, err, "setting active installer for %q", installer.Filename)
 				}
 
+				// GitOps writes the pin here but never reads it back: the YAML is the source of truth for
+				// GitOps-managed titles, so this only keeps the table consistent for the API and the cron.
+				if installer.RollbackVersion != "" {
+					if err := setPinnedVersionDB(ctx, tx, globalOrTeamID, titleID, installer.RollbackVersion); err != nil {
+						return ctxerr.Wrapf(ctx, err, "pinning version for %q", installer.Filename)
+					}
+				} else if err := deletePinnedVersionDB(ctx, tx, globalOrTeamID, titleID); err != nil {
+					return ctxerr.Wrapf(ctx, err, "clearing pin for %q", installer.Filename)
+				}
+
 				// Re-point policies from any non-FMA installers for this title to the active FMA installer.
+				// TODO(pin): this does not re-point policies that point at another *cached FMA version* when the
+				// active version flips (e.g. after a version pin), so an install policy can be left pointing at an
+				// inactive installer. The PATCH path (SetFleetMaintainedAppActiveInstaller) re-points all of the
+				// title's installers; this should be made consistent.
 				if _, err := tx.ExecContext(ctx, `
 					UPDATE policies SET software_installer_id = ?
 					WHERE software_installer_id IN (

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4006,7 +4006,7 @@ func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *f
 func (ds *Datastore) GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error) {
 	var version string
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &version, `
-		SELECT pinned_version FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
+		SELECT pinned_version FROM software_title_team_pins WHERE team_id = ? AND title_id = ?
 	`, ptr.ValOrZero(teamID), titleID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get pinned version")
@@ -4030,7 +4030,7 @@ func (ds *Datastore) DeletePinnedVersion(ctx context.Context, teamID *uint, titl
 
 func setPinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint, version string) error {
 	_, err := ex.ExecContext(ctx, `
-		INSERT INTO software_title_team_pins (global_or_team_id, title_id, pinned_version)
+		INSERT INTO software_title_team_pins (team_id, title_id, pinned_version)
 		VALUES (?, ?, ?)
 		ON DUPLICATE KEY UPDATE pinned_version = VALUES(pinned_version)
 	`, globalOrTeamID, titleID, version)
@@ -4039,7 +4039,7 @@ func setPinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID 
 
 func deletePinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint) error {
 	_, err := ex.ExecContext(ctx, `
-		DELETE FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
+		DELETE FROM software_title_team_pins WHERE team_id = ? AND title_id = ?
 	`, globalOrTeamID, titleID)
 	return err
 }

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -673,6 +673,35 @@ func (ds *Datastore) UpdateInstallerSelfServiceFlag(ctx context.Context, selfSer
 	return nil
 }
 
+func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error {
+	var globalOrTeamID uint
+	if teamID != nil {
+		globalOrTeamID = *teamID
+	}
+
+	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE software_installers
+			SET is_active = (id = ?)
+			WHERE global_or_team_id = ? AND fleet_maintained_app_id = ?
+		`, installerID, globalOrTeamID, fmaID); err != nil {
+			return ctxerr.Wrap(ctx, err, "setting active fleet-maintained app installer")
+		}
+
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE policies SET software_installer_id = ?
+			WHERE software_installer_id IN (
+				SELECT id FROM software_installers
+				WHERE global_or_team_id = ? AND title_id = ? AND id != ?
+			)
+		`, installerID, globalOrTeamID, titleID, installerID); err != nil {
+			return ctxerr.Wrap(ctx, err, "re-pointing policies to active fleet-maintained app installer")
+		}
+
+		return nil
+	})
+}
+
 func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload) error {
 	if payload.InstallScript == nil || payload.UninstallScript == nil || payload.PreInstallQuery == nil || payload.SelfService == nil {
 		return ctxerr.Wrap(ctx, errors.New("missing installer update payload fields"), "update installer record")

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -58,6 +58,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"SoftwareTitleDisplayName", testSoftwareTitleDisplayName},
 		{"AddSoftwareTitleToMatchingSoftware", testAddSoftwareTitleToMatchingSoftware},
 		{"FleetMaintainedAppInstallerUpdates", testFleetMaintainedAppInstallerUpdates},
+		{"SoftwareTitlePins", testSoftwareTitlePins},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
 		{"CustomToFMAInstallerReplacement", testCustomToFMAInstallerReplacement},
 		{"GetInstallerByTeamAndURL", testGetInstallerByTeamAndURL},
@@ -5740,4 +5741,72 @@ func testGetSoftwareTitlesForInstallAll(t *testing.T, ds *Datastore) {
 	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, macHost, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"chrome", "slack", "zoom"}, names(got))
+}
+
+func testSoftwareTitlePins(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	fma, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Maintained1",
+		Slug:             "maintained1",
+		Platform:         "darwin",
+		UniqueIdentifier: "fleet.maintained1",
+	})
+	require.NoError(t, err)
+
+	tfr, err := fleet.NewTempFileReader(strings.NewReader("file contents"), t.TempDir)
+	require.NoError(t, err)
+	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "testpkg",
+		Source:               "apps",
+		Platform:             "darwin",
+		InstallScript:        "echo install",
+		UninstallScript:      "echo uninstall",
+		InstallerFile:        tfr,
+		StorageID:            "storageid1",
+		Filename:             "test.pkg",
+		Version:              "1.0",
+		UserID:               user.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: new(fma.ID),
+	})
+	require.NoError(t, err)
+
+	noTeam := new(uint(0))
+	otherTeam := new(uint(42))
+
+	// No row -> not found; the caller treats this as "Latest".
+	_, err = ds.GetPinnedVersion(ctx, noTeam, titleID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	// A literal pin round-trips.
+	require.NoError(t, ds.SetPinnedVersion(ctx, noTeam, titleID, "1.0"))
+	pin, err := ds.GetPinnedVersion(ctx, noTeam, titleID)
+	require.NoError(t, err)
+	require.Equal(t, new("1.0"), pin)
+
+	// Upsert overwrites in place (literal -> caret).
+	require.NoError(t, ds.SetPinnedVersion(ctx, noTeam, titleID, "^1"))
+	pin, err = ds.GetPinnedVersion(ctx, noTeam, titleID)
+	require.NoError(t, err)
+	require.Equal(t, new("^1"), pin)
+
+	// A different team's pin on the same title is independent.
+	require.NoError(t, ds.SetPinnedVersion(ctx, otherTeam, titleID, "2.0"))
+	pin, err = ds.GetPinnedVersion(ctx, otherTeam, titleID)
+	require.NoError(t, err)
+	require.Equal(t, new("2.0"), pin)
+	pin, err = ds.GetPinnedVersion(ctx, noTeam, titleID)
+	require.NoError(t, err)
+	require.Equal(t, new("^1"), pin)
+
+	// Deleting one team's pin leaves the other intact; deleting again is a no-op.
+	require.NoError(t, ds.DeletePinnedVersion(ctx, noTeam, titleID))
+	_, err = ds.GetPinnedVersion(ctx, noTeam, titleID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	require.NoError(t, ds.DeletePinnedVersion(ctx, noTeam, titleID))
+	pin, err = ds.GetPinnedVersion(ctx, otherTeam, titleID)
+	require.NoError(t, err)
+	require.Equal(t, new("2.0"), pin)
 }

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -1010,7 +1010,7 @@ func (ds *Datastore) getFleetMaintainedVersionsByTitleIDs(ctx context.Context, q
 	}
 
 	query := `
-		SELECT si.id, si.version, si.title_id
+		SELECT si.id, si.version, si.title_id, si.uploaded_at
 			FROM software_installers si
 		WHERE si.title_id IN (?) AND si.global_or_team_id = ? AND si.fleet_maintained_app_id IS NOT NULL
 		ORDER BY si.title_id, si.uploaded_at DESC

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -1027,8 +1027,6 @@ func (ds *Datastore) DeletePinnedVersion(ctx context.Context, teamID *uint, titl
 	return nil
 }
 
-// setPinnedVersionDB and deletePinnedVersionDB take an executor so they can run on either ds.writer or a
-// transaction (e.g. from BatchSetSoftwareInstallers); callers wrap the returned error with context.
 func setPinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint, version string) error {
 	_, err := ex.ExecContext(ctx, `
 		INSERT INTO software_title_team_pins (global_or_team_id, title_id, pinned_version)

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -1002,47 +1002,6 @@ func (ds *Datastore) GetFleetMaintainedVersionsByTitleID(ctx context.Context, te
 	return result[titleID], nil
 }
 
-func (ds *Datastore) GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error) {
-	var version string
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &version, `
-		SELECT pinned_version FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
-	`, ptr.ValOrZero(teamID), titleID)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "get pinned version")
-	}
-	return &version, nil
-}
-
-func (ds *Datastore) SetPinnedVersion(ctx context.Context, teamID *uint, titleID uint, version string) error {
-	if err := setPinnedVersionDB(ctx, ds.writer(ctx), ptr.ValOrZero(teamID), titleID, version); err != nil {
-		return ctxerr.Wrap(ctx, err, "set pinned version")
-	}
-	return nil
-}
-
-func (ds *Datastore) DeletePinnedVersion(ctx context.Context, teamID *uint, titleID uint) error {
-	if err := deletePinnedVersionDB(ctx, ds.writer(ctx), ptr.ValOrZero(teamID), titleID); err != nil {
-		return ctxerr.Wrap(ctx, err, "delete pinned version")
-	}
-	return nil
-}
-
-func setPinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint, version string) error {
-	_, err := ex.ExecContext(ctx, `
-		INSERT INTO software_title_team_pins (global_or_team_id, title_id, pinned_version)
-		VALUES (?, ?, ?)
-		ON DUPLICATE KEY UPDATE pinned_version = VALUES(pinned_version)
-	`, globalOrTeamID, titleID, version)
-	return err
-}
-
-func deletePinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint) error {
-	_, err := ex.ExecContext(ctx, `
-		DELETE FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
-	`, globalOrTeamID, titleID)
-	return err
-}
-
 // getFleetMaintainedVersionsByTitleIDs returns all cached versions of fleet-maintained apps
 // for the given title IDs and team, keyed by title ID.
 func (ds *Datastore) getFleetMaintainedVersionsByTitleIDs(ctx context.Context, q sqlx.QueryerContext, titleIDs []uint, teamID uint, byVersion bool) (map[uint][]fleet.FleetMaintainedVersion, error) {
@@ -1078,7 +1037,7 @@ func (ds *Datastore) getFleetMaintainedVersionsByTitleIDs(ctx context.Context, q
 	}
 
 	if byVersion {
-		// Sort by semantic version
+		// sort by semantic version
 		for id := range result {
 			slices.SortFunc(result[id], func(a fleet.FleetMaintainedVersion, b fleet.FleetMaintainedVersion) int {
 				aVersion, aErr := fleet.VersionToSemverVersion(a.Version)

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -1054,12 +1054,8 @@ func (ds *Datastore) getFleetMaintainedVersionsByTitleIDs(ctx context.Context, q
 		SELECT si.id, si.version, si.title_id
 			FROM software_installers si
 		WHERE si.title_id IN (?) AND si.global_or_team_id = ? AND si.fleet_maintained_app_id IS NOT NULL
+		ORDER BY si.title_id, si.uploaded_at DESC
 	`
-	if byVersion {
-		query += ` ORDER BY si.version DESC`
-	} else {
-		query += ` ORDER BY si.title_id, si.uploaded_at DESC`
-	}
 
 	query, args, err := sqlx.In(query, titleIDs, teamID)
 	if err != nil {
@@ -1079,6 +1075,20 @@ func (ds *Datastore) getFleetMaintainedVersionsByTitleIDs(ctx context.Context, q
 	result := make(map[uint][]fleet.FleetMaintainedVersion, len(titleIDs))
 	for _, row := range rows {
 		result[row.TitleID] = append(result[row.TitleID], row.FleetMaintainedVersion)
+	}
+
+	if byVersion {
+		// Sort by semantic version
+		for id := range result {
+			slices.SortFunc(result[id], func(a fleet.FleetMaintainedVersion, b fleet.FleetMaintainedVersion) int {
+				aVersion, aErr := fleet.VersionToSemverVersion(a.Version)
+				bVersion, bErr := fleet.VersionToSemverVersion(b.Version)
+				if aErr != nil || bErr != nil {
+					return strings.Compare(b.Version, a.Version)
+				}
+				return bVersion.Compare(aVersion)
+			})
+		}
 	}
 
 	return result, nil

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -1002,6 +1002,49 @@ func (ds *Datastore) GetFleetMaintainedVersionsByTitleID(ctx context.Context, te
 	return result[titleID], nil
 }
 
+func (ds *Datastore) GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error) {
+	var version string
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &version, `
+		SELECT pinned_version FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
+	`, ptr.ValOrZero(teamID), titleID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get pinned version")
+	}
+	return &version, nil
+}
+
+func (ds *Datastore) SetPinnedVersion(ctx context.Context, teamID *uint, titleID uint, version string) error {
+	if err := setPinnedVersionDB(ctx, ds.writer(ctx), ptr.ValOrZero(teamID), titleID, version); err != nil {
+		return ctxerr.Wrap(ctx, err, "set pinned version")
+	}
+	return nil
+}
+
+func (ds *Datastore) DeletePinnedVersion(ctx context.Context, teamID *uint, titleID uint) error {
+	if err := deletePinnedVersionDB(ctx, ds.writer(ctx), ptr.ValOrZero(teamID), titleID); err != nil {
+		return ctxerr.Wrap(ctx, err, "delete pinned version")
+	}
+	return nil
+}
+
+// setPinnedVersionDB and deletePinnedVersionDB take an executor so they can run on either ds.writer or a
+// transaction (e.g. from BatchSetSoftwareInstallers); callers wrap the returned error with context.
+func setPinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint, version string) error {
+	_, err := ex.ExecContext(ctx, `
+		INSERT INTO software_title_team_pins (global_or_team_id, title_id, pinned_version)
+		VALUES (?, ?, ?)
+		ON DUPLICATE KEY UPDATE pinned_version = VALUES(pinned_version)
+	`, globalOrTeamID, titleID, version)
+	return err
+}
+
+func deletePinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeamID uint, titleID uint) error {
+	_, err := ex.ExecContext(ctx, `
+		DELETE FROM software_title_team_pins WHERE global_or_team_id = ? AND title_id = ?
+	`, globalOrTeamID, titleID)
+	return err
+}
+
 // getFleetMaintainedVersionsByTitleIDs returns all cached versions of fleet-maintained apps
 // for the given title IDs and team, keyed by title ID.
 func (ds *Datastore) getFleetMaintainedVersionsByTitleIDs(ctx context.Context, q sqlx.QueryerContext, titleIDs []uint, teamID uint, byVersion bool) (map[uint][]fleet.FleetMaintainedVersion, error) {

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -202,6 +202,17 @@ func testTeamsGetSetDelete(t *testing.T, ds *Datastore) {
 					return err
 				}
 
+				_, err = q.ExecContext(
+					context.Background(),
+					"INSERT INTO software_title_team_pins (team_id, title_id, pinned_version) VALUES (?, ?, ?)",
+					team.ID,
+					titleID,
+					"^1",
+				)
+				if err != nil {
+					return err
+				}
+
 				// Insert the team label on a in-house application.
 				res, err = q.ExecContext(context.Background(), fmt.Sprintf(`INSERT INTO software_titles (name, source) VALUES ('ipa_test-%s', 'ipados_apps')`, tt.name))
 				if err != nil {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1186,6 +1186,9 @@ type ActivityTypeEditedSoftware struct {
 	LabelsIncludeAll    []ActivitySoftwareLabel `json:"labels_include_all,omitempty"`
 	SoftwareTitleID     uint                    `json:"software_title_id"`
 	SoftwareDisplayName string                  `json:"software_display_name"`
+	// PinnedVersion is the version a Fleet-maintained app was pinned to (a literal version or a "^major" caret).
+	// nil means the title is set to "Latest" (no pin).
+	PinnedVersion *string `json:"pinned_version,omitempty"`
 }
 
 func (a ActivityTypeEditedSoftware) ActivityName() string {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1186,9 +1186,6 @@ type ActivityTypeEditedSoftware struct {
 	LabelsIncludeAll    []ActivitySoftwareLabel `json:"labels_include_all,omitempty"`
 	SoftwareTitleID     uint                    `json:"software_title_id"`
 	SoftwareDisplayName string                  `json:"software_display_name"`
-	// PinnedVersion is the version a Fleet-maintained app was pinned to (a literal version or a "^major" caret).
-	// nil means the title is set to "Latest" (no pin).
-	PinnedVersion *string `json:"pinned_version,omitempty"`
 }
 
 func (a ActivityTypeEditedSoftware) ActivityName() string {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2677,6 +2677,16 @@ type Datastore interface {
 	// cached versions inactive, re-pointing the title's policies to the active installer.
 	SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error
 
+	// GetPinnedVersion returns the pinned version expression (a literal version or a
+	// "^major" caret) for the given team and title, or nil if the title is not pinned (Latest).
+	GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error)
+
+	// SetPinnedVersion upserts the pinned version expression for the given team and title.
+	SetPinnedVersion(ctx context.Context, teamID *uint, titleID uint, version string) error
+
+	// DeletePinnedVersion removes the pin for the given team and title (back to Latest).
+	DeletePinnedVersion(ctx context.Context, teamID *uint, titleID uint) error
+
 	// HasFMAInstallerVersion returns true if the given FMA version is already
 	// cached as a software installer for the given team.
 	HasFMAInstallerVersion(ctx context.Context, teamID *uint, fmaID uint, version string) (bool, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2672,9 +2672,9 @@ type Datastore interface {
 	// the versions will be sorted by their version semver or string.
 	GetFleetMaintainedVersionsByTitleID(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]FleetMaintainedVersion, error)
 
-	// SetFleetMaintainedAppActiveInstaller sets the active installer, sets
-	// other installers of the title to inactive and repoints policies.
-	SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error
+	// SetFleetMaintainedAppActiveInstaller sets the active installer, sets other installers of the title
+	// to inactive, repoints policies, and records or clears the pinned version.
+	SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *UpdateSoftwareInstallerPayload, activeInstallerID uint) error
 
 	// GetPinnedVersion returns the pinned version for a team and software title.
 	GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2672,6 +2672,11 @@ type Datastore interface {
 	// the versions will be sorted by the version string.
 	GetFleetMaintainedVersionsByTitleID(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]FleetMaintainedVersion, error)
 
+	// SetFleetMaintainedAppActiveInstaller marks installerID as the active version
+	// of the fleet-maintained app (fmaID) for the given team and sets all other
+	// cached versions inactive, re-pointing the title's policies to the active installer.
+	SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error
+
 	// HasFMAInstallerVersion returns true if the given FMA version is already
 	// cached as a software installer for the given team.
 	HasFMAInstallerVersion(ctx context.Context, teamID *uint, fmaID uint, version string) (bool, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2669,22 +2669,20 @@ type Datastore interface {
 
 	// GetFleetMaintainedVersionsByTitleID returns all cached versions of a
 	// fleet-maintained app for the given title and team. If byVersion is true
-	// the versions are sorted newest-first by semantic version, otherwise by upload time.
+	// the versions will be sorted by their version semver or string.
 	GetFleetMaintainedVersionsByTitleID(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]FleetMaintainedVersion, error)
 
-	// SetFleetMaintainedAppActiveInstaller marks installerID as the active version
-	// of the fleet-maintained app (fmaID) for the given team and sets all other
-	// cached versions inactive, re-pointing the title's policies to the active installer.
+	// SetFleetMaintainedAppActiveInstaller sets the active installer, sets
+	// other installers of the title to inactive and repoints policies.
 	SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error
 
-	// GetPinnedVersion returns the pinned version expression (a literal version or a
-	// "^major" caret) for the given team and title, or nil if the title is not pinned (Latest).
+	// GetPinnedVersion returns the pinned version for a team and software title.
 	GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error)
 
-	// SetPinnedVersion upserts the pinned version expression for the given team and title.
+	// SetPinnedVersion upserts the pinned version for the team and title.
 	SetPinnedVersion(ctx context.Context, teamID *uint, titleID uint, version string) error
 
-	// DeletePinnedVersion removes the pin for the given team and title (back to Latest).
+	// DeletePinnedVersion removes the pin for the given team and title.
 	DeletePinnedVersion(ctx context.Context, teamID *uint, titleID uint) error
 
 	// HasFMAInstallerVersion returns true if the given FMA version is already

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2669,7 +2669,7 @@ type Datastore interface {
 
 	// GetFleetMaintainedVersionsByTitleID returns all cached versions of a
 	// fleet-maintained app for the given title and team. If byVersion is true
-	// the versions will be sorted by the version string.
+	// the versions are sorted newest-first by semantic version, otherwise by upload time.
 	GetFleetMaintainedVersionsByTitleID(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]FleetMaintainedVersion, error)
 
 	// SetFleetMaintainedAppActiveInstaller marks installerID as the active version

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -380,6 +380,8 @@ type FleetMaintainedVersion struct {
 	ID uint `json:"id" db:"id"`
 	// Version is the version string.
 	Version string `json:"version" db:"version"`
+	// UploadedAt is when this version was added to the database.
+	UploadedAt time.Time `json:"uploaded_at" db:"uploaded_at"`
 }
 
 // SoftwareTitle represents a title backed by the `software_titles` table.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -693,9 +693,8 @@ type UpdateSoftwareInstallerPayload struct {
 	CategoryIDs     []uint
 	// DisplayName is an end-user friendly name.
 	DisplayName *string
-	// RollbackVersion pins a Fleet-maintained app to a specific cached version; the wire-level field is "version".
-	// nil means the field was omitted, so the active version is left unchanged; a non-nil empty string means "Latest".
-	RollbackVersion *string
+	// Pins a Fleet-maintained app to a specific or major version
+	PinnedVersion *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged; explicit empty means clear.
 	Configuration []byte
 }
@@ -705,7 +704,7 @@ func (u *UpdateSoftwareInstallerPayload) IsNoopPayload(existing *SoftwareTitle) 
 		u.InstallScript == nil && u.PostInstallScript == nil && u.UninstallScript == nil &&
 		u.LabelsIncludeAny == nil && u.LabelsExcludeAny == nil && u.LabelsIncludeAll == nil &&
 		u.DisplayName == nil && u.CategoryIDs == nil && u.Configuration == nil &&
-		u.RollbackVersion == nil
+		u.PinnedVersion == nil
 }
 
 // DownloadSoftwareInstallerPayload is the payload for downloading a software installer.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -116,8 +116,7 @@ type SoftwareInstaller struct {
 	// FleetMaintainedAppID is the related Fleet-maintained app for this installer (if not nil).
 	FleetMaintainedAppID    *uint                    `json:"fleet_maintained_app_id" db:"fleet_maintained_app_id"`
 	FleetMaintainedVersions []FleetMaintainedVersion `json:"fleet_maintained_versions,omitempty"`
-	// PinnedVersion is the version a Fleet-maintained app is pinned to (if not nil).
-	PinnedVersion *string `json:"pinned_version,omitempty" db:"-"`
+	PinnedVersion           *string                  `json:"pinned_version,omitempty" db:"-"`
 	// AutomaticInstallPolicies is the list of policies that trigger automatic
 	// installation of this software.
 	AutomaticInstallPolicies []AutomaticInstallPolicy `json:"automatic_install_policies" db:"-"`
@@ -694,9 +693,8 @@ type UpdateSoftwareInstallerPayload struct {
 	CategoryIDs     []uint
 	// DisplayName is an end-user friendly name.
 	DisplayName *string
-	// RollbackVersion pins a Fleet-maintained app to a specific cached version (the wire-level field is "version").
-	// Named RollbackVersion for parity with the GitOps SoftwareInstallerPayload. nil means the field was omitted
-	// (leave the active version untouched); a non-nil empty string means "Latest".
+	// RollbackVersion pins a Fleet-maintained app to a specific cached version; the wire-level field is "version".
+	// nil means the field was omitted, so the active version is left unchanged; a non-nil empty string means "Latest".
 	RollbackVersion *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged; explicit empty means clear.
 	Configuration []byte

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -116,6 +116,8 @@ type SoftwareInstaller struct {
 	// FleetMaintainedAppID is the related Fleet-maintained app for this installer (if not nil).
 	FleetMaintainedAppID    *uint                    `json:"fleet_maintained_app_id" db:"fleet_maintained_app_id"`
 	FleetMaintainedVersions []FleetMaintainedVersion `json:"fleet_maintained_versions,omitempty"`
+	// PinnedVersion is the version a Fleet-maintained app is pinned to (if not nil).
+	PinnedVersion *string `json:"pinned_version,omitempty" db:"-"`
 	// AutomaticInstallPolicies is the list of policies that trigger automatic
 	// installation of this software.
 	AutomaticInstallPolicies []AutomaticInstallPolicy `json:"automatic_install_policies" db:"-"`

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -692,6 +692,10 @@ type UpdateSoftwareInstallerPayload struct {
 	CategoryIDs     []uint
 	// DisplayName is an end-user friendly name.
 	DisplayName *string
+	// RollbackVersion pins a Fleet-maintained app to a specific cached version (the wire-level field is "version").
+	// Named RollbackVersion for parity with the GitOps SoftwareInstallerPayload. nil means the field was omitted
+	// (leave the active version untouched); a non-nil empty string means "Latest".
+	RollbackVersion *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged; explicit empty means clear.
 	Configuration []byte
 }
@@ -700,7 +704,8 @@ func (u *UpdateSoftwareInstallerPayload) IsNoopPayload(existing *SoftwareTitle) 
 	return u.SelfService == nil && u.InstallerFile == nil && u.PreInstallQuery == nil &&
 		u.InstallScript == nil && u.PostInstallScript == nil && u.UninstallScript == nil &&
 		u.LabelsIncludeAny == nil && u.LabelsExcludeAny == nil && u.LabelsIncludeAll == nil &&
-		u.DisplayName == nil && u.CategoryIDs == nil && u.Configuration == nil
+		u.DisplayName == nil && u.CategoryIDs == nil && u.Configuration == nil &&
+		u.RollbackVersion == nil
 }
 
 // DownloadSoftwareInstallerPayload is the payload for downloading a software installer.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1566,7 +1566,7 @@ type GetSoftwareInstallerMetadataByTeamAndTitleIDFunc func(ctx context.Context, 
 
 type GetFleetMaintainedVersionsByTitleIDFunc func(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error)
 
-type SetFleetMaintainedAppActiveInstallerFunc func(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error
+type SetFleetMaintainedAppActiveInstallerFunc func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error
 
 type GetPinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint) (*string, error)
 
@@ -10655,11 +10655,11 @@ func (s *DataStore) GetFleetMaintainedVersionsByTitleID(ctx context.Context, tea
 	return s.GetFleetMaintainedVersionsByTitleIDFunc(ctx, teamID, titleID, byVersion)
 }
 
-func (s *DataStore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error {
+func (s *DataStore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
 	s.mu.Lock()
 	s.SetFleetMaintainedAppActiveInstallerFuncInvoked = true
 	s.mu.Unlock()
-	return s.SetFleetMaintainedAppActiveInstallerFunc(ctx, teamID, titleID, fmaID, installerID)
+	return s.SetFleetMaintainedAppActiveInstallerFunc(ctx, payload, activeInstallerID)
 }
 
 func (s *DataStore) GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1568,6 +1568,12 @@ type GetFleetMaintainedVersionsByTitleIDFunc func(ctx context.Context, teamID *u
 
 type SetFleetMaintainedAppActiveInstallerFunc func(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error
 
+type GetPinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint) (*string, error)
+
+type SetPinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint, version string) error
+
+type DeletePinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint) error
+
 type HasFMAInstallerVersionFunc func(ctx context.Context, teamID *uint, fmaID uint, version string) (bool, error)
 
 type GetCachedFMAInstallerMetadataFunc func(ctx context.Context, teamID *uint, fmaID uint, version string) (*fleet.MaintainedApp, error)
@@ -4426,6 +4432,15 @@ type DataStore struct {
 
 	SetFleetMaintainedAppActiveInstallerFunc        SetFleetMaintainedAppActiveInstallerFunc
 	SetFleetMaintainedAppActiveInstallerFuncInvoked bool
+
+	GetPinnedVersionFunc        GetPinnedVersionFunc
+	GetPinnedVersionFuncInvoked bool
+
+	SetPinnedVersionFunc        SetPinnedVersionFunc
+	SetPinnedVersionFuncInvoked bool
+
+	DeletePinnedVersionFunc        DeletePinnedVersionFunc
+	DeletePinnedVersionFuncInvoked bool
 
 	HasFMAInstallerVersionFunc        HasFMAInstallerVersionFunc
 	HasFMAInstallerVersionFuncInvoked bool
@@ -10645,6 +10660,27 @@ func (s *DataStore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, te
 	s.SetFleetMaintainedAppActiveInstallerFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetFleetMaintainedAppActiveInstallerFunc(ctx, teamID, titleID, fmaID, installerID)
+}
+
+func (s *DataStore) GetPinnedVersion(ctx context.Context, teamID *uint, titleID uint) (*string, error) {
+	s.mu.Lock()
+	s.GetPinnedVersionFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetPinnedVersionFunc(ctx, teamID, titleID)
+}
+
+func (s *DataStore) SetPinnedVersion(ctx context.Context, teamID *uint, titleID uint, version string) error {
+	s.mu.Lock()
+	s.SetPinnedVersionFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetPinnedVersionFunc(ctx, teamID, titleID, version)
+}
+
+func (s *DataStore) DeletePinnedVersion(ctx context.Context, teamID *uint, titleID uint) error {
+	s.mu.Lock()
+	s.DeletePinnedVersionFuncInvoked = true
+	s.mu.Unlock()
+	return s.DeletePinnedVersionFunc(ctx, teamID, titleID)
 }
 
 func (s *DataStore) HasFMAInstallerVersion(ctx context.Context, teamID *uint, fmaID uint, version string) (bool, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1566,6 +1566,8 @@ type GetSoftwareInstallerMetadataByTeamAndTitleIDFunc func(ctx context.Context, 
 
 type GetFleetMaintainedVersionsByTitleIDFunc func(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error)
 
+type SetFleetMaintainedAppActiveInstallerFunc func(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error
+
 type HasFMAInstallerVersionFunc func(ctx context.Context, teamID *uint, fmaID uint, version string) (bool, error)
 
 type GetCachedFMAInstallerMetadataFunc func(ctx context.Context, teamID *uint, fmaID uint, version string) (*fleet.MaintainedApp, error)
@@ -4421,6 +4423,9 @@ type DataStore struct {
 
 	GetFleetMaintainedVersionsByTitleIDFunc        GetFleetMaintainedVersionsByTitleIDFunc
 	GetFleetMaintainedVersionsByTitleIDFuncInvoked bool
+
+	SetFleetMaintainedAppActiveInstallerFunc        SetFleetMaintainedAppActiveInstallerFunc
+	SetFleetMaintainedAppActiveInstallerFuncInvoked bool
 
 	HasFMAInstallerVersionFunc        HasFMAInstallerVersionFunc
 	HasFMAInstallerVersionFuncInvoked bool
@@ -10633,6 +10638,13 @@ func (s *DataStore) GetFleetMaintainedVersionsByTitleID(ctx context.Context, tea
 	s.GetFleetMaintainedVersionsByTitleIDFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetFleetMaintainedVersionsByTitleIDFunc(ctx, teamID, titleID, byVersion)
+}
+
+func (s *DataStore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, teamID *uint, titleID uint, fmaID uint, installerID uint) error {
+	s.mu.Lock()
+	s.SetFleetMaintainedAppActiveInstallerFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetFleetMaintainedAppActiveInstallerFunc(ctx, teamID, titleID, fmaID, installerID)
 }
 
 func (s *DataStore) HasFMAInstallerVersion(ctx context.Context, teamID *uint, fmaID uint, version string) (bool, error) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32827,3 +32827,162 @@ func (s *integrationEnterpriseTestSuite) TestFMAReplacedInstallerLabelScopeListA
 	resp := s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", host.ID, titleID), nil, http.StatusBadRequest)
 	require.Contains(t, extractServerErrorText(resp.Body), "Couldn't install. Host isn't member of the labels defined for this software title.")
 }
+
+func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
+	t := s.T()
+	ctx := context.Background()
+
+	// Real FMA mock servers for zoom/windows with a mutable version, so we can cache multiple versions and drive
+	// the GitOps (batch) path end to end. patchQuery makes the app patchable so a patch policy can be created.
+	zoom := &fmaTestState{
+		version:        "1.0",
+		installerBytes: []byte("zoom-1.0"),
+		installerPath:  "/zoom.msi",
+		patchQuery:     "SELECT 1 FROM osquery_info;",
+	}
+	startFMAServers(t, s.ds, map[string]*fmaTestState{"/zoom/windows.json": zoom})
+
+	var teamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{
+		TeamPayload: fleet.TeamPayload{Name: new("fma_pin_" + t.Name())},
+	}, http.StatusOK, &teamResp)
+	team := *teamResp.Team
+
+	batchSet := func(software []*fleet.SoftwareInstallerPayload) []fleet.SoftwarePackageResponse {
+		var resp batchSetSoftwareInstallersResponse
+		s.DoJSON("POST", "/api/latest/fleet/software/batch",
+			batchSetSoftwareInstallersRequest{Software: software, TeamName: team.Name},
+			http.StatusAccepted, &resp, "team_name", team.Name)
+		return waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, resp.RequestUUID)
+	}
+	bumpVersion := func(version string, bytes []byte) {
+		zoom.version = version
+		zoom.installerBytes = bytes
+		zoom.ComputeSHA(bytes)
+	}
+
+	// Cache v1.0, then bump the manifest and cache v2.0 (GitOps applies, no pin).
+	pkgs := batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
+	require.NotEmpty(t, pkgs)
+	require.NotNil(t, pkgs[0].TitleID)
+	titleID := *pkgs[0].TitleID
+
+	bumpVersion("2.0", []byte("zoom-2.0"))
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
+
+	getPkg := func() *fleet.SoftwareInstaller {
+		var resp getSoftwareTitleResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, http.StatusOK, &resp, "team_id", fmt.Sprint(team.ID))
+		require.NotNil(t, resp.SoftwareTitle)
+		require.NotNil(t, resp.SoftwareTitle.SoftwarePackage)
+		return resp.SoftwareTitle.SoftwarePackage
+	}
+	idForVersion := func(p *fleet.SoftwareInstaller, version string) uint {
+		for _, v := range p.FleetMaintainedVersions {
+			if v.Version == version {
+				return v.ID
+			}
+		}
+		t.Fatalf("version %q is not cached (have %+v)", version, p.FleetMaintainedVersions)
+		return 0
+	}
+	policyInstallerID := func(policyID uint) uint {
+		var id *uint
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &id, "SELECT software_installer_id FROM policies WHERE id = ?", policyID)
+		})
+		require.NotNilf(t, id, "policy %d has no software_installer_id", policyID)
+		return *id
+	}
+	// Patch policies are title-scoped (patch_software_title_id), not installer-scoped, so they don't carry a
+	// software_installer_id and aren't re-pointed on a version flip — they stay attached to the title.
+	patchPolicyTitleID := func(policyID uint) uint {
+		var id *uint
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &id, "SELECT patch_software_title_id FROM policies WHERE id = ?", policyID)
+		})
+		require.NotNilf(t, id, "patch policy %d has no patch_software_title_id", policyID)
+		return *id
+	}
+
+	// Two cached versions; GitOps left the title on Latest (newest active, no pin).
+	p := getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Nil(t, p.PinnedVersion)
+	idV1 := idForVersion(p, "1.0")
+	idV2 := idForVersion(p, "2.0")
+	require.Equal(t, idV2, p.InstallerID)
+
+	// Dependencies on the title: an install-automation policy (carries software_installer_id) and a patch policy
+	// (title-scoped via patch_software_title_id). A PATCH pin re-points the install policy to the active installer.
+	var installPol fleet.TeamPolicyResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), fleet.TeamPolicyRequest{
+		Name: "install zoom", Query: "SELECT 1 FROM osquery_info;", SoftwareTitleID: &titleID,
+	}, http.StatusOK, &installPol)
+	var patchPol fleet.TeamPolicyResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), fleet.TeamPolicyRequest{
+		Type: new("patch"), PatchSoftwareTitleID: &titleID,
+	}, http.StatusOK, &patchPol)
+	require.Equal(t, idV2, policyInstallerID(installPol.Policy.ID))
+	require.Equal(t, titleID, patchPolicyTitleID(patchPol.Policy.ID))
+
+	// assertState checks the active installer id + version + pinned_version, and the dependent policies.
+	assertState := func(msg string, wantID uint, wantVersion string, wantPinned *string, installPolicyRepoints bool) {
+		p := getPkg()
+		require.Equalf(t, wantID, p.InstallerID, "%s: active installer id", msg)
+		require.Equalf(t, wantVersion, p.Version, "%s: active version", msg)
+		if wantPinned == nil {
+			require.Nilf(t, p.PinnedVersion, "%s: pinned_version", msg)
+		} else {
+			require.NotNilf(t, p.PinnedVersion, "%s: pinned_version", msg)
+			require.Equalf(t, *wantPinned, *p.PinnedVersion, "%s: pinned_version", msg)
+		}
+		// The PATCH path re-points install policies to the active installer; the GitOps/batch path does not yet
+		// re-point off an inactive cached version (TODO in BatchSetSoftwareInstallers), so only assert it where it holds.
+		if installPolicyRepoints {
+			require.Equalf(t, wantID, policyInstallerID(installPol.Policy.ID), "%s: install policy re-point", msg)
+		}
+		// Patch policy stays attached to the title across pins (title-scoped, not installer-scoped).
+		require.Equalf(t, titleID, patchPolicyTitleID(patchPol.Policy.ID), "%s: patch policy title", msg)
+	}
+
+	patchVersion := func(version string) {
+		body, headers := generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
+			"team_id": {fmt.Sprint(team.ID)},
+			"version": {version},
+		})
+		s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusOK, headers)
+	}
+
+	// --- UI (PATCH) pins ---
+
+	// Rollback to an older cached version.
+	patchVersion("1.0")
+	assertState("patch rollback 1.0", idV1, "1.0", new("1.0"), true)
+
+	// Pin a major; resolves to the newest cached minor in that major.
+	patchVersion("^2")
+	assertState("patch pin ^2", idV2, "2.0", new("^2"), true)
+
+	// Back to Latest clears the pin row.
+	patchVersion("")
+	assertState("patch latest", idV2, "2.0", nil, true)
+
+	// --- Last write wins: a GitOps apply with no version sets Latest, regardless of a prior UI pin ---
+	// (install-policy re-pointing on GitOps active-flips is a known gap, see assertState / the TODO in
+	// BatchSetSoftwareInstallers, hence installPolicyRepoints=false below.)
+	patchVersion("1.0")
+	assertState("patch re-pin 1.0", idV1, "1.0", new("1.0"), true)
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
+	assertState("gitops no-version -> latest", idV2, "2.0", nil, false)
+
+	// --- GitOps pins persist the verbatim expression ---
+
+	// Literal rollback via GitOps.
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "1.0"}})
+	assertState("gitops literal 1.0", idV1, "1.0", new("1.0"), false)
+
+	// Caret pin via GitOps (latest major); the "^2" string is stored verbatim despite the erase-for-hydrate path.
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "^2"}})
+	assertState("gitops caret ^2", idV2, "2.0", new("^2"), false)
+}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29012,6 +29012,8 @@ func (s *integrationEnterpriseTestSuite) TestPinMajorVersion() {
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, http.StatusOK, &titleResp, "team_id", "0")
 		require.NotNil(t, titleResp.SoftwareTitle)
 		require.Equal(t, "1.0", titleResp.SoftwareTitle.SoftwarePackage.Version)
+		require.WithinDuration(t, time.Now(), titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[0].UploadedAt, 5*time.Second)
+		installer10UploadedAt := titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[0].UploadedAt
 
 		// update manifest to 1.1, FleetMaintainedVersions should have 1.0, 1.1
 		// installer version should be 1.1, while still pinned to ^1
@@ -29030,6 +29032,9 @@ func (s *integrationEnterpriseTestSuite) TestPinMajorVersion() {
 		require.Equal(t, "1.1", titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[0].Version)
 		require.Equal(t, "1.0", titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[1].Version)
 		require.Equal(t, "1.1", titleResp.SoftwareTitle.SoftwarePackage.Version)
+		require.WithinDuration(t, time.Now(), titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[0].UploadedAt, 5*time.Second)
+		installer11UploadedAt := titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[0].UploadedAt
+		require.WithinDuration(t, installer10UploadedAt, titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[1].UploadedAt, 5*time.Second)
 
 		// pin version to 1.0? then pin to ^1, installer should be 1.1. if fleet keeps enough versions we need to test this.
 		// maybe unnecessary test, can remove to speed it up
@@ -29072,6 +29077,8 @@ func (s *integrationEnterpriseTestSuite) TestPinMajorVersion() {
 		require.Equal(t, "1.1", titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[0].Version)
 		require.Equal(t, "1.0", titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[1].Version)
 		require.Equal(t, "1.1", titleResp.SoftwareTitle.SoftwarePackage.Version)
+		require.WithinDuration(t, installer11UploadedAt, titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[0].UploadedAt, 5*time.Second)
+		require.WithinDuration(t, installer10UploadedAt, titleResp.SoftwareTitle.SoftwarePackage.FleetMaintainedVersions[1].UploadedAt, 5*time.Second)
 	})
 
 	// Test pinning ^1 for the first time when only 2.0 is available from manifest

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32942,6 +32942,13 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	require.Equal(t, new("^2"), p.PinnedVersion)
 	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
 
+	// A caret with no cached installer in that major keeps the newest cached version instead of erroring.
+	patchVersion("^9")
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Equal(t, new("^9"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+
 	// Empty clears the pin row, back to Latest.
 	patchVersion("")
 	p = getPkg()
@@ -32949,7 +32956,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	require.Nil(t, p.PinnedVersion)
 	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
 
-	// --- GitOps pins persist the verbatim expression ---
+	// --- GitOps pins persist the pin expression as written ---
 
 	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "1.0"}})
 	p = getPkg()
@@ -33038,16 +33045,8 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// --- Validation ---
 
-	// A caret with no cached installer in that major is rejected on the update endpoint. (GitOps instead keeps the
-	// newest cached version — that behavior is intentionally different.)
-	body, headers := generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
-		"team_id": {fmt.Sprint(team.ID)},
-		"version": {"^999"},
-	})
-	s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusNotFound, headers)
-
 	// "version" can't be changed in the same PATCH as another field.
-	body, headers = generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
+	body, headers := generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
 		"team_id":        {fmt.Sprint(team.ID)},
 		"version":        {"2.0"},
 		"install_script": {"echo changed"},

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -33043,6 +33043,25 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	require.Nil(t, p.PinnedVersion)
 	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
 
+	// Newest is determined by semantic version, not string order: 10.0 is newer than 4.0 even though it sorts
+	// earlier lexicographically.
+	bumpVersion("10.0", []byte("zoom-10.0"))
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
+	p = getPkg()
+	require.Equal(t, "10.0", p.Version)
+
+	// Pin the older 4.0, then clear to Latest and confirm it resolves to 10.0, not the string-larger "4.0".
+	patchVersion("4.0")
+	p = getPkg()
+	require.Equal(t, "4.0", p.Version)
+	require.Equal(t, new("4.0"), p.PinnedVersion)
+
+	patchVersion("")
+	p = getPkg()
+	require.Equal(t, "10.0", p.Version)
+	require.Nil(t, p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+
 	// --- Validation ---
 
 	// "version" can't be changed in the same PATCH as another field.

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32877,15 +32877,6 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 		require.NotNil(t, resp.SoftwareTitle.SoftwarePackage)
 		return resp.SoftwareTitle.SoftwarePackage
 	}
-	idForVersion := func(p *fleet.SoftwareInstaller, version string) uint {
-		for _, v := range p.FleetMaintainedVersions {
-			if v.Version == version {
-				return v.ID
-			}
-		}
-		t.Fatalf("version %q is not cached (have %+v)", version, p.FleetMaintainedVersions)
-		return 0
-	}
 	policyInstallerID := func(policyID uint) uint {
 		var id *uint
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
@@ -32905,16 +32896,14 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 		return *id
 	}
 
-	// Two cached versions; GitOps left the title on Latest (newest active, no pin).
+	// Two cached versions (1.0, 2.0); the no-version GitOps applies above left the title on Latest (active = newest,
+	// no pin).
 	p := getPkg()
 	require.Equal(t, "2.0", p.Version)
 	require.Nil(t, p.PinnedVersion)
-	idV1 := idForVersion(p, "1.0")
-	idV2 := idForVersion(p, "2.0")
-	require.Equal(t, idV2, p.InstallerID)
 
-	// Dependencies on the title: an install-automation policy (carries software_installer_id) and a patch policy
-	// (title-scoped via patch_software_title_id). A PATCH pin re-points the install policy to the active installer.
+	// Dependencies on the title: an install-automation policy (carries software_installer_id, re-pointed to the
+	// active installer on a flip) and a patch policy (title-scoped via patch_software_title_id, never re-pointed).
 	var installPol fleet.TeamPolicyResponse
 	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), fleet.TeamPolicyRequest{
 		Name: "install zoom", Query: "SELECT 1 FROM osquery_info;", SoftwareTitleID: &titleID,
@@ -32923,26 +32912,9 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), fleet.TeamPolicyRequest{
 		Type: new("patch"), PatchSoftwareTitleID: &titleID,
 	}, http.StatusOK, &patchPol)
-	require.Equal(t, idV2, policyInstallerID(installPol.Policy.ID))
-	require.Equal(t, titleID, patchPolicyTitleID(patchPol.Policy.ID))
 
-	// assertState checks the active installer id + version + pinned_version, and the dependent policies.
-	assertState := func(msg string, wantID uint, wantVersion string, wantPinned *string) {
-		p := getPkg()
-		require.Equalf(t, wantID, p.InstallerID, "%s: active installer id", msg)
-		require.Equalf(t, wantVersion, p.Version, "%s: active version", msg)
-		if wantPinned == nil {
-			require.Nilf(t, p.PinnedVersion, "%s: pinned_version", msg)
-		} else {
-			require.NotNilf(t, p.PinnedVersion, "%s: pinned_version", msg)
-			require.Equalf(t, *wantPinned, *p.PinnedVersion, "%s: pinned_version", msg)
-		}
-		// Both the PATCH and the GitOps/batch paths re-point install policies to the active installer, so a policy
-		// never points at an inactive cached version.
-		require.Equalf(t, wantID, policyInstallerID(installPol.Policy.ID), "%s: install policy re-point", msg)
-		// Patch policy stays attached to the title across pins (title-scoped, not installer-scoped).
-		require.Equalf(t, titleID, patchPolicyTitleID(patchPol.Policy.ID), "%s: patch policy title", msg)
-	}
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+	require.Equal(t, titleID, patchPolicyTitleID(patchPol.Policy.ID))
 
 	patchVersion := func(version string) {
 		body, headers := generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
@@ -32952,38 +32924,146 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 		s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusOK, headers)
 	}
 
-	// --- UI (PATCH) pins ---
+	// --- UI (PATCH) pins, on the static 1.0/2.0 cache ---
 
-	// Rollback to an older cached version.
+	// Rollback to an older cached version. The install policy is re-pointed to the now-active installer; the patch
+	// policy is title-scoped and stays put.
 	patchVersion("1.0")
-	assertState("patch rollback 1.0", idV1, "1.0", new("1.0"))
+	p = getPkg()
+	require.Equal(t, "1.0", p.Version)
+	require.Equal(t, new("1.0"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+	require.Equal(t, titleID, patchPolicyTitleID(patchPol.Policy.ID))
 
-	// Pin a major; resolves to the newest cached minor in that major.
+	// Caret resolves to the newest cached minor in that major.
 	patchVersion("^2")
-	assertState("patch pin ^2", idV2, "2.0", new("^2"))
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Equal(t, new("^2"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
 
-	// A caret with no matching cached major resolves to the newest cached version instead of erroring (matching
-	// GitOps): "^9" means "up to 9.x", so with only 1.x/2.x cached it pins to the latest.
+	// A caret with no matching cached major resolves to the newest cached version instead of erroring: "^9" means
+	// "up to 9.x", so with only 1.x/2.x cached it pins to the latest (matching the GitOps fallback).
 	patchVersion("^9")
-	assertState("patch caret ^9 -> latest cached", idV2, "2.0", new("^9"))
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Equal(t, new("^9"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
 
-	// Back to Latest clears the pin row.
+	// Empty clears the pin row, back to Latest.
 	patchVersion("")
-	assertState("patch latest", idV2, "2.0", nil)
-
-	// --- Last write wins: a GitOps apply with no version sets Latest, regardless of a prior UI pin ---
-	patchVersion("1.0")
-	assertState("patch re-pin 1.0", idV1, "1.0", new("1.0"))
-	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
-	assertState("gitops no-version -> latest", idV2, "2.0", nil)
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Nil(t, p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
 
 	// --- GitOps pins persist the verbatim expression ---
 
-	// Literal rollback via GitOps.
 	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "1.0"}})
-	assertState("gitops literal 1.0", idV1, "1.0", new("1.0"))
+	p = getPkg()
+	require.Equal(t, "1.0", p.Version)
+	require.Equal(t, new("1.0"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+	require.Equal(t, titleID, patchPolicyTitleID(patchPol.Policy.ID)) // patch policy stays title-scoped across a GitOps flip
 
-	// Caret pin via GitOps (latest major); the "^2" string is stored verbatim despite the erase-for-hydrate path.
 	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "^2"}})
-	assertState("gitops caret ^2", idV2, "2.0", new("^2"))
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Equal(t, new("^2"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+
+	// Last write wins: a GitOps apply with no version resets a prior UI pin back to Latest.
+	patchVersion("1.0")
+	p = getPkg()
+	require.Equal(t, "1.0", p.Version)
+	require.Equal(t, new("1.0"), p.PinnedVersion)
+
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Nil(t, p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+
+	// --- New versions released over time (each GitOps run can bring a newer manifest version) ---
+
+	// A caret pin tracks a newly released minor in the pinned major: releasing 2.5 under "^2" moves the active
+	// version forward to 2.5.
+	patchVersion("^2")
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Equal(t, new("^2"), p.PinnedVersion)
+
+	bumpVersion("2.5", []byte("zoom-2.5"))
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "^2"}})
+	p = getPkg()
+	require.Equal(t, "2.5", p.Version)
+	require.Equal(t, new("^2"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+	// The cache caps at 2 versions per title, so caching 2.5 evicts the oldest (1.0).
+	require.Len(t, p.FleetMaintainedVersions, 2)
+	require.ElementsMatch(t, []string{"2.0", "2.5"},
+		[]string{p.FleetMaintainedVersions[0].Version, p.FleetMaintainedVersions[1].Version},
+		"caching a new minor evicts the oldest cached version")
+
+	// A caret pin ignores a newly released major: releasing 3.0 under "^2" leaves the active version on the newest
+	// cached in-major version, and 3.0 is never cached.
+	bumpVersion("3.0", []byte("zoom-3.0"))
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "^2"}})
+	p = getPkg()
+	require.Equal(t, "2.5", p.Version)
+	require.Equal(t, new("^2"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+	require.Len(t, p.FleetMaintainedVersions, 2)
+	require.ElementsMatch(t, []string{"2.0", "2.5"},
+		[]string{p.FleetMaintainedVersions[0].Version, p.FleetMaintainedVersions[1].Version},
+		"a new major must not be cached under a caret pin")
+
+	// A literal pin holds across a new release: releasing 4.0 under a "2.0" pin keeps the active version on 2.0, and
+	// 4.0 is never cached (the literal pin fetches its exact cached version, not the latest manifest).
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "2.0"}})
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Equal(t, new("2.0"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID)) // flip 2.5 -> 2.0 re-points the install policy
+
+	bumpVersion("4.0", []byte("zoom-4.0"))
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "2.0"}})
+	p = getPkg()
+	require.Equal(t, "2.0", p.Version)
+	require.Equal(t, new("2.0"), p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+	require.Len(t, p.FleetMaintainedVersions, 2)
+	require.ElementsMatch(t, []string{"2.0", "2.5"},
+		[]string{p.FleetMaintainedVersions[0].Version, p.FleetMaintainedVersions[1].Version},
+		"a literal pin must not cache a newer release")
+
+	// Clearing the pin lets Latest track the new release.
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
+	p = getPkg()
+	require.Equal(t, "4.0", p.Version)
+	require.Nil(t, p.PinnedVersion)
+	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
+
+	// --- Validation ---
+
+	// "version" can't be changed in the same PATCH as another field.
+	body, headers := generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
+		"team_id":        {fmt.Sprint(team.ID)},
+		"version":        {"2.0"},
+		"install_script": {"echo changed"},
+	})
+	s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusBadRequest, headers)
+
+	// "version" is only valid for a Fleet-maintained app, not a custom package.
+	s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript: "echo install",
+		Filename:      "ruby.deb",
+		TeamID:        &team.ID,
+	}, http.StatusOK, "")
+	customTitleID := getSoftwareTitleID(t, s.ds, "ruby", "deb_packages")
+	body, headers = generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
+		"team_id": {fmt.Sprint(team.ID)},
+		"version": {"1.0"},
+	})
+	s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", customTitleID), body.Bytes(), http.StatusBadRequest, headers)
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32927,7 +32927,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	require.Equal(t, titleID, patchPolicyTitleID(patchPol.Policy.ID))
 
 	// assertState checks the active installer id + version + pinned_version, and the dependent policies.
-	assertState := func(msg string, wantID uint, wantVersion string, wantPinned *string, installPolicyRepoints bool) {
+	assertState := func(msg string, wantID uint, wantVersion string, wantPinned *string) {
 		p := getPkg()
 		require.Equalf(t, wantID, p.InstallerID, "%s: active installer id", msg)
 		require.Equalf(t, wantVersion, p.Version, "%s: active version", msg)
@@ -32937,11 +32937,9 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 			require.NotNilf(t, p.PinnedVersion, "%s: pinned_version", msg)
 			require.Equalf(t, *wantPinned, *p.PinnedVersion, "%s: pinned_version", msg)
 		}
-		// The PATCH path re-points install policies to the active installer; the GitOps/batch path does not yet
-		// re-point off an inactive cached version (TODO in BatchSetSoftwareInstallers), so only assert it where it holds.
-		if installPolicyRepoints {
-			require.Equalf(t, wantID, policyInstallerID(installPol.Policy.ID), "%s: install policy re-point", msg)
-		}
+		// Both the PATCH and the GitOps/batch paths re-point install policies to the active installer, so a policy
+		// never points at an inactive cached version.
+		require.Equalf(t, wantID, policyInstallerID(installPol.Policy.ID), "%s: install policy re-point", msg)
 		// Patch policy stays attached to the title across pins (title-scoped, not installer-scoped).
 		require.Equalf(t, titleID, patchPolicyTitleID(patchPol.Policy.ID), "%s: patch policy title", msg)
 	}
@@ -32958,31 +32956,34 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// Rollback to an older cached version.
 	patchVersion("1.0")
-	assertState("patch rollback 1.0", idV1, "1.0", new("1.0"), true)
+	assertState("patch rollback 1.0", idV1, "1.0", new("1.0"))
 
 	// Pin a major; resolves to the newest cached minor in that major.
 	patchVersion("^2")
-	assertState("patch pin ^2", idV2, "2.0", new("^2"), true)
+	assertState("patch pin ^2", idV2, "2.0", new("^2"))
+
+	// A caret with no matching cached major resolves to the newest cached version instead of erroring (matching
+	// GitOps): "^9" means "up to 9.x", so with only 1.x/2.x cached it pins to the latest.
+	patchVersion("^9")
+	assertState("patch caret ^9 -> latest cached", idV2, "2.0", new("^9"))
 
 	// Back to Latest clears the pin row.
 	patchVersion("")
-	assertState("patch latest", idV2, "2.0", nil, true)
+	assertState("patch latest", idV2, "2.0", nil)
 
 	// --- Last write wins: a GitOps apply with no version sets Latest, regardless of a prior UI pin ---
-	// (install-policy re-pointing on GitOps active-flips is a known gap, see assertState / the TODO in
-	// BatchSetSoftwareInstallers, hence installPolicyRepoints=false below.)
 	patchVersion("1.0")
-	assertState("patch re-pin 1.0", idV1, "1.0", new("1.0"), true)
+	assertState("patch re-pin 1.0", idV1, "1.0", new("1.0"))
 	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
-	assertState("gitops no-version -> latest", idV2, "2.0", nil, false)
+	assertState("gitops no-version -> latest", idV2, "2.0", nil)
 
 	// --- GitOps pins persist the verbatim expression ---
 
 	// Literal rollback via GitOps.
 	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "1.0"}})
-	assertState("gitops literal 1.0", idV1, "1.0", new("1.0"), false)
+	assertState("gitops literal 1.0", idV1, "1.0", new("1.0"))
 
 	// Caret pin via GitOps (latest major); the "^2" string is stored verbatim despite the erase-for-hydrate path.
 	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "^2"}})
-	assertState("gitops caret ^2", idV2, "2.0", new("^2"), false)
+	assertState("gitops caret ^2", idV2, "2.0", new("^2"))
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32942,14 +32942,6 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	require.Equal(t, new("^2"), p.PinnedVersion)
 	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
 
-	// A caret with no matching cached major resolves to the newest cached version instead of erroring: "^9" means
-	// "up to 9.x", so with only 1.x/2.x cached it pins to the latest (matching the GitOps fallback).
-	patchVersion("^9")
-	p = getPkg()
-	require.Equal(t, "2.0", p.Version)
-	require.Equal(t, new("^9"), p.PinnedVersion)
-	require.Equal(t, p.InstallerID, policyInstallerID(installPol.Policy.ID))
-
 	// Empty clears the pin row, back to Latest.
 	patchVersion("")
 	p = getPkg()
@@ -33046,8 +33038,16 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// --- Validation ---
 
-	// "version" can't be changed in the same PATCH as another field.
+	// A caret with no cached installer in that major is rejected on the update endpoint. (GitOps instead keeps the
+	// newest cached version — that behavior is intentionally different.)
 	body, headers := generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
+		"team_id": {fmt.Sprint(team.ID)},
+		"version": {"^999"},
+	})
+	s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusNotFound, headers)
+
+	// "version" can't be changed in the same PATCH as another field.
+	body, headers = generateMultipartRequest(t, "", "", nil, s.token, map[string][]string{
 		"team_id":        {fmt.Sprint(team.ID)},
 		"version":        {"2.0"},
 		"install_script": {"echo changed"},

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	authzctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -55,6 +56,9 @@ type updateSoftwareInstallerRequest struct {
 	LabelsIncludeAll  []string
 	Categories        []string
 	DisplayName       *string
+	// Version is the wire-level field for pinning a Fleet-maintained app to a specific cached version. nil means
+	// the field was omitted (leave the active version untouched); a present empty string means "Latest".
+	Version *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged.
 	Configuration []byte
 }
@@ -142,6 +146,13 @@ func (updateSoftwareInstallerRequest) DecodeRequest(ctx context.Context, r *http
 
 	if cfg, ok := r.MultipartForm.Value["configuration"]; ok && len(cfg) > 0 {
 		decoded.Configuration = []byte(cfg[0])
+	}
+
+	// Only set Version when the field is present so we can distinguish "omitted" (leave the active version
+	// untouched) from a present empty string ("Latest"). Trim whitespace; empty after trimming means "Latest".
+	if versionMultipart, ok := r.MultipartForm.Value["version"]; ok && len(versionMultipart) > 0 {
+		trimmed := strings.TrimSpace(versionMultipart[0])
+		decoded.Version = &trimmed
 	}
 
 	val, ok = r.MultipartForm.Value["self_service"]
@@ -259,6 +270,7 @@ func updateSoftwareInstallerEndpoint(ctx context.Context, request interface{}, s
 		Categories:        req.Categories,
 		DisplayName:       req.DisplayName,
 		Configuration:     req.Configuration,
+		RollbackVersion:   req.Version,
 	}
 	if req.File != nil {
 		ff, err := req.File.Open()

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 
 	authzctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -149,8 +148,7 @@ func (updateSoftwareInstallerRequest) DecodeRequest(ctx context.Context, r *http
 
 	// Only set Version when the field is present, so an omitted field stays nil and an empty value means "Latest".
 	if versionMultipart, ok := r.MultipartForm.Value["version"]; ok && len(versionMultipart) > 0 {
-		trimmed := strings.TrimSpace(versionMultipart[0])
-		decoded.Version = &trimmed
+		decoded.Version = &versionMultipart[0]
 	}
 
 	val, ok = r.MultipartForm.Value["self_service"]

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -268,7 +268,7 @@ func updateSoftwareInstallerEndpoint(ctx context.Context, request interface{}, s
 		Categories:        req.Categories,
 		DisplayName:       req.DisplayName,
 		Configuration:     req.Configuration,
-		RollbackVersion:   req.Version,
+		PinnedVersion:     req.Version,
 	}
 	if req.File != nil {
 		ff, err := req.File.Open()

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -56,8 +56,7 @@ type updateSoftwareInstallerRequest struct {
 	LabelsIncludeAll  []string
 	Categories        []string
 	DisplayName       *string
-	// Version is the wire-level field for pinning a Fleet-maintained app to a specific cached version. nil means
-	// the field was omitted (leave the active version untouched); a present empty string means "Latest".
+	// Version pins a Fleet-maintained app to a cached version; empty means "Latest", omitted leaves it unchanged.
 	Version *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged.
 	Configuration []byte
@@ -148,8 +147,7 @@ func (updateSoftwareInstallerRequest) DecodeRequest(ctx context.Context, r *http
 		decoded.Configuration = []byte(cfg[0])
 	}
 
-	// Only set Version when the field is present so we can distinguish "omitted" (leave the active version
-	// untouched) from a present empty string ("Latest"). Trim whitespace; empty after trimming means "Latest".
+	// Only set Version when the field is present, so an omitted field stays nil and an empty value means "Latest".
 	if versionMultipart, ok := r.MultipartForm.Value["version"]; ok && len(versionMultipart) > 0 {
 		trimmed := strings.TrimSpace(versionMultipart[0])
 		decoded.Version = &trimmed

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -209,9 +211,12 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 				}
 				meta.FleetMaintainedVersions = fmaVersions
 
-				// TODO(storage): populate meta.PinnedVersion with the stored pin string (literal / "^major" / nil for
-				// Latest). is_active only tells us which row is active, not the pin intent, so this needs the pinned
-				// version persisted first (see the pin-string storage design). Left nil until then.
+				// No pin row means the title tracks "Latest" (nil pinned_version); any other error is real.
+				pinnedVersion, err := svc.ds.GetPinnedVersion(ctx, teamID, id)
+				if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return nil, ctxerr.Wrap(ctx, err, "get pinned version")
+				}
+				meta.PinnedVersion = pinnedVersion
 
 				// Populate PatchPolicy if there is one
 				patchPolicy, err := svc.ds.GetPatchPolicy(ctx, teamID, id)

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -209,6 +209,10 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 				}
 				meta.FleetMaintainedVersions = fmaVersions
 
+				// TODO(storage): populate meta.PinnedVersion with the stored pin string (literal / "^major" / nil for
+				// Latest). is_active only tells us which row is active, not the pin intent, so this needs the pinned
+				// version persisted first (see the pin-string storage design). Left nil until then.
+
 				// Populate PatchPolicy if there is one
 				patchPolicy, err := svc.ds.GetPatchPolicy(ctx, teamID, id)
 				if err != nil && !fleet.IsNotFound(err) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46726 

Updates the `PATCH /api/v1/fleet/software/titles/:id/package` endpoint to be able to set the pinned version in the `software_title_team_pins` table and set the active installer if it changed.

`GET /software/titles/:id` returns the pinned version for a title from that table now.

A few small fixes and updates that are related to this feature but not strictly in the scope of the subtask are also included (see individual comments).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

This setting is already handled by gitops, this PR adds control of it with the update software installer api

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
    - TODO in another PR
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version pinning for Fleet-maintained app installers, allowing teams to lock to specific versions or clear pins to use "Latest"
  * Policies automatically repoint to the newly active installer when a version pin is changed
  * Support for semantic version syntax including caret-style version constraints

* **Tests**
  * Added comprehensive integration test for Fleet-maintained app version pinning workflows and validation rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->