### PR TITLE
Add per-host policy reset via host_id query param

### DIFF
--- a/changes/38670-policy-status-page
+++ b/changes/38670-policy-status-page
@@ -1,4 +1,4 @@
-- Added `POST /api/v1/fleet/policies/:policy_id/reset` endpoint to reset a policy's pass/fail results, clearing counts and membership immediately.
+- Added `POST /api/v1/fleet/policies/:policy_id/reset` endpoint to reset a policy's pass/fail results, clearing counts and membership immediately. Pass the `host_id` query parameter to reset only a single host's result for the policy.
 - Updated policy details page to show automations and labels as a single property. Also changed the layout of policy properties.
 - Added `GET /api/v1/fleet/policies/:id/automation_activities` endpoint to list automation activities for a policy.
 - Added per-host activity log entries when policy automations (webhook, tickets, Google Calendar, and Microsoft conditional access) fail or succeed.

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -198,7 +198,7 @@ describe("PolicyAutomationsActivitiesTable", () => {
     expect(await screen.findByText("No automation runs")).toBeInTheDocument();
   });
 
-  it("calls the reset endpoint when the reset is confirmed", async () => {
+  it("resets the whole policy (no host_id) from the table header", async () => {
     (policiesAPI.getAutomationActivities as jest.Mock).mockResolvedValue(
       mockResponse([mockActivity()], 1)
     );
@@ -215,6 +215,37 @@ describe("PolicyAutomationsActivitiesTable", () => {
     await user.click(screen.getByRole("button", { name: "Reset policy" }));
     await user.click(screen.getByRole("button", { name: "Reset" }));
 
-    await waitFor(() => expect(policiesAPI.reset).toHaveBeenCalledWith(123));
+    await waitFor(() =>
+      expect(policiesAPI.reset).toHaveBeenCalledWith(123, undefined)
+    );
+  });
+
+  it("resets scoped to the host (host_id) from a run's details", async () => {
+    (policiesAPI.getAutomationActivities as jest.Mock).mockResolvedValue(
+      mockResponse([mockActivity()], 1)
+    );
+    (policiesAPI.reset as jest.Mock).mockResolvedValue(undefined);
+
+    const { user } = render(
+      <PolicyAutomationsActivitiesTable
+        policy={mockPolicy}
+        currentAutomatedPolicies={[]}
+        canResetPolicy
+      />
+    );
+
+    // Open the run's details modal, then trigger the host-scoped reset. The
+    // table header also renders a "Reset policy" button, so target the one in
+    // the details modal (the last in the DOM).
+    await user.click(await screen.findByText("Software installed (1Password)"));
+    const resetButtons = screen.getAllByRole("button", {
+      name: /reset policy/i,
+    });
+    await user.click(resetButtons[resetButtons.length - 1]);
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    await waitFor(() =>
+      expect(policiesAPI.reset).toHaveBeenCalledWith(123, 42)
+    );
   });
 });

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
@@ -40,6 +40,12 @@ const DEFAULT_SORT_DIRECTION: OrderDirection = "desc";
 
 type StatusFilter = NonNullable<IGetPolicyAutomationActivitiesParams["status"]>;
 
+// What a pending reset applies to: the whole policy (from the table header) or a
+// single host (from a specific run). Drives both the API scope and modal copy.
+type ResetTarget =
+  | { type: "policy" }
+  | { type: "host"; hostId: number; hostDisplayName: string };
+
 const STATUS_FILTER_OPTIONS: CustomOptionType[] = [
   { label: "All", value: "" },
   { label: "Successful", value: "success" },
@@ -78,10 +84,8 @@ const PolicyAutomationsActivitiesTable = ({
     selectedActivity,
     setSelectedActivity,
   ] = useState<IPolicyAutomationActivity | null>(null);
-  const [showResetModal, setShowResetModal] = useState(false);
-  const [resetHostDisplayName, setResetHostDisplayName] = useState<
-    string | undefined
-  >(undefined);
+  // null when no reset modal is open.
+  const [resetTarget, setResetTarget] = useState<ResetTarget | null>(null);
 
   const { data, isLoading, isError } = useQuery<
     IPolicyAutomationActivitiesResponse,
@@ -111,13 +115,17 @@ const PolicyAutomationsActivitiesTable = ({
   );
 
   const { mutateAsync: resetPolicy, isLoading: isResetting } = useMutation(
-    () => policiesAPI.reset(policyId),
+    (target: ResetTarget) =>
+      policiesAPI.reset(
+        policyId,
+        target.type === "host" ? target.hostId : undefined
+      ),
     {
       onSuccess: () => {
         renderFlash("success", "Policy reset successfully.");
         queryClient.invalidateQueries(["policyAutomationActivities", policyId]);
         queryClient.invalidateQueries(["policy", policyId]);
-        setShowResetModal(false);
+        setResetTarget(null);
       },
       onError: () => {
         renderFlash("error", "Couldn't reset policy. Please try again.");
@@ -153,16 +161,17 @@ const PolicyAutomationsActivitiesTable = ({
   );
 
   const onClickResetPolicy = useCallback(() => {
-    setResetHostDisplayName(undefined);
-    setShowResetModal(true);
+    setResetTarget({ type: "policy" });
   }, []);
 
-  // The reset is always policy-wide; the host name is only used to make the
-  // confirmation copy concrete when the reset is opened from a specific run.
   const onResetFromActivity = useCallback(() => {
-    setResetHostDisplayName(selectedActivity?.host_display_name);
+    if (!selectedActivity) return;
+    setResetTarget({
+      type: "host",
+      hostId: selectedActivity.host_id,
+      hostDisplayName: selectedActivity.host_display_name,
+    });
     setSelectedActivity(null);
-    setShowResetModal(true);
   }, [selectedActivity]);
 
   const isFiltered = searchQuery !== "" || statusFilter !== "";
@@ -266,15 +275,19 @@ const PolicyAutomationsActivitiesTable = ({
           onResetPolicy={canResetPolicy ? onResetFromActivity : undefined}
         />
       )}
-      {showResetModal && (
+      {resetTarget && (
         <PolicyResetModal
           policy={policy}
-          hostDisplayName={resetHostDisplayName}
+          hostDisplayName={
+            resetTarget.type === "host"
+              ? resetTarget.hostDisplayName
+              : undefined
+          }
           currentAutomatedPolicies={currentAutomatedPolicies}
           otherAutomationType={otherAutomationType}
           isResetting={isResetting}
-          onSubmit={resetPolicy}
-          onCancel={() => setShowResetModal(false)}
+          onSubmit={() => resetPolicy(resetTarget)}
+          onCancel={() => setResetTarget(null)}
         />
       )}
     </div>

--- a/frontend/services/entities/policies.ts
+++ b/frontend/services/entities/policies.ts
@@ -2,7 +2,10 @@
 
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { buildQueryStringFromParams } from "utilities/url";
+import {
+  buildQueryStringFromParams,
+  getPathWithQueryParams,
+} from "utilities/url";
 import {
   IPolicyAutomationActivity,
   IStoredPolicyResponse,
@@ -64,9 +67,10 @@ export default {
     return sendRequest("GET", path);
   },
 
-  reset: (id: number): Promise<void> => {
+  reset: (id: number, hostId?: number): Promise<void> => {
     const { POLICY_RESET } = endpoints;
+    const path = getPathWithQueryParams(POLICY_RESET(id), { host_id: hostId });
 
-    return sendRequest("POST", POLICY_RESET(id));
+    return sendRequest("POST", path);
   },
 };

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -367,11 +367,34 @@ func (ds *Datastore) PolicyLite(ctx context.Context, id uint) (*fleet.PolicyLite
 	return &policy, nil
 }
 
-// ResetPolicy clears a policy's pass/fail results: it wipes all policy_membership
-// rows and policy_stats rows for the policy and resets automation retry attempts.
-// This is the same cleanup performed when a policy's query is modified.
-func (ds *Datastore) ResetPolicy(ctx context.Context, policyID uint) error {
+// ResetPolicy clears a policy's pass/fail results. When hostID is nil it resets the
+// policy across all hosts (wiping policy_membership and policy_stats and resetting
+// automation retry attempts, identical to a query-change side-effect). When hostID is
+// set it resets only that host's result: it deletes the host's policy_membership row
+// for the policy and resets that host's automation retry attempts for the policy.
+//
+// It returns whether anything was actually reset. For a per-host reset this is false
+// when the host had no result for the policy (no policy_membership row to delete);
+// callers can use this to skip emitting an activity for a no-op. A policy-wide reset
+// always reports true.
+func (ds *Datastore) ResetPolicy(ctx context.Context, policyID uint, hostID *uint) (bool, error) {
+	reset := true
 	if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		if hostID != nil {
+			res, err := tx.ExecContext(ctx,
+				`DELETE FROM policy_membership WHERE host_id = ? AND policy_id = ?`, *hostID, policyID,
+			)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "delete host policy membership")
+			}
+			rows, err := res.RowsAffected()
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "rows affected deleting host policy membership")
+			}
+			reset = rows > 0
+			return resetHostPolicyAutomationAttempts(ctx, tx, *hostID, []uint{policyID})
+		}
+
 		if err := resetPolicyAutomationAttempts(ctx, tx, policyID); err != nil {
 			return ctxerr.Wrap(ctx, err, "reset policy automation attempts")
 		}
@@ -379,9 +402,9 @@ func (ds *Datastore) ResetPolicy(ctx context.Context, policyID uint) error {
 		// when removing all memberships, so "" is fine.
 		return cleanupPolicy(ctx, tx, tx, policyID, "", true, true, ds.logger)
 	}); err != nil {
-		return ctxerr.Wrap(ctx, err, "resetting policy")
+		return false, ctxerr.Wrap(ctx, err, "resetting policy")
 	}
-	return nil
+	return reset, nil
 }
 
 // SavePolicy updates some fields of the given policy on the datastore.
@@ -459,22 +482,29 @@ func (ds *Datastore) ResetPolicyAutomationRetryAttemptsForHost(ctx context.Conte
 		return nil
 	}
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		q, args, err := sqlx.In(resetScriptAttemptsStmt, hostID, policyIDs)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "building reset host script attempts query")
-		}
-		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
-			return ctxerr.Wrap(ctx, err, "reset host script attempts")
-		}
-		q, args, err = sqlx.In(resetInstallAttemptsStmt, hostID, policyIDs)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "building reset host install attempts query")
-		}
-		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
-			return ctxerr.Wrap(ctx, err, "reset host install attempts")
-		}
-		return nil
+		return resetHostPolicyAutomationAttempts(ctx, tx, hostID, policyIDs)
 	})
+}
+
+// resetHostPolicyAutomationAttempts marks the host's prior script and software install
+// attempts (across the given policies) as "old sequence" by setting attempt_number=0,
+// so the next attempt restarts the sequence at 1.
+func resetHostPolicyAutomationAttempts(ctx context.Context, db sqlx.ExtContext, hostID uint, policyIDs []uint) error {
+	q, args, err := sqlx.In(resetScriptAttemptsStmt, hostID, policyIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building reset host script attempts query")
+	}
+	if _, err := db.ExecContext(ctx, q, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "reset host script attempts")
+	}
+	q, args, err = sqlx.In(resetInstallAttemptsStmt, hostID, policyIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building reset host install attempts query")
+	}
+	if _, err := db.ExecContext(ctx, q, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "reset host install attempts")
+	}
+	return nil
 }
 
 // resetPolicyAutomationAttempts resets all attempt numbers for script and software install executions

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -100,6 +100,7 @@ func TestPolicies(t *testing.T) {
 		{"ApplyPolicySpecNoSpuriousStatsReset", testApplyPolicySpecNoSpuriousStatsReset},
 		{"RecordPolicyQueryExecutionsDeletedPolicy", testRecordPolicyQueryExecutionsDeletedPolicy},
 		{"ResetPolicy", testResetPolicy},
+		{"ResetHostPolicy", testResetHostPolicy},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -8741,7 +8742,9 @@ func testResetPolicy(t *testing.T, ds *Datastore) {
 	})
 
 	// --- action ---
-	require.NoError(t, ds.ResetPolicy(ctx, policy.ID))
+	reset, err := ds.ResetPolicy(ctx, policy.ID, nil)
+	require.NoError(t, err)
+	require.True(t, reset, "policy-wide reset always reports reset=true")
 
 	// policy_membership for policy must be empty.
 	var memberCount int
@@ -8785,4 +8788,117 @@ func testResetPolicy(t *testing.T, ds *Datastore) {
 			`SELECT attempt_number FROM host_script_results WHERE execution_id = 'other-script-1'`)
 	})
 	require.Equal(t, 3, attemptNum, "other policy attempt_number must be untouched")
+}
+
+func testResetHostPolicy(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Two hosts that both have a result for the policy.
+	host1 := test.NewHost(t, ds, "rhp-host1", "1.1.1.1", "uuid-rhp-host1", "node-key-rhp-host1", time.Now())
+	host2 := test.NewHost(t, ds, "rhp-host2", "1.1.1.2", "uuid-rhp-host2", "node-key-rhp-host2", time.Now())
+
+	// Policy we'll reset for host1, plus a second policy to prove scoping.
+	policy, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name:  t.Name(),
+		Query: "SELECT 1;",
+	})
+	require.NoError(t, err)
+	otherPolicy, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name:  t.Name() + "-other",
+		Query: "SELECT 2;",
+	})
+	require.NoError(t, err)
+
+	// Seed membership: host1 + host2 on policy, host1 on otherPolicy.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO policy_membership (policy_id, host_id, passes) VALUES (?,?,0),(?,?,1),(?,?,1)`,
+			policy.ID, host1.ID,
+			policy.ID, host2.ID,
+			otherPolicy.ID, host1.ID,
+		)
+		return err
+	})
+
+	// script_contents row to satisfy FK on host_script_results.
+	checksum := md5.Sum([]byte(t.Name())) //nolint:gosec // md5 only for test fixture
+	var scriptContentID int64
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		res, err := q.ExecContext(ctx,
+			`INSERT INTO script_contents (md5_checksum, contents) VALUES (?, ?)`,
+			checksum[:], "echo test",
+		)
+		if err != nil {
+			return err
+		}
+		scriptContentID, err = res.LastInsertId()
+		return err
+	})
+
+	// Automation attempt rows: host1/policy (to be reset), host2/policy and
+	// host1/otherPolicy (must be untouched).
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO host_script_results (host_id, execution_id, script_content_id, output, exit_code, policy_id, attempt_number) VALUES
+				(?,'rhp-h1-policy',?,'out',0,?,2),
+				(?,'rhp-h2-policy',?,'out',0,?,4),
+				(?,'rhp-h1-other',?,'out',0,?,3)`,
+			host1.ID, scriptContentID, policy.ID,
+			host2.ID, scriptContentID, policy.ID,
+			host1.ID, scriptContentID, otherPolicy.ID,
+		)
+		return err
+	})
+
+	// --- action: reset host1's result for policy only ---
+	reset, err := ds.ResetPolicy(ctx, policy.ID, &host1.ID)
+	require.NoError(t, err)
+	require.True(t, reset, "host had a result, so reset must report true")
+
+	// host1's membership for policy is gone; host2's remains.
+	var count int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &count,
+			`SELECT COUNT(*) FROM policy_membership WHERE policy_id = ? AND host_id = ?`, policy.ID, host1.ID)
+	})
+	require.Equal(t, 0, count, "host1 membership for policy must be deleted")
+
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &count,
+			`SELECT COUNT(*) FROM policy_membership WHERE policy_id = ? AND host_id = ?`, policy.ID, host2.ID)
+	})
+	require.Equal(t, 1, count, "host2 membership for policy must be untouched")
+
+	// host1's membership for the other policy is untouched.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &count,
+			`SELECT COUNT(*) FROM policy_membership WHERE policy_id = ? AND host_id = ?`, otherPolicy.ID, host1.ID)
+	})
+	require.Equal(t, 1, count, "host1 membership for other policy must be untouched")
+
+	// host1's attempt for policy reset to 0; the other two untouched.
+	var attemptNum int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &attemptNum,
+			`SELECT attempt_number FROM host_script_results WHERE execution_id = 'rhp-h1-policy'`)
+	})
+	require.Equal(t, 0, attemptNum, "host1 policy attempt_number must be reset")
+
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &attemptNum,
+			`SELECT attempt_number FROM host_script_results WHERE execution_id = 'rhp-h2-policy'`)
+	})
+	require.Equal(t, 4, attemptNum, "host2 policy attempt_number must be untouched")
+
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &attemptNum,
+			`SELECT attempt_number FROM host_script_results WHERE execution_id = 'rhp-h1-other'`)
+	})
+	require.Equal(t, 3, attemptNum, "host1 other-policy attempt_number must be untouched")
+
+	// Resetting host1 again (it no longer has a result for the policy) is a no-op
+	// and must report reset=false so callers can skip emitting an activity.
+	reset, err = ds.ResetPolicy(ctx, policy.ID, &host1.ID)
+	require.NoError(t, err)
+	require.False(t, reset, "resetting a host with no result for the policy must report false")
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -161,6 +161,27 @@ func (a ActivityTypeResetPolicy) ActivityName() string {
 	return "reset_policy"
 }
 
+type ActivityTypeResetHostPolicy struct {
+	HostID          uint    `json:"host_id"`
+	HostDisplayName string  `json:"host_display_name"`
+	PolicyID        uint    `json:"policy_id"`
+	PolicyName      string  `json:"policy_name"`
+	TeamID          *int64  `json:"team_id,omitempty" renameto:"fleet_id"`
+	TeamName        *string `json:"team_name,omitempty" renameto:"fleet_name"`
+}
+
+func (a ActivityTypeResetHostPolicy) ActivityName() string {
+	return "reset_host_policy"
+}
+
+func (a ActivityTypeResetHostPolicy) HostIDs() []uint {
+	return []uint{a.HostID}
+}
+
+func (a ActivityTypeResetHostPolicy) HostOnly() bool {
+	return true
+}
+
 type ActivityTypeAppliedSpecPolicy struct {
 	Policies []*PolicySpec `json:"policies"`
 }

--- a/server/fleet/api_policies.go
+++ b/server/fleet/api_policies.go
@@ -107,6 +107,9 @@ func (r ModifyGlobalPolicyResponse) Error() error { return r.Err }
 
 type ResetPolicyRequest struct {
 	PolicyID uint `url:"policy_id"`
+	// HostID, when set, scopes the reset to a single host's result for the policy
+	// instead of resetting the policy's results across all hosts.
+	HostID *uint `query:"host_id,optional"`
 }
 
 type ResetPolicyResponse struct {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -949,9 +949,14 @@ type Datastore interface {
 	//
 	// It is also used to update team policies.
 	SavePolicy(ctx context.Context, p *Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error
-	// ResetPolicy clears pass/fail results: wipes policy_membership, policy_stats,
-	// and resets automation retry attempts, identical to a query-change side-effect.
-	ResetPolicy(ctx context.Context, policyID uint) error
+	// ResetPolicy clears a policy's pass/fail results. When hostID is nil it resets the
+	// policy across all hosts (wiping policy_membership, policy_stats, and automation
+	// retry attempts, identical to a query-change side-effect). When hostID is set it
+	// resets only that host's result for the policy.
+	//
+	// It returns whether anything was actually reset. A per-host reset reports false
+	// when the host had no result for the policy; a policy-wide reset always reports true.
+	ResetPolicy(ctx context.Context, policyID uint, hostID *uint) (bool, error)
 
 	ListGlobalPolicies(ctx context.Context, opts ListOptions) ([]*Policy, error)
 	PoliciesByID(ctx context.Context, ids []uint) (map[uint]*Policy, error)

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -745,7 +745,10 @@ type Service interface {
 	DeleteGlobalPolicies(ctx context.Context, ids []uint) ([]uint, error)
 	ModifyGlobalPolicy(ctx context.Context, id uint, p ModifyPolicyPayload) (*Policy, error)
 	GetPolicyByID(ctx context.Context, policyID uint) (*Policy, error)
-	ResetPolicy(ctx context.Context, policyID uint) error
+	// ResetPolicy clears a policy's pass/fail results. When hostID is nil it resets
+	// the policy's results across all hosts; when hostID is set it resets only that
+	// host's result for the policy.
+	ResetPolicy(ctx context.Context, policyID uint, hostID *uint) error
 	ListPolicyAutomationActivities(ctx context.Context, policyID uint, opts ListOptions, status string) ([]*PolicyAutomationActivity, *PaginationMetadata, error)
 	ApplyPolicySpecs(ctx context.Context, policies []*PolicySpec) error
 	CountGlobalPolicies(ctx context.Context, matchQuery string) (int, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -680,7 +680,7 @@ type ListPolicyAutomationActivitiesFunc func(ctx context.Context, policyID uint,
 
 type SavePolicyFunc func(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error
 
-type ResetPolicyFunc func(ctx context.Context, policyID uint) error
+type ResetPolicyFunc func(ctx context.Context, policyID uint, hostID *uint) (bool, error)
 
 type ListGlobalPoliciesFunc func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error)
 
@@ -7544,11 +7544,11 @@ func (s *DataStore) SavePolicy(ctx context.Context, p *fleet.Policy, shouldRemov
 	return s.SavePolicyFunc(ctx, p, shouldRemoveAllPolicyMemberships, removePolicyStats)
 }
 
-func (s *DataStore) ResetPolicy(ctx context.Context, policyID uint) error {
+func (s *DataStore) ResetPolicy(ctx context.Context, policyID uint, hostID *uint) (bool, error) {
 	s.mu.Lock()
 	s.ResetPolicyFuncInvoked = true
 	s.mu.Unlock()
-	return s.ResetPolicyFunc(ctx, policyID)
+	return s.ResetPolicyFunc(ctx, policyID, hostID)
 }
 
 func (s *DataStore) ListGlobalPolicies(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -462,7 +462,7 @@ type ModifyGlobalPolicyFunc func(ctx context.Context, id uint, p fleet.ModifyPol
 
 type GetPolicyByIDFunc func(ctx context.Context, policyID uint) (*fleet.Policy, error)
 
-type ResetPolicyFunc func(ctx context.Context, policyID uint) error
+type ResetPolicyFunc func(ctx context.Context, policyID uint, hostID *uint) error
 
 type ListPolicyAutomationActivitiesFunc func(ctx context.Context, policyID uint, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error)
 
@@ -3881,11 +3881,11 @@ func (s *Service) GetPolicyByID(ctx context.Context, policyID uint) (*fleet.Poli
 	return s.GetPolicyByIDFunc(ctx, policyID)
 }
 
-func (s *Service) ResetPolicy(ctx context.Context, policyID uint) error {
+func (s *Service) ResetPolicy(ctx context.Context, policyID uint, hostID *uint) error {
 	s.mu.Lock()
 	s.ResetPolicyFuncInvoked = true
 	s.mu.Unlock()
-	return s.ResetPolicyFunc(ctx, policyID)
+	return s.ResetPolicyFunc(ctx, policyID, hostID)
 }
 
 func (s *Service) ListPolicyAutomationActivities(ctx context.Context, policyID uint, opts fleet.ListOptions, status string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -670,7 +670,10 @@ func TestResetPolicyAuth(t *testing.T) {
 			ds.PolicyFunc = func(_ context.Context, id uint) (*fleet.Policy, error) {
 				return &fleet.Policy{PolicyData: fleet.PolicyData{ID: id, TeamID: tt.policyTeamID}}, nil
 			}
-			ds.ResetPolicyFunc = func(_ context.Context, _ uint) error { return nil }
+			ds.ResetPolicyFunc = func(_ context.Context, _ uint, _ *uint) (bool, error) { return true, nil }
+			ds.HostLiteByIDFunc = func(_ context.Context, id uint) (*fleet.HostLite, error) {
+				return &fleet.HostLite{ID: id}, nil
+			}
 
 			opts := &TestServerOpts{}
 			svc, baseCtx := newTestService(t, ds, nil, nil, opts)
@@ -679,9 +682,23 @@ func TestResetPolicyAuth(t *testing.T) {
 			}
 			ctx := viewer.NewContext(baseCtx, viewer.Viewer{User: tt.user})
 
-			err := svc.ResetPolicy(ctx, policyID)
+			// Authorization is identical for the policy-wide reset and the
+			// per-host reset, so exercise both shapes through the same matrix.
+			err := svc.ResetPolicy(ctx, policyID, nil)
 			checkAuthErr(t, tt.shouldFailWrite, err)
-			if !tt.shouldFailWrite {
+			if tt.shouldFailWrite {
+				require.False(t, ds.ResetPolicyFuncInvoked, "datastore must not be written when authorization is denied")
+			} else {
+				require.True(t, ds.ResetPolicyFuncInvoked)
+			}
+
+			ds.ResetPolicyFuncInvoked = false
+			hostID := uint(123)
+			err = svc.ResetPolicy(ctx, policyID, &hostID)
+			checkAuthErr(t, tt.shouldFailWrite, err)
+			if tt.shouldFailWrite {
+				require.False(t, ds.ResetPolicyFuncInvoked, "datastore must not be written when authorization is denied")
+			} else {
 				require.True(t, ds.ResetPolicyFuncInvoked)
 			}
 		})
@@ -699,7 +716,7 @@ func TestResetPolicyNotFound(t *testing.T) {
 	user := &fleet.User{GlobalRole: new(fleet.RoleAdmin)}
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 
-	err := svc.ResetPolicy(ctx, 999)
+	err := svc.ResetPolicy(ctx, 999, nil)
 	require.Error(t, err)
 	require.True(t, fleet.IsNotFound(err))
 }
@@ -713,7 +730,10 @@ func TestResetPolicyEmitsActivity(t *testing.T) {
 		ds.PolicyFunc = func(_ context.Context, id uint) (*fleet.Policy, error) {
 			return &fleet.Policy{PolicyData: fleet.PolicyData{ID: id, Name: policyName, TeamID: teamID}}, nil
 		}
-		ds.ResetPolicyFunc = func(_ context.Context, _ uint) error { return nil }
+		ds.ResetPolicyFunc = func(_ context.Context, _ uint, _ *uint) (bool, error) { return true, nil }
+		ds.HostLiteByIDFunc = func(_ context.Context, id uint) (*fleet.HostLite, error) {
+			return &fleet.HostLite{ID: id, Hostname: "test-host"}, nil
+		}
 		opts := &TestServerOpts{}
 		svc, baseCtx := newTestService(t, ds, nil, nil, opts)
 		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
@@ -733,7 +753,7 @@ func TestResetPolicyEmitsActivity(t *testing.T) {
 			return nil
 		}
 
-		require.NoError(t, svc.ResetPolicy(ctx, policyID))
+		require.NoError(t, svc.ResetPolicy(ctx, policyID, nil))
 		require.True(t, ds.ResetPolicyFuncInvoked)
 		require.True(t, opts.ActivityMock.NewActivityFuncInvoked)
 
@@ -755,7 +775,7 @@ func TestResetPolicyEmitsActivity(t *testing.T) {
 			return nil
 		}
 
-		require.NoError(t, svc.ResetPolicy(ctx, policyID))
+		require.NoError(t, svc.ResetPolicy(ctx, policyID, nil))
 		require.True(t, ds.ResetPolicyFuncInvoked)
 		require.True(t, opts.ActivityMock.NewActivityFuncInvoked)
 
@@ -766,5 +786,40 @@ func TestResetPolicyEmitsActivity(t *testing.T) {
 		require.NotNil(t, act.TeamID)
 		require.Equal(t, int64(0), *act.TeamID)
 		require.Nil(t, act.TeamName)
+	})
+
+	t.Run("per-host reset emits reset_host_policy", func(t *testing.T) {
+		ds, svc, ctx, opts := newSvc(nil)
+		var capturedActivity activity_api.ActivityDetails
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, a activity_api.ActivityDetails) error {
+			capturedActivity = a
+			return nil
+		}
+
+		hostID := uint(55)
+		require.NoError(t, svc.ResetPolicy(ctx, policyID, &hostID))
+		require.True(t, ds.ResetPolicyFuncInvoked)
+		require.True(t, ds.HostLiteByIDFuncInvoked)
+		require.True(t, opts.ActivityMock.NewActivityFuncInvoked)
+
+		act, ok := capturedActivity.(fleet.ActivityTypeResetHostPolicy)
+		require.True(t, ok)
+		require.Equal(t, hostID, act.HostID)
+		require.Equal(t, "test-host", act.HostDisplayName)
+		require.Equal(t, policyID, act.PolicyID)
+		require.Equal(t, policyName, act.PolicyName)
+		require.NotNil(t, act.TeamID)
+		require.Equal(t, int64(-1), *act.TeamID)
+	})
+
+	t.Run("per-host reset with nothing to reset emits no activity", func(t *testing.T) {
+		ds, svc, ctx, opts := newSvc(nil)
+		// Datastore reports the host had no result for the policy.
+		ds.ResetPolicyFunc = func(_ context.Context, _ uint, _ *uint) (bool, error) { return false, nil }
+
+		hostID := uint(55)
+		require.NoError(t, svc.ResetPolicy(ctx, policyID, &hostID))
+		require.True(t, ds.ResetPolicyFuncInvoked)
+		require.False(t, opts.ActivityMock.NewActivityFuncInvoked, "no activity for a no-op reset")
 	})
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32954,3 +32954,92 @@ func (s *integrationEnterpriseTestSuite) TestResetPolicy() {
 	// 404 for a nonexistent policy.
 	s.Do("POST", "/api/latest/fleet/policies/999999/reset", nil, http.StatusNotFound)
 }
+
+func (s *integrationEnterpriseTestSuite) TestResetHostPolicy() {
+	t := s.T()
+	ctx := t.Context()
+
+	hosts := s.createHosts(t, "darwin", "darwin")
+	host1, host2 := hosts[0], hosts[1]
+
+	// --- global policy, two failing hosts ---
+	createGlobalResp := fleet.GlobalPolicyResponse{}
+	s.DoJSON("POST", "/api/latest/fleet/policies", fleet.GlobalPolicyRequest{
+		Name:  "reset-host-test-global",
+		Query: "SELECT 1;",
+	}, http.StatusOK, &createGlobalResp)
+	globalPolicy := createGlobalResp.Policy
+	require.NotZero(t, globalPolicy.ID)
+
+	for _, h := range []*fleet.Host{host1, host2} {
+		s.DoJSONWithoutAuth("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+			h,
+			map[uint]*bool{globalPolicy.ID: new(false)},
+		), http.StatusOK, new(submitDistributedQueryResultsResponse))
+	}
+	require.NoError(t, s.ds.UpdateHostPolicyCounts(ctx))
+
+	getResp := fleet.GetPolicyByIDResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d", globalPolicy.ID), nil, http.StatusOK, &getResp)
+	require.Equal(t, uint(2), getResp.Policy.FailingHostCount)
+
+	// Reset only host1's result for the policy.
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/policies/%d/reset?host_id=%d", globalPolicy.ID, host1.ID), nil, http.StatusOK)
+
+	// After re-aggregating, only host2 remains failing.
+	require.NoError(t, s.ds.UpdateHostPolicyCounts(ctx))
+	getResp = fleet.GetPolicyByIDResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d", globalPolicy.ID), nil, http.StatusOK, &getResp)
+	require.Equal(t, uint(1), getResp.Policy.FailingHostCount)
+
+	// reset_host_policy is a host-only activity: it appears on the host's activity
+	// timeline and is kept out of the global feed. Global policy emits team_id/fleet_id: -1.
+	expectedGlobalDetails := fmt.Sprintf(
+		`{"host_id":%d,"host_display_name":"%s","policy_id":%d,"policy_name":"reset-host-test-global","team_id":-1,"fleet_id":-1}`,
+		host1.ID, host1.DisplayName(), globalPolicy.ID,
+	)
+	s.lastHostActivityMatches(host1.ID, "reset_host_policy", expectedGlobalDetails, 0)
+	s.lastActivityOfTypeDoesNotMatch("reset_host_policy", expectedGlobalDetails, 0)
+
+	// --- team policy ---
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "reset-host-policy-team"})
+	require.NoError(t, err)
+
+	createTeamResp := fleet.TeamPolicyResponse{}
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team.ID), fleet.TeamPolicyRequest{
+		Name:  "reset-host-test-team",
+		Query: "SELECT 1;",
+	}, http.StatusOK, &createTeamResp)
+	teamPolicy := createTeamResp.Policy
+	require.NotZero(t, teamPolicy.ID)
+
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host2.ID})))
+	s.DoJSONWithoutAuth("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		host2,
+		map[uint]*bool{teamPolicy.ID: new(false)},
+	), http.StatusOK, new(submitDistributedQueryResultsResponse))
+	require.NoError(t, s.ds.UpdateHostPolicyCounts(ctx))
+
+	getResp = fleet.GetPolicyByIDResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d", teamPolicy.ID), nil, http.StatusOK, &getResp)
+	require.Equal(t, uint(1), getResp.Policy.FailingHostCount)
+
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/policies/%d/reset?host_id=%d", teamPolicy.ID, host2.ID), nil, http.StatusOK)
+
+	require.NoError(t, s.ds.UpdateHostPolicyCounts(ctx))
+	getResp = fleet.GetPolicyByIDResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d", teamPolicy.ID), nil, http.StatusOK, &getResp)
+	require.Equal(t, uint(0), getResp.Policy.FailingHostCount)
+
+	// Activity carries the team fields and lands on the host's timeline.
+	s.lastHostActivityMatches(host2.ID, "reset_host_policy", fmt.Sprintf(
+		`{"host_id":%d,"host_display_name":"%s","policy_id":%d,"policy_name":"reset-host-test-team","team_id":%d,"fleet_id":%d,"team_name":"reset-host-policy-team","fleet_name":"reset-host-policy-team"}`,
+		host2.ID, host2.DisplayName(), teamPolicy.ID, team.ID, team.ID,
+	), 0)
+
+	// 404 for a nonexistent host. Derive an ID guaranteed not to exist by deleting an
+	// existing host (host1 is done being used) and reusing its now-free ID, rather than
+	// hardcoding one that could collide with a real host as the suite's DB grows.
+	require.NoError(t, s.ds.DeleteHost(ctx, host1.ID))
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/policies/%d/reset?host_id=%d", globalPolicy.ID, host1.ID), nil, http.StatusNotFound)
+}

--- a/server/service/policies.go
+++ b/server/service/policies.go
@@ -58,11 +58,11 @@ func (svc Service) GetPolicyByID(ctx context.Context, policyID uint) (*fleet.Pol
 
 func resetPolicyEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*fleet.ResetPolicyRequest)
-	err := svc.ResetPolicy(ctx, req.PolicyID)
+	err := svc.ResetPolicy(ctx, req.PolicyID, req.HostID)
 	return fleet.ResetPolicyResponse{Err: err}, nil
 }
 
-func (svc Service) ResetPolicy(ctx context.Context, policyID uint) error {
+func (svc Service) ResetPolicy(ctx context.Context, policyID uint, hostID *uint) error {
 	// Load first to authorize against the policy's actual team.
 	policy, err := svc.ds.Policy(ctx, policyID)
 	if err != nil {
@@ -71,10 +71,6 @@ func (svc Service) ResetPolicy(ctx context.Context, policyID uint) error {
 	}
 	if err := svc.authz.Authorize(ctx, policy, fleet.ActionWrite); err != nil {
 		return err
-	}
-
-	if err := svc.ds.ResetPolicy(ctx, policyID); err != nil {
-		return ctxerr.Wrap(ctx, err, "reset policy")
 	}
 
 	var activityTeamID *int64
@@ -98,12 +94,44 @@ func (svc Service) ResetPolicy(ctx context.Context, policyID uint) error {
 		}
 	}
 
-	if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeResetPolicy{
+	// When a host is specified, load it up front so we can validate it exists (404)
+	// and include its display name in the activity.
+	var host *fleet.HostLite
+	if hostID != nil {
+		host, err = svc.ds.HostLiteByID(ctx, *hostID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "loading host")
+		}
+	}
+
+	reset, err := svc.ds.ResetPolicy(ctx, policyID, hostID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "reset policy")
+	}
+	// Nothing was reset (e.g. the host had no result for the policy): skip the
+	// activity so we don't record a no-op.
+	if !reset {
+		return nil
+	}
+
+	// A per-host reset and a policy-wide reset emit different activities.
+	var activity fleet.ActivityDetails = fleet.ActivityTypeResetPolicy{
 		ID:       policy.ID,
 		Name:     policy.Name,
 		TeamID:   activityTeamID,
 		TeamName: teamName,
-	}); err != nil {
+	}
+	if host != nil {
+		activity = fleet.ActivityTypeResetHostPolicy{
+			HostID:          host.ID,
+			HostDisplayName: host.DisplayName(),
+			PolicyID:        policy.ID,
+			PolicyName:      policy.Name,
+			TeamID:          activityTeamID,
+			TeamName:        teamName,
+		}
+	}
+	if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), activity); err != nil {
 		return ctxerr.Wrap(ctx, err, "create activity for policy reset")
 	}
 	return nil


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #46904

Extend POST /api/v1/fleet/policies/:policy_id/reset with an optional host_id query parameter. When set, the reset clears only that host's result for the policy (deletes its policy_membership row and resets its automation retry attempts) instead of resetting the policy across all hosts.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The policy reset API now supports scoping resets to a single host via an optional `host_id` query parameter, allowing targeted result clearing without affecting other hosts.
  * Added activity tracking for host-specific policy resets with host and policy details.

* **Tests**
  * Added tests verifying host-scoped policy reset behavior for global and team policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->