### PR TITLE
Create linux_triggerrefetch.sh

### DIFF
--- a/docs/solutions/linux/scripts/linux_triggerrefetch.sh
+++ b/docs/solutions/linux/scripts/linux_triggerrefetch.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
+set -euo pipefail
 
-orbit_identifier=$(cat /opt/orbit/identifier | tr -d '[:space:]')
 fleet_url="https://fleet.yourdomain.com"
+identifier_file="/opt/orbit/identifier"
+
+if [[ ! -r "$identifier_file" ]]; then
+    echo "Missing or unreadable orbit identifier: $identifier_file" >&2
+    exit 1
+fi
+
+orbit_identifier="$(tr -d '[:space:]' < "$identifier_file")"
+if [[ -z "$orbit_identifier" ]]; then
+    echo "Orbit identifier is empty." >&2
+    exit 1
+fi
 
 echo "Triggering refetch..."
 
-if curl -sf -X POST "$fleet_url/api/v1/fleet/device/$orbit_identifier/refetch" > /dev/null; then
+if curl -sf --connect-timeout 5 --max-time 20 -X POST \
+  "$fleet_url/api/v1/fleet/device/$orbit_identifier/refetch" > /dev/null; then
     echo "Refetch triggered successfully!"
 else
-    echo "Refetch failed!"
-    exit 0
+    rc=$?
+    echo "Refetch failed!" >&2
+    exit "$rc"
 fi

--- a/docs/solutions/linux/scripts/linux_triggerrefetch.sh
+++ b/docs/solutions/linux/scripts/linux_triggerrefetch.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+orbit_identifier=$(cat /opt/orbit/identifier | tr -d '[:space:]')
+fleet_url="https://fleet.yourdomain.com"
+
+echo "Triggering refetch..."
+
+if curl -sf -X POST "$fleet_url/api/v1/fleet/device/$orbit_identifier/refetch" > /dev/null; then
+    echo "Refetch triggered successfully!"
+else
+    echo "Refetch failed!"
+    exit 0
+fi


### PR DESCRIPTION
Adds a simple .sh script that can trigger a refetch locally from a host if required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Linux script used to trigger Fleet refetch operations. It now runs with stricter Bash safety, validates and trims the system identifier before sending the request, and reports clear success/failure status while returning the appropriate nonzero exit code on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->