### PR TITLE
Use universal VS Code installer for the macOS FMA

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
@@ -43,6 +43,7 @@ var Funcs = map[string][]func(*maintained_apps.FMAManifestApp) (*maintained_apps
 	"anka-virtualization/darwin":    {AnkaVersionShortener},
 	"pd/darwin":                     {PdVersionTransformer},
 	"sonos/darwin":                  {SonosVersionTransformer},
+	"visual-studio-code/darwin":     {VSCodeUniversalInstaller},
 }
 
 func ChromePKGInstaller(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/vscode.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/vscode.go
@@ -1,0 +1,28 @@
+package externalrefs
+
+import (
+	"strings"
+
+	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
+)
+
+// VSCodeUniversalInstaller rewrites Homebrew's Apple-silicon-only download URL
+// to the architecture-independent "universal" build, so the FMA installs on
+// both Intel and Apple silicon Macs.
+//
+// Homebrew exposes the arm64 build as the cask's url:
+//
+//	https://update.code.visualstudio.com/<version>/darwin-arm64/stable
+//
+// Microsoft serves the universal build at the arch-less path:
+//
+//	https://update.code.visualstudio.com/<version>/darwin/stable
+//
+// Since the URL (and therefore the artifact) changes, the Homebrew SHA256 no
+// longer applies; set it to "no_check" as the other installer-URL overrides do.
+func VSCodeUniversalInstaller(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {
+	app.InstallerURL = strings.Replace(app.InstallerURL, "/darwin-arm64/", "/darwin/", 1)
+	app.SHA256 = "no_check"
+
+	return app, nil
+}

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.125.0') < 0);"
       },
-      "installer_url": "https://update.code.visualstudio.com/1.125.0/darwin-arm64/stable",
+      "installer_url": "https://update.code.visualstudio.com/1.125.0/darwin/stable",
       "install_script_ref": "e6d54100",
       "uninstall_script_ref": "c6e93467",
-      "sha256": "74c498bdcaf20ddf16aaef061f09eba79a72449c0bce957d0432e7a7259cc46d",
+      "sha256": "no_check",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Add VSCodeUniversalInstaller to rewrite Homebrew's arm64-only VS Code URL to the architecture-independent "darwin" (universal) path and set SHA256 to "no_check". Register the transformer in external_refs main.go and update the visual-studio-code darwin.json to use the new installer_url and no_check sha256 so the FMA installs work on both Intel and Apple Silicon Macs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS installation support for Visual Studio Code with universal installer path configuration.

* **Updates**
  * Updated installer URL routing to use architecture-agnostic deployment path for improved compatibility.
  * Modified SHA256 verification settings for the macOS installer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->