### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/apidog/darwin.json
+++ b/ee/maintained-apps/outputs/apidog/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.8.34",
+      "version": "2.8.35",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app' AND version_compare(bundle_short_version, '2.8.34') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app' AND version_compare(bundle_short_version, '2.8.35') < 0);"
       },
-      "installer_url": "https://file-assets.apidog.com/download/2.8.34/legacy-Apidog-macOS-arm64-2.8.34.dmg",
+      "installer_url": "https://file-assets.apidog.com/download/2.8.35/legacy-Apidog-macOS-arm64-2.8.35.dmg",
       "install_script_ref": "164bc8ef",
       "uninstall_script_ref": "b51190cf",
-      "sha256": "36c38058bd80974f8284588604b36cb87878588a197af190365d98b0eb722991",
+      "sha256": "4249b8ab7c471a1e94c7c5dc5a38886a51c8a8ba21410811a3651d888fa97548",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.35.6",
+      "version": "2.35.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.7') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.6.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.7.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "8e05199addae4b53d7a280f56e4c8b7c1d299c05dcf0a5e4ed9cb56854137314",
+      "sha256": "b7cfc16db46ac3784fb610d34a78e99e24614e8c494eb1be20b1cdc21b2086a5",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/bezel/darwin.json
+++ b/ee/maintained-apps/outputs/bezel/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.4.0",
+      "version": "4.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct' AND version_compare(bundle_short_version, '4.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct' AND version_compare(bundle_short_version, '4.4.1') < 0);"
       },
-      "installer_url": "https://download.nonstrict.eu/bezel/Bezel-4.4.0.zip",
+      "installer_url": "https://download.nonstrict.eu/bezel/Bezel-4.4.1.zip",
       "install_script_ref": "6ddd4f59",
       "uninstall_script_ref": "539e1578",
-      "sha256": "25c984d26873ccd2318e549a4c54467cea8349241e27bc7ffdd70d1e91f58ba7",
+      "sha256": "861e929b5e13bc41ec20fd8628b8007955c136218848eb75fc672a91997672d2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/boom-3d/darwin.json
+++ b/ee/maintained-apps/outputs/boom-3d/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.2.6",
+      "version": "2.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.globaldelight.Boom3D';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.globaldelight.Boom3D' AND version_compare(bundle_short_version, '2.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.globaldelight.Boom3D' AND version_compare(bundle_short_version, '2.3.0') < 0);"
       },
       "installer_url": "https://dfvk972795zr9.cloudfront.net/Boom3Dmac/webstore/Boom3D.dmg",
       "install_script_ref": "1284004f",

--- a/ee/maintained-apps/outputs/clockify/windows.json
+++ b/ee/maintained-apps/outputs/clockify/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.' AND version_compare(version, '2.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.' AND version_compare(version, '2.2.1') < 0);"
       },
       "installer_url": "https://clockify.me/downloads/clockify-setup.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "f7f14087",
-      "sha256": "420f7dddcaa69a3275c01057687783b69495cdaf86e191dbb94ed58ef6f770d5",
+      "sha256": "478da3fd0a16d9e4dda9c9087378243eb82975f30cd5063f6aa27ed348859973",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/cyberduck/darwin.json
+++ b/ee/maintained-apps/outputs/cyberduck/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.4.1",
+      "version": "9.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck' AND version_compare(bundle_short_version, '9.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck' AND version_compare(bundle_short_version, '9.5.0') < 0);"
       },
-      "installer_url": "https://update.cyberduck.io/Cyberduck-9.4.1.44384.zip",
+      "installer_url": "https://update.cyberduck.io/Cyberduck-9.5.0.45237.zip",
       "install_script_ref": "3390ca0f",
       "uninstall_script_ref": "8d609003",
-      "sha256": "b733be43f89a668a86ab3f2933ca25c9f799959491533d59e77978cdba74b1e2",
+      "sha256": "c35aea13bf617b1fbc66030c7978ded1360ea1ac67b2ab057492ac3dc961bc1d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/deezer/darwin.json
+++ b/ee/maintained-apps/outputs/deezer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.1.240",
+      "version": "7.1.250",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop' AND version_compare(bundle_short_version, '7.1.240') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop' AND version_compare(bundle_short_version, '7.1.250') < 0);"
       },
-      "installer_url": "https://www.deezer.com/desktop/download/artifact-darwin-x64-7.1.240",
+      "installer_url": "https://www.deezer.com/desktop/download/artifact-darwin-x64-7.1.250",
       "install_script_ref": "17993903",
       "uninstall_script_ref": "7a7ca836",
-      "sha256": "e2cafba2fde56f9bdb74ce98f008a47b99cc82bbbc0ff21e9b0382a66812da8b",
+      "sha256": "3cc0c917a86e2b3663b25949fc5a16485b5e7ac5aa3adfd180a7eae84ddd584c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "152.0",
+      "version": "152.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '152.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '152.0.1') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/152.0/mac/en-US/Firefox%20152.0.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/152.0.1/mac/en-US/Firefox%20152.0.1.dmg",
       "install_script_ref": "b5e4c76e",
       "uninstall_script_ref": "b85c0267",
-      "sha256": "b8a46188850d2fb32f16ad3c0829b08cd689bc714b8ee18fd9b09bb60629004d",
+      "sha256": "3398cb6c17077f536bd534af3a98b66ef850689532f82ddc3df05533b8018ede",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/godot/darwin.json
+++ b/ee/maintained-apps/outputs/godot/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.3",
+      "version": "4.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.godotengine.godot';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.godotengine.godot' AND version_compare(bundle_short_version, '4.6.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.godotengine.godot' AND version_compare(bundle_short_version, '4.7') < 0);"
       },
-      "installer_url": "https://github.com/godotengine/godot/releases/download/4.6.3-stable/Godot_v4.6.3-stable_macos.universal.zip",
+      "installer_url": "https://github.com/godotengine/godot/releases/download/4.7-stable/Godot_v4.7-stable_macos.universal.zip",
       "install_script_ref": "3961919e",
       "uninstall_script_ref": "1e19fc0d",
-      "sha256": "30630f3e9b11e10b35c1f90ba8814185dcec43fae1a48345159be7552c64bfe8",
+      "sha256": "a6708c336f690e0dd8abd3d587d661707f4f33ed436946a3ec000d2fb497fd6c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.324.2",
+      "version": "7.345.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.324.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.345.3') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.324.2/Granola-7.324.2-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.345.3/Granola-7.345.3-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "b7cb621811a15ba908486df78dbc0b9aa5e1126109bbb477251ab00210c9da68",
+      "sha256": "0e1702c25a8c9c0084b7d3ecc97a798f3c495565ac47a8d19bae9c26514693a2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/insomnia/darwin.json
+++ b/ee/maintained-apps/outputs/insomnia/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '13.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '13.0.1') < 0);"
       },
-      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4013.0.0/Insomnia.Core-13.0.0.dmg",
+      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4013.0.1/Insomnia.Core-13.0.1.dmg",
       "install_script_ref": "80491bd1",
       "uninstall_script_ref": "093d2a58",
-      "sha256": "b0f97b2970bc675dcb159bf1b8a834da20dbb6b0b19fffd8aebf0038e7f7543e",
+      "sha256": "bdc06eb2131ee7d8c366920cc84e6a1f70f40e0af4fc9080568c33b72a9d8520",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/insomnia/windows.json
+++ b/ee/maintained-apps/outputs/insomnia/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Insomnia' AND publisher = 'Kong';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Insomnia' AND publisher = 'Kong' AND version_compare(version, '13.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Insomnia' AND publisher = 'Kong' AND version_compare(version, '13.0.1') < 0);"
       },
-      "installer_url": "https://github.com/Kong/insomnia/releases/download/core@13.0.0/Insomnia.Core-13.0.0.exe",
+      "installer_url": "https://github.com/Kong/insomnia/releases/download/core@13.0.1/Insomnia.Core-13.0.1.exe",
       "install_script_ref": "a20529f5",
       "uninstall_script_ref": "b9ba50cf",
-      "sha256": "2b1ef8612fefcf4002585da919e6b56943ffd1336109f53a778f822afd752be4",
+      "sha256": "78c8fbd4cbe6d7d1d4f43bfe23bfa477ce01291c83d9316d6b55c62200368a48",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/pgadmin4/darwin.json
+++ b/ee/maintained-apps/outputs/pgadmin4/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.15",
+      "version": "9.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4' AND version_compare(bundle_short_version, '9.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4' AND version_compare(bundle_short_version, '9.16') < 0);"
       },
-      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.15/macos/pgadmin4-9.15-arm64.dmg",
+      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.16/macos/pgadmin4-9.16-arm64.dmg",
       "install_script_ref": "a3638f28",
       "uninstall_script_ref": "212c6861",
-      "sha256": "79e2ae4fadbd83044d7ae94b10c974480ce278bfb43f63e79091cbb22aba8efa",
+      "sha256": "ba8da45576cae9ed91b23d67094c97de1daf3b793b42a4fe65c1ff1a120ea174",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/smultron/darwin.json
+++ b/ee/maintained-apps/outputs/smultron/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "14.4.8",
+      "version": "14.4.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.peterborgapps.Smultron14';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.peterborgapps.Smultron14' AND version_compare(bundle_short_version, '14.4.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.peterborgapps.Smultron14' AND version_compare(bundle_short_version, '14.4.9') < 0);"
       },
       "installer_url": "https://www.peterborgapps.com/downloads/Smultron14.zip",
       "install_script_ref": "ec7c60f9",

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.22.1",
+      "version": "2.23.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.22.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.23.0') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.22.1.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.23.0.dmg",
       "install_script_ref": "5f8295ce",
       "uninstall_script_ref": "a5d6883d",
-      "sha256": "f22a62b1804f81b2539bd3280cd568e0a07a3c54b10fcda472cc4e5028d18eb9",
+      "sha256": "eea8a88ffa2e902bc74b87ddccecb09029cdd5cd5ec76df1b6aa53fed68b1a2c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tuple/darwin.json
+++ b/ee/maintained-apps/outputs/tuple/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.5",
+      "version": "3.0.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app' AND version_compare(bundle_short_version, '3.0.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app' AND version_compare(bundle_short_version, '3.0.6') < 0);"
       },
-      "installer_url": "https://d32ifkf9k9ezcg.cloudfront.net/production/sparkle/tuple-3.0.5-2026-06-05-9277d388e.zip",
+      "installer_url": "https://d32ifkf9k9ezcg.cloudfront.net/production/sparkle/tuple-3.0.6-2026-06-18-0c8d42eabd.zip",
       "install_script_ref": "ff9821fc",
       "uninstall_script_ref": "03815558",
-      "sha256": "5e53ed5f8e92f70c9d473a904f4b89c9de2cc940e76bab5b45794bfa58a448c6",
+      "sha256": "19a4bac059193bcd133f568be80842ed9db9a7084d7c72de509a1f268233382d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.24.17",
+      "version": "26.24.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.24.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.24.19') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata for 17 maintained applications including Apidog, AWS CLI, Bezel, Boom3D, Clockify, Cyberduck, Deezer, Firefox, Godot, Granola, Insomnia, pgAdmin4, Smultron, Spokenly, Tuple, and WhatsApp across macOS and Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->