### PR TITLE
Fleet Desktop - Self-service: Install all button visibility, count, and enabled-state rules

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -319,7 +319,10 @@ describe("SelfServiceCard", () => {
     });
   });
 
-  it("disables the install-all button when an item in the category is in-progress", async () => {
+  // BE confirmed install_all dedupes against in-flight items (#39018), so the
+  // button stays enabled while a prior batch is processing — the user can
+  // queue any remaining eligible items without waiting.
+  it("keeps the install-all button enabled when an item in the category is in-progress and there are still uninstalled items", async () => {
     const props = createTestProps({
       queryParams: { ...DEFAULT_QUERY_PARAMS, category_id: 42 },
       enhancedSoftware: [
@@ -340,7 +343,7 @@ describe("SelfServiceCard", () => {
     const button = await screen.findByRole("button", {
       name: /Install all/i,
     });
-    expect(button).toBeDisabled();
+    expect(button).toBeEnabled();
   });
 
   it("posts to install_all and fires onInstallAllSuccess when the confirm modal is submitted", async () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -323,6 +323,7 @@ describe("SelfServiceCard", () => {
   // click only queues whatever's still eligible. The button stays enabled
   // whenever count > 0. See #47855.
   it("keeps the install-all button enabled when an item is in progress and there are still uninstalled items", async () => {
+    const props = createTestProps({
       enhancedSoftware: [
         {
           ...createMockDeviceSoftware({ name: "uninstalled-app" }),

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -319,12 +319,11 @@ describe("SelfServiceCard", () => {
     });
   });
 
-  // BE confirmed install_all dedupes against in-flight items (#39018), so the
-  // button stays enabled while a prior batch is processing — the user can
-  // queue any remaining eligible items without waiting.
+  // `install_all` skips items already in INSTALLED_OR_IN_FLIGHT, so a second
+  // click only queues whatever's still eligible. The button stays enabled
+  // whenever count > 0. See #47855.
   it("keeps the install-all button enabled when an item in the category is in-progress and there are still uninstalled items", async () => {
     const props = createTestProps({
-      queryParams: { ...DEFAULT_QUERY_PARAMS, category_id: 42 },
       enhancedSoftware: [
         {
           ...createMockDeviceSoftware({ name: "uninstalled-app" }),

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -322,8 +322,7 @@ describe("SelfServiceCard", () => {
   // `install_all` skips items already in INSTALLED_OR_IN_FLIGHT, so a second
   // click only queues whatever's still eligible. The button stays enabled
   // whenever count > 0. See #47855.
-  it("keeps the install-all button enabled when an item in the category is in-progress and there are still uninstalled items", async () => {
-    const props = createTestProps({
+  it("keeps the install-all button enabled when an item is in progress and there are still uninstalled items", async () => {
       enhancedSoftware: [
         {
           ...createMockDeviceSoftware({ name: "uninstalled-app" }),

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -232,7 +232,8 @@ const SelfServiceCard = ({
       })
     : softwareInSelectedCategory;
 
-  // The button is shown in the "All" filter and in any selected category. On
+  // The button is shown on desktop in the "All" filter and in any selected
+  // category. On
   // "All", `categoryId` is undefined; the click posts to install_all without a
   // category_id query param and the BE installs every eligible (uninstalled,
   // not-in-progress) self-service item. Visibility, count, and disabled state

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -232,12 +232,11 @@ const SelfServiceCard = ({
       })
     : softwareInSelectedCategory;
 
-  // The button shows in all four variants (including "All"). On "All",
-  // `categoryId` is undefined; the click posts to install_all without a
+  // The button is shown in the "All" filter and in any selected category. On
+  // "All", `categoryId` is undefined; the click posts to install_all without a
   // category_id query param and the BE installs every eligible (uninstalled,
-  // not-in-progress) self-service item. Disabled state is driven purely by
-  // hasInProgressInCategory || uninstalledCount === 0 — no special case for
-  // categoryId === undefined.
+  // not-in-progress) self-service item. Visibility, count, and disabled state
+  // are owned by InstallAllInCategoryButton — see #47855 for the full rules.
   const installAllButton = !isMobileView ? (
     <InstallAllInCategoryButton
       uninstalledCount={uninstalledCount}

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
@@ -28,18 +28,57 @@ describe("InstallAllInCategoryButton", () => {
     ).toBeInTheDocument();
   });
 
-  it("is disabled when uninstalledCount is 0", () => {
+  it("renders without the (0) suffix and stays disabled when count is 0 but an install is in progress", () => {
     const render = createCustomRenderer({ withBackendMock: true });
-    render(<InstallAllInCategoryButton {...baseProps} uninstalledCount={0} />);
-    expect(screen.getByRole("button", { name: /Install all/i })).toBeDisabled();
+    render(
+      <InstallAllInCategoryButton
+        {...baseProps}
+        uninstalledCount={0}
+        hasInProgressInCategory
+      />
+    );
+    const button = screen.getByRole("button", { name: /^Install all$/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+    expect(screen.queryByText(/\(0\)/)).not.toBeInTheDocument();
   });
 
-  it("is disabled when hasInProgressInCategory is true", () => {
+  it("is not rendered when count is 0 and nothing is in progress", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<InstallAllInCategoryButton {...baseProps} uninstalledCount={0} />);
+    expect(
+      screen.queryByRole("button", { name: /Install all/i })
+    ).not.toBeInTheDocument();
+  });
+
+  // Per design intent, `hasInProgressInCategory` is only true for
+  // install/script in-flight statuses (see helpers.ts). A category whose only
+  // active work is an "updating..." item should report hasInProgressInCategory
+  // = false, so the button is hidden when count is also 0.
+  it("is not rendered when count is 0 and the parent reports no install_all in flight", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <InstallAllInCategoryButton
+        {...baseProps}
+        uninstalledCount={0}
+        hasInProgressInCategory={false}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /Install all/i })
+    ).not.toBeInTheDocument();
+  });
+
+  // Per BE confirmation (install_all dedupes against in-flight items), re-
+  // clicking during a batch is safe — so when there are still actionable items
+  // we keep the button enabled instead of forcing the user to wait out the
+  // first batch. See #39018.
+  it("stays enabled when count > 0 even if an install_all batch is in flight", () => {
     const render = createCustomRenderer({ withBackendMock: true });
     render(
       <InstallAllInCategoryButton {...baseProps} hasInProgressInCategory />
     );
-    expect(screen.getByRole("button", { name: /Install all/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Install all/i })).toBeEnabled();
   });
 
   it("opens the confirmation modal when clicked", async () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
@@ -69,10 +69,10 @@ describe("InstallAllInCategoryButton", () => {
     ).not.toBeInTheDocument();
   });
 
-  // Per BE confirmation (install_all dedupes against in-flight items), re-
-  // clicking during a batch is safe — so when there are still actionable items
-  // we keep the button enabled instead of forcing the user to wait out the
-  // first batch. See #39018.
+  // `install_all` skips items already in INSTALLED_OR_IN_FLIGHT, so a second
+  // click during a batch only queues whatever is still eligible. The button
+  // stays enabled whenever there's something actionable to click. See #47855
+  // for the full visibility/count/enabled rules.
   it("stays enabled when count > 0 even if an install_all batch is in flight", () => {
     const render = createCustomRenderer({ withBackendMock: true });
     render(

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
@@ -52,7 +52,23 @@ const InstallAllInCategoryButton = ({
     }
   }, [deviceToken, categoryId, onSuccess, renderFlash]);
 
-  const isDisabled = hasInProgressInCategory || uninstalledCount === 0;
+  // Hide the button entirely when there's nothing eligible AND nothing already
+  // running. With a previous install_all batch still in flight, keep the button
+  // visible without the "(0)" suffix — re-clicking is safe on the backend
+  // (in-flight items are skipped) and lets the user queue any newly-eligible
+  // items without waiting out the first batch.
+  if (uninstalledCount === 0 && !hasInProgressInCategory) {
+    return null;
+  }
+
+  // Only render disabled in the "no actionable items, but a prior batch is
+  // still running" branch. When count > 0 we always allow the click — the BE
+  // dedupes against in-flight items.
+  const isDisabled = uninstalledCount === 0;
+  const label =
+    uninstalledCount === 0
+      ? "Install all"
+      : `Install all (${uninstalledCount})`;
 
   return (
     <>
@@ -63,7 +79,7 @@ const InstallAllInCategoryButton = ({
         disabled={isDisabled}
       >
         <Icon name="install" color="ui-fleet-black-75" />
-        Install all ({uninstalledCount})
+        {label}
       </Button>
       {showModal && (
         <InstallAllInCategoryModal

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
@@ -61,10 +61,9 @@ const InstallAllInCategoryButton = ({
     return null;
   }
 
-  // count === 0 only survives the early-return when a batch is in flight, so
-  // disabled means exactly that case. When count > 0 we always allow the
-  // click: `install_all` skips items already in INSTALLED_OR_IN_FLIGHT, so a
-  // second click during a batch only queues whatever is still eligible.
+  // `count === 0` only reaches this line during an in-flight batch (the
+  // early-return handles count=0 with no batch). That's the one and only
+  // state where the button renders disabled.
   const isDisabled = uninstalledCount === 0;
   const label =
     uninstalledCount === 0

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
@@ -52,18 +52,19 @@ const InstallAllInCategoryButton = ({
     }
   }, [deviceToken, categoryId, onSuccess, renderFlash]);
 
-  // Hide the button entirely when there's nothing eligible AND nothing already
-  // running. With a previous install_all batch still in flight, keep the button
-  // visible without the "(0)" suffix — re-clicking is safe on the backend
-  // (in-flight items are skipped) and lets the user queue any newly-eligible
-  // items without waiting out the first batch.
+  // Nothing eligible and no install_all batch running — drop the button from
+  // the DOM. When a previous batch IS still running (count === 0 &&
+  // hasInProgressInCategory), fall through and render a disabled "Install all"
+  // (no count) so the user keeps a visual anchor on the action they triggered
+  // until items settle.
   if (uninstalledCount === 0 && !hasInProgressInCategory) {
     return null;
   }
 
-  // Only render disabled in the "no actionable items, but a prior batch is
-  // still running" branch. When count > 0 we always allow the click — the BE
-  // dedupes against in-flight items.
+  // count === 0 only survives the early-return when a batch is in flight, so
+  // disabled means exactly that case. When count > 0 we always allow the
+  // click: `install_all` skips items already in INSTALLED_OR_IN_FLIGHT, so a
+  // second click during a batch only queues whatever is still eligible.
   const isDisabled = uninstalledCount === 0;
   const label =
     uninstalledCount === 0

--- a/frontend/pages/hosts/details/cards/Software/SelfService/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/helpers.tests.ts
@@ -128,20 +128,29 @@ describe("hasInProgressInstallAllItems", () => {
     ).toBe(true);
   });
 
-  it("returns true for pending statuses (offline-host scheduled)", () => {
+  it("returns true for install/script in-flight statuses", () => {
+    expect(hasInProgressInstallAllItems([makeItem("installing")])).toBe(true);
+    expect(hasInProgressInstallAllItems([makeItem("running_script")])).toBe(
+      true
+    );
     expect(hasInProgressInstallAllItems([makeItem("pending_install")])).toBe(
       true
     );
-    expect(hasInProgressInstallAllItems([makeItem("pending_uninstall")])).toBe(
+    expect(hasInProgressInstallAllItems([makeItem("pending_script")])).toBe(
       true
     );
   });
 
-  it("returns true for uninstalling / updating / running_script", () => {
-    expect(hasInProgressInstallAllItems([makeItem("uninstalling")])).toBe(true);
-    expect(hasInProgressInstallAllItems([makeItem("updating")])).toBe(true);
-    expect(hasInProgressInstallAllItems([makeItem("running_script")])).toBe(
-      true
+  it("returns false for update/uninstall in-flight statuses (not install_all operations)", () => {
+    expect(hasInProgressInstallAllItems([makeItem("updating")])).toBe(false);
+    expect(hasInProgressInstallAllItems([makeItem("uninstalling")])).toBe(
+      false
+    );
+    expect(hasInProgressInstallAllItems([makeItem("pending_update")])).toBe(
+      false
+    );
+    expect(hasInProgressInstallAllItems([makeItem("pending_uninstall")])).toBe(
+      false
     );
   });
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
@@ -14,6 +14,17 @@ const IN_PROGRESS_UI_STATUSES = new Set<string>([
   ...HOST_SOFTWARE_UI_PENDING_STATUSES,
 ]);
 
+/** Statuses that specifically indicate an install_all-style operation is in
+ * flight. Narrower than IN_PROGRESS_UI_STATUSES: updates and uninstalls aren't
+ * triggered by install_all, so they shouldn't keep the button visible after
+ * `uninstalledCount` drops to 0. */
+const INSTALL_ALL_IN_FLIGHT_UI_STATUSES = new Set<string>([
+  "installing",
+  "running_script",
+  "pending_install",
+  "pending_script",
+]);
+
 /** Statuses indicating the user cannot click "Install" — already done or in-flight. */
 const INSTALLED_OR_IN_FLIGHT_UI_STATUSES = new Set<string>([
   ...IN_PROGRESS_UI_STATUSES,
@@ -96,9 +107,12 @@ export const countUninstalledForInstallAll = (
     (item) => !INSTALLED_OR_IN_FLIGHT_UI_STATUSES.has(item.ui_status)
   ).length;
 
-/** True if any item in the list is currently in-progress (install_all should
- * be disabled until they all leave that state). */
+/** True if any item in the list is currently being installed/scripted by an
+ * install_all-style operation. Updates and uninstalls don't count — those are
+ * orthogonal operations and shouldn't keep the install_all button visible. */
 export const hasInProgressInstallAllItems = (
   software: IDeviceSoftwareWithUiStatus[]
 ): boolean =>
-  software.some((item) => IN_PROGRESS_UI_STATUSES.has(item.ui_status));
+  software.some((item) =>
+    INSTALL_ALL_IN_FLIGHT_UI_STATUSES.has(item.ui_status)
+  );


### PR DESCRIPTION
## Issue
Closes #47855

## Description
- **Narrowed `hasInProgressInstallAllItems`** (`frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts`) to a new `INSTALL_ALL_IN_FLIGHT_UI_STATUSES` set: `installing`, `running_script`, `pending_install`, `pending_script`. `updating` / `uninstalling` / `pending_update` / `pending_uninstall` no longer count as install-all in-flight — they're orthogonal operations and shouldn't keep the button visible after `count` drops to 0.
- **Hide the button entirely** when `count === 0 && !inProgress` (`InstallAllInCategoryButton.tsx`). Steady states and update/uninstall-only categories no longer render a dead "Install all (0)" affordance.
- **Drop the `(0)` suffix** when `count === 0` but a previous install-all batch is still in flight. Label collapses to "Install all" so the user sees the action they just triggered is still here, just not actionable again until items settle.
- **Always enabled when `count > 0`**, regardless of in-flight state. BE dedupes against `INSTALLED_OR_IN_FLIGHT` items per [Slack with Jonathan](https://github.com/fleetdm/fleet/issues/39018), so re-clicking during a batch is safe and lets users queue newly-eligible items without waiting.
- Updated `helpers.tests.ts` (`updating` / `uninstalling` / `pending_update` / `pending_uninstall` now assert `false`), `InstallAllInCategoryButton.tests.tsx` (button is hidden / shown-without-count / stays-enabled in the right rows), and `SelfServiceCard.tests.tsx` (renamed the prior "disables when in-progress" test to assert it stays enabled).

## Screenrecording

https://github.com/user-attachments/assets/411746d1-ce18-4176-a6e9-e661929d6567

## Testing
- [x] Added/updated automated tests — `helpers.tests.ts` covers the narrowed install_all-in-flight set, `InstallAllInCategoryButton.tests.tsx` covers all four button rows (visible-with-count enabled, visible-without-count disabled, hidden when nothing to do, stays enabled while a batch is in flight), `SelfServiceCard.tests.tsx` updated for the always-enabled-when-count-positive rule.
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Install all” button logic: it’s hidden when there are no eligible items and no install-all operation is in progress.
  * The button’s enabled/disabled state and label now depend on eligible remaining items (with “(n)” shown when applicable), rather than any in-progress item broadly.
* **Tests**
  * Updated unit/component tests to cover new visibility, labeling, and in-flight install-all status handling rules.
* **Documentation**
  * Clarified the install-all behavior for desktop, including how category-less installs behave.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->