### PR TITLE
Fix tooltips to center of label row

### DIFF
--- a/changes/44325-gitops-mode-tooltip-label
+++ b/changes/44325-gitops-mode-tooltip-label
@@ -1,0 +1,1 @@
+- Fixed the GitOps mode tooltip on disabled settings fields so it points at the field's label instead of the center of the label, input, and help text.

--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tests.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tests.tsx
@@ -259,4 +259,45 @@ describe("GitOpsModeTooltipWrapper", () => {
       expect(screen.getByRole("tooltip")).toBeInTheDocument();
     });
   });
+
+  // When the wrapped content is a group (multiple fields/controls) rather than a single
+  // field, keep whole-wrapper anchoring so hovering any control still shows the tooltip.
+  it("keeps whole-wrapper anchoring for grouped content with multiple controls", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          isTeamAdmin: false,
+          config: {
+            gitops: {
+              gitops_mode_enabled: true,
+              repository_url: "a.b.cc",
+            },
+          },
+        },
+      },
+    });
+
+    const { user } = render(
+      <GitOpsModeTooltipWrapper
+        position="left"
+        renderChildren={(disableChildren) => (
+          <div>
+            <Checkbox disabled={disableChildren} name="first" value={false}>
+              First option
+            </Checkbox>
+            <Checkbox disabled={disableChildren} name="second" value={false}>
+              Second option
+            </Checkbox>
+          </div>
+        )}
+      />
+    );
+
+    // Hovering the second control (not the first) still shows the tooltip.
+    await user.hover(screen.getByText("Second option"));
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tests.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tests.tsx
@@ -4,6 +4,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import Button from "components/buttons/Button";
+import Checkbox from "components/forms/fields/Checkbox";
 
 import GitOpsModeTooltipWrapper from "./GitOpsModeTooltipWrapper";
 
@@ -202,5 +203,60 @@ describe("GitOpsModeTooltipWrapper", () => {
     const btn = screen.getByText("Save");
     await user.click(btn);
     expect(onSave).not.toHaveBeenCalled();
+  });
+
+  // For a wrapped form field, the tooltip anchors to the label/control row rather than the
+  // whole field, so the arrow points at the label instead of the center of
+  // label + input + help text (#44325). jsdom has no layout, so the geometric arrow position
+  // is verified manually; here we assert the anchor binding and trigger behavior.
+  it("anchors the tooltip to the field's control row, not the help text, when GOM is enabled", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          isTeamAdmin: false,
+          config: {
+            gitops: {
+              gitops_mode_enabled: true,
+              repository_url: "a.b.cc",
+            },
+          },
+        },
+      },
+    });
+
+    const { user, container } = render(
+      <GitOpsModeTooltipWrapper
+        position="left"
+        renderChildren={(disableChildren) => (
+          <Checkbox
+            disabled={disableChildren}
+            name="deleteActivities"
+            value={false}
+            helpText="This setting will delete existing results."
+          >
+            Delete activities
+          </Checkbox>
+        )}
+      />
+    );
+
+    // The anchor target (the checkbox's control row) and the help text are distinct
+    // elements; the help text must never be the anchor.
+    const controlRow = container.querySelector(".form-field > label");
+    expect(controlRow).not.toBeNull();
+    expect(
+      container.querySelector(".form-field__help-text")
+    ).toBeInTheDocument();
+
+    // Hovering the help text (not an anchor) does not open the tooltip...
+    await user.hover(screen.getByText(/will delete existing results/i));
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    // ...but hovering the control row does.
+    await user.hover(screen.getByText("Delete activities"));
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
@@ -41,14 +41,21 @@ const GitOpsModeTooltipWrapper = ({
   const { gitOpsModeEnabled, repoURL } = useGitOpsMode(entityType);
 
   const wrapperRef = useRef<HTMLSpanElement>(null);
-  const [hasFirstRow, setHasFirstRow] = useState(false);
+  const [hasSingleFieldRow, setHasSingleFieldRow] = useState(false);
   // Prefix makes this a valid CSS id selector (lodash uniqueId returns a bare number).
   const wrapperId = useMemo(() => uniqueId(`${baseClass}-`), []);
 
   useLayoutEffect(() => {
-    setHasFirstRow(
-      !!wrapperRef.current?.querySelector(FIRST_ROW_PARTS.join(", "))
+    // Only re-anchor when the wrapped content is a single FormField (its root element is the
+    // `.form-field`, as rendered by Checkbox/InputField/Dropdown) with exactly one label
+    // row. Groups (e.g. a fieldset of radios + a checkbox wrapped in a div) and non-field
+    // content (buttons, icon rows) keep whole-wrapper anchoring so hovering anywhere still
+    // shows the tooltip.
+    const root = wrapperRef.current?.firstElementChild;
+    const rows = wrapperRef.current?.querySelectorAll(
+      FIRST_ROW_PARTS.join(", ")
     );
+    setHasSingleFieldRow(!!root?.matches(".form-field") && rows?.length === 1);
   }, []);
 
   if (!gitOpsModeEnabled) {
@@ -66,9 +73,9 @@ const GitOpsModeTooltipWrapper = ({
   });
 
   // Anchor to the field's first row so the arrow points at the label regardless of input,
-  // help-text, or tooltip-content height. Falls back to the whole wrapper for non-field
-  // content (buttons, icon rows), preserving the previous centered behavior there.
-  const anchorSelect = hasFirstRow
+  // help-text, or tooltip-content height. Falls back to the whole wrapper otherwise,
+  // preserving the previous centered, hover-anywhere behavior.
+  const anchorSelect = hasSingleFieldRow
     ? FIRST_ROW_PARTS.map((part) => `#${wrapperId} ${part}`).join(", ")
     : `#${wrapperId}`;
 

--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
@@ -1,10 +1,10 @@
 import classnames from "classnames";
-import TooltipWrapper, {
-  ITooltipWrapper,
-} from "components/TooltipWrapper/TooltipWrapper";
+import { uniqueId } from "lodash";
+import { ITooltipWrapper } from "components/TooltipWrapper/TooltipWrapper";
 import useGitOpsMode from "hooks/useGitOpsMode";
 import { IGitOpsExceptions } from "interfaces/config";
-import React from "react";
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Tooltip as ReactTooltip5 } from "react-tooltip-5";
 import { getGitOpsModeTipContent } from "utilities/helpers";
 
 interface IGitOpsModeTooltipWrapper {
@@ -23,6 +23,13 @@ interface IGitOpsModeTooltipWrapper {
 
 const baseClass = "gitops-mode-tooltip-wrapper";
 
+// The label/control row of a wrapped FormField. FormField renders the label as a
+// direct-child <label> for inputs/dropdowns, and a checkbox's control row is also a
+// direct-child <label>. The help text is a <span class="form-field__help-text"> and is
+// intentionally never matched, so the tooltip anchors at the label rather than the
+// geometric center of label + input + help text.
+const FIRST_ROW_PARTS = [".form-field__label", ".form-field > label"];
+
 const GitOpsModeTooltipWrapper = ({
   position = "top",
   tipOffset,
@@ -32,6 +39,17 @@ const GitOpsModeTooltipWrapper = ({
   isInputField = false,
 }: IGitOpsModeTooltipWrapper) => {
   const { gitOpsModeEnabled, repoURL } = useGitOpsMode(entityType);
+
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  const [hasFirstRow, setHasFirstRow] = useState(false);
+  // Prefix makes this a valid CSS id selector (lodash uniqueId returns a bare number).
+  const wrapperId = useMemo(() => uniqueId(`${baseClass}-`), []);
+
+  useLayoutEffect(() => {
+    setHasFirstRow(
+      !!wrapperRef.current?.querySelector(FIRST_ROW_PARTS.join(", "))
+    );
+  }, []);
 
   if (!gitOpsModeEnabled) {
     return <>{renderChildren()}</>;
@@ -47,18 +65,31 @@ const GitOpsModeTooltipWrapper = ({
     [`${baseClass}--inputfield`]: isInputField,
   });
 
+  // Anchor to the field's first row so the arrow points at the label regardless of input,
+  // help-text, or tooltip-content height. Falls back to the whole wrapper for non-field
+  // content (buttons, icon rows), preserving the previous centered behavior there.
+  const anchorSelect = hasFirstRow
+    ? FIRST_ROW_PARTS.map((part) => `#${wrapperId} ${part}`).join(", ")
+    : `#${wrapperId}`;
+
   return (
-    <TooltipWrapper
-      className={wrapperClass}
-      position={position}
-      tipOffset={tipOffset}
-      tipContent={tipContent}
-      underline={false}
-      showArrow
-      fixedPositionStrategy={fixedPositionStrategy}
-    >
+    <span ref={wrapperRef} id={wrapperId} className={wrapperClass}>
       {renderChildren(true)}
-    </TooltipWrapper>
+      <ReactTooltip5
+        className={`${baseClass}__tip-text`}
+        anchorSelect={anchorSelect}
+        place={position}
+        offset={tipOffset ?? 5}
+        opacity={1}
+        disableStyleInjection
+        clickable
+        delayShow={250}
+        delayHide={250}
+        positionStrategy={fixedPositionStrategy ? "fixed" : "absolute"}
+      >
+        {tipContent}
+      </ReactTooltip5>
+    </span>
   );
 };
 

--- a/frontend/components/GitOpsModeTooltipWrapper/_styles.scss
+++ b/frontend/components/GitOpsModeTooltipWrapper/_styles.scss
@@ -1,19 +1,23 @@
 .gitops-mode-tooltip-wrapper {
+  // Arrow styles target the nested react-tooltip via descendant selectors (mirrors the
+  // shared TooltipWrapper, which this component no longer delegates to).
+  @include tooltip5-arrow-styles;
+  display: inline-flex;
+
   &__tooltip-content {
     display: flex;
     flex-direction: column;
     align-items: center;
   }
 
-  &--inputfield {
-    .component__tooltip-wrapper__element {
-      width: 100%;
-    }
+  &__tip-text {
+    @include tooltip-text;
+    cursor: default;
   }
 
-  .component__tooltip-wrapper {
-    &__tip-text {
-      cursor: default;
-    }
+  // Inputs/dropdowns must stretch to full width.
+  &--inputfield {
+    display: block;
+    width: 100%;
   }
 }


### PR DESCRIPTION
**Related issue:** Resolves #44325

## Summary

In GitOps mode, disabled settings fields show a "Manage in YAML (GitOps mode)" tooltip via `GitOpsModeTooltipWrapper`. The wrapper passed the entire field (label + input + help text) to the shared `TooltipWrapper`, so react-tooltip anchored to the whole field's bounding box. For `position="left"`/`"right"` fields this centered the tooltip vertically across the field, landing the arrow between the input and the help text instead of at the label.

This change anchors the tooltip to the field's label/control row (via react-tooltip-5 `anchorSelect` scoped to a unique wrapper id), so the arrow points at the label regardless of input, help-text, or tooltip-content length. The change is contained to `GitOpsModeTooltipWrapper`, leaving `TooltipWrapper` untouched. Non-field usages (buttons, icon rows) fall back to the previous whole-element anchoring.

# Checklist for submitter

  - [x] Changes file added for user-visible changes in `changes/`.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually

Verified manually with Playwright against a live instance in GitOps mode: the tooltip arrow points at the checkbox/control row (incl. fields with help text) and at the label for `isInputField` inputs; button usages are unchanged.

<img width="1726" height="1041" alt="Screenshot 2026-06-18 at 15 31 08" src="https://github.com/user-attachments/assets/58229743-58d4-4b26-b69d-c78ca2e6b3b1" />
<img width="1721" height="1040" alt="Screenshot 2026-06-18 at 15 30 58" src="https://github.com/user-attachments/assets/253db973-2a57-4f62-9d6f-2d18f0c2a7ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GitOps mode tooltip positioning for disabled settings fields. Tooltips now properly target field labels instead of the combined label/input/help element area, improving visual alignment and clarity.

* **Tests**
  * Enhanced test coverage for GitOps mode tooltip anchoring with tests for single form fields and grouped field controls to ensure correct positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->