### PR TITLE
Website: Move quote in homepage hero section, update page heading

### DIFF
--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -29,17 +29,16 @@
 
   [purpose='hero-background-image'] {
     background: url('/images/homepage-hero-2500x420@2x.png');
-    background-size: auto 433px;
+    background-size: auto 329px;
     background-repeat: no-repeat;
     background-position-x: calc(~'100% + -56%');
     background-position-y: top;
   }
+
   [purpose='homepage-hero'] {
-    padding-top: 64px;
-    padding-left: 64px;
-    padding-bottom: 120px;
+    padding: 64px;
     max-width: 1200px;
-    height: 448px;
+    // height: 448px;
   }
   [purpose='ticker-container'] {
     overflow: hidden;
@@ -69,12 +68,12 @@
     }
   }
   [purpose='hero-text'] {
-    max-width: 500px;
+    max-width: 490px;
     text-align: left;
     h1 {
       max-width: 640px;
-      font-size: 48px;
-      margin-bottom: 16px;
+      font-size: 32px;
+      margin-bottom: 32px;
     }
     [purpose='hero-subtitle'] {
       color: #515774;
@@ -115,17 +114,15 @@
     margin-left: auto;
     margin-right: auto;
   }
-  [purpose='hero-quote-author'] {
+  [purpose='hero-quote'] {
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-bottom: 32px;
-    margin-top: 24px;
     [purpose='hero-quote-profile-image'] {
 
-      margin-right: 16px;
+      margin-right: 24px;
       img {
-        height: 72px;
+        height: 60px;
       }
     }
     [purpose='quote-author-info'] {
@@ -922,6 +919,49 @@
       padding-left: 64px;
     }
 
+    [purpose='hero-text'] {
+      max-width: 380px;
+    }
+    [purpose='hero-quote'] {
+      [purpose='hero-quote-profile-image'] {
+
+        img {
+          height: 60px;
+        }
+      }
+      [purpose='quote-author-info'] {
+        [purpose='quote-text'] {
+          font-size: 15px;
+        }
+
+        [purpose='quote-author-name'] {
+          font-size: 10px;
+        }
+        [purpose='quote-author-title'] {
+          font-size: 12px;
+        }
+
+      }
+    }
+    [purpose='statistics'] {
+      [purpose='statistics-column'] {
+        display: flex;
+        flex-direction: row;
+      }
+      [purpose='customers'] {
+        padding: 8px 16px;
+      }
+      [purpose='devices'] {
+        padding: 8px 16px;
+      }
+      [purpose='countries'] {
+        padding: 8px 16px;
+      }
+      [purpose='response-time'] {
+        padding: 8px 16px;
+      }
+    }
+
     [purpose='page-section'] {
       margin-bottom: 120px;
     }
@@ -1172,7 +1212,7 @@
     [purpose='homepage-hero'] {
       // height: 100%;
       // padding: 48px 27px 330px 24px;
-      height: 720px;
+      height: 540px;
     }
     [purpose='hero-container'] {
       background: linear-gradient(180deg, #FFF 0%, #EEF7F8 150px);
@@ -1185,7 +1225,7 @@
     }
     [purpose='hero-text'] {
       width: 100%;
-      // max-width: 100%;
+      max-width: 100%;
       [purpose='button-row'] {
         [purpose='cta-button'] {
           width: unset;
@@ -1360,15 +1400,15 @@
       margin-bottom: 80px;
     }
     [purpose='homepage-hero'] {
-      padding-bottom: 307px;
-      padding-top: 48px;
+      padding-top: 32px;
       padding-left: 16px;
       padding-right: 16px;
+      height: 600px;
     }
 
     [purpose='hero-text'] {
       h1 {
-        font-size: 32px;
+        font-size: 24px;
       }
     }
     [purpose='homepage-content'] {
@@ -1517,11 +1557,7 @@
   //  ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
   //
   @media (max-width: 375px) {
-    [purpose='hero-text'] {
-      h1 {
-        font-size: 28px;
-      }
-    }
+
     h1 {
       font-size: 28px;
       line-height: 120%;
@@ -1552,7 +1588,7 @@
     }
 
     [purpose='hero-background-image'] {
-      background-size: auto 220px;
+      background-size: auto 265px;
     }
     [purpose='ticker-container'] {
       white-space: unset;

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -16,7 +16,7 @@
             </h1>
             <p purpose="hero-subtitle">Open MDM, patching, and vuln management for every OS.</p>
             <div purpose="button-row" class="d-flex justify-content-start align-items-center">
-              <a purpose="cta-button" href="/register">Try it yourself</a>
+              <a purpose="cta-button" href="/contact">Get a demo</a>
               <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
             </div>
           </div>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -6,30 +6,23 @@
   */%>
   <%/* Hero container */%>
   <div purpose="hero-container">
-      <div purpose="hero-background-image">
-        <div purpose="homepage-hero" class="mx-auto">
-          <div class="d-flex flex-row justify-content-start justify-content-sm-center justify-content-md-start align-items-start">
-            <%/* Hero text */%>
-            <div purpose="hero-text" class="d-flex flex-column justify-content-start">
-              <h4>Open device management</h4>
-              <h1>“I just moved 10,000<br> Macs to Fleet”</h1>
-              <div purpose="hero-quote-author" class="d-flex flex-row align-items-center">
-                <div purpose="hero-quote-profile-image">
-                  <img alt="Wes Whetstone" src="/images/homepage-hero-wes-whetstone-86x72@2x.png">
-                </div>
-                <div purpose="quote-author-info">
-                  <p purpose="quote-author-name">Wes Whetstone</p>
-                  <p purpose="quote-author-title">Client Platform Engineer at Stripe</p>
-                </div>
-              </div>
-              <div purpose="button-row" class="d-flex justify-content-start align-items-center">
-                <a purpose="cta-button" href="/contact">Get a demo</a>
-                <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
-              </div>
+    <div purpose="hero-background-image">
+      <div purpose="homepage-hero" class="mx-auto">
+        <div class="d-flex flex-row justify-content-start justify-content-sm-center justify-content-md-start align-items-start">
+          <%/* Hero text */%>
+          <div purpose="hero-text" class="d-flex flex-column justify-content-start">
+            <h1>
+              Manage, update, and secure all your devices like it's 2026
+            </h1>
+            <p purpose="hero-subtitle">Open MDM, patching, and vuln management for every OS.</p>
+            <div purpose="button-row" class="d-flex justify-content-start align-items-center">
+              <a purpose="cta-button" href="/register">Try it yourself</a>
+              <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
             </div>
           </div>
         </div>
       </div>
+    </div>
   </div>
   <%/* Row of logos */%>
   <div purpose="hero-logos" class="mx-auto">
@@ -38,6 +31,17 @@
   <%/* Homepage content */%>
   <div purpose="homepage-content" class="container">
     <div purpose="page-section">
+    <div purpose="quote-and-statistics">
+      <div purpose="hero-quote" >
+        <div purpose="hero-quote-profile-image">
+          <img alt="Wes Whetstone" src="/images/homepage-hero-wes-whetstone-86x72@2x.png">
+        </div>
+        <div purpose="quote-author-info">
+          <p purpose="quote-text">“I just moved 10,000 Macs to Fleet”</p>
+          <p purpose="quote-author-name">Wes Whetstone</p>
+          <p purpose="quote-author-title">Client Platform Engineer at Stripe</p>
+        </div>
+      </div>
       <a purpose="statistics" class="d-flex" href="/customers" no-underline>
         <div purpose="statistics-column">
           <div purpose="customers" class="d-none d-sm-block">
@@ -68,6 +72,7 @@
           </div>
         </div>
       </a>
+    </div>
     </div>
     <div purpose="page-section" class="mb-0">
       <div purpose="homepage-text-block">


### PR DESCRIPTION
Changes:
- Brought back the "Manage, update, and secure all your devices like it's 2026" heading on the homepage
- Moved the quote from Wes on the homepage to be next to the statistics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates

* **Updates**
  * Refreshed homepage hero section with new headline and supporting text
  * Added new call-to-action buttons: "Get a demo" and "Join a workshop"
  * Enhanced hero layout and styling with improved responsiveness across all device sizes
  * Restructured testimonial quote section with improved visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->