### PR TITLE
Undo rename from utilities to support

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7889,12 +7889,12 @@ software:
 
 	teamExisting := []fleet.SoftwareCategory{
 		{ID: 100, Name: "🌎 Browsers", TeamID: 1},
-		{ID: 101, Name: "💻 Productivity", TeamID: 1},
+		{ID: 101, Name: "🖥️ Productivity", TeamID: 1},
 		{ID: 102, Name: "Stale Category", TeamID: 1},
 	}
 	noTeamExisting := []fleet.SoftwareCategory{
 		{ID: 200, Name: "🌎 Browsers", TeamID: 0},
-		{ID: 201, Name: "💻 Productivity", TeamID: 0},
+		{ID: 201, Name: "🖥️ Productivity", TeamID: 0},
 		{ID: 202, Name: "Stale No-team Category", TeamID: 0},
 	}
 

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
@@ -344,7 +344,9 @@ describe("SelfServiceCategoriesPage", () => {
     const { user } = render(<SelfServiceCategoriesPage {...baseProps} />);
 
     await screen.findByText("🛠️ Utilities");
-    await user.click(screen.getByRole("button", { name: "Delete 🛠️ Utilities" }));
+    await user.click(
+      screen.getByRole("button", { name: "Delete 🛠️ Utilities" })
+    );
     const modal = await getOpenModal();
 
     const deleteBtn = within(modal).getByRole("button", { name: /^Delete$/ });
@@ -412,7 +414,9 @@ describe("SelfServiceCategoriesPage", () => {
     const { user } = render(<SelfServiceCategoriesPage {...baseProps} />);
 
     await screen.findByText("🛠️ Utilities");
-    await user.click(screen.getByRole("button", { name: "Delete 🛠️ Utilities" }));
+    await user.click(
+      screen.getByRole("button", { name: "Delete 🛠️ Utilities" })
+    );
     const modal = await getOpenModal();
 
     await user.click(within(modal).getByRole("button", { name: /Cancel/ }));
@@ -487,7 +491,9 @@ describe("SelfServiceCategoriesPage", () => {
     const { user } = render(<SelfServiceCategoriesPage {...baseProps} />);
 
     await screen.findByText("🛠️ Utilities");
-    await user.click(screen.getByRole("button", { name: "Delete 🛠️ Utilities" }));
+    await user.click(
+      screen.getByRole("button", { name: "Delete 🛠️ Utilities" })
+    );
 
     const modal = await getOpenModal();
     expect(

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tests.tsx
@@ -333,7 +333,7 @@ describe("SelfServiceCategoriesPage", () => {
 
   it("flashes an error and re-enables the Delete button when delete fails", async () => {
     mockServer.use(
-      listSelfServiceCategoriesHandler([{ id: 1, name: "🛟 Support" }]),
+      listSelfServiceCategoriesHandler([{ id: 1, name: "🛠️ Utilities" }]),
       deleteSelfServiceCategoryErrorHandler
     );
     const render = createCustomRenderer({
@@ -343,8 +343,8 @@ describe("SelfServiceCategoriesPage", () => {
 
     const { user } = render(<SelfServiceCategoriesPage {...baseProps} />);
 
-    await screen.findByText("🛟 Support");
-    await user.click(screen.getByRole("button", { name: "Delete 🛟 Support" }));
+    await screen.findByText("🛠️ Utilities");
+    await user.click(screen.getByRole("button", { name: "Delete 🛠️ Utilities" }));
     const modal = await getOpenModal();
 
     const deleteBtn = within(modal).getByRole("button", { name: /^Delete$/ });
@@ -402,7 +402,7 @@ describe("SelfServiceCategoriesPage", () => {
 
   it("closes the Delete modal when Cancel is clicked", async () => {
     mockServer.use(
-      listSelfServiceCategoriesHandler([{ id: 1, name: "🛟 Support" }])
+      listSelfServiceCategoriesHandler([{ id: 1, name: "🛠️ Utilities" }])
     );
     const render = createCustomRenderer({
       withBackendMock: true,
@@ -411,8 +411,8 @@ describe("SelfServiceCategoriesPage", () => {
 
     const { user } = render(<SelfServiceCategoriesPage {...baseProps} />);
 
-    await screen.findByText("🛟 Support");
-    await user.click(screen.getByRole("button", { name: "Delete 🛟 Support" }));
+    await screen.findByText("🛠️ Utilities");
+    await user.click(screen.getByRole("button", { name: "Delete 🛠️ Utilities" }));
     const modal = await getOpenModal();
 
     await user.click(within(modal).getByRole("button", { name: /Cancel/ }));
@@ -476,7 +476,7 @@ describe("SelfServiceCategoriesPage", () => {
 
   it("deletes a category on confirm", async () => {
     mockServer.use(
-      listSelfServiceCategoriesHandler([{ id: 1, name: "🛟 Support" }]),
+      listSelfServiceCategoriesHandler([{ id: 1, name: "🛠️ Utilities" }]),
       deleteSelfServiceCategoryHandler
     );
     const render = createCustomRenderer({
@@ -486,8 +486,8 @@ describe("SelfServiceCategoriesPage", () => {
 
     const { user } = render(<SelfServiceCategoriesPage {...baseProps} />);
 
-    await screen.findByText("🛟 Support");
-    await user.click(screen.getByRole("button", { name: "Delete 🛟 Support" }));
+    await screen.findByText("🛠️ Utilities");
+    await user.click(screen.getByRole("button", { name: "Delete 🛠️ Utilities" }));
 
     const modal = await getOpenModal();
     expect(

--- a/frontend/test/handlers/self-service-categories-handlers.ts
+++ b/frontend/test/handlers/self-service-categories-handlers.ts
@@ -29,7 +29,7 @@ export const listSelfServiceCategoriesHandler = (
     { id: 1, name: "🌎 Browsers" },
     { id: 2, name: "👬 Communication" },
     { id: 3, name: "🧰 Developer tools" },
-    { id: 4, name: "💻 Productivity" },
+    { id: 4, name: "🖥️ Productivity" },
     { id: 5, name: "🔐 Security" },
   ]
 ) =>
@@ -52,7 +52,7 @@ export const listDeviceSelfServiceCategoriesHandler = (
     { id: 1, name: "🌎 Browsers" },
     { id: 2, name: "👬 Communication" },
     { id: 3, name: "🧰 Developer tools" },
-    { id: 4, name: "💻 Productivity" },
+    { id: 4, name: "🖥️ Productivity" },
     { id: 5, name: "🔐 Security" },
   ]
 ) =>

--- a/server/datastore/mysql/in_house_apps_test.go
+++ b/server/datastore/mysql/in_house_apps_test.go
@@ -853,7 +853,7 @@ func testBatchSetInHouseInstallers(t *testing.T, ds *Datastore) {
 
 	// change ipa2 self-service and add categories
 	ipa2.SelfService = !ipa2.SelfService
-	ipa2.Categories = []string{"👬 Communication", "💻 Productivity"}
+	ipa2.Categories = []string{"👬 Communication", "🖥️ Productivity"}
 	catIDs, err := ds.GetSoftwareCategoryIDs(ctx, team.ID, ipa2.Categories)
 	require.NoError(t, err)
 	ipa2.CategoryIDs = catIDs

--- a/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories.go
+++ b/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories.go
@@ -44,7 +44,7 @@ SET name = CASE name
 	WHEN 'Developer tools'  THEN '🧰 Developer tools'
 	WHEN 'Productivity'     THEN '💻 Productivity'
 	WHEN 'Security'         THEN '🔐 Security'
-	WHEN 'Utilities'        THEN '🛟 Support'
+	WHEN 'Utilities'        THEN '🛠️ Utilities'
 	ELSE name
 END
 WHERE team_id = 0
@@ -76,7 +76,7 @@ ORDER BY t.id, FIELD(sc.name,
 	'🧰 Developer tools',
 	'💻 Productivity',
 	'🔐 Security',
-	'🛟 Support')
+	'🛠️ Utilities')
 `); err != nil {
 				return errors.Wrap(err, "backfilling per-fleet default categories")
 			}

--- a/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories.go
+++ b/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories.go
@@ -42,7 +42,7 @@ SET name = CASE name
 	WHEN 'Browsers'         THEN '🌎 Browsers'
 	WHEN 'Communication'    THEN '👬 Communication'
 	WHEN 'Developer tools'  THEN '🧰 Developer tools'
-	WHEN 'Productivity'     THEN '💻 Productivity'
+	WHEN 'Productivity'     THEN '🖥️ Productivity'
 	WHEN 'Security'         THEN '🔐 Security'
 	WHEN 'Utilities'        THEN '🛠️ Utilities'
 	ELSE name
@@ -74,7 +74,7 @@ ORDER BY t.id, FIELD(sc.name,
 	'🌎 Browsers',
 	'👬 Communication',
 	'🧰 Developer tools',
-	'💻 Productivity',
+	'🖥️ Productivity',
 	'🔐 Security',
 	'🛠️ Utilities')
 `); err != nil {

--- a/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories_test.go
+++ b/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories_test.go
@@ -69,7 +69,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		"Developer tools": "🧰 Developer tools",
 		"Productivity":    "💻 Productivity",
 		"Security":        "🔐 Security",
-		"Utilities":       "🛟 Support",
+		"Utilities":       "🛠️ Utilities",
 	}
 	for oldName, newName := range expectedRenames {
 		oldID, ok := preID[oldName]
@@ -88,7 +88,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		"🧰 Developer tools",
 		"💻 Productivity",
 		"🔐 Security",
-		"🛟 Support",
+		"🛠️ Utilities",
 	}
 
 	// Both teams have all 6 defaults in canonical order with sequential IDs.

--- a/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories_test.go
+++ b/server/datastore/mysql/migrations/tables/20260608160653_AddTeamIDToSoftwareCategories_test.go
@@ -67,7 +67,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		"Browsers":        "🌎 Browsers",
 		"Communication":   "👬 Communication",
 		"Developer tools": "🧰 Developer tools",
-		"Productivity":    "💻 Productivity",
+		"Productivity":    "🖥️ Productivity",
 		"Security":        "🔐 Security",
 		"Utilities":       "🛠️ Utilities",
 	}
@@ -86,7 +86,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		"🌎 Browsers",
 		"👬 Communication",
 		"🧰 Developer tools",
-		"💻 Productivity",
+		"🖥️ Productivity",
 		"🔐 Security",
 		"🛠️ Utilities",
 	}
@@ -139,8 +139,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	require.NoError(t, db.Get(&inHouseLinkedCatID,
 		`SELECT software_category_id FROM in_house_app_software_categories WHERE in_house_app_id = ?`,
 		inHouseAppA))
-	require.Equal(t, teamARows[3].ID, inHouseLinkedCatID, "team A in-house app should link to team A's 💻 Productivity")
-	require.Equal(t, "💻 Productivity", teamARows[3].Name)
+	require.Equal(t, teamARows[3].ID, inHouseLinkedCatID, "team A in-house app should link to team A's 🖥️ Productivity")
+	require.Equal(t, "🖥️ Productivity", teamARows[3].Name)
 
 	assertLinkGone := func(query string, parentID uint, label string) {
 		var dummy uint

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -2894,7 +2894,7 @@ CREATE TABLE `software_categories` (
   UNIQUE KEY `idx_software_categories_team_id_name` (`team_id`,`name`)
 ) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `software_categories` VALUES (1,'💻 Productivity',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(2,'🌎 Browsers',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(3,'👬 Communication',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(4,'🧰 Developer tools',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(5,'🔐 Security',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(6,'🛟 Support',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000');
+INSERT INTO `software_categories` VALUES (1,'💻 Productivity',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(2,'🌎 Browsers',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(3,'👬 Communication',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(4,'🧰 Developer tools',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(5,'🔐 Security',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(6,'🛠️ Utilities',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000');
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software_cpe` (

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -2894,7 +2894,7 @@ CREATE TABLE `software_categories` (
   UNIQUE KEY `idx_software_categories_team_id_name` (`team_id`,`name`)
 ) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `software_categories` VALUES (1,'💻 Productivity',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(2,'🌎 Browsers',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(3,'👬 Communication',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(4,'🧰 Developer tools',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(5,'🔐 Security',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(6,'🛠️ Utilities',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000');
+INSERT INTO `software_categories` VALUES (1,'🖥️ Productivity',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(2,'🌎 Browsers',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(3,'👬 Communication',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(4,'🧰 Developer tools',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(5,'🔐 Security',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(6,'🛠️ Utilities',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000');
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software_cpe` (

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -12973,7 +12973,7 @@ func testGetSoftwareCategoryNameToIDMap(t *testing.T, ds *Datastore) {
 	var emojiProductivity, emojiSecurity fleet.SoftwareCategory
 	for _, c := range seeded {
 		switch c.Name {
-		case "💻 Productivity":
+		case "🖥️ Productivity":
 			emojiProductivity = c
 		case "🔐 Security":
 			emojiSecurity = c

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -897,7 +897,7 @@ var DefaultSelfServiceCategoryNames = []string{
 	"🌎 Browsers",
 	"👬 Communication",
 	"🧰 Developer tools",
-	"💻 Productivity",
+	"🖥️ Productivity",
 	"🔐 Security",
 	"🛠️ Utilities",
 }
@@ -909,7 +909,7 @@ var LegacySoftwareCategoryNames = map[string]string{
 	"Browsers":        "🌎 Browsers",
 	"Communication":   "👬 Communication",
 	"Developer tools": "🧰 Developer tools",
-	"Productivity":    "💻 Productivity",
+	"Productivity":    "🖥️ Productivity",
 	"Security":        "🔐 Security",
 	"Utilities":       "🛠️ Utilities",
 }

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -899,7 +899,7 @@ var DefaultSelfServiceCategoryNames = []string{
 	"🧰 Developer tools",
 	"💻 Productivity",
 	"🔐 Security",
-	"🛟 Support",
+	"🛠️ Utilities",
 }
 
 // Map the old default category names that don't include emojis to the new ones
@@ -911,7 +911,7 @@ var LegacySoftwareCategoryNames = map[string]string{
 	"Developer tools": "🧰 Developer tools",
 	"Productivity":    "💻 Productivity",
 	"Security":        "🔐 Security",
-	"Utilities":       "🛟 Support",
+	"Utilities":       "🛠️ Utilities",
 }
 
 func TranslateLegacySoftwareCategoryNames(names []string) []string {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -22495,12 +22495,12 @@ func (s *integrationEnterpriseTestSuite) TestBatchSoftwareInstallerAndFMACategor
 			categories: optjson.SetSlice([]string{"👬 Communication", "💻 Productivity"}),
 		},
 		{
-			desc:       "valid categories 3 - Security and Support",
-			categories: optjson.SetSlice([]string{"🔐 Security", "🛟 Support"}),
+			desc:       "valid categories 3 - Security and Utilities",
+			categories: optjson.SetSlice([]string{"🔐 Security", "🛠️ Utilities"}),
 		},
 		{
 			desc:       "valid categories 4 - mixed with new categories",
-			categories: optjson.SetSlice([]string{"🔐 Security", "🧰 Developer tools", "🛟 Support"}),
+			categories: optjson.SetSlice([]string{"🔐 Security", "🧰 Developer tools", "🛠️ Utilities"}),
 		},
 		{
 			// omitted categories (unset) fall back to the FMA's manifest default

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -13557,7 +13557,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 		s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusOK, headers)
 
 		expectedPayload := *payload
-		expectedPayload.Categories = []string{"🌎 Browsers", "💻 Productivity"}
+		expectedPayload.Categories = []string{"🌎 Browsers", "🖥️ Productivity"}
 		expectedPayload.SelfService = true
 		checkSoftwareInstaller(t, s.ds, payload)
 
@@ -21057,7 +21057,7 @@ func (s *integrationEnterpriseTestSuite) TestMaintainedApps() {
 	titleResponse := getSoftwareTitleResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/software/titles/%d", title.ID), nil, http.StatusOK, &titleResponse, "team_id", "0")
 	require.NotNil(t, titleResponse.SoftwareTitle.SoftwarePackage)
-	require.Equal(t, []string{"💻 Productivity"}, titleResponse.SoftwareTitle.SoftwarePackage.Categories)
+	require.Equal(t, []string{"🖥️ Productivity"}, titleResponse.SoftwareTitle.SoftwarePackage.Categories)
 
 	i, err = s.ds.GetSoftwareInstallerMetadataByID(context.Background(), getSoftwareInstallerIDByMAppID(4))
 	require.NoError(t, err)
@@ -22492,7 +22492,7 @@ func (s *integrationEnterpriseTestSuite) TestBatchSoftwareInstallerAndFMACategor
 		},
 		{
 			desc:       "valid categories 2",
-			categories: optjson.SetSlice([]string{"👬 Communication", "💻 Productivity"}),
+			categories: optjson.SetSlice([]string{"👬 Communication", "🖥️ Productivity"}),
 		},
 		{
 			desc:       "valid categories 3 - Security and Utilities",
@@ -22505,7 +22505,7 @@ func (s *integrationEnterpriseTestSuite) TestBatchSoftwareInstallerAndFMACategor
 		{
 			// omitted categories (unset) fall back to the FMA's manifest default
 			desc:                 "omitted categories use FMA default",
-			fmaDefaultCategories: []string{"💻 Productivity"},
+			fmaDefaultCategories: []string{"🖥️ Productivity"},
 		},
 		{
 			// an explicitly empty categories list sets zero categories (no manifest default)
@@ -26506,7 +26506,7 @@ func (s *integrationEnterpriseTestSuite) TestInHouseAppCRUD() {
 		s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusOK, headers)
 		expectedPayload := *payload
 		expectedPayload.LabelsExcludeAny = []string{labelResp.Label.Name}
-		expectedPayload.Categories = []string{"💻 Productivity", "🌎 Browsers"}
+		expectedPayload.Categories = []string{"🖥️ Productivity", "🌎 Browsers"}
 
 		meta, err := s.ds.GetInHouseAppMetadataByTeamAndTitleID(context.Background(), &createTeamResp.Team.ID, installerID)
 		require.NoError(t, err)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -21070,7 +21070,7 @@ func (s *integrationMDMTestSuite) TestSoftwareCategories() {
 
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/software/titles/%d", vppAppTitleID), nil, http.StatusOK, &titleResponse, "team_id", "0")
 	require.NotNil(t, titleResponse.SoftwareTitle.AppStoreApp)
-	require.ElementsMatch(t, []string{"🔐 Security", "🛟 Support"}, titleResponse.SoftwareTitle.AppStoreApp.Categories)
+	require.ElementsMatch(t, []string{"🔐 Security", "🛠️ Utilities"}, titleResponse.SoftwareTitle.AppStoreApp.Categories)
 
 	// empty out categories via gitops
 	s.DoJSON("POST",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
Tested with fleet maintained apps and VPP in UI and gitops 

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations
N/A since this is just editing the existing migration
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
    - newly added custom category, or default category, was cleared if was not in the yaml file
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “Productivity” category emoji/name and the “Utilities” category emoji/name across the system for consistent display and behavior.
* **Tests**
  * Updated unit, integration, and handler tests to expect the corrected category strings and delete-button labels.
* **Chores**
  * Refreshed database seed data and migration/test expectations to align default and per-team category names, preserving IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->