### PR TITLE
Extract /api/ timeout-override middleware out of runServeCmd

### DIFF
--- a/cmd/fleet/http_middleware.go
+++ b/cmd/fleet/http_middleware.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/scripts"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
+)
+
+// apiTimeoutOverrideHandler wraps the main API handler with per-route request
+// read/write deadline overrides for endpoints that legitimately run long:
+// synchronous script runs, large software-installer and bootstrap-package
+// uploads, the Android enterprise signup SSE stream, and large MDM profile
+// batch operations. For package-upload routes it also caps the request body and
+// threads the configured max installer size through the request context.
+//
+// Deadline overrides are best-effort: if the ResponseWriter does not support
+// SetReadDeadline/SetWriteDeadline the error is logged and the request proceeds.
+func apiTimeoutOverrideHandler(apiHandler http.Handler, cfg config.FleetConfig, logger *slog.Logger) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/scripts/run/sync") {
+			// when running a script synchronously, we wait a while for a script
+			// execution result, so the write timeout (to write the response)
+			// must be extended.
+			rc := http.NewResponseController(rw)
+			// add an additional 30 seconds to prevent race conditions where the
+			// request is terminated early.
+			if err := rc.SetWriteDeadline(time.Now().Add(scripts.MaxServerWaitTime + (30 * time.Second))); err != nil {
+				logger.ErrorContext(req.Context(),
+					"http middleware failed to override endpoint write timeout for script sync run",
+					"response_writer_type", fmt.Sprintf("%T", rw),
+					"response_writer", fmt.Sprintf("%+v", rw),
+					"err", err,
+				)
+			}
+		}
+
+		if (req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/software/package")) ||
+			(req.Method == http.MethodPatch && strings.HasSuffix(req.URL.Path, "/package") && strings.Contains(req.URL.Path,
+				"/fleet/software/titles/")) ||
+			(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/bootstrap")) ||
+			(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet_maintained_apps")) ||
+			(req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/package/token")) ||
+			(req.Method == http.MethodPost && strings.Contains(req.URL.Path, "orbit/software_install/package")) {
+			var zeroTime time.Time
+			rc := http.NewResponseController(rw)
+			// For large software installers and bootstrap packages, the server time needs time to read the full
+			// request body so we use the zero value to remove the deadline and override the
+			// default read timeout.
+			// TODO: Is this really how we want to handle this? Or would an arbitrarily long
+			// timeout be better?
+			if err := rc.SetReadDeadline(zeroTime); err != nil {
+				logger.ErrorContext(req.Context(),
+					"http middleware failed to override endpoint read timeout for software package upload",
+					"response_writer_type", fmt.Sprintf("%T", rw),
+					"response_writer", fmt.Sprintf("%+v", rw),
+					"err", err,
+				)
+			}
+			// For large software installers, the server time needs time to store the
+			// installer to S3 (or the configured storage location) and write the response
+			// body so we use the zero value to remove the deadline and override the
+			// default write timeout.
+			// TODO: Is this really how we want to handle this? Or would an arbitrarily long
+			// timeout be better?
+			if err := rc.SetWriteDeadline(zeroTime); err != nil {
+				logger.ErrorContext(req.Context(),
+					"http middleware failed to override endpoint write timeout for software package upload",
+					"response_writer_type", fmt.Sprintf("%T", rw),
+					"response_writer", fmt.Sprintf("%+v", rw),
+					"err", err,
+				)
+			}
+
+			// We need to add the context value here because we need the installer max size when doing request
+			// parsing, which happens somewhere where we're only passed the request (and not the service object)
+			req.Body = http.MaxBytesReader(rw, req.Body, cfg.Server.MaxInstallerSizeBytes)
+			req = req.WithContext(installersize.NewContext(req.Context(), cfg.Server.MaxInstallerSizeBytes))
+		}
+
+		if req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/fleet/android_enterprise/signup_sse") {
+			// When enabling Android MDM, frontend UI will wait for the admin to finish the setup in Google.
+			rc := http.NewResponseController(rw)
+			if err := rc.SetWriteDeadline(time.Now().Add(30 * time.Minute)); err != nil {
+				logger.ErrorContext(req.Context(),
+					"http middleware failed to override endpoint write timeout for android enterpriset setup",
+					"response_writer_type", fmt.Sprintf("%T", rw),
+					"response_writer", fmt.Sprintf("%+v", rw),
+					"err", err,
+				)
+			}
+		}
+
+		if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/mdm/profiles/batch") ||
+			(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/configuration_profiles/batch")) {
+			// For customers using large profiles and/or large numbers of profiles, the
+			// server needs time to completely read the request body and also to process
+			// all the side effects of a potentially large number of profiles being changed
+			// across a large number of hosts, so set the timeouts a bit higher than default
+			rc := http.NewResponseController(rw)
+			if err := rc.SetWriteDeadline(time.Now().Add(5 * time.Minute)); err != nil {
+				logger.ErrorContext(req.Context(),
+					"http middleware failed to override endpoint write timeout for MDM profiles batch endpoint",
+					"response_writer_type", fmt.Sprintf("%T", rw),
+					"response_writer", fmt.Sprintf("%+v", rw),
+					"err", err,
+				)
+			}
+			if err := rc.SetReadDeadline(time.Now().Add(5 * time.Minute)); err != nil {
+				logger.ErrorContext(req.Context(),
+					"http middleware failed to override endpoint read timeout for MDM profiles batch endpoint",
+					"response_writer_type", fmt.Sprintf("%T", rw),
+					"response_writer", fmt.Sprintf("%+v", rw),
+					"err", err,
+				)
+			}
+		}
+
+		apiHandler.ServeHTTP(rw, req)
+	}
+}

--- a/cmd/fleet/http_middleware_test.go
+++ b/cmd/fleet/http_middleware_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPITimeoutOverrideHandler(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	const customMax int64 = 4242
+
+	cfg := config.FleetConfig{}
+	cfg.Server.MaxInstallerSizeBytes = customMax
+
+	for _, tc := range []struct {
+		name              string
+		method            string
+		path              string
+		wantInstallerSize int64
+	}{
+		{
+			name:              "software package upload threads configured max size",
+			method:            http.MethodPost,
+			path:              "/api/latest/fleet/software/package",
+			wantInstallerSize: customMax,
+		},
+		{
+			name:              "bootstrap package upload threads configured max size",
+			method:            http.MethodPost,
+			path:              "/api/latest/fleet/mdm/bootstrap",
+			wantInstallerSize: customMax,
+		},
+		{
+			name:              "non-upload request leaves the default max size",
+			method:            http.MethodGet,
+			path:              "/api/latest/fleet/hosts",
+			wantInstallerSize: installersize.MaxSoftwareInstallerSize,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				called bool
+				seen   int64
+			)
+			downstream := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+				called = true
+				seen = installersize.FromContext(req.Context())
+			})
+
+			apiTimeoutOverrideHandler(downstream, cfg, logger).ServeHTTP(
+				httptest.NewRecorder(),
+				httptest.NewRequest(tc.method, tc.path, nil),
+			)
+
+			assert.True(t, called, "the wrapped API handler must always be invoked")
+			assert.Equal(t, tc.wantInstallerSize, seen)
+		})
+	}
+}

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -34,7 +34,6 @@ import (
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
 	"github.com/fleetdm/fleet/v4/ee/server/service/scep"
-	"github.com/fleetdm/fleet/v4/pkg/scripts"
 	"github.com/fleetdm/fleet/v4/pkg/str"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/acl/acmeacl"
@@ -49,7 +48,6 @@ import (
 	chart_bootstrap "github.com/fleetdm/fleet/v4/server/chart/bootstrap"
 	configpkg "github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
 	licensectx "github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/datastore/failing"
 	"github.com/fleetdm/fleet/v4/server/datastore/filesystem"
@@ -937,107 +935,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	// See https://pkg.go.dev/net/http#NewResponseController which explains
 	// the Unwrap method that the prometheus wrapper of http.ResponseWriter
 	// does not implement.
-	rootMux.HandleFunc("/api/", func(rw http.ResponseWriter, req *http.Request) {
-		if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/scripts/run/sync") {
-			// when running a script synchronously, we wait a while for a script
-			// execution result, so the write timeout (to write the response)
-			// must be extended.
-			rc := http.NewResponseController(rw)
-			// add an additional 30 seconds to prevent race conditions where the
-			// request is terminated early.
-			if err := rc.SetWriteDeadline(time.Now().Add(scripts.MaxServerWaitTime + (30 * time.Second))); err != nil {
-				logger.ErrorContext(req.Context(),
-					"http middleware failed to override endpoint write timeout for script sync run",
-					"response_writer_type", fmt.Sprintf("%T", rw),
-					"response_writer", fmt.Sprintf("%+v", rw),
-					"err", err,
-				)
-			}
-		}
-
-		if (req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/software/package")) ||
-			(req.Method == http.MethodPatch && strings.HasSuffix(req.URL.Path, "/package") && strings.Contains(req.URL.Path,
-				"/fleet/software/titles/")) ||
-			(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/bootstrap")) ||
-			(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet_maintained_apps")) ||
-			(req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/package/token")) ||
-			(req.Method == http.MethodPost && strings.Contains(req.URL.Path, "orbit/software_install/package")) {
-			var zeroTime time.Time
-			rc := http.NewResponseController(rw)
-			// For large software installers and bootstrap packages, the server time needs time to read the full
-			// request body so we use the zero value to remove the deadline and override the
-			// default read timeout.
-			// TODO: Is this really how we want to handle this? Or would an arbitrarily long
-			// timeout be better?
-			if err := rc.SetReadDeadline(zeroTime); err != nil {
-				logger.ErrorContext(req.Context(),
-					"http middleware failed to override endpoint read timeout for software package upload",
-					"response_writer_type", fmt.Sprintf("%T", rw),
-					"response_writer", fmt.Sprintf("%+v", rw),
-					"err", err,
-				)
-			}
-			// For large software installers, the server time needs time to store the
-			// installer to S3 (or the configured storage location) and write the response
-			// body so we use the zero value to remove the deadline and override the
-			// default write timeout.
-			// TODO: Is this really how we want to handle this? Or would an arbitrarily long
-			// timeout be better?
-			if err := rc.SetWriteDeadline(zeroTime); err != nil {
-				logger.ErrorContext(req.Context(),
-					"http middleware failed to override endpoint write timeout for software package upload",
-					"response_writer_type", fmt.Sprintf("%T", rw),
-					"response_writer", fmt.Sprintf("%+v", rw),
-					"err", err,
-				)
-			}
-
-			// We need to add the context value here because we need the installer max size when doing request
-			// parsing, which happens somewhere where we're only passed the request (and not the service object)
-			req.Body = http.MaxBytesReader(rw, req.Body, config.Server.MaxInstallerSizeBytes)
-			req = req.WithContext(installersize.NewContext(req.Context(), config.Server.MaxInstallerSizeBytes))
-		}
-
-		if req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/fleet/android_enterprise/signup_sse") {
-			// When enabling Android MDM, frontend UI will wait for the admin to finish the setup in Google.
-			rc := http.NewResponseController(rw)
-			if err := rc.SetWriteDeadline(time.Now().Add(30 * time.Minute)); err != nil {
-				logger.ErrorContext(req.Context(),
-					"http middleware failed to override endpoint write timeout for android enterpriset setup",
-					"response_writer_type", fmt.Sprintf("%T", rw),
-					"response_writer", fmt.Sprintf("%+v", rw),
-					"err", err,
-				)
-			}
-		}
-
-		if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/mdm/profiles/batch") ||
-			(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/configuration_profiles/batch")) {
-			// For customers using large profiles and/or large numbers of profiles, the
-			// server needs time to completely read the request body and also to process
-			// all the side effects of a potentially large number of profiles being changed
-			// across a large number of hosts, so set the timeouts a bit higher than default
-			rc := http.NewResponseController(rw)
-			if err := rc.SetWriteDeadline(time.Now().Add(5 * time.Minute)); err != nil {
-				logger.ErrorContext(req.Context(),
-					"http middleware failed to override endpoint write timeout for MDM profiles batch endpoint",
-					"response_writer_type", fmt.Sprintf("%T", rw),
-					"response_writer", fmt.Sprintf("%+v", rw),
-					"err", err,
-				)
-			}
-			if err := rc.SetReadDeadline(time.Now().Add(5 * time.Minute)); err != nil {
-				logger.ErrorContext(req.Context(),
-					"http middleware failed to override endpoint read timeout for MDM profiles batch endpoint",
-					"response_writer_type", fmt.Sprintf("%T", rw),
-					"response_writer", fmt.Sprintf("%+v", rw),
-					"err", err,
-				)
-			}
-		}
-
-		apiHandler.ServeHTTP(rw, req)
-	})
+	rootMux.HandleFunc("/api/", apiTimeoutOverrideHandler(apiHandler, config, logger))
 	// The `/api/{version}/fleet/scim` base path is used by SCIM handler. In order to route the `details` route to the apiHandler,
 	// we have to explicitly handle that path at the root. The Go router takes precedence for a more specific path. The v1/latest are used in the path for it to be more specific.
 	// The Fleet API was designed this way for end-user simplicity.


### PR DESCRIPTION
Extracts the `/api/` request timeout/body-size override middleware out of `runServeCmd` and into `apiTimeoutOverrideHandler` in a new `cmd/fleet/http_middleware.go`. Same pattern as the prior extractions on this issue (#44929, #45343, #45583, #46166, #46421, #46517, #46742, #46830, #46893, #47151, #47562). `runServeCmd` drops from ~1000 to ~900 lines, and `serve.go` from 1475 to 1373.

The middleware is the `~100`-line `rootMux.HandleFunc("/api/", ...)` closure that applies per-route read/write deadline overrides for endpoints that legitimately run long — synchronous script runs, large software-installer and bootstrap-package uploads, the Android enterprise signup SSE stream, and large MDM profile batch operations — and, for package-upload routes, caps the request body and threads the configured max installer size through the request context.

Behavior is preserved — the handler is moved verbatim and wired into `rootMux` via a single `apiTimeoutOverrideHandler(apiHandler, config, logger)` call, so the same routes get the same overrides and every request still falls through to `apiHandler.ServeHTTP`. The now-unused `scripts` and `installersize` imports drop out of `serve.go`.

On test scope: `TestAPITimeoutOverrideHandler` verifies the real decision in this middleware — that package-upload paths thread the configured max installer size into the request context (and non-upload requests keep the default) — and that the wrapped API handler is always invoked. The deadline overrides themselves go through `http.ResponseController`, which a unit-test `ResponseRecorder` doesn't support (the handler logs and proceeds, as in production), so those are exercised by booting the server rather than asserted in a unit test.

**Related issue:** Refs #33370

# Checklist for submitter

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually (verified via local server boot)
- Changes file: not applicable — internal refactor with no user-visible behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved timeout handling for long-running operations across the API. Script execution, file uploads, Server-Sent Event streams, and batch operations now have optimized request timeouts and body size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->