### PR TITLE
Fleet UI: Self-service category search input text color, weird scrollbar

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -1,3 +1,13 @@
+// Sandbox mode was removed years ago but .main-content still carries
+// `overflow: auto` for it. On the self-service page, that overflow
+// container catches the absolutely-positioned category dropdown when it
+// extends past the page bottom, producing an inner scrollbar instead of
+// the document scrollbar at the viewport edge. TODO: revisit removing
+// overflow: auto from .main-content globally.
+.main-content:has(.software-self-service) {
+  overflow: initial;
+}
+
 .software-self-service {
   @include vertical-page-tab-panel-layout;
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/CategoryFilter/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/CategoryFilter/_styles.scss
@@ -67,7 +67,7 @@
     border: solid 1px $ui-fleet-black-10;
     border-radius: $border-radius;
     padding: 9.5px 12px 9.5px 36px;
-    color: $core-fleet-blue;
+    color: $core-fleet-black;
     font-family: "Inter", sans-serif;
     font-size: $x-small;
     box-sizing: border-box;


### PR DESCRIPTION
## Issue
Closes #47892
Closes #47912

## Description
- Bug fix (root cause): `.self-service-category-filter__search-input` set `color: $core-fleet-blue` (#3E4771 navy), which was inconsistent with every other Fleet input. Switched to `$core-fleet-black` to match standard input styling.
- Bug fix (related): on the Self-service page, the absolutely-positioned category dropdown was extending past the bottom of `.main-content`, which still carries `overflow: auto` from removed sandbox-mode banner support. That produced an inner scrollbar on `.main-content` instead of letting the document scrollbar handle it. Scoped `overflow: initial` to `.main-content:has(.software-self-service)` so only the self-service page gets the override (mirrors the `.dashboard-page` pattern). Left a TODO to revisit removing `overflow: auto` from `.main-content` globally.

## Screenrecording
- Search text color + category dropdown scrollbar on a tall page


https://github.com/user-attachments/assets/5c54b7b5-5e96-4eb4-ad68-b74afa5d9443

<img width="722" height="536" alt="Screenshot 2026-06-19 at 10 13 38 AM" src="https://github.com/user-attachments/assets/f8abb50f-4970-4a65-a60c-6d9518fff013" />
<img width="642" height="574" alt="Screenshot 2026-06-19 at 10 16 13 AM" src="https://github.com/user-attachments/assets/497ea404-d8ac-4e17-85f7-8b024e25630f" />



## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Updated the self-service category filter search input text color from blue to black for improved visibility.
  * Adjusted layout styling for the self-service page to prevent an unwanted inner scrollbar by resetting the main content overflow behavior when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->