### PR TITLE
For R.C. - Fleet UI: Self-service category search input text color, weird scrollbar (#47913)

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -1,3 +1,13 @@
+// Sandbox mode was removed years ago but .main-content still carries
+// `overflow: auto` for it. On the self-service page, that overflow
+// container catches the absolutely-positioned category dropdown when it
+// extends past the page bottom, producing an inner scrollbar instead of
+// the document scrollbar at the viewport edge. TODO: revisit removing
+// overflow: auto from .main-content globally.
+.main-content:has(.software-self-service) {
+  overflow: initial;
+}
+
 .software-self-service {
   @include vertical-page-tab-panel-layout;
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/CategoryFilter/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/CategoryFilter/_styles.scss
@@ -67,7 +67,7 @@
     border: solid 1px $ui-fleet-black-10;
     border-radius: $border-radius;
     padding: 9.5px 12px 9.5px 36px;
-    color: $core-fleet-blue;
+    color: $core-fleet-black;
     font-family: "Inter", sans-serif;
     font-size: $x-small;
     box-sizing: border-box;


### PR DESCRIPTION
## Issue
Closes #47892
Closees #47912 

## Description
- Previously merged into `main` with #47913
- This is for the 4.87.0 R.C.