### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/houdahspot/darwin.json
+++ b/ee/maintained-apps/outputs/houdahspot/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.houdah.HoudahSpot6';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.houdah.HoudahSpot6' AND version_compare(bundle_short_version, '6.8.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.houdah.HoudahSpot6' AND version_compare(bundle_short_version, '6.8.2') < 0);"
       },
-      "installer_url": "https://dl.houdah.com/houdahSpot/updates/cast_assets/906c763d-9739-48da-a68a-d43b144c0a92/HoudahSpot_6.8.1.dmg",
+      "installer_url": "https://dl.houdah.com/houdahSpot/updates/cast_assets/156b5d02-8e40-4b77-bcda-d1c6e91c16ad/HoudahSpot_6.8.2.dmg",
       "install_script_ref": "9a0ba4bc",
       "uninstall_script_ref": "c4ab567f",
-      "sha256": "0b014bed899f45302010767e3988e1f0fa98d28427287d178811599da7028ce0",
+      "sha256": "588d1faed0be87f550fdeb2445427396b2650862f7d899e952d577d272557ad1",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * HoudahSpot macOS application updated to version 6.8.2 with refreshed installation assets and security verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->