### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/arc/windows.json
+++ b/ee/maintained-apps/outputs/arc/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.110.1.2",
+      "version": "1.111.0.274",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York' AND version_compare(version, '1.110.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York' AND version_compare(version, '1.111.0.274') < 0);"
       },
-      "installer_url": "https://releases.arc.net/windows/prod/1.110.1.2/Arc.x64.msix",
+      "installer_url": "https://releases.arc.net/windows/prod/1.111.0.274/Arc.x64.msix",
       "install_script_ref": "d2d5c7dc",
       "uninstall_script_ref": "ebcac670",
-      "sha256": "9e54dc0a9bc33436f44b8eaca83f98c2e4e13b3b392d8239a07d7ad637c1c283",
+      "sha256": "26a88064a730abce8371cfcd66a31c57422b2811b98a5456ba1808f2993a85ee",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/batfi/darwin.json
+++ b/ee/maintained-apps/outputs/batfi/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.0.5",
+      "version": "3.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'software.micropixels.BatFi';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'software.micropixels.BatFi' AND version_compare(bundle_short_version, '3.0.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'software.micropixels.BatFi' AND version_compare(bundle_short_version, '3.1.0') < 0);"
       },
       "installer_url": "https://files.micropixels.software/batfi/BatFi-latest.zip",
       "install_script_ref": "818757b8",

--- a/ee/maintained-apps/outputs/goodsync/darwin.json
+++ b/ee/maintained-apps/outputs/goodsync/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "12.11.3",
+      "version": "12.11.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sibersystems.goodsyncmac2000';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sibersystems.goodsyncmac2000' AND version_compare(bundle_short_version, '12.11.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sibersystems.goodsyncmac2000' AND version_compare(bundle_short_version, '12.11.4') < 0);"
       },
       "installer_url": "https://www.goodsync.com/download/goodsync-vsub-mac.dmg",
       "install_script_ref": "005e7498",

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.345.3",
+      "version": "7.345.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.345.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.345.5') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.345.3/Granola-7.345.3-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.345.5/Granola-7.345.5-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "0e1702c25a8c9c0084b7d3ecc97a798f3c495565ac47a8d19bae9c26514693a2",
+      "sha256": "c258146a46e44322b0eed706d38bbcdb1775680360079a32b0b6c3362fe10d68",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/readest/darwin.json
+++ b/ee/maintained-apps/outputs/readest/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.11.4",
+      "version": "0.11.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bilingify.readest';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bilingify.readest' AND version_compare(bundle_short_version, '0.11.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bilingify.readest' AND version_compare(bundle_short_version, '0.11.10') < 0);"
       },
-      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.4/Readest_0.11.4_universal.dmg",
+      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.10/Readest_0.11.10_universal.dmg",
       "install_script_ref": "3e736c25",
       "uninstall_script_ref": "13037b35",
-      "sha256": "52732e9dda711e48b51a938f22a3e93ab24e24c06f5045988ff08dd324bd518b",
+      "sha256": "9d78f7bfd0c29fce4df0229b32f4dd71b107ca3fa3882833d1e705f45f466705",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version metadata and checksums for Arc (1.111.0.274), BatFi (3.1.0), GoodSync (12.11.4), Granola (7.345.5), and Readest (0.11.10).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->