### PR TITLE
Disambiguate FMAs sharing macOS bundle IDs

### DIFF
--- a/changes/42445-firefox-esr-shared-bundle-identifier
+++ b/changes/42445-firefox-esr-shared-bundle-identifier
@@ -1,0 +1,1 @@
+- Fixed Fleet-maintained apps that share a macOS bundle identifier (for example Firefox and Firefox ESR) so that adding one no longer renames its software title to the other, and no longer shows the other as already added.

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -124,7 +124,9 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 const fleetMaintainedAppsTeamJoin = `
 			FROM fleet_maintained_apps fma
 			LEFT JOIN (
-				SELECT DISTINCT st.id, st.unique_identifier, st.name, si.platform, si.fleet_maintained_app_id
+				-- COALESCE the platform so VPP-added titles (no installer row) still
+				-- carry a platform for the platform-scoped identifier fallback below.
+				SELECT DISTINCT st.id, st.unique_identifier, st.name, COALESCE(si.platform, va.platform) AS platform, si.fleet_maintained_app_id
 				FROM software_titles st
 				LEFT JOIN
 					software_installers si
@@ -144,9 +146,12 @@ const fleetMaintainedAppsTeamJoin = `
 				-- Match the exact FMA the title was added with, so a shared bundle
 				-- identifier (Firefox vs Firefox ESR) doesn't mark the sibling added.
 				ON team_titles.fleet_maintained_app_id = fma.id
-				-- Not added via an FMA: fall back to the bundle identifier.
+				-- Not added via an FMA: fall back to the bundle identifier, scoped to
+				-- the same platform so a darwin title can't match a windows FMA (or
+				-- vice versa) when their identifiers happen to collide.
 				OR (
 					team_titles.fleet_maintained_app_id IS NULL
+					AND team_titles.platform = fma.platform
 					AND team_titles.unique_identifier = fma.unique_identifier
 				)
 				-- pattern match fma name to a similar title name, since upgrade_code is not surfaced in fma table

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -33,8 +33,6 @@ ON DUPLICATE KEY UPDATE
 
 	var appID uint
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		var err error
-
 		// upsert the maintained app
 		res, err := tx.ExecContext(ctx, upsertStmt, app.Name, app.Slug, app.Platform, app.UniqueIdentifier)
 		if err != nil {
@@ -42,39 +40,6 @@ ON DUPLICATE KEY UPDATE
 		}
 		id, _ := res.LastInsertId()
 		appID = uint(id) //nolint:gosec // dismiss G115
-
-		// For darwin apps, update existing software_titles and software entries
-		// to use the FMA canonical name. This ensures consistency when an FMA
-		// is added for software that was previously ingested with osquery-reported names.
-		//
-		// We only run these UPDATEs when the FMA was actually inserted or modified.
-		// MySQL's ON DUPLICATE KEY UPDATE returns RowsAffected:
-		//   0 = duplicate key, no changes (existing FMA with same values)
-		//   1 = new row inserted
-		//   2 = duplicate key, values changed
-		// Skip if RowsAffected == 0 since nothing changed.
-		rowsAffected, _ := res.RowsAffected()
-		if app.Platform == "darwin" && app.UniqueIdentifier != "" && rowsAffected > 0 {
-			_, err = tx.ExecContext(ctx, `
-				UPDATE software_titles
-				SET name = ?
-				WHERE bundle_identifier = ?
-					AND name != ?
-			`, app.Name, app.UniqueIdentifier, app.Name)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "update software_titles names for FMA")
-			}
-
-			_, err = tx.ExecContext(ctx, `
-				UPDATE software
-				SET name = ?
-				WHERE bundle_identifier = ?
-					AND name != ?
-			`, app.Name, app.UniqueIdentifier, app.Name)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "update software names for FMA")
-			}
-		}
 
 		return nil
 	})
@@ -86,6 +51,95 @@ ON DUPLICATE KEY UPDATE
 	return app, nil
 }
 
+// ReconcileMaintainedAppSoftwareNames normalizes the names of macOS
+// software_titles (and the matching software inventory rows) so they use the
+// canonical Fleet-maintained app name instead of the osquery- or
+// installer-reported name (e.g. "Code" -> "Microsoft Visual Studio Code").
+//
+// It is called once per maintained-apps sync (hourly), is set-based, and is
+// idempotent, so it self-heals: a row that already matches is left untouched.
+//
+// Because an FMA's unique_identifier (the macOS bundle identifier) is NOT unique
+// across the FMA list — Firefox and Firefox ESR both report org.mozilla.firefox,
+// LibreOffice and a future LibreOffice-still would share org.libreoffice.script —
+// renaming purely by bundle identifier is ambiguous and would clobber titles with
+// whichever sibling FMA was synced last. To stay correct it renames in two passes:
+//
+//  1. Precise: a title that was added via a specific FMA is linked through
+//     software_installers.fleet_maintained_app_id. When that link resolves to a
+//     single FMA name, use it — this disambiguates shared identifiers because we
+//     know exactly which FMA the user added, and it repairs titles previously
+//     mislabeled by the old blind-rename behavior.
+//
+//  2. Heuristic: for titles not added via an FMA (osquery-detected, custom
+//     installer, VPP), fall back to matching by bundle identifier, but ONLY when
+//     that identifier maps to exactly one FMA name. Shared identifiers are skipped
+//     entirely, since there is no single correct canonical name.
+func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) error {
+	// titleNameByFMA maps each software_title to the canonical name of the single
+	// darwin FMA it was added with, resolved through its installer link
+	// (software_installers.fleet_maintained_app_id). A title linked to
+	// differently-named FMAs (e.g. Firefox on one team, Firefox ESR on another,
+	// sharing one global title) is excluded by the HAVING clause, since we cannot
+	// pick a single name for it. Grouping to one row per title also keeps the
+	// UPDATEs below from fanning out over a title's per-team installer rows.
+	const titleNameByFMA = `
+		SELECT si.title_id, MIN(fma.name) AS name
+		FROM software_installers si
+		JOIN fleet_maintained_apps fma
+			ON fma.id = si.fleet_maintained_app_id AND fma.platform = 'darwin'
+		GROUP BY si.title_id
+		HAVING COUNT(DISTINCT fma.name) = 1`
+
+	// unambiguousByIdentifier is the set of darwin bundle identifiers that map to
+	// exactly one FMA name. Identifiers shared by differently-named FMAs (Firefox /
+	// Firefox ESR) are excluded by the HAVING clause and never auto-renamed.
+	const unambiguousByIdentifier = `
+		SELECT unique_identifier, MIN(name) AS name
+		FROM fleet_maintained_apps
+		WHERE platform = 'darwin'
+		GROUP BY unique_identifier
+		HAVING COUNT(DISTINCT name) = 1`
+
+	updates := []struct {
+		label string
+		stmt  string
+	}{
+		// Pass 1 (precise): rename titles linked to a single FMA via their installer.
+		{"software_titles by installer link", `
+			UPDATE software_titles st
+				JOIN (` + titleNameByFMA + `) fma ON fma.title_id = st.id
+			SET st.name = fma.name
+			WHERE st.name <> fma.name`},
+		{"software by installer link", `
+			UPDATE software s
+				JOIN (` + titleNameByFMA + `) fma ON fma.title_id = s.title_id
+			SET s.name = fma.name
+			WHERE s.name <> fma.name`},
+
+		// Pass 2 (heuristic): rename rows matched by an unambiguous bundle identifier.
+		{"software_titles by bundle identifier", `
+			UPDATE software_titles st
+				JOIN (` + unambiguousByIdentifier + `) fma ON fma.unique_identifier = st.bundle_identifier
+			SET st.name = fma.name
+			WHERE st.name <> fma.name`},
+		{"software by bundle identifier", `
+			UPDATE software s
+				JOIN (` + unambiguousByIdentifier + `) fma ON fma.unique_identifier = s.bundle_identifier
+			SET s.name = fma.name
+			WHERE s.name <> fma.name`},
+	}
+
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		for _, u := range updates {
+			if _, err := tx.ExecContext(ctx, u.stmt); err != nil {
+				return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: %s", u.label)
+			}
+		}
+		return nil
+	})
+}
+
 // fleetMaintainedAppsTeamJoin is the FROM clause plus the LEFT JOIN that
 // determines, for a given team, whether each Fleet-maintained app has already
 // been added (via a software installer or VPP app). team_titles.id is non-NULL
@@ -94,7 +148,7 @@ ON DUPLICATE KEY UPDATE
 const fleetMaintainedAppsTeamJoin = `
 			FROM fleet_maintained_apps fma
 			LEFT JOIN (
-				SELECT DISTINCT st.id, st.unique_identifier, st.name, si.platform
+				SELECT DISTINCT st.id, st.unique_identifier, st.name, si.platform, si.fleet_maintained_app_id
 				FROM software_titles st
 				LEFT JOIN
 					software_installers si
@@ -111,10 +165,21 @@ const fleetMaintainedAppsTeamJoin = `
 					AND vat.global_or_team_id = ?
 				WHERE si.id IS NOT NULL OR vat.id IS NOT NULL
 			) team_titles
-				ON team_titles.unique_identifier = fma.unique_identifier
+				-- When the title was added via a specific FMA, match that exact app by
+				-- its installer link. This disambiguates FMAs that share a bundle
+				-- identifier (e.g. Firefox vs Firefox ESR): adding Firefox must not mark
+				-- Firefox ESR as added.
+				ON team_titles.fleet_maintained_app_id = fma.id
+				-- Otherwise (detected-only, custom installer, or VPP), the title is not
+				-- tied to a specific FMA, so fall back to matching by bundle identifier.
+				OR (
+					team_titles.fleet_maintained_app_id IS NULL
+					AND team_titles.unique_identifier = fma.unique_identifier
+				)
 				-- pattern match fma name to a similar title name, since upgrade_code is not surfaced in fma table
 				OR (
-					team_titles.platform = fma.platform
+					team_titles.fleet_maintained_app_id IS NULL
+					AND team_titles.platform = fma.platform
 					AND fma.platform = 'windows'
 					-- Box Drive is the only FMA at the point of writing this where unique_identifier is shorter than name
 					AND team_titles.name LIKE CONCAT(LEAST(fma.name, fma.unique_identifier), '%')
@@ -297,7 +362,16 @@ func (ds *Datastore) ListAvailableFleetMaintainedApps(ctx context.Context, teamI
 }
 
 func (ds *Datastore) GetFMANamesByIdentifier(ctx context.Context) (map[string]string, error) {
-	query := `SELECT unique_identifier, name FROM fleet_maintained_apps WHERE platform = 'darwin'`
+	// Only return identifiers that map to exactly one FMA name. A bundle
+	// identifier shared by differently-named FMAs (e.g. org.mozilla.firefox for
+	// both Firefox and Firefox ESR) has no single canonical name, so it is
+	// omitted here and callers fall back to the osquery-reported name.
+	query := `
+		SELECT unique_identifier, MIN(name) AS name
+		FROM fleet_maintained_apps
+		WHERE platform = 'darwin'
+		GROUP BY unique_identifier
+		HAVING COUNT(DISTINCT name) = 1`
 
 	rows, err := ds.reader(ctx).QueryContext(ctx, query)
 	if err != nil {

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -33,7 +33,6 @@ ON DUPLICATE KEY UPDATE
 
 	var appID uint
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		// upsert the maintained app
 		res, err := tx.ExecContext(ctx, upsertStmt, app.Name, app.Slug, app.Platform, app.UniqueIdentifier)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "upsert maintained app")
@@ -51,38 +50,17 @@ ON DUPLICATE KEY UPDATE
 	return app, nil
 }
 
-// ReconcileMaintainedAppSoftwareNames normalizes the names of macOS
-// software_titles (and the matching software inventory rows) so they use the
-// canonical Fleet-maintained app name instead of the osquery- or
-// installer-reported name (e.g. "Code" -> "Microsoft Visual Studio Code").
+// ReconcileMaintainedAppSoftwareNames renames macOS software_titles and software
+// rows to the canonical FMA name (e.g. "Code" -> "Microsoft Visual Studio Code").
+// Called once per sync; set-based and idempotent.
 //
-// It is called once per maintained-apps sync (hourly), is set-based, and is
-// idempotent, so it self-heals: a row that already matches is left untouched.
-//
-// Because an FMA's unique_identifier (the macOS bundle identifier) is NOT unique
-// across the FMA list — Firefox and Firefox ESR both report org.mozilla.firefox,
-// LibreOffice and a future LibreOffice-still would share org.libreoffice.script —
-// renaming purely by bundle identifier is ambiguous and would clobber titles with
-// whichever sibling FMA was synced last. To stay correct it renames in two passes:
-//
-//  1. Precise: a title that was added via a specific FMA is linked through
-//     software_installers.fleet_maintained_app_id. When that link resolves to a
-//     single FMA name, use it — this disambiguates shared identifiers because we
-//     know exactly which FMA the user added, and it repairs titles previously
-//     mislabeled by the old blind-rename behavior.
-//
-//  2. Heuristic: for titles not added via an FMA (osquery-detected, custom
-//     installer, VPP), fall back to matching by bundle identifier, but ONLY when
-//     that identifier maps to exactly one FMA name. Shared identifiers are skipped
-//     entirely, since there is no single correct canonical name.
+// A bundle identifier is not unique across FMAs (Firefox and Firefox ESR both use
+// org.mozilla.firefox), so renaming by identifier alone is ambiguous. It renames in
+// two passes: first by the precise installer link, then by bundle identifier but
+// only when it maps to a single FMA name.
 func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) error {
-	// titleNameByFMA maps each software_title to the canonical name of the single
-	// darwin FMA it was added with, resolved through its installer link
-	// (software_installers.fleet_maintained_app_id). A title linked to
-	// differently-named FMAs (e.g. Firefox on one team, Firefox ESR on another,
-	// sharing one global title) is excluded by the HAVING clause, since we cannot
-	// pick a single name for it. Grouping to one row per title also keeps the
-	// UPDATEs below from fanning out over a title's per-team installer rows.
+	// title_id -> name, for titles linked to a single FMA via their installer.
+	// GROUP BY also collapses a title's per-team installer rows to avoid fan-out.
 	const titleNameByFMA = `
 		SELECT si.title_id, MIN(fma.name) AS name
 		FROM software_installers si
@@ -91,9 +69,7 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 		GROUP BY si.title_id
 		HAVING COUNT(DISTINCT fma.name) = 1`
 
-	// unambiguousByIdentifier is the set of darwin bundle identifiers that map to
-	// exactly one FMA name. Identifiers shared by differently-named FMAs (Firefox /
-	// Firefox ESR) are excluded by the HAVING clause and never auto-renamed.
+	// darwin bundle identifiers mapping to exactly one FMA name; shared ones are excluded.
 	const unambiguousByIdentifier = `
 		SELECT unique_identifier, MIN(name) AS name
 		FROM fleet_maintained_apps
@@ -105,7 +81,7 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 		label string
 		stmt  string
 	}{
-		// Pass 1 (precise): rename titles linked to a single FMA via their installer.
+		// Pass 1: precise, via installer link.
 		{"software_titles by installer link", `
 			UPDATE software_titles st
 				JOIN (` + titleNameByFMA + `) fma ON fma.title_id = st.id
@@ -117,7 +93,7 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 			SET s.name = fma.name
 			WHERE s.name <> fma.name`},
 
-		// Pass 2 (heuristic): rename rows matched by an unambiguous bundle identifier.
+		// Pass 2: by bundle identifier, unambiguous only.
 		{"software_titles by bundle identifier", `
 			UPDATE software_titles st
 				JOIN (` + unambiguousByIdentifier + `) fma ON fma.unique_identifier = st.bundle_identifier
@@ -165,13 +141,10 @@ const fleetMaintainedAppsTeamJoin = `
 					AND vat.global_or_team_id = ?
 				WHERE si.id IS NOT NULL OR vat.id IS NOT NULL
 			) team_titles
-				-- When the title was added via a specific FMA, match that exact app by
-				-- its installer link. This disambiguates FMAs that share a bundle
-				-- identifier (e.g. Firefox vs Firefox ESR): adding Firefox must not mark
-				-- Firefox ESR as added.
+				-- Match the exact FMA the title was added with, so a shared bundle
+				-- identifier (Firefox vs Firefox ESR) doesn't mark the sibling added.
 				ON team_titles.fleet_maintained_app_id = fma.id
-				-- Otherwise (detected-only, custom installer, or VPP), the title is not
-				-- tied to a specific FMA, so fall back to matching by bundle identifier.
+				-- Not added via an FMA: fall back to the bundle identifier.
 				OR (
 					team_titles.fleet_maintained_app_id IS NULL
 					AND team_titles.unique_identifier = fma.unique_identifier
@@ -362,10 +335,8 @@ func (ds *Datastore) ListAvailableFleetMaintainedApps(ctx context.Context, teamI
 }
 
 func (ds *Datastore) GetFMANamesByIdentifier(ctx context.Context) (map[string]string, error) {
-	// Only return identifiers that map to exactly one FMA name. A bundle
-	// identifier shared by differently-named FMAs (e.g. org.mozilla.firefox for
-	// both Firefox and Firefox ESR) has no single canonical name, so it is
-	// omitted here and callers fall back to the osquery-reported name.
+	// Only identifiers mapping to one FMA name; shared ones (Firefox/ESR) have no
+	// single canonical name, so callers fall back to the osquery-reported name.
 	query := `
 		SELECT unique_identifier, MIN(name) AS name
 		FROM fleet_maintained_apps

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -937,6 +937,21 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
+	// The upsert itself must not rename; confirm the pre-reconcile state still has
+	// the osquery name in both the software and software_titles tables.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &softwareNames,
+			`SELECT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode' ORDER BY version`)
+	})
+	require.Len(t, softwareNames, 2)
+	require.Equal(t, "Code", softwareNames[0])
+	require.Equal(t, "Code", softwareNames[1])
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &titleName,
+			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode'`)
+	})
+	require.Equal(t, "Code", titleName)
+
 	// The upsert doesn't rename; the reconcile pass does (unambiguous identifier).
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
@@ -1067,6 +1082,14 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 	// (Regression: the title used to flip to "Mozilla Firefox ESR" by sync order.)
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 	require.Equal(t, "Firefox.app", titleName())
+	// Reconcile updates the software table with a separate statement, so assert it
+	// too: with an ambiguous identifier and no FMA link, that row is left alone.
+	var ambiguousSoftwareName string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &ambiguousSoftwareName,
+			`SELECT name FROM software WHERE bundle_identifier = 'org.mozilla.firefox'`)
+	})
+	require.Equal(t, "Firefox.app", ambiguousSoftwareName)
 
 	// Add the Firefox (non-ESR) FMA, linking the existing title to a specific FMA.
 	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -937,9 +937,7 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// The upsert alone does not rename anything; the reconcile pass (run once per
-	// sync) does. com.microsoft.VSCode maps to a single FMA name, so it is renamed
-	// via the unambiguous-identifier pass.
+	// The upsert doesn't rename; the reconcile pass does (unambiguous identifier).
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
 	// Verify software entries were updated to use the FMA canonical name
@@ -1000,8 +998,7 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
-	// The darwin software should NOT have been renamed (reconcile only matches
-	// darwin FMAs against macOS bundle identifiers).
+	// A Windows FMA must not rename darwin software.
 	var someAppName string
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		return sqlx.GetContext(ctx, q, &someAppName,
@@ -1010,11 +1007,9 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	require.Equal(t, "Some App", someAppName)
 }
 
-// testReconcileSoftwareNamesSharedIdentifier covers the Firefox / Firefox ESR
-// case: two FMAs sharing one bundle identifier (org.mozilla.firefox). The
-// reconcile pass must NOT guess a canonical name from the shared identifier
-// alone, but MUST use the specific FMA a title was added with when that link
-// exists.
+// testReconcileSoftwareNamesSharedIdentifier: two FMAs sharing a bundle identifier
+// (Firefox / Firefox ESR). Reconcile must not guess a name from the identifier
+// alone, but must use the specific FMA a title was added with.
 func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
@@ -1065,19 +1060,15 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 		return name
 	}
 
-	// Ingestion must not have guessed a canonical name for the shared identifier.
+	// Ingestion must not guess a name for the shared identifier.
 	require.Equal(t, "Firefox.app", titleName())
 
-	// Reconciling must leave it alone: with no FMA installer link and an ambiguous
-	// identifier, there is no single correct name. (Regression test for the bug
-	// where the title flipped to "Mozilla Firefox ESR" depending on sync order.)
+	// No FMA link and an ambiguous identifier: reconcile must leave it alone.
+	// (Regression: the title used to flip to "Mozilla Firefox ESR" by sync order.)
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 	require.Equal(t, "Firefox.app", titleName())
 
-	// Now the user adds the Firefox (non-ESR) FMA. This links the existing title
-	// to a specific FMA via software_installers.fleet_maintained_app_id. The
-	// install reuses the existing title (matched by bundle identifier), so the
-	// name is still "Firefox.app" until reconcile runs.
+	// Add the Firefox (non-ESR) FMA, linking the existing title to a specific FMA.
 	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
 		Title:                "Mozilla Firefox",
 		TeamID:               &team.ID,
@@ -1092,12 +1083,10 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// The install reuses the existing osquery title, so the name is unchanged
-	// until reconcile runs.
+	// The install reuses the existing title, so the name is unchanged until reconcile.
 	require.Equal(t, "Firefox.app", titleName())
 
-	// Reconcile now resolves the ambiguity via the installer link and renames the
-	// title (and software inventory) to the specific FMA the user added.
+	// Reconcile resolves the ambiguity via the installer link.
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 	require.Equal(t, "Mozilla Firefox", titleName())
 
@@ -1109,9 +1098,8 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 	require.Equal(t, "Mozilla Firefox", softwareName)
 }
 
-// testListAvailableAppsSharedIdentifier verifies that adding one of two FMAs
-// that share a bundle identifier (Firefox) does not mark its sibling (Firefox
-// ESR) as added in the maintained-apps list.
+// testListAvailableAppsSharedIdentifier: adding Firefox must not mark its
+// bundle-identifier sibling Firefox ESR as added.
 func testListAvailableAppsSharedIdentifier(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
@@ -1165,8 +1153,7 @@ func testListAvailableAppsSharedIdentifier(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// Firefox is now added; Firefox ESR must remain available (not added), even
-	// though it shares the same bundle identifier.
+	// Firefox is added; ESR must remain available despite the shared identifier.
 	require.Equal(t, &titleID, titleIDFor(firefox.ID))
 	require.Nil(t, titleIDFor(esr.ID))
 
@@ -1227,9 +1214,8 @@ func testGetFMANamesByIdentifier(t *testing.T, ds *Datastore) {
 	_, ok := names["Microsoft Visual Studio Code"]
 	require.False(t, ok)
 
-	// Add two darwin FMAs sharing one bundle identifier (Firefox / Firefox ESR).
-	// The shared identifier is ambiguous, so it must be omitted entirely rather
-	// than resolving to whichever name was inserted last.
+	// Two FMAs sharing a bundle identifier (Firefox/ESR) must be omitted, not
+	// resolved to whichever was inserted last.
 	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
 		Name:             "Mozilla Firefox",
 		Slug:             "firefox/darwin",

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -29,7 +29,9 @@ func TestMaintainedApps(t *testing.T) {
 		{"ListAvailableAppsWindows", testListAvailableAppsWindows},
 		{"SoftwareTitleRenamingWindows", testSoftwareTitleRenamingWindows},
 		{"GetFMANamesByIdentifier", testGetFMANamesByIdentifier},
-		{"UpsertMaintainedAppUpdatesSoftware", testUpsertMaintainedAppUpdatesSoftware},
+		{"ReconcileSoftwareNames", testReconcileSoftwareNames},
+		{"ReconcileSoftwareNamesSharedIdentifier", testReconcileSoftwareNamesSharedIdentifier},
+		{"ListAvailableAppsSharedIdentifier", testListAvailableAppsSharedIdentifier},
 	}
 
 	for _, c := range cases {
@@ -873,7 +875,7 @@ func testSoftwareTitleRenamingWindows(t *testing.T, ds *Datastore) {
 	require.Equal(t, "Hello", sw[1].Name)
 }
 
-func testUpsertMaintainedAppUpdatesSoftware(t *testing.T, ds *Datastore) {
+func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
 	// Create a host to associate software with
@@ -935,6 +937,11 @@ func testUpsertMaintainedAppUpdatesSoftware(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
+	// The upsert alone does not rename anything; the reconcile pass (run once per
+	// sync) does. com.microsoft.VSCode maps to a single FMA name, so it is renamed
+	// via the unambiguous-identifier pass.
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+
 	// Verify software entries were updated to use the FMA canonical name
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		return sqlx.SelectContext(ctx, q, &softwareNames,
@@ -951,7 +958,7 @@ func testUpsertMaintainedAppUpdatesSoftware(t *testing.T, ds *Datastore) {
 	})
 	require.Equal(t, "Microsoft Visual Studio Code", titleName)
 
-	// Verify upserting the same FMA again doesn't cause issues (idempotent)
+	// Verify upserting the same FMA again and reconciling doesn't cause issues (idempotent)
 	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
 		Name:             "Microsoft Visual Studio Code",
 		Slug:             "visual-studio-code/darwin",
@@ -959,6 +966,7 @@ func testUpsertMaintainedAppUpdatesSoftware(t *testing.T, ds *Datastore) {
 		UniqueIdentifier: "com.microsoft.VSCode",
 	})
 	require.NoError(t, err)
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
 	// Names should still be the FMA canonical name
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -990,14 +998,188 @@ func testUpsertMaintainedAppUpdatesSoftware(t *testing.T, ds *Datastore) {
 		UniqueIdentifier: "com.example.someapp", // Same identifier but different platform
 	})
 	require.NoError(t, err)
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
-	// The darwin software should NOT have been renamed
+	// The darwin software should NOT have been renamed (reconcile only matches
+	// darwin FMAs against macOS bundle identifiers).
 	var someAppName string
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		return sqlx.GetContext(ctx, q, &someAppName,
 			`SELECT name FROM software WHERE bundle_identifier = 'com.example.someapp'`)
 	})
 	require.Equal(t, "Some App", someAppName)
+}
+
+// testReconcileSoftwareNamesSharedIdentifier covers the Firefox / Firefox ESR
+// case: two FMAs sharing one bundle identifier (org.mozilla.firefox). The
+// reconcile pass must NOT guess a canonical name from the shared identifier
+// alone, but MUST use the specific FMA a title was added with when that link
+// exists.
+func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	user := test.NewUser(t, ds, "Ford Prefect", "ford@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team Firefox"})
+	require.NoError(t, err)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "firefox-host",
+		Platform:        "darwin",
+		OsqueryHostID:   new("ff-osquery-id"),
+		NodeKey:         new("ff-node-key"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		PolicyUpdatedAt: ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+	})
+	require.NoError(t, err)
+
+	// Two FMAs that share the same macOS bundle identifier.
+	firefox, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox",
+		Slug:             "firefox/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox ESR",
+		Slug:             "firefox@esr/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+
+	// A host reports Firefox via osquery (name "Firefox.app"), with no FMA added.
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
+		{Name: "Firefox.app", Version: "120.0", Source: "apps", BundleIdentifier: "org.mozilla.firefox"},
+	})
+	require.NoError(t, err)
+
+	titleName := func() string {
+		var name string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &name,
+				`SELECT name FROM software_titles WHERE bundle_identifier = 'org.mozilla.firefox'`)
+		})
+		return name
+	}
+
+	// Ingestion must not have guessed a canonical name for the shared identifier.
+	require.Equal(t, "Firefox.app", titleName())
+
+	// Reconciling must leave it alone: with no FMA installer link and an ambiguous
+	// identifier, there is no single correct name. (Regression test for the bug
+	// where the title flipped to "Mozilla Firefox ESR" depending on sync order.)
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+	require.Equal(t, "Firefox.app", titleName())
+
+	// Now the user adds the Firefox (non-ESR) FMA. This links the existing title
+	// to a specific FMA via software_installers.fleet_maintained_app_id. The
+	// install reuses the existing title (matched by bundle identifier), so the
+	// name is still "Firefox.app" until reconcile runs.
+	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "Mozilla Firefox",
+		TeamID:               &team.ID,
+		Source:               "apps",
+		InstallScript:        "nothing",
+		Filename:             "Firefox.dmg",
+		UserID:               user.ID,
+		Platform:             string(fleet.MacOSPlatform),
+		BundleIdentifier:     "org.mozilla.firefox",
+		FleetMaintainedAppID: &firefox.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	// The install reuses the existing osquery title, so the name is unchanged
+	// until reconcile runs.
+	require.Equal(t, "Firefox.app", titleName())
+
+	// Reconcile now resolves the ambiguity via the installer link and renames the
+	// title (and software inventory) to the specific FMA the user added.
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+	require.Equal(t, "Mozilla Firefox", titleName())
+
+	var softwareName string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &softwareName,
+			`SELECT name FROM software WHERE title_id = ? AND bundle_identifier = 'org.mozilla.firefox'`, titleID)
+	})
+	require.Equal(t, "Mozilla Firefox", softwareName)
+}
+
+// testListAvailableAppsSharedIdentifier verifies that adding one of two FMAs
+// that share a bundle identifier (Firefox) does not mark its sibling (Firefox
+// ESR) as added in the maintained-apps list.
+func testListAvailableAppsSharedIdentifier(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	user := test.NewUser(t, ds, "Arthur Dent", "arthur@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team 42"})
+	require.NoError(t, err)
+
+	firefox, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox",
+		Slug:             "firefox/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+	esr, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox ESR",
+		Slug:             "firefox@esr/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+
+	titleIDFor := func(appID uint) *uint {
+		apps, _, err := ds.ListAvailableFleetMaintainedApps(ctx, &team.ID, fleet.MaintainedAppListOptions{})
+		require.NoError(t, err)
+		for _, a := range apps {
+			if a.ID == appID {
+				return a.TitleID
+			}
+		}
+		t.Fatalf("app %d not found in list", appID)
+		return nil
+	}
+
+	// Before adding anything, neither shows as added.
+	require.Nil(t, titleIDFor(firefox.ID))
+	require.Nil(t, titleIDFor(esr.ID))
+
+	// Add the Firefox (non-ESR) FMA, linked via fleet_maintained_app_id.
+	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "Mozilla Firefox",
+		TeamID:               &team.ID,
+		Source:               "apps",
+		InstallScript:        "nothing",
+		Filename:             "Firefox.dmg",
+		UserID:               user.ID,
+		Platform:             string(fleet.MacOSPlatform),
+		BundleIdentifier:     "org.mozilla.firefox",
+		FleetMaintainedAppID: &firefox.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	// Firefox is now added; Firefox ESR must remain available (not added), even
+	// though it shares the same bundle identifier.
+	require.Equal(t, &titleID, titleIDFor(firefox.ID))
+	require.Nil(t, titleIDFor(esr.ID))
+
+	// The "available only" filter must still surface ESR but hide Firefox.
+	availApps, _, err := ds.ListAvailableFleetMaintainedApps(ctx, &team.ID,
+		fleet.MaintainedAppListOptions{AvailableOnly: true})
+	require.NoError(t, err)
+	var slugs []string
+	for _, a := range availApps {
+		slugs = append(slugs, a.Slug)
+	}
+	require.Contains(t, slugs, "firefox@esr/darwin")
+	require.NotContains(t, slugs, "firefox/darwin")
 }
 
 func testGetFMANamesByIdentifier(t *testing.T, ds *Datastore) {
@@ -1043,5 +1225,29 @@ func testGetFMANamesByIdentifier(t *testing.T, ds *Datastore) {
 
 	// Windows identifier should not be present
 	_, ok := names["Microsoft Visual Studio Code"]
+	require.False(t, ok)
+
+	// Add two darwin FMAs sharing one bundle identifier (Firefox / Firefox ESR).
+	// The shared identifier is ambiguous, so it must be omitted entirely rather
+	// than resolving to whichever name was inserted last.
+	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox",
+		Slug:             "firefox/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox ESR",
+		Slug:             "firefox@esr/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+
+	names, err = ds.GetFMANamesByIdentifier(ctx)
+	require.NoError(t, err)
+	require.Len(t, names, 2) // still only the two unambiguous identifiers
+	_, ok = names["org.mozilla.firefox"]
 	require.False(t, ok)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3011,9 +3011,19 @@ type Datastore interface {
 	// metadata provided via app.
 	UpsertMaintainedApp(ctx context.Context, app *MaintainedApp) (*MaintainedApp, error)
 
+	// ReconcileMaintainedAppSoftwareNames normalizes macOS software_titles and
+	// software inventory rows to use the canonical Fleet-maintained app name. It is
+	// called once per maintained-apps sync, is set-based and idempotent (so it
+	// self-heals), and is ambiguity-aware: titles added via a specific FMA are
+	// renamed via their installer link, while titles matched only by bundle
+	// identifier are renamed only when that identifier maps to a single FMA name.
+	ReconcileMaintainedAppSoftwareNames(ctx context.Context) error
+
 	// GetFMANamesByIdentifier returns a map of unique_identifier -> canonical name
-	// for all Fleet-maintained apps on macOS. This is used during software ingestion
-	// to use the FMA name instead of the osquery-reported name.
+	// for Fleet-maintained apps on macOS. This is used during software ingestion to
+	// use the FMA name instead of the osquery-reported name. Identifiers shared by
+	// differently-named FMAs (e.g. Firefox and Firefox ESR) are omitted, since no
+	// single canonical name applies.
 	GetFMANamesByIdentifier(ctx context.Context) (map[string]string, error)
 
 	// /////////////////////////////////////////////////////////////////////////////

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3011,19 +3011,14 @@ type Datastore interface {
 	// metadata provided via app.
 	UpsertMaintainedApp(ctx context.Context, app *MaintainedApp) (*MaintainedApp, error)
 
-	// ReconcileMaintainedAppSoftwareNames normalizes macOS software_titles and
-	// software inventory rows to use the canonical Fleet-maintained app name. It is
-	// called once per maintained-apps sync, is set-based and idempotent (so it
-	// self-heals), and is ambiguity-aware: titles added via a specific FMA are
-	// renamed via their installer link, while titles matched only by bundle
-	// identifier are renamed only when that identifier maps to a single FMA name.
+	// ReconcileMaintainedAppSoftwareNames renames macOS software_titles and software
+	// rows to the canonical FMA name. Called once per sync; set-based, idempotent,
+	// and ambiguity-aware for FMAs that share a bundle identifier.
 	ReconcileMaintainedAppSoftwareNames(ctx context.Context) error
 
-	// GetFMANamesByIdentifier returns a map of unique_identifier -> canonical name
-	// for Fleet-maintained apps on macOS. This is used during software ingestion to
-	// use the FMA name instead of the osquery-reported name. Identifiers shared by
-	// differently-named FMAs (e.g. Firefox and Firefox ESR) are omitted, since no
-	// single canonical name applies.
+	// GetFMANamesByIdentifier returns unique_identifier -> canonical name for macOS
+	// FMAs, used during software ingestion. Identifiers shared by differently-named
+	// FMAs (e.g. Firefox and Firefox ESR) are omitted.
 	GetFMANamesByIdentifier(ctx context.Context) (map[string]string, error)
 
 	// /////////////////////////////////////////////////////////////////////////////

--- a/server/mdm/maintainedapps/apps_list_test.go
+++ b/server/mdm/maintainedapps/apps_list_test.go
@@ -11,27 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// knownSharedDarwinIdentifiers allowlists macOS bundle identifiers that are
-// intentionally shared by more than one differently-named Fleet-maintained app.
-//
-// Sharing a bundle identifier is ambiguous on macOS: osquery reports the same
-// identifier for every app, so there is no way to tell them apart from inventory
-// alone. The server handles this deliberately — see ReconcileMaintainedAppSoftwareNames
-// (renames by identifier only when it maps to a single FMA name, otherwise uses the
-// installer link) and fleetMaintainedAppsTeamJoin (marks an app "added" via its
-// installer link rather than the shared identifier). This test fails on any NEW
-// shared identifier so the collision is consciously reviewed against those paths
-// instead of silently reintroducing https://github.com/fleetdm/fleet/issues/42445.
-//
-// If a new collision is intentional, confirm the paths above handle it and then add
-// the identifier here with a comment naming the apps.
+// knownSharedDarwinIdentifiers allowlists macOS bundle identifiers intentionally
+// shared by more than one differently-named FMA. Such collisions are ambiguous and
+// must be handled by ReconcileMaintainedAppSoftwareNames and fleetMaintainedAppsTeamJoin
+// (see https://github.com/fleetdm/fleet/issues/42445). The test below fails on any
+// new one so it's reviewed against those paths before being added here.
 var knownSharedDarwinIdentifiers = map[string]string{
 	"org.mozilla.firefox": "Mozilla Firefox and Mozilla Firefox ESR",
 }
 
-// TestNoUnexpectedSharedDarwinIdentifiers guards the maintained-apps manifest
-// against new macOS FMAs that share a bundle identifier with a differently-named
-// app without being accounted for in knownSharedDarwinIdentifiers.
 func TestNoUnexpectedSharedDarwinIdentifiers(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	base := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filename))))

--- a/server/mdm/maintainedapps/apps_list_test.go
+++ b/server/mdm/maintainedapps/apps_list_test.go
@@ -1,0 +1,74 @@
+package maintained_apps
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// knownSharedDarwinIdentifiers allowlists macOS bundle identifiers that are
+// intentionally shared by more than one differently-named Fleet-maintained app.
+//
+// Sharing a bundle identifier is ambiguous on macOS: osquery reports the same
+// identifier for every app, so there is no way to tell them apart from inventory
+// alone. The server handles this deliberately — see ReconcileMaintainedAppSoftwareNames
+// (renames by identifier only when it maps to a single FMA name, otherwise uses the
+// installer link) and fleetMaintainedAppsTeamJoin (marks an app "added" via its
+// installer link rather than the shared identifier). This test fails on any NEW
+// shared identifier so the collision is consciously reviewed against those paths
+// instead of silently reintroducing https://github.com/fleetdm/fleet/issues/42445.
+//
+// If a new collision is intentional, confirm the paths above handle it and then add
+// the identifier here with a comment naming the apps.
+var knownSharedDarwinIdentifiers = map[string]string{
+	"org.mozilla.firefox": "Mozilla Firefox and Mozilla Firefox ESR",
+}
+
+// TestNoUnexpectedSharedDarwinIdentifiers guards the maintained-apps manifest
+// against new macOS FMAs that share a bundle identifier with a differently-named
+// app without being accounted for in knownSharedDarwinIdentifiers.
+func TestNoUnexpectedSharedDarwinIdentifiers(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	base := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filename))))
+	b, err := os.ReadFile(filepath.Join(base, "ee/maintained-apps/outputs/apps.json"))
+	require.NoError(t, err)
+
+	var appsList AppsList
+	require.NoError(t, json.Unmarshal(b, &appsList))
+
+	namesByIdentifier := make(map[string]map[string]struct{})
+	for _, app := range appsList.Apps {
+		if app.Platform != "darwin" || app.UniqueIdentifier == "" {
+			continue
+		}
+		if namesByIdentifier[app.UniqueIdentifier] == nil {
+			namesByIdentifier[app.UniqueIdentifier] = make(map[string]struct{})
+		}
+		namesByIdentifier[app.UniqueIdentifier][app.Name] = struct{}{}
+	}
+
+	for identifier, nameSet := range namesByIdentifier {
+		if len(nameSet) <= 1 {
+			continue
+		}
+		names := make([]string, 0, len(nameSet))
+		for name := range nameSet {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		_, allowed := knownSharedDarwinIdentifiers[identifier]
+		require.Truef(t, allowed,
+			"macOS bundle identifier %q is shared by multiple differently-named Fleet-maintained apps (%v) "+
+				"but is not in knownSharedDarwinIdentifiers.\n"+
+				"Shared identifiers are ambiguous and must be handled by ReconcileMaintainedAppSoftwareNames and "+
+				"fleetMaintainedAppsTeamJoin. If this is intentional, confirm those paths handle it and add %q to "+
+				"knownSharedDarwinIdentifiers with a comment.",
+			identifier, names, identifier)
+	}
+}

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -153,10 +153,8 @@ func upsertMaintainedApps(ctx context.Context, appsList *AppsList, ds fleet.Data
 		return ctxerr.Wrap(ctx, err, "clear removed maintained apps during refresh")
 	}
 
-	// Normalize existing software_titles / software names to the canonical FMA
-	// names now that the full app list is in the DB. This runs after the loop so
-	// it sees every app at once and is unaffected by upsert order, which matters
-	// for FMAs that share a bundle identifier (e.g. Firefox / Firefox ESR).
+	// Normalize software names to canonical FMA names. Runs after the loop so it
+	// sees every app at once, which matters for FMAs sharing a bundle identifier.
 	if err := ds.ReconcileMaintainedAppSoftwareNames(ctx); err != nil {
 		return ctxerr.Wrap(ctx, err, "reconcile maintained app software names during refresh")
 	}

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -153,6 +153,14 @@ func upsertMaintainedApps(ctx context.Context, appsList *AppsList, ds fleet.Data
 		return ctxerr.Wrap(ctx, err, "clear removed maintained apps during refresh")
 	}
 
+	// Normalize existing software_titles / software names to the canonical FMA
+	// names now that the full app list is in the DB. This runs after the loop so
+	// it sees every app at once and is unaffected by upsert order, which matters
+	// for FMAs that share a bundle identifier (e.g. Firefox / Firefox ESR).
+	if err := ds.ReconcileMaintainedAppSoftwareNames(ctx); err != nil {
+		return ctxerr.Wrap(ctx, err, "reconcile maintained app software names during refresh")
+	}
+
 	return nil
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1760,6 +1760,8 @@ type GetMaintainedAppBySlugFunc func(ctx context.Context, slug string, teamID *u
 
 type UpsertMaintainedAppFunc func(ctx context.Context, app *fleet.MaintainedApp) (*fleet.MaintainedApp, error)
 
+type ReconcileMaintainedAppSoftwareNamesFunc func(ctx context.Context) error
+
 type GetFMANamesByIdentifierFunc func(ctx context.Context) (map[string]string, error)
 
 type BulkUpsertMDMManagedCertificatesFunc func(ctx context.Context, payload []*fleet.MDMManagedCertificate) error
@@ -4720,6 +4722,9 @@ type DataStore struct {
 
 	UpsertMaintainedAppFunc        UpsertMaintainedAppFunc
 	UpsertMaintainedAppFuncInvoked bool
+
+	ReconcileMaintainedAppSoftwareNamesFunc        ReconcileMaintainedAppSoftwareNamesFunc
+	ReconcileMaintainedAppSoftwareNamesFuncInvoked bool
 
 	GetFMANamesByIdentifierFunc        GetFMANamesByIdentifierFunc
 	GetFMANamesByIdentifierFuncInvoked bool
@@ -11332,6 +11337,13 @@ func (s *DataStore) UpsertMaintainedApp(ctx context.Context, app *fleet.Maintain
 	s.UpsertMaintainedAppFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpsertMaintainedAppFunc(ctx, app)
+}
+
+func (s *DataStore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) error {
+	s.mu.Lock()
+	s.ReconcileMaintainedAppSoftwareNamesFuncInvoked = true
+	s.mu.Unlock()
+	return s.ReconcileMaintainedAppSoftwareNamesFunc(ctx)
 }
 
 func (s *DataStore) GetFMANamesByIdentifier(ctx context.Context) (map[string]string, error) {


### PR DESCRIPTION
Fix handling of Fleet-maintained apps that share a macOS bundle identifier (e.g. Firefox and Firefox ESR). Removed the blind rename from UpsertMaintainedApp and added ReconcileMaintainedAppSoftwareNames: a two-pass, idempotent reconciliation that (1) renames titles tied to a single FMA via installer links and (2) heuristically renames by bundle identifier only when the identifier maps to exactly one FMA name. Updated team join logic to prefer matching by installer link and fall back to bundle identifier, changed GetFMANamesByIdentifier to omit ambiguous identifiers, added a call to reconcile during the maintained-apps sync, and extended the datastore interface and mock accordingly. Added tests and a manifest check for known shared identifiers, plus a changelog entry.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42445

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where macOS apps sharing a bundle identifier (e.g., Firefox and Firefox ESR) would incorrectly report each other as already installed and could have their software titles unexpectedly changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->