### PR TITLE
Add hosts to external storage exclusion labels

### DIFF
--- a/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
@@ -2,4 +2,5 @@
   description: Macs that should NOT receive the read-only external storage DDM profile. Add a host to this manual label to allow read-write external storage on that Mac.
   label_membership_type: manual
   platform: darwin
-  hosts: []
+  hosts:
+    - "1339"

--- a/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
@@ -3,4 +3,4 @@
   label_membership_type: manual
   platform: darwin
   hosts:
-    - "1339" #47980
+    - "1339"   #47980

--- a/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
@@ -3,4 +3,4 @@
   label_membership_type: manual
   platform: darwin
   hosts:
-    - "1339"
+    - "1339" #47980

--- a/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/macs-excluded-from-external-storage-restrictions.yml
@@ -1,6 +1,5 @@
 - name: Macs excluded from external storage restrictions
   description: Macs that should NOT receive the read-only external storage DDM profile. Add a host to this manual label to allow read-write external storage on that Mac.
   label_membership_type: manual
-  platform: darwin
   hosts:
     - "1339"   #47980

--- a/it-and-security/lib/all/labels/windows-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/windows-excluded-from-external-storage-restrictions.yml
@@ -2,4 +2,5 @@
   description: Windows hosts that should NOT receive the read-only removable storage profile. Add a host to this manual label to allow read-write removable storage on that device.
   label_membership_type: manual
   platform: windows
-  hosts: []
+  hosts:
+    - "1230"

--- a/it-and-security/lib/all/labels/windows-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/windows-excluded-from-external-storage-restrictions.yml
@@ -3,4 +3,4 @@
   label_membership_type: manual
   platform: windows
   hosts:
-    - "1230"
+    - "1230"   #47980

--- a/it-and-security/lib/all/labels/windows-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/windows-excluded-from-external-storage-restrictions.yml
@@ -1,6 +1,5 @@
 - name: Windows hosts excluded from external storage restrictions
   description: Windows hosts that should NOT receive the read-only removable storage profile. Add a host to this manual label to allow read-write removable storage on that device.
   label_membership_type: manual
-  platform: windows
   hosts:
     - "1230"   #47980


### PR DESCRIPTION
Add device IDs to manual labels to exempt specific machines from read-only external/removable storage restrictions. The macs label now includes host "1339" and the windows label includes host "1230", allowing these devices to receive read-write external/removable storage profiles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external storage restriction policies to exclude additional macOS and Windows hosts from restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->