### PR TITLE
Remove platform field from Linux exclusion label

### DIFF
--- a/it-and-security/lib/all/labels/linux-excluded-from-external-storage-restrictions.yml
+++ b/it-and-security/lib/all/labels/linux-excluded-from-external-storage-restrictions.yml
@@ -1,5 +1,4 @@
 - name: Linux hosts excluded from external storage restrictions
   description: Linux hosts that should NOT be enforced to read-only removable storage. Add a host to this manual label to skip the udev-rule policy on that device. Note - if the udev rule was already installed prior to exclusion, it must be removed manually from /etc/udev/rules.d/99-fleet-readonly-removable-storage.rules.
   label_membership_type: manual
-  platform: linux
   hosts: []


### PR DESCRIPTION
Removed platform specification for Linux hosts in external storage restrictions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed platform-specific scoping from external storage restrictions label configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->