### PR TITLE
Unblock mobile GitOps by temporarily removing app store categories

### DIFF
--- a/it-and-security/fleets/company-owned-mobile-devices.yml
+++ b/it-and-security/fleets/company-owned-mobile-devices.yml
@@ -36,8 +36,6 @@ software:
       self_service: true
       setup_experience: true
       platform: ios
-      categories:
-        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -46,8 +44,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -56,8 +52,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -65,8 +59,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -74,8 +66,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -83,8 +73,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "490179405" # Okta Verify
       display_name: "Okta Verify"
       self_service: true
@@ -93,8 +81,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Security"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -103,17 +89,12 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Security"
     # iPadOS apps
     - app_store_id: "618783545" # Slack
       display_name: "Slack"
       self_service: true
       setup_experience: true
       platform: ipados
-      categories:
-        - "Productivity"
-        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -122,8 +103,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -132,8 +111,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -142,8 +119,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Security"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -151,8 +126,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -160,8 +133,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -169,8 +140,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     # Android apps
     - app_store_id: "us.zoom.videomeetings" # Zoom
       platform: android

--- a/it-and-security/fleets/personal-mobile-devices.yml
+++ b/it-and-security/fleets/personal-mobile-devices.yml
@@ -34,8 +34,6 @@ software:
       self_service: true
       setup_experience: true
       platform: ios
-      categories:
-        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -44,8 +42,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -54,8 +50,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -63,8 +57,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -72,8 +64,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -81,8 +71,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "490179405" # Okta Verify
       display_name: "Okta Verify"
       self_service: true
@@ -91,8 +79,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Security"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -101,17 +87,12 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Security"
     # iPadOS apps
     - app_store_id: "618783545" # Slack
       display_name: "Slack"
       self_service: true
       setup_experience: true
       platform: ipados
-      categories:
-        - "Productivity"
-        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -120,8 +101,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -130,8 +109,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -140,8 +117,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Security"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -149,8 +124,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -158,8 +131,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -167,8 +138,6 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
-      categories:
-        - "Productivity"
     # Android apps
     - app_store_id: "us.zoom.videomeetings" # Zoom
       platform: android


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Related to #47981

## What this does (dogfood GitOps unblock — step 1 of 2)

The GitOps run for the mobile-device fleets fails while applying app store apps:

```
applying app store apps for fleet: "📱🏢 Employee-issued mobile devices":
Validation Failed: Error 1062 (23000): Duplicate entry '303-?️ Productivity'
for key 'software_categories.idx_software_categories_team_id_name'
```

**Root cause:** the category names in the YAML are correct (plain `"Productivity"`, etc., which translate server-side to the canonical emoji names). The conflict is a **stale stored category row** for the team. The `software_categories.(team_id, name)` unique index uses `utf8mb4_unicode_ci`, which treats the Unicode variation selector `U+FE0F` as ignorable. An earlier build stored Productivity as `🖥 Productivity` (no selector); today's code produces the canonical `🖥️ Productivity` (with selector). Those are *equal* to the index but *distinct* to Go's `strings.EqualFold`, so the existence check misses the stale row and the insert collides. This only affects the two variation-selector categories — `🖥️ Productivity` and `🛠️ Utilities` — which is why the failure is on Productivity.

**This PR (step 1):** temporarily removes the `categories:` blocks from `company-owned-mobile-devices.yml` and `personal-mobile-devices.yml`. With no categories to insert, the app store batch applies cleanly, and Fleet's `deleteUnusedSelfServiceCategories` cleanup then purges the stale rows for those teams. Apps still install; they're just uncategorized until step 2.

**Step 2 (follow-up):** once this is applied, revert this PR to re-add the categories. The teams will have no stale rows by then, so the canonical categories get created fresh and the apps are categorized correctly.

The permanent fix (makes the category insert idempotent so any stored byte form is tolerated) is tracked separately under #47981.

> Note: `workstations.yml` uses the same categories and may need the same treatment if that fleet also has a stale row — not included here since only the mobile fleets are confirmed failing.

# Checklist for submitter

- [x] Changes file: N/A — dogfood GitOps config only, no product code or user-visible product change.
- [x] Input data is properly validated: N/A — removing config, no new inputs.

## Testing

- [x] Verified both files remain valid YAML and all 24 app store apps per fleet are preserved (only `categories:` blocks removed; comments/formatting intact).
- [ ] Confirm a GitOps dry run passes before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified app catalog entries for iOS and iPadOS devices by removing category metadata while preserving all app functionality and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->