### PR TITLE
Revert "Unblock mobile GitOps by temporarily removing app store categories"

### DIFF
--- a/it-and-security/fleets/company-owned-mobile-devices.yml
+++ b/it-and-security/fleets/company-owned-mobile-devices.yml
@@ -36,6 +36,8 @@ software:
       self_service: true
       setup_experience: true
       platform: ios
+      categories:
+        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -44,6 +46,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -52,6 +56,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -59,6 +65,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -66,6 +74,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -73,6 +83,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "490179405" # Okta Verify
       display_name: "Okta Verify"
       self_service: true
@@ -81,6 +93,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Security"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -89,12 +103,17 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Security"
     # iPadOS apps
     - app_store_id: "618783545" # Slack
       display_name: "Slack"
       self_service: true
       setup_experience: true
       platform: ipados
+      categories:
+        - "Productivity"
+        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -103,6 +122,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -111,6 +132,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -119,6 +142,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Security"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -126,6 +151,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -133,6 +160,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -140,6 +169,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     # Android apps
     - app_store_id: "us.zoom.videomeetings" # Zoom
       platform: android

--- a/it-and-security/fleets/personal-mobile-devices.yml
+++ b/it-and-security/fleets/personal-mobile-devices.yml
@@ -34,6 +34,8 @@ software:
       self_service: true
       setup_experience: true
       platform: ios
+      categories:
+        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -42,6 +44,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -50,6 +54,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -57,6 +63,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -64,6 +72,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -71,6 +81,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "490179405" # Okta Verify
       display_name: "Okta Verify"
       self_service: true
@@ -79,6 +91,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Security"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -87,12 +101,17 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Security"
     # iPadOS apps
     - app_store_id: "618783545" # Slack
       display_name: "Slack"
       self_service: true
       setup_experience: true
       platform: ipados
+      categories:
+        - "Productivity"
+        - "Communication"
     - app_store_id: "546505307" # Zoom
       display_name: "Zoom"
       self_service: true
@@ -101,6 +120,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
     - app_store_id: "6473753684" # Claude
       display_name: "Claude"
       self_service: true
@@ -109,6 +130,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "1511601750" # 1Password
       display_name: "1Password"
       self_service: true
@@ -117,6 +140,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Security"
     - app_store_id: "842842640" # Google Docs
       display_name: "Google Docs"
       self_service: true
@@ -124,6 +149,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       display_name: "Google Sheets"
       self_service: true
@@ -131,6 +158,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       display_name: "Google Drive"
       self_service: true
@@ -138,6 +167,8 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "21:00"
       auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     # Android apps
     - app_store_id: "us.zoom.videomeetings" # Zoom
       platform: android


### PR DESCRIPTION
Reverts fleetdm/fleet#47984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added application categorization metadata to mobile device configurations for iOS and iPadOS platforms, enhancing organization and management of apps across company-owned and personal device fleets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->