### PR TITLE
Website: Update linux-management.ejs - Lead with self-service

### DIFF
--- a/website/views/pages/linux-management.ejs
+++ b/website/views/pages/linux-management.ejs
@@ -12,7 +12,7 @@
               <p>Fleet brings open device management, patching, and vulnerability detection to Linux. Support device choice without losing visibility or control.</p>
             </div>
             <div purpose="button-row" class="d-flex">
-              <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+              <a purpose="cta-button" class="btn btn-primary" href="/try">Test it out</a>
               <animated-arrow-button href="/pricing">View pricing</animated-arrow-button>
             </div>
           </div>
@@ -378,7 +378,7 @@
         </div>
         <div purpose="button-row" class="d-flex justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
-          <animated-arrow-button href="/try">Try it yourself</animated-arrow-button>
+          <animated-arrow-button href="/docs">Read the docs</animated-arrow-button>
         </div>
       </div>
       </div>


### PR DESCRIPTION
Website: Update linux-management.ejs - Lead with self-service flow so it's easier for folks with small linux fleets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated call-to-action links on the Linux Management page: the primary button now directs to testing, while the secondary button links to documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->