### PR TITLE
Fix layout issue with tooltips

### DIFF
--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
@@ -86,7 +86,10 @@ const GitOpsModeTooltipWrapper = ({
         className={`${baseClass}__tip-text`}
         anchorSelect={anchorSelect}
         place={position}
-        offset={tipOffset ?? 5}
+        // This wrapper always renders an arrow. A 5px offset leaves no gap between the
+        // arrow and a button (e.g. "Add certificate authority"), so non-field content
+        // gets extra clearance. Field tooltips anchor to the label row and read fine at 5.
+        offset={tipOffset ?? (hasSingleFieldRow ? 5 : 8)}
         opacity={1}
         disableStyleInjection
         clickable

--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
@@ -42,6 +42,7 @@ const GitOpsModeTooltipWrapper = ({
 
   const wrapperRef = useRef<HTMLSpanElement>(null);
   const [hasSingleFieldRow, setHasSingleFieldRow] = useState(false);
+  const [wrapsField, setWrapsField] = useState(true);
   // Prefix makes this a valid CSS id selector (lodash uniqueId returns a bare number).
   const wrapperId = useMemo(() => uniqueId(`${baseClass}-`), []);
 
@@ -56,6 +57,10 @@ const GitOpsModeTooltipWrapper = ({
       FIRST_ROW_PARTS.join(", ")
     );
     setHasSingleFieldRow(!!root?.matches(".form-field") && rows?.length === 1);
+    // Field content (a single field or a group of them) keeps full width so the disabled
+    // row stays the hover target; only non-field content (buttons, icon rows) hugs its
+    // content so the tooltip centers on the button rather than the full form row.
+    setWrapsField(!!wrapperRef.current?.querySelector(".form-field"));
   }, []);
 
   if (!gitOpsModeEnabled) {
@@ -70,6 +75,7 @@ const GitOpsModeTooltipWrapper = ({
 
   const wrapperClass = classnames(baseClass, {
     [`${baseClass}--inputfield`]: isInputField,
+    [`${baseClass}--hug`]: !wrapsField && !isInputField,
   });
 
   // Anchor to the field's first row so the arrow points at the label regardless of input,

--- a/frontend/components/GitOpsModeTooltipWrapper/_styles.scss
+++ b/frontend/components/GitOpsModeTooltipWrapper/_styles.scss
@@ -3,11 +3,6 @@
   // shared TooltipWrapper, which this component no longer delegates to).
   @include tooltip5-arrow-styles;
   display: inline-flex;
-  // Hug the wrapped content so the tooltip (anchored to this span) centers on a button
-  // rather than the whole row. The global `form > * { width: 100% }` rule (_global.scss)
-  // would otherwise stretch the span to the full form width. Inputs/dropdowns opt back
-  // into full width via the `--inputfield` modifier below.
-  width: fit-content;
 
   &__tooltip-content {
     display: flex;
@@ -24,5 +19,13 @@
   &--inputfield {
     display: block;
     width: 100%;
+  }
+
+  // Non-field content (buttons, icon rows) hugs its content so the tooltip centers on the
+  // button. Without this, the global `form > * { width: 100% }` rule (_global.scss) stretches
+  // the span to the full form width and the arrow drifts to the form center. Field wrappers
+  // deliberately keep full width so the disabled row stays the hover target.
+  &--hug {
+    width: fit-content;
   }
 }

--- a/frontend/components/GitOpsModeTooltipWrapper/_styles.scss
+++ b/frontend/components/GitOpsModeTooltipWrapper/_styles.scss
@@ -3,6 +3,11 @@
   // shared TooltipWrapper, which this component no longer delegates to).
   @include tooltip5-arrow-styles;
   display: inline-flex;
+  // Hug the wrapped content so the tooltip (anchored to this span) centers on a button
+  // rather than the whole row. The global `form > * { width: 100% }` rule (_global.scss)
+  // would otherwise stretch the span to the full form width. Inputs/dropdowns opt back
+  // into full width via the `--inputfield` modifier below.
+  width: fit-content;
 
   &__tooltip-content {
     display: flex;


### PR DESCRIPTION
## Summary

  This is a follow-up to #47861, the previous PR for #44325.

  # Checklist for submitter

  ## Testing

  - [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitOps mode tooltip arrow positioning by adapting the default offset based on whether it’s associated with a single form field row.
* **Style**
  * Refined the tooltip wrapper layout so non-form-field content “hugs” its contents instead of stretching to full form width, improving alignment and centering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1728" height="1045" alt="Screenshot 2026-06-22 at 10 46 46" src="https://github.com/user-attachments/assets/53f96b70-59ec-422c-8750-324aea21b184" />
