### PR TITLE
Fix VS Code macOS FMA installing Intel build on Apple Silicon (#48010)

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/external_refs/vscode.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/vscode.go
@@ -6,21 +6,17 @@ import (
 	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
 )
 
-// VSCodeUniversalInstaller rewrites Homebrew's arm64-only VS Code download URL
-// to Microsoft's universal build, so the FMA installs natively on both Intel
-// and Apple silicon Macs.
+// VSCodeUniversalInstaller rewrites Homebrew's Apple-silicon-only download URL
+// to the architecture-independent "universal" build, so the FMA installs on
+// both Intel and Apple silicon Macs.
 //
-// Homebrew exposes only architecture-specific builds and no universal variant:
+// Homebrew exposes the arm64 build as the cask's url:
 //
-//	https://update.code.visualstudio.com/<version>/darwin-arm64/stable  (arm64)
-//	https://update.code.visualstudio.com/<version>/darwin/stable        (intel)
+//	https://update.code.visualstudio.com/<version>/darwin-arm64/stable
 //
-// Microsoft serves the universal (x86_64 + arm64) build at a path Homebrew
-// doesn't reference:
+// Microsoft serves the universal build at:
 //
 //	https://update.code.visualstudio.com/<version>/darwin-universal/stable
-//
-// /darwin/ is the Intel build, not universal.
 //
 // Since the URL (and therefore the artifact) changes, the Homebrew SHA256 no
 // longer applies; set it to "no_check" as the other installer-URL overrides do.

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/vscode.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/vscode.go
@@ -6,22 +6,26 @@ import (
 	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
 )
 
-// VSCodeUniversalInstaller rewrites Homebrew's Apple-silicon-only download URL
-// to the architecture-independent "universal" build, so the FMA installs on
-// both Intel and Apple silicon Macs.
+// VSCodeUniversalInstaller rewrites Homebrew's arm64-only VS Code download URL
+// to Microsoft's universal build, so the FMA installs natively on both Intel
+// and Apple silicon Macs.
 //
-// Homebrew exposes the arm64 build as the cask's url:
+// Homebrew exposes only architecture-specific builds and no universal variant:
 //
-//	https://update.code.visualstudio.com/<version>/darwin-arm64/stable
+//	https://update.code.visualstudio.com/<version>/darwin-arm64/stable  (arm64)
+//	https://update.code.visualstudio.com/<version>/darwin/stable        (intel)
 //
-// Microsoft serves the universal build at the arch-less path:
+// Microsoft serves the universal (x86_64 + arm64) build at a path Homebrew
+// doesn't reference:
 //
-//	https://update.code.visualstudio.com/<version>/darwin/stable
+//	https://update.code.visualstudio.com/<version>/darwin-universal/stable
+//
+// /darwin/ is the Intel build, not universal.
 //
 // Since the URL (and therefore the artifact) changes, the Homebrew SHA256 no
 // longer applies; set it to "no_check" as the other installer-URL overrides do.
 func VSCodeUniversalInstaller(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {
-	app.InstallerURL = strings.Replace(app.InstallerURL, "/darwin-arm64/", "/darwin/", 1)
+	app.InstallerURL = strings.Replace(app.InstallerURL, "/darwin-arm64/", "/darwin-universal/", 1)
 	app.SHA256 = "no_check"
 
 	return app, nil


### PR DESCRIPTION
Fixes #48010.

VSCodeUniversalInstaller pointed at /darwin/stable (Intel). 
Changed to /darwin-universal/stable, the actual universal build. sha256 stays no_check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VS Code installation handling for Apple Silicon Macs to use the universal build variant by adjusting the download URL mapping, resulting in better compatibility during installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->