### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/adobe-acrobat-pro/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-pro/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.001.21662",
+      "version": "26.001.21677",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro' AND version_compare(bundle_short_version, '26.001.21662') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro' AND version_compare(bundle_short_version, '26.001.21677') < 0);"
       },
       "installer_url": "https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg",
       "install_script_ref": "7bd42f17",

--- a/ee/maintained-apps/outputs/adobe-creative-cloud/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-creative-cloud/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.9.1.1",
+      "version": "6.10.0.252.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.acc.AdobeCreativeCloud';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.acc.AdobeCreativeCloud' AND version_compare(bundle_short_version, '6.9.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.acc.AdobeCreativeCloud' AND version_compare(bundle_short_version, '6.10.0.252.3') < 0);"
       },
-      "installer_url": "https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.9.1/1/macarm64/ACCCx6_9_1_1.dmg",
+      "installer_url": "https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.10.0/252.3/macarm64/ACCCx6_10_0_252_3.dmg",
       "install_script_ref": "a331ea84",
       "uninstall_script_ref": "e002ddef",
-      "sha256": "3a5c62f6e0be6bf38c7fa169744bc6545b3d9a1512974cb2acff80df315a1a91",
+      "sha256": "d02fc307e32b583c0552fbbca87cfe40b098f2fc707a12b033dff726091a21d6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/clockify/windows.json
+++ b/ee/maintained-apps/outputs/clockify/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.' AND version_compare(version, '2.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Clockify' AND publisher = 'CAKE.com Inc.' AND version_compare(version, '2.2.2') < 0);"
       },
       "installer_url": "https://clockify.me/downloads/clockify-setup.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "f7f14087",
-      "sha256": "478da3fd0a16d9e4dda9c9087378243eb82975f30cd5063f6aa27ed348859973",
+      "sha256": "a9f4e841670da6db6dc27624281a48720508fcedf717da2cd636a393da2feb4c",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.37.0",
+      "version": "0.37.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.37.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.37.2') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.37.0/CodexBar-macos-universal-0.37.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.37.2/CodexBar-macos-universal-0.37.2.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "b7d7c7c93992208686c7733f3feffdb77eb4921550cc6cfe3b4802aff692c237",
+      "sha256": "dc8f7c3c7fde007d46f6ea7ed408b05ec8711a865135fddb171b31e56df6ba77",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/dbvisualizer/darwin.json
+++ b/ee/maintained-apps/outputs/dbvisualizer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.2",
+      "version": "26.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbvis.DbVisualizer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbvis.DbVisualizer' AND version_compare(bundle_short_version, '26.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbvis.DbVisualizer' AND version_compare(bundle_short_version, '26.2') < 0);"
       },
-      "installer_url": "https://www.dbvis.com/product_download/dbvis-26.1.2/media/dbvis_macos-aarch64_26_1_2.dmg",
+      "installer_url": "https://www.dbvis.com/product_download/dbvis-26.2/media/dbvis_macos-aarch64_26_2.dmg",
       "install_script_ref": "c91f4544",
       "uninstall_script_ref": "9d3a4eb0",
-      "sha256": "9e09387fe2361c9ddc49de33fd336129f70d8e2550e448dc2fbfc3e79519c8b4",
+      "sha256": "d64b29ee7830d674629c16eca133b22b39c13ef06a19063c573185b207f346fd",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dbvisualizer/windows.json
+++ b/ee/maintained-apps/outputs/dbvisualizer/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.2",
+      "version": "26.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'DbVisualizer' AND publisher = 'DbVis Software AB';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'DbVisualizer' AND publisher = 'DbVis Software AB' AND version_compare(version, '26.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'DbVisualizer' AND publisher = 'DbVis Software AB' AND version_compare(version, '26.2') < 0);"
       },
-      "installer_url": "https://www.dbvis.com/product_download/dbvis-26.1.2/media/dbvis_windows-x64_26_1_2_jre.exe",
+      "installer_url": "https://www.dbvis.com/product_download/dbvis-26.2/media/dbvis_windows-x64_26_2_jre.exe",
       "install_script_ref": "a8ba6613",
       "uninstall_script_ref": "32e47ba9",
-      "sha256": "347b6ad57564ecc7d071a58e6c3e951da2d51e4e60c9582769e5b65bc7bc3839",
+      "sha256": "d5164243f3d15d7a07f3fedb289a73c3736b28c87efa62f8fdf57fa02d9f4d9a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/glyphs/darwin.json
+++ b/ee/maintained-apps/outputs/glyphs/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.GeorgSeifert.Glyphs3';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.GeorgSeifert.Glyphs3' AND version_compare(bundle_short_version, '3.5') < 0);"
       },
-      "installer_url": "https://updates.glyphsapp.com/Glyphs3.5-3528.zip",
+      "installer_url": "https://updates.glyphsapp.com/Glyphs3.5-3529.zip",
       "install_script_ref": "a5e9ac58",
       "uninstall_script_ref": "b1245f10",
-      "sha256": "3967d9344e8adeeeec5cbcbe8101cbf9d9018cf3d895a75d82a8348e7ec02d3a",
+      "sha256": "d9f3c6ed4a0bd09bc2f29fc196fc8d311b7e13070ad773c643ce7421bbd6566b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.4') < 0);"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.3/Hive-1.2.3-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.4/Hive-1.2.4-arm64.dmg",
       "install_script_ref": "6b39e7ad",
       "uninstall_script_ref": "78bb4e43",
-      "sha256": "3e5912e6e8adbcc44ade2a3d0f9271d8ce6f7dba87887e7c56a6955db9db2655",
+      "sha256": "ccce046f35f0fda76b6a12709ffa0c8e2a50eb3654e986e5ac1271b461c3208d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/macpacker/darwin.json
+++ b/ee/maintained-apps/outputs/macpacker/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.15.2",
+      "version": "0.15.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sarensx.MacPacker';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sarensx.MacPacker' AND version_compare(bundle_short_version, '0.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sarensx.MacPacker' AND version_compare(bundle_short_version, '0.15.3') < 0);"
       },
-      "installer_url": "https://macpacker-releases.s3.amazonaws.com/MacPacker_v0.15.2.zip",
+      "installer_url": "https://macpacker-releases.s3.amazonaws.com/MacPacker_v0.15.3.zip",
       "install_script_ref": "a8350ac7",
       "uninstall_script_ref": "fd696a74",
-      "sha256": "6213bf8fb18690fee2ef288061e753d1512010759cb8efc41141b7f7aa52908e",
+      "sha256": "c1e4fb89822bdc1ff2eaf34f2d4a60ea5ad7c9e3b6f94a7c87f74f8d8f8db10a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/parallels/darwin.json
+++ b/ee/maintained-apps/outputs/parallels/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.3.3",
+      "version": "26.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.parallels.desktop.console';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.parallels.desktop.console' AND version_compare(bundle_short_version, '26.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.parallels.desktop.console' AND version_compare(bundle_short_version, '26.4.0') < 0);"
       },
-      "installer_url": "https://download.parallels.com/desktop/v26/26.3.3-57507/ParallelsDesktop-26.3.3-57507.dmg",
+      "installer_url": "https://download.parallels.com/desktop/v26/26.4.0-57513/ParallelsDesktop-26.4.0-57513.dmg",
       "install_script_ref": "108147d0",
       "uninstall_script_ref": "340de022",
-      "sha256": "417af3750e9e6378a4830303d75ff312461abbf5f49a69b6ba4e8ef76afcc35a",
+      "sha256": "424ba5fa1661d09ee0f3e0fe4fb44b99faed2b68bdd3ec25b2b7e6e6d35a62e8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.15.8",
+      "version": "12.16.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.15.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.16.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.15.8/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.16.0/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "f5a551cc4da4fccb0b7a1e6606eb0aa9cf2d380346b157c267df590d14316530",
+      "sha256": "71e793769fb8fef0bdd3cc6805981cf9250ec462f5e2a250aa515dd02d26c4aa",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/processspy/darwin.json
+++ b/ee/maintained-apps/outputs/processspy/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.4",
+      "version": "1.14.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.itone.ProcessSpy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.itone.ProcessSpy' AND version_compare(bundle_short_version, '1.13.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.itone.ProcessSpy' AND version_compare(bundle_short_version, '1.14.0') < 0);"
       },
-      "installer_url": "https://process-spy.app/archive/ProcessSpy_1.13.4.dmg",
+      "installer_url": "https://process-spy.app/archive/ProcessSpy_1.14.0.dmg",
       "install_script_ref": "8cc3c9e8",
       "uninstall_script_ref": "0ab29be3",
-      "sha256": "1514f0f247be5b0ca390d00f2c959c808c8bc5f0f023a08d0bfbbe3922c2673f",
+      "sha256": "628f72b63846547618a97c64f94efa41956ef4f5e2d95ec08b0e942964c87730",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/proton-mail/darwin.json
+++ b/ee/maintained-apps/outputs/proton-mail/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.12.1",
+      "version": "1.13.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop' AND version_compare(bundle_short_version, '1.12.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop' AND version_compare(bundle_short_version, '1.13.3') < 0);"
       },
-      "installer_url": "https://proton.me/download/mail/macos/1.12.1/ProtonMail-desktop.dmg",
+      "installer_url": "https://proton.me/download/mail/macos/1.13.3/ProtonMail-desktop.dmg",
       "install_script_ref": "036ed883",
       "uninstall_script_ref": "8e5ef0af",
-      "sha256": "cbc2a01e6f2921b2d001bd7fa480293416ec6848b995d2276385573418934252",
+      "sha256": "0b4511866c5c6d07cff2e31ef2746e531e5fd092f404cbefad615f5c709547dd",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.104.19",
+      "version": "1.104.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.19') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.20') < 0);"
       },
-      "installer_url": "https://releases.raycast.com/releases/1.104.19/download?build=arm",
+      "installer_url": "https://releases.raycast.com/releases/1.104.20/download?build=arm",
       "install_script_ref": "ee3bb800",
       "uninstall_script_ref": "cb893329",
-      "sha256": "930fce0739993513e8ef738e7267a33a5961288138242cda924add4a6bc6f076",
+      "sha256": "294091342c42a007ad1035c83c1b0370c067baba411f71a74b4319fb8aca09f0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/reminders-menubar/darwin.json
+++ b/ee/maintained-apps/outputs/reminders-menubar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'br.com.damascenorafael.reminders-menubar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'br.com.damascenorafael.reminders-menubar' AND version_compare(bundle_short_version, '2.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'br.com.damascenorafael.reminders-menubar' AND version_compare(bundle_short_version, '2.1.0') < 0);"
       },
-      "installer_url": "https://github.com/DamascenoRafael/reminders-menubar/releases/download/v2.0.0/reminders-menubar.zip",
+      "installer_url": "https://github.com/DamascenoRafael/reminders-menubar/releases/download/v2.1.0/reminders-menubar.zip",
       "install_script_ref": "8c3858a5",
       "uninstall_script_ref": "467090f2",
-      "sha256": "7c71704fb79ac4488bf88edc43df8e0cff08bfadbefecf378c14df6bd21f93f9",
+      "sha256": "8e4f43e089849950f4631b121a8a4536352c457622ab7c1a4e36441d6303dff9",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/royal-tsx/windows.json
+++ b/ee/maintained-apps/outputs/royal-tsx/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.4.50522.0",
+      "version": "7.4.50622.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Royal TS V7' AND publisher = 'Royal Apps GmbH';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Royal TS V7' AND publisher = 'Royal Apps GmbH' AND version_compare(version, '7.4.50522.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Royal TS V7' AND publisher = 'Royal Apps GmbH' AND version_compare(version, '7.4.50622.0') < 0);"
       },
-      "installer_url": "https://download.royalapps.com/royalts/royaltsinstaller_7.04.50522.0_x64.msi",
+      "installer_url": "https://download.royalapps.com/royalts/royaltsinstaller_7.04.50622.0_x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "451ca1a9",
-      "sha256": "b6a733698f6aa8d0c2f97a2f7e1dad6d3808fd4777d837acf27f3e711d26a21f",
+      "sha256": "15ab43f81302b03084438bad5c4337ca1713d8251e0d615b0e9d48b6f91cdf1e",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/shapr3d/darwin.json
+++ b/ee/maintained-apps/outputs/shapr3d/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.100.0.11031",
+      "version": "26.110.0.11116",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr' AND version_compare(bundle_short_version, '26.100.0.11031') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr' AND version_compare(bundle_short_version, '26.110.0.11116') < 0);"
       },
-      "installer_url": "https://download.shapr3d.com/mac/Shapr3D-26.100.0.11031.dmg",
+      "installer_url": "https://download.shapr3d.com/mac/Shapr3D-26.110.0.11116.dmg",
       "install_script_ref": "f6e027de",
       "uninstall_script_ref": "261544b8",
-      "sha256": "eede9465a1f7d718d40707afd0871655fd3d200d79ee40194845605572a2130b",
+      "sha256": "fb0d772b543032df6621b5c9b679bac6dd4e6a74d3f706b5b1c5a8d0c01a9fd6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.24.21",
+      "version": "26.25.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.24.21') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.25.12') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata for 17 applications across macOS and Windows to support their latest releases and ensure patch detection remains current. Affected applications: Adobe Acrobat Pro, Adobe Creative Cloud, Clockify, CodexBar, DBVisualizer, Glyphs, Hive App, MacPacker, Parallels, Postman, ProcessSpy, Proton Mail, Raycast, Reminders Menubar, Royal TS, Shapr3D, and WhatsApp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->