### PR TITLE
Compress windows_mdm_responses envelopes on the Windows MDM hot path (#44188)

### DIFF
--- a/changes/44188-compress-windows-mdm-responses
+++ b/changes/44188-compress-windows-mdm-responses
@@ -1,0 +1,1 @@
+* Reduced database write pressure on the Windows MDM check-in path by gzip-compressing stored device response envelopes.

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -923,9 +923,19 @@ ORDER BY
 // removed entirely. Legacy rows written before this change carry no prefix and are returned verbatim by decompressWindowsMDMResponse.
 const windowsMDMResponseCompressedPrefix = "gz1:"
 
+// windowsMDMResponseCompressMinBytes is the size below which an envelope is stored verbatim. gzip has ~18 bytes of framing overhead and
+// base64 adds ~33%, so compressing a tiny payload would inflate it. Real envelopes are 2-20 KB (issue #44188) and always clear this bar; only
+// trivially small payloads are stored uncompressed, where the absolute waste of skipping compression is negligible.
+const windowsMDMResponseCompressMinBytes = 256
+
 // compressWindowsMDMResponse gzip-compresses and base64-encodes a full SyncML response envelope for storage in windows_mdm_responses,
-// tagging the result with windowsMDMResponseCompressedPrefix so it can be distinguished from legacy uncompressed rows on read.
+// tagging the result with windowsMDMResponseCompressedPrefix so it can be distinguished from legacy uncompressed rows on read. Payloads
+// below windowsMDMResponseCompressMinBytes are returned verbatim (no prefix) to avoid inflating them; the read path handles unprefixed
+// values transparently.
 func compressWindowsMDMResponse(raw []byte) ([]byte, error) {
+	if len(raw) < windowsMDMResponseCompressMinBytes {
+		return raw, nil
+	}
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	if _, err := gw.Write(raw); err != nil {

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -944,8 +944,12 @@ func compressWindowsMDMResponse(raw []byte) ([]byte, error) {
 	if err := gw.Close(); err != nil {
 		return nil, err
 	}
-	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
-	return append([]byte(windowsMDMResponseCompressedPrefix), encoded...), nil
+	// Encode directly into a single pre-sized buffer (prefix + base64) to avoid the extra string allocation and copy on this hot path.
+	prefix := windowsMDMResponseCompressedPrefix
+	out := make([]byte, len(prefix)+base64.StdEncoding.EncodedLen(buf.Len()))
+	copy(out, prefix)
+	base64.StdEncoding.Encode(out[len(prefix):], buf.Bytes())
+	return out, nil
 }
 
 // decompressWindowsMDMResponse reverses compressWindowsMDMResponse. Values without windowsMDMResponseCompressedPrefix (legacy uncompressed
@@ -955,11 +959,14 @@ func decompressWindowsMDMResponse(stored []byte) ([]byte, error) {
 	if !bytes.HasPrefix(stored, prefix) {
 		return stored, nil
 	}
-	decoded, err := base64.StdEncoding.DecodeString(string(stored[len(prefix):]))
+	// Decode the base64 payload directly from the []byte to avoid an extra string copy.
+	b64 := stored[len(prefix):]
+	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(b64)))
+	n, err := base64.StdEncoding.Decode(decoded, b64)
 	if err != nil {
 		return nil, err
 	}
-	gr, err := gzip.NewReader(bytes.NewReader(decoded))
+	gr, err := gzip.NewReader(bytes.NewReader(decoded[:n]))
 	if err != nil {
 		return nil, err
 	}

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -2,11 +2,14 @@ package mysql
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"slices"
 	"strings"
@@ -914,6 +917,46 @@ ORDER BY
 	return commands, nil
 }
 
+// windowsMDMResponseCompressedPrefix marks a windows_mdm_responses.raw_response value that has been gzip-compressed and base64-encoded.
+// The column is MEDIUMTEXT (utf8mb4), so raw gzip bytes cannot be stored directly; base64 keeps the value charset-safe. This is a stopgap
+// (issue #44188) to shrink the row size and the redo-log/commit-quorum pressure of the Windows MDM check-in hot path until the table is
+// removed entirely. Legacy rows written before this change carry no prefix and are returned verbatim by decompressWindowsMDMResponse.
+const windowsMDMResponseCompressedPrefix = "gz1:"
+
+// compressWindowsMDMResponse gzip-compresses and base64-encodes a full SyncML response envelope for storage in windows_mdm_responses,
+// tagging the result with windowsMDMResponseCompressedPrefix so it can be distinguished from legacy uncompressed rows on read.
+func compressWindowsMDMResponse(raw []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(raw); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return append([]byte(windowsMDMResponseCompressedPrefix), encoded...), nil
+}
+
+// decompressWindowsMDMResponse reverses compressWindowsMDMResponse. Values without windowsMDMResponseCompressedPrefix (legacy uncompressed
+// rows, or the empty string from a LEFT JOIN miss) are returned unchanged.
+func decompressWindowsMDMResponse(stored []byte) ([]byte, error) {
+	prefix := []byte(windowsMDMResponseCompressedPrefix)
+	if !bytes.HasPrefix(stored, prefix) {
+		return stored, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(string(stored[len(prefix):]))
+	if err != nil {
+		return nil, err
+	}
+	gr, err := gzip.NewReader(bytes.NewReader(decoded))
+	if err != nil {
+		return nil, err
+	}
+	defer gr.Close()
+	return io.ReadAll(gr)
+}
+
 func (ds *Datastore) MDMWindowsSaveResponse(ctx context.Context, enrolledDevice *fleet.MDMWindowsEnrolledDevice, enrichedSyncML fleet.EnrichedSyncML, commandIDsBeingResent []string) (*fleet.MDMWindowsSaveResponseResult, error) {
 	if len(enrichedSyncML.Raw) == 0 {
 		return nil, ctxerr.New(ctx, "empty raw response")
@@ -926,9 +969,13 @@ func (ds *Datastore) MDMWindowsSaveResponse(ctx context.Context, enrolledDevice 
 	if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		result = nil
 
-		// store the full response
+		// store the full response, gzip-compressed to shrink the row and reduce redo-log/commit-quorum pressure on this hot path (#44188)
+		compressedResp, err := compressWindowsMDMResponse(enrichedSyncML.Raw)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "compressing full response")
+		}
 		const saveFullRespStmt = `INSERT INTO windows_mdm_responses (enrollment_id, raw_response) VALUES (?, ?)`
-		sqlResult, err := tx.ExecContext(ctx, saveFullRespStmt, enrolledDevice.ID, enrichedSyncML.Raw)
+		sqlResult, err := tx.ExecContext(ctx, saveFullRespStmt, enrolledDevice.ID, compressedResp)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "saving full response")
 		}
@@ -1284,6 +1331,16 @@ WHERE
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get command results")
+	}
+
+	// raw_response is stored gzip-compressed (see compressWindowsMDMResponse); restore the original envelope for the API response. Legacy
+	// uncompressed rows and empty (LEFT JOIN miss) values pass through unchanged.
+	for _, r := range results {
+		decompressed, err := decompressWindowsMDMResponse(r.Result)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "decompressing windows mdm response")
+		}
+		r.Result = decompressed
 	}
 
 	return results, nil

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -3872,6 +3872,56 @@ func windowsConfigProfileForTest(t *testing.T, name, locURI string, labels ...*f
 	return prof
 }
 
+func TestCompressWindowsMDMResponse(t *testing.T) {
+	t.Run("round-trip restores the original envelope", func(t *testing.T) {
+		original := []byte(`<SyncML xmlns="SYNCML:SYNCML1.2"><SyncHdr><VerDTD>1.2</VerDTD></SyncHdr><SyncBody><Status><CmdID>1</CmdID><Data>200</Data></Status></SyncBody></SyncML>`)
+		compressed, err := compressWindowsMDMResponse(original)
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(string(compressed), windowsMDMResponseCompressedPrefix))
+
+		decompressed, err := decompressWindowsMDMResponse(compressed)
+		require.NoError(t, err)
+		require.Equal(t, original, decompressed)
+	})
+
+	t.Run("compression shrinks a realistic envelope", func(t *testing.T) {
+		// A typical SyncML envelope is highly compressible XML; build a representative one with repeated structure.
+		var sb strings.Builder
+		sb.WriteString(`<SyncML xmlns="SYNCML:SYNCML1.2"><SyncHdr><VerDTD>1.2</VerDTD></SyncHdr><SyncBody>`)
+		for range 200 {
+			sb.WriteString(`<Status><CmdID>1</CmdID><MsgRef>1</MsgRef><CmdRef>2</CmdRef><Cmd>Replace</Cmd><Data>200</Data></Status>`)
+		}
+		sb.WriteString(`</SyncBody></SyncML>`)
+		original := []byte(sb.String())
+
+		compressed, err := compressWindowsMDMResponse(original)
+		require.NoError(t, err)
+		require.Less(t, len(compressed), len(original), "compressed (incl. base64 + prefix) must be smaller than the original envelope")
+
+		decompressed, err := decompressWindowsMDMResponse(compressed)
+		require.NoError(t, err)
+		require.Equal(t, original, decompressed)
+	})
+
+	t.Run("legacy uncompressed value passes through unchanged", func(t *testing.T) {
+		legacy := []byte("some-response")
+		out, err := decompressWindowsMDMResponse(legacy)
+		require.NoError(t, err)
+		require.Equal(t, legacy, out)
+	})
+
+	t.Run("empty value passes through unchanged", func(t *testing.T) {
+		out, err := decompressWindowsMDMResponse([]byte{})
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+
+	t.Run("prefixed but invalid payload errors", func(t *testing.T) {
+		_, err := decompressWindowsMDMResponse([]byte(windowsMDMResponseCompressedPrefix + "not-base64!!"))
+		require.Error(t, err)
+	})
+}
+
 func testSaveResponse(t *testing.T, ds *Datastore) {
 	// Set up: 3 devices, 1 command, 1 response for 1 device
 	enrolledDevice1 := createEnrolledDevice(t, ds)
@@ -3955,6 +4005,17 @@ VALUES (?, 'pending', 'install', ?, 'disable-onedrive', ?)`, enrolledDevice1.Hos
 	assert.Equal(t, enrolledDevice1.HostUUID, results[0].HostUUID)
 	assert.Equal(t, cmd.CommandUUID, results[0].CommandUUID)
 	assert.Equal(t, "200", results[0].Status)
+	// The read path must transparently restore the original envelope even though it is stored gzip-compressed (#44188).
+	assert.Equal(t, enrichedSyncML.Raw, results[0].Result)
+
+	// And the row on disk must actually be compressed (carry the prefix), not the raw envelope.
+	var storedResp string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &storedResp,
+			`SELECT raw_response FROM windows_mdm_responses WHERE enrollment_id = ?`, enrolledDevice1.ID)
+	})
+	assert.True(t, strings.HasPrefix(storedResp, windowsMDMResponseCompressedPrefix), "stored raw_response must be compressed")
+	assert.NotContains(t, storedResp, "<SyncML", "stored raw_response must not contain the plaintext envelope")
 
 	var count int
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -3874,12 +3874,28 @@ func windowsConfigProfileForTest(t *testing.T, name, locURI string, labels ...*f
 
 func TestCompressWindowsMDMResponse(t *testing.T) {
 	t.Run("round-trip restores the original envelope", func(t *testing.T) {
-		original := []byte(`<SyncML xmlns="SYNCML:SYNCML1.2"><SyncHdr><VerDTD>1.2</VerDTD></SyncHdr><SyncBody><Status><CmdID>1</CmdID><Data>200</Data></Status></SyncBody></SyncML>`)
+		// Pad past windowsMDMResponseCompressMinBytes so the value is actually compressed (and prefixed).
+		original := []byte(`<SyncML xmlns="SYNCML:SYNCML1.2"><SyncHdr><VerDTD>1.2</VerDTD></SyncHdr><SyncBody><Status><CmdID>1</CmdID><Data>200</Data></Status>` +
+			strings.Repeat("<Status><CmdID>2</CmdID><Data>200</Data></Status>", 10) + `</SyncBody></SyncML>`)
+		require.GreaterOrEqual(t, len(original), windowsMDMResponseCompressMinBytes)
 		compressed, err := compressWindowsMDMResponse(original)
 		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(string(compressed), windowsMDMResponseCompressedPrefix))
 
 		decompressed, err := decompressWindowsMDMResponse(compressed)
+		require.NoError(t, err)
+		require.Equal(t, original, decompressed)
+	})
+
+	t.Run("small envelope is stored verbatim to avoid inflation", func(t *testing.T) {
+		original := []byte(`<SyncML/>`)
+		require.Less(t, len(original), windowsMDMResponseCompressMinBytes)
+		stored, err := compressWindowsMDMResponse(original)
+		require.NoError(t, err)
+		require.Equal(t, original, stored, "small payloads must be stored uncompressed and unprefixed")
+		require.False(t, strings.HasPrefix(string(stored), windowsMDMResponseCompressedPrefix))
+
+		decompressed, err := decompressWindowsMDMResponse(stored)
 		require.NoError(t, err)
 		require.Equal(t, original, decompressed)
 	})

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -9091,6 +9092,18 @@ func (s *integrationMDMTestSuite) TestWindowsMDM() {
 			WHERE command_uuid = ?
 			`, cmdUUID)
 		})
+		// raw_response is stored gzip-compressed (see compressWindowsMDMResponse); decompress it so it matches the decompressed envelope the
+		// API returns in Result. Envelopes below the compression threshold are stored verbatim (no prefix) and pass through unchanged.
+		const gzipPrefix = "gz1:"
+		if bytes.HasPrefix(fullResult, []byte(gzipPrefix)) {
+			decoded, err := base64.StdEncoding.DecodeString(string(fullResult[len(gzipPrefix):]))
+			require.NoError(t, err)
+			gr, err := gzip.NewReader(bytes.NewReader(decoded))
+			require.NoError(t, err)
+			defer gr.Close()
+			fullResult, err = io.ReadAll(gr)
+			require.NoError(t, err)
+		}
 		return fullResult
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves 

## Summary

Stopgap to relieve the top DB writer on the Windows MDM check-in hot path. Every Windows MDM check-in that acks a previously enqueued command writes the full inbound SyncML envelope to `windows_mdm_responses.raw_response` (`MEDIUMTEXT`). At 10k Windows hosts this is the largest cumulative writer in the system, and large rows expand the redo-log record and lengthen the Aurora commit-quorum wait.

This change gzip-compresses and base64-encodes the envelope before storing it, shrinking the row (gzip on XML is ~8-10x; base64 nets ~5-7x). base64 keeps the value charset-safe in the existing `utf8mb4 MEDIUMTEXT` column, so **no schema migration is needed**. A migration was deliberately avoided: the table is unbounded and monotonically growing, so a `MEDIUMTEXT -> MEDIUMBLOB` `ALTER` would rewrite the entire (huge) table and hammer the exact I/O subsystem we are trying to relieve.

The read path (`GetMDMWindowsCommandResults`) transparently decompresses, so the public API `result` field is unchanged. Stored values carry a `gz1:` marker prefix; legacy uncompressed rows and empty (`LEFT JOIN` miss) values lack the marker and pass through verbatim, preserving backward compatibility.

This is a stopgap ahead of the structural fix in #44188 (dropping `windows_mdm_responses` entirely and reconstructing the read-side `result` from per-command data).

### Rollback note

Rows written by this binary are only readable by this binary (an older binary would return the base64 blob as `result`). This is a low-traffic admin command-results lookup, so the impact of a rollback window is cosmetic, not data loss.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

  - `TestCompressWindowsMDMResponse` (pure unit): round-trip, compression actually shrinks a realistic envelope, legacy/empty passthrough, invalid-payload error.
  - Extended `testSaveResponse` to assert the full DB round-trip restores the original envelope and that the on-disk row is actually compressed (carries the `gz1:` prefix, no plaintext `<SyncML`).
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results (it reduces write load on the dominant writer)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced database write pressure for Windows MDM device check-ins by storing large SyncML response envelopes in gzip+base64 form with a `gz1:` prefix.
  * Preserved backward compatibility by transparently decompressing `gz1:` payloads when retrieving Windows MDM command results; legacy/uncompressed and small payloads remain unchanged.
* **Testing**
  * Added unit tests covering round-trip correctness, prefixing/size rules, legacy pass-through, empty inputs, and invalid prefixed payload errors.
  * Updated integration test handling to automatically decompress `gz1:`-prefixed API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->