### PR TITLE
Made team label membership checks more robust

### DIFF
--- a/changes/16279-cross-team-label-membership
+++ b/changes/16279-cross-team-label-membership
@@ -1,0 +1,1 @@
+- Made authorization more robust when creating labels from manual hosts.

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -110,8 +110,26 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 		}
 	}
 
-	// first create the new label, which will fail if the name is not unique
+	// For a manual label, resolve the target hosts and verify the caller is
+	// authorized to write labels to each of them before creating anything, so
+	// that a user with write access to one team cannot attach hosts from
+	// another team by supplying their IDs.
 	var err error
+	var manualHostIDs []uint
+	if label.LabelMembershipType == fleet.LabelMembershipTypeManual {
+		manualHostIDs = p.HostIDs
+		if len(p.Hosts) > 0 {
+			manualHostIDs, err = svc.ds.HostIDsByIdentifier(ctx, filter, p.Hosts)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		if err := svc.authorizeWriteLabelOnHosts(ctx, manualHostIDs); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// first create the new label, which will fail if the name is not unique
 	label, err = svc.ds.NewLabel(ctx, label)
 	if err != nil {
 		return nil, nil, err
@@ -126,16 +144,45 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 	}
 
 	if label.LabelMembershipType == fleet.LabelMembershipTypeManual {
-		hostIDs := p.HostIDs
-		if len(p.Hosts) > 0 {
-			hostIDs, err = svc.ds.HostIDsByIdentifier(ctx, filter, p.Hosts)
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-		return svc.ds.UpdateLabelMembershipByHostIDs(ctx, *label, hostIDs, filter)
+		return svc.ds.UpdateLabelMembershipByHostIDs(ctx, *label, manualHostIDs, filter)
 	}
 	return label, nil, nil
+}
+
+// authorizeWriteLabelOnHosts verifies that the caller is authorized to write
+// labels (the write_host_label action) to every host in hostIDs. It returns a
+// permission error if the caller lacks write access to any of them, which
+// prevents attaching hosts from teams the caller can't write to via their raw
+// IDs.
+func (svc *Service) authorizeWriteLabelOnHosts(ctx context.Context, hostIDs []uint) error {
+	if len(hostIDs) == 0 {
+		return nil
+	}
+
+	hosts, err := svc.ds.ListHostsLiteByIDs(ctx, hostIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "load hosts for label membership authorization")
+	}
+
+	// Make sure every requested host exists. A non-existent ID is not returned
+	// by ListHostsLiteByIDs and would otherwise skip the authorization check
+	// below. Use a set so that duplicate IDs in the request are tolerated.
+	foundIDs := make(map[uint]struct{}, len(hosts))
+	for _, host := range hosts {
+		foundIDs[host.ID] = struct{}{}
+	}
+	for _, id := range hostIDs {
+		if _, ok := foundIDs[id]; !ok {
+			return fleet.NewInvalidArgumentError("host_ids", fmt.Sprintf("host %d does not exist", id))
+		}
+	}
+
+	for _, host := range hosts {
+		if err := svc.authz.Authorize(ctx, host, fleet.ActionWriteHostLabel); err != nil {
+			return ctxerr.Wrap(ctx, err)
+		}
+	}
+	return nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -215,6 +262,13 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 
 	if len(hostIDs) > 0 && label.LabelMembershipType != fleet.LabelMembershipTypeManual {
 		return nil, nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
+	}
+
+	// Verify the caller is authorized to write labels to each target host
+	// before updating membership, so that hosts from teams the caller can't
+	// write to cannot be attached via their raw IDs.
+	if err := svc.authorizeWriteLabelOnHosts(ctx, hostIDs); err != nil {
+		return nil, nil, err
 	}
 
 	if hostIDs != nil {

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -599,6 +599,213 @@ func TestLabelsWithReplica(t *testing.T) {
 	require.Equal(t, user.ID, *lblWithName.AuthorID)
 }
 
+func TestLabelCrossTeamHostMembership(t *testing.T) {
+	ds := mysqltest.CreateMySQLDS(t)
+	defer ds.Close()
+
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	// A global admin used only to inspect the resulting label membership.
+	adminUser, err := ds.NewUser(ctx, &fleet.User{
+		Name:       "Admin",
+		Password:   []byte("p4ssw0rd.123"),
+		Email:      "admin@example.com",
+		GlobalRole: new(fleet.RoleAdmin),
+	})
+	require.NoError(t, err)
+	adminFilter := fleet.TeamFilter{User: adminUser}
+
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "team2"})
+	require.NoError(t, err)
+
+	// A user who can only write to team1 (team admins/maintainers are allowed
+	// to create global labels per the authorization policy).
+	team1User, err := ds.NewUser(ctx, &fleet.User{
+		Name:     "Team1 Maintainer",
+		Password: []byte("p4ssw0rd.123"),
+		Email:    "team1@example.com",
+		Teams: []fleet.UserTeam{
+			{Team: fleet.Team{ID: team1.ID}, Role: fleet.RoleMaintainer},
+		},
+	})
+	require.NoError(t, err)
+	team1Ctx := viewer.NewContext(ctx, viewer.Viewer{User: team1User})
+
+	// A host on team1 (team1User can write to it) and a host on team2 (it can't).
+	team1Host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "team1-host",
+		HardwareSerial:  uuid.NewString(),
+		UUID:            uuid.NewString(),
+		Platform:        "darwin",
+		LastEnrolledAt:  time.Now(),
+		DetailUpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team1.ID, []uint{team1Host.ID})))
+
+	team2Host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "team2-host",
+		HardwareSerial:  uuid.NewString(),
+		UUID:            uuid.NewString(),
+		Platform:        "darwin",
+		LastEnrolledAt:  time.Now(),
+		DetailUpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team2.ID, []uint{team2Host.ID})))
+
+	t.Run("NewLabel rejects cross-team host_ids", func(t *testing.T) {
+		_, _, err := svc.NewLabel(team1Ctx, fleet.LabelPayload{
+			Name:    "cross-team-create",
+			HostIDs: []uint{team2Host.ID},
+		})
+		// team1User has no write access to the team2 host, so this must fail
+		// authorization rather than silently attaching the host.
+		checkAuthErr(t, true, err)
+	})
+
+	t.Run("ModifyLabel rejects cross-team host_ids", func(t *testing.T) {
+		// Create an empty manual global label as the team1 user.
+		lbl, _, err := svc.NewLabel(team1Ctx, fleet.LabelPayload{Name: "cross-team-modify"})
+		require.NoError(t, err)
+
+		_, _, err = svc.ModifyLabel(team1Ctx, lbl.ID, fleet.ModifyLabelPayload{
+			HostIDs: []uint{team2Host.ID},
+		})
+		checkAuthErr(t, true, err)
+
+		// The membership must be unchanged (empty).
+		hosts, err := ds.ListHostsInLabel(ctx, adminFilter, lbl.ID, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Empty(t, hosts, "team1 user must not attach a team2 host via raw host_ids")
+	})
+
+	t.Run("read-only access to the target team is rejected", func(t *testing.T) {
+		// A user who can write to team1 but only has read-only (observer_plus)
+		// access to team2 must not be able to attach team2 hosts: membership is
+		// a write operation and requires write authorization on the host.
+		readOnlyUser, err := ds.NewUser(ctx, &fleet.User{
+			Name:     "Team1 Maintainer, Team2 Observer+",
+			Password: []byte("p4ssw0rd.123"),
+			Email:    "team1team2@example.com",
+			Teams: []fleet.UserTeam{
+				{Team: fleet.Team{ID: team1.ID}, Role: fleet.RoleMaintainer},
+				{Team: fleet.Team{ID: team2.ID}, Role: fleet.RoleObserverPlus},
+			},
+		})
+		require.NoError(t, err)
+		readOnlyCtx := viewer.NewContext(ctx, viewer.Viewer{User: readOnlyUser})
+
+		_, _, err = svc.NewLabel(readOnlyCtx, fleet.LabelPayload{
+			Name:    "read-only-target-team",
+			HostIDs: []uint{team2Host.ID},
+		})
+		checkAuthErr(t, true, err)
+	})
+
+	t.Run("read-only access to the target team is rejected by host name", func(t *testing.T) {
+		// The by-name path resolves identifiers the caller can see, so an
+		// observer_plus on team2 resolves the team2 host and must then be
+		// rejected by the write-authorization check (unlike a user with no
+		// access to team2, for whom the host name resolves to nothing).
+		readOnlyUser, err := ds.NewUser(ctx, &fleet.User{
+			Name:     "Team1 Maintainer, Team2 Observer+ (by name)",
+			Password: []byte("p4ssw0rd.123"),
+			Email:    "team1team2-byname@example.com",
+			Teams: []fleet.UserTeam{
+				{Team: fleet.Team{ID: team1.ID}, Role: fleet.RoleMaintainer},
+				{Team: fleet.Team{ID: team2.ID}, Role: fleet.RoleObserverPlus},
+			},
+		})
+		require.NoError(t, err)
+		readOnlyCtx := viewer.NewContext(ctx, viewer.Viewer{User: readOnlyUser})
+
+		_, _, err = svc.NewLabel(readOnlyCtx, fleet.LabelPayload{
+			Name:  "read-only-target-team-by-name",
+			Hosts: []string{"team2-host"},
+		})
+		checkAuthErr(t, true, err)
+	})
+
+	t.Run("a mix of in-scope and out-of-scope hosts is rejected atomically", func(t *testing.T) {
+		// Create a manual label with an in-scope team1 host, then attempt to
+		// add a second team1 host together with the out-of-scope team2 host.
+		// The request must be rejected and leave membership unchanged, so the
+		// in-scope host is not partially applied.
+		team1Host2, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:        "team1-host-2",
+			HardwareSerial:  uuid.NewString(),
+			UUID:            uuid.NewString(),
+			Platform:        "darwin",
+			LastEnrolledAt:  time.Now(),
+			DetailUpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team1.ID, []uint{team1Host2.ID})))
+
+		lbl, _, err := svc.NewLabel(team1Ctx, fleet.LabelPayload{
+			Name:    "atomic-mix",
+			HostIDs: []uint{team1Host.ID},
+		})
+		require.NoError(t, err)
+
+		_, _, err = svc.ModifyLabel(team1Ctx, lbl.ID, fleet.ModifyLabelPayload{
+			HostIDs: []uint{team1Host2.ID, team2Host.ID},
+		})
+		checkAuthErr(t, true, err)
+
+		// Membership must be unchanged: still only the original team1 host.
+		hosts, err := ds.ListHostsInLabel(ctx, adminFilter, lbl.ID, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Len(t, hosts, 1)
+		require.Equal(t, team1Host.ID, hosts[0].ID)
+	})
+
+	t.Run("non-existent host_ids are rejected", func(t *testing.T) {
+		// A host ID that does not exist must not silently bypass the
+		// authorization check; the request is rejected as invalid.
+		_, _, err := svc.NewLabel(team1Ctx, fleet.LabelPayload{
+			Name:    "missing-host",
+			HostIDs: []uint{999999},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "does not exist")
+	})
+
+	t.Run("hosts the caller can write to are still allowed", func(t *testing.T) {
+		// Sanity check that the write-authorization check doesn't over-restrict:
+		// team1User can attach a team1 host to a global label they create, both
+		// by ID and by name, and can remove all hosts.
+		lbl, hostIDs, err := svc.NewLabel(team1Ctx, fleet.LabelPayload{
+			Name:    "in-scope-create",
+			HostIDs: []uint{team1Host.ID},
+		})
+		require.NoError(t, err)
+		require.ElementsMatch(t, []uint{team1Host.ID}, hostIDs)
+
+		hosts, err := ds.ListHostsInLabel(ctx, adminFilter, lbl.ID, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Len(t, hosts, 1)
+		require.Equal(t, team1Host.ID, hosts[0].ID)
+
+		// Modifying by name with an in-scope host is allowed.
+		_, hostIDs, err = svc.ModifyLabel(team1Ctx, lbl.ID, fleet.ModifyLabelPayload{
+			Hosts: []string{"team1-host"},
+		})
+		require.NoError(t, err)
+		require.ElementsMatch(t, []uint{team1Host.ID}, hostIDs)
+
+		// Removing all hosts (empty list) is allowed and needs no host authz.
+		_, hostIDs, err = svc.ModifyLabel(team1Ctx, lbl.ID, fleet.ModifyLabelPayload{
+			Hosts: []string{},
+		})
+		require.NoError(t, err)
+		require.Empty(t, hostIDs)
+	})
+}
+
 func TestBatchValidateLabels(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
@@ -875,6 +1082,19 @@ func TestApplyLabelSpecsManualLabelNilHosts(t *testing.T) {
 	require.ErrorContains(t, err, "declared as host_vitals but contains hosts")
 }
 
+// mockListHostsLiteByIDs sets up ListHostsLiteByIDs to return a lite host for
+// each requested ID, so that label membership authorization can run in tests
+// that use a mock datastore.
+func mockListHostsLiteByIDs(ds *mock.Store) {
+	ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+		hosts := make([]*fleet.Host, 0, len(ids))
+		for _, id := range ids {
+			hosts = append(hosts, &fleet.Host{ID: id})
+		}
+		return hosts, nil
+	}
+}
+
 func TestNewManualLabel(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
@@ -888,6 +1108,7 @@ func TestNewManualLabel(t *testing.T) {
 	ds.HostIDsByIdentifierFunc = func(ctx context.Context, filter fleet.TeamFilter, hostnames []string) ([]uint, error) {
 		return []uint{99, 100}, nil
 	}
+	mockListHostsLiteByIDs(ds)
 
 	t.Run("using hostnames", func(t *testing.T) {
 		ds.UpdateLabelMembershipByHostIDsFunc = func(ctx context.Context, label fleet.Label, hostIds []uint, teamFilter fleet.TeamFilter) (*fleet.Label, []uint, error) {
@@ -932,6 +1153,7 @@ func TestModifyManualLabel(t *testing.T) {
 	ds.HostIDsByIdentifierFunc = func(ctx context.Context, filter fleet.TeamFilter, hostnames []string) ([]uint, error) {
 		return []uint{99, 100}, nil
 	}
+	mockListHostsLiteByIDs(ds)
 	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
 		return &fleet.LabelWithTeamName{Label: *lbl}, nil, nil
 	}


### PR DESCRIPTION
When creating a manual label, make the checks around manual host more robust.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened label authorization when creating and modifying manual labels, including host ID resolution. The system now validates all requested hosts up front and blocks the entire membership update if any host is outside the caller’s write scope.
* **Tests**
  * Added MySQL-backed coverage to verify cross-team host membership changes are rejected, non-existent hosts are denied, and valid in-scope updates succeed atomically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->