### PR TITLE
Add Solarized Light theme

### DIFF
--- a/changes/solarized-theme
+++ b/changes/solarized-theme
@@ -1,0 +1,1 @@
+Add Solarized Light theme option

--- a/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
+++ b/frontend/pages/AccountPage/AccountSidePanel/AccountSidePanel.tsx
@@ -109,6 +109,14 @@ const AccountSidePanel = ({
           checked={themeMode === "dark"}
           onChange={onThemeSelect}
         />
+        <Radio
+          id="theme-solarized"
+          name="theme"
+          value="solarized"
+          label="Solarized"
+          checked={themeMode === "solarized"}
+          onChange={onThemeSelect}
+        />
       </div>
       {isPremiumTier && <DataSet title="Fleets" value={teamsText} />}
       <DataSet title="Role" value={roleText} />

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -297,6 +297,15 @@
     --level-4: #009a7d;
     --level-5: #005b4a;
 
+    body.solarized-mode & {
+      --level-0: #eee8d5;
+      --level-1: #d9e8e6;
+      --level-2: #b2d9d4;
+      --level-3: #84c8c1;
+      --level-4: #5bb2aa;
+      --level-5: #479891;
+    }
+
     body.dark-mode & {
       --level-0: #515256;
       --level-1: #2e363d;

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -211,6 +211,112 @@ body.dark-mode {
   --dropdown-menu-outline: var(--ui-fleet-black-10);
 }
 
+// ---------------------------------------------------------------------------
+// Solarized Light — Ethan Schoonover's palette
+// https://ethanschoonover.com/solarized/
+// ---------------------------------------------------------------------------
+body.solarized-mode {
+  // Solarized base tones:
+  //   base3  #fdf6e3  (main background)    base03 #002b36  (darkest)
+  //   base2  #eee8d5  (bg highlights)      base02 #073642
+  //   base1  #93a1a1  (secondary content)  base01 #586e75  (emphasis)
+  //   base0  #839496  (lighter body)       base00 #657b83  (body text)
+
+  --core-fleet-black: #586e75; // base01
+  --core-fleet-green: #2aa198; // cyan
+  --core-fleet-white: #fdf6e3; // base3
+  --ui-fleet-black-75: #657b83; // base00
+  --ui-fleet-black-50: #839496; // base0
+  --ui-fleet-black-33: #93a1a1; // base1
+  --ui-fleet-black-25: #c9d1cb; // blue-gray tint
+  --ui-fleet-black-10: #dce5dc; // blue-gray border
+  --ui-fleet-black-5: #edf2ee; // cool off-white
+
+  // Secondary / interaction
+  --ui-fleet-black-75-over: #4b6068;
+  --ui-fleet-black-75-down: #3f545c;
+  --core-fleet-green-over: #239089;
+  --core-fleet-green-down: #1d7d77;
+  --ui-fleet-black-5-down: #e3ebe5;
+
+  // Core accent — lean into Solarized blue
+  --core-fleet-blue: #268bd2; // blue
+  --core-vibrant-blue: #268bd2; // blue (primary action color)
+  --core-vibrant-red: #dc322f; // red
+  --core-fleet-purple: #6c71c4; // violet
+  --core-dark-blue-grey: #2aa198; // cyan
+  --site-nav-on-hover: #dce5dc; // cool highlight
+
+  // UI — blue-gray surfaces
+  --ui-fleet-blue-10: #f0f4f1; // cool tinted white
+  --ui-dark-blue-gray: #839496; // base0
+  --ui-blue-gray: #d0dbd3; // blue-gray border
+  --ui-gray: #c9d4cc; // blue-gray mid
+  --ui-light-grey: #f0f4f1; // cool tinted white
+  --ui-off-white: #f0f4f1; // cool tinted white
+  --ui-shadow: #c0cdc3; // blue-gray shadow
+  --ui-vibrant-blue-50: rgba(38, 139, 210, 0.35); // blue semi
+  --ui-vibrant-blue-25: #d5e8f5; // blue very light
+  --ui-vibrant-blue-10: #e8f1f8; // blue ultra light
+  --tooltip-bg: #073642; // base02
+
+  // Notifications & status
+  --ui-offline: #839496; // base0
+  --ui-success: #859900; // green
+  --ui-warning: #b58900; // yellow
+  --ui-error: #dc322f; // red
+  --ui-info: #268bd2; // blue
+  --ui-yellow-banner: #f5efdc;
+  --ui-yellow-banner-outline: #d6cea8;
+
+  // Toast surfaces
+  --ui-success-toast-bg: #859900;
+  --ui-error-toast-bg: #dc322f;
+
+  // Flash backgrounds
+  --ui-success-flash-bg: #e5f0d8;
+  --ui-error-flash-bg: #f8e5e5;
+
+  // TS COLORS aliases
+  --core-fleet-red: #dc322f;
+  --ui-blue-hover: #1a7abd; // blue darkened
+  --ui-blue-pressed: #15679e; // blue darker
+  --ui-blue-50: rgba(38, 139, 210, 0.35);
+  --ui-blue-25: #d5e8f5;
+  --ui-blue-10: #e8f1f8;
+  --status-success: #859900;
+  --status-warning: #b58900;
+  --status-error: #dc322f;
+
+  // Rainbow
+  --rainbow-orange: #cb4b16; // orange
+  --rainbow-green: #859900; // green
+  --rainbow-blue: #268bd2; // blue
+
+  // Gradients — cool blue-gray tint
+  --gradient-background: #e5ede7;
+
+  // Button hover / active
+  --core-vibrant-red-over: #c82a28;
+  --core-vibrant-red-down: #b02523;
+  --core-vibrant-blue-over: #1a7abd; // blue darkened
+  --core-vibrant-blue-down: #15679e; // blue darker
+  --ui-success-over: #748700;
+  --ui-success-down: #636f00;
+  --core-fleet-blue-over: #1f78b8;
+  --core-fleet-blue-down: #19669e;
+
+  // Nav active underline
+  --nav-active-underline: #268bd2; // blue
+
+  // Overlays
+  --core-fleet-black-overlay-40: rgba(7, 54, 66, 0.4); // base02 overlay
+  --core-fleet-black-overlay-05: rgba(88, 110, 117, 0.07);
+  --loading-overlay: rgba(253, 246, 227, 0.85);
+
+  --dropdown-menu-outline: transparent;
+}
+
 // =============================================================================
 // SCSS variable aliases — every existing component stylesheet keeps working.
 // =============================================================================

--- a/frontend/utilities/theme.ts
+++ b/frontend/utilities/theme.ts
@@ -1,10 +1,15 @@
 const THEME_KEY = "fleet-theme";
 const TRANSITION_MS = 300;
 
-export type ThemeMode = "system" | "light" | "dark";
+export type ThemeMode = "system" | "light" | "dark" | "solarized";
+
+const THEME_CLASSES = ["dark-mode", "solarized-mode"] as const;
 
 const isThemeMode = (value: unknown): value is ThemeMode =>
-  value === "system" || value === "light" || value === "dark";
+  value === "system" ||
+  value === "light" ||
+  value === "dark" ||
+  value === "solarized";
 
 const systemPrefersDark = (): boolean => {
   return (
@@ -24,6 +29,14 @@ export const getThemeMode = (): ThemeMode => {
   return isThemeMode(stored) ? stored : "system";
 };
 
+/** Returns the body class to apply for a given mode, or null for light. */
+const resolveThemeClass = (mode: ThemeMode): string | null => {
+  if (mode === "dark") return "dark-mode";
+  if (mode === "solarized") return "solarized-mode";
+  if (mode === "system") return systemPrefersDark() ? "dark-mode" : null;
+  return null; // light
+};
+
 const resolveDark = (mode: ThemeMode): boolean =>
   mode === "system" ? systemPrefersDark() : mode === "dark";
 
@@ -31,16 +44,23 @@ export const isDarkMode = (): boolean => resolveDark(getThemeMode());
 
 // Apply a theme change to the DOM and notify listeners. `animate` adds a
 // blanket transition class so the whole UI cross-fades instead of snapping.
-const applyDarkMode = (dark: boolean, animate: boolean): void => {
+const applyTheme = (mode: ThemeMode, animate: boolean): void => {
   if (animate) {
     document.body.classList.add("theme-transition");
     setTimeout(() => {
       document.body.classList.remove("theme-transition");
     }, TRANSITION_MS);
   }
-  document.body.classList.toggle("dark-mode", dark);
+  // Clear all theme classes, then set the resolved one.
+  THEME_CLASSES.forEach((cls) => document.body.classList.remove(cls));
+  const cls = resolveThemeClass(mode);
+  if (cls) {
+    document.body.classList.add(cls);
+  }
   window.dispatchEvent(
-    new CustomEvent("fleet-theme-change", { detail: { dark } })
+    new CustomEvent("fleet-theme-change", {
+      detail: { dark: resolveDark(mode) },
+    })
   );
 };
 
@@ -55,23 +75,24 @@ export const setThemeMode = (mode: ThemeMode): void => {
     // localStorage can throw in restricted environments; the DOM still
     // gets the updated theme below, the choice just won't persist.
   }
-  applyDarkMode(resolveDark(mode), true);
+  applyTheme(mode, true);
 };
 
 export const initTheme = (): void => {
   const mode = getThemeMode();
-  if (resolveDark(mode)) {
-    document.body.classList.add("dark-mode");
+  const cls = resolveThemeClass(mode);
+  if (cls) {
+    document.body.classList.add(cls);
   }
 
-  // Follow OS theme changes live — but only while the user is on "system".
-  // Once they've picked light or dark explicitly, their choice sticks
-  // regardless of what the OS does.
+  // Follow OS theme changes live -- but only while the user is on "system".
+  // Once they've picked light, dark, or solarized explicitly, their choice
+  // sticks regardless of what the OS does.
   if (typeof window !== "undefined" && window.matchMedia) {
     const media = window.matchMedia("(prefers-color-scheme: dark)");
-    media.addEventListener("change", (e) => {
+    media.addEventListener("change", () => {
       if (getThemeMode() !== "system") return;
-      applyDarkMode(e.matches, true);
+      applyTheme("system", true);
     });
   }
 };


### PR DESCRIPTION
**Related issue:** N/A

## Summary

- Adds a "Solarized" option to the theme picker (My Account > Theme), based on [Ethan Schoonover's Solarized Light palette](https://ethanschoonover.com/solarized/)
- Maps all ~70 CSS custom properties to Solarized base tones and accent colors with blue-gray tinted surfaces
- Adds a soothing heatmap color ramp for the Hosts online checkerboard chart

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] QA'd all new/changed functionality manually

## Images

<img width="1299" height="843" alt="image" src="https://github.com/user-attachments/assets/00a20675-57ac-427b-9090-17ba081d4848" />
<img width="1316" height="474" alt="image" src="https://github.com/user-attachments/assets/b73628a5-9583-49e3-b9f3-02796115ac01" />
<img width="1311" height="830" alt="image" src="https://github.com/user-attachments/assets/83ae6e42-d0d4-4aed-a31f-1f48833f6444" />

