### PR TITLE
Versions modal, multi-row Library, pinned state

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -115,9 +115,10 @@ export interface ISoftwareAppStoreAppStatus {
   failed: number;
 }
 
-interface IFleetMaintainedVersion {
+export interface IFleetMaintainedVersion {
   id: number;
   version: string;
+  uploaded_at: string;
 }
 
 export interface ISoftwarePackage {
@@ -147,6 +148,9 @@ export interface ISoftwarePackage {
   categories?: SoftwareCategory[] | null;
   fleet_maintained_app_id?: number | null;
   fleet_maintained_versions?: IFleetMaintainedVersion[] | null;
+  /** Version pin: null/absent = Latest, exact version = exact pin, caret
+   * ("^149") = major-version pin. */
+  pinned_version?: string | null;
   hash_sha256?: string | null;
   /** XML plist string for iOS/iPadOS in-house .ipa managed app configuration. */
   configuration?: string;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tests.tsx
@@ -45,6 +45,7 @@ describe("Software Summary Card", () => {
         router={router}
         refetchSoftwareTitle={jest.fn()}
         onToggleViewYaml={jest.fn()}
+        onClickVersions={jest.fn()}
       />
     );
     // Get the text with aria label "software display name"
@@ -97,6 +98,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -120,6 +122,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -144,6 +147,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -170,6 +174,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -194,6 +199,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -217,6 +223,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -239,6 +246,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -262,6 +270,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -302,6 +311,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -320,6 +330,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -355,6 +366,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -393,6 +405,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -432,6 +445,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -451,6 +465,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -470,6 +485,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -487,6 +503,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -504,6 +521,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -523,6 +541,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -545,6 +564,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -564,6 +584,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -581,6 +602,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -603,6 +625,7 @@ describe("Software Summary Card", () => {
           router={pushedRouter}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -629,6 +652,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 
@@ -650,6 +674,7 @@ describe("Software Summary Card", () => {
           router={router}
           refetchSoftwareTitle={jest.fn()}
           onToggleViewYaml={jest.fn()}
+          onClickVersions={jest.fn()}
         />
       );
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -37,6 +37,9 @@ interface ISoftwareSummaryCard {
   router: InjectedRouter;
   refetchSoftwareTitle: () => void;
   onToggleViewYaml: () => void;
+  /** Opens the page-owned Versions modal; the Actions item is gated here by
+   * `canManageVersions`. */
+  onClickVersions: () => void;
 }
 
 const baseClass = "software-summary-card";
@@ -48,6 +51,7 @@ const SoftwareSummaryCard = ({
   router,
   refetchSoftwareTitle,
   onToggleViewYaml,
+  onClickVersions,
 }: ISoftwareSummaryCard) => {
   const { isPremiumTier } = useContext(AppContext);
   const installerResult = useSoftwareInstaller(softwareTitle);
@@ -246,9 +250,6 @@ const SoftwareSummaryCard = ({
   const onClickEditConfiguration = () => setShowEditConfigurationModal(true);
   const onClickEditAutoUpdateConfig = () =>
     setShowEditAutoUpdateConfigModal(true);
-  // Versions modal wiring lands in #47623; for now this is a no-op placeholder
-  // so the Actions item can render with proper gating.
-  const onClickVersions = () => undefined;
 
   return (
     <>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -47,7 +47,9 @@ import LibraryItemAccordion, {
 import LibraryItemAccordionList from "./LibraryItemAccordion/LibraryItemAccordionList";
 import EditSoftwareModal from "./EditSoftwareModal";
 import DeleteSoftwareModal from "./DeleteSoftwareModal";
+import VersionsModal from "./VersionsModal";
 import { getDisplayedSoftwareName } from "../helpers";
+import { buildLibraryVersionRows } from "./helpers";
 import TitleVersionsTable from "./TitleVersionsTable";
 import ViewYamlModal from "./ViewYamlModal";
 
@@ -113,6 +115,9 @@ const SoftwareTitleDetailsPage = ({
 
   const [showLibraryEditModal, setShowLibraryEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  // Page-owned so both the Actions menu and the Library accordion badge open
+  // the same Versions modal.
+  const [showVersionsModal, setShowVersionsModal] = useState(false);
 
   const {
     data: softwareTitle,
@@ -213,6 +218,7 @@ const SoftwareTitleDetailsPage = ({
         router={router}
         refetchSoftwareTitle={refetchSoftwareTitle}
         onToggleViewYaml={onToggleViewYaml}
+        onClickVersions={() => setShowVersionsModal(true)}
       />
     );
   };
@@ -233,8 +239,6 @@ const SoftwareTitleDetailsPage = ({
         fleet_id: currentTeamId ?? APP_CONTEXT_NO_TEAM_ID,
       });
 
-    // TODO #47623 multi-row rendering — render one accordion per version,
-    // and lift installer-meta lookup to per-row (only the latest is "active").
     const libraryAccordionList = () => {
       const pkg = title.software_package;
       const appStore = title.app_store_app;
@@ -283,36 +287,50 @@ const SoftwareTitleDetailsPage = ({
       const { installed, pending, failed } = aggregateInstallStatusCounts(
         pkg.status
       );
+      // FMAs list every cached version (active row badged from the pin, the
+      // rest dimmed rollback candidates); other packages render a single row.
+      const rows = buildLibraryVersionRows({
+        fleetMaintainedVersions: pkg.fleet_maintained_versions,
+        activeVersion: pkg.version,
+        pinnedVersion: pkg.pinned_version,
+        addedTimestamp: pkg.uploaded_at,
+      });
       return (
         <LibraryItemAccordionList>
-          <LibraryItemAccordion
-            filename={pkg.name}
-            version={pkg.version}
-            addedAt={pkg.uploaded_at}
-            installerType="package"
-            isFma={isFma}
-            isLatestFmaVersion={isLatestFmaVersion}
-            isScriptPackage={isScriptPackage}
-            isTarballPackage={title.source === "tgz_packages"}
-            isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(title.source)}
-            isActive
-            badgeState="latest"
-            labels={labels}
-            labelKind={kind}
-            canEditSoftware={canEditSoftware}
-            installed={installed}
-            pending={pending}
-            failed={failed}
-            installedPath={statusPath("installed")}
-            pendingPath={statusPath("pending")}
-            failedPath={statusPath("failed")}
-            hashSha256={pkg.hash_sha256 ?? null}
-            downloadUrl={pkg.url}
-            onLabelCountClick={openEditModal}
-            onLabelsClick={openEditModal}
-            onDownloadClick={onDownloadInstaller}
-            onTrashClick={() => setShowDeleteModal(true)}
-          />
+          {rows.map((row) => (
+            <LibraryItemAccordion
+              key={row.id}
+              filename={pkg.name}
+              version={row.version}
+              addedAt={row.uploaded_at}
+              installerType="package"
+              isFma={isFma}
+              isLatestFmaVersion={row.isActive && isLatestFmaVersion}
+              isScriptPackage={isScriptPackage}
+              isTarballPackage={title.source === "tgz_packages"}
+              isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(title.source)}
+              isActive={row.isActive}
+              badgeState={row.badgeState}
+              labels={row.isActive ? labels : null}
+              labelKind={kind}
+              canEditSoftware={canEditSoftware}
+              installed={row.isActive ? installed : 0}
+              pending={row.isActive ? pending : 0}
+              failed={row.isActive ? failed : 0}
+              installedPath={statusPath("installed")}
+              pendingPath={statusPath("pending")}
+              failedPath={statusPath("failed")}
+              hashSha256={row.isActive ? pkg.hash_sha256 ?? null : null}
+              downloadUrl={row.isActive ? pkg.url : undefined}
+              onBadgeClick={
+                isFma ? () => setShowVersionsModal(true) : undefined
+              }
+              onLabelCountClick={openEditModal}
+              onLabelsClick={openEditModal}
+              onDownloadClick={onDownloadInstaller}
+              onTrashClick={() => setShowDeleteModal(true)}
+            />
+          ))}
         </LibraryItemAccordionList>
       );
     };
@@ -419,6 +437,19 @@ const SoftwareTitleDetailsPage = ({
     );
   };
 
+  const renderVersionsModal = (title: ISoftwareTitleDetails) => {
+    if (!showVersionsModal || !title.software_package) return null;
+    return (
+      <VersionsModal
+        softwareTitle={title}
+        softwareId={softwareId}
+        teamId={currentTeamId ?? APP_CONTEXT_NO_TEAM_ID}
+        refetchSoftwareTitle={refetchSoftwareTitle}
+        onExit={() => setShowVersionsModal(false)}
+      />
+    );
+  };
+
   const renderContent = () => {
     if (isSoftwareTitleLoading) {
       return <Spinner />;
@@ -445,6 +476,7 @@ const SoftwareTitleDetailsPage = ({
           {renderLibraryEditModal(softwareTitle)}
           {renderDeleteModal()}
           {renderViewYamlModal(softwareTitle)}
+          {renderVersionsModal(softwareTitle)}
         </>
       );
     }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -323,7 +323,9 @@ const SoftwareTitleDetailsPage = ({
               hashSha256={row.isActive ? pkg.hash_sha256 ?? null : null}
               downloadUrl={row.isActive ? pkg.url : undefined}
               onBadgeClick={
-                isFma ? () => setShowVersionsModal(true) : undefined
+                isFma && canEditSoftware
+                  ? () => setShowVersionsModal(true)
+                  : undefined
               }
               onLabelCountClick={openEditModal}
               onLabelsClick={openEditModal}
@@ -438,12 +440,20 @@ const SoftwareTitleDetailsPage = ({
   };
 
   const renderVersionsModal = (title: ISoftwareTitleDetails) => {
-    if (!showVersionsModal || !title.software_package) return null;
+    // `teamIdForApi` is undefined on "All teams" (where `currentTeamId` is the
+    // -1 sentinel); guard so we never PATCH `fleet_id=-1`. Mirrors the delete modal.
+    if (
+      !showVersionsModal ||
+      !title.software_package ||
+      typeof teamIdForApi !== "number"
+    ) {
+      return null;
+    }
     return (
       <VersionsModal
         softwareTitle={title}
         softwareId={softwareId}
-        teamId={currentTeamId ?? APP_CONTEXT_NO_TEAM_ID}
+        teamId={teamIdForApi}
         refetchSoftwareTitle={refetchSoftwareTitle}
         onExit={() => setShowVersionsModal(false)}
       />

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tests.tsx
@@ -84,6 +84,21 @@ describe("VersionsModal", () => {
     ).toBeChecked();
   });
 
+  it("formats an aged-out caret pin as a major-version option (no '^' leak)", () => {
+    // Pinned to ^148 but only 149.x is cached, so deriveVersionOptions emits
+    // only ^149 — the fallback must synthesize a properly-labeled ^148 option.
+    renderModal({
+      pinned_version: "^148",
+      fleet_maintained_versions: [
+        { id: 1, version: "149.0.2", uploaded_at: "2026-01-02T00:00:00Z" },
+      ],
+    });
+    expect(
+      screen.getByRole("radio", { name: "Pin to major version (148)" })
+    ).toBeChecked();
+    expect(screen.queryByText(/\^148/)).not.toBeInTheDocument();
+  });
+
   it("enables Save once the selection changes and PATCHes the chosen version on save", async () => {
     const editSpy = jest
       .spyOn(softwareAPI, "editSoftwarePackage")

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tests.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+
+import { createCustomRenderer } from "test/test-utils";
+import {
+  createMockSoftwareTitle,
+  createMockSoftwarePackage,
+} from "__mocks__/softwareMock";
+import { ISoftwarePackage } from "interfaces/software";
+import softwareAPI from "services/entities/software";
+
+import VersionsModal from "./VersionsModal";
+
+const fmaPackage = (overrides?: Partial<ISoftwarePackage>) =>
+  createMockSoftwarePackage({
+    fleet_maintained_app_id: 5,
+    version: "149.0.2",
+    fleet_maintained_versions: [
+      { id: 1, version: "149.0.2", uploaded_at: "2026-01-02T00:00:00Z" },
+      { id: 2, version: "148.0.1", uploaded_at: "2026-01-01T00:00:00Z" },
+    ],
+    ...overrides,
+  });
+
+const renderModal = (pkgOverrides?: Partial<ISoftwarePackage>) => {
+  const onExit = jest.fn();
+  const refetchSoftwareTitle = jest.fn();
+  const renderFlash = jest.fn();
+  const render = createCustomRenderer({
+    context: {
+      app: {
+        isPremiumTier: true,
+        config: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          gitops: { gitops_mode_enabled: false, repository_url: "" } as any,
+        },
+      },
+      notification: { renderFlash },
+    },
+  });
+  const title = createMockSoftwareTitle({
+    software_package: fmaPackage(pkgOverrides),
+  });
+  const utils = render(
+    <VersionsModal
+      softwareTitle={title}
+      softwareId={1}
+      teamId={1}
+      refetchSoftwareTitle={refetchSoftwareTitle}
+      onExit={onExit}
+    />
+  );
+  return { ...utils, onExit, refetchSoftwareTitle, renderFlash };
+};
+
+describe("VersionsModal", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("preselects 'Automatically update to latest' when there is no pin, with Save disabled", () => {
+    renderModal({ pinned_version: null });
+    expect(
+      screen.getByRole("radio", { name: "Automatically update to latest" })
+    ).toBeChecked();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("preselects the matching exact-version radio for an exact pin", () => {
+    renderModal({ pinned_version: "148.0.1" });
+    expect(screen.getByRole("radio", { name: "Pin to 148.0.1" })).toBeChecked();
+  });
+
+  it("preselects the major-version radio for a caret pin", () => {
+    renderModal({
+      pinned_version: "^149",
+      fleet_maintained_versions: [
+        { id: 1, version: "149.0.2", uploaded_at: "2026-01-02T00:00:00Z" },
+        { id: 2, version: "149.0.1", uploaded_at: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    expect(
+      screen.getByRole("radio", { name: "Pin to major version (149)" })
+    ).toBeChecked();
+  });
+
+  it("enables Save once the selection changes and PATCHes the chosen version on save", async () => {
+    const editSpy = jest
+      .spyOn(softwareAPI, "editSoftwarePackage")
+      .mockResolvedValue({} as never);
+    const { user, onExit, refetchSoftwareTitle, renderFlash } = renderModal({
+      pinned_version: null,
+    });
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+
+    await user.click(screen.getByRole("radio", { name: "Pin to 148.0.1" }));
+    expect(saveButton).toBeEnabled();
+
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(editSpy).toHaveBeenCalledWith({
+        data: { pinnedVersion: "148.0.1" },
+        softwareId: 1,
+        teamId: 1,
+      });
+    });
+    expect(renderFlash).toHaveBeenCalledWith("success", expect.anything());
+    expect(refetchSoftwareTitle).toHaveBeenCalled();
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it("flashes an error and leaves the modal open when the PATCH fails", async () => {
+    jest
+      .spyOn(softwareAPI, "editSoftwarePackage")
+      .mockRejectedValue(new Error("boom"));
+    const { user, onExit, renderFlash } = renderModal({ pinned_version: null });
+
+    await user.click(screen.getByRole("radio", { name: "Pin to 149.0.2" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(renderFlash).toHaveBeenCalledWith(
+        "error",
+        expect.stringContaining("Couldn't update version")
+      );
+    });
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tsx
@@ -45,9 +45,13 @@ const VersionsModal = ({
   const options = useMemo(() => {
     const opts = deriveVersionOptions(pkg?.fleet_maintained_versions ?? []);
     // A pin no longer among the cached versions still needs an option so the
-    // modal opens on the right radio.
+    // modal opens on the right radio. Format a caret major the same way as the
+    // derived options rather than leaking "^N" into the label.
     if (initialValue && !opts.some((o) => o.value === initialValue)) {
-      opts.push({ value: initialValue, label: `Pin to ${initialValue}` });
+      const label = initialValue.startsWith("^")
+        ? `Pin to major version (${initialValue.slice(1)})`
+        : `Pin to ${initialValue}`;
+      opts.push({ value: initialValue, label });
     }
     return opts;
   }, [pkg?.fleet_maintained_versions, initialValue]);

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tsx
@@ -1,0 +1,142 @@
+import React, { useContext, useMemo, useState } from "react";
+
+import { NotificationContext } from "context/notification";
+import { ISoftwareTitleDetails } from "interfaces/software";
+import softwareAPI from "services/entities/software";
+import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
+
+import Card from "components/Card";
+import Modal from "components/Modal";
+import ModalFooter from "components/ModalFooter";
+import Button from "components/buttons/Button";
+import Radio from "components/forms/fields/Radio";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+
+import { deriveVersionOptions, getPreselectedVersionValue } from "./helpers";
+
+const baseClass = "versions-modal";
+
+/** Version-pin branch of `editSoftwarePackage`. `pinnedVersion` is sent as the
+ * `version` field: "" clears the pin (Latest), else an exact or caret value. */
+export interface IVersionPinFormData {
+  pinnedVersion: string;
+}
+
+interface IVersionsModalProps {
+  softwareTitle: ISoftwareTitleDetails;
+  softwareId: number;
+  teamId: number;
+  refetchSoftwareTitle: () => void;
+  onExit: () => void;
+}
+
+const VersionsModal = ({
+  softwareTitle,
+  softwareId,
+  teamId,
+  refetchSoftwareTitle,
+  onExit,
+}: IVersionsModalProps) => {
+  const { renderFlash } = useContext(NotificationContext);
+
+  const pkg = softwareTitle.software_package;
+  const initialValue = getPreselectedVersionValue(pkg?.pinned_version);
+
+  const options = useMemo(() => {
+    const opts = deriveVersionOptions(pkg?.fleet_maintained_versions ?? []);
+    // A pin no longer among the cached versions still needs an option so the
+    // modal opens on the right radio.
+    if (initialValue && !opts.some((o) => o.value === initialValue)) {
+      opts.push({ value: initialValue, label: `Pin to ${initialValue}` });
+    }
+    return opts;
+  }, [pkg?.fleet_maintained_versions, initialValue]);
+
+  const [selectedValue, setSelectedValue] = useState(initialValue);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const hasChanges = selectedValue !== initialValue;
+
+  const onSave = async (evt: React.MouseEvent<HTMLButtonElement>) => {
+    evt.preventDefault();
+    setIsSaving(true);
+    try {
+      await softwareAPI.editSoftwarePackage({
+        data: { pinnedVersion: selectedValue },
+        softwareId,
+        teamId,
+      });
+      renderFlash(
+        "success",
+        <>
+          Successfully updated{" "}
+          <b>
+            {getDisplayedSoftwareName(
+              softwareTitle.name,
+              softwareTitle.display_name
+            )}
+          </b>{" "}
+          version.
+        </>
+      );
+      refetchSoftwareTitle();
+      onExit();
+    } catch (error) {
+      renderFlash("error", "Couldn't update version. Please try again.");
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Modal className={baseClass} title="Versions" onExit={onExit}>
+      <>
+        <div className={`${baseClass}__form`}>
+          <Card paddingSize="medium" borderRadiusSize="medium">
+            <fieldset className="form-field">
+              {options.map((option) => {
+                const optionId = option.value || "latest";
+                return (
+                  <Radio
+                    key={optionId}
+                    name="versionPin"
+                    id={`version-pin-${optionId}`}
+                    label={option.label}
+                    value={option.value}
+                    checked={selectedValue === option.value}
+                    onChange={setSelectedValue}
+                  />
+                );
+              })}
+            </fieldset>
+          </Card>
+        </div>
+        <ModalFooter
+          primaryButtons={
+            <>
+              <Button onClick={onExit} variant="inverse">
+                Cancel
+              </Button>
+              <GitOpsModeTooltipWrapper
+                entityType="software"
+                position="right"
+                tipOffset={8}
+                renderChildren={(disableChildren) => (
+                  <Button
+                    type="submit"
+                    onClick={onSave}
+                    isLoading={isSaving}
+                    disabled={!hasChanges || isSaving || !!disableChildren}
+                  >
+                    Save
+                  </Button>
+                )}
+              />
+            </>
+          }
+        />
+      </>
+    </Modal>
+  );
+};
+
+export default VersionsModal;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/_styles.scss
@@ -1,0 +1,14 @@
+.versions-modal {
+  &__form {
+    margin-bottom: $pad-medium;
+
+    fieldset {
+      display: flex;
+      flex-direction: column;
+      gap: $pad-small;
+      border: 0;
+      padding: 0;
+      margin: 0;
+    }
+  }
+}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/helpers.tests.ts
@@ -1,0 +1,72 @@
+import {
+  deriveVersionOptions,
+  getPreselectedVersionValue,
+  LATEST_VERSION_VALUE,
+} from "./helpers";
+
+const v = (id: number, version: string) => ({
+  id,
+  version,
+  uploaded_at: "2026-01-01T00:00:00Z",
+});
+
+describe("VersionsModal helpers", () => {
+  describe("deriveVersionOptions", () => {
+    it("always leads with the 'Latest' option", () => {
+      const opts = deriveVersionOptions([]);
+      expect(opts).toEqual([
+        {
+          value: LATEST_VERSION_VALUE,
+          label: "Automatically update to latest",
+        },
+      ]);
+    });
+
+    it("orders Latest, then exact pins (newest first), then the major option", () => {
+      // Mirrors the Figma example: two cached versions in different majors.
+      const opts = deriveVersionOptions([
+        v(1, "148.0.7778.179"),
+        v(2, "149.0.7827.54"),
+      ]);
+      expect(opts).toEqual([
+        {
+          value: LATEST_VERSION_VALUE,
+          label: "Automatically update to latest",
+        },
+        { value: "149.0.7827.54", label: "Pin to 149.0.7827.54" },
+        { value: "148.0.7778.179", label: "Pin to 148.0.7778.179" },
+        { value: "^149", label: "Pin to major version (149)" },
+      ]);
+    });
+
+    it("offers a single major option tracking the latest version's major", () => {
+      const opts = deriveVersionOptions([
+        v(1, "149.0.7827.54"),
+        v(2, "149.0.7700.0"),
+        v(3, "148.0.1"),
+      ]);
+      const majorOpts = opts.filter((o) => o.value.startsWith("^"));
+      expect(majorOpts).toEqual([
+        { value: "^149", label: "Pin to major version (149)" },
+      ]);
+      // Major option is last, after the exact pins.
+      expect(opts[opts.length - 1].value).toBe("^149");
+    });
+  });
+
+  describe("getPreselectedVersionValue", () => {
+    it("maps null/undefined/empty to Latest", () => {
+      expect(getPreselectedVersionValue(null)).toBe(LATEST_VERSION_VALUE);
+      expect(getPreselectedVersionValue(undefined)).toBe(LATEST_VERSION_VALUE);
+      expect(getPreselectedVersionValue("")).toBe(LATEST_VERSION_VALUE);
+    });
+
+    it("passes through an exact-version pin", () => {
+      expect(getPreselectedVersionValue("149.0.7827.54")).toBe("149.0.7827.54");
+    });
+
+    it("passes through a major-version pin", () => {
+      expect(getPreselectedVersionValue("^149")).toBe("^149");
+    });
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/helpers.ts
@@ -1,0 +1,55 @@
+import { compareVersions } from "utilities/helpers";
+import { IFleetMaintainedVersion } from "interfaces/software";
+
+/** Radio value meaning "track Latest" (no pin). Sent to the API as an empty
+ * `version` field, which the backend treats as clearing the pin. */
+export const LATEST_VERSION_VALUE = "";
+
+export interface IVersionOption {
+  /** Radio value, also the `version` value PATCHed to the API:
+   * "" = Latest, "149.0.7827.54" = exact pin, "^149" = major-version pin. */
+  value: string;
+  label: string;
+}
+
+const majorOf = (version: string): string => version.split(".")[0];
+
+/**
+ * Builds the Versions modal radio options from a title's cached versions, in
+ * the design's order: "Automatically update to latest", then a "Pin to
+ * {version}" per cached version (newest first), then a single "Pin to major
+ * version (N)" tracking the latest version's major (stays on N.x, never jumps
+ * to N+1).
+ */
+export const deriveVersionOptions = (
+  versions: IFleetMaintainedVersion[]
+): IVersionOption[] => {
+  const sorted = [...versions].sort((a, b) =>
+    compareVersions(b.version, a.version)
+  );
+
+  const options: IVersionOption[] = [
+    { value: LATEST_VERSION_VALUE, label: "Automatically update to latest" },
+  ];
+
+  sorted.forEach((v) => {
+    options.push({ value: v.version, label: `Pin to ${v.version}` });
+  });
+
+  if (sorted.length) {
+    const major = majorOf(sorted[0].version);
+    options.push({
+      value: `^${major}`,
+      label: `Pin to major version (${major})`,
+    });
+  }
+
+  return options;
+};
+
+/** Maps a title's `pinned_version` to the radio value selected when the modal
+ * opens: null/undefined/"" → Latest; otherwise the pin string itself
+ * ("^149" or an exact version), which matches its option's value. */
+export const getPreselectedVersionValue = (
+  pinnedVersion: string | null | undefined
+): string => pinnedVersion || LATEST_VERSION_VALUE;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/index.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VersionsModal";

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
@@ -1,7 +1,71 @@
 import { ISoftwareTitleDetails } from "interfaces/software";
-import { getInstallerCardInfo } from "./helpers";
+import { buildLibraryVersionRows, getInstallerCardInfo } from "./helpers";
+
+const v = (id: number, version: string) => ({
+  id,
+  version,
+  uploaded_at: "2026-01-01T00:00:00Z",
+});
 
 describe("SoftwareTitleDetailsPage helpers", () => {
+  describe("buildLibraryVersionRows", () => {
+    it("renders a single active 'Latest' row when there is no cached-version list", () => {
+      expect(
+        buildLibraryVersionRows({
+          fleetMaintainedVersions: null,
+          activeVersion: "1.2.3",
+          pinnedVersion: null,
+          addedTimestamp: "2026-02-02T00:00:00Z",
+        })
+      ).toEqual([
+        {
+          id: -1,
+          version: "1.2.3",
+          uploaded_at: "2026-02-02T00:00:00Z",
+          isActive: true,
+          badgeState: "latest",
+        },
+      ]);
+    });
+
+    it("marks the active-version row active with a 'latest' badge when unpinned", () => {
+      const rows = buildLibraryVersionRows({
+        fleetMaintainedVersions: [
+          v(1, "149.0.7827.54"),
+          v(2, "148.0.7778.179"),
+        ],
+        activeVersion: "149.0.7827.54",
+        pinnedVersion: null,
+        addedTimestamp: "x",
+      });
+      expect(rows.map((r) => [r.version, r.isActive, r.badgeState])).toEqual([
+        ["149.0.7827.54", true, "latest"],
+        ["148.0.7778.179", false, undefined],
+      ]);
+    });
+
+    it("badges the active row 'pinned' for an exact pin and 'majorVersion' for a caret pin", () => {
+      const exact = buildLibraryVersionRows({
+        fleetMaintainedVersions: [
+          v(1, "149.0.7827.54"),
+          v(2, "148.0.7778.179"),
+        ],
+        activeVersion: "148.0.7778.179",
+        pinnedVersion: "148.0.7778.179",
+        addedTimestamp: "x",
+      });
+      expect(exact.find((r) => r.isActive)?.badgeState).toBe("pinned");
+
+      const major = buildLibraryVersionRows({
+        fleetMaintainedVersions: [v(1, "149.0.7827.54")],
+        activeVersion: "149.0.7827.54",
+        pinnedVersion: "^149",
+        addedTimestamp: "x",
+      });
+      expect(major[0].badgeState).toBe("majorVersion");
+    });
+  });
+
   describe("getPackageCardInfo", () => {
     it("returns the correct data for a software package (and without a custom display_name)", () => {
       const softwareTitle: ISoftwareTitleDetails = {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
@@ -5,8 +5,11 @@ import {
   aggregateInstallStatusCounts,
   SCRIPT_PACKAGE_SOURCES,
   ISoftwarePackage,
+  IFleetMaintainedVersion,
 } from "interfaces/software";
 import { getDisplayedSoftwareName } from "../helpers";
+import { deriveAccordionRowState } from "./LibraryItemAccordion/helpers";
+import { LibraryItemBadgeState } from "./LibraryItemAccordion/LibraryItemAccordion";
 
 export interface InstallerCardInfo {
   softwareTitleName: string;
@@ -30,7 +33,50 @@ export interface InstallerCardInfo {
   autoUpdateEndTime?: string;
 }
 
-// eslint-disable-next-line import/prefer-default-export
+export interface ILibraryVersionRow {
+  id: number;
+  version: string;
+  uploaded_at: string;
+  isActive: boolean;
+  badgeState?: LibraryItemBadgeState;
+}
+
+/** Builds the Library accordion rows for a title: one row per cached
+ * Fleet-maintained version (the active row badged from the pin, the rest dimmed
+ * rollback candidates), or a single active "Latest" row for installer types
+ * that have no cached-version list. */
+export const buildLibraryVersionRows = ({
+  fleetMaintainedVersions,
+  activeVersion,
+  pinnedVersion,
+  addedTimestamp,
+}: {
+  fleetMaintainedVersions?: IFleetMaintainedVersion[] | null;
+  activeVersion: string | null;
+  pinnedVersion?: string | null;
+  addedTimestamp: string;
+}): ILibraryVersionRow[] => {
+  if (fleetMaintainedVersions?.length) {
+    return fleetMaintainedVersions.map((v) => ({
+      ...v,
+      ...deriveAccordionRowState({
+        rowVersion: v.version,
+        activeVersion,
+        pinnedVersion,
+      }),
+    }));
+  }
+  return [
+    {
+      id: -1,
+      version: activeVersion ?? "",
+      uploaded_at: addedTimestamp,
+      isActive: true,
+      badgeState: "latest",
+    },
+  ];
+};
+
 export const getInstallerCardInfo = (
   softwareTitle: ISoftwareTitleDetails
 ): InstallerCardInfo => {

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -38,6 +38,7 @@ import { IAddFleetMaintainedData } from "pages/SoftwarePage/SoftwareAddPage/Soft
 import { listNamesFromSelectedLabels } from "services/entities/labels";
 import { ISoftwareAndroidFormData } from "pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm";
 import { ISoftwareConfigurationFormData } from "pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal";
+import { IVersionPinFormData } from "pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal";
 
 export interface ISoftwareApiParams {
   page?: number;
@@ -605,7 +606,8 @@ export default {
     data:
       | IEditPackageFormData
       | ISoftwareDisplayNameFormData
-      | ISoftwareConfigurationFormData;
+      | ISoftwareConfigurationFormData
+      | IVersionPinFormData;
     orignalPackage?: ISoftwarePackage;
     softwareId: number;
     teamId: number;
@@ -620,6 +622,10 @@ export default {
     if ("configuration" in data) {
       // Handles Edit configuration form (iOS/iPadOS in-house apps)
       formData.append("configuration", data.configuration);
+    } else if ("pinnedVersion" in data) {
+      // Handles the Versions modal: pin an FMA to a cached version. An empty
+      // string clears the pin (back to "Latest"); the backend reads `version`.
+      formData.append("version", data.pinnedVersion);
     } else if ("displayName" in data) {
       // Handles Edit display name form only
       handleDisplayNameForm(data, formData);


### PR DESCRIPTION
**Related issue:** Resolves #47623

  ## Summary

  Wires up the Fleet-maintained app version-pinning UI on the software title details page:

  - **Versions modal** — opened from Actions ▾ → Versions or the active row's version badge. Choose *Automatically update to latest*, pin to an exact version, or pin to a major version; pre-selected from the current pin, and Save is disabled with a tooltip in GitOps mode.
  - **Multi-row Library** — one accordion row per cached version; the active/pinned row is badged (Latest / Pinned / Major version) and older versions are dimmed.
  - Adds `pinned_version` to the software-package interface and a `version` field to the installer `PATCH` request.

  Frontend only; targets the `feat/38504-auto-update-pin-rollback-fma` feature branch (backend, layout, and accordion already merged there).

  # Checklist for submitter

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually

https://github.com/user-attachments/assets/f9822cfa-57d2-4f0c-9918-c5ee914f0431

