### PR TITLE
Website: update logos on partners page

### DIFF
--- a/website/assets/styles/pages/partners.less
+++ b/website/assets/styles/pages/partners.less
@@ -243,7 +243,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     position: relative;
     width: 100%;
     gap: 32px;

--- a/website/assets/styles/pages/partners.less
+++ b/website/assets/styles/pages/partners.less
@@ -215,9 +215,31 @@
     flex-direction: column;
     gap: @inner-gap-s;
   }
-  [purpose='logo-carousel'] {
+  [purpose='logos-grid'] {
     justify-content: center;
     display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    width: 100%;
+    gap: 32px;
+    img {
+      vertical-align: middle;
+      height: 32px;
+      -webkit-transform-style: preserve-3d;
+      -webkit-backface-visibility: hidden;
+      display: flex;
+    }
+    [purpose='logo-row'] {
+      display: flex;
+      flex-direction: row;
+      gap: 32px;
+    }
+  }
+  [purpose='logo-carousel'] {
+    justify-content: center;
+    display: none;
     align-items: center;
     position: relative;
     width: 100%;
@@ -248,17 +270,17 @@
       animation: none;
       background: linear-gradient(90deg, rgba(255, 255, 255, 0.00) 0%, #FFF 100%);
     }
-  }
-  [purpose='logo-row'] {
-    white-space: nowrap;
-    animation: scroll-horizontal @animation-duration linear infinite;
-    -webkit-transform-style: preserve-3d;
-    -webkit-backface-visibility: hidden;
-    &.safari-13-scroll-animation {
-      animation: scroll-horizontal-safari-13 @animation-duration linear infinite;
-    }
-    &.ios-13-scroll-animation {
-      animation: scroll-horizontal-ios-13 @animation-duration linear infinite;
+    [purpose='logo-row'] {
+      white-space: nowrap;
+      animation: scroll-horizontal 80s linear infinite;
+      -webkit-transform-style: preserve-3d;
+      -webkit-backface-visibility: hidden;
+      &.safari-13-scroll-animation {
+        animation: scroll-horizontal-safari-13 80s linear infinite;
+      }
+      &.ios-13-scroll-animation {
+        animation: scroll-horizontal-ios-13 80s linear infinite;
+      }
     }
   }
   @keyframes scroll-horizontal {
@@ -566,6 +588,9 @@
     }
     [purpose='landing-page-content'] {
       gap: @section-gap-m;
+    }
+    [purpose='logo-carousel'] {
+      display: flex;
     }
     [purpose='details-cards'] {
       display: flex;

--- a/website/assets/styles/pages/partners.less
+++ b/website/assets/styles/pages/partners.less
@@ -215,6 +215,29 @@
     flex-direction: column;
     gap: @inner-gap-s;
   }
+
+  [purpose='logo-table'] {
+    img {
+      max-height: 32px;
+    }
+    table-layout: fixed;
+    width: 100%;
+    [purpose='logo-container'] {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    td {
+      height: 76px;
+      &:not(:last-of-type) {
+        border-right: 1px solid #E2E4EA;
+      }
+    }
+    tr:not(:last-of-type) {
+      border-bottom: 1px solid #E2E4EA;
+    }
+  }
+
   [purpose='logos-grid'] {
     justify-content: center;
     display: flex;
@@ -589,8 +612,10 @@
     [purpose='landing-page-content'] {
       gap: @section-gap-m;
     }
-    [purpose='logo-carousel'] {
-      display: flex;
+    [purpose='logo-table'] {
+      img {
+        max-height: 28px;
+      }
     }
     [purpose='details-cards'] {
       display: flex;
@@ -647,6 +672,10 @@
       font-weight: 800;
       line-height: 120%;
     }
+    [purpose='logo-carousel'] {
+      display: flex;
+    }
+
     [purpose='landing-page-container'] {
       padding: 32px 24px 0px 24px;
     }

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -22,7 +22,7 @@
             Trusted by leading partners
           </div>
           <div class="d-none d-lg-flex">
-            <table purpose="logo-table">
+            <table purpose="logo-table" role="presentation">
               <tr>
                 <td>
                   <div purpose="logo-container">
@@ -107,7 +107,7 @@
             </table>
           </div>
           <div class="d-none d-sm-flex d-lg-none">
-            <table purpose="logo-table">
+            <table purpose="logo-table" role="presentation">
               <tr>
                 <td>
                   <div purpose="logo-container">
@@ -228,7 +228,7 @@
               <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png">
               <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
               <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
-              <img alt="AWS logo" src="/images/logo-aws-36x36@2x.png">
+              <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
               <img alt="JSOC IT logo" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
             </div>
             <div purpose="fade-left"></div>

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -31,7 +31,7 @@
                 </td>
                 <td>
                   <div purpose="logo-container">
-                    <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+                    <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png">
                   </div>
                 </td>
                 <td>
@@ -116,7 +116,7 @@
                 </td>
                 <td>
                   <div purpose="logo-container">
-                    <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+                    <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png">
                   </div>
                 </td>
                 <td>
@@ -199,7 +199,7 @@
           <div purpose="logo-carousel">
             <div purpose="logo-row" class="d-flex flex-row align-items-center" :class="[isIosThirteen ? 'ios-13-scroll-animation' : isSafariThirteen ? 'safari-13-scroll-animation' : '']">
               <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
-              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png">
               <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
@@ -216,7 +216,7 @@
             </div>
             <div purpose="logo-row" class="d-flex flex-row align-items-center" :class="[isIosThirteen ? 'ios-13-scroll-animation' : isSafariThirteen ? 'safari-13-scroll-animation' : '']">
               <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
-              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png">
               <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
               <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
               <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -21,6 +21,50 @@
           <div purpose="logos-header">
             Trusted by leading partners
           </div>
+          <div purpose="logos-grid" class="d-none d-md-flex d-lg-none">
+            <div purpose="logo-row">
+              <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
+              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+              <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
+              <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
+              <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
+            </div>
+            <div purpose="logo-row">
+              <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
+              <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
+              <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
+              <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
+              <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
+            </div>
+            <div purpose="logo-row">
+              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+              <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
+              <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
+              <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
+              <img alt="JSOC IT logo" style="height: 45px;" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
+            </div>
+          </div>
+          <div purpose="logos-grid" class="d-none d-lg-flex">
+            <div purpose="logo-row">
+              <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
+              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+              <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
+              <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
+              <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
+              <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
+              <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
+              <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
+            </div>
+            <div purpose="logo-row">
+              <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
+              <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
+              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+              <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
+              <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
+              <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
+              <img alt="JSOC IT logo" style="height: 45px;" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
+            </div>
+          </div>
           <div purpose="logo-carousel">
             <div purpose="logo-row" class="d-flex flex-row align-items-center" :class="[isIosThirteen ? 'ios-13-scroll-animation' : isSafariThirteen ? 'safari-13-scroll-animation' : '']">
               <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -73,7 +73,7 @@
                 </td>
                 <td>
                   <div purpose="logo-container">
-                    <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+                    <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png">
                   </div>
                 </td>
               </tr>
@@ -163,7 +163,7 @@
               <tr>
                 <td>
                   <div purpose="logo-container">
-                    <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+                    <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png">
                   </div>
                 </td>
                 <td>
@@ -208,7 +208,7 @@
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
-              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png">
               <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
               <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
               <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
@@ -225,7 +225,7 @@
               <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
               <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
               <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
-              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png">
               <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
               <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
               <img alt="AWS logo" src="/images/logo-aws-36x36@2x.png">

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -21,49 +21,180 @@
           <div purpose="logos-header">
             Trusted by leading partners
           </div>
-          <div purpose="logos-grid" class="d-none d-md-flex d-lg-none">
-            <div purpose="logo-row">
-              <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
-              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
-              <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
-              <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
-              <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
-            </div>
-            <div purpose="logo-row">
-              <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
-              <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
-              <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
-              <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
-            </div>
-            <div purpose="logo-row">
-              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
-              <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
-              <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
-              <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
-              <img alt="JSOC IT logo" style="height: 45px;" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
-            </div>
+          <div class="d-none d-lg-flex">
+            <table purpose="logo-table">
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="JSOC IT logo" style="height: 45px;" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
+                  </div>
+                </td>
+                <td>
+                    <div purpose="logo-container">
+                  <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
+                  </div>
+                </td>
+              </tr>
+            </table>
           </div>
-          <div purpose="logos-grid" class="d-none d-lg-flex">
-            <div purpose="logo-row">
-              <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
-              <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
-              <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
-              <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
-              <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
-              <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
-              <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
-              <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
-            </div>
-            <div purpose="logo-row">
-              <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
-              <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
-              <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
-              <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
-              <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
-              <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
-              <img alt="JSOC IT logo" style="height: 45px;" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
-            </div>
+          <div class="d-none d-sm-flex d-lg-none">
+            <table purpose="logo-table">
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Amaris logo" src="/images/logos/partner-logo-amaris-86x32.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Denali logo" src="/images/logos/partner-logo-denali-55x32@2x.png ">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="SHI logo" src="/images/logos/partner-logo-shi-70x32@2x.png">
+                  </div>
+                </td>
+
+              </tr>
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Myriad logo" src="/images/logos/partner-logo-myriad-360-146x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="3eye logo" src="/images/logos/partner-logo-3eye-74x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="CDW logo" src="/images/logos/partner-logo-cdw-60x32@2x.png">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Primo logo" src="/images/logos/partner-logo-primo-108x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Wediggit logo" src="/images/logos/partner-logo-wediggit-94x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="nDuo logo" src="/images/logos/partner-logo-nduo-100x32@2x.png">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="JSOC IT logo" style="height: 45px;" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
+                  </div>
+                </td>
+                <td>
+                    <div purpose="logo-container">
+                  <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
+                  </div>
+                </td>
+                <td>
+                  <div purpose="logo-container">
+                    <img alt="Deel logo" src="/images/logos/partner-logo-deel-88x32@2x.png">
+                  </div>
+                </td>
+              </tr>
+            </table>
           </div>
           <div purpose="logo-carousel">
             <div purpose="logo-row" class="d-flex flex-row align-items-center" :class="[isIosThirteen ? 'ios-13-scroll-animation' : isSafariThirteen ? 'safari-13-scroll-animation' : '']">
@@ -80,7 +211,7 @@
               <img alt="Deeploi logo" src="/images/logos/partner-logo-deeploi-117x32@2x.png ">
               <img alt="Treeline logo" src="/images/logos/partner-logo-treeline-157x32@2x.png">
               <img alt="Stratix logo" src="/images/logos/partner-logo-stratix-172x58@2x.png">
-              <img alt="AWS logo" src="/images/logo-aws-36x36@2x.png">
+              <img alt="AWS logo" src="/images/platform/logo-aws-59x36@2x.png">
               <img alt="JSOC IT logo" src="/images/logos/partner-logo-jsoc-it-108x60@2x.png">
             </div>
             <div purpose="logo-row" class="d-flex flex-row align-items-center" :class="[isIosThirteen ? 'ios-13-scroll-animation' : isSafariThirteen ? 'safari-13-scroll-animation' : '']">


### PR DESCRIPTION
Changes:
- Updated the partners page to display partners' logos in a grid on larger screens (under 575px, the logo carousel is shown to users)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the Partners page logo area with responsive layouts: desktop uses a structured logo table, while smaller screens use an alternate table with centered logo grids and improved table styling.
  * Updated the logo carousel to be hidden by default, re-enabled on the smallest breakpoint, and adjusted horizontal scroll timing (including Safari/iOS-specific variants).
  * Refreshed carousel logo ordering and visuals, including updating the AWS logo asset and minor carousel markup cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->