### PR TITLE
Add pinned_version to edited_software activity

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -646,6 +646,7 @@ func (cmd *GenerateGitopsCommand) Run() error {
 	}
 
 	emptyVal := regexp.MustCompile(`(?m):\s*(null|""|\[\]|\{\})\s*$`)
+	softwareVersion := regexp.MustCompile(`(?m)^([ \t]+version: )([^"\n].*)$`)
 	// Add comments to the result.
 	for path, fileToWrite := range cmd.FilesToWrite {
 		fullPath := fmt.Sprintf("%s/%s", cmd.CLI.String("dir"), path)
@@ -670,6 +671,8 @@ func (cmd *GenerateGitopsCommand) Run() error {
 			b = emptyVal.ReplaceAll(b, []byte(":"))
 			// Unescape any unicode chars added by the YAML marshaler.
 			b = unescapeUnicodeU8(b)
+			// Keep software versions quoted so YAML treats them as strings (e.g. "10.0" must not become a float).
+			b = softwareVersion.ReplaceAll(b, []byte(`${1}"${2}"`))
 		} else {
 			switch fileToWrite := fileToWrite.(type) {
 			case []byte:

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -2262,6 +2262,9 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			delete(softwareSpec, "hash_sha256")
 			delete(softwareSpec, "url")
 			softwareSpec["slug"] = slug
+			if pv := softwareTitle.SoftwarePackage.PinnedVersion; pv != nil && *pv != "" {
+				softwareSpec["version"] = *pv
+			}
 		case sw.SoftwarePackage != nil:
 			packages = append(packages, softwareSpec)
 		case sw.AppStoreApp != nil:

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -664,6 +664,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				SelfService:          true,
 				Platform:             "windows",
 				FleetMaintainedAppID: ptr.Uint(2),
+				PinnedVersion:        new("1.2.3"),
 			},
 			IconUrl: ptr.String("/api/icon5.png"),
 		}, nil
@@ -677,6 +678,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				SelfService:          true,
 				Platform:             "windows",
 				FleetMaintainedAppID: ptr.Uint(3),
+				PinnedVersion:        new("^123"),
 			},
 		}, nil
 	default:

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -664,7 +664,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				SelfService:          true,
 				Platform:             "windows",
 				FleetMaintainedAppID: ptr.Uint(2),
-				PinnedVersion:        new("1.2.3"),
+				PinnedVersion:        new("10.0"),
 			},
 			IconUrl: ptr.String("/api/icon5.png"),
 		}, nil

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -34,7 +34,7 @@ fleet_maintained_apps:
       - Label A
       - Label B
     self_service: true
-    version: 1.2.3
+    version: "10.0"
   - slug: fma3/windows
     self_service: true
     version: ^123

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -34,8 +34,10 @@ fleet_maintained_apps:
       - Label A
       - Label B
     self_service: true
+    version: 1.2.3
   - slug: fma3/windows
     self_service: true
+    version: ^123
 app_store_apps:
   - app_store_id: "1234567890"
     labels_exclude_any:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -209,10 +209,10 @@ software:
     - Label B
     self_service: true
     slug: fma2/windows
-    version: 1.2.3
+    version: "1.2.3"
   - self_service: true
     slug: fma3/windows
-    version: ^123
+    version: "^123"
   packages:
   - categories:
     - Browsers

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -209,7 +209,7 @@ software:
     - Label B
     self_service: true
     slug: fma2/windows
-    version: "1.2.3"
+    version: "10.0"
   - self_service: true
     slug: fma3/windows
     version: "^123"

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -209,8 +209,10 @@ software:
     - Label B
     self_service: true
     slug: fma2/windows
+    version: 1.2.3
   - self_service: true
     slug: fma3/windows
+    version: ^123
   packages:
   - categories:
     - Browsers

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -674,11 +674,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			activeInstallerID = versions[0].ID
 		case usesCaret:
 			for _, v := range versions {
-				matches, err := versionMatchesMajor(v.Version, majorVersionString)
-				if err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "comparing Fleet-maintained app major version")
-				}
-				if matches {
+				if versionMatchesMajor(v.Version, majorVersionString) {
 					activeInstallerID = v.ID
 					break
 				}
@@ -2531,12 +2527,7 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 	}
 
 	if usesCaret {
-		matches, err := versionMatchesMajor(app.Version, majorVersionString)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "comparing Fleet-maintained app major version")
-		}
-
-		if !matches {
+		if !versionMatchesMajor(app.Version, majorVersionString) {
 			// We cannot use the FMA we just got the manifest for since it is on a different major
 			// version, so we try to find the latest cached version and use that instead.
 			if app.TitleID == nil {
@@ -3999,14 +3990,7 @@ func parsePinnedVersion(ctx context.Context, version string) (majorVersion strin
 	return majorVersion, usesCaret, nil
 }
 
-func versionMatchesMajor(version string, majorVersion string) (bool, error) {
-	v, err := fleet.VersionToSemverVersion(version)
-	if err != nil {
-		return false, err
-	}
-	major, err := fleet.VersionToSemverVersion(majorVersion)
-	if err != nil {
-		return false, err
-	}
-	return v.Major() == major.Major(), nil
+func versionMatchesMajor(version string, majorVersion string) bool {
+	versionMajor, _, _ := strings.Cut(version, ".")
+	return versionMajor == majorVersion
 }

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -3977,17 +3978,17 @@ func (svc *Service) batchAddSelfServiceCategories(ctx context.Context, teamID *u
 	return allCategories, nil
 }
 
-func parsePinnedVersion(ctx context.Context, version string) (majorVersion string, usesCaret bool, err error) {
-	majorVersion, usesCaret = strings.CutPrefix(version, "^")
+func parsePinnedVersion(ctx context.Context, version string) (trimmedVersion string, usesCaret bool, err error) {
+	trimmedVersion, usesCaret = strings.CutPrefix(version, "^")
 	if usesCaret {
-		if len(majorVersion) == 0 {
+		if len(trimmedVersion) == 0 {
 			return "", false, fleet.NewUserMessageError(errEmptyCaretVersion, http.StatusBadRequest)
 		}
-		if parts := strings.Split(version, "."); len(parts) > 1 {
+		if _, err := strconv.ParseUint(trimmedVersion, 10, 64); err != nil {
 			return "", false, fleet.NewUserMessageError(errNonMajorVersion, http.StatusBadRequest)
 		}
 	}
-	return majorVersion, usesCaret, nil
+	return trimmedVersion, usesCaret, nil
 }
 
 func versionMatchesMajor(version string, majorVersion string) bool {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -821,6 +821,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		if payload.DisplayName != nil {
 			activity.SoftwareDisplayName = *payload.DisplayName
 		}
+		if payload.PinnedVersion != nil && *payload.PinnedVersion != "" {
+			activity.PinnedVersion = payload.PinnedVersion
+		}
 		if err := svc.NewActivity(ctx, vc.User, activity); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "creating activity for edited software")
 		}

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -1743,3 +1743,65 @@ func TestGetBatchSetSoftwareInstallersResultMissingDeletedKey(t *testing.T) {
 	require.Empty(t, packages)
 	require.Empty(t, deletedPackages)
 }
+
+func TestVersionMatchesMajor(t *testing.T) {
+	// Versions taken from ee/maintained-apps/outputs; most are not valid semver. The leading dot-segment is
+	// compared as a string, so a leading-zero or bare major stays distinct from "2"/"10"/"12".
+	cases := []struct {
+		version      string
+		majorVersion string
+		want         bool
+	}{
+		{"149.1.91.172", "149", true},
+		{"149.1.91.172", "150", false},
+		{"149.1.91.172", "14", false},
+		{"6.0.4.11438", "6", true},
+		{"25.0.208.0", "25", true},
+		{"221.0.0.0.0", "221", true},
+		{"0.2026.06.10.09.27.01", "0", true},
+		{"8.0.47.CE", "8", true},
+		{"2.2.18d", "2", true},
+		{"1.2.92.148.g882cc571", "1", true},
+		{"114.0.4-release.20250509.32955", "114", true},
+		{"2026.05.0+218", "2026", true},
+		{"02.07.01.62", "02", true},
+		{"02.07.01.62", "2", false},
+		{"20250302", "20250302", true},
+		{"183", "183", true},
+		{"149", "149", true},
+		{"1.21b", "1", true},
+		{"10.0.1", "1", false},
+		{"12.0", "1", false},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, versionMatchesMajor(c.version, c.majorVersion), "version %q caret ^%s", c.version, c.majorVersion)
+	}
+}
+
+func TestParsePinnedVersion(t *testing.T) {
+	cases := []struct {
+		name      string
+		version   string
+		wantMajor string
+		wantCaret bool
+		wantErr   string
+	}{
+		{name: "latest is empty", version: "", wantMajor: "", wantCaret: false},
+		{name: "literal 4-component is not a caret", version: "149.0.7827.115", wantMajor: "149.0.7827.115", wantCaret: false},
+		{name: "caret major", version: "^149", wantMajor: "149", wantCaret: true},
+		{name: "caret leading-zero major", version: "^02", wantMajor: "02", wantCaret: true},
+		{name: "empty caret", version: "^", wantErr: errEmptyCaretVersion.Error()},
+		{name: "caret with minor", version: "^149.0", wantErr: errNonMajorVersion.Error()},
+		{name: "caret 4-component", version: "^149.1.91.172", wantErr: errNonMajorVersion.Error()},
+	}
+	for _, c := range cases {
+		major, caret, err := parsePinnedVersion(t.Context(), c.version)
+		if c.wantErr != "" {
+			require.ErrorContainsf(t, err, c.wantErr, "case %s", c.name)
+			continue
+		}
+		require.NoErrorf(t, err, "case %s", c.name)
+		assert.Equalf(t, c.wantMajor, major, "case %s", c.name)
+		assert.Equalf(t, c.wantCaret, caret, "case %s", c.name)
+	}
+}

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -1793,6 +1793,7 @@ func TestParsePinnedVersion(t *testing.T) {
 		{name: "empty caret", version: "^", wantErr: errEmptyCaretVersion.Error()},
 		{name: "caret with minor", version: "^149.0", wantErr: errNonMajorVersion.Error()},
 		{name: "caret 4-component", version: "^149.1.91.172", wantErr: errNonMajorVersion.Error()},
+		{name: "caret non-numeric", version: "^abc", wantErr: errNonMajorVersion.Error()},
 	}
 	for _, c := range cases {
 		major, caret, err := parsePinnedVersion(t.Context(), c.version)

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1186,6 +1186,7 @@ type ActivityTypeEditedSoftware struct {
 	LabelsIncludeAll    []ActivitySoftwareLabel `json:"labels_include_all,omitempty"`
 	SoftwareTitleID     uint                    `json:"software_title_id"`
 	SoftwareDisplayName string                  `json:"software_display_name"`
+	PinnedVersion       *string                 `json:"pinned_version"`
 }
 
 func (a ActivityTypeEditedSoftware) ActivityName() string {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -13002,7 +13002,8 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 			TeamID:            nil,
 		}, http.StatusOK, "")
 		activityData = fmt.Sprintf(`{"software_title": "ruby", "software_package": "ruby.deb", "software_icon_url": null, "team_name": null,
-		"team_id": null, "fleet_name": null, "fleet_id": null, "self_service": true, "software_title_id": %d, "labels_include_any": [{"id": %d, "name": %q}], "software_display_name": ""}`,
+		"team_id": null, "fleet_name": null, "fleet_id": null, "self_service": true, "software_title_id": %d, "labels_include_any": [{"id": %d, "name": %q}], "software_display_name": "",
+		"pinned_version": null}`,
 			titleID, lblA.ID, lblA.Name)
 		s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)
 
@@ -13070,7 +13071,8 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 		s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusOK, headers)
 
 		activityData = fmt.Sprintf(`{"software_title": "ruby", "software_package": "ruby.deb", "software_icon_url": null, "team_name": null,
-		"team_id": null, "fleet_name": null, "fleet_id": null, "self_service": true, "labels_include_any": [{"id": %d, "name": %q}], "software_title_id": %d, "software_display_name": ""}`,
+		"team_id": null, "fleet_name": null, "fleet_id": null, "self_service": true, "labels_include_any": [{"id": %d, "name": %q}], "software_title_id": %d, "software_display_name": "",
+		"pinned_version": null}`,
 			lblA.ID, lblA.Name, titleID)
 		s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)
 
@@ -13138,7 +13140,8 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 
 		// the edited-software activity should still carry labels_include_all
 		activityData = fmt.Sprintf(`{"software_title": "ruby", "software_package": "ruby.deb", "software_icon_url": null, "team_name": null,
-		"team_id": null, "fleet_name": null, "fleet_id": null, "self_service": true, "software_title_id": %d, "labels_include_all": [{"id": %d, "name": %q}], "software_display_name": ""}`,
+		"team_id": null, "fleet_name": null, "fleet_id": null, "self_service": true, "software_title_id": %d, "labels_include_all": [{"id": %d, "name": %q}], "software_display_name": "",
+		"pinned_version": null}`,
 			titleID, labelResp.Label.ID, t.Name())
 		s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32850,7 +32850,19 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 		installerPath:  "/zoom.msi",
 		patchQuery:     "SELECT 1 FROM osquery_info;",
 	}
-	startFMAServers(t, s.ds, map[string]*fmaTestState{"/zoom/windows.json": zoom})
+	// Google Chrome ships 4-component versions (e.g. 149.0.7827.156), which are not valid semver. It rides along
+	// on every batch apply below pinned to "^149", exercising the GitOps major match against a non-semver
+	// version — that used to fail the whole apply with "Invalid Semantic Version".
+	chrome := &fmaTestState{
+		version:        "149.0.7827.156",
+		installerBytes: []byte("chrome-149"),
+		installerPath:  "/googlechrome.msi",
+		patchQuery:     "SELECT 1 FROM osquery_info;",
+	}
+	startFMAServers(t, s.ds, map[string]*fmaTestState{
+		"/zoom/windows.json":          zoom,
+		"/google-chrome/windows.json": chrome,
+	})
 
 	var teamResp teamResponse
 	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{
@@ -32859,6 +32871,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	team := *teamResp.Team
 
 	batchSet := func(software []*fleet.SoftwareInstallerPayload) []fleet.SoftwarePackageResponse {
+		software = append(software, &fleet.SoftwareInstallerPayload{Slug: new("google-chrome/windows"), RollbackVersion: "^149"})
 		var resp batchSetSoftwareInstallersResponse
 		s.DoJSON("POST", "/api/latest/fleet/software/batch",
 			batchSetSoftwareInstallersRequest{Software: software, TeamName: team.Name},
@@ -32873,9 +32886,18 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// Cache v1.0, then bump the manifest and cache v2.0 (GitOps applies, no pin).
 	pkgs := batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
-	require.NotEmpty(t, pkgs)
-	require.NotNil(t, pkgs[0].TitleID)
-	titleID := *pkgs[0].TitleID
+	var titleID, chromeTitleID uint
+	for _, pkg := range pkgs {
+		require.NotNil(t, pkg.TitleID)
+		switch pkg.Slug {
+		case "zoom/windows":
+			titleID = *pkg.TitleID
+		case "google-chrome/windows":
+			chromeTitleID = *pkg.TitleID
+		}
+	}
+	require.NotZero(t, titleID)
+	require.NotZero(t, chromeTitleID)
 
 	bumpVersion("2.0", []byte("zoom-2.0"))
 	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
@@ -32911,6 +32933,11 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	p := getPkg()
 	require.Equal(t, "2.0", p.Version)
 	require.Nil(t, p.PinnedVersion)
+	// Chrome's ^149 caret resolved against its 4-component version on the applies above.
+	var chromeResp getSoftwareTitleResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", chromeTitleID), nil, http.StatusOK, &chromeResp, "team_id", fmt.Sprint(team.ID))
+	require.Equal(t, "149.0.7827.156", chromeResp.SoftwareTitle.SoftwarePackage.Version)
+	require.Equal(t, new("^149"), chromeResp.SoftwareTitle.SoftwarePackage.PinnedVersion)
 
 	// Dependencies on the title: an install-automation policy (carries software_installer_id, re-pointed to the
 	// active installer on a flip) and a patch policy (title-scoped via patch_software_title_id, never re-pointed).

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32930,12 +32930,24 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 		})
 		s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusOK, headers)
 	}
+	// requireLastPinActivity asserts the latest activity is an edited_software with want as pinned_version.
+	// Marshaling want renders a pin as "1.0"/"^2" and a cleared pin (nil) as null, so no branching is needed.
+	requireLastPinActivity := func(want *string) {
+		pinnedVersion, err := json.Marshal(want)
+		require.NoError(t, err)
+		s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), fmt.Sprintf(
+			`{"team_id": %d, "fleet_id": %d, "team_name": %q, "fleet_name": %q, "self_service": false, `+
+				`"software_title": "Zoom Workplace (X64)", "software_package": "zoom.msi", "software_icon_url": null, `+
+				`"software_title_id": %d, "software_display_name": "", "pinned_version": %s}`,
+			team.ID, team.ID, team.Name, team.Name, titleID, pinnedVersion), 0)
+	}
 
 	// --- UI (PATCH) pins, on the static 1.0/2.0 cache ---
 
 	// Rollback to an older cached version. The install policy is re-pointed to the now-active installer; the patch
 	// policy is title-scoped and stays put.
 	patchVersion("1.0")
+	requireLastPinActivity(new("1.0"))
 	p = getPkg()
 	require.Equal(t, "1.0", p.Version)
 	require.Equal(t, new("1.0"), p.PinnedVersion)
@@ -32944,6 +32956,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// Caret resolves to the newest cached minor in that major.
 	patchVersion("^2")
+	requireLastPinActivity(new("^2"))
 	p = getPkg()
 	require.Equal(t, "2.0", p.Version)
 	require.Equal(t, new("^2"), p.PinnedVersion)
@@ -32951,6 +32964,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// A caret with no cached installer in that major keeps the newest cached version instead of erroring.
 	patchVersion("^9")
+	requireLastPinActivity(new("^9"))
 	p = getPkg()
 	require.Equal(t, "2.0", p.Version)
 	require.Equal(t, new("^9"), p.PinnedVersion)
@@ -32958,6 +32972,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// Empty clears the pin row, back to Latest.
 	patchVersion("")
+	requireLastPinActivity(nil)
 	p = getPkg()
 	require.Equal(t, "2.0", p.Version)
 	require.Nil(t, p.PinnedVersion)
@@ -32980,6 +32995,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// Last write wins: a GitOps apply with no version resets a prior UI pin back to Latest.
 	patchVersion("1.0")
+	requireLastPinActivity(new("1.0"))
 	p = getPkg()
 	require.Equal(t, "1.0", p.Version)
 	require.Equal(t, new("1.0"), p.PinnedVersion)
@@ -32995,6 +33011,7 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 	// A caret pin tracks a newly released minor in the pinned major: releasing 2.5 under "^2" moves the active
 	// version forward to 2.5.
 	patchVersion("^2")
+	requireLastPinActivity(new("^2"))
 	p = getPkg()
 	require.Equal(t, "2.0", p.Version)
 	require.Equal(t, new("^2"), p.PinnedVersion)
@@ -33059,11 +33076,13 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	// Pin the older 4.0, then clear to Latest and confirm it resolves to 10.0, not the string-larger "4.0".
 	patchVersion("4.0")
+	requireLastPinActivity(new("4.0"))
 	p = getPkg()
 	require.Equal(t, "4.0", p.Version)
 	require.Equal(t, new("4.0"), p.PinnedVersion)
 
 	patchVersion("")
+	requireLastPinActivity(nil)
 	p = getPkg()
 	require.Equal(t, "10.0", p.Version)
 	require.Nil(t, p.PinnedVersion)

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -112,7 +112,8 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 	    "team_id": %d,
 		"self_service": false,
 		"software_title_id": %d,
-		"software_display_name": "%s"
+		"software_display_name": "%s",
+		"pinned_version": null
 	}`,
 		team.Name, team.Name, team.ID, team.ID, titleID, "RubyUpdate1")
 	s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)
@@ -168,7 +169,8 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 	    "team_id": %d,
 		"self_service": true,
 		"software_title_id": %d,
-		"software_display_name": "%s"
+		"software_display_name": "%s",
+		"pinned_version": null
 	}`,
 		team.Name, team.Name, team.ID, team.ID, titleID, "RubyUpdate1")
 	s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)
@@ -475,7 +477,8 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 		    "team_id": %d,
 			"self_service": true,
 			"software_title_id": %d,
-			"software_display_name": "%s"
+			"software_display_name": "%s",
+			"pinned_version": null
 		}`,
 		team.Name, team.Name, team.ID, team.ID, titleID, "InHouseAppUpdate2")
 	s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -1815,7 +1815,7 @@ func (s *integrationMDMTestSuite) TestInHouseAppSelfInstall() {
 	s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{SelfService: ptr.Bool(true), TitleID: titleID, TeamID: nil},
 		http.StatusOK, "")
 	activityData = fmt.Sprintf(`{"software_title": "ipa_test", "software_package": "ipa_test.ipa", "software_display_name": "", "software_icon_url": null, "fleet_name": null, "team_name": null,
-		"fleet_id": null, "team_id": null, "self_service": true, "software_title_id": %d}`, titleID)
+		"fleet_id": null, "team_id": null, "self_service": true, "software_title_id": %d, "pinned_version": null}`, titleID)
 	s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)
 
 	// self-install request is accepted


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47679 
Adds a few things:
- exports pinned version in `generate-gitops` enclosed in double quotes
- adds `pinned_version` to the edited software activity. When set to a full or major version it shows up in details, when set to latest or unchanged it shows up as `pinned_version: null` (some other fields like display_name also dont show up when unchanged)
- fixes a bug where some FMA's like google chrome couldn't be pinned to major version because they couldn't be converted to semver (by just splitting the version on periods instead of converting to semver)


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Software titles now support version pinning in GitOps exports for fleet-managed applications, with pinned version values properly formatted as quoted strings in the exported YAML configuration
  * Activity logs now record when pinned version information is modified during software editing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->