### PR TITLE
Okta conditional access certificates

### DIFF
--- a/articles/okta-conditional-access-integration.md
+++ b/articles/okta-conditional-access-integration.md
@@ -75,7 +75,7 @@ Replace:
 3. Copy the profile to a new `.mobileconfig` file and save.
 4. Follow the instructions in the [custom OS settings](https://fleetdm.com/guides/custom-os-settings) guide to deploy the profile to the hosts where you want conditional access to apply.
 
-Deploying this profile will deploy a SCEP certificate to your hosts. These certificates are valid for 1 year and 33 days.
+Deploying this profile will deploy a SCEP certificate to your hosts. These certificates are valid for 1 year and 33 days and Fleet will automatically renew them. [Learn more](https://fleetdm.com/guides/connect-end-user-to-wifi-with-certificate#renewal).
 
 > If using GitOps, use the challenge in a [secret variable](https://fleetdm.com/guides/secrets-in-scripts-and-configuration-profiles), instead of hardcoding into the profile.
 


### PR DESCRIPTION
Fleet added automatic renewal for SCEP certificates that are not proxied through Fleet:
- https://github.com/fleetdm/fleet/issues/40639

I think the Okta conditional access certificate is one of these.
