### PR TITLE
Fleet UI: Auto-dismiss success toasts after navigation

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -69,9 +69,9 @@ Use react-router, not `window.location` / `window.history`. Direct window mutati
 - Internal `<CustomLink>` (and any `router.push` / `<Link>`) to a fleet-scoped route MUST preserve the current fleet via `getPathWithQueryParams(PATHS.X, { fleet_id: teamId })`. Linking to the bare path drops fleet context and lands the user on the wrong fleet. Applies to any path that reads `fleet_id` from the query string (most `/software`, `/hosts`, `/policies`, `/queries`, `/controls` routes). `getPathWithQueryParams` filters undefined/null, so pass `teamId` directly — `fleet_id=0` (No team) is a valid, intentional value and must be preserved.
 
 ## Notifications
-- Use `renderFlash(alertType, message)` from `NotificationContext`
-- Types: `"success"`, `"error"`, `"warning-filled"`
-- Use `renderMultiFlash()` for batch operations
+- Use `notify.success(msg)` / `notify.error(msg, { response })` / `notify.batch([...])` from `components/ToastNotification`.
+- **Call `notify.*` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page (#48088).
+- Success auto-dismisses after 5s; errors are sticky.
 
 ## XSS Prevention
 - ALWAYS sanitize user-generated HTML before `dangerouslySetInnerHTML`. Approved helpers:

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -70,8 +70,8 @@ Use react-router, not `window.location` / `window.history`. Direct window mutati
 
 ## Notifications
 - Use `notify.success(msg)` / `notify.error(msg, { response })` / `notify.batch([...])` from `components/ToastNotification`.
-- **Call `notify.*` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page (#48088).
-- Success auto-dismisses after 5s; errors are sticky.
+- **When showing a success toast and navigating, call `notify.success` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page (#48088).
+- Success toasts auto-dismiss after 5s by default; error toasts are sticky by default.
 
 ## XSS Prevention
 - ALWAYS sanitize user-generated HTML before `dangerouslySetInnerHTML`. Approved helpers:

--- a/frontend/components/EmailTokenRedirect/EmailTokenRedirect.tsx
+++ b/frontend/components/EmailTokenRedirect/EmailTokenRedirect.tsx
@@ -24,8 +24,8 @@ const EmailTokenRedirect = ({
       if (currentUser && token) {
         try {
           await usersAPI.confirmEmailChange(currentUser, token);
-          router.push(PATHS.ACCOUNT);
           notify.success("Email updated successfully.");
+          router.push(PATHS.ACCOUNT);
         } catch (error) {
           console.log(error);
           router.push(PATHS.LOGIN);

--- a/frontend/components/ToastNotification/ToastNotification.tsx
+++ b/frontend/components/ToastNotification/ToastNotification.tsx
@@ -239,10 +239,10 @@ const nextToastId = (): ToastId => {
 export const notify: INotify = {
   success: (message, options) => {
     const id = options?.id ?? nextToastId();
-    // Defer one tick:
-    // Toast fired in the same handler as a router.push is then created AFTER the
-    // route change — and after the route-change dismiss — so it lands on the
-    // destination page whether the caller notifies before or after navigating.
+    // Defer one tick so the toast is created after the route-change
+    // dismiss above, landing it on the destination page. Call notify
+    // before router.push — the reverse order can break auto-dismiss
+    // on the destination page (#48088).
     setTimeout(() => {
       toast.custom(
         (sonnerId) => (

--- a/frontend/components/ToastNotification/ToastNotification.tsx
+++ b/frontend/components/ToastNotification/ToastNotification.tsx
@@ -240,9 +240,9 @@ export const notify: INotify = {
   success: (message, options) => {
     const id = options?.id ?? nextToastId();
     // Defer one tick so the toast is created after the route-change
-    // dismiss above, landing it on the destination page. Call notify
-    // before router.push — the reverse order can break auto-dismiss
-    // on the destination page (#48088).
+    // dismiss above, landing it on the destination page. When a handler
+    // both navigates and shows a success toast, call notify.success
+    // before router.push — the reverse order can break auto-dismiss (#48088).
     setTimeout(() => {
       toast.custom(
         (sonnerId) => (

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -575,7 +575,6 @@ initialized. View currently working contexts in the [context directory](../conte
 
 ```typescript
 // Consuming a context — destructure what you need from useContext
-const { renderFlash } = useContext(NotificationContext);
 const { currentUser, isPremiumTier } = useContext(AppContext);
 ```
 
@@ -584,7 +583,6 @@ const { currentUser, isPremiumTier } = useContext(AppContext);
 | Context | Purpose | Use this when |
 |---|---|---|
 | `AppContext` | Global app state: current user, config, team selection, role flags, license info | You need user identity, permissions, feature flags, or the active fleet |
-| `NotificationContext` | Flash message banners (`renderFlash`, `renderMultiFlash`, `hideFlash`) | You need to show success/error/warning notifications after an action |
 | `PolicyContext` | In-progress policy editing state: name, query, resolution, platform, labels | You're on the policy edit/create flow and need to persist form state across steps |
 | `QueryContext` | In-progress report editing state: name, query body, frequency, targets, logging | You're on the report edit/create flow and need to persist form state across steps |
 | `RoutingContext` | Stores a redirect location for post-auth navigation | You need to redirect the user after login (e.g., deep link they hit while logged out) |
@@ -615,7 +613,7 @@ const PageOrComponent = (props) => {
       // do something
     } catch(error) {
       console.error(error);
-      // maybe trigger renderFlash
+      // maybe trigger notify.error
     }
   };
 
@@ -695,7 +693,7 @@ try {
   await softwareAPI.install()
   // successful messgae
 } catch (e) {
-  renderFlash("error", getErrorMessage(e))
+  notify.error(getErrorMessage(e))
 }
 
 /* in helpers.tsx */
@@ -1067,20 +1065,18 @@ then the [app's context](#react-context) should be used.
 If you are dealing with a page that *updates* any kind of config, set the local
 config with the response of your update call to make sure it has the latest.
 
-### Rendering flash messages
+### Toast notifications
 
-Flash messages by default will be hidden when the user performs any navigation that changes the URL,
-in addition to the timeout set for success messages. The `renderFlash` method from notification
-context accepts an optional third `options` argument which contains an optional
-`persistOnPageChange` boolean field that can be set to `true` to negate this default behavior.
+Use `notify.success(msg)` / `notify.error(msg, { response })` / `notify.batch([...])` from
+`components/ToastNotification`. Success toasts auto-dismiss after 5s; error toasts are sticky.
+All toasts are dismissed automatically on URL change.
 
-If the `renderFlash` is accompanied by a router push, it's important to push to the router *before*
-calling `renderFlash`. If the push comes after the `renderFlash` call,
-the flash message may register the `push` and immediately hide itself.
+**Call `notify.*` before `router.push` / `router.replace`** — the reverse order can break
+auto-dismiss on the destination page (#48088).
 
 ```tsx
-// first push
+// first notify
+notify.error("Something went wrong");
+// then push
 router.push(newPath);
-// then flash
-renderFlash("error", "Something went wrong");
 ```

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -1068,11 +1068,10 @@ config with the response of your update call to make sure it has the latest.
 ### Toast notifications
 
 Use `notify.success(msg)` / `notify.error(msg, { response })` / `notify.batch([...])` from
-`components/ToastNotification`. Success toasts auto-dismiss after 5s; error toasts are sticky.
-All toasts are dismissed automatically on URL change.
+`components/ToastNotification`. Success toasts auto-dismiss after 5s by default; error toasts are sticky by default.
+Visible toasts are dismissed automatically on URL change.
 
-**Call `notify.*` before `router.push` / `router.replace`** — the reverse order can break
-auto-dismiss on the destination page (#48088).
+**When showing a success toast and navigating, call `notify.success` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page (#48088).
 
 ```tsx
 // first notify

--- a/frontend/pages/ConfirmInvitePage/ConfirmInvitePage.tsx
+++ b/frontend/pages/ConfirmInvitePage/ConfirmInvitePage.tsx
@@ -56,10 +56,10 @@ const ConfirmInvitePage = ({ router, params }: IConfirmInvitePageProps) => {
 
       try {
         await usersAPI.create(dataForAPI);
-        router.push(paths.LOGIN);
         notify.success(
           "Registration successful! For security purposes, please log in."
         );
+        router.push(paths.LOGIN);
       } catch (error) {
         const reason = getErrorReason(error);
         console.error(reason);

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
@@ -69,8 +69,8 @@ const AppleMdmPage = ({ router }: { router: InjectedRouter }) => {
     try {
       await mdmAppleAPI.deleteApplePushCertificate();
       await queryClient.invalidateQueries(["config"]);
-      router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
       notify.success("MDM turned off successfully.");
+      router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
     } catch (e) {
       notify.error("Couldn't turn off MDM. Please try again.", {
         response: e,

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -300,8 +300,8 @@ const TeamDetailsWrapper = ({
 
     try {
       await teamsAPI.destroy(teamIdForApi);
-      router.push(PATHS.ADMIN_FLEETS);
       notify.success("Fleet removed");
+      router.push(PATHS.ADMIN_FLEETS);
     } catch (response) {
       notify.error("Something went wrong removing the fleet", { response });
       console.error(response);

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -300,7 +300,7 @@ const TeamDetailsWrapper = ({
 
     try {
       await teamsAPI.destroy(teamIdForApi);
-      notify.success("Fleet removed");
+      notify.success(`Successfully deleted ${currentTeamName}.`);
       router.push(PATHS.ADMIN_FLEETS);
     } catch (response) {
       notify.error("Something went wrong removing the fleet", { response });
@@ -309,7 +309,7 @@ const TeamDetailsWrapper = ({
       toggleDeleteFleetModal();
       setIsUpdatingTeams(false);
     }
-  }, [teamIdForApi, router, toggleDeleteFleetModal]);
+  }, [teamIdForApi, currentTeamName, router, toggleDeleteFleetModal]);
 
   const onEditSubmit = useCallback(
     async (formData: ITeamFormData) => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -722,8 +722,8 @@ const HostDetailsPage = ({
       setIsUpdating(true);
       try {
         await hostAPI.destroy(host);
-        router.push(PATHS.MANAGE_HOSTS);
         notify.success(`Host "${host.display_name}" was successfully deleted.`);
+        router.push(PATHS.MANAGE_HOSTS);
       } catch (error) {
         console.log(error);
         notify.error(`Host "${host.display_name}" could not be deleted.`, {

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -337,8 +337,8 @@ const NewLabelPage = ({
     setIsUpdating(true);
     try {
       await labelsAPI.create(formData);
-      router.push(PATHS.MANAGE_LABELS);
       notify.success("Label added successfully.");
+      router.push(PATHS.MANAGE_LABELS);
     } catch (error) {
       const status = (error as { status: number }).status;
       let errorMessage = "Couldn't add label. Please try again.";

--- a/frontend/pages/packs/EditPackPage/EditPackPage.tsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.tsx
@@ -156,8 +156,8 @@ const EditPacksPage = ({
     packsAPI
       .update(packId, updatedPack)
       .then(() => {
-        router.push(PATHS.MANAGE_PACKS);
         notify.success(`Successfully updated this pack.`);
+        router.push(PATHS.MANAGE_PACKS);
       })
       .catch((e) => {
         if (

--- a/frontend/pages/packs/PackComposerPage/PackComposerPage.tsx
+++ b/frontend/pages/packs/PackComposerPage/PackComposerPage.tsx
@@ -49,8 +49,8 @@ const PackComposerPage = ({ router }: IPackComposerPageProps): JSX.Element => {
       const {
         pack: { id: packID },
       } = await create(formData);
-      router.push(PATHS.PACK(packID));
       notify.success("Pack successfully created. Add queries to your pack.");
+      router.push(PATHS.PACK(packID));
     } catch (e) {
       if (
         getErrorReason(e, {

--- a/frontend/pages/policies/edit/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/edit/screens/QueryEditor.tsx
@@ -181,12 +181,12 @@ const QueryEditor = ({
             );
           }
         }
+        notify.success("Policy created.");
         router.push(
           getPathWithQueryParams(PATHS.POLICY_DETAILS(policy.id), {
             fleet_id: policy.team_id,
           })
         );
-        notify.success("Policy created.");
       } catch (createError) {
         if (getErrorReason(createError).includes("already exists")) {
           setBackendValidators({

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -262,13 +262,13 @@ const EditQueryPage = ({
     setIsQuerySaving(true);
     try {
       const { query } = await queryAPI.create(formData);
+      notify.success("Report created.");
       router.push(
         getPathWithQueryParams(PATHS.REPORT_DETAILS(query.id), {
           fleet_id: query.team_id,
           host_id: hostId,
         })
       );
-      notify.success("Report created.");
       setBackendValidators({});
     } catch (createError) {
       if (getErrorReason(createError).includes("already exists")) {


### PR DESCRIPTION
## Issue
Closes #48088

## Description
- Bug fix (root cause): `notify.success(...)` called after `router.push(...)` can fail to auto-dismiss on the destination page. Reorder to `notify.*` then `router.push` lets the deferred-tick mechanism in the toast wrapper queue the toast cleanly. Confirmed manually fixes Policy created (#48088).
- Defensive: applied the same one-line swap at 9 other callsites with the same `router.push` → `notify.success` pattern (TeamDetailsWrapper, AppleMdmPage, NewLabelPage, EditQueryPage, PackComposerPage, EditPackPage, ConfirmInvitePage, HostDetailsPage, EmailTokenRedirect). Manual one-shot testing can't rule out a flaky race at those, so swapping defensively rather than relying on observation.
- Drive-by copy: the fleet delete toast in `TeamDetailsWrapper` said `"Fleet removed"`, but the sibling delete-from-list flow (`ManageFleetsPage.tsx`) and the dominant codebase pattern is `Successfully deleted ${name}.`. Aligned the two so both fleet delete paths produce the same toast.
- Docs: rewrote the stale "Rendering flash messages" section in `frontend/docs/patterns.md` — it documented the *opposite* ordering rule for the removed `renderFlash` API and was actively misleading anyone writing new toast code. Updated surrounding examples to use `notify`.
- Rule: added the ordering rule to `.claude/rules/fleet-frontend.md` Notifications section and a short comment in `ToastNotification.tsx` near the `setTimeout` deferral pointing to #48088.

## Screenrecording
- Policy created toast auto-dismissing after 5 seconds


<!-- recording goes here -->


## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
- Manual checklist below (More info); pending QA Playwright sweep (~20× per case) to catch any flaky timing.

## More info

**Expected for each:** toast appears bottom-right, auto-dismisses after 5 seconds without interaction.
**Bug signature:** toast stays visible until manually clicked (X) or the next navigation.

- [x] **Policy created.** — Policies → Add policy → Save → fill in name + change targets → Save  
  `frontend/pages/policies/edit/screens/QueryEditor.tsx:184-189`
- [ ] **Email updated successfully.** — Account → change email → open confirmation link (or visit `/login/email/<token>`) → lands on `/account`  
  `frontend/components/EmailTokenRedirect/EmailTokenRedirect.tsx:27-28`
- [ ] **MDM turned off successfully.** — Settings → Integrations → Mobile device management (MDM) → Apple (with APNs configured) → Turn off MDM → confirm in modal  
  `frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx:72-73`
- [x] **Label added successfully.** — Hosts → Add label → fill in name + query → Save  
  `frontend/pages/labels/NewLabelPage/NewLabelPage.tsx:340-341`
- [ ] **Registration successful! For security purposes, please log in.** — Open an invite link (`/login/invites/<token>`) → fill in name + password → Submit → lands on `/login`  
  `frontend/pages/ConfirmInvitePage/ConfirmInvitePage.tsx:59-62`
- [x] **Host "\<name>" was successfully deleted.** — Hosts → click any host → Actions → Delete → confirm in modal  
  `frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx:725-726`
- [x] **Successfully deleted \<fleet name>.** — Settings → Fleets → click a fleet → Settings tab → Delete fleet → confirm in modal  
  `frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx:303-304`
- [x] **Pack successfully created. Add queries to your pack.** — Reports → Manage packs → Create new pack → fill in name → Save → lands on `/packs/<id>`  
  `frontend/pages/packs/PackComposerPage/PackComposerPage.tsx:52-53`
- [x] **Successfully updated this pack.** — Reports → Manage packs → click any pack → change anything (e.g. description) → Save changes → lands on `/packs/manage`  
  `frontend/pages/packs/EditPackPage/EditPackPage.tsx:159-160`
- [x] **Report created.** — Reports → Add report → write any SQL → Save → fill in name → Save → lands on `/reports/<id>`  
  `frontend/pages/queries/edit/EditQueryPage.tsx:265-271`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification timing across workflows: success notifications now display before page navigation, ensuring users see confirmation of completed actions before transitioning to the next page. This enhances feedback clarity on operations like email updates, registrations, fleet deletions, host removals, label creation, and policy edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->