### PR TITLE
Auto-update FMA cron

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2258,6 +2258,32 @@ func newMaintainedAppSchedule(
 	return s, nil
 }
 
+func newMaintainedAppsAutoUpdateSchedule(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	logger *slog.Logger,
+) (*schedule.Schedule, error) {
+	const (
+		name            = string(fleet.CronMaintainedAppsAutoUpdate)
+		defaultInterval = 1 * time.Hour
+		priorJobDiff    = -(defaultInterval - 30*time.Second)
+	)
+
+	logger = logger.With("cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, defaultInterval, ds, ds,
+		schedule.WithLogger(logger),
+		// ensures it runs a few seconds after Fleet is started
+		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
+		schedule.WithJob("maintained_apps_auto_update", func(ctx context.Context) error {
+			return eeservice.AutoUpdateFleetMaintainedApps(ctx, ds, logger)
+		}),
+	)
+
+	return s, nil
+}
+
 func newRefreshVPPAppVersionsSchedule(
 	ctx context.Context,
 	instanceID string,

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2262,6 +2262,7 @@ func newMaintainedAppsAutoUpdateSchedule(
 	ctx context.Context,
 	instanceID string,
 	ds fleet.Datastore,
+	softwareInstallStore fleet.SoftwareInstallerStore,
 	logger *slog.Logger,
 ) (*schedule.Schedule, error) {
 	const (
@@ -2277,7 +2278,7 @@ func newMaintainedAppsAutoUpdateSchedule(
 		// ensures it runs a few seconds after Fleet is started
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("maintained_apps_auto_update", func(ctx context.Context) error {
-			return eeservice.AutoUpdateFleetMaintainedApps(ctx, ds, logger)
+			return eeservice.AutoUpdateFleetMaintainedApps(ctx, ds, softwareInstallStore, logger)
 		}),
 	)
 

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -306,7 +306,7 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 	})
 
 	deps.register("failed to register maintained apps auto-update schedule", func() (fleet.CronSchedule, error) {
-		return newMaintainedAppsAutoUpdateSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
+		return newMaintainedAppsAutoUpdateSchedule(ctx, deps.instanceID, deps.ds, deps.softwareInstallStore, deps.logger)
 	})
 
 	deps.register("failed to register refresh vpp app versions schedule", func() (fleet.CronSchedule, error) {

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -305,6 +305,10 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 		return newMaintainedAppSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
 	})
 
+	deps.register("failed to register maintained apps auto-update schedule", func() (fleet.CronSchedule, error) {
+		return newMaintainedAppsAutoUpdateSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
+	})
+
 	deps.register("failed to register refresh vpp app versions schedule", func() (fleet.CronSchedule, error) {
 		return newRefreshVPPAppVersionsSchedule(ctx, deps.instanceID, deps.ds, deps.logger, apple_apps.Configure(ctx, deps.ds, deps.config.License.Key, deps.config.MDM.AppleConnectJWT))
 	})

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -5,25 +5,50 @@ import (
 	"database/sql"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/file"
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	maintained_apps "github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
 )
 
 // AutoUpdateFleetMaintainedApps walks every active Fleet-maintained app
-// installer and, where its pin state allows, advances it to a newer version
-// already cached for the team — it never fetches new versions from upstream.
-// A failure on one app is logged and skipped so a single bad row can't stall
-// the whole run.
-func AutoUpdateFleetMaintainedApps(ctx context.Context, ds fleet.Datastore, logger *slog.Logger) error {
+// installer and, where its pin state allows, downloads the newest published
+// version into the team's cache and advances the active installer to it. When
+// softwareInstallStore is nil (e.g. the installer store isn't configured) it
+// degrades to promote-only: it advances among versions already cached but
+// fetches nothing from upstream. A failure on one app is logged and skipped so a
+// single bad row can't stall the whole run.
+func AutoUpdateFleetMaintainedApps(ctx context.Context, ds fleet.Datastore, softwareInstallStore fleet.SoftwareInstallerStore, logger *slog.Logger) error {
 	candidates, err := ds.ListFleetMaintainedAppActiveInstallers(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "listing active fleet-maintained app installers")
 	}
 
+	// One HTTP client and one manifest cache for the whole run, so each distinct
+	// manifest is fetched at most once regardless of how many teams use the app.
+	var client *http.Client
+	if softwareInstallStore != nil {
+		timeout := maintained_apps.InstallerTimeout
+		if v := dev_mode.Env("FLEET_DEV_MAINTAINED_APPS_INSTALLER_TIMEOUT"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil {
+				timeout = d
+			}
+		}
+		client = fleethttp.NewClient(fleethttp.WithTimeout(timeout))
+	}
+	manifests := map[string]*manifestEntry{}
+
 	for _, c := range candidates {
-		if err := autoUpdateOneFleetMaintainedApp(ctx, ds, logger, c); err != nil {
+		if err := autoUpdateOneFleetMaintainedApp(ctx, ds, softwareInstallStore, client, logger, c, manifests); err != nil {
 			logger.ErrorContext(ctx, "auto-updating fleet-maintained app",
 				"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug, "err", err)
 		}
@@ -31,7 +56,15 @@ func AutoUpdateFleetMaintainedApps(ctx context.Context, ds fleet.Datastore, logg
 	return nil
 }
 
-func autoUpdateOneFleetMaintainedApp(ctx context.Context, ds fleet.Datastore, logger *slog.Logger, c fleet.FMAAutoUpdateCandidate) error {
+func autoUpdateOneFleetMaintainedApp(
+	ctx context.Context,
+	ds fleet.Datastore,
+	store fleet.SoftwareInstallerStore,
+	client *http.Client,
+	logger *slog.Logger,
+	c fleet.FMAAutoUpdateCandidate,
+	manifests map[string]*manifestEntry,
+) error {
 	pinned, err := ds.GetPinnedVersion(ctx, c.TeamID, c.TitleID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return ctxerr.Wrap(ctx, err, "getting pinned version")
@@ -41,11 +74,30 @@ func autoUpdateOneFleetMaintainedApp(ctx context.Context, ds fleet.Datastore, lo
 		pin = *pinned
 	}
 
-	// A literal pin never advances.
+	// A literal pin never advances and never pre-caches: the version is already
+	// cached and nothing newer is wanted (re-pinning is handled on-demand).
 	if pin != "" && !strings.HasPrefix(pin, "^") {
 		return nil
 	}
 
+	// Download the latest published version when the store is configured and the
+	// pin would actually promote to it. Download failures are isolated: we log and
+	// still try to promote among whatever is already cached.
+	if store != nil && client != nil {
+		if err := downloadNewVersionIfEligible(ctx, ds, store, logger, c, pin, client, manifests); err != nil {
+			logger.ErrorContext(ctx, "downloading new fleet-maintained app version",
+				"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug, "err", err)
+		}
+	}
+
+	return promoteFleetMaintainedApp(ctx, ds, logger, c, pin)
+}
+
+// promoteFleetMaintainedApp advances the active installer to the newest cached
+// version the pin allows, without ever rewriting the pin (a nil PinnedVersion
+// leaves it untouched, so an admin pin changed between this read and write is
+// never clobbered).
+func promoteFleetMaintainedApp(ctx context.Context, ds fleet.Datastore, logger *slog.Logger, c fleet.FMAAutoUpdateCandidate, pin string) error {
 	// Cached versions, semver-sorted newest-first.
 	versions, err := ds.GetFleetMaintainedVersionsByTitleID(ctx, c.TeamID, c.TitleID, true)
 	if err != nil {
@@ -61,10 +113,6 @@ func autoUpdateOneFleetMaintainedApp(ctx context.Context, ds fleet.Datastore, lo
 		return nil
 	}
 
-	// PinnedVersion stays nil: the cron only flips the active installer and must
-	// not rewrite the pin, or it could clobber a pin an admin changed between this
-	// read and write. Latest stays Latest (no row created) and a caret pin is left
-	// in place.
 	payload := &fleet.UpdateSoftwareInstallerPayload{
 		TeamID:  c.TeamID,
 		TitleID: c.TitleID,
@@ -81,6 +129,170 @@ func autoUpdateOneFleetMaintainedApp(ctx context.Context, ds fleet.Datastore, lo
 		"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug,
 		"from", c.Version, "to", target.Version, "pin", pin)
 	return nil
+}
+
+// manifestEntry memoizes the hydrated latest manifest (or its fetch error) for a
+// slug across the run, so N teams sharing an app fetch the manifest once.
+type manifestEntry struct {
+	app *fleet.MaintainedApp
+	err error
+}
+
+// downloadNewVersionIfEligible fetches the latest manifest, and if the pin would
+// promote to it and it isn't already cached, downloads the installer and caches
+// it (inactive) for the team. Promotion happens separately, after this returns,
+// so the bytes are always stored before the active flag flips.
+func downloadNewVersionIfEligible(
+	ctx context.Context,
+	ds fleet.Datastore,
+	store fleet.SoftwareInstallerStore,
+	logger *slog.Logger,
+	c fleet.FMAAutoUpdateCandidate,
+	pin string,
+	client *http.Client,
+	manifests map[string]*manifestEntry,
+) error {
+	app, err := hydrateLatestManifest(ctx, ds, c, manifests)
+	if err != nil {
+		return err
+	}
+
+	// Caret pin: caching a version the pin can never promote to wastes a slot, so
+	// only download when latest is within the pinned major. Empty pin always takes
+	// latest; literal pins were filtered out by the caller.
+	if pin != "" && !versionMatchesMajor(app.Version, strings.TrimPrefix(pin, "^")) {
+		return nil
+	}
+
+	if app.Version != "latest" {
+		has, err := ds.HasFMAInstallerVersion(ctx, c.TeamID, c.FleetMaintainedAppID, app.Version)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking cached version")
+		}
+		if has {
+			return nil
+		}
+	}
+
+	// Byte dedup: when the expected hash is known and already in the store (another
+	// team cached the same version), skip the HTTP download and reuse the bytes.
+	storageID := app.SHA256
+	needBytes := true
+	if app.SHA256 != noCheckHash && app.Version != "latest" {
+		exists, err := store.Exists(ctx, app.SHA256)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking installer store")
+		}
+		needBytes = !exists
+	}
+
+	version := app.Version
+	filename := ""
+	var tfr *fleet.TempFileReader
+	if needBytes {
+		tfr, filename, err = maintained_apps.DownloadInstaller(ctx, app.InstallerURL, client)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "downloading app installer")
+		}
+		defer tfr.Close()
+
+		gotHash, err := file.SHA256FromTempFileReader(tfr)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "calculating SHA256 hash")
+		}
+		if app.SHA256 != noCheckHash {
+			if gotHash != app.SHA256 {
+				return ctxerr.New(ctx, "mismatch in maintained app SHA256 hash")
+			}
+		} else {
+			storageID = gotHash
+		}
+
+		if version == "latest" { // download URL isn't version-pinned; extract version from installer
+			meta, err := file.ExtractInstallerMetadata(tfr)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "extracting installer metadata")
+			}
+			if err := tfr.Rewind(); err != nil {
+				return ctxerr.Wrap(ctx, err, "resetting installer file reader")
+			}
+			version = meta.Version
+		}
+	}
+
+	// Re-check the cache once the concrete version is known (covers "latest").
+	if version != app.Version {
+		has, err := ds.HasFMAInstallerVersion(ctx, c.TeamID, c.FleetMaintainedAppID, version)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking cached version")
+		}
+		if has {
+			return nil
+		}
+	}
+
+	if filename == "" { // bytes were reused; derive a filename from the URL
+		if u, err := url.Parse(app.InstallerURL); err == nil {
+			filename = path.Base(u.Path)
+		}
+	}
+
+	payload := &fleet.UploadSoftwareInstallerPayload{
+		TeamID:          c.TeamID,
+		Version:         version,
+		Filename:        filename,
+		Extension:       strings.TrimLeft(filepath.Ext(filename), "."),
+		StorageID:       storageID,
+		URL:             app.InstallerURL,
+		UpgradeCode:     app.UpgradeCode,
+		PatchQuery:      app.PatchQuery,
+		InstallScript:   app.InstallScript,
+		UninstallScript: app.UninstallScript,
+		InstallerFile:   tfr,
+	}
+
+	if _, err := ds.InsertFleetMaintainedAppVersion(ctx, c.InstallerID, payload); err != nil {
+		return ctxerr.Wrap(ctx, err, "caching new fleet-maintained app version")
+	}
+
+	// Store bytes before the caller promotes, so the active row never points at
+	// installer bytes that aren't in the store yet.
+	if needBytes && tfr != nil {
+		exists, err := store.Exists(ctx, storageID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking installer store")
+		}
+		if !exists {
+			if err := store.Put(ctx, storageID, tfr); err != nil {
+				return ctxerr.Wrap(ctx, err, "storing installer")
+			}
+		}
+	}
+
+	logger.InfoContext(ctx, "cached new fleet-maintained app version",
+		"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug,
+		"from", c.Version, "to", version, "pin", pin)
+	return nil
+}
+
+func hydrateLatestManifest(ctx context.Context, ds fleet.Datastore, c fleet.FMAAutoUpdateCandidate, manifests map[string]*manifestEntry) (*fleet.MaintainedApp, error) {
+	if e, ok := manifests[c.Slug]; ok {
+		return e.app, e.err
+	}
+	app, err := func() (*fleet.MaintainedApp, error) {
+		skeleton, err := ds.GetMaintainedAppByID(ctx, c.FleetMaintainedAppID, c.TeamID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting maintained app by id")
+		}
+		// version "" fetches the latest from the remote manifest; teamID/cache are unused.
+		hydrated, err := maintained_apps.Hydrate(ctx, skeleton, "", c.TeamID, nil)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "hydrating app from manifest")
+		}
+		return hydrated, nil
+	}()
+	manifests[c.Slug] = &manifestEntry{app: app, err: err}
+	return app, err
 }
 
 // selectAutoUpdateTarget picks the cached version the pin allows the cron to

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -235,17 +235,23 @@ func downloadNewVersionIfEligible(
 			}
 		}
 	} else {
-		// Bytes already cached: recover the package IDs from an existing installer
-		// with identical content so the uninstall script can still be substituted.
+		// Bytes already cached: recover the package IDs and upgrade code from an
+		// existing installer with identical content (same SHA ⇒ same metadata) so
+		// the uninstall script can still be substituted.
 		if existing, err := ds.GetTeamsWithInstallerByHash(ctx, storageID, ""); err == nil {
 			for _, installers := range existing {
+				done := false
 				for _, e := range installers {
 					if e.PackageIDList != "" {
 						packageIDs = strings.Split(e.PackageIDList, ",")
+						if e.UpgradeCode != "" {
+							upgradeCode = e.UpgradeCode
+						}
+						done = true
 						break
 					}
 				}
-				if len(packageIDs) > 0 {
+				if done {
 					break
 				}
 			}
@@ -291,6 +297,13 @@ func downloadNewVersionIfEligible(
 	// GitOps materialization path (no-op when there are no package IDs).
 	if err := preProcessUninstallScript(payload); err != nil {
 		return ctxerr.Wrap(ctx, err, "processing uninstall script")
+	}
+	// Refuse to persist a row whose uninstall script still has unsubstituted
+	// template variables (e.g. metadata extraction failed and preProcess silently
+	// no-op'd): promoting it would record uninstalls as succeeding while the app
+	// stays installed. Skip this candidate; the next run retries.
+	if file.PackageIDRegex.MatchString(payload.UninstallScript) || file.UpgradeCodeRegex.MatchString(payload.UninstallScript) {
+		return ctxerr.Errorf(ctx, "uninstall script for %q still has unsubstituted template variables; skipping cache", c.Slug)
 	}
 
 	// Store the bytes before creating the DB row, so a Put failure can't leave a

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -157,14 +157,16 @@ func downloadNewVersionIfEligible(
 		return err
 	}
 
-	// Caret pin: caching a version the pin can never promote to wastes a slot, so
-	// only download when latest is within the pinned major. Empty pin always takes
-	// latest; literal pins were filtered out by the caller.
-	if pin != "" && !versionMatchesMajor(app.Version, strings.TrimPrefix(pin, "^")) {
-		return nil
-	}
-
-	if app.Version != "latest" {
+	// For a concrete manifest version the eligibility gates can run up front. For a
+	// "latest" manifest the real version isn't known until the installer is
+	// extracted, so the caret-major and cache checks are deferred until after that.
+	isLatest := app.Version == "latest"
+	if !isLatest {
+		// Caret pin: caching a version the pin can never promote to wastes a slot.
+		// Empty pin always takes latest; literal pins were filtered out by the caller.
+		if pin != "" && !versionMatchesMajor(app.Version, strings.TrimPrefix(pin, "^")) {
+			return nil
+		}
 		has, err := ds.HasFMAInstallerVersion(ctx, c.TeamID, c.FleetMaintainedAppID, app.Version)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "checking cached version")
@@ -178,7 +180,7 @@ func downloadNewVersionIfEligible(
 	// team cached the same version), skip the HTTP download and reuse the bytes.
 	storageID := app.SHA256
 	needBytes := true
-	if app.SHA256 != noCheckHash && app.Version != "latest" {
+	if app.SHA256 != noCheckHash && !isLatest {
 		exists, err := store.Exists(ctx, app.SHA256)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "checking installer store")
@@ -188,6 +190,8 @@ func downloadNewVersionIfEligible(
 
 	version := app.Version
 	filename := ""
+	upgradeCode := app.UpgradeCode
+	var packageIDs []string
 	var tfr *fleet.TempFileReader
 	if needBytes {
 		tfr, filename, err = maintained_apps.DownloadInstaller(ctx, app.InstallerURL, client)
@@ -208,19 +212,50 @@ func downloadNewVersionIfEligible(
 			storageID = gotHash
 		}
 
-		if version == "latest" { // download URL isn't version-pinned; extract version from installer
-			meta, err := file.ExtractInstallerMetadata(tfr)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "extracting installer metadata")
+		// Extract the concrete version (for "latest") and the package IDs / upgrade
+		// code needed to substitute the uninstall script. Best-effort except when
+		// it's the only way to resolve a "latest" version. Rewind unconditionally —
+		// extraction consumes the reader and the bytes are stored below.
+		meta, metaErr := file.ExtractInstallerMetadata(tfr)
+		if err := tfr.Rewind(); err != nil {
+			return ctxerr.Wrap(ctx, err, "resetting installer file reader")
+		}
+		if metaErr != nil {
+			if isLatest {
+				return ctxerr.Wrap(ctx, metaErr, "extracting installer metadata")
 			}
-			if err := tfr.Rewind(); err != nil {
-				return ctxerr.Wrap(ctx, err, "resetting installer file reader")
+			logger.WarnContext(ctx, "extracting fleet-maintained app installer metadata", "slug", c.Slug, "err", metaErr)
+		} else {
+			if isLatest {
+				version = meta.Version
 			}
-			version = meta.Version
+			packageIDs = meta.PackageIDs
+			if meta.UpgradeCode != "" {
+				upgradeCode = meta.UpgradeCode
+			}
+		}
+	} else {
+		// Bytes already cached: recover the package IDs from an existing installer
+		// with identical content so the uninstall script can still be substituted.
+		if existing, err := ds.GetTeamsWithInstallerByHash(ctx, storageID, ""); err == nil {
+			for _, installers := range existing {
+				for _, e := range installers {
+					if e.PackageIDList != "" {
+						packageIDs = strings.Split(e.PackageIDList, ",")
+						break
+					}
+				}
+				if len(packageIDs) > 0 {
+					break
+				}
+			}
 		}
 	}
 
-	// Re-check the cache once the concrete version is known (covers "latest").
+	// Apply the deferred gates now that the concrete version is known ("latest").
+	if isLatest && pin != "" && !versionMatchesMajor(version, strings.TrimPrefix(pin, "^")) {
+		return nil
+	}
 	if version != app.Version {
 		has, err := ds.HasFMAInstallerVersion(ctx, c.TeamID, c.FleetMaintainedAppID, version)
 		if err != nil {
@@ -244,19 +279,23 @@ func downloadNewVersionIfEligible(
 		Extension:       strings.TrimLeft(filepath.Ext(filename), "."),
 		StorageID:       storageID,
 		URL:             app.InstallerURL,
-		UpgradeCode:     app.UpgradeCode,
+		UpgradeCode:     upgradeCode,
 		PatchQuery:      app.PatchQuery,
 		InstallScript:   app.InstallScript,
 		UninstallScript: app.UninstallScript,
+		PackageIDs:      packageIDs,
 		InstallerFile:   tfr,
 	}
 
-	if _, err := ds.InsertFleetMaintainedAppVersion(ctx, c.InstallerID, payload); err != nil {
-		return ctxerr.Wrap(ctx, err, "caching new fleet-maintained app version")
+	// Substitute $PACKAGE_ID / $UPGRADE_CODE in the uninstall script, matching the
+	// GitOps materialization path (no-op when there are no package IDs).
+	if err := preProcessUninstallScript(payload); err != nil {
+		return ctxerr.Wrap(ctx, err, "processing uninstall script")
 	}
 
-	// Store bytes before the caller promotes, so the active row never points at
-	// installer bytes that aren't in the store yet.
+	// Store the bytes before creating the DB row, so a Put failure can't leave a
+	// row pointing at installer bytes that aren't in the store — which the caller
+	// would then promote the active installer to.
 	if needBytes && tfr != nil {
 		exists, err := store.Exists(ctx, storageID)
 		if err != nil {
@@ -267,6 +306,10 @@ func downloadNewVersionIfEligible(
 				return ctxerr.Wrap(ctx, err, "storing installer")
 			}
 		}
+	}
+
+	if _, err := ds.InsertFleetMaintainedAppVersion(ctx, c.InstallerID, payload); err != nil {
+		return ctxerr.Wrap(ctx, err, "caching new fleet-maintained app version")
 	}
 
 	logger.InfoContext(ctx, "cached new fleet-maintained app version",

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+// AutoUpdateFleetMaintainedApps walks every active Fleet-maintained app
+// installer and, where its pin state allows, advances it to a newer version
+// already cached for the team — it never fetches new versions from upstream.
+// A failure on one app is logged and skipped so a single bad row can't stall
+// the whole run.
+func AutoUpdateFleetMaintainedApps(ctx context.Context, ds fleet.Datastore, logger *slog.Logger) error {
+	candidates, err := ds.ListFleetMaintainedAppActiveInstallers(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "listing active fleet-maintained app installers")
+	}
+
+	for _, c := range candidates {
+		if err := autoUpdateOneFleetMaintainedApp(ctx, ds, logger, c); err != nil {
+			logger.ErrorContext(ctx, "auto-updating fleet-maintained app",
+				"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug, "err", err)
+		}
+	}
+	return nil
+}
+
+func autoUpdateOneFleetMaintainedApp(ctx context.Context, ds fleet.Datastore, logger *slog.Logger, c fleet.FMAAutoUpdateCandidate) error {
+	pinned, err := ds.GetPinnedVersion(ctx, c.TeamID, c.TitleID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return ctxerr.Wrap(ctx, err, "getting pinned version")
+	}
+	pin := ""
+	if pinned != nil {
+		pin = *pinned
+	}
+
+	// A literal pin never advances.
+	if pin != "" && !strings.HasPrefix(pin, "^") {
+		return nil
+	}
+
+	// Cached versions, semver-sorted newest-first.
+	versions, err := ds.GetFleetMaintainedVersionsByTitleID(ctx, c.TeamID, c.TitleID, true)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting cached versions")
+	}
+	if len(versions) == 0 {
+		return nil
+	}
+
+	target, ok := selectAutoUpdateTarget(versions, pin)
+	if !ok || target.ID == c.InstallerID {
+		// No newer eligible version, or already on it.
+		return nil
+	}
+
+	payload := &fleet.UpdateSoftwareInstallerPayload{
+		TeamID:        c.TeamID,
+		TitleID:       c.TitleID,
+		PinnedVersion: &pin,
+	}
+	if err := ds.SetFleetMaintainedAppActiveInstaller(ctx, payload, target.ID); err != nil {
+		return ctxerr.Wrap(ctx, err, "setting active installer")
+	}
+	// Cancel pending installs of the version we advanced away from.
+	if err := ds.ProcessInstallerUpdateSideEffects(ctx, c.InstallerID, true, false); err != nil {
+		return ctxerr.Wrap(ctx, err, "processing installer update side effects")
+	}
+
+	logger.InfoContext(ctx, "advanced fleet-maintained app to newer cached version",
+		"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug,
+		"from", c.Version, "to", target.Version, "pin", pin)
+	return nil
+}
+
+// selectAutoUpdateTarget picks the cached version the pin allows the cron to
+// advance to. versions must be semver-sorted newest-first. An empty pin means
+// Latest (newest). A caret pin returns the newest version within its major, or
+// ok=false when no cached version satisfies the major (so the cron skips rather
+// than crossing into another major, unlike the on-demand PATCH path).
+func selectAutoUpdateTarget(versions []fleet.FleetMaintainedVersion, pin string) (fleet.FleetMaintainedVersion, bool) {
+	if pin == "" {
+		return versions[0], true
+	}
+	// Caret pin: parsePinnedVersion already validated the shape on write.
+	major := strings.TrimPrefix(pin, "^")
+	for _, v := range versions {
+		if versionMatchesMajor(v.Version, major) {
+			return v, true
+		}
+	}
+	return fleet.FleetMaintainedVersion{}, false
+}
+
+// teamIDForLog renders an optional team ID for structured logs; slog prints a
+// *uint as its address, so the value (or "none") is surfaced here instead.
+func teamIDForLog(p *uint) any {
+	if p == nil {
+		return "none"
+	}
+	return *p
+}

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -235,26 +235,16 @@ func downloadNewVersionIfEligible(
 			}
 		}
 	} else {
-		// Bytes already cached: recover the package IDs and upgrade code from an
-		// existing installer with identical content (same SHA ⇒ same metadata) so
-		// the uninstall script can still be substituted.
-		if existing, err := ds.GetTeamsWithInstallerByHash(ctx, storageID, ""); err == nil {
-			for _, installers := range existing {
-				done := false
-				for _, e := range installers {
-					if e.PackageIDList != "" {
-						packageIDs = strings.Split(e.PackageIDList, ",")
-						if e.UpgradeCode != "" {
-							upgradeCode = e.UpgradeCode
-						}
-						done = true
-						break
-					}
-				}
-				if done {
-					break
-				}
-			}
+		// Bytes already cached (possibly only on an inactive row after a rollback):
+		// recover the package IDs and upgrade code from any installer with the same
+		// content hash so the uninstall script can still be substituted.
+		pids, ucode, err := ds.GetSoftwareInstallerMetadataByStorageID(ctx, storageID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "recovering cached installer metadata")
+		}
+		packageIDs = pids
+		if ucode != "" {
+			upgradeCode = ucode
 		}
 	}
 

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -61,10 +61,13 @@ func autoUpdateOneFleetMaintainedApp(ctx context.Context, ds fleet.Datastore, lo
 		return nil
 	}
 
+	// PinnedVersion stays nil: the cron only flips the active installer and must
+	// not rewrite the pin, or it could clobber a pin an admin changed between this
+	// read and write. Latest stays Latest (no row created) and a caret pin is left
+	// in place.
 	payload := &fleet.UpdateSoftwareInstallerPayload{
-		TeamID:        c.TeamID,
-		TitleID:       c.TitleID,
-		PinnedVersion: &pin,
+		TeamID:  c.TeamID,
+		TitleID: c.TitleID,
 	}
 	if err := ds.SetFleetMaintainedAppActiveInstaller(ctx, payload, target.ID); err != nil {
 		return ctxerr.Wrap(ctx, err, "setting active installer")

--- a/ee/server/service/maintained_apps_auto_update_download_test.go
+++ b/ee/server/service/maintained_apps_auto_update_download_test.go
@@ -1,0 +1,252 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	ma "github.com/fleetdm/fleet/v4/ee/maintained-apps"
+	"github.com/fleetdm/fleet/v4/server/dev_mode"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	mocksoftware "github.com/fleetdm/fleet/v4/server/mock/software"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFMASlug    = "chrome/darwin"
+	testFMALatest  = "150.0.0"
+	testFMAAppID   = uint(5)
+	testFMATitleID = uint(1)
+)
+
+// fakeManifestServer serves the latest manifest for testFMASlug plus the
+// installer it points at, and counts hits so tests can assert fetch-once and
+// byte-dedup behavior.
+type fakeManifestServer struct {
+	srv           *httptest.Server
+	sha           string
+	bytes         []byte
+	manifestHits  int
+	installerHits int
+	mu            sync.Mutex
+}
+
+func newFakeManifestServer(t *testing.T) *fakeManifestServer {
+	f := &fakeManifestServer{bytes: []byte("fake installer payload")}
+	sum := sha256.Sum256(f.bytes)
+	f.sha = hex.EncodeToString(sum[:])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+testFMASlug+".json", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.manifestHits++
+		f.mu.Unlock()
+		manifest := ma.FMAManifestFile{
+			Versions: []*ma.FMAManifestApp{{
+				Version:            testFMALatest,
+				InstallerURL:       f.srv.URL + "/installer.pkg",
+				SHA256:             f.sha,
+				InstallScriptRef:   "i",
+				UninstallScriptRef: "u",
+				Queries:            ma.FMAQueries{Exists: "SELECT 1", Patched: "SELECT 2"},
+				DefaultCategories:  []string{"Browsers"},
+			}},
+			Refs: map[string]string{"i": "echo install", "u": "echo uninstall"},
+		}
+		_ = json.NewEncoder(w).Encode(manifest)
+	})
+	mux.HandleFunc("/installer.pkg", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.installerHits++
+		f.mu.Unlock()
+		_, _ = w.Write(f.bytes)
+	})
+
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", f.srv.URL, t)
+	return f
+}
+
+// memStore is a stateful in-memory SoftwareInstallerStore so byte-dedup across
+// teams behaves like the real store (a Put makes a later Exists true).
+func memStore(seed ...string) *mocksoftware.SoftwareInstallerStore {
+	var mu sync.Mutex
+	have := map[string]struct{}{}
+	for _, s := range seed {
+		have[s] = struct{}{}
+	}
+	store := &mocksoftware.SoftwareInstallerStore{}
+	store.ExistsFunc = func(ctx context.Context, id string) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		_, ok := have[id]
+		return ok, nil
+	}
+	store.PutFunc = func(ctx context.Context, id string, content io.ReadSeeker) error {
+		mu.Lock()
+		have[id] = struct{}{}
+		mu.Unlock()
+		return nil
+	}
+	return store
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// baseDownloadStore wires a mock datastore for the download-then-promote flow:
+// one unpinned candidate on the given version, hydrating from the fake server.
+func baseDownloadStore(t *testing.T, activeVersion string, activeID uint) *mock.Store {
+	ds := new(mock.Store)
+	teamID := uint(1)
+	ds.ListFleetMaintainedAppActiveInstallersFunc = func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
+		return []fleet.FMAAutoUpdateCandidate{{
+			TeamID: &teamID, TitleID: testFMATitleID, FleetMaintainedAppID: testFMAAppID,
+			InstallerID: activeID, Version: activeVersion, Slug: testFMASlug,
+		}}, nil
+	}
+	ds.GetPinnedVersionFunc = func(ctx context.Context, tmID *uint, titleID uint) (*string, error) {
+		return nil, nil // Latest
+	}
+	ds.GetMaintainedAppByIDFunc = func(ctx context.Context, appID uint, tmID *uint) (*fleet.MaintainedApp, error) {
+		return &fleet.MaintainedApp{ID: testFMAAppID, Name: "Google Chrome", Slug: testFMASlug, Platform: "darwin"}, nil
+	}
+	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, error) {
+		return false, nil
+	}
+	// After the insert, the new version is the newest cached one.
+	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
+		return []fleet.FleetMaintainedVersion{{ID: 13, Version: testFMALatest}, {ID: activeID, Version: activeVersion}}, nil
+	}
+	ds.SetFleetMaintainedAppActiveInstallerFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
+		require.Nil(t, payload.PinnedVersion, "cron must not write the pin row")
+		return nil
+	}
+	ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, a, b bool) error { return nil }
+	return ds
+}
+
+func TestAutoUpdateDownloadsAndPromotes(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	ds := baseDownloadStore(t, "149.0.0", 9)
+
+	var gotActiveInstaller uint
+	var gotPayload *fleet.UploadSoftwareInstallerPayload
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		gotActiveInstaller = activeInstallerID
+		gotPayload = payload
+		return 13, nil
+	}
+
+	store := memStore()
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, store, discardLogger()))
+
+	// Downloaded, validated, and cached the new version.
+	require.Equal(t, 1, srv.installerHits)
+	require.True(t, ds.InsertFleetMaintainedAppVersionFuncInvoked)
+	require.NotNil(t, gotPayload)
+	require.Equal(t, uint(9), gotActiveInstaller, "clones from the current active installer")
+	require.Equal(t, testFMALatest, gotPayload.Version)
+	require.Equal(t, srv.sha, gotPayload.StorageID)
+	require.Equal(t, "installer.pkg", gotPayload.Filename)
+	require.Equal(t, "pkg", gotPayload.Extension)
+	require.Equal(t, "echo install", gotPayload.InstallScript)
+	require.True(t, store.PutFuncInvoked, "stores bytes before promotion")
+
+	// Then promoted to the freshly cached version.
+	require.True(t, ds.SetFleetMaintainedAppActiveInstallerFuncInvoked)
+}
+
+func TestAutoUpdateByteDedupSkipsDownload(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	ds := baseDownloadStore(t, "149.0.0", 9)
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		require.Equal(t, "installer.pkg", payload.Filename, "filename derived from URL when bytes reused")
+		return 13, nil
+	}
+
+	store := memStore(srv.sha) // bytes already present (another team cached them)
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, store, discardLogger()))
+
+	require.Equal(t, 0, srv.installerHits, "must not re-download bytes already in the store")
+	require.True(t, ds.InsertFleetMaintainedAppVersionFuncInvoked, "still creates the per-team row")
+	require.False(t, store.PutFuncInvoked)
+}
+
+func TestAutoUpdateAlreadyCachedSkipsInsert(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	ds := baseDownloadStore(t, "149.0.0", 9)
+	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, error) {
+		return true, nil // already cached
+	}
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		t.Fatal("must not insert when the version is already cached")
+		return 0, nil
+	}
+
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
+	require.Equal(t, 0, srv.installerHits)
+	require.False(t, ds.InsertFleetMaintainedAppVersionFuncInvoked)
+	// Promotion among cached still runs.
+	require.True(t, ds.GetFleetMaintainedVersionsByTitleIDFuncInvoked)
+}
+
+func TestAutoUpdateCaretMajorExceededSkipsDownload(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	ds := baseDownloadStore(t, "147.0.5", 8)
+	pin := "^147" // latest is 150.x — out of the pinned major
+	ds.GetPinnedVersionFunc = func(ctx context.Context, tmID *uint, titleID uint) (*string, error) {
+		return &pin, nil
+	}
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		t.Fatal("must not download/cache a version outside the pinned major")
+		return 0, nil
+	}
+	// Only an in-major version is cached; promotion stays within the major.
+	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
+		return []fleet.FleetMaintainedVersion{{ID: 8, Version: "147.0.5"}}, nil
+	}
+
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
+	require.Equal(t, 1, srv.manifestHits, "manifest fetched to learn the latest version")
+	require.Equal(t, 0, srv.installerHits, "no download outside the pinned major")
+	require.False(t, ds.InsertFleetMaintainedAppVersionFuncInvoked)
+}
+
+func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	ds := new(mock.Store)
+	teamA, teamB := uint(1), uint(2)
+	ds.ListFleetMaintainedAppActiveInstallersFunc = func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
+		return []fleet.FMAAutoUpdateCandidate{
+			{TeamID: &teamA, TitleID: testFMATitleID, FleetMaintainedAppID: testFMAAppID, InstallerID: 9, Version: "149.0.0", Slug: testFMASlug},
+			{TeamID: &teamB, TitleID: 2, FleetMaintainedAppID: testFMAAppID, InstallerID: 19, Version: "149.0.0", Slug: testFMASlug},
+		}, nil
+	}
+	ds.GetPinnedVersionFunc = func(ctx context.Context, tmID *uint, titleID uint) (*string, error) { return nil, nil }
+	ds.GetMaintainedAppByIDFunc = func(ctx context.Context, appID uint, tmID *uint) (*fleet.MaintainedApp, error) {
+		return &fleet.MaintainedApp{ID: testFMAAppID, Name: "Google Chrome", Slug: testFMASlug, Platform: "darwin"}, nil
+	}
+	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, error) { return false, nil }
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		return 13, nil
+	}
+	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
+		return []fleet.FleetMaintainedVersion{{ID: 13, Version: testFMALatest}}, nil
+	}
+	ds.SetFleetMaintainedAppActiveInstallerFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error { return nil }
+	ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, a, b bool) error { return nil }
+
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
+
+	require.Equal(t, 1, srv.manifestHits, "manifest fetched once per slug across teams")
+	require.Equal(t, 1, srv.installerHits, "bytes downloaded once, reused across teams via the store")
+}

--- a/ee/server/service/maintained_apps_auto_update_download_test.go
+++ b/ee/server/service/maintained_apps_auto_update_download_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -34,13 +35,16 @@ type fakeManifestServer struct {
 	srv           *httptest.Server
 	sha           string
 	bytes         []byte
+	version       string // manifest version to advertise (default testFMALatest)
+	uninstall     string // uninstall script ref body (default "echo uninstall")
+	upgradeCode   string // manifest upgrade_code (default empty)
 	manifestHits  int
 	installerHits int
 	mu            sync.Mutex
 }
 
 func newFakeManifestServer(t *testing.T) *fakeManifestServer {
-	f := &fakeManifestServer{bytes: []byte("fake installer payload")}
+	f := &fakeManifestServer{bytes: []byte("fake installer payload"), version: testFMALatest, uninstall: "echo uninstall"}
 	sum := sha256.Sum256(f.bytes)
 	f.sha = hex.EncodeToString(sum[:])
 
@@ -51,15 +55,16 @@ func newFakeManifestServer(t *testing.T) *fakeManifestServer {
 		f.mu.Unlock()
 		manifest := ma.FMAManifestFile{
 			Versions: []*ma.FMAManifestApp{{
-				Version:            testFMALatest,
+				Version:            f.version,
 				InstallerURL:       f.srv.URL + "/installer.pkg",
 				SHA256:             f.sha,
+				UpgradeCode:        f.upgradeCode,
 				InstallScriptRef:   "i",
 				UninstallScriptRef: "u",
 				Queries:            ma.FMAQueries{Exists: "SELECT 1", Patched: "SELECT 2"},
 				DefaultCategories:  []string{"Browsers"},
 			}},
-			Refs: map[string]string{"i": "echo install", "u": "echo uninstall"},
+			Refs: map[string]string{"i": "echo install", "u": f.uninstall},
 		}
 		_ = json.NewEncoder(w).Encode(manifest)
 	})
@@ -121,6 +126,10 @@ func baseDownloadStore(t *testing.T, activeVersion string, activeID uint) *mock.
 	}
 	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, error) {
 		return false, nil
+	}
+	// No existing same-content installer by default (byte-dedup package-ID lookup).
+	ds.GetTeamsWithInstallerByHashFunc = func(ctx context.Context, sha256, url string) (map[uint][]*fleet.ExistingSoftwareInstaller, error) {
+		return nil, nil
 	}
 	// After the insert, the new version is the newest cached one.
 	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
@@ -236,6 +245,9 @@ func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
 		return &fleet.MaintainedApp{ID: testFMAAppID, Name: "Google Chrome", Slug: testFMASlug, Platform: "darwin"}, nil
 	}
 	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, error) { return false, nil }
+	ds.GetTeamsWithInstallerByHashFunc = func(ctx context.Context, sha256, url string) (map[uint][]*fleet.ExistingSoftwareInstaller, error) {
+		return nil, nil
+	}
 	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 		return 13, nil
 	}
@@ -251,4 +263,64 @@ func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
 
 	require.Equal(t, 1, srv.manifestHits, "manifest fetched once per slug across teams")
 	require.Equal(t, 1, srv.installerHits, "bytes downloaded once, reused across teams via the store")
+}
+
+// [5] A store.Put failure must NOT leave a DB row (which the caller would then
+// promote to byte-less storage). Bytes are stored before the row is inserted.
+func TestAutoUpdatePutFailureSkipsInsert(t *testing.T) {
+	_ = newFakeManifestServer(t)
+	ds := baseDownloadStore(t, "149.0.0", 9)
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		t.Fatal("must not insert the DB row when storing bytes fails")
+		return 0, nil
+	}
+	store := &mocksoftware.SoftwareInstallerStore{}
+	store.ExistsFunc = func(ctx context.Context, id string) (bool, error) { return false, nil }
+	store.PutFunc = func(ctx context.Context, id string, content io.ReadSeeker) error {
+		return errors.New("store unavailable")
+	}
+
+	// The candidate's download errors, but the run is isolated and returns nil.
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, store, discardLogger()))
+	require.False(t, ds.InsertFleetMaintainedAppVersionFuncInvoked)
+}
+
+// [4] The uninstall script's $PACKAGE_ID is substituted (here via the byte-dedup
+// path, where package IDs are recovered from the existing same-content installer).
+func TestAutoUpdateSubstitutesUninstallScript(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	srv.uninstall = "msiexec /x $PACKAGE_ID /qn"
+	ds := baseDownloadStore(t, "149.0.0", 9)
+	ds.GetTeamsWithInstallerByHashFunc = func(ctx context.Context, sha256, url string) (map[uint][]*fleet.ExistingSoftwareInstaller, error) {
+		return map[uint][]*fleet.ExistingSoftwareInstaller{0: {{PackageIDList: "ABC"}}}, nil
+	}
+	var gotPayload *fleet.UploadSoftwareInstallerPayload
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		gotPayload = payload
+		return 13, nil
+	}
+
+	store := memStore(srv.sha) // byte-dedup: no download, package IDs come from the lookup
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, store, discardLogger()))
+	require.NotNil(t, gotPayload)
+	require.NotContains(t, gotPayload.UninstallScript, "$PACKAGE_ID", "placeholder must be substituted")
+	require.Contains(t, gotPayload.UninstallScript, "ABC")
+}
+
+// [6] A caret pin with a "latest" manifest must not early-return before the real
+// version is resolved — it should proceed to download (then bail here because the
+// fake bytes can't be parsed).
+func TestAutoUpdateCaretLatestAttemptsDownload(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	srv.version = "latest"
+	ds := baseDownloadStore(t, "150.0.0", 9)
+	pin := "^150"
+	ds.GetPinnedVersionFunc = func(ctx context.Context, tmID *uint, titleID uint) (*string, error) { return &pin, nil }
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		t.Fatal("fake bytes can't resolve a latest version; insert should not happen")
+		return 0, nil
+	}
+
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
+	require.Equal(t, 1, srv.installerHits, "caret+latest must attempt the download, not early-return")
 }

--- a/ee/server/service/maintained_apps_auto_update_download_test.go
+++ b/ee/server/service/maintained_apps_auto_update_download_test.go
@@ -242,7 +242,9 @@ func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
 	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
 		return []fleet.FleetMaintainedVersion{{ID: 13, Version: testFMALatest}}, nil
 	}
-	ds.SetFleetMaintainedAppActiveInstallerFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error { return nil }
+	ds.SetFleetMaintainedAppActiveInstallerFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
+		return nil
+	}
 	ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, a, b bool) error { return nil }
 
 	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))

--- a/ee/server/service/maintained_apps_auto_update_download_test.go
+++ b/ee/server/service/maintained_apps_auto_update_download_test.go
@@ -127,9 +127,9 @@ func baseDownloadStore(t *testing.T, activeVersion string, activeID uint) *mock.
 	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, error) {
 		return false, nil
 	}
-	// No existing same-content installer by default (byte-dedup package-ID lookup).
-	ds.GetTeamsWithInstallerByHashFunc = func(ctx context.Context, sha256, url string) (map[uint][]*fleet.ExistingSoftwareInstaller, error) {
-		return nil, nil
+	// No recoverable metadata by default (byte-dedup path).
+	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) ([]string, string, error) {
+		return nil, "", nil
 	}
 	// After the insert, the new version is the newest cached one.
 	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
@@ -245,8 +245,8 @@ func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
 		return &fleet.MaintainedApp{ID: testFMAAppID, Name: "Google Chrome", Slug: testFMASlug, Platform: "darwin"}, nil
 	}
 	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, error) { return false, nil }
-	ds.GetTeamsWithInstallerByHashFunc = func(ctx context.Context, sha256, url string) (map[uint][]*fleet.ExistingSoftwareInstaller, error) {
-		return nil, nil
+	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) ([]string, string, error) {
+		return nil, "", nil
 	}
 	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 		return 13, nil
@@ -291,8 +291,8 @@ func TestAutoUpdateSubstitutesUninstallScript(t *testing.T) {
 	srv := newFakeManifestServer(t)
 	srv.uninstall = "msiexec /x $PACKAGE_ID /qn"
 	ds := baseDownloadStore(t, "149.0.0", 9)
-	ds.GetTeamsWithInstallerByHashFunc = func(ctx context.Context, sha256, url string) (map[uint][]*fleet.ExistingSoftwareInstaller, error) {
-		return map[uint][]*fleet.ExistingSoftwareInstaller{0: {{PackageIDList: "ABC"}}}, nil
+	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) ([]string, string, error) {
+		return []string{"ABC"}, "", nil
 	}
 	var gotPayload *fleet.UploadSoftwareInstallerPayload
 	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {

--- a/ee/server/service/maintained_apps_auto_update_download_test.go
+++ b/ee/server/service/maintained_apps_auto_update_download_test.go
@@ -324,3 +324,22 @@ func TestAutoUpdateCaretLatestAttemptsDownload(t *testing.T) {
 	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
 	require.Equal(t, 1, srv.installerHits, "caret+latest must attempt the download, not early-return")
 }
+
+// [comment 1] When no package IDs can be recovered (e.g. metadata extraction
+// fails) and the uninstall script still contains template variables, the cron
+// must NOT persist/promote the version — otherwise uninstalls record success
+// while the app stays installed.
+func TestAutoUpdateUnsubstitutedUninstallSkipsInsert(t *testing.T) {
+	srv := newFakeManifestServer(t)
+	srv.uninstall = "msiexec /x $PACKAGE_ID /qn"
+	ds := baseDownloadStore(t, "149.0.0", 9)
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		t.Fatal("must not cache a version whose uninstall script still has $PACKAGE_ID")
+		return 0, nil
+	}
+
+	// Download path: the fake bytes can't be parsed, so no package IDs are recovered
+	// and the $PACKAGE_ID placeholder survives — the candidate must be skipped.
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
+	require.False(t, ds.InsertFleetMaintainedAppVersionFuncInvoked)
+}

--- a/ee/server/service/maintained_apps_auto_update_test.go
+++ b/ee/server/service/maintained_apps_auto_update_test.go
@@ -37,9 +37,9 @@ func TestAutoUpdateFleetMaintainedApps(t *testing.T) {
 	cases := []struct {
 		name string
 		// pin: nil => no pin row (Latest); otherwise the stored expression.
-		pin           *string
-		active        fleet.FMAAutoUpdateCandidate
-		cached        []fleet.FleetMaintainedVersion
+		pin          *string
+		active       fleet.FMAAutoUpdateCandidate
+		cached       []fleet.FleetMaintainedVersion
 		wantFlip     bool
 		wantActiveID uint // installer ID bound active (when wantFlip)
 		wantOldID    uint // installer ID whose side effects are processed

--- a/ee/server/service/maintained_apps_auto_update_test.go
+++ b/ee/server/service/maintained_apps_auto_update_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoUpdateFleetMaintainedApps(t *testing.T) {
+	// Cached versions for the title, semver-sorted newest-first (as the real
+	// datastore returns them with byVersion=true).
+	versions := []fleet.FleetMaintainedVersion{
+		{ID: 12, Version: "149.0.2"},
+		{ID: 11, Version: "147.0.9"},
+		{ID: 9, Version: "148.0.1"},
+		{ID: 8, Version: "147.0.5"},
+	}
+
+	teamID := uint(1)
+	candidate := func(activeID uint, activeVer string) fleet.FMAAutoUpdateCandidate {
+		return fleet.FMAAutoUpdateCandidate{
+			TeamID:      &teamID,
+			TitleID:     1,
+			InstallerID: activeID,
+			Version:     activeVer,
+			Slug:        "chrome/darwin",
+		}
+	}
+
+	cases := []struct {
+		name string
+		// pin: nil => no pin row (Latest); otherwise the stored expression.
+		pin           *string
+		active        fleet.FMAAutoUpdateCandidate
+		cached        []fleet.FleetMaintainedVersion
+		wantFlip      bool
+		wantActiveID  uint   // installer ID bound active (when wantFlip)
+		wantOldID     uint   // installer ID whose side effects are processed
+		wantPinStored string // PinnedVersion sent to the flip (when wantFlip)
+	}{
+		{
+			name:          "Latest advances to newest cached",
+			pin:           nil,
+			active:        candidate(9, "148.0.1"),
+			cached:        versions,
+			wantFlip:      true,
+			wantActiveID:  12,
+			wantOldID:     9,
+			wantPinStored: "",
+		},
+		{
+			name:     "Latest already on newest is a no-op",
+			pin:      nil,
+			active:   candidate(12, "149.0.2"),
+			cached:   versions,
+			wantFlip: false,
+		},
+		{
+			name:          "caret advances within major",
+			pin:           new("^147"),
+			active:        candidate(8, "147.0.5"),
+			cached:        versions,
+			wantFlip:      true,
+			wantActiveID:  11, // 147.0.9, newest within major 147
+			wantOldID:     8,
+			wantPinStored: "^147",
+		},
+		{
+			name:     "caret never crosses major when no in-major version is cached",
+			pin:      new("^147"),
+			active:   candidate(12, "149.0.2"),
+			cached:   []fleet.FleetMaintainedVersion{{ID: 12, Version: "149.0.2"}},
+			wantFlip: false,
+		},
+		{
+			name:     "literal pin never advances",
+			pin:      new("148.0.1"),
+			active:   candidate(9, "148.0.1"),
+			cached:   versions,
+			wantFlip: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+
+			ds.ListFleetMaintainedAppActiveInstallersFunc = func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
+				return []fleet.FMAAutoUpdateCandidate{tc.active}, nil
+			}
+			ds.GetPinnedVersionFunc = func(ctx context.Context, tmID *uint, titleID uint) (*string, error) {
+				if tc.pin == nil {
+					return nil, sql.ErrNoRows
+				}
+				return tc.pin, nil
+			}
+			ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
+				return tc.cached, nil
+			}
+
+			var gotActiveID, gotOldID uint
+			var gotPin string
+			ds.SetFleetMaintainedAppActiveInstallerFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
+				gotActiveID = activeInstallerID
+				require.NotNil(t, payload.PinnedVersion)
+				gotPin = *payload.PinnedVersion
+				return nil
+			}
+			ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, wasMetadataUpdated, wasPackageUpdated bool) error {
+				gotOldID = installerID
+				return nil
+			}
+
+			err := AutoUpdateFleetMaintainedApps(context.Background(), ds, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantFlip, ds.SetFleetMaintainedAppActiveInstallerFuncInvoked)
+			require.Equal(t, tc.wantFlip, ds.ProcessInstallerUpdateSideEffectsFuncInvoked)
+			if tc.wantFlip {
+				require.Equal(t, tc.wantActiveID, gotActiveID)
+				require.Equal(t, tc.wantOldID, gotOldID)
+				require.Equal(t, tc.wantPinStored, gotPin)
+			}
+			// A literal pin short-circuits before querying cached versions.
+			if tc.pin != nil && *tc.pin != "" && (*tc.pin)[0] != '^' {
+				require.False(t, ds.GetFleetMaintainedVersionsByTitleIDFuncInvoked)
+			}
+		})
+	}
+}
+
+func TestAutoUpdateFleetMaintainedAppsContinuesPastError(t *testing.T) {
+	ds := new(mock.Store)
+	teamID := uint(1)
+	ds.ListFleetMaintainedAppActiveInstallersFunc = func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
+		return []fleet.FMAAutoUpdateCandidate{
+			{TeamID: &teamID, TitleID: 1, InstallerID: 9, Slug: "bad/darwin"},
+			{TeamID: &teamID, TitleID: 2, InstallerID: 20, Slug: "good/darwin"},
+		}, nil
+	}
+	ds.GetPinnedVersionFunc = func(ctx context.Context, tmID *uint, titleID uint) (*string, error) {
+		if titleID == 1 {
+			return nil, errors.New("boom")
+		}
+		return nil, sql.ErrNoRows
+	}
+	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error) {
+		return []fleet.FleetMaintainedVersion{{ID: 21, Version: "2.0.0"}}, nil
+	}
+	var flippedTitle uint
+	ds.SetFleetMaintainedAppActiveInstallerFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
+		flippedTitle = payload.TitleID
+		return nil
+	}
+	ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, wasMetadataUpdated, wasPackageUpdated bool) error {
+		return nil
+	}
+
+	// The first candidate errors; the run must still process the second.
+	err := AutoUpdateFleetMaintainedApps(context.Background(), ds, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	require.True(t, ds.SetFleetMaintainedAppActiveInstallerFuncInvoked)
+	require.Equal(t, uint(2), flippedTitle)
+}

--- a/ee/server/service/maintained_apps_auto_update_test.go
+++ b/ee/server/service/maintained_apps_auto_update_test.go
@@ -115,7 +115,9 @@ func TestAutoUpdateFleetMaintainedApps(t *testing.T) {
 				return nil
 			}
 
-			err := AutoUpdateFleetMaintainedApps(context.Background(), ds, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			// nil store: promote-only mode (no upstream download), exercising
+			// advancement among already-cached versions.
+			err := AutoUpdateFleetMaintainedApps(context.Background(), ds, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 			require.NoError(t, err)
 
 			require.Equal(t, tc.wantFlip, ds.SetFleetMaintainedAppActiveInstallerFuncInvoked)
@@ -160,7 +162,7 @@ func TestAutoUpdateFleetMaintainedAppsContinuesPastError(t *testing.T) {
 	}
 
 	// The first candidate errors; the run must still process the second.
-	err := AutoUpdateFleetMaintainedApps(context.Background(), ds, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	err := AutoUpdateFleetMaintainedApps(context.Background(), ds, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	require.NoError(t, err)
 	require.True(t, ds.SetFleetMaintainedAppActiveInstallerFuncInvoked)
 	require.Equal(t, uint(2), flippedTitle)

--- a/ee/server/service/maintained_apps_auto_update_test.go
+++ b/ee/server/service/maintained_apps_auto_update_test.go
@@ -40,20 +40,18 @@ func TestAutoUpdateFleetMaintainedApps(t *testing.T) {
 		pin           *string
 		active        fleet.FMAAutoUpdateCandidate
 		cached        []fleet.FleetMaintainedVersion
-		wantFlip      bool
-		wantActiveID  uint   // installer ID bound active (when wantFlip)
-		wantOldID     uint   // installer ID whose side effects are processed
-		wantPinStored string // PinnedVersion sent to the flip (when wantFlip)
+		wantFlip     bool
+		wantActiveID uint // installer ID bound active (when wantFlip)
+		wantOldID    uint // installer ID whose side effects are processed
 	}{
 		{
-			name:          "Latest advances to newest cached",
-			pin:           nil,
-			active:        candidate(9, "148.0.1"),
-			cached:        versions,
-			wantFlip:      true,
-			wantActiveID:  12,
-			wantOldID:     9,
-			wantPinStored: "",
+			name:         "Latest advances to newest cached",
+			pin:          nil,
+			active:       candidate(9, "148.0.1"),
+			cached:       versions,
+			wantFlip:     true,
+			wantActiveID: 12,
+			wantOldID:    9,
 		},
 		{
 			name:     "Latest already on newest is a no-op",
@@ -63,14 +61,13 @@ func TestAutoUpdateFleetMaintainedApps(t *testing.T) {
 			wantFlip: false,
 		},
 		{
-			name:          "caret advances within major",
-			pin:           new("^147"),
-			active:        candidate(8, "147.0.5"),
-			cached:        versions,
-			wantFlip:      true,
-			wantActiveID:  11, // 147.0.9, newest within major 147
-			wantOldID:     8,
-			wantPinStored: "^147",
+			name:         "caret advances within major",
+			pin:          new("^147"),
+			active:       candidate(8, "147.0.5"),
+			cached:       versions,
+			wantFlip:     true,
+			wantActiveID: 11, // 147.0.9, newest within major 147
+			wantOldID:    8,
 		},
 		{
 			name:     "caret never crosses major when no in-major version is cached",
@@ -106,11 +103,11 @@ func TestAutoUpdateFleetMaintainedApps(t *testing.T) {
 			}
 
 			var gotActiveID, gotOldID uint
-			var gotPin string
 			ds.SetFleetMaintainedAppActiveInstallerFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
 				gotActiveID = activeInstallerID
-				require.NotNil(t, payload.PinnedVersion)
-				gotPin = *payload.PinnedVersion
+				// The cron must never write pin state, or it could clobber a
+				// concurrent admin pin change.
+				require.Nil(t, payload.PinnedVersion, "cron must not write the pin row")
 				return nil
 			}
 			ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, wasMetadataUpdated, wasPackageUpdated bool) error {
@@ -126,7 +123,6 @@ func TestAutoUpdateFleetMaintainedApps(t *testing.T) {
 			if tc.wantFlip {
 				require.Equal(t, tc.wantActiveID, gotActiveID)
 				require.Equal(t, tc.wantOldID, gotOldID)
-				require.Equal(t, tc.wantPinStored, gotPin)
 			}
 			// A literal pin short-circuits before querying cached versions.
 			if tc.pin != nil && *tc.pin != "" && (*tc.pin)[0] != '^' {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -776,7 +776,7 @@ func (ds *Datastore) InsertFleetMaintainedAppVersion(ctx context.Context, active
 INSERT INTO software_installers (
 	team_id, global_or_team_id, title_id, package_ids, pre_install_query, platform,
 	self_service, user_id, user_name, user_email, fleet_maintained_app_id,
-	post_install_script_content_id,
+	post_install_script_content_id, install_during_setup,
 	storage_id, filename, extension, version,
 	install_script_content_id, uninstall_script_content_id,
 	url, upgrade_code, is_active, patch_query
@@ -784,7 +784,7 @@ INSERT INTO software_installers (
 SELECT
 	team_id, global_or_team_id, title_id, package_ids, pre_install_query, platform,
 	self_service, user_id, user_name, user_email, fleet_maintained_app_id,
-	post_install_script_content_id,
+	post_install_script_content_id, install_during_setup,
 	?, ?, ?, ?,
 	?, ?,
 	?, ?, 0, ?
@@ -823,8 +823,9 @@ FROM software_installers WHERE id = ?`,
 			return ctxerr.Wrap(ctx, err, "clone installer categories")
 		}
 
-		// Evict versions beyond the cap, always protecting the active installer.
-		return ds.evictOldFMAVersions(ctx, tx, src.GlobalOrTeamID, src.TitleID, activeInstallerID)
+		// Evict versions beyond the cap, protecting the live active row and the row
+		// we just inserted.
+		return ds.evictOldFMAVersions(ctx, tx, src.GlobalOrTeamID, src.TitleID, installerID)
 	})
 	if err != nil {
 		return 0, err
@@ -833,11 +834,27 @@ FROM software_installers WHERE id = ?`,
 }
 
 // evictOldFMAVersions caps cached FMA versions for a (team, title) at
-// maxCachedFMAVersions, always keeping protectInstallerID (the active version)
-// and otherwise the most recently uploaded versions. Policies on evicted rows
-// are re-pointed to the protected installer before the rows are deleted. Mirrors
-// the eviction logic in BatchSetSoftwareInstallers.
-func (ds *Datastore) evictOldFMAVersions(ctx context.Context, tx sqlx.ExtContext, globalOrTeamID, titleID, protectInstallerID uint) error {
+// maxCachedFMAVersions. It always keeps the row that is currently is_active=1
+// (an admin may have promoted a different cached version during the cron's
+// download window) and newInstallerID (the row just inserted, about to be
+// promoted), then the most recently uploaded versions. Policies on evicted rows
+// are re-pointed to the active installer before the rows are deleted. Mirrors the
+// eviction logic in BatchSetSoftwareInstallers.
+func (ds *Datastore) evictOldFMAVersions(ctx context.Context, tx sqlx.ExtContext, globalOrTeamID, titleID, newInstallerID uint) error {
+	// Resolve the live active row rather than trusting the caller's (possibly
+	// stale) view, so a concurrent admin promotion isn't evicted out from under us.
+	var activeID uint
+	err := sqlx.GetContext(ctx, tx, &activeID, `
+		SELECT id FROM software_installers
+		WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL AND is_active = 1
+		LIMIT 1`, globalOrTeamID, titleID)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return ctxerr.Wrap(ctx, err, "find active FMA installer for eviction")
+		}
+		activeID = newInstallerID
+	}
+
 	fmaVersions, err := ds.getFleetMaintainedVersionsByTitleIDs(ctx, tx, []uint{titleID}, globalOrTeamID, false)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list FMA installer versions for eviction")
@@ -847,8 +864,8 @@ func (ds *Datastore) evictOldFMAVersions(ctx context.Context, tx sqlx.ExtContext
 		return nil
 	}
 
-	// Keep set: protected installer + most recent up to the cap.
-	keepSet := map[uint]bool{protectInstallerID: true}
+	// Keep set: live active + newly inserted, then most recent up to the cap.
+	keepSet := map[uint]bool{newInstallerID: true, activeID: true}
 	for _, v := range versions {
 		if len(keepSet) >= maxCachedFMAVersions {
 			break
@@ -857,14 +874,14 @@ func (ds *Datastore) evictOldFMAVersions(ctx context.Context, tx sqlx.ExtContext
 	}
 	keepIDs := slices.Collect(maps.Keys(keepSet))
 
-	// Re-point policies referencing soon-to-be-evicted versions to the protected one.
+	// Re-point policies referencing soon-to-be-evicted versions to the active one.
 	rePointStmt, rePointArgs, err := sqlx.In(
 		`UPDATE policies SET software_installer_id = ?
 		WHERE software_installer_id IN (
 			SELECT id FROM software_installers
 			WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL AND id NOT IN (?)
 		)`,
-		protectInstallerID, globalOrTeamID, titleID, keepIDs,
+		activeID, globalOrTeamID, titleID, keepIDs,
 	)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "build FMA policy re-point query")

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -774,24 +774,24 @@ func (ds *Datastore) InsertFleetMaintainedAppVersion(ctx context.Context, active
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		res, err := tx.ExecContext(ctx, `
 INSERT INTO software_installers (
-	team_id, global_or_team_id, title_id, package_ids, pre_install_query, platform,
+	team_id, global_or_team_id, title_id, pre_install_query, platform,
 	self_service, user_id, user_name, user_email, fleet_maintained_app_id,
 	post_install_script_content_id, install_during_setup,
 	storage_id, filename, extension, version,
 	install_script_content_id, uninstall_script_content_id,
-	url, upgrade_code, is_active, patch_query
+	url, upgrade_code, is_active, patch_query, package_ids
 )
 SELECT
-	team_id, global_or_team_id, title_id, package_ids, pre_install_query, platform,
+	team_id, global_or_team_id, title_id, pre_install_query, platform,
 	self_service, user_id, user_name, user_email, fleet_maintained_app_id,
 	post_install_script_content_id, install_during_setup,
 	?, ?, ?, ?,
 	?, ?,
-	?, ?, 0, ?
+	?, ?, 0, ?, ?
 FROM software_installers WHERE id = ?`,
 			payload.StorageID, payload.Filename, payload.Extension, payload.Version,
 			installScriptID, uninstallScriptID,
-			payload.URL, payload.UpgradeCode, payload.PatchQuery,
+			payload.URL, payload.UpgradeCode, payload.PatchQuery, strings.Join(payload.PackageIDs, ","),
 			activeInstallerID,
 		)
 		if err != nil {
@@ -3954,6 +3954,7 @@ SELECT
 	st.bundle_identifier,
 	st.name AS title,
 	si.package_ids,
+	si.upgrade_code,
 	si.install_script_content_id
 FROM
 	software_installers si
@@ -3976,6 +3977,7 @@ SELECT
 	st.bundle_identifier,
 	st.name AS title,
 	'' AS package_ids,
+	'' AS upgrade_code,
 	0 AS install_script_content_id
 FROM
 	in_house_apps iha

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -716,11 +716,10 @@ func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, p
 
 func (ds *Datastore) ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
 	var candidates []fleet.FMAAutoUpdateCandidate
-	// NULLIF maps the no-team scope (global_or_team_id = 0) to NULL so it scans
-	// into a nil *uint, matching the no-team convention used elsewhere.
+	// team_id is NULL for the no-team scope, so it scans straight into the nil *uint.
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &candidates, `
 		SELECT
-			NULLIF(si.global_or_team_id, 0) AS global_or_team_id,
+			si.team_id,
 			si.title_id,
 			si.fleet_maintained_app_id,
 			si.id AS installer_id,

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -711,6 +711,27 @@ func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, p
 	})
 }
 
+func (ds *Datastore) ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
+	var candidates []fleet.FMAAutoUpdateCandidate
+	// NULLIF maps the no-team scope (global_or_team_id = 0) to NULL so it scans
+	// into a nil *uint, matching the no-team convention used elsewhere.
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &candidates, `
+		SELECT
+			NULLIF(si.global_or_team_id, 0) AS global_or_team_id,
+			si.title_id,
+			si.id AS installer_id,
+			si.version,
+			fma.slug
+		FROM software_installers si
+		INNER JOIN fleet_maintained_apps fma ON fma.id = si.fleet_maintained_app_id
+		WHERE si.fleet_maintained_app_id IS NOT NULL AND si.is_active = 1
+	`)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing active fleet-maintained app installers")
+	}
+	return candidates, nil
+}
+
 func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload) error {
 	if payload.InstallScript == nil || payload.UninstallScript == nil || payload.PreInstallQuery == nil || payload.SelfService == nil {
 		return ctxerr.Wrap(ctx, errors.New("missing installer update payload fields"), "update installer record")

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -674,9 +674,6 @@ func (ds *Datastore) UpdateInstallerSelfServiceFlag(ctx context.Context, selfSer
 }
 
 func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {
-	if payload.PinnedVersion == nil {
-		return ctxerr.New(ctx, "pinned version is required to set the active Fleet-maintained app installer")
-	}
 	tmID := ptr.ValOrZero(payload.TeamID)
 
 	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
@@ -698,7 +695,13 @@ func (ds *Datastore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, p
 			return ctxerr.Wrap(ctx, err, "re-pointing policies to active fleet-maintained app installer")
 		}
 
-		// record the pin in the same transaction; an empty version clears it (Latest)
+		// A nil pin means the caller manages the pin row separately and it must be
+		// left as-is. The auto-update cron relies on this so it can flip the active
+		// installer without clobbering a pin an admin changed concurrently. A
+		// non-nil pin is authoritative: empty clears it (Latest), else it's upserted.
+		if payload.PinnedVersion == nil {
+			return nil
+		}
 		if *payload.PinnedVersion == "" {
 			if err := deletePinnedVersionDB(ctx, tx, tmID, payload.TitleID); err != nil {
 				return ctxerr.Wrap(ctx, err, "clearing Fleet-maintained app pin")

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -772,6 +772,25 @@ func (ds *Datastore) InsertFleetMaintainedAppVersion(ctx context.Context, active
 	}
 
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		// Resolve the live active row inside the tx and use it as the clone source,
+		// so per-team config the admin edited on a row they promoted during the
+		// cron's download window isn't cloned from the caller's stale view. FOR
+		// UPDATE serializes against a concurrent promotion. Falls back to the
+		// caller-supplied id only if nothing is active.
+		cloneFromID := activeInstallerID
+		var liveActiveID uint
+		switch err := sqlx.GetContext(ctx, tx, &liveActiveID, `
+			SELECT id FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL AND is_active = 1
+			LIMIT 1 FOR UPDATE`, src.GlobalOrTeamID, src.TitleID); {
+		case err == nil:
+			cloneFromID = liveActiveID
+		case errors.Is(err, sql.ErrNoRows):
+			// no active row; keep caller-supplied id
+		default:
+			return ctxerr.Wrap(ctx, err, "resolve live active installer for clone")
+		}
+
 		res, err := tx.ExecContext(ctx, `
 INSERT INTO software_installers (
 	team_id, global_or_team_id, title_id, pre_install_query, platform,
@@ -792,7 +811,7 @@ FROM software_installers WHERE id = ?`,
 			payload.StorageID, payload.Filename, payload.Extension, payload.Version,
 			installScriptID, uninstallScriptID,
 			payload.URL, payload.UpgradeCode, payload.PatchQuery, strings.Join(payload.PackageIDs, ","),
-			activeInstallerID,
+			cloneFromID,
 		)
 		if err != nil {
 			if IsDuplicate(err) {
@@ -811,21 +830,21 @@ FROM software_installers WHERE id = ?`,
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO software_installer_labels (software_installer_id, label_id, exclude, require_all)
 			SELECT ?, label_id, exclude, require_all FROM software_installer_labels WHERE software_installer_id = ?`,
-			installerID, activeInstallerID,
+			installerID, cloneFromID,
 		); err != nil {
 			return ctxerr.Wrap(ctx, err, "clone installer labels")
 		}
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO software_installer_software_categories (software_installer_id, software_category_id)
 			SELECT ?, software_category_id FROM software_installer_software_categories WHERE software_installer_id = ?`,
-			installerID, activeInstallerID,
+			installerID, cloneFromID,
 		); err != nil {
 			return ctxerr.Wrap(ctx, err, "clone installer categories")
 		}
 
-		// Evict versions beyond the cap, protecting the live active row and the row
-		// we just inserted.
-		return ds.evictOldFMAVersions(ctx, tx, src.GlobalOrTeamID, src.TitleID, installerID)
+		// Evict versions beyond the cap, protecting the live active row (the clone
+		// source) and the row we just inserted.
+		return ds.evictOldFMAVersions(ctx, tx, src.GlobalOrTeamID, src.TitleID, installerID, cloneFromID)
 	})
 	if err != nil {
 		return 0, err
@@ -834,27 +853,12 @@ FROM software_installers WHERE id = ?`,
 }
 
 // evictOldFMAVersions caps cached FMA versions for a (team, title) at
-// maxCachedFMAVersions. It always keeps the row that is currently is_active=1
-// (an admin may have promoted a different cached version during the cron's
-// download window) and newInstallerID (the row just inserted, about to be
-// promoted), then the most recently uploaded versions. Policies on evicted rows
-// are re-pointed to the active installer before the rows are deleted. Mirrors the
-// eviction logic in BatchSetSoftwareInstallers.
-func (ds *Datastore) evictOldFMAVersions(ctx context.Context, tx sqlx.ExtContext, globalOrTeamID, titleID, newInstallerID uint) error {
-	// Resolve the live active row rather than trusting the caller's (possibly
-	// stale) view, so a concurrent admin promotion isn't evicted out from under us.
-	var activeID uint
-	err := sqlx.GetContext(ctx, tx, &activeID, `
-		SELECT id FROM software_installers
-		WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL AND is_active = 1
-		LIMIT 1`, globalOrTeamID, titleID)
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			return ctxerr.Wrap(ctx, err, "find active FMA installer for eviction")
-		}
-		activeID = newInstallerID
-	}
-
+// maxCachedFMAVersions. It always keeps activeID (the live is_active=1 row,
+// resolved by the caller under FOR UPDATE) and newInstallerID (the row just
+// inserted, about to be promoted), then the most recently uploaded versions.
+// Policies on evicted rows are re-pointed to the active installer before the rows
+// are deleted. Mirrors the eviction logic in BatchSetSoftwareInstallers.
+func (ds *Datastore) evictOldFMAVersions(ctx context.Context, tx sqlx.ExtContext, globalOrTeamID, titleID, newInstallerID, activeID uint) error {
 	fmaVersions, err := ds.getFleetMaintainedVersionsByTitleIDs(ctx, tx, []uint{titleID}, globalOrTeamID, false)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list FMA installer versions for eviction")

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -852,6 +852,36 @@ FROM software_installers WHERE id = ?`,
 	return installerID, nil
 }
 
+// GetSoftwareInstallerMetadataByStorageID returns the package IDs and upgrade
+// code of any cached installer (active or inactive) with the given storage_id.
+// A content hash uniquely identifies the bytes, so the metadata is the same
+// regardless of which row is currently active — the auto-update cron uses this to
+// recover uninstall-script substitution values on the byte-dedup path without
+// re-downloading. Returns empty values (no error) when nothing matches.
+func (ds *Datastore) GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error) {
+	var row struct {
+		PackageIDs  string `db:"package_ids"`
+		UpgradeCode string `db:"upgrade_code"`
+	}
+	// Prefer a row that actually carries package IDs (the MSI/EXE row).
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &row, `
+		SELECT package_ids, upgrade_code FROM software_installers
+		WHERE storage_id = ?
+		ORDER BY (package_ids = '') ASC, id ASC
+		LIMIT 1`, storageID)
+	switch {
+	case err == nil:
+		if row.PackageIDs != "" {
+			packageIDs = strings.Split(row.PackageIDs, ",")
+		}
+		return packageIDs, row.UpgradeCode, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, "", nil
+	default:
+		return nil, "", ctxerr.Wrap(ctx, err, "get software installer metadata by storage id")
+	}
+}
+
 // evictOldFMAVersions caps cached FMA versions for a (team, title) at
 // maxCachedFMAVersions. It always keeps activeID (the live is_active=1 row,
 // resolved by the caller under FOR UPDATE) and newInstallerID (the row just
@@ -3958,7 +3988,6 @@ SELECT
 	st.bundle_identifier,
 	st.name AS title,
 	si.package_ids,
-	si.upgrade_code,
 	si.install_script_content_id
 FROM
 	software_installers si
@@ -3981,7 +4010,6 @@ SELECT
 	st.bundle_identifier,
 	st.name AS title,
 	'' AS package_ids,
-	'' AS upgrade_code,
 	0 AS install_script_content_id
 FROM
 	in_house_apps iha

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -722,6 +722,7 @@ func (ds *Datastore) ListFleetMaintainedAppActiveInstallers(ctx context.Context)
 		SELECT
 			NULLIF(si.global_or_team_id, 0) AS global_or_team_id,
 			si.title_id,
+			si.fleet_maintained_app_id,
 			si.id AS installer_id,
 			si.version,
 			fma.slug
@@ -733,6 +734,158 @@ func (ds *Datastore) ListFleetMaintainedAppActiveInstallers(ctx context.Context)
 		return nil, ctxerr.Wrap(ctx, err, "listing active fleet-maintained app installers")
 	}
 	return candidates, nil
+}
+
+// InsertFleetMaintainedAppVersion caches a newly downloaded version of an
+// already-installed Fleet-maintained app. It clones the currently active
+// installer (activeInstallerID) so the team's per-installer configuration —
+// self-service, labels, categories, pre-install query, attribution — is carried
+// forward, overriding only the version-specific fields from the manifest
+// payload. The new row is inserted inactive (is_active = 0); the caller promotes
+// it separately via SetFleetMaintainedAppActiveInstaller. The team pin is never
+// written here. Versions beyond maxCachedFMAVersions are evicted, always
+// protecting the active installer, with policies on evicted rows re-pointed to
+// it. The call is idempotent: if the version is already cached, its existing
+// installer ID is returned without inserting.
+func (ds *Datastore) InsertFleetMaintainedAppVersion(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, err error) {
+	// Resolve script content IDs outside the transaction (matches MatchOrCreateSoftwareInstaller).
+	installScriptID, err := ds.getOrGenerateScriptContentsID(ctx, payload.InstallScript)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "get or generate install script contents ID")
+	}
+	uninstallScriptID, err := ds.getOrGenerateScriptContentsID(ctx, payload.UninstallScript)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "get or generate uninstall script contents ID")
+	}
+
+	// Read the scope (team, title) from the active installer so the cron
+	// doesn't need to pass them and they always agree with the row being cloned.
+	var src struct {
+		TitleID        uint `db:"title_id"`
+		GlobalOrTeamID uint `db:"global_or_team_id"`
+	}
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &src,
+		`SELECT title_id, global_or_team_id FROM software_installers WHERE id = ?`,
+		activeInstallerID,
+	); err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "load active installer scope")
+	}
+
+	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		res, err := tx.ExecContext(ctx, `
+INSERT INTO software_installers (
+	team_id, global_or_team_id, title_id, package_ids, pre_install_query, platform,
+	self_service, user_id, user_name, user_email, fleet_maintained_app_id,
+	post_install_script_content_id,
+	storage_id, filename, extension, version,
+	install_script_content_id, uninstall_script_content_id,
+	url, upgrade_code, is_active, patch_query
+)
+SELECT
+	team_id, global_or_team_id, title_id, package_ids, pre_install_query, platform,
+	self_service, user_id, user_name, user_email, fleet_maintained_app_id,
+	post_install_script_content_id,
+	?, ?, ?, ?,
+	?, ?,
+	?, ?, 0, ?
+FROM software_installers WHERE id = ?`,
+			payload.StorageID, payload.Filename, payload.Extension, payload.Version,
+			installScriptID, uninstallScriptID,
+			payload.URL, payload.UpgradeCode, payload.PatchQuery,
+			activeInstallerID,
+		)
+		if err != nil {
+			if IsDuplicate(err) {
+				// Version already cached for this team/title; return the existing row.
+				return sqlx.GetContext(ctx, tx, &installerID, `
+					SELECT id FROM software_installers
+					WHERE global_or_team_id = ? AND title_id = ? AND version = ?`,
+					src.GlobalOrTeamID, src.TitleID, payload.Version)
+			}
+			return ctxerr.Wrap(ctx, err, "insert fleet-maintained app version")
+		}
+		id, _ := res.LastInsertId()
+		installerID = uint(id) //nolint:gosec // dismiss G115
+
+		// Clone the active installer's labels and categories onto the new version.
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO software_installer_labels (software_installer_id, label_id, exclude, require_all)
+			SELECT ?, label_id, exclude, require_all FROM software_installer_labels WHERE software_installer_id = ?`,
+			installerID, activeInstallerID,
+		); err != nil {
+			return ctxerr.Wrap(ctx, err, "clone installer labels")
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO software_installer_software_categories (software_installer_id, software_category_id)
+			SELECT ?, software_category_id FROM software_installer_software_categories WHERE software_installer_id = ?`,
+			installerID, activeInstallerID,
+		); err != nil {
+			return ctxerr.Wrap(ctx, err, "clone installer categories")
+		}
+
+		// Evict versions beyond the cap, always protecting the active installer.
+		return ds.evictOldFMAVersions(ctx, tx, src.GlobalOrTeamID, src.TitleID, activeInstallerID)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return installerID, nil
+}
+
+// evictOldFMAVersions caps cached FMA versions for a (team, title) at
+// maxCachedFMAVersions, always keeping protectInstallerID (the active version)
+// and otherwise the most recently uploaded versions. Policies on evicted rows
+// are re-pointed to the protected installer before the rows are deleted. Mirrors
+// the eviction logic in BatchSetSoftwareInstallers.
+func (ds *Datastore) evictOldFMAVersions(ctx context.Context, tx sqlx.ExtContext, globalOrTeamID, titleID, protectInstallerID uint) error {
+	fmaVersions, err := ds.getFleetMaintainedVersionsByTitleIDs(ctx, tx, []uint{titleID}, globalOrTeamID, false)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list FMA installer versions for eviction")
+	}
+	versions := fmaVersions[titleID]
+	if len(versions) <= maxCachedFMAVersions {
+		return nil
+	}
+
+	// Keep set: protected installer + most recent up to the cap.
+	keepSet := map[uint]bool{protectInstallerID: true}
+	for _, v := range versions {
+		if len(keepSet) >= maxCachedFMAVersions {
+			break
+		}
+		keepSet[v.ID] = true
+	}
+	keepIDs := slices.Collect(maps.Keys(keepSet))
+
+	// Re-point policies referencing soon-to-be-evicted versions to the protected one.
+	rePointStmt, rePointArgs, err := sqlx.In(
+		`UPDATE policies SET software_installer_id = ?
+		WHERE software_installer_id IN (
+			SELECT id FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL AND id NOT IN (?)
+		)`,
+		protectInstallerID, globalOrTeamID, titleID, keepIDs,
+	)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build FMA policy re-point query")
+	}
+	if _, err := tx.ExecContext(ctx, rePointStmt, rePointArgs...); err != nil {
+		return ctxerr.Wrap(ctx, err, "re-point policies for evicted FMA versions")
+	}
+
+	// Delete evicted rows (with side effects), skipping the kept ones.
+	for _, v := range versions {
+		if keepSet[v.ID] {
+			continue
+		}
+		if _, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, v.ID, true, true, false); err != nil {
+			return ctxerr.Wrapf(ctx, err, "side effects for evicted installer id %d", v.ID)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, v.ID); err != nil {
+			return ctxerr.Wrapf(ctx, err, "delete evicted installer id %d", v.ID)
+		}
+	}
+	return nil
 }
 
 func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload) error {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -61,6 +61,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"ListFleetMaintainedAppActiveInstallers", testListFleetMaintainedAppActiveInstallers},
 		{"InsertFleetMaintainedAppVersion", testInsertFleetMaintainedAppVersion},
 		{"InsertFleetMaintainedAppVersionProtectsLiveActive", testInsertFleetMaintainedAppVersionProtectsLiveActive},
+		{"InsertFleetMaintainedAppVersionClonesLiveActive", testInsertFleetMaintainedAppVersionClonesLiveActive},
 		{"SoftwareTitlePins", testSoftwareTitlePins},
 		{"SetFleetMaintainedAppActiveInstallerPin", testSetFleetMaintainedAppActiveInstallerPin},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
@@ -4969,6 +4970,68 @@ func testInsertFleetMaintainedAppVersionProtectsLiveActive(t *testing.T, ds *Dat
 			`SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id = ? ORDER BY id`, team.ID, titleID)
 	})
 	require.ElementsMatch(t, []uint{v2, v3}, remaining, "live active (v2) protected, stale v1 evicted")
+}
+
+// testInsertFleetMaintainedAppVersionClonesLiveActive verifies the new version's
+// per-team config is cloned from the row that is actually is_active=1 at insert
+// time, not from the caller's (possibly stale) activeInstallerID — e.g. when an
+// admin promotes a different cached row and edits it during the download window.
+func testInsertFleetMaintainedAppVersionClonesLiveActive(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Carol", "carol@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-fma-clone-live"})
+	require.NoError(t, err)
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name: "Maintained3", Slug: "maintained3", Platform: "darwin", UniqueIdentifier: "fleet.maintained3",
+	})
+	require.NoError(t, err)
+	newFile := func(s string) *fleet.TempFileReader {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(s), t.TempDir)
+		require.NoError(t, err)
+		return tfr
+	}
+
+	// v1 active with self-service OFF.
+	v1, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title: "FooFMA", Source: "apps", Platform: "darwin", InstallScript: "echo i", UninstallScript: "echo u",
+		SelfService: false, InstallerFile: newFile("v1"), StorageID: "clone-v1", Filename: "foo-1.0.pkg", Extension: "pkg",
+		Version: "1.0", UserID: user.ID, TeamID: &team.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: new(maintainedApp.ID),
+	})
+	require.NoError(t, err)
+
+	// Cache v2, promote it, and turn ON self-service + setup-experience on it
+	// (simulating an admin rollback + edit during the cron's download window).
+	v2, err := ds.InsertFleetMaintainedAppVersion(ctx, v1, &fleet.UploadSoftwareInstallerPayload{
+		Version: "2.0", Filename: "foo-2.0.pkg", Extension: "pkg", StorageID: "clone-v2",
+		URL: "https://example.test/2", InstallScript: "echo i2", UninstallScript: "echo u2",
+	})
+	require.NoError(t, err)
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`UPDATE software_installers SET is_active = (id = ?), self_service = (id = ?), install_during_setup = (id = ?)
+			 WHERE global_or_team_id = ? AND fleet_maintained_app_id = ?`,
+			v2, v2, v2, team.ID, maintainedApp.ID)
+		return err
+	})
+
+	// Insert v3 with the STALE caller id (v1). Config must clone from live active (v2).
+	v3, err := ds.InsertFleetMaintainedAppVersion(ctx, v1, &fleet.UploadSoftwareInstallerPayload{
+		Version: "3.0", Filename: "foo-3.0.pkg", Extension: "pkg", StorageID: "clone-v3",
+		URL: "https://example.test/3", InstallScript: "echo i3", UninstallScript: "echo u3",
+	})
+	require.NoError(t, err)
+
+	var r struct {
+		SelfService        bool `db:"self_service"`
+		InstallDuringSetup bool `db:"install_during_setup"`
+	}
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &r,
+			`SELECT self_service, install_during_setup FROM software_installers WHERE id = ?`, v3)
+	})
+	require.True(t, r.SelfService, "self_service cloned from live active (v2), not stale v1")
+	require.True(t, r.InstallDuringSetup, "install_during_setup cloned from live active (v2), not stale v1")
 }
 
 func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4801,7 +4801,8 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 		PreInstallQuery: "SELECT pre", PostInstallScript: "echo post",
 		SelfService:   true,
 		InstallerFile: newFile("v1"), StorageID: "sha-v1", Filename: "foo-1.0.pkg", Extension: "pkg",
-		Version: "1.0", UserID: user.ID, TeamID: &team.ID,
+		PackageIDs: []string{"OLD-PKG"},
+		Version:    "1.0", UserID: user.ID, TeamID: &team.ID,
 		ValidatedLabels: &fleet.LabelIdentsWithScope{
 			LabelScope: fleet.LabelScopeIncludeAny,
 			ByName:     map[string]fleet.LabelIdent{lbl.Name: {LabelID: lbl.ID, LabelName: lbl.Name}},
@@ -4822,10 +4823,12 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 		return err
 	})
 
-	// Cache v2 (inactive), cloning v1's config.
+	// Cache v2 (inactive), cloning v1's config; package_ids must come from the
+	// payload (version-specific MSI ProductCode), not be cloned from v1.
 	v2ID, err := ds.InsertFleetMaintainedAppVersion(ctx, activeID, &fleet.UploadSoftwareInstallerPayload{
 		Version: "2.0", Filename: "foo-2.0.pkg", Extension: "pkg", StorageID: "sha-v2",
-		URL: "https://example.test/foo-2.0.pkg", InstallScript: "echo install v2", UninstallScript: "echo uninstall v2",
+		PackageIDs: []string{"NEW-PKG"},
+		URL:        "https://example.test/foo-2.0.pkg", InstallScript: "echo install v2", UninstallScript: "echo uninstall v2",
 	})
 	require.NoError(t, err)
 	require.NotEqual(t, activeID, v2ID)
@@ -4837,6 +4840,7 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 		Pre                string `db:"pre_install_query"`
 		Version            string `db:"version"`
 		Storage            string `db:"storage_id"`
+		PackageIDs         string `db:"package_ids"`
 		InstallID          *uint  `db:"install_script_content_id"`
 		PostID             *uint  `db:"post_install_script_content_id"`
 	}
@@ -4844,7 +4848,7 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 		var r row
 		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 			return sqlx.GetContext(ctx, q, &r,
-				`SELECT is_active, self_service, install_during_setup, pre_install_query, version, storage_id, install_script_content_id, post_install_script_content_id
+				`SELECT is_active, self_service, install_during_setup, pre_install_query, version, storage_id, package_ids, install_script_content_id, post_install_script_content_id
 				 FROM software_installers WHERE id = ?`, id)
 		})
 		return r
@@ -4857,6 +4861,7 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 	// Config carried forward.
 	require.True(t, r2.SelfService)
 	require.True(t, r2.InstallDuringSetup, "install_during_setup must be carried forward")
+	require.Equal(t, "NEW-PKG", r2.PackageIDs, "package_ids must be bound from payload, not cloned from v1")
 	require.Equal(t, "SELECT pre", r2.Pre)
 	require.Equal(t, "2.0", r2.Version)
 	require.Equal(t, "sha-v2", r2.Storage)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -59,6 +59,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"AddSoftwareTitleToMatchingSoftware", testAddSoftwareTitleToMatchingSoftware},
 		{"FleetMaintainedAppInstallerUpdates", testFleetMaintainedAppInstallerUpdates},
 		{"ListFleetMaintainedAppActiveInstallers", testListFleetMaintainedAppActiveInstallers},
+		{"InsertFleetMaintainedAppVersion", testInsertFleetMaintainedAppVersion},
 		{"SoftwareTitlePins", testSoftwareTitlePins},
 		{"SetFleetMaintainedAppActiveInstallerPin", testSetFleetMaintainedAppActiveInstallerPin},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
@@ -4764,11 +4765,144 @@ func testListFleetMaintainedAppActiveInstallers(t *testing.T, ds *Datastore) {
 	require.Equal(t, team1.ID, *t1.TeamID)
 	require.Equal(t, "1.0", t1.Version)
 	require.Equal(t, "maintained1", t1.Slug)
+	require.Equal(t, maintainedApp.ID, t1.FleetMaintainedAppID)
 
 	nt := byInstallerID[fmaNoTeam]
 	require.Nil(t, nt.TeamID) // no-team scope maps to nil
 	require.Equal(t, "2.0", nt.Version)
 	require.Equal(t, "maintained1", nt.Slug)
+}
+
+func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-fma-insert"})
+	require.NoError(t, err)
+
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name: "Maintained1", Slug: "maintained1", Platform: "darwin", UniqueIdentifier: "fleet.maintained1",
+	})
+	require.NoError(t, err)
+
+	lbl, err := ds.NewLabel(ctx, &fleet.Label{Name: "lbl-fma", Query: "SELECT 1"})
+	require.NoError(t, err)
+
+	newFile := func(s string) *fleet.TempFileReader {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(s), t.TempDir)
+		require.NoError(t, err)
+		return tfr
+	}
+
+	// Active v1 installer with per-team config the cron must carry forward.
+	activeID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title: "FooFMA", Source: "apps", Platform: "darwin",
+		InstallScript: "echo install v1", UninstallScript: "echo uninstall v1",
+		PreInstallQuery: "SELECT pre", PostInstallScript: "echo post",
+		SelfService:   true,
+		InstallerFile: newFile("v1"), StorageID: "sha-v1", Filename: "foo-1.0.pkg", Extension: "pkg",
+		Version: "1.0", UserID: user.ID, TeamID: &team.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{
+			LabelScope: fleet.LabelScopeIncludeAny,
+			ByName:     map[string]fleet.LabelIdent{lbl.Name: {LabelID: lbl.ID, LabelName: lbl.Name}},
+		},
+		FleetMaintainedAppID: new(maintainedApp.ID),
+	})
+	require.NoError(t, err)
+
+	// Seed a caret pin that must survive the insert untouched.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO software_title_team_pins (team_id, title_id, pinned_version) VALUES (?, ?, ?)`,
+			team.ID, titleID, "^1")
+		return err
+	})
+
+	// Cache v2 (inactive), cloning v1's config.
+	v2ID, err := ds.InsertFleetMaintainedAppVersion(ctx, activeID, &fleet.UploadSoftwareInstallerPayload{
+		Version: "2.0", Filename: "foo-2.0.pkg", Extension: "pkg", StorageID: "sha-v2",
+		URL: "https://example.test/foo-2.0.pkg", InstallScript: "echo install v2", UninstallScript: "echo uninstall v2",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, activeID, v2ID)
+
+	type row struct {
+		Active      bool   `db:"is_active"`
+		SelfService bool   `db:"self_service"`
+		Pre         string `db:"pre_install_query"`
+		Version     string `db:"version"`
+		Storage     string `db:"storage_id"`
+		InstallID   *uint  `db:"install_script_content_id"`
+		PostID      *uint  `db:"post_install_script_content_id"`
+	}
+	getRow := func(id uint) row {
+		var r row
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &r,
+				`SELECT is_active, self_service, pre_install_query, version, storage_id, install_script_content_id, post_install_script_content_id
+				 FROM software_installers WHERE id = ?`, id)
+		})
+		return r
+	}
+	r1, r2 := getRow(activeID), getRow(v2ID)
+
+	// v1 stays active; v2 inactive.
+	require.True(t, r1.Active)
+	require.False(t, r2.Active)
+	// Config carried forward.
+	require.True(t, r2.SelfService)
+	require.Equal(t, "SELECT pre", r2.Pre)
+	require.Equal(t, "2.0", r2.Version)
+	require.Equal(t, "sha-v2", r2.Storage)
+	// New install script for the new version; post-install carried forward.
+	require.NotNil(t, r2.InstallID)
+	require.NotNil(t, r1.InstallID)
+	require.NotEqual(t, *r1.InstallID, *r2.InstallID)
+	require.NotNil(t, r2.PostID)
+	require.NotNil(t, r1.PostID)
+	require.Equal(t, *r1.PostID, *r2.PostID)
+
+	// Label cloned onto v2.
+	var labelCount int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &labelCount,
+			`SELECT COUNT(*) FROM software_installer_labels WHERE software_installer_id = ? AND label_id = ?`, v2ID, lbl.ID)
+	})
+	require.Equal(t, 1, labelCount)
+
+	// Pin untouched.
+	pin, err := ds.GetPinnedVersion(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.NotNil(t, pin)
+	require.Equal(t, "^1", *pin)
+
+	// Idempotent: re-caching v2 returns the same id, no new row.
+	again, err := ds.InsertFleetMaintainedAppVersion(ctx, activeID, &fleet.UploadSoftwareInstallerPayload{
+		Version: "2.0", Filename: "foo-2.0.pkg", Extension: "pkg", StorageID: "sha-v2",
+		URL: "https://example.test/foo-2.0.pkg", InstallScript: "echo install v2", UninstallScript: "echo uninstall v2",
+	})
+	require.NoError(t, err)
+	require.Equal(t, v2ID, again)
+
+	// Force v2 to be the oldest non-active version so eviction is deterministic.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE software_installers SET uploaded_at = '2000-01-01 00:00:00' WHERE id = ?`, v2ID)
+		return err
+	})
+
+	// Eviction: caching v3 brings the count to 3; the oldest non-active (v2) is
+	// evicted while the active installer (v1) is always protected.
+	v3ID, err := ds.InsertFleetMaintainedAppVersion(ctx, activeID, &fleet.UploadSoftwareInstallerPayload{
+		Version: "3.0", Filename: "foo-3.0.pkg", Extension: "pkg", StorageID: "sha-v3",
+		URL: "https://example.test/foo-3.0.pkg", InstallScript: "echo install v3", UninstallScript: "echo uninstall v3",
+	})
+	require.NoError(t, err)
+
+	var remaining []uint
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &remaining,
+			`SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id = ? ORDER BY id`, team.ID, titleID)
+	})
+	require.ElementsMatch(t, []uint{activeID, v3ID}, remaining, "v2 evicted, active protected")
 }
 
 func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -60,6 +60,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"FleetMaintainedAppInstallerUpdates", testFleetMaintainedAppInstallerUpdates},
 		{"ListFleetMaintainedAppActiveInstallers", testListFleetMaintainedAppActiveInstallers},
 		{"SoftwareTitlePins", testSoftwareTitlePins},
+		{"SetFleetMaintainedAppActiveInstallerPin", testSetFleetMaintainedAppActiveInstallerPin},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
 		{"CustomToFMAInstallerReplacement", testCustomToFMAInstallerReplacement},
 		{"GetInstallerByTeamAndURL", testGetInstallerByTeamAndURL},
@@ -5923,4 +5924,70 @@ func testSoftwareTitlePins(t *testing.T, ds *Datastore) {
 	pin, err = ds.GetPinnedVersion(ctx, otherTeam, titleID)
 	require.NoError(t, err)
 	require.Equal(t, new("2.0"), pin)
+}
+
+func testSetFleetMaintainedAppActiveInstallerPin(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	fma, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name: "Maintained1", Slug: "maintained1", Platform: "darwin", UniqueIdentifier: "fleet.maintained1",
+	})
+	require.NoError(t, err)
+
+	tfr, err := fleet.NewTempFileReader(strings.NewReader("file contents"), t.TempDir)
+	require.NoError(t, err)
+	v1ID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title: "testpkg", Source: "apps", Platform: "darwin",
+		InstallScript: "echo install", UninstallScript: "echo uninstall",
+		InstallerFile: tfr, StorageID: "storageid1", Filename: "test.pkg", Version: "1.0",
+		UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{}, FleetMaintainedAppID: new(fma.ID),
+	})
+	require.NoError(t, err)
+
+	// Add a second cached version (inactive) for the same no-team title.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO software_installers
+				(team_id, global_or_team_id, storage_id, filename, extension, version, platform, title_id,
+				 fleet_maintained_app_id, install_script_content_id, uninstall_script_content_id, is_active, package_ids, patch_query)
+			SELECT team_id, global_or_team_id, 'storageid2', filename, extension, '2.0', platform, title_id,
+				fleet_maintained_app_id, install_script_content_id, uninstall_script_content_id, 0, package_ids, patch_query
+			FROM software_installers WHERE id = ?
+		`, v1ID)
+		return err
+	})
+	var v2ID uint
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &v2ID, `SELECT id FROM software_installers WHERE title_id=? AND global_or_team_id=0 AND version='2.0'`, titleID)
+	})
+
+	activeID := func() uint {
+		var id uint
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &id, `SELECT id FROM software_installers WHERE title_id=? AND global_or_team_id=0 AND is_active=1`, titleID)
+		})
+		return id
+	}
+
+	// A non-nil pin is authoritative: it upserts the pin row.
+	require.NoError(t, ds.SetFleetMaintainedAppActiveInstaller(ctx, &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, PinnedVersion: new("^1")}, v1ID))
+	require.Equal(t, v1ID, activeID())
+	pin, err := ds.GetPinnedVersion(ctx, nil, titleID)
+	require.NoError(t, err)
+	require.Equal(t, new("^1"), pin)
+
+	// A nil pin flips the active installer but leaves the pin row untouched —
+	// this is what the auto-update cron relies on to avoid clobbering an admin's pin.
+	require.NoError(t, ds.SetFleetMaintainedAppActiveInstaller(ctx, &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, PinnedVersion: nil}, v2ID))
+	require.Equal(t, v2ID, activeID())
+	pin, err = ds.GetPinnedVersion(ctx, nil, titleID)
+	require.NoError(t, err)
+	require.Equal(t, new("^1"), pin) // unchanged
+
+	// A non-nil empty pin clears it (Latest).
+	require.NoError(t, ds.SetFleetMaintainedAppActiveInstaller(ctx, &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, PinnedVersion: new("")}, v1ID))
+	require.Equal(t, v1ID, activeID())
+	_, err = ds.GetPinnedVersion(ctx, nil, titleID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -62,6 +62,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"InsertFleetMaintainedAppVersion", testInsertFleetMaintainedAppVersion},
 		{"InsertFleetMaintainedAppVersionProtectsLiveActive", testInsertFleetMaintainedAppVersionProtectsLiveActive},
 		{"InsertFleetMaintainedAppVersionClonesLiveActive", testInsertFleetMaintainedAppVersionClonesLiveActive},
+		{"GetSoftwareInstallerMetadataByStorageID", testGetSoftwareInstallerMetadataByStorageID},
 		{"SoftwareTitlePins", testSoftwareTitlePins},
 		{"SetFleetMaintainedAppActiveInstallerPin", testSetFleetMaintainedAppActiveInstallerPin},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
@@ -5032,6 +5033,52 @@ func testInsertFleetMaintainedAppVersionClonesLiveActive(t *testing.T, ds *Datas
 	})
 	require.True(t, r.SelfService, "self_service cloned from live active (v2), not stale v1")
 	require.True(t, r.InstallDuringSetup, "install_during_setup cloned from live active (v2), not stale v1")
+}
+
+// testGetSoftwareInstallerMetadataByStorageID verifies metadata recovery works
+// for any row with the content hash — including an inactive one (e.g. after a
+// rollback) — so the cron's byte-dedup path isn't locked out when no team has the
+// version active.
+func testGetSoftwareInstallerMetadataByStorageID(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Dave", "dave@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-fma-meta-hash"})
+	require.NoError(t, err)
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name: "Maintained4", Slug: "maintained4", Platform: "windows", UniqueIdentifier: "fleet.maintained4",
+	})
+	require.NoError(t, err)
+	newFile := func(s string) *fleet.TempFileReader {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(s), t.TempDir)
+		require.NoError(t, err)
+		return tfr
+	}
+
+	id, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title: "FooFMA", Source: "programs", Platform: "windows", InstallScript: "echo i", UninstallScript: "echo u",
+		PackageIDs: []string{"PROD-CODE"}, UpgradeCode: "UP-CODE",
+		InstallerFile: newFile("v1"), StorageID: "hash-meta-1", Filename: "foo.msi", Extension: "msi",
+		Version: "1.0", UserID: user.ID, TeamID: &team.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: new(maintainedApp.ID),
+	})
+	require.NoError(t, err)
+
+	// Make it inactive — the is_active=1-filtered lookups would miss it.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE software_installers SET is_active = 0 WHERE id = ?`, id)
+		return err
+	})
+
+	pids, ucode, err := ds.GetSoftwareInstallerMetadataByStorageID(ctx, "hash-meta-1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"PROD-CODE"}, pids, "recovers package IDs from an inactive row")
+	require.Equal(t, "UP-CODE", ucode)
+
+	// Unknown hash → empty, no error.
+	pids, ucode, err = ds.GetSoftwareInstallerMetadataByStorageID(ctx, "no-such-hash")
+	require.NoError(t, err)
+	require.Empty(t, pids)
+	require.Empty(t, ucode)
 }
 
 func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -58,6 +58,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"SoftwareTitleDisplayName", testSoftwareTitleDisplayName},
 		{"AddSoftwareTitleToMatchingSoftware", testAddSoftwareTitleToMatchingSoftware},
 		{"FleetMaintainedAppInstallerUpdates", testFleetMaintainedAppInstallerUpdates},
+		{"ListFleetMaintainedAppActiveInstallers", testListFleetMaintainedAppActiveInstallers},
 		{"SoftwareTitlePins", testSoftwareTitlePins},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
 		{"CustomToFMAInstallerReplacement", testCustomToFMAInstallerReplacement},
@@ -4654,6 +4655,119 @@ func testFleetMaintainedAppInstallerUpdates(t *testing.T, ds *Datastore) {
 	require.NotEqual(t, postInstallScript, installer.PostInstallScriptContentID)
 	require.NotEqual(t, uninstallScript, installer.UninstallScriptContentID)
 	require.Equal(t, "SELECT 1 DIFFERENT", installer.PreInstallQuery)
+}
+
+func testListFleetMaintainedAppActiveInstallers(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "team2"})
+	require.NoError(t, err)
+
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Maintained1",
+		Slug:             "maintained1",
+		Platform:         "darwin",
+		UniqueIdentifier: "fleet.maintained1",
+	})
+	require.NoError(t, err)
+
+	newFile := func(s string) *fleet.TempFileReader {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(s), t.TempDir)
+		require.NoError(t, err)
+		return tfr
+	}
+
+	// Active FMA installer on team1.
+	fmaTeam1, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "FooFMA",
+		Source:               "apps",
+		Platform:             "darwin",
+		InstallScript:        "echo install",
+		UninstallScript:      "echo uninstall",
+		InstallerFile:        newFile("t1"),
+		StorageID:            "storage-t1",
+		Filename:             "foo.pkg",
+		Version:              "1.0",
+		UserID:               user.ID,
+		TeamID:               &team1.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: new(maintainedApp.ID),
+	})
+	require.NoError(t, err)
+
+	// Active FMA installer on no-team.
+	fmaNoTeam, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "FooFMA",
+		Source:               "apps",
+		Platform:             "darwin",
+		InstallScript:        "echo install",
+		UninstallScript:      "echo uninstall",
+		InstallerFile:        newFile("nt"),
+		StorageID:            "storage-nt",
+		Filename:             "foo.pkg",
+		Version:              "2.0",
+		UserID:               user.ID,
+		TeamID:               nil,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: new(maintainedApp.ID),
+	})
+	require.NoError(t, err)
+
+	// Non-FMA installer on team2 — must be excluded.
+	customTeam2, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:           "Custom",
+		Source:          "apps",
+		Platform:        "darwin",
+		InstallScript:   "echo install",
+		UninstallScript: "echo uninstall",
+		InstallerFile:   newFile("c2"),
+		StorageID:       "storage-c2",
+		Filename:        "custom.pkg",
+		Version:         "9.0",
+		UserID:          user.ID,
+		TeamID:          &team2.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	// An inactive (older) cached version of team1's FMA — must be excluded.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO software_installers
+				(team_id, global_or_team_id, storage_id, filename, extension, version, platform, title_id,
+				 fleet_maintained_app_id, install_script_content_id, uninstall_script_content_id, is_active, package_ids, patch_query)
+			SELECT team_id, global_or_team_id, 'storage-t1-old', filename, extension, '0.9', platform, title_id,
+				fleet_maintained_app_id, install_script_content_id, uninstall_script_content_id, 0, package_ids, patch_query
+			FROM software_installers WHERE id = ?
+		`, fmaTeam1)
+		return err
+	})
+
+	got, err := ds.ListFleetMaintainedAppActiveInstallers(ctx)
+	require.NoError(t, err)
+
+	byInstallerID := make(map[uint]fleet.FMAAutoUpdateCandidate, len(got))
+	for _, c := range got {
+		byInstallerID[c.InstallerID] = c
+	}
+
+	// Only the two active FMA rows are returned; the custom installer and the
+	// inactive version are excluded.
+	require.Len(t, got, 2)
+	require.NotContains(t, byInstallerID, customTeam2)
+
+	t1 := byInstallerID[fmaTeam1]
+	require.NotNil(t, t1.TeamID)
+	require.Equal(t, team1.ID, *t1.TeamID)
+	require.Equal(t, "1.0", t1.Version)
+	require.Equal(t, "maintained1", t1.Slug)
+
+	nt := byInstallerID[fmaNoTeam]
+	require.Nil(t, nt.TeamID) // no-team scope maps to nil
+	require.Equal(t, "2.0", nt.Version)
+	require.Equal(t, "maintained1", nt.Slug)
 }
 
 func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -60,6 +60,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"FleetMaintainedAppInstallerUpdates", testFleetMaintainedAppInstallerUpdates},
 		{"ListFleetMaintainedAppActiveInstallers", testListFleetMaintainedAppActiveInstallers},
 		{"InsertFleetMaintainedAppVersion", testInsertFleetMaintainedAppVersion},
+		{"InsertFleetMaintainedAppVersionProtectsLiveActive", testInsertFleetMaintainedAppVersionProtectsLiveActive},
 		{"SoftwareTitlePins", testSoftwareTitlePins},
 		{"SetFleetMaintainedAppActiveInstallerPin", testSetFleetMaintainedAppActiveInstallerPin},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
@@ -4809,11 +4810,15 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// Seed a caret pin that must survive the insert untouched.
+	// Seed a caret pin that must survive the insert untouched, and mark v1 for the
+	// setup experience so we can assert the flag is carried forward.
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		_, err := q.ExecContext(ctx,
+		if _, err := q.ExecContext(ctx,
 			`INSERT INTO software_title_team_pins (team_id, title_id, pinned_version) VALUES (?, ?, ?)`,
-			team.ID, titleID, "^1")
+			team.ID, titleID, "^1"); err != nil {
+			return err
+		}
+		_, err := q.ExecContext(ctx, `UPDATE software_installers SET install_during_setup = 1 WHERE id = ?`, activeID)
 		return err
 	})
 
@@ -4826,19 +4831,20 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 	require.NotEqual(t, activeID, v2ID)
 
 	type row struct {
-		Active      bool   `db:"is_active"`
-		SelfService bool   `db:"self_service"`
-		Pre         string `db:"pre_install_query"`
-		Version     string `db:"version"`
-		Storage     string `db:"storage_id"`
-		InstallID   *uint  `db:"install_script_content_id"`
-		PostID      *uint  `db:"post_install_script_content_id"`
+		Active             bool   `db:"is_active"`
+		SelfService        bool   `db:"self_service"`
+		InstallDuringSetup bool   `db:"install_during_setup"`
+		Pre                string `db:"pre_install_query"`
+		Version            string `db:"version"`
+		Storage            string `db:"storage_id"`
+		InstallID          *uint  `db:"install_script_content_id"`
+		PostID             *uint  `db:"post_install_script_content_id"`
 	}
 	getRow := func(id uint) row {
 		var r row
 		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 			return sqlx.GetContext(ctx, q, &r,
-				`SELECT is_active, self_service, pre_install_query, version, storage_id, install_script_content_id, post_install_script_content_id
+				`SELECT is_active, self_service, install_during_setup, pre_install_query, version, storage_id, install_script_content_id, post_install_script_content_id
 				 FROM software_installers WHERE id = ?`, id)
 		})
 		return r
@@ -4850,6 +4856,7 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 	require.False(t, r2.Active)
 	// Config carried forward.
 	require.True(t, r2.SelfService)
+	require.True(t, r2.InstallDuringSetup, "install_during_setup must be carried forward")
 	require.Equal(t, "SELECT pre", r2.Pre)
 	require.Equal(t, "2.0", r2.Version)
 	require.Equal(t, "sha-v2", r2.Storage)
@@ -4903,6 +4910,60 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 			`SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id = ? ORDER BY id`, team.ID, titleID)
 	})
 	require.ElementsMatch(t, []uint{activeID, v3ID}, remaining, "v2 evicted, active protected")
+}
+
+// testInsertFleetMaintainedAppVersionProtectsLiveActive verifies that eviction
+// keeps the row that is actually is_active=1 at eviction time (e.g. an admin
+// rollback during the cron's download window), not the caller's stale view.
+func testInsertFleetMaintainedAppVersionProtectsLiveActive(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Bob", "bob@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-fma-live-active"})
+	require.NoError(t, err)
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name: "Maintained2", Slug: "maintained2", Platform: "darwin", UniqueIdentifier: "fleet.maintained2",
+	})
+	require.NoError(t, err)
+	newFile := func(s string) *fleet.TempFileReader {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(s), t.TempDir)
+		require.NoError(t, err)
+		return tfr
+	}
+
+	v1, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title: "FooFMA", Source: "apps", Platform: "darwin", InstallScript: "echo i", UninstallScript: "echo u",
+		InstallerFile: newFile("v1"), StorageID: "live-v1", Filename: "foo-1.0.pkg", Extension: "pkg",
+		Version: "1.0", UserID: user.ID, TeamID: &team.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: new(maintainedApp.ID),
+	})
+	require.NoError(t, err)
+
+	// Cache v2, then promote it to active (simulating a concurrent admin rollback).
+	v2, err := ds.InsertFleetMaintainedAppVersion(ctx, v1, &fleet.UploadSoftwareInstallerPayload{
+		Version: "2.0", Filename: "foo-2.0.pkg", Extension: "pkg", StorageID: "live-v2",
+		URL: "https://example.test/2", InstallScript: "echo i2", UninstallScript: "echo u2",
+	})
+	require.NoError(t, err)
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE software_installers SET is_active = (id = ?) WHERE global_or_team_id = ? AND fleet_maintained_app_id = ?`,
+			v2, team.ID, maintainedApp.ID)
+		return err
+	})
+
+	// Insert v3 passing the STALE active id (v1). Eviction must protect the live
+	// active (v2) and the new row (v3), evicting v1 — not evict v2.
+	v3, err := ds.InsertFleetMaintainedAppVersion(ctx, v1, &fleet.UploadSoftwareInstallerPayload{
+		Version: "3.0", Filename: "foo-3.0.pkg", Extension: "pkg", StorageID: "live-v3",
+		URL: "https://example.test/3", InstallScript: "echo i3", UninstallScript: "echo u3",
+	})
+	require.NoError(t, err)
+
+	var remaining []uint
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &remaining,
+			`SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id = ? ORDER BY id`, team.ID, titleID)
+	})
+	require.ElementsMatch(t, []uint{v2, v3}, remaining, "live active (v2) protected, stale v1 evicted")
 }
 
 func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -32,6 +32,10 @@ const (
 	CronUninstallSoftwareMigration   CronScheduleName = "uninstall_software_migration"
 	CronUpgradeCodeSoftwareMigration CronScheduleName = "upgrade_code_software_migration"
 	CronMaintainedApps               CronScheduleName = "maintained_apps"
+	// CronMaintainedAppsAutoUpdate advances each Fleet-maintained app's active
+	// installer to the newest cached version its pin state allows. Premium only;
+	// runs every 1h.
+	CronMaintainedAppsAutoUpdate CronScheduleName = "maintained_apps_auto_update"
 	// CronRefreshVPPAppVersions updates the versions of VPP apps in Fleet to the latest value. Runs
 	// every 1h.
 	CronRefreshVPPAppVersions          CronScheduleName = "refresh_vpp_app_versions"

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2678,7 +2678,8 @@ type Datastore interface {
 	ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]FMAAutoUpdateCandidate, error)
 
 	// SetFleetMaintainedAppActiveInstaller sets the active installer, sets other installers of the title
-	// to inactive, repoints policies, and records or clears the pinned version.
+	// to inactive, and repoints policies. A non-nil payload.PinnedVersion records ("" clears it to Latest)
+	// or upserts the pin; a nil payload.PinnedVersion leaves the pin row untouched.
 	SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *UpdateSoftwareInstallerPayload, activeInstallerID uint) error
 
 	// GetPinnedVersion returns the pinned version for a team and software title.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2677,6 +2677,12 @@ type Datastore interface {
 	// Used by the auto-update cron to decide whether to advance versions.
 	ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]FMAAutoUpdateCandidate, error)
 
+	// GetSoftwareInstallerMetadataByStorageID returns the package IDs and upgrade
+	// code of any cached installer (active or inactive) with the given storage_id.
+	// Used by the auto-update cron to recover uninstall-script substitution values
+	// on the byte-dedup path. Returns empty values (no error) when nothing matches.
+	GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error)
+
 	// InsertFleetMaintainedAppVersion caches a newly downloaded version of an
 	// already-installed Fleet-maintained app, cloning the active installer's
 	// per-team config (self-service, labels, categories, pre-install query) and

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2672,6 +2672,11 @@ type Datastore interface {
 	// the versions will be sorted by their version semver or string.
 	GetFleetMaintainedVersionsByTitleID(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]FleetMaintainedVersion, error)
 
+	// ListFleetMaintainedAppActiveInstallers returns the active installer for
+	// every (team, title) backed by a Fleet-maintained app, across all teams.
+	// Used by the auto-update cron to decide whether to advance versions.
+	ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]FMAAutoUpdateCandidate, error)
+
 	// SetFleetMaintainedAppActiveInstaller sets the active installer, sets other installers of the title
 	// to inactive, repoints policies, and records or clears the pinned version.
 	SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *UpdateSoftwareInstallerPayload, activeInstallerID uint) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2677,6 +2677,15 @@ type Datastore interface {
 	// Used by the auto-update cron to decide whether to advance versions.
 	ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]FMAAutoUpdateCandidate, error)
 
+	// InsertFleetMaintainedAppVersion caches a newly downloaded version of an
+	// already-installed Fleet-maintained app, cloning the active installer's
+	// per-team config (self-service, labels, categories, pre-install query) and
+	// overriding only version-specific fields from the payload. The row is
+	// inserted inactive; the caller promotes it separately. The pin is never
+	// written. Versions beyond the cap are evicted, protecting activeInstallerID.
+	// Idempotent: returns the existing installer ID if the version is already cached.
+	InsertFleetMaintainedAppVersion(ctx context.Context, activeInstallerID uint, payload *UploadSoftwareInstallerPayload) (installerID uint, err error)
+
 	// SetFleetMaintainedAppActiveInstaller sets the active installer, sets other installers of the title
 	// to inactive, and repoints policies. A non-nil payload.PinnedVersion records ("" clears it to Latest)
 	// or upserts the pin; a nil payload.PinnedVersion leaves the pin row untouched.

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -392,6 +392,10 @@ type FMAAutoUpdateCandidate struct {
 	TeamID *uint `db:"global_or_team_id"`
 	// TitleID is the software_titles.id.
 	TitleID uint `db:"title_id"`
+	// FleetMaintainedAppID is the fleet_maintained_apps.id backing this title,
+	// used to hydrate the latest manifest and check the cache without a second
+	// lookup.
+	FleetMaintainedAppID uint `db:"fleet_maintained_app_id"`
 	// InstallerID is the currently active software_installers.id.
 	InstallerID uint `db:"installer_id"`
 	// Version is the currently active version (for logging).

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -388,8 +388,8 @@ type FleetMaintainedVersion struct {
 // by a Fleet-maintained app. The auto-update cron uses it to decide whether to
 // advance the active version among the team's cached versions.
 type FMAAutoUpdateCandidate struct {
-	// TeamID is nil for the no-team scope (global_or_team_id = 0).
-	TeamID *uint `db:"global_or_team_id"`
+	// TeamID is nil for the no-team scope (the team_id column is NULL there).
+	TeamID *uint `db:"team_id"`
 	// TitleID is the software_titles.id.
 	TitleID uint `db:"title_id"`
 	// FleetMaintainedAppID is the fleet_maintained_apps.id backing this title,

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -384,6 +384,22 @@ type FleetMaintainedVersion struct {
 	UploadedAt time.Time `json:"uploaded_at" db:"uploaded_at"`
 }
 
+// FMAAutoUpdateCandidate is the active installer for one (team, title) backed
+// by a Fleet-maintained app. The auto-update cron uses it to decide whether to
+// advance the active version among the team's cached versions.
+type FMAAutoUpdateCandidate struct {
+	// TeamID is nil for the no-team scope (global_or_team_id = 0).
+	TeamID *uint `db:"global_or_team_id"`
+	// TitleID is the software_titles.id.
+	TitleID uint `db:"title_id"`
+	// InstallerID is the currently active software_installers.id.
+	InstallerID uint `db:"installer_id"`
+	// Version is the currently active version (for logging).
+	Version string `db:"version"`
+	// Slug is the Fleet-maintained app slug (for logging).
+	Slug string `db:"slug"`
+}
+
 // SoftwareTitle represents a title backed by the `software_titles` table.
 type SoftwareTitle struct {
 	ID uint `json:"id" db:"id"`

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -655,6 +655,7 @@ type ExistingSoftwareInstaller struct {
 	Title                  string  `db:"title"`
 	PackageIDList          string  `db:"package_ids"`
 	PackageIDs             []string
+	UpgradeCode            string  `db:"upgrade_code"`
 	StorageID              string  `db:"storage_id"`
 	HTTPETag               *string `db:"http_etag"`
 	InstallScriptContentID uint    `db:"install_script_content_id"`

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -655,7 +655,6 @@ type ExistingSoftwareInstaller struct {
 	Title                  string  `db:"title"`
 	PackageIDList          string  `db:"package_ids"`
 	PackageIDs             []string
-	UpgradeCode            string  `db:"upgrade_code"`
 	StorageID              string  `db:"storage_id"`
 	HTTPETag               *string `db:"http_etag"`
 	InstallScriptContentID uint    `db:"install_script_content_id"`

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1568,6 +1568,8 @@ type GetFleetMaintainedVersionsByTitleIDFunc func(ctx context.Context, teamID *u
 
 type ListFleetMaintainedAppActiveInstallersFunc func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error)
 
+type GetSoftwareInstallerMetadataByStorageIDFunc func(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error)
+
 type InsertFleetMaintainedAppVersionFunc func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, err error)
 
 type SetFleetMaintainedAppActiveInstallerFunc func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error
@@ -4436,6 +4438,9 @@ type DataStore struct {
 
 	ListFleetMaintainedAppActiveInstallersFunc        ListFleetMaintainedAppActiveInstallersFunc
 	ListFleetMaintainedAppActiveInstallersFuncInvoked bool
+
+	GetSoftwareInstallerMetadataByStorageIDFunc        GetSoftwareInstallerMetadataByStorageIDFunc
+	GetSoftwareInstallerMetadataByStorageIDFuncInvoked bool
 
 	InsertFleetMaintainedAppVersionFunc        InsertFleetMaintainedAppVersionFunc
 	InsertFleetMaintainedAppVersionFuncInvoked bool
@@ -10670,6 +10675,13 @@ func (s *DataStore) ListFleetMaintainedAppActiveInstallers(ctx context.Context) 
 	s.ListFleetMaintainedAppActiveInstallersFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListFleetMaintainedAppActiveInstallersFunc(ctx)
+}
+
+func (s *DataStore) GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error) {
+	s.mu.Lock()
+	s.GetSoftwareInstallerMetadataByStorageIDFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetSoftwareInstallerMetadataByStorageIDFunc(ctx, storageID)
 }
 
 func (s *DataStore) InsertFleetMaintainedAppVersion(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, err error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1568,6 +1568,8 @@ type GetFleetMaintainedVersionsByTitleIDFunc func(ctx context.Context, teamID *u
 
 type ListFleetMaintainedAppActiveInstallersFunc func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error)
 
+type InsertFleetMaintainedAppVersionFunc func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, err error)
+
 type SetFleetMaintainedAppActiveInstallerFunc func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error
 
 type GetPinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint) (*string, error)
@@ -4434,6 +4436,9 @@ type DataStore struct {
 
 	ListFleetMaintainedAppActiveInstallersFunc        ListFleetMaintainedAppActiveInstallersFunc
 	ListFleetMaintainedAppActiveInstallersFuncInvoked bool
+
+	InsertFleetMaintainedAppVersionFunc        InsertFleetMaintainedAppVersionFunc
+	InsertFleetMaintainedAppVersionFuncInvoked bool
 
 	SetFleetMaintainedAppActiveInstallerFunc        SetFleetMaintainedAppActiveInstallerFunc
 	SetFleetMaintainedAppActiveInstallerFuncInvoked bool
@@ -10665,6 +10670,13 @@ func (s *DataStore) ListFleetMaintainedAppActiveInstallers(ctx context.Context) 
 	s.ListFleetMaintainedAppActiveInstallersFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListFleetMaintainedAppActiveInstallersFunc(ctx)
+}
+
+func (s *DataStore) InsertFleetMaintainedAppVersion(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, err error) {
+	s.mu.Lock()
+	s.InsertFleetMaintainedAppVersionFuncInvoked = true
+	s.mu.Unlock()
+	return s.InsertFleetMaintainedAppVersionFunc(ctx, activeInstallerID, payload)
 }
 
 func (s *DataStore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1566,6 +1566,8 @@ type GetSoftwareInstallerMetadataByTeamAndTitleIDFunc func(ctx context.Context, 
 
 type GetFleetMaintainedVersionsByTitleIDFunc func(ctx context.Context, teamID *uint, titleID uint, byVersion bool) ([]fleet.FleetMaintainedVersion, error)
 
+type ListFleetMaintainedAppActiveInstallersFunc func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error)
+
 type SetFleetMaintainedAppActiveInstallerFunc func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error
 
 type GetPinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint) (*string, error)
@@ -4429,6 +4431,9 @@ type DataStore struct {
 
 	GetFleetMaintainedVersionsByTitleIDFunc        GetFleetMaintainedVersionsByTitleIDFunc
 	GetFleetMaintainedVersionsByTitleIDFuncInvoked bool
+
+	ListFleetMaintainedAppActiveInstallersFunc        ListFleetMaintainedAppActiveInstallersFunc
+	ListFleetMaintainedAppActiveInstallersFuncInvoked bool
 
 	SetFleetMaintainedAppActiveInstallerFunc        SetFleetMaintainedAppActiveInstallerFunc
 	SetFleetMaintainedAppActiveInstallerFuncInvoked bool
@@ -10653,6 +10658,13 @@ func (s *DataStore) GetFleetMaintainedVersionsByTitleID(ctx context.Context, tea
 	s.GetFleetMaintainedVersionsByTitleIDFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetFleetMaintainedVersionsByTitleIDFunc(ctx, teamID, titleID, byVersion)
+}
+
+func (s *DataStore) ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
+	s.mu.Lock()
+	s.ListFleetMaintainedAppActiveInstallersFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListFleetMaintainedAppActiveInstallersFunc(ctx)
 }
 
 func (s *DataStore) SetFleetMaintainedAppActiveInstaller(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, activeInstallerID uint) error {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -27178,79 +27178,21 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	computeSHA := func(b []byte) string {
-		h := sha256.New()
-		h.Write(b)
-		return hex.EncodeToString(h.Sum(nil))
-	}
-
-	type fmaTestState struct {
-		version        string
-		installerBytes []byte
-		sha256         string
-	}
-	warpState := &fmaTestState{version: "1.0", installerBytes: []byte("abc")}
-	warpState.sha256 = computeSHA(warpState.installerBytes)
-
+	// Mock the FMA manifest + installer CDN via the shared helper. The state is
+	// mutable: bumping warp.version/installerBytes (+ ComputeSHA) below simulates a
+	// newly published upstream version on the next cron run.
 	const slug = "cloudflare-warp/windows"
-	var downloadMu sync.Mutex
-	downloaded := false
-
-	installerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		downloadMu.Lock()
-		defer downloadMu.Unlock()
-		if r.URL.Path == "/cloudflare-warp.msi" {
-			downloaded = true
-			_, _ = w.Write(warpState.installerBytes)
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer installerServer.Close()
-
-	maintainedappstest.SyncApps(t, s.ds)
-
-	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/"+slug+".json" {
-			http.NotFound(w, r)
-			return
-		}
-		manifest := ma.FMAManifestFile{
-			Versions: []*ma.FMAManifestApp{{
-				Version:            warpState.version,
-				Queries:            ma.FMAQueries{Exists: "SELECT 1 FROM osquery_info;"},
-				InstallerURL:       installerServer.URL + "/cloudflare-warp.msi",
-				InstallScriptRef:   "foobaz",
-				UninstallScriptRef: "foobaz",
-				SHA256:             warpState.sha256,
-				DefaultCategories:  []string{"Productivity"},
-			}},
-			Refs: map[string]string{"foobaz": "Hello World!"},
-		}
-		_ = json.NewEncoder(w).Encode(manifest)
-	}))
-	t.Cleanup(manifestServer.Close)
-	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL)
-	defer dev_mode.ClearOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL")
+	warp := &fmaTestState{version: "1.0", installerBytes: []byte("abc"), installerPath: "/cloudflare-warp.msi"}
+	startFMAServers(t, s.ds, map[string]*fmaTestState{"/" + slug + ".json": warp})
 
 	// --- helpers ---
-	setManifest := func(version string, bytes []byte) {
-		warpState.version = version
-		warpState.installerBytes = bytes
-		warpState.sha256 = computeSHA(bytes)
+	setManifest := func(version string, b []byte) {
+		warp.version = version
+		warp.installerBytes = b
+		warp.ComputeSHA(b)
 	}
 	runCron := func() {
 		require.NoError(t, eeservice.AutoUpdateFleetMaintainedApps(ctx, s.ds, s.softwareInstallStore, logger))
-	}
-	resetDownloaded := func() {
-		downloadMu.Lock()
-		downloaded = false
-		downloadMu.Unlock()
-	}
-	wasDownloaded := func() bool {
-		downloadMu.Lock()
-		defer downloadMu.Unlock()
-		return downloaded
 	}
 	activeTitle := func(teamID uint) fleet.SoftwareTitleListResult {
 		var resp listSoftwareTitlesResponse
@@ -27304,9 +27246,7 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
 
 	// === Section A: unpinned advances to the newly published version ===
 	setManifest("2.0", []byte("def"))
-	resetDownloaded()
 	runCron()
-	require.True(t, wasDownloaded(), "should download the new version")
 	title = activeTitle(team.ID)
 	require.Equal(t, "2.0", title.SoftwarePackage.Version)
 	require.Len(t, title.SoftwarePackage.FleetMaintainedVersions, 2)
@@ -27332,38 +27272,28 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
 	r.Body.Close()
 	require.Equal(t, []byte("def"), body, "auto-updated installer should serve v2.0 bytes")
 
-	// === Section B: a literal pin blocks auto-advance and any download ===
+	// === Section B: a literal pin blocks auto-advance ===
 	setPin(team.ID, titleID, "2.0")
 	setManifest("3.0", []byte("ghi"))
-	resetDownloaded()
 	runCron()
-	require.False(t, wasDownloaded(), "literal pin must not trigger a download")
 	require.Equal(t, "2.0", activeTitle(team.ID).SoftwarePackage.Version, "literal pin must not advance")
 
 	// === Section C: caret pin advances within major, never across ===
 	clearPin(team.ID, titleID)
-	resetDownloaded()
 	runCron() // unpinned: advance to the published 3.0
-	require.True(t, wasDownloaded())
 	require.Equal(t, "3.0", activeTitle(team.ID).SoftwarePackage.Version)
 
 	setPin(team.ID, titleID, "^3")
 	setManifest("3.1", []byte("j31"))
-	resetDownloaded()
 	runCron()
-	require.True(t, wasDownloaded(), "caret pin advances within its major")
-	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version)
+	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version, "caret pin advances within its major")
 
 	setManifest("4.0", []byte("k40"))
-	resetDownloaded()
 	runCron()
-	require.False(t, wasDownloaded(), "caret pin must not download across majors")
 	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version, "caret pin must not cross major")
 
 	// === Section D: a re-run with nothing new is a no-op ===
-	resetDownloaded()
 	runCron()
-	require.False(t, wasDownloaded(), "idempotent re-run downloads nothing")
 	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version)
 }
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -27173,6 +27173,200 @@ func (s *integrationEnterpriseTestSuite) TestUpdateSoftwareAutoUpdateConfig() {
 	s.lastActivityMatches(fleet.ActivityEditedAppStoreApp{}.ActivityName(), fmt.Sprintf(`{"app_store_id":"adam_vpp_app_1", "auto_update_enabled":false, "platform":"ipados", "self_service":false, "software_display_name":"Updated Display Name", "software_icon_url":null, "software_title":"vpp1", "software_title_id":%d, "team_id":%d, "team_name":"%s", "fleet_id":%d, "fleet_name":"%s"}`, vppApp.TitleID, team.ID, team.Name, team.ID, team.Name), 0)
 }
 
+func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
+	t := s.T()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	computeSHA := func(b []byte) string {
+		h := sha256.New()
+		h.Write(b)
+		return hex.EncodeToString(h.Sum(nil))
+	}
+
+	type fmaTestState struct {
+		version        string
+		installerBytes []byte
+		sha256         string
+	}
+	warpState := &fmaTestState{version: "1.0", installerBytes: []byte("abc")}
+	warpState.sha256 = computeSHA(warpState.installerBytes)
+
+	const slug = "cloudflare-warp/windows"
+	var downloadMu sync.Mutex
+	downloaded := false
+
+	installerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downloadMu.Lock()
+		defer downloadMu.Unlock()
+		if r.URL.Path == "/cloudflare-warp.msi" {
+			downloaded = true
+			_, _ = w.Write(warpState.installerBytes)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer installerServer.Close()
+
+	maintainedappstest.SyncApps(t, s.ds)
+
+	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/"+slug+".json" {
+			http.NotFound(w, r)
+			return
+		}
+		manifest := ma.FMAManifestFile{
+			Versions: []*ma.FMAManifestApp{{
+				Version:            warpState.version,
+				Queries:            ma.FMAQueries{Exists: "SELECT 1 FROM osquery_info;"},
+				InstallerURL:       installerServer.URL + "/cloudflare-warp.msi",
+				InstallScriptRef:   "foobaz",
+				UninstallScriptRef: "foobaz",
+				SHA256:             warpState.sha256,
+				DefaultCategories:  []string{"Productivity"},
+			}},
+			Refs: map[string]string{"foobaz": "Hello World!"},
+		}
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	t.Cleanup(manifestServer.Close)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL)
+	defer dev_mode.ClearOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL")
+
+	// --- helpers ---
+	setManifest := func(version string, bytes []byte) {
+		warpState.version = version
+		warpState.installerBytes = bytes
+		warpState.sha256 = computeSHA(bytes)
+	}
+	runCron := func() {
+		require.NoError(t, eeservice.AutoUpdateFleetMaintainedApps(ctx, s.ds, s.softwareInstallStore, logger))
+	}
+	resetDownloaded := func() {
+		downloadMu.Lock()
+		downloaded = false
+		downloadMu.Unlock()
+	}
+	wasDownloaded := func() bool {
+		downloadMu.Lock()
+		defer downloadMu.Unlock()
+		return downloaded
+	}
+	activeTitle := func(teamID uint) fleet.SoftwareTitleListResult {
+		var resp listSoftwareTitlesResponse
+		s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusOK, &resp,
+			"per_page", "1", "order_key", "name", "order_direction", "desc",
+			"available_for_install", "true", "team_id", fmt.Sprintf("%d", teamID))
+		require.Equal(t, 1, resp.Count)
+		return resp.SoftwareTitles[0]
+	}
+	activeSelfService := func(teamID, titleID uint) bool {
+		var ss bool
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &ss,
+				`SELECT self_service FROM software_installers WHERE global_or_team_id = ? AND title_id = ? AND is_active = 1`,
+				teamID, titleID)
+		})
+		return ss
+	}
+	setPin := func(teamID, titleID uint, pin string) {
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx,
+				`INSERT INTO software_title_team_pins (team_id, title_id, pinned_version) VALUES (?, ?, ?)
+				 ON DUPLICATE KEY UPDATE pinned_version = VALUES(pinned_version)`, teamID, titleID, pin)
+			return err
+		})
+	}
+	clearPin := func(teamID, titleID uint) {
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `DELETE FROM software_title_team_pins WHERE team_id = ? AND title_id = ?`, teamID, titleID)
+			return err
+		})
+	}
+
+	// --- setup: team with cloudflare-warp v1.0, self-service on ---
+	var teamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{
+		TeamPayload: fleet.TeamPayload{Name: new("team_" + t.Name())},
+	}, http.StatusOK, &teamResp)
+	team := *teamResp.Team
+
+	var batchResp batchSetSoftwareInstallersResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/batch",
+		batchSetSoftwareInstallersRequest{Software: []*fleet.SoftwareInstallerPayload{{Slug: new(slug), SelfService: true}}, TeamName: team.Name},
+		http.StatusAccepted, &batchResp, "team_name", team.Name, "team_id", fmt.Sprint(team.ID))
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, batchResp.RequestUUID)
+
+	title := activeTitle(team.ID)
+	require.Equal(t, "1.0", title.SoftwarePackage.Version)
+	titleID := title.ID
+	require.True(t, activeSelfService(team.ID, titleID))
+
+	// === Section A: unpinned advances to the newly published version ===
+	setManifest("2.0", []byte("def"))
+	resetDownloaded()
+	runCron()
+	require.True(t, wasDownloaded(), "should download the new version")
+	title = activeTitle(team.ID)
+	require.Equal(t, "2.0", title.SoftwarePackage.Version)
+	require.Len(t, title.SoftwarePackage.FleetMaintainedVersions, 2)
+	// Per-team config is carried forward onto the new version.
+	require.True(t, activeSelfService(team.ID, titleID), "self-service must survive the auto-update")
+
+	// The cached bytes are real and installable: a host install serves v2.0 bytes.
+	host := createOrbitEnrolledHost(t, "windows", "orbit-autoupdate", s.ds)
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", host.ID, titleID), installSoftwareRequest{}, http.StatusAccepted)
+	var installerID uint
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &installerID, `
+			SELECT software_installer_id FROM host_software_installs
+			WHERE host_id = ? AND software_installer_id IS NOT NULL AND install_script_exit_code IS NULL
+			ORDER BY created_at DESC LIMIT 1`, host.ID)
+	})
+	r := s.Do("POST", "/api/fleet/orbit/software_install/package?alt=media", fleet.OrbitDownloadSoftwareInstallerRequest{
+		InstallerID: installerID, OrbitNodeKey: *host.OrbitNodeKey,
+	}, http.StatusOK)
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	r.Body.Close()
+	require.Equal(t, []byte("def"), body, "auto-updated installer should serve v2.0 bytes")
+
+	// === Section B: a literal pin blocks auto-advance and any download ===
+	setPin(team.ID, titleID, "2.0")
+	setManifest("3.0", []byte("ghi"))
+	resetDownloaded()
+	runCron()
+	require.False(t, wasDownloaded(), "literal pin must not trigger a download")
+	require.Equal(t, "2.0", activeTitle(team.ID).SoftwarePackage.Version, "literal pin must not advance")
+
+	// === Section C: caret pin advances within major, never across ===
+	clearPin(team.ID, titleID)
+	resetDownloaded()
+	runCron() // unpinned: advance to the published 3.0
+	require.True(t, wasDownloaded())
+	require.Equal(t, "3.0", activeTitle(team.ID).SoftwarePackage.Version)
+
+	setPin(team.ID, titleID, "^3")
+	setManifest("3.1", []byte("j31"))
+	resetDownloaded()
+	runCron()
+	require.True(t, wasDownloaded(), "caret pin advances within its major")
+	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version)
+
+	setManifest("4.0", []byte("k40"))
+	resetDownloaded()
+	runCron()
+	require.False(t, wasDownloaded(), "caret pin must not download across majors")
+	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version, "caret pin must not cross major")
+
+	// === Section D: a re-run with nothing new is a no-op ===
+	resetDownloaded()
+	runCron()
+	require.False(t, wasDownloaded(), "idempotent re-run downloads nothing")
+	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version)
+}
+
 func (s *integrationEnterpriseTestSuite) TestFMAVersionRollback() {
 	t := s.T()
 	ctx := context.Background()


### PR DESCRIPTION
 **Related issue:** Resolves #47681

Adds an hourly, Premium-only cron (maintained_apps_auto_update) that keeps Fleet-maintained apps current. For each FMA-backed active installer (per team), it fetches the latest manifest, downloads and caches a newly-published version when the pin allows, and advances the team's active installer based on the pin state:

  - Unpinned (Latest): download/cache the newest published version and advance the active installer to it.
  - Caret pin (^N): advance to the newest version within major N (downloading it if newly published). Never cross into another major.
  - Literal pin: never advance and never download.

  New versions are cached as additional software_installers rows (no schema change; reuses the existing (global_or_team_id, title_id, version) index), capped at the two most recent per team for rollback.

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
  - [x] Timeouts are implemented and retries are limited to avoid infinite loops

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually