### PR TITLE
Fleet UI: Add CopyButton component, fix Copied! badge in dark mode

### DIFF
--- a/changes/47989-copied-badge
+++ b/changes/47989-copied-badge
@@ -1,0 +1,1 @@
+- Fixed Copied! confirmation badges showing the wrong border color and clipping in dark mode.

--- a/frontend/components/Editor/Editor.tsx
+++ b/frontend/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, ReactNode, useState, useCallback } from "react";
+import React, { ReactNode } from "react";
 
 import classnames from "classnames";
 import AceEditor from "react-ace";
@@ -8,11 +8,8 @@ import "ace-builds/src-noconflict/mode-python";
 import "ace-builds/src-noconflict/mode-xml";
 import { Ace } from "ace-builds";
 
-import { stringToClipboard } from "utilities/copy_text";
-
 import TooltipWrapper from "components/TooltipWrapper";
-import Button from "components/buttons/Button";
-import Icon from "components/Icon";
+import CopyButton from "components/buttons/CopyButton";
 
 const baseClass = "editor";
 
@@ -91,37 +88,10 @@ const Editor = ({
     [`${baseClass}__error`]: !!error,
   });
 
-  const [showCopiedMessage, setShowCopiedMessage] = useState(false);
-
-  const onClickCopy = useCallback(
-    (e: MouseEvent) => {
-      e.preventDefault();
-      stringToClipboard(value).then(() => {
-        setShowCopiedMessage(true);
-        setTimeout(() => {
-          setShowCopiedMessage(false);
-        }, 2000);
-      });
-    },
-    [value]
-  );
-
   const renderCopyButton = () => {
-    const copyButtonValue = <Icon name="copy" />;
-    const wrapperClasses = classnames(`${baseClass}__copy-wrapper`);
-
-    const copiedConfirmationClasses = classnames(
-      `${baseClass}__copied-confirmation`
-    );
-
     return (
-      <div className={wrapperClasses}>
-        {showCopiedMessage && (
-          <span className={copiedConfirmationClasses}>Copied!</span>
-        )}
-        <Button variant={"icon"} onClick={onClickCopy} iconStroke>
-          {copyButtonValue}
-        </Button>
+      <div className={`${baseClass}__copy-wrapper`}>
+        <CopyButton copyText={value ?? ""} />
       </div>
     );
   };

--- a/frontend/components/Editor/_styles.scss
+++ b/frontend/components/Editor/_styles.scss
@@ -29,8 +29,4 @@
     display: flex;
     align-items: center;
   }
-
-  &__copied-confirmation {
-    @include copy-message;
-  }
 }

--- a/frontend/components/SQLEditor/SQLEditor.tsx
+++ b/frontend/components/SQLEditor/SQLEditor.tsx
@@ -285,7 +285,7 @@ const SQLEditor = ({
         <div className={`${baseClass}__label-actions`}>
           {labelActionComponent}
           {enableCopy && (
-            <CopyButton copyText={value || ""} variant="text-icon" size="small">
+            <CopyButton copyText={value || ""} variant="inverse" size="small">
               Copy <Icon name="copy" />
             </CopyButton>
           )}

--- a/frontend/components/SQLEditor/SQLEditor.tsx
+++ b/frontend/components/SQLEditor/SQLEditor.tsx
@@ -18,8 +18,7 @@ import {
   sqlKeyWords,
 } from "utilities/sql_tools";
 
-import { stringToClipboard } from "utilities/copy_text";
-import Button from "components/buttons/Button";
+import CopyButton from "components/buttons/CopyButton";
 import Icon from "components/Icon";
 
 import "./mode";
@@ -79,7 +78,6 @@ const SQLEditor = ({
   enableCopy = false,
 }: ISQLEditorProps): JSX.Element => {
   const editorRef = useRef<ReactAce>(null);
-  const [copied, setCopied] = React.useState(false);
 
   /** Keeps label actions clickable and removes all mouse/keyboard access/hover states of editor */
   const isReadonlyCopy = _readOnly && enableCopy && !disabled;
@@ -90,13 +88,6 @@ const SQLEditor = ({
     // This is for read only that has a copy button so we disallow selecting the text
     [`${baseClass}__wrapper--readonly-copy`]: !!isReadonlyCopy,
   });
-
-  const onClickCopy = () => {
-    stringToClipboard(value || "").then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  };
 
   const fixHotkeys = (editor: Ace.Editor) => {
     editor.commands.removeCommand("gotoline");
@@ -294,26 +285,14 @@ const SQLEditor = ({
         <div className={`${baseClass}__label-actions`}>
           {labelActionComponent}
           {enableCopy && (
-            <div className={`${baseClass}__copy-wrapper`}>
-              {copied && (
-                <span className={`${baseClass}__copied-confirmation`}>
-                  Copied!
-                </span>
-              )}
-              <Button
-                variant="text-icon"
-                onClick={onClickCopy}
-                size="small"
-                iconStroke
-              >
-                Copy <Icon name="copy" />
-              </Button>
-            </div>
+            <CopyButton copyText={value || ""} variant="text-icon" size="small">
+              Copy <Icon name="copy" />
+            </CopyButton>
           )}
         </div>
       </div>
     );
-  }, [error, label, labelActionComponent, enableCopy, copied]);
+  }, [error, label, labelActionComponent, enableCopy, value]);
 
   const renderHelpText = () => {
     if (helpText) {

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -25,16 +25,6 @@
         flex: 0 0 auto;
       }
 
-      .sql-editor__copy-wrapper {
-        display: flex;
-        align-items: center;
-        gap: $pad-xxsmall;
-      }
-
-      .sql-editor__copied-confirmation {
-        @include copy-message;
-      }
-
       button {
         height: initial; // aligning space between label and textarea
         margin: -$pad-small 0;

--- a/frontend/components/ToastNotification/ToastCard.tsx
+++ b/frontend/components/ToastNotification/ToastCard.tsx
@@ -3,9 +3,9 @@ import classnames from "classnames";
 import { toast } from "sonner";
 
 import Icon from "components/Icon";
+import CopyButton from "components/buttons/CopyButton";
 import { Colors } from "styles/var/colors";
 import { syntaxHighlight } from "utilities/helpers";
-import { stringToClipboard } from "utilities/copy_text";
 
 const baseClass = "toast-notification";
 
@@ -86,8 +86,6 @@ const ToastCard = ({
     }
   }
 
-  const [copied, setCopied] = useState(false);
-
   // Capture when the toast first rendered. Snapshotted once via the lazy
   // initializer so the timestamp stays stable across re-renders (toggling
   // the panel, clicking copy, etc.). Not shown in the UI — only included
@@ -102,17 +100,6 @@ const ToastCard = ({
   const copyText = [detailLabel, `Timestamp: ${timestamp}`, "", detailText]
     .filter((line) => line !== undefined)
     .join("\n");
-
-  const handleCopy = (): void => {
-    stringToClipboard(copyText)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      })
-      .catch(() => {
-        // Clipboard API may reject in insecure contexts — stay silent.
-      });
-  };
 
   const panelId = `${baseClass}__panel-${toastId}`;
 
@@ -174,19 +161,11 @@ const ToastCard = ({
         >
           <div className={`${baseClass}__panel-header`}>
             <span className={`${baseClass}__panel-label`}>{detailLabel}</span>
-            <button
-              type="button"
-              className={`${baseClass}__copy-button`}
-              aria-label="Copy raw response to clipboard"
-              onClick={handleCopy}
-            >
-              {copied && (
-                <span className={`${baseClass}__copy-confirmation`}>
-                  Copied!
-                </span>
-              )}
-              <Icon name="copy" color="ui-fleet-black-75" />
-            </button>
+            <CopyButton
+              copyText={copyText}
+              size="small"
+              ariaLabel="Copy raw response to clipboard"
+            />
           </div>
           <pre
             className={`${baseClass}__json-block`}

--- a/frontend/components/ToastNotification/_styles.scss
+++ b/frontend/components/ToastNotification/_styles.scss
@@ -186,33 +186,6 @@ $toast-notification-width: 500px;
     color: $core-fleet-black;
   }
 
-  &__copy-button {
-    appearance: none;
-    background: transparent;
-    border: 0;
-    padding: $pad-xsmall;
-    margin: 0;
-    cursor: pointer;
-    color: $ui-fleet-black-75;
-    display: inline-flex;
-    align-items: center;
-    gap: $pad-xsmall;
-    border-radius: $border-radius;
-    transition: background-color 150ms ease-in-out, color 150ms ease-in-out;
-
-    &:hover,
-    &:focus-visible {
-      background-color: $ui-fleet-black-5;
-      color: $core-fleet-black;
-      outline: none;
-    }
-  }
-
-  &__copy-confirmation {
-    font-size: $xx-small;
-    color: $ui-fleet-black-75;
-  }
-
   // Light JSON block — overrides the global dark `pre` to match the ace-fleet
   // editor theme.
   &__json-block {

--- a/frontend/components/buttons/CopyButton/CopyButton.stories.tsx
+++ b/frontend/components/buttons/CopyButton/CopyButton.stories.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import Icon from "components/Icon";
+
+import CopyButton from "./CopyButton";
+
+const DEFAULT_ARGS = {
+  copyText: "FLEET-MAINTAINED-APP-SLUG",
+};
+
+const meta: Meta<typeof CopyButton> = {
+  component: CopyButton,
+  title: "Components/CopyButton",
+  argTypes: {
+    variant: { control: false },
+  },
+  args: DEFAULT_ARGS,
+};
+
+export default meta;
+type Story = StoryObj<typeof CopyButton>;
+
+const inlineRow: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+  fontSize: 14,
+};
+
+export const IconVariant: Story = {
+  args: { ...DEFAULT_ARGS, variant: "icon" },
+  render: (args) => (
+    <span style={inlineRow}>
+      <span>fleet-maintained-app-slug</span>
+      <CopyButton {...args} />
+    </span>
+  ),
+};
+
+export const CompactVariant: Story = {
+  args: { ...DEFAULT_ARGS, variant: "compact" },
+  render: (args) => (
+    <span style={inlineRow}>
+      <span>fleet-maintained-app-slug</span>
+      <CopyButton {...args} />
+    </span>
+  ),
+};
+
+export const InverseVariant: Story = {
+  args: { ...DEFAULT_ARGS, variant: "inverse" },
+  render: (args) => (
+    <span style={inlineRow}>
+      <code>SELECT * FROM users;</code>
+      <CopyButton {...args}>
+        Copy <Icon name="copy" />
+      </CopyButton>
+    </span>
+  ),
+};

--- a/frontend/components/buttons/CopyButton/CopyButton.tests.tsx
+++ b/frontend/components/buttons/CopyButton/CopyButton.tests.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import CopyButton from "./CopyButton";
+
+describe("CopyButton component", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("renders the copy icon by default", () => {
+    render(<CopyButton copyText="abc" />);
+    expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
+  });
+
+  it("copies text to the clipboard on click", async () => {
+    const writeText = jest
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+    render(<CopyButton copyText="hello" />);
+    await userEvent.click(screen.getByRole("button"));
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it('shows "Copied!" after a successful copy', async () => {
+    render(<CopyButton copyText="hello" />);
+    await userEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(screen.getByText("Copied!")).toBeInTheDocument()
+    );
+  });
+
+  it('shows "Copy failed" if the clipboard call rejects', async () => {
+    jest
+      .spyOn(navigator.clipboard, "writeText")
+      .mockRejectedValueOnce(new Error("blocked"));
+    render(<CopyButton copyText="hello" />);
+    await userEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(screen.getByText("Copy failed")).toBeInTheDocument()
+    );
+  });
+
+  it("renders custom children when provided", () => {
+    render(
+      <CopyButton copyText="abc">
+        <span>Copy me</span>
+      </CopyButton>
+    );
+    expect(screen.getByText("Copy me")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/buttons/CopyButton/CopyButton.tsx
+++ b/frontend/components/buttons/CopyButton/CopyButton.tsx
@@ -23,6 +23,10 @@ interface ICopyButtonProps {
   size?: "small" | "wide" | "default";
   className?: string;
   ariaLabel?: string;
+  /** Distance in px from the anchor to the tooltip. Defaults to `4` — tight
+   *  for inline-with-text copy actions. Pass `10` to match react-tooltip 5's
+   *  own default when the trigger is a larger floating button. */
+  tooltipOffset?: number;
 }
 
 const baseClass = "copy-button";
@@ -38,6 +42,7 @@ const CopyButton = ({
   size,
   className,
   ariaLabel = "Copy to clipboard",
+  tooltipOffset = 4,
 }: ICopyButtonProps) => {
   const [message, setMessage] = useState<string | null>(null);
   const tipIdRef = useRef(uniqueId("copy-button-tooltip-"));
@@ -53,6 +58,11 @@ const CopyButton = ({
 
   const onClick = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
+    // Fleet Button's --icon variant uses :focus (not :focus-visible) for its
+    // hover-background, so a mouse click leaves the button visually "stuck"
+    // highlighted. Drop focus once the copy fires.
+    evt.currentTarget.blur();
+
     stringToClipboard(copyText)
       .then(() => setMessage(SUCCESS_MESSAGE))
       .catch(() => setMessage(ERROR_MESSAGE));
@@ -85,6 +95,7 @@ const CopyButton = ({
         id={tipIdRef.current}
         isOpen={message !== null}
         place="left"
+        offset={tooltipOffset}
         opacity={1}
         disableStyleInjection
         noArrow

--- a/frontend/components/buttons/CopyButton/CopyButton.tsx
+++ b/frontend/components/buttons/CopyButton/CopyButton.tsx
@@ -60,17 +60,33 @@ const CopyButton = ({
     evt.preventDefault();
     // Fleet Button's --icon variant uses :focus (not :focus-visible) for its
     // hover-background, so a mouse click leaves the button visually "stuck"
-    // highlighted. Drop focus once the copy fires.
-    evt.currentTarget.blur();
+    // highlighted. Drop focus only for mouse activations — keyboard Enter/
+    // Space report `detail === 0` and must keep their tab position.
+    if (evt.detail !== 0) {
+      evt.currentTarget.blur();
+    }
 
-    stringToClipboard(copyText)
-      .then(() => setMessage(SUCCESS_MESSAGE))
-      .catch(() => setMessage(ERROR_MESSAGE));
-
+    // Cancel any previous click's hide timer so the new badge gets the full
+    // window — and so the hide doesn't race a slow `writeText()` (>1s would
+    // leave the message visible with no timer to clear it).
     if (timerRef.current) {
       clearTimeout(timerRef.current);
+      timerRef.current = null;
     }
-    timerRef.current = setTimeout(() => setMessage(null), HIDE_AFTER_MS);
+
+    const scheduleHide = () => {
+      timerRef.current = setTimeout(() => setMessage(null), HIDE_AFTER_MS);
+    };
+
+    stringToClipboard(copyText)
+      .then(() => {
+        setMessage(SUCCESS_MESSAGE);
+        scheduleHide();
+      })
+      .catch(() => {
+        setMessage(ERROR_MESSAGE);
+        scheduleHide();
+      });
   };
 
   const isCompact = variant === "compact";

--- a/frontend/components/buttons/CopyButton/CopyButton.tsx
+++ b/frontend/components/buttons/CopyButton/CopyButton.tsx
@@ -7,20 +7,19 @@ import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import { stringToClipboard } from "utilities/copy_text";
 
-type CopyButtonVariant = "icon" | "text-icon" | "compact";
+type CopyButtonVariant = "icon" | "inverse" | "compact";
 
 interface ICopyButtonProps {
   copyText: string;
   /** Override the button's content. Defaults to `<Icon name="copy" />`. */
   children?: React.ReactNode;
   /** `"icon"` (default) — standard 36×36 icon button.
-   *  `"text-icon"` — icon next to text (use with children).
+   *  `"inverse"` — bordered icon-with-text button (use with children).
    *  `"compact"` — icon collapsed to its natural size, no extra vertical
    *  chrome. Use for inline-with-text copy actions so the surrounding row
    *  doesn't grow to button height. */
   variant?: CopyButtonVariant;
-  iconStroke?: boolean;
-  size?: "small" | "wide" | "default";
+  size?: "small" | "default";
   className?: string;
   ariaLabel?: string;
   /** Distance in px from the anchor to the tooltip. Defaults to `4` — tight
@@ -38,7 +37,6 @@ const CopyButton = ({
   copyText,
   children,
   variant = "icon",
-  iconStroke = true,
   size,
   className,
   ariaLabel = "Copy to clipboard",
@@ -96,7 +94,7 @@ const CopyButton = ({
       <Button
         variant={isCompact ? "icon" : variant}
         size={size}
-        iconStroke={iconStroke}
+        iconStroke
         onClick={onClick}
         className={classnames(
           `${baseClass}__button`,

--- a/frontend/components/buttons/CopyButton/CopyButton.tsx
+++ b/frontend/components/buttons/CopyButton/CopyButton.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef, useState } from "react";
+import classnames from "classnames";
+import { Tooltip as ReactTooltip5 } from "react-tooltip-5";
+import { uniqueId } from "lodash";
+
+import Button from "components/buttons/Button";
+import Icon from "components/Icon";
+import { stringToClipboard } from "utilities/copy_text";
+
+type CopyButtonVariant = "icon" | "text-icon" | "compact";
+
+interface ICopyButtonProps {
+  copyText: string;
+  /** Override the button's content. Defaults to `<Icon name="copy" />`. */
+  children?: React.ReactNode;
+  /** `"icon"` (default) — standard 36×36 icon button.
+   *  `"text-icon"` — icon next to text (use with children).
+   *  `"compact"` — icon collapsed to its natural size, no extra vertical
+   *  chrome. Use for inline-with-text copy actions so the surrounding row
+   *  doesn't grow to button height. */
+  variant?: CopyButtonVariant;
+  iconStroke?: boolean;
+  size?: "small" | "wide" | "default";
+  className?: string;
+  ariaLabel?: string;
+}
+
+const baseClass = "copy-button";
+const HIDE_AFTER_MS = 1000;
+const SUCCESS_MESSAGE = "Copied!";
+const ERROR_MESSAGE = "Copy failed";
+
+const CopyButton = ({
+  copyText,
+  children,
+  variant = "icon",
+  iconStroke = true,
+  size,
+  className,
+  ariaLabel = "Copy to clipboard",
+}: ICopyButtonProps) => {
+  const [message, setMessage] = useState<string | null>(null);
+  const tipIdRef = useRef(uniqueId("copy-button-tooltip-"));
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const onClick = (evt: React.MouseEvent<HTMLButtonElement>) => {
+    evt.preventDefault();
+    stringToClipboard(copyText)
+      .then(() => setMessage(SUCCESS_MESSAGE))
+      .catch(() => setMessage(ERROR_MESSAGE));
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => setMessage(null), HIDE_AFTER_MS);
+  };
+
+  const isCompact = variant === "compact";
+
+  return (
+    <span className={baseClass} data-tooltip-id={tipIdRef.current}>
+      <Button
+        variant={isCompact ? "icon" : variant}
+        size={size}
+        iconStroke={iconStroke}
+        onClick={onClick}
+        className={classnames(
+          `${baseClass}__button`,
+          { [`${baseClass}__button--compact`]: isCompact },
+          className
+        )}
+        ariaLabel={ariaLabel}
+      >
+        {children ?? <Icon name="copy" />}
+      </Button>
+      <ReactTooltip5
+        id={tipIdRef.current}
+        isOpen={message !== null}
+        place="left"
+        opacity={1}
+        disableStyleInjection
+        noArrow
+        className={`${baseClass}__tooltip`}
+      >
+        {message}
+      </ReactTooltip5>
+    </span>
+  );
+};
+
+export default CopyButton;

--- a/frontend/components/buttons/CopyButton/_styles.scss
+++ b/frontend/components/buttons/CopyButton/_styles.scss
@@ -9,6 +9,19 @@
     min-height: 0;
     width: auto;
     padding: 2px;
+
+    // Fleet Button's focus indicator is a `::after` pseudo with a 1px
+    // border, which paints 1px past the 20×20 footprint. Swap it for an
+    // inset outline so the focus ring stays within the bounds.
+    &::after {
+      content: none;
+    }
+
+    &:focus-visible {
+      outline: 1px solid $core-focused-outline;
+      outline-offset: -1px;
+      border-radius: $border-radius;
+    }
   }
 
   // Chained with `.react-tooltip` so ancestor rules targeting the bare

--- a/frontend/components/buttons/CopyButton/_styles.scss
+++ b/frontend/components/buttons/CopyButton/_styles.scss
@@ -1,0 +1,31 @@
+.copy-button {
+  display: inline-flex;
+
+  // Collapse Fleet Button's default 36px footprint down to a 20×20 hit area
+  // (16px icon + 2px padding) so the button fits inside a 21px line-height
+  // row without growing it.
+  &__button--compact.button {
+    height: auto;
+    min-height: 0;
+    width: auto;
+    padding: 2px;
+  }
+
+  // Chained with `.react-tooltip` so ancestor rules targeting the bare
+  // `.react-tooltip` class (e.g. min-width overrides inside modals) cannot
+  // bloat the confirmation badge.
+  &__tooltip.react-tooltip {
+    width: auto;
+    min-width: 0;
+    background-color: $ui-light-grey;
+    border: 1px solid $ui-fleet-black-10;
+    border-radius: 10px;
+    padding: 2px 6px;
+    color: $core-fleet-black;
+    font-size: $x-small;
+    font-weight: $regular;
+    line-height: 1.2;
+    white-space: nowrap;
+    z-index: 100;
+  }
+}

--- a/frontend/components/buttons/CopyButton/index.ts
+++ b/frontend/components/buttons/CopyButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CopyButton";

--- a/frontend/components/forms/fields/InputField/InputField.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tsx
@@ -3,10 +3,8 @@ import classnames from "classnames";
 
 import { PlacesType } from "react-tooltip-5";
 
-import { stringToClipboard } from "utilities/copy_text";
-
 import FormField from "components/forms/FormField";
-import Button from "components/buttons/Button";
+import CopyButton from "components/buttons/CopyButton";
 import Icon from "components/Icon";
 
 const baseClass = "input-field";
@@ -91,7 +89,6 @@ const InputField = ({
   min,
   max,
 }: IInputFieldProps): JSX.Element => {
-  const [copied, setCopied] = useState(false);
   const [showSecret, setShowSecret] = useState(false);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
 
@@ -123,18 +120,7 @@ const InputField = ({
     setShowSecret((prev) => !prev);
   }, []);
 
-  const onClickCopy = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      stringToClipboard(value).then(() => {
-        setCopied(true);
-        setTimeout(() => {
-          setCopied(false);
-        }, 2000);
-      });
-    },
-    [value]
-  );
+  const copyText = typeof value === "string" ? value : String(value ?? "");
 
   // Old-style icon copy button for textarea (positioned absolutely above textarea)
   const renderTextareaCopyButton = () => {
@@ -142,12 +128,7 @@ const InputField = ({
       <div
         className={`${baseClass}__copy-wrapper ${baseClass}__copy-wrapper--text-area`}
       >
-        {copied && (
-          <span className={`${baseClass}__copied-confirmation`}>Copied!</span>
-        )}
-        <Button variant="icon" onClick={onClickCopy} size="small" iconStroke>
-          <Icon name="copy" />
-        </Button>
+        <CopyButton copyText={copyText} size="small" />
       </div>
     );
   };
@@ -157,21 +138,10 @@ const InputField = ({
     return (
       <div className={`${baseClass}__action-buttons`}>
         {enableCopy && (
-          <div className={`${baseClass}__action-button-wrapper`}>
-            {copied && (
-              <span className={`${baseClass}__copied-confirmation`}>
-                Copied!
-              </span>
-            )}
-            <button
-              type="button"
-              className={`${baseClass}__action-button`}
-              onClick={onClickCopy}
-              aria-label="Copy to clipboard"
-            >
-              <Icon name="copy" />
-            </button>
-          </div>
+          <CopyButton
+            copyText={copyText}
+            className={`${baseClass}__action-button`}
+          />
         )}
         {enableShowSecret && (
           <button

--- a/frontend/components/forms/fields/InputField/InputField.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tsx
@@ -141,6 +141,7 @@ const InputField = ({
           <CopyButton
             copyText={copyText}
             className={`${baseClass}__action-button`}
+            tooltipOffset={10}
           />
         )}
         {enableShowSecret && (

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -123,10 +123,6 @@
     flex-shrink: 0;
   }
 
-  &__action-button-wrapper {
-    position: relative;
-  }
-
   &__action-button {
     @include bordered-icon-button;
 
@@ -134,21 +130,6 @@
       width: 16px;
       height: 16px;
     }
-  }
-
-  &__copied-confirmation {
-    @include copy-message;
-  }
-
-  // Positioning for new bordered action buttons — float to the left of the button
-  &__action-button-wrapper &__copied-confirmation {
-    position: absolute;
-    top: 50%;
-    right: calc(100% + $pad-xsmall);
-    transform: translateY(-50%);
-    margin: 0;
-    white-space: nowrap;
-    pointer-events: none;
   }
 }
 

--- a/frontend/pages/ManageControlsPage/Variables/Variables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tsx
@@ -10,7 +10,6 @@ import { IVariable } from "interfaces/variables";
 
 import { AppContext } from "context/app";
 
-import { stringToClipboard } from "utilities/copy_text";
 import {
   DEFAULT_USE_QUERY_OPTIONS,
   FLEET_WEBSITE_URL,
@@ -20,6 +19,7 @@ import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import ListItem from "components/ListItem/ListItem";
 import PaginatedList, { IPaginatedListHandle } from "components/PaginatedList";
 import Button from "components/buttons/Button";
+import CopyButton from "components/buttons/CopyButton";
 import Spinner from "components/Spinner";
 import EmptyState from "components/EmptyState";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
@@ -42,10 +42,6 @@ interface IVariablesProps {
 
 const Variables = ({ router, location }: IVariablesProps) => {
   const paginatedListRef = useRef<IPaginatedListHandle<IVariable>>(null);
-
-  const [copyMessage, setCopyMessage] = useState("");
-  const [copiedVariableName, setCopiedVariableName] = useState("");
-  const copyMessageTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [variableToDelete, setVariableToDelete] = useState<
@@ -105,36 +101,6 @@ const Variables = ({ router, location }: IVariablesProps) => {
     return `$FLEET_SECRET_${variableName.toUpperCase()}`;
   };
 
-  const onCopyVariableName = (evt: React.MouseEvent, variableName: string) => {
-    evt.preventDefault();
-
-    if (copyMessageTimeoutIdRef.current) {
-      clearTimeout(copyMessageTimeoutIdRef.current);
-    }
-
-    setCopiedVariableName(variableName);
-    stringToClipboard(getTokenFromVariableName(variableName))
-      .then(() => setCopyMessage("Copied!"))
-      .catch(() => setCopyMessage("Copy failed"));
-
-    // Clear message after 1 second
-    copyMessageTimeoutIdRef.current = setTimeout(() => {
-      setCopyMessage("");
-      setCopiedVariableName("");
-    }, 1000);
-
-    return false;
-  };
-
-  // Cleanup timeout on unmount.
-  useEffect(() => {
-    return () => {
-      if (copyMessageTimeoutIdRef.current) {
-        clearTimeout(copyMessageTimeoutIdRef.current);
-      }
-    };
-  }, []);
-
   const renderVariableRow = (variable: IVariable) => (
     <>
       <ListItem
@@ -146,20 +112,10 @@ const Variables = ({ router, location }: IVariablesProps) => {
               <HumanTimeDiffWithDateTip timeString={variable.updated_at} />{" "}
               &bull; {getTokenFromVariableName(variable.name)}
             </span>
-            <Button
-              variant="unstyled"
-              className={`${baseClass}__copy-variable-icon`}
-              onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
-                onCopyVariableName(e, variable.name)
-              }
-            >
-              <Icon name="copy" />
-            </Button>
-            {copyMessage && copiedVariableName === variable.name && (
-              <span
-                className={`${baseClass}__copy-message`}
-              >{`${copyMessage} `}</span>
-            )}
+            <CopyButton
+              copyText={getTokenFromVariableName(variable.name)}
+              variant="compact"
+            />
           </span>
         }
       />

--- a/frontend/pages/ManageControlsPage/Variables/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Variables/_styles.scss
@@ -2,13 +2,6 @@
   @include vertical-page-tab-panel-layout;
   margin-top: $gap-page-component; // Required as these Tabs don't use TabPanel
 
-  &__copy-message {
-    @include copy-message;
-    vertical-align: bottom;
-    font-size: $xx-small;
-    margin-left: $pad-xsmall;
-  }
-
   &__page-header {
     display: flex;
     justify-content: space-between;
@@ -32,14 +25,6 @@
       }
     }
 
-    .variables__copy-variable-icon {
-      margin: -12px 0 -12px 4px;
-      vertical-align: bottom;
-      .children-wrapper {
-        opacity: 1;
-      }
-    }
-
     &:hover,
     &:focus-within {
       cursor: default;
@@ -53,6 +38,8 @@
       min-width: 0;
       > span {
         display: flex;
+        align-items: center;
+        gap: $pad-xsmall;
       }
     }
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
 
-import { stringToClipboard } from "utilities/copy_text";
 import {
   LEARN_MORE_ABOUT_BASE_LINK,
   PLATFORM_DISPLAY_NAMES,
@@ -11,7 +10,7 @@ import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
+import CopyButton from "components/buttons/CopyButton";
 import CustomLink from "components/CustomLink";
 
 const baseClass = "fleet-app-details-modal";
@@ -53,21 +52,6 @@ const FleetAppDetailsModal = ({
   url,
   onCancel,
 }: IFleetAppDetailsModalProps) => {
-  const [copyMessage, setCopyMessage] = useState("");
-
-  const onCopySlug = (evt: React.MouseEvent) => {
-    evt.preventDefault();
-
-    stringToClipboard(slug)
-      .then(() => setCopyMessage("Copied!"))
-      .catch(() => setCopyMessage("Copy failed"));
-
-    // Clear message after 1 second
-    setTimeout(() => setCopyMessage(""), 1000);
-
-    return false;
-  };
-
   let versionElement = <>{version}</>;
   if (version === "latest") {
     versionElement = (
@@ -99,21 +83,7 @@ const FleetAppDetailsModal = ({
             }
             value={
               <>
-                {slug}{" "}
-                <div className={`${baseClass}__action-overlay`}>
-                  {copyMessage && (
-                    <div
-                      className={`${baseClass}__copy-message`}
-                    >{`${copyMessage} `}</div>
-                  )}
-                </div>
-                <Button
-                  variant="unstyled"
-                  className={`${baseClass}__copy-secret-icon`}
-                  onClick={onCopySlug}
-                >
-                  <Icon name="copy" />
-                </Button>
+                {slug} <CopyButton copyText={slug} variant="compact" />
               </>
             }
           />

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/_styles.scss
@@ -13,26 +13,10 @@
   // Used for gap between slug and copy icon
   dd {
     gap: $pad-xsmall;
-  }
-
-  &__copy-message {
-    @include copy-message;
-  }
-
-  &__action-overlay {
-    display: flex;
-    justify-content: flex-end;
     align-items: center;
-    position: relative;
-    width: 0;
-    height: 16px;
-
-    span {
-      font-weight: $regular;
-    }
   }
 
-  .react-tooltip {
+  dt .react-tooltip {
     min-width: 120px;
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
@@ -1,10 +1,9 @@
 /** TODO: This component is similar to other UI elements that can
  * be abstracted to use a shared base component (e.g. DetailsWidget) */
 
-import React, { useState } from "react";
+import React from "react";
 import classnames from "classnames";
 
-import { stringToClipboard } from "utilities/copy_text";
 import { internationalTimeFormat } from "utilities/helpers";
 import { addedFromNow } from "utilities/date_format";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
@@ -16,8 +15,7 @@ import { isAndroidWebApp } from "pages/SoftwarePage/helpers";
 import Graphic from "components/Graphic";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import TooltipWrapper from "components/TooltipWrapper";
-import Button from "components/buttons/Button";
-import Icon from "components/Icon";
+import CopyButton from "components/buttons/CopyButton";
 import CustomLink from "components/CustomLink";
 import AndroidLatestVersionWithTooltip from "components/MDM/AndroidLatestVersionWithTooltip";
 
@@ -92,21 +90,6 @@ const InstallerDetailsWidget = ({
   customDetails,
 }: IInstallerDetailsWidgetProps) => {
   const classNames = classnames(baseClass, className);
-
-  const [copyMessage, setCopyMessage] = useState("");
-
-  const onCopySha256 = (evt: React.MouseEvent) => {
-    evt.preventDefault();
-
-    stringToClipboard(sha256)
-      .then(() => setCopyMessage("Copied!"))
-      .catch(() => setCopyMessage("Copy failed"));
-
-    // Clear message after 1 second
-    setTimeout(() => setCopyMessage(""), 1000);
-
-    return false;
-  };
 
   const renderIcon = () => {
     if (installerType === "app-store") {
@@ -221,23 +204,7 @@ const InstallerDetailsWidget = ({
             >
               {sha256.slice(0, 7)}&hellip;
             </TooltipWrapper>
-            <div className={`${baseClass}__sha-copy-button`}>
-              <Button
-                variant="icon"
-                size="small"
-                iconStroke
-                onClick={onCopySha256}
-              >
-                <Icon name="copy" />
-              </Button>
-            </div>
-            <div className={`${baseClass}__copy-overlay`}>
-              {copyMessage && (
-                <div
-                  className={`${baseClass}__copy-message`}
-                >{`${copyMessage} `}</div>
-              )}
-            </div>
+            <CopyButton copyText={sha256} variant="compact" />
           </span>
         </>
       ) : (

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/_styles.scss
@@ -26,21 +26,6 @@
   &__sha256 {
     display: flex;
     align-items: center;
-    margin: -$pad-small 0; // Remove vertical padding but keep clickable area
-  }
-
-  &__copy-overlay {
-    display: flex;
-    position: relative;
-    left: -95px;
-  }
-
-  &__sha-copy-button {
-    display: flex;
-    align-items: center;
-  }
-
-  &__copy-message {
-    @include copy-message;
+    gap: $pad-xsmall;
   }
 }

--- a/frontend/pages/SoftwarePage/components/tables/HashCell/HashCell.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/HashCell/HashCell.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import { flatMap } from "lodash";
-import { stringToClipboard } from "utilities/copy_text";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
+import CopyButton from "components/buttons/CopyButton";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import { IHostSoftware, ISoftwareInstallVersion } from "interfaces/software";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
@@ -19,39 +18,13 @@ const HashCell = ({
   installedVersion,
   onClickMultipleHashes,
 }: IHashCellProps) => {
-  const [copyMessage, setCopyMessage] = useState("");
-
-  const onCopySha256 = (hash: string) => (evt: React.MouseEvent) => {
-    evt.preventDefault();
-
-    stringToClipboard(hash)
-      .then(() => setCopyMessage("Copied!"))
-      .catch(() => setCopyMessage("Copy failed"));
-
-    // Clear message after 1 second
-    setTimeout(() => setCopyMessage(""), 1000);
-
-    return false;
-  };
-
   const renderHash = (hash: string) => {
     return (
       <>
         <span className={`${baseClass}__sha256`}>
           {hash.slice(0, 7)}&hellip;{" "}
         </span>
-        <div className={`${baseClass}__sha-copy-button`}>
-          <Button variant="icon" iconStroke onClick={onCopySha256(hash)}>
-            <Icon name="copy" />
-          </Button>
-        </div>
-        <div className={`${baseClass}__copy-overlay`}>
-          {copyMessage && (
-            <div
-              className={`${baseClass}__copy-message`}
-            >{`${copyMessage} `}</div>
-          )}
-        </div>
+        <CopyButton copyText={hash} variant="compact" />
       </>
     );
   };

--- a/frontend/pages/SoftwarePage/components/tables/HashCell/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/tables/HashCell/_styles.scss
@@ -2,28 +2,11 @@
   display: flex;
   flex-direction: row;
   gap: $pad-xsmall;
-  position: relative;
+  align-items: center;
 
   &__sha256 {
     display: flex;
     align-items: center;
     width: 70px; // Consistent to align copy icons
-  }
-
-  &__copy-overlay {
-    display: flex;
-    position: absolute;
-    right: 0;
-    height: 25px; // diff from installer details widget
-    align-self: center; // diff from installer details widget
-  }
-
-  &__sha-copy-button {
-    display: flex;
-    align-items: center;
-  }
-
-  &__copy-message {
-    @include copy-message;
   }
 }

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
@@ -47,21 +47,6 @@
     resize: none;
   }
 
-  &__oauth-scopes-copy-icon-wrapper {
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: center;
-    position: relative;
-    top: 36px;
-    right: 16px;
-    height: 0;
-    gap: 0.5rem;
-  }
-
-  &__copy-message {
-    @include copy-message;
-  }
-
   &__code {
     font-family: "SourceCodePro", $monospace;
   }

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -28,7 +28,7 @@
   &__sw-install-status-dropdown,
   &__script-batch-status-dropdown {
     .dropdown__select {
-      border: 1px solid #e2e4ea;
+      border: 1px solid $ui-fleet-black-10;
     }
 
     .Select-multi-value-wrapper {

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -130,7 +130,7 @@
 
   &__inherited-policies-table {
     th {
-      border-right: 1px solid #e2e4ea !important;
+      border-right: 1px solid $ui-fleet-black-10 !important;
     }
 
     .table-container__header {

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 
-import { notify } from "components/ToastNotification";
 import { IPolicyAutomationActivity } from "interfaces/policy";
-import { stringToClipboard } from "utilities/copy_text";
 import PATHS from "router/paths";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
+import CopyButton from "components/buttons/CopyButton";
 import CustomLink from "components/CustomLink";
 import DataSet from "components/DataSet";
 import Textarea from "components/Textarea";
@@ -35,12 +34,6 @@ const PolicyAutomationActivityDetailsModal = ({
 }: IPolicyAutomationActivityDetailsModalProps): JSX.Element => {
   const { status, created_at, host_id, host_display_name } = activity;
   const detailOutput = getDetailOutputText(activity);
-
-  const onCopyDetails = () => {
-    stringToClipboard(detailOutput)
-      .then(() => notify.success("Details copied to clipboard."))
-      .catch(() => notify.error("Couldn't copy to clipboard."));
-  };
 
   return (
     <Modal title="Details" onExit={onCancel} className={baseClass}>
@@ -79,14 +72,11 @@ const PolicyAutomationActivityDetailsModal = ({
             label={
               <div className={`${baseClass}__details-label`}>
                 <span>Details</span>
-                <Button
-                  variant="icon"
-                  onClick={onCopyDetails}
-                  className={`${baseClass}__copy`}
+                <CopyButton
+                  copyText={detailOutput}
+                  size="small"
                   ariaLabel="Copy details"
-                >
-                  <Icon name="copy" />
-                </Button>
+                />
               </div>
             }
           >

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/_styles.scss
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/_styles.scss
@@ -37,7 +37,4 @@
     gap: $pad-small;
   }
 
-  &__copy {
-    padding: 0;
-  }
 }

--- a/frontend/pages/policies/edit/components/PolicyErrorsTable/_styles.scss
+++ b/frontend/pages/policies/edit/components/PolicyErrorsTable/_styles.scss
@@ -102,7 +102,7 @@
 }
 
 .no-team-policy {
-  border: 1px solid #e2e4ea;
+  border: 1px solid $ui-fleet-black-10;
   box-sizing: border-box;
   border-radius: 8px;
 }

--- a/frontend/pages/policies/edit/components/PolicyResultsTable/_styles.scss
+++ b/frontend/pages/policies/edit/components/PolicyResultsTable/_styles.scss
@@ -120,7 +120,7 @@
 }
 
 .no-team-policy {
-  border: 1px solid #e2e4ea;
+  border: 1px solid $ui-fleet-black-10;
   box-sizing: border-box;
   border-radius: 8px;
 }

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -218,17 +218,6 @@ $max-width: 2560px;
   }
 }
 
-@mixin copy-message {
-  font-weight: $regular;
-  font-size: $x-small;
-  vertical-align: top;
-  background-color: $ui-light-grey;
-  border: solid 1px #e2e4ea;
-  border-radius: 10px;
-  padding: 2px 6px;
-  margin: -4px 0;
-}
-
 @mixin color-contrasted-sections {
   .section {
     display: flex;


### PR DESCRIPTION
## Issue
Closes #47989

Also fixes two unreleased bugs surfaced while auditing copy-button usage across the app (both noted in #47989):
- `PolicyAutomationActivityDetailsModal` fired `notify.success` / `notify.error` toasts on click of the copy icon — wrong feedback pattern for an inline copy action.
- `ToastCard`'s expandable error-detail panel had a bespoke copy button with an inline \"Copied!\" span — diverged from the rest of the app.

## Description
- **Bug fix (root cause, dark-mode border):** `@mixin copy-message` in `frontend/styles/var/mixins.scss` hardcoded its border as `#e2e4ea` (the light-mode value of `\$ui-fleet-black-10`) with no dark-mode override. Eight components consumed the mixin; all rendered a light-grey border on dark surface in dark mode. Mixin removed; `CopyButton`'s own SCSS uses `\$ui-fleet-black-10` so dark mode resolves to `#474c58`.
- **Bug fix (root cause, clipping):** the slug's Copied! badge was clipped by `.fleet-app-details-modal .data-set { overflow: hidden }` (kept intentionally for the URL `TooltipTruncatedText` ellipsis) combined with a `__action-overlay` div of `width: 0` that pushed the badge to overflow leftward into the clipped region. Fix: badge is now a react-tooltip 5 tooltip rendered out of the flow tree — `overflow: hidden` ancestors can't clip it.
- **New component:** `frontend/components/buttons/CopyButton/` — Fleet Button + react-tooltip 5 in controlled `isOpen` mode. Hardcoded `\"Copied!\"` / `\"Copy failed\"` / 1000ms / `place=\"left\"`. Variant API: `\"icon\"` (default 36×36) | `\"inverse\"` (label + icon, e.g. \"Copy [icon]\") | `\"compact\"` (20×20 hit area: 16px icon + 2px padding) for inline-with-text actions inside a 21px line-height row. Optional `size: \"small\" | \"default\"` and `tooltipOffset` (default 4, override per call site).
- **Compact uses an inset outline for focus**, not Fleet Button's `::after` border pseudo, so the focus ring stays within the 20×20 footprint instead of bleeding 1px past it.
- **Keyboard-safe**: `evt.currentTarget.blur()` is gated on `evt.detail !== 0` so keyboard Enter / Space activations keep their tab position. Mouse clicks still drop focus (Fleet Button's `--icon` uses `:focus` not `:focus-visible` for its hover background — without the blur, mouse clicks leave the button stuck-highlighted).
- **Race fix on hide timer**: `setTimeout(setMessage(null), 1000)` moved inside the clipboard promise's `.then`/`.catch` so the 1s window starts when the message becomes visible, not at click time. Previously a slow `writeText()` (>1s) would fire the no-op hide first, then the late resolution would stick the badge until the next click.
- **Migrated 9 sites to `CopyButton`** — each lost its local `copyMessage` / `copied` state, `__copied-confirmation` / `__copy-message` spans, `__copy-overlay` / `__action-overlay` wrappers, the `setTimeout` cleanup `useEffect`, and the bespoke negative-margin / absolute-positioning hacks:
  - `FleetAppDetailsModal` (slug) — `variant=\"compact\"`
  - `HashCell` (SHA-256) — `variant=\"compact\"`
  - `InstallerDetailsWidget` (SHA-256) — `variant=\"compact\"`
  - `Variables` (token) — `variant=\"compact\"`
  - `Editor` (full editor copy) — default `icon`
  - `SQLEditor` (\"Copy [icon]\" button) — `variant=\"inverse\"` `size=\"small\"`
  - `InputField` textarea path — `icon` `size=\"small\"`; bordered action-button path — `icon` `size=\"default\"` with `tooltipOffset=10` (matches react-tooltip 5 default for the larger 36×36 trigger)
  - `PolicyAutomationActivityDetailsModal` (activity details copy) — `icon` `size=\"small\"`; removed the `notify.success` / `notify.error` toasts
  - `ToastCard` (toast detail-panel copy) — `icon` `size=\"small\"`; removed the bespoke `<button class=\"toast-notification__copy-button\">` + `__copy-confirmation` span
- **Storybook**: `CopyButton.stories.tsx` with three stories (`IconVariant`, `CompactVariant`, `InverseVariant`), each rendered next to representative sibling text at 14px so the inline behavior is visible.
- **Tightened modal tooltip rule**: `.fleet-app-details-modal .react-tooltip { min-width: 120px }` scoped to `dt .react-tooltip` so it only applies to DataSet title tooltips, not any tooltip rendered inside the modal. `CopyButton.__tooltip` is chained as `.copy-button__tooltip.react-tooltip` with `min-width: 0` defensively.
- **Drive-by**: 4 more hardcoded `#e2e4ea` borders in policies + hosts SCSS swapped to `\$ui-fleet-black-10`. `@mixin copy-message` deleted (no remaining consumers). Dead `__copy-message` / `__oauth-scopes-copy-icon-wrapper` rules in `Calendars/_styles.scss` deleted. Unused `.variables__copy-variable-icon` rule deleted.
- **Tests**: `CopyButton.tests.tsx` covers default render, success copy, error copy, custom children, clipboard write (5/5 pass). All affected existing test suites still pass: Variables, InputField, HashCell, Editor, SQLEditor, FleetAppDetailsModal, InstallerDetailsWidget (70/70).

## Screenrecording

https://github.com/user-attachments/assets/ed81d7a4-387c-4caf-9df3-35e7fa7da035



https://github.com/user-attachments/assets/29a59316-a8b1-49a8-857b-7409dee92676

## Testing
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- Manual QA checklist below covers each of the 9 migrated sites in both light and dark mode.

## QA checklist

**Expected for each:** click the copy icon → \"Copied!\" badge appears to the left of the icon, auto-dismisses after 1s. In dark mode: badge background `#1e2128`, border `#474c58`, text `#e2e4ea` — no light-grey badge on dark surface, no clipped edge.

- [x] **Fleet-maintained app slug (the original bug)** — Software → Add software → Fleet-maintained apps → Show details on any app → click copy next to the slug. Light + dark.
- [x] **Software hash (table cell)** — anywhere `HashCell` renders a SHA-256 with the copy icon (host software details with installer hashes) → click the copy icon in that cell. Light + dark.
- [x] **Installer SHA-256 (details widget)** — Software → click any installer title with a SHA-256 hash → click the copy icon next to the hash in the installer details card. Light + dark.
- [x] **Custom variable token** — Controls → Settings → Custom variables → hover a row → click the copy icon next to `\$FLEET_SECRET_XYZ`. Confirm 8px gap between token text and copy icon, no shift in row height. Light + dark.
- [x] **Editor copy** — anywhere `Editor` is used with `enableCopy` (script editors, etc.) → click the floating copy button at top-right of the editor. Light + dark.
- [x] **SQL editor copy** — Hosts → Labels → click any dynamic label → Edit → \"Copy [icon]\" text-icon button next to the **Query** field label. Light + dark.
- [x] **InputField textarea copy** — Settings → Integrations → Calendars (Google Calendar OAuth scopes textarea), Host details → command activity → \"Command details\" modal (request payload / response textareas), or Hosts → Add hosts → non-Chromebook tabs (Fleetd installer instructions). Click the small floating copy button. Light + dark.
- [x] **InputField bordered action button** — anywhere an InputField with `enableCopy` + `enableShowSecret` renders the bordered icon-button pair (e.g. a secret-token input) → confirm (a) the copy button visually matches the show-secret eye button next to it; (b) clicking copy shows \"Copied!\" tooltip. Light + dark.
- [ ] **Policy automation activity details** — Policies → click any policy with automation history → click an activity row → \"Details\" modal opens → click copy icon next to **Details** label. Confirm: tooltip appears (no toast). Light + dark.
- [ ] **Toast detail-panel copy** — trigger an error toast that includes a `detail` payload (any failing API call with a JSON error body) → click the chevron to expand the panel → click copy icon next to **Raw response** label. Light + dark.

### Regressions to verify
- [ ] `FleetAppDetailsModal`: the **URL** value still truncates with ellipsis + hover tooltip (the `overflow: hidden` rule that originally caused the bug is still in place for this).
- [ ] `FleetAppDetailsModal`: DataSet **title** tooltips (slug, URL, Version \"Latest\") still show with `min-width: 120px` and proper width.
- [ ] `Variables`: hovering a row still reveals the copy icon (opacity 0 → 1 transition on `.button > .children-wrapper`).
- [ ] `InputField` bordered pair: copy + show-secret eye buttons still align in a row with `gap: \$pad-xsmall` between them, identical bordered visual.
- [ ] `HashCell` table row height didn't change (compact variant should keep it at the text baseline, not 36px).
- [ ] **Keyboard accessibility**: tab to any CopyButton, press Enter or Space → copy fires, tooltip shows, **focus stays on the button** (tab to next element should go forward, not back to the top of the page).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified copy-to-clipboard experience with consistent "Copied!" confirmation feedback across the application.

* **Bug Fixes**
  * Fixed the "Copied!" confirmation badge border color and clipping issues in dark mode.
  * Improved copy functionality styling and messaging consistency throughout the application.

* **Style**
  * Updated UI color values to use design tokens for better consistency.
  * Enhanced spacing and alignment in copy-related UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->