### PR TITLE
Add route for configuration profile assets

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1380,7 +1380,6 @@ module.exports.routes = {
   'GET /learn-more-about/self-service-categories': '/guides/software-self-service#manage-self-service-categories',
   'GET /learn-more-about/linux-wipe': '/guides/lock-wipe-hosts#linux-wipe-behavior',
   'GET /learn-more-about/configuration-profile-assets': '/articles/custom-os-settings#apple-declarations-ddm',
- 
 
   // Sitemap
   // =============================================================================================================

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1379,6 +1379,8 @@ module.exports.routes = {
   'GET /learn-more-about/vulnerability-exposure-cves': '/articles/dashboard-vulnerability-exposure',
   'GET /learn-more-about/self-service-categories': '/guides/software-self-service#manage-self-service-categories',
   'GET /learn-more-about/linux-wipe': '/guides/lock-wipe-hosts#linux-wipe-behavior',
+  'GET /learn-more-about/configuration-profile-assets': '/articles/custom-os-settings#apple-declarations-ddm',
+ 
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38986


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new convenience redirect route for `GET /learn-more-about/configuration-profile-assets`, sending users to the related configuration profile assets article section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->