### PR TITLE
Website: update custom `<ol>` marker styles

### DIFF
--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -595,6 +595,7 @@
         text-align: center;
         line-height: 20px;
         text-indent: 0px;
+        white-space: nowrap;
       }
     }
     a > code:not(.hljs):not(.nohighlight):not(.mermaid) {

--- a/website/assets/styles/pages/articles/basic-webinar.less
+++ b/website/assets/styles/pages/articles/basic-webinar.less
@@ -403,6 +403,7 @@
         text-align: center;
         line-height: 20px;
         text-indent: 0px;
+        white-space: nowrap;
       }
     }
     a > code:not(.hljs):not(.nohighlight):not(.mermaid) {

--- a/website/assets/styles/pages/articles/basic-whitepaper.less
+++ b/website/assets/styles/pages/articles/basic-whitepaper.less
@@ -347,6 +347,7 @@
         text-align: center;
         line-height: 20px;
         text-indent: 0px;
+        white-space: nowrap;
       }
     }
     a > code:not(.hljs):not(.nohighlight):not(.mermaid) {

--- a/website/assets/styles/pages/articles/case-study.less
+++ b/website/assets/styles/pages/articles/case-study.less
@@ -414,6 +414,7 @@
         text-align: center;
         line-height: 20px;
         text-indent: 0px;
+        white-space: nowrap;
       }
     }
     a > code:not(.hljs):not(.nohighlight):not(.mermaid) {

--- a/website/assets/styles/pages/docs/app-details.less
+++ b/website/assets/styles/pages/docs/app-details.less
@@ -140,6 +140,7 @@
           text-align: center;
           line-height: 20px;
           text-indent: 0px;
+          white-space: nowrap;
         }
       }
     }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -682,6 +682,7 @@
           text-align: center;
           line-height: 20px;
           text-indent: 0px;
+          white-space: nowrap;
         }
       }
 

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -338,6 +338,7 @@
         text-align: center;
         line-height: 20px;
         text-indent: 0px;
+        white-space: nowrap;
       }
     }
     img {

--- a/website/assets/styles/pages/legal/privacy.less
+++ b/website/assets/styles/pages/legal/privacy.less
@@ -541,6 +541,7 @@
         text-align: center;
         line-height: 20px;
         text-indent: 0px;
+        white-space: nowrap;
       }
     }
     a > code:not(.hljs):not(.nohighlight):not(.mermaid) {

--- a/website/assets/styles/pages/legal/terms.less
+++ b/website/assets/styles/pages/legal/terms.less
@@ -440,6 +440,7 @@
         text-align: center;
         line-height: 20px;
         text-indent: 0px;
+        white-space: nowrap;
       }
     }
     a > code:not(.hljs):not(.nohighlight):not(.mermaid) {


### PR DESCRIPTION
Changes:
- Updated the custom `<ol>` marker we use in Markdown content to not break onto multiple lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed list numbering display across multiple pages (articles, webinars, whitepapers, case studies, documentation, handbooks, and legal pages) to prevent counter text from wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->