### PR TITLE
Download a newly-published FMA version when pinned to it

### DIFF
--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -165,8 +165,12 @@ type FMAInstallerCache interface {
 
 // Hydrate pulls information from app-level FMA manifests into an FMA skeleton
 // pulled from the database. If version is non-empty and cache is provided, it
-// loads the metadata from the local cache, returning an error if the version is
-// not cached. If no version is specified, it fetches the latest from the remote manifest.
+// loads the metadata from the local cache. On a cache miss it falls back to the
+// remote manifest, so a published-but-not-yet-cached version (e.g. a freshly
+// released latest an admin is pinning to in a single GitOps apply) can still be
+// hydrated and downloaded; if the requested version isn't currently published
+// either, it returns a "version not available" error. If no version is specified,
+// it fetches the latest from the remote manifest.
 func Hydrate(ctx context.Context, app *fleet.MaintainedApp, version string, teamID *uint, cache FMAInstallerCache) (*fleet.MaintainedApp, error) {
 	if version != "" && cache == nil {
 		return nil, ctxerr.New(ctx, "no fma version cache provided")
@@ -175,33 +179,29 @@ func Hydrate(ctx context.Context, app *fleet.MaintainedApp, version string, team
 	// If a specific version is requested and we have a cache, try the cache first.
 	if version != "" && cache != nil {
 		cached, err := cache.GetCachedFMAInstallerMetadata(ctx, teamID, app.ID, version)
-		if err != nil {
-			if fleet.IsNotFound(err) {
-				// Version not found in cache - return the same error as BatchSetSoftwareInstallers
-				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-					Message: fmt.Sprintf(
-						"Couldn't edit %q: specified version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.",
-						app.Name,
-					),
-				})
-			}
+		if err != nil && !fleet.IsNotFound(err) {
 			return nil, ctxerr.Wrap(ctx, err, "get cached FMA installer metadata")
 		}
-
-		// Copy installer-level fields from cache onto the app,
-		// preserving the app-level fields (ID, Name, Slug, etc.)
-		// that were already loaded from the database.
-		app.Version = cached.Version
-		app.Platform = cached.Platform
-		app.InstallerURL = cached.InstallerURL
-		app.SHA256 = cached.SHA256
-		app.InstallScript = cached.InstallScript
-		app.UninstallScript = cached.UninstallScript
-		app.AutomaticInstallQuery = cached.AutomaticInstallQuery
-		app.Categories = cached.Categories
-		app.UpgradeCode = cached.UpgradeCode
-		app.PatchQuery = cached.PatchQuery
-		return app, nil
+		if err == nil {
+			// Copy installer-level fields from cache onto the app,
+			// preserving the app-level fields (ID, Name, Slug, etc.)
+			// that were already loaded from the database.
+			app.Version = cached.Version
+			app.Platform = cached.Platform
+			app.InstallerURL = cached.InstallerURL
+			app.SHA256 = cached.SHA256
+			app.InstallScript = cached.InstallScript
+			app.UninstallScript = cached.UninstallScript
+			app.AutomaticInstallQuery = cached.AutomaticInstallQuery
+			app.Categories = cached.Categories
+			app.UpgradeCode = cached.UpgradeCode
+			app.PatchQuery = cached.PatchQuery
+			return app, nil
+		}
+		// Cache miss: fall through to the remote manifest so a not-yet-cached
+		// version an admin is pinning to can still be hydrated and downloaded. The
+		// requested version must match a currently-published manifest version
+		// (selected below), otherwise it's reported as not available.
 	}
 
 	body, err := fetchManifestFile(ctx, fmt.Sprintf("/%s.json", app.Slug))
@@ -213,18 +213,45 @@ func Hydrate(ctx context.Context, app *fleet.MaintainedApp, version string, team
 	if err := json.Unmarshal(body, &manifest); err != nil {
 		return nil, ctxerr.Wrapf(ctx, err, "unmarshal FMA manifest for %s", app.Slug)
 	}
-	manifest.Versions[0].Slug = app.Slug
 
-	app.Version = manifest.Versions[0].Version
-	app.Platform = manifest.Versions[0].Platform()
-	app.InstallerURL = manifest.Versions[0].InstallerURL
-	app.SHA256 = manifest.Versions[0].SHA256
-	app.InstallScript = manifest.Refs[manifest.Versions[0].InstallScriptRef]
-	app.UninstallScript = manifest.Refs[manifest.Versions[0].UninstallScriptRef]
-	app.AutomaticInstallQuery = manifest.Versions[0].Queries.Exists
-	app.Categories = manifest.Versions[0].DefaultCategories
-	app.UpgradeCode = manifest.Versions[0].UpgradeCode
-	app.PatchQuery = manifest.Versions[0].Queries.Patched
+	// Hydrate from the requested version when pinning to a not-yet-cached version,
+	// otherwise the latest. A malformed manifest with no versions falls through to
+	// the not-available error below rather than panicking.
+	var selected *ma.FMAManifestApp
+	if version == "" {
+		if len(manifest.Versions) > 0 {
+			selected = manifest.Versions[0]
+		}
+	} else {
+		for _, v := range manifest.Versions {
+			if v.Version == version {
+				selected = v
+				break
+			}
+		}
+	}
+	if selected == nil {
+		// Manifests expose only currently-published versions, so a version that's
+		// neither cached nor published (e.g. evicted or older) can't be fetched.
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: fmt.Sprintf(
+				"Couldn't edit %q: specified version is not available. Available versions are listed in the Fleet UI under Actions > Edit software.",
+				app.Name,
+			),
+		})
+	}
+	selected.Slug = app.Slug
+
+	app.Version = selected.Version
+	app.Platform = selected.Platform()
+	app.InstallerURL = selected.InstallerURL
+	app.SHA256 = selected.SHA256
+	app.InstallScript = manifest.Refs[selected.InstallScriptRef]
+	app.UninstallScript = manifest.Refs[selected.UninstallScriptRef]
+	app.AutomaticInstallQuery = selected.Queries.Exists
+	app.Categories = selected.DefaultCategories
+	app.UpgradeCode = selected.UpgradeCode
+	app.PatchQuery = selected.Queries.Patched
 
 	return app, nil
 }

--- a/server/mdm/maintainedapps/sync_test.go
+++ b/server/mdm/maintainedapps/sync_test.go
@@ -1,16 +1,105 @@
 package maintained_apps
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
+	ma "github.com/fleetdm/fleet/v4/ee/maintained-apps"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeFMACache is a minimal FMAInstallerCache backed by an in-memory version map.
+type fakeFMACache struct {
+	versions map[string]*fleet.MaintainedApp
+}
+
+func (c fakeFMACache) GetCachedFMAInstallerMetadata(_ context.Context, _ *uint, _ uint, version string) (*fleet.MaintainedApp, error) {
+	if a, ok := c.versions[version]; ok {
+		return a, nil
+	}
+	return nil, fmaNotFoundErr{}
+}
+
+type fmaNotFoundErr struct{}
+
+func (fmaNotFoundErr) Error() string    { return "not found" }
+func (fmaNotFoundErr) IsNotFound() bool { return true }
+
+func TestHydrate(t *testing.T) {
+	const slug = "test-app/darwin"
+	newApp := func() *fleet.MaintainedApp {
+		return &fleet.MaintainedApp{ID: 1, Name: "Test App", Slug: slug}
+	}
+
+	// Mock manifest server publishing 2.0 as the latest (currently-published) version.
+	var manifestHits atomic.Int32
+	manifest := ma.FMAManifestFile{
+		Versions: []*ma.FMAManifestApp{{
+			Version:            "2.0",
+			InstallerURL:       "https://example.com/test-2.0.pkg",
+			SHA256:             "hash-2.0",
+			InstallScriptRef:   "i",
+			UninstallScriptRef: "u",
+			Queries:            ma.FMAQueries{Exists: "exists", Patched: "patched"},
+			DefaultCategories:  []string{"Productivity"},
+		}},
+		Refs: map[string]string{"i": "install", "u": "uninstall"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		manifestHits.Add(1)
+		assert.Equal(t, "/"+slug+".json", r.URL.Path)
+		assert.NoError(t, json.NewEncoder(w).Encode(manifest))
+	}))
+	defer srv.Close()
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", srv.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", srv.URL, t)
+
+	// Cache holds only an older 1.0 (still cached, not the published latest).
+	cache := fakeFMACache{versions: map[string]*fleet.MaintainedApp{
+		"1.0": {Version: "1.0", Platform: "darwin", InstallerURL: "cached-1.0", SHA256: "hash-1.0", InstallScript: "ci", UninstallScript: "cu"},
+	}}
+
+	t.Run("no version requested hydrates the latest published version", func(t *testing.T) {
+		app, err := Hydrate(t.Context(), newApp(), "", nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, "2.0", app.Version)
+		require.Equal(t, "https://example.com/test-2.0.pkg", app.InstallerURL)
+		require.Equal(t, "install", app.InstallScript)
+	})
+
+	t.Run("a cached version is served from the cache without a manifest fetch", func(t *testing.T) {
+		before := manifestHits.Load()
+		app, err := Hydrate(t.Context(), newApp(), "1.0", nil, cache)
+		require.NoError(t, err)
+		require.Equal(t, "1.0", app.Version)
+		require.Equal(t, "cached-1.0", app.InstallerURL)
+		require.Equal(t, before, manifestHits.Load(), "cache hit must not fetch the manifest")
+	})
+
+	t.Run("an uncached but published version falls back to the manifest", func(t *testing.T) {
+		// Pinning to a freshly-published version that isn't cached must hydrate
+		// from the manifest so it gets downloaded, rather than erroring.
+		app, err := Hydrate(t.Context(), newApp(), "2.0", nil, cache)
+		require.NoError(t, err)
+		require.Equal(t, "2.0", app.Version)
+		require.Equal(t, "https://example.com/test-2.0.pkg", app.InstallerURL)
+		require.Equal(t, "darwin", app.Platform)
+		require.Equal(t, "install", app.InstallScript)
+	})
+
+	t.Run("an uncached and unpublished version is not available", func(t *testing.T) {
+		_, err := Hydrate(t.Context(), newApp(), "9.9", nil, cache)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "specified version is not available")
+	})
+}
 
 // newTestAppsJSON returns a valid apps.json payload for testing.
 func newTestAppsJSON() []byte {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -27510,6 +27510,31 @@ func (s *integrationEnterpriseTestSuite) TestFMAVersionRollback() {
 	title = getActiveTitleForTeam(team.ID)
 	require.Equal(t, "3.0", title.SoftwarePackage.Version, "active version should remain 3.0 after failed rollback to evicted version")
 
+	// ---- Test bumping a pin to a newly-published version ----
+	// A version published upstream but not yet cached must be downloadable in a
+	// single apply when pinned to directly. Previously this failed with
+	// "specified version is not available" because a literal pin only resolved
+	// against the already-cached set.
+	resetFMAState(warpState, "4.0", []byte("jkl")) // publish 4.0 upstream; not yet cached
+	downloadMu.Lock()
+	delete(downloadedSlugs, "cloudflare-warp/windows")
+	downloadMu.Unlock()
+
+	packages = batchSet(team, []*fleet.SoftwareInstallerPayload{
+		{Slug: new("cloudflare-warp/windows"), SelfService: true, RollbackVersion: "4.0"},
+	})
+	require.Len(t, packages, 2)
+
+	// 4.0 is downloaded, cached, and becomes the active version in one apply.
+	downloadMu.Lock()
+	warpDownloaded = downloadedSlugs["cloudflare-warp/windows"]
+	downloadMu.Unlock()
+	require.True(t, warpDownloaded, "a newly-published pinned version must be downloaded")
+
+	title = getActiveTitleForTeam(team.ID)
+	require.Equal(t, "4.0", title.SoftwarePackage.Version)
+	require.Equal(t, "4.0", title.SoftwarePackage.FleetMaintainedVersions[0].Version)
+
 	// Attempt to add a custom package that will map to the same software title. Should fail
 	// (this tests the "custom installer vs existing FMA" direction).
 	installerContent := "installerbytes"


### PR DESCRIPTION
**Related issue:** Resolves #47215

  ## Summary

  Pinning an FMA to a version via GitOps only resolved against versions already cached on the instance. Bumping a pin to a freshly released version failed with `specified version is not available` because Fleet never downloaded a pinned version it hadn't cached.

  `Hydrate` now falls back to the published app manifest on a cache miss. When the requested version is currently published, Fleet downloads and caches it, so an admin can bump a pin to a new version in a single apply. A version that's neither cached nor published still returns the same error.

  # Checklist for submitter

  - [x] Timeouts are implemented and retries are limited to avoid infinite loops

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually