### PR TITLE
Fix My device software list appending macos_applications param on pagination

### DIFF
--- a/changes/39017-mydevice-macos-applications-query-param
+++ b/changes/39017-mydevice-macos-applications-query-param
@@ -1,0 +1,1 @@
+- Fixed the **My device > Software** tab appending a `macos_applications` query parameter to the URL when paginating, even though that page has no /Applications filter.

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -162,13 +162,16 @@ const HostSoftware = ({
     ? isPremiumTierProp
     : isPremiumTierFromContext;
 
-  // The /Applications filter only applies to macOS hosts, and defaults to ON
-  // (only top-level applications) when the host is macOS and no explicit value
-  // is set in the URL. It is left undefined for other platforms so the param is
-  // not sent to the API.
-  const macosApplicationsFilter = isMacOS(platform)
-    ? queryParams.macos_applications ?? true
-    : undefined;
+  // The /Applications filter only applies to macOS hosts on the host details
+  // page, and defaults to ON (only top-level applications) when the host is
+  // macOS and no explicit value is set in the URL. It is left undefined for
+  // other platforms, and on the My device page (which has no filter dropdown),
+  // so the param is neither sent to the API nor appended to the URL on
+  // pagination.
+  const macosApplicationsFilter =
+    !isMyDevicePage && isMacOS(platform)
+      ? queryParams.macos_applications ?? true
+      : undefined;
 
   const isUnsupported = isIPadOrIPhone(platform) && queryParams.vulnerable; // no Android software and no vulnerable software for iOS
 

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
@@ -1,14 +1,26 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import { noop } from "lodash";
 import { HostPlatform } from "interfaces/platform";
 
 import createMockUser from "__mocks__/userMock";
-import { createMockGetHostSoftwareResponse } from "__mocks__/hostMock";
+import {
+  createMockGetHostSoftwareResponse,
+  createMockHostSoftware,
+} from "__mocks__/hostMock";
 import HostSoftwareTable from "./HostSoftwareTable";
 
 const mockRouter = createMockRouter();
+
+// Server-side pagination only renders when a full page of rows is present
+// (DEFAULT_PAGE_SIZE = 20) and there are further results.
+const fullPageWithNextResults = createMockGetHostSoftwareResponse({
+  software: Array.from({ length: 20 }, (_, index) =>
+    createMockHostSoftware({ id: index + 1 })
+  ),
+  meta: { has_next_results: true, has_previous_results: false },
+});
 
 describe("HostSoftwareTable", () => {
   const baseProps = {
@@ -141,5 +153,38 @@ describe("HostSoftwareTable", () => {
 
     expect(screen.queryByText("Applications")).not.toBeInTheDocument();
     expect(screen.queryByText("Full inventory")).not.toBeInTheDocument();
+  });
+
+  it("appends macos_applications to the URL on pagination when the filter is set", () => {
+    mockRouter.replace.mockClear();
+    renderWithContext({
+      platform: "darwin",
+      macosApplicationsFilter: true,
+      data: fullPageWithNextResults,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(mockRouter.replace).toHaveBeenCalledWith(
+      expect.stringContaining("macos_applications=true")
+    );
+  });
+
+  it("does not append macos_applications to the URL on pagination when the filter is undefined (My device page)", () => {
+    mockRouter.replace.mockClear();
+    renderWithContext({
+      platform: "darwin",
+      // My device page leaves the filter undefined since it has no dropdown.
+      macosApplicationsFilter: undefined,
+      isMyDevicePage: true,
+      data: fullPageWithNextResults,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(mockRouter.replace).toHaveBeenCalledTimes(1);
+    expect(mockRouter.replace).not.toHaveBeenCalledWith(
+      expect.stringContaining("macos_applications")
+    );
   });
 });

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tests.tsx
@@ -156,8 +156,9 @@ describe("HostSoftwareTable", () => {
   });
 
   it("appends macos_applications to the URL on pagination when the filter is set", () => {
-    mockRouter.replace.mockClear();
+    const router = createMockRouter();
     renderWithContext({
+      router,
       platform: "darwin",
       macosApplicationsFilter: true,
       data: fullPageWithNextResults,
@@ -165,14 +166,15 @@ describe("HostSoftwareTable", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
-    expect(mockRouter.replace).toHaveBeenCalledWith(
+    expect(router.replace).toHaveBeenCalledWith(
       expect.stringContaining("macos_applications=true")
     );
   });
 
   it("does not append macos_applications to the URL on pagination when the filter is undefined (My device page)", () => {
-    mockRouter.replace.mockClear();
+    const router = createMockRouter();
     renderWithContext({
+      router,
       platform: "darwin",
       // My device page leaves the filter undefined since it has no dropdown.
       macosApplicationsFilter: undefined,
@@ -182,8 +184,8 @@ describe("HostSoftwareTable", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
-    expect(mockRouter.replace).toHaveBeenCalledTimes(1);
-    expect(mockRouter.replace).not.toHaveBeenCalledWith(
+    expect(router.replace).toHaveBeenCalledTimes(1);
+    expect(router.replace).not.toHaveBeenCalledWith(
       expect.stringContaining("macos_applications")
     );
   });


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39017
Related issue: Resolves #47846

Follow up for https://github.com/fleetdm/fleet/pull/46223
## Summary

PR #46223 introduced a `macos_applications` query param for the host details software list, controlled by an `/Applications` filter dropdown. On the **My device > Software** tab, that dropdown is intentionally hidden — but `macosApplicationsFilter` was still computed as defined (`true`) for macOS devices, so paginating the list appended `macos_applications=true` to the URL.

The fix gates `macosApplicationsFilter` on `!isMyDevicePage` at its source in `HostSoftware.tsx`, leaving it `undefined` on the My device page. This is a single root-cause change: it stops the param from being appended to the URL on pagination, sent to the API, or otherwise leaking into a page that has no filter control.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Added two regression tests in `HostSoftwareTable.tests.tsx`: pagination appends `macos_applications` when the filter is set (host details page), and does **not** append it when the filter is undefined (My device page).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination in **My device > Software** so it no longer incorrectly adds the `macos_applications` query parameter when the current page shouldn’t use the macOS Applications filter.

* **Tests**
  * Added/updated pagination tests to cover macOS versus non-macOS and **My device** page behavior, verifying whether the `macos_applications` parameter is included in navigation URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->