### PR TITLE
Google Workspace IdP [1/6]: activity types (frontend + backend)

### DIFF
--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -161,6 +161,9 @@ export enum ActivityType {
   DeletedCustomVariable = "deleted_custom_variable",
   EditedSetupExperienceSoftware = "edited_setup_experience_software",
   EditedHostIdpData = "edited_host_idp_data",
+  AddedGoogleWorkspaceIntegration = "added_google_workspace_integration",
+  EditedGoogleWorkspaceIntegration = "edited_google_workspace_integration",
+  DeletedGoogleWorkspaceIntegration = "deleted_google_workspace_integration",
   AddedCertificate = "added_certificate",
   DeletedCertificate = "deleted_certificate",
   InstalledCertificate = "installed_certificate",
@@ -347,6 +350,7 @@ export interface IActivityDetails {
   ticket_key?: string;
   ticket_id?: number;
   custom_variable_name?: string;
+  domain?: string;
   host_idp_username?: string;
   idp_full_name?: string;
   tenant_id?: string;
@@ -547,6 +551,12 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
   [ActivityType.EditedSetupExperienceSoftware]:
     "Edited setup experience software",
   [ActivityType.EditedHostIdpData]: "Edited host identity provider (IdP) data",
+  [ActivityType.AddedGoogleWorkspaceIntegration]:
+    "Added Google Workspace integration",
+  [ActivityType.EditedGoogleWorkspaceIntegration]:
+    "Edited Google Workspace integration",
+  [ActivityType.DeletedGoogleWorkspaceIntegration]:
+    "Deleted Google Workspace integration",
   [ActivityType.AddedCertificate]: "Added certificate",
   [ActivityType.DeletedCertificate]: "Deleted certificate",
   [ActivityType.InstalledCertificate]: "Installed certificate",

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1681,6 +1681,54 @@ const TAGGED_TEMPLATES = {
   deletedConditionalAccessOkta: () => (
     <> deleted Okta conditional access configuration.</>
   ),
+  addedGoogleWorkspaceIntegration: (activity: IActivity) => {
+    const { domain } = activity.details ?? {};
+    return (
+      <>
+        {" "}
+        added the Google Workspace integration
+        {domain ? (
+          <>
+            {" "}
+            for <strong>{domain}</strong>
+          </>
+        ) : null}
+        .
+      </>
+    );
+  },
+  editedGoogleWorkspaceIntegration: (activity: IActivity) => {
+    const { domain } = activity.details ?? {};
+    return (
+      <>
+        {" "}
+        edited the Google Workspace integration
+        {domain ? (
+          <>
+            {" "}
+            for <strong>{domain}</strong>
+          </>
+        ) : null}
+        .
+      </>
+    );
+  },
+  deletedGoogleWorkspaceIntegration: (activity: IActivity) => {
+    const { domain } = activity.details ?? {};
+    return (
+      <>
+        {" "}
+        deleted the Google Workspace integration
+        {domain ? (
+          <>
+            {" "}
+            for <strong>{domain}</strong>
+          </>
+        ) : null}
+        .
+      </>
+    );
+  },
   hostBypassedConditionalAccess: (activity: IActivity) => {
     const idpFullName = activity.details?.idp_full_name;
     const hostDisplayName = activity.details?.host_display_name;
@@ -2521,6 +2569,15 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     }
     case ActivityType.DeletedConditionalAccessOkta: {
       return TAGGED_TEMPLATES.deletedConditionalAccessOkta();
+    }
+    case ActivityType.AddedGoogleWorkspaceIntegration: {
+      return TAGGED_TEMPLATES.addedGoogleWorkspaceIntegration(activity);
+    }
+    case ActivityType.EditedGoogleWorkspaceIntegration: {
+      return TAGGED_TEMPLATES.editedGoogleWorkspaceIntegration(activity);
+    }
+    case ActivityType.DeletedGoogleWorkspaceIntegration: {
+      return TAGGED_TEMPLATES.deletedGoogleWorkspaceIntegration(activity);
     }
     case ActivityType.UpdatedConditionalAccessBypass: {
       return TAGGED_TEMPLATES.updatedConditionalAccessBypass();

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1681,44 +1681,12 @@ const TAGGED_TEMPLATES = {
   deletedConditionalAccessOkta: () => (
     <> deleted Okta conditional access configuration.</>
   ),
-  addedGoogleWorkspaceIntegration: (activity: IActivity) => {
+  googleWorkspaceIntegration: (verb: string) => (activity: IActivity) => {
     const { domain } = activity.details ?? {};
     return (
       <>
         {" "}
-        added the Google Workspace integration
-        {domain ? (
-          <>
-            {" "}
-            for <strong>{domain}</strong>
-          </>
-        ) : null}
-        .
-      </>
-    );
-  },
-  editedGoogleWorkspaceIntegration: (activity: IActivity) => {
-    const { domain } = activity.details ?? {};
-    return (
-      <>
-        {" "}
-        edited the Google Workspace integration
-        {domain ? (
-          <>
-            {" "}
-            for <strong>{domain}</strong>
-          </>
-        ) : null}
-        .
-      </>
-    );
-  },
-  deletedGoogleWorkspaceIntegration: (activity: IActivity) => {
-    const { domain } = activity.details ?? {};
-    return (
-      <>
-        {" "}
-        deleted the Google Workspace integration
+        {verb} the Google Workspace integration
         {domain ? (
           <>
             {" "}
@@ -2571,13 +2539,13 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
       return TAGGED_TEMPLATES.deletedConditionalAccessOkta();
     }
     case ActivityType.AddedGoogleWorkspaceIntegration: {
-      return TAGGED_TEMPLATES.addedGoogleWorkspaceIntegration(activity);
+      return TAGGED_TEMPLATES.googleWorkspaceIntegration("added")(activity);
     }
     case ActivityType.EditedGoogleWorkspaceIntegration: {
-      return TAGGED_TEMPLATES.editedGoogleWorkspaceIntegration(activity);
+      return TAGGED_TEMPLATES.googleWorkspaceIntegration("edited")(activity);
     }
     case ActivityType.DeletedGoogleWorkspaceIntegration: {
-      return TAGGED_TEMPLATES.deletedGoogleWorkspaceIntegration(activity);
+      return TAGGED_TEMPLATES.googleWorkspaceIntegration("deleted")(activity);
     }
     case ActivityType.UpdatedConditionalAccessBypass: {
       return TAGGED_TEMPLATES.updatedConditionalAccessBypass();

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1722,6 +1722,30 @@ func (a ActivityTypeDeletedConditionalAccessOkta) ActivityName() string {
 	return "deleted_conditional_access_okta"
 }
 
+type ActivityTypeAddedGoogleWorkspaceIntegration struct {
+	Domain string `json:"domain"`
+}
+
+func (a ActivityTypeAddedGoogleWorkspaceIntegration) ActivityName() string {
+	return "added_google_workspace_integration"
+}
+
+type ActivityTypeEditedGoogleWorkspaceIntegration struct {
+	Domain string `json:"domain"`
+}
+
+func (a ActivityTypeEditedGoogleWorkspaceIntegration) ActivityName() string {
+	return "edited_google_workspace_integration"
+}
+
+type ActivityTypeDeletedGoogleWorkspaceIntegration struct {
+	Domain string `json:"domain"`
+}
+
+func (a ActivityTypeDeletedGoogleWorkspaceIntegration) ActivityName() string {
+	return "deleted_google_workspace_integration"
+}
+
 type ActivityTypeEnabledConditionalAccessAutomations struct {
 	TeamID   *uint  `json:"team_id" renameto:"fleet_id"`
 	TeamName string `json:"team_name" renameto:"fleet_name"`


### PR DESCRIPTION
### 🥞 Stack (review/merge bottom-up)

1. **#48164 — Activity types (FE+BE) ⬅ this PR**
2. #48165 — Backend (cron + directory sync)
3. #48166 — Usage statistics
4. #48167 — fleetctl generate-gitops
5. #48168 — Settings UI

📄 Documentation is tracked separately in #48169 (targets `docs-v4.89.0`).

---

## Summary

**PR 1 of 6** — splits the Google Workspace IdP host-vitals feature into a reviewable stack.

Adds the **activity types** for the Google Workspace integration, frontend and backend:
- Backend: `added_google_workspace_integration`, `edited_google_workspace_integration`, `deleted_google_workspace_integration` (`server/fleet/activities.go`).
- Frontend: activity-feed rendering for those three types (`activity.ts` enum + display names + `domain` detail; `GlobalActivityItem.tsx` templates).

> 🥞 **Stacked PR.** Base: `main`.

**Related issue:** Resolves #42915

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements).
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops.

## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new Google Workspace integration activity entries: added, edited, and deleted.
  * Activity feeds now display the integration domain when available.
  * New filter labels were added for these activity types.

* **Bug Fixes**
  * Activity details now render Google Workspace integration events correctly in the dashboard feed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->