### PR TITLE
[Activity] Document edited account provisioning in audit logs

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -3008,6 +3008,23 @@ This activity contains the following fields:
 }
 ```
 
+## edited_account_provisioning
+
+Generated when settings for account provisioning are edited.
+
+This activity contains the following fields:
+- "fleet_id": the ID of the fleet the label belonged to.
+- "fleet_name": the name of the fleet the label belonged to.
+
+#### Example
+
+```json
+{
+  "fleet_id": 1,
+  "fleet_name": "💻 Workstations"
+}
+```
+
 ## added_label_to_host
 
 Generated when a label is added to a host.


### PR DESCRIPTION
Moves reference doc changes from #46950 to `docs-v4.89.0`.

Originally documented for `docs-v4.88.0` — feature pushed to this release.

**Related:** #46950