### PR TITLE
Fix duplicated URL prefix in transactional email links for subpath deployments

### DIFF
--- a/changes/46642-subpath-email-links
+++ b/changes/46642-subpath-email-links
@@ -1,0 +1,1 @@
+* Fixed password reset, user invite, MFA login, change-email confirmation, and SMTP test emails to no longer duplicate the URL prefix in their links when Fleet is deployed under a subpath.

--- a/server/service/email_links_subpath_test.go
+++ b/server/service/email_links_subpath_test.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/server/authz"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mail"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover transactional email links in subpath deployments. The
+// server URL already carries the subpath, so the link base URL must equal the
+// server URL exactly. Re-appending the URL prefix duplicates the subpath and
+// produces links that 404.
+
+const (
+	subpathServerURL = "https://acme.co/subpath"
+	subpathPrefix    = "/subpath"
+)
+
+func subpathTestConfig() config.FleetConfig {
+	cfg := config.TestConfig()
+	cfg.Server.URLPrefix = subpathPrefix
+	return cfg
+}
+
+func TestEmailLinkBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		serverURL string
+		urlPrefix string
+		want      string
+	}{
+		{"no prefix", "https://acme.co", "", "https://acme.co"},
+		{"prefix in server url only", "https://acme.co/subpath", "/subpath", "https://acme.co/subpath"},
+		{"prefix in url prefix only", "https://acme.co", "/subpath", "https://acme.co/subpath"},
+		{"prefix in url prefix, server url trailing slash", "https://acme.co/", "/subpath", "https://acme.co/subpath"},
+		{"prefix in both", "https://acme.co/subpath", "/subpath", "https://acme.co/subpath"},
+		{"prefix in both, trailing slash", "https://acme.co/subpath/", "/subpath", "https://acme.co/subpath/"},
+		{"distinct prefix not yet present", "https://acme.co", "/apps/fleet", "https://acme.co/apps/fleet"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, string(emailLinkBaseURL(tc.serverURL, tc.urlPrefix)))
+		})
+	}
+}
+
+func TestInviteNewUserEmailLinkSubpath(t *testing.T) {
+	ds := new(mock.Store)
+	ds.UserByEmailFunc = mock.UserWithEmailNotFound()
+	ds.NewInviteFunc = func(ctx context.Context, i *fleet.Invite) (*fleet.Invite, error) { return i, nil }
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{ServerURL: subpathServerURL}}, nil
+	}
+
+	var sent fleet.Email
+	mailer := &mockMailService{SendEmailFn: func(e fleet.Email) error { sent = e; return nil }}
+
+	svc := &Service{
+		ds:          ds,
+		config:      subpathTestConfig(),
+		mailService: mailer,
+		clock:       clock.NewMockClock(),
+		authz:       authz.Must(),
+		logger:      discardLogger(),
+	}
+
+	_, err := svc.InviteNewUser(test.UserContext(t.Context(), test.UserAdmin), fleet.InvitePayload{
+		Email: new("user@acme.co"),
+	})
+	require.NoError(t, err)
+	require.True(t, mailer.Invoked)
+
+	m, ok := sent.Mailer.(*mail.InviteMailer)
+	require.True(t, ok)
+	require.Equal(t, subpathServerURL, string(m.BaseURL))
+}
+
+func TestRequestPasswordResetEmailLinkSubpath(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			ServerSettings: fleet.ServerSettings{ServerURL: subpathServerURL},
+			SMTPSettings:   &fleet.SMTPSettings{SMTPConfigured: true},
+		}, nil
+	}
+	ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
+		return &fleet.User{ID: 1, Email: email}, nil
+	}
+	ds.NewPasswordResetRequestFunc = func(ctx context.Context, req *fleet.PasswordResetRequest) (*fleet.PasswordResetRequest, error) {
+		return req, nil
+	}
+
+	var sent fleet.Email
+	mailer := &mockMailService{SendEmailFn: func(e fleet.Email) error { sent = e; return nil }}
+
+	svc := &Service{
+		ds:          ds,
+		config:      subpathTestConfig(),
+		mailService: mailer,
+		clock:       clock.NewMockClock(),
+		authz:       authz.Must(),
+		logger:      discardLogger(),
+	}
+
+	require.NoError(t, svc.RequestPasswordReset(t.Context(), "user@acme.co"))
+	require.True(t, mailer.Invoked)
+
+	m, ok := sent.Mailer.(*mail.PasswordResetMailer)
+	require.True(t, ok)
+	require.Equal(t, subpathServerURL, string(m.BaseURL))
+}
+
+func TestModifyEmailAddressLinkSubpath(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{ServerURL: subpathServerURL}}, nil
+	}
+	ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
+		return nil, sql.ErrNoRows
+	}
+	ds.InviteByEmailFunc = func(ctx context.Context, email string) (*fleet.Invite, error) {
+		return nil, sql.ErrNoRows
+	}
+	ds.PendingEmailChangeFunc = func(ctx context.Context, userID uint, newEmail, token string) error {
+		return nil
+	}
+
+	var sent fleet.Email
+	mailer := &mockMailService{SendEmailFn: func(e fleet.Email) error { sent = e; return nil }}
+
+	svc := &Service{
+		ds:          ds,
+		config:      subpathTestConfig(),
+		mailService: mailer,
+		clock:       clock.NewMockClock(),
+		authz:       authz.Must(),
+		logger:      discardLogger(),
+	}
+
+	user := &fleet.User{ID: 1, Email: "old@acme.co"}
+	require.NoError(t, svc.modifyEmailAddress(t.Context(), user, "new@acme.co", nil))
+	require.True(t, mailer.Invoked)
+
+	m, ok := sent.Mailer.(*mail.ChangeEmailMailer)
+	require.True(t, ok)
+	require.Equal(t, subpathServerURL, string(m.BaseURL))
+}
+
+func TestMakeMFAEmailLinkSubpath(t *testing.T) {
+	ds := new(mock.Store)
+	ds.NewMFATokenFunc = func(ctx context.Context, userID uint) (string, error) { return "mfa-token", nil }
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{ServerURL: subpathServerURL}}, nil
+	}
+
+	var sent fleet.Email
+	mailer := &mockMailService{SendEmailFn: func(e fleet.Email) error { sent = e; return nil }}
+
+	svc := &Service{
+		ds:          ds,
+		config:      subpathTestConfig(),
+		mailService: mailer,
+		clock:       clock.NewMockClock(),
+		authz:       authz.Must(),
+		logger:      discardLogger(),
+	}
+
+	require.NoError(t, svc.makeMFAEmail(t.Context(), fleet.User{ID: 1, Name: "Bob", Email: "bob@acme.co"}))
+	require.True(t, mailer.Invoked)
+
+	m, ok := sent.Mailer.(*mail.MFAMailer)
+	require.True(t, ok)
+	require.Equal(t, subpathServerURL, string(m.BaseURL))
+}

--- a/server/service/invites.go
+++ b/server/service/invites.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"html/template"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server"
@@ -122,7 +121,7 @@ func (svc *Service) InviteNewUser(ctx context.Context, payload fleet.InvitePaylo
 		SMTPSettings: smtpSettings,
 		Mailer: &mail.InviteMailer{
 			Invite:    invite,
-			BaseURL:   template.URL(config.ServerSettings.ServerURL + svc.config.Server.URLPrefix),
+			BaseURL:   emailLinkBaseURL(config.ServerSettings.ServerURL, svc.config.Server.URLPrefix),
 			AssetURL:  getAssetURL(),
 			OrgName:   config.OrgInfo.OrgName,
 			InvitedBy: invitedBy,

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -224,4 +226,18 @@ type validationMiddleware struct {
 // getAssetURL simply returns the base url used for retrieving image assets from fleetdm.com.
 func getAssetURL() template.URL {
 	return template.URL("https://fleetdm.com/images/permanent")
+}
+
+// emailLinkBaseURL returns the base URL used to build links in transactional
+// emails. The server URL is the source of truth; the URL prefix is appended
+// only when the server URL does not already carry it. This keeps links correct
+// whether an operator configures the subpath in the server URL, in the URL
+// prefix, or both, instead of duplicating it (e.g. https://host/p/p/login).
+func emailLinkBaseURL(serverURL, urlPrefix string) template.URL {
+	if urlPrefix != "" && !strings.HasSuffix(strings.TrimSuffix(serverURL, "/"), urlPrefix) {
+		if joined, err := url.JoinPath(serverURL, urlPrefix); err == nil {
+			serverURL = joined
+		}
+	}
+	return template.URL(serverURL) //nolint:gosec // G203: operator-configured URL, not user input
 }

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"html/template"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server"
@@ -57,7 +56,7 @@ func (svc *Service) sendTestEmail(ctx context.Context, config *fleet.AppConfig) 
 		Subject: "Hello from Fleet",
 		To:      []string{vc.User.Email},
 		Mailer: &mail.SMTPTestMailer{
-			BaseURL:  template.URL(config.ServerSettings.ServerURL + svc.config.Server.URLPrefix),
+			BaseURL:  emailLinkBaseURL(config.ServerSettings.ServerURL, svc.config.Server.URLPrefix),
 			AssetURL: getAssetURL(),
 		},
 		SMTPSettings: smtpSettings,

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -881,7 +881,7 @@ func (svc *Service) makeMFAEmail(ctx context.Context, user fleet.User) error {
 		Mailer: &mail.MFAMailer{
 			FullName: user.Name,
 			Token:    token,
-			BaseURL:  template.URL(config.ServerSettings.ServerURL + svc.config.Server.URLPrefix), //nolint:gosec // dismiss G203
+			BaseURL:  emailLinkBaseURL(config.ServerSettings.ServerURL, svc.config.Server.URLPrefix),
 			AssetURL: getAssetURL(),
 		},
 	}

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"html/template"
 	"net/http"
 	"strings"
 	"time"
@@ -1303,7 +1302,7 @@ func (svc *Service) modifyEmailAddress(ctx context.Context, user *fleet.User, em
 		ServerURL:    config.ServerSettings.ServerURL,
 		Mailer: &mail.ChangeEmailMailer{
 			Token:    token,
-			BaseURL:  template.URL(config.ServerSettings.ServerURL + svc.config.Server.URLPrefix),
+			BaseURL:  emailLinkBaseURL(config.ServerSettings.ServerURL, svc.config.Server.URLPrefix),
 			AssetURL: getAssetURL(),
 		},
 	}
@@ -1561,7 +1560,7 @@ func (svc *Service) RequestPasswordReset(ctx context.Context, email string) erro
 		SMTPSettings: smtpSettings,
 		ServerURL:    config.ServerSettings.ServerURL,
 		Mailer: &mail.PasswordResetMailer{
-			BaseURL:  template.URL(config.ServerSettings.ServerURL + svc.config.Server.URLPrefix),
+			BaseURL:  emailLinkBaseURL(config.ServerSettings.ServerURL, svc.config.Server.URLPrefix),
 			AssetURL: getAssetURL(),
 			Token:    token,
 		},


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #46642

When Fleet is deployed under a subpath, server_url already carries that subpath, so the email link base was being built as server_url + url_prefix, duplicating the path (e.g. https://host/subpath/subpath/login/reset) and producing 404 links.

Use server_url directly as the link base, matching how the rest of the codebase already treats server_url as the full external base URL.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transactional email links (password reset, user invite, MFA login, email change confirmation, and SMTP test emails) to generate correct URLs when the app is deployed under a subpath.
  * Prevented duplicated subpath prefixes in generated email links.
* **Tests**
  * Added subpath-deployment test coverage to verify the email link base URL is derived correctly across multiple URL-prefix scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->