### PR TITLE
Fleet UI: Prevent button label wrap globally on narrow viewports

### DIFF
--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -117,6 +117,7 @@ $base-class: "button";
   border: 0;
   position: relative;
   cursor: pointer;
+  white-space: nowrap;
 
   &:focus {
     outline: none;
@@ -139,13 +140,11 @@ $base-class: "button";
       $core-fleet-green-down
     );
     display: flex;
-    text-wrap: nowrap;
   }
 
   &--success {
     @include button-variant($ui-success, $ui-success-over, $ui-success-down);
     display: flex;
-    text-wrap: nowrap;
   }
 
   &--alert {
@@ -178,7 +177,6 @@ $base-class: "button";
     font-size: $xx-small;
     padding: $pad-xsmall 10px;
     height: 24px;
-    white-space: nowrap;
 
     &:active {
       box-shadow: inset 2px 2px 2px rgba(0, 0, 0, 0.25);
@@ -205,7 +203,6 @@ $base-class: "button";
     font-weight: $bold;
     padding: 0 $pad-small;
     height: 28px;
-    white-space: nowrap;
 
     &:hover,
     &:focus {
@@ -232,6 +229,7 @@ $base-class: "button";
     display: inline-flex;
     align-items: center;
     gap: $pad-xsmall;
+    white-space: normal;
 
     &:focus {
       outline: none;
@@ -264,7 +262,6 @@ $base-class: "button";
     font-size: $x-small;
     font-weight: $bold;
     cursor: pointer;
-    white-space: nowrap;
 
     img {
       transform: scale(0.5);
@@ -340,7 +337,6 @@ $base-class: "button";
     font-size: $x-small;
     font-weight: $bold;
     cursor: pointer;
-    white-space: nowrap;
 
     &__small {
       @include button-pad-4px-8px;
@@ -465,6 +461,7 @@ $base-class: "button";
     height: auto;
     line-height: normal;
     font-weight: normal;
+    white-space: normal;
 
     &:active {
       box-shadow: none;
@@ -486,6 +483,7 @@ $base-class: "button";
     width: 100%;
     border-radius: 0px;
     border-bottom: 1px solid $ui-fleet-black-10;
+    white-space: normal;
 
     &:active {
       box-shadow: none;


### PR DESCRIPTION
## Issue
Closes #47026

## Description
- Bug fix (root cause): the `Button` component's `--inverse` variant was missing a `white-space: nowrap` rule, so the "Add custom variable" header button on Controls › Variables wrapped its label onto two lines at viewport widths ≤904px. Several other variants (`--default`, `--success`, `--pill`, `--grey-pill`, `--text-icon`, `--icon`, `--brand-inverse-icon`) had each been patched individually with the same nowrap rule over time — `--inverse` was just never added, and the same gap exists today for `--alert`, `--inverse-alert`, and `--oversized`.
- Global fix: moved `white-space: nowrap` onto the base `.button` selector so every chrome'd variant inherits the rule by default, removed the now-redundant per-variant declarations, and added explicit `white-space: normal` opt-outs on `--link`, `--unstyled`, and `--unstyled-modal-query` — the three text-like variants where multi-line wrapping is the intended behavior (e.g. `--unstyled-modal-query` is a multi-line block button with `flex-direction: column`).

## Screenrecording
- "Add custom variable" header button at ~900px viewport, before vs after


  

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button text wrapping behavior across several button styles for more consistent display.
  * Prevented some buttons from wrapping unexpectedly, while allowing link and unstyled variants to wrap naturally where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->