### PR TITLE
Cleanup an edge case sql error in migration cleanup

### DIFF
--- a/tools/migration-cleanup/main.go
+++ b/tools/migration-cleanup/main.go
@@ -529,13 +529,17 @@ func buildSQL(tableName string, stmts sqlStatements, renames []migrationRename) 
 
 	lines = append(lines, fmt.Sprintf("SELECT (SELECT MAX(id) FROM `%s` WHERE id > (SELECT id FROM `%s` WHERE version_id = %d)) - (SELECT id FROM `%s` WHERE version_id = %d) + 1 INTO @%s;", tableName, tableName, maxNewVID, tableName, minNewVID, varName))
 
+	targetIDVar := "target_id_" + tableName
 	var whereClause string
 	if movesUp {
 		whereClause = fmt.Sprintf("WHERE version_id BETWEEN %d AND %d", minNewVID, maxNewVID)
 		lines = append(lines, fmt.Sprintf("SELECT %d INTO @%s;", maxNewVID, maxMovedVar))
 	} else {
-		whereClause = fmt.Sprintf("WHERE id < (SELECT id FROM `%s` WHERE version_id = %d) AND version_id > %d", tableName, minNewVID, maxNewVID)
-		lines = append(lines, fmt.Sprintf("SELECT MAX(version_id) INTO @%s FROM `%s` %s ;", maxMovedVar, tableName, whereClause))
+		// Extract the target row's id into a variable first so we don't reference
+		// the same table in a subquery inside an UPDATE (MySQL doesn't allow that).
+		lines = append(lines, fmt.Sprintf("SELECT id INTO @%s FROM `%s` WHERE version_id = %d;", targetIDVar, tableName, minNewVID))
+		whereClause = fmt.Sprintf("WHERE id < @%s AND version_id > %d", targetIDVar, maxNewVID)
+		lines = append(lines, fmt.Sprintf("SELECT MAX(version_id) INTO @%s FROM `%s` %s;", maxMovedVar, tableName, whereClause))
 	}
 
 	lines = append(lines,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL generation for certain migration updates to avoid a self-referencing subquery issue.
  * Updated the generated query flow to select the target row first, then apply the update more reliably.
  * Aligned the version lookup query formatting with the revised condition handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->