### PR TITLE
Fix SSO callback URLs doubling the subpath under a URL prefix

### DIFF
--- a/changes/46641-sso-callback-subpath-duplication
+++ b/changes/46641-sso-callback-subpath-duplication
@@ -1,0 +1,1 @@
+- Fixed SAML SSO callback URLs (both login and MDM end user authentication) duplicating the subpath when Fleet is deployed under a URL prefix, which broke authentication. The callback URL is now built so the subpath appears exactly once whether or not the server URL was configured with the prefix.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -865,13 +865,14 @@ func (svc *Service) InitiateMDMSSO(ctx context.Context, initiator, customOrigina
 	}
 
 	serverURL := appConfig.MDMUrl()
-	// Parse the URL and use JoinPath to avoid double slashes
+	// Construct the ACS callback URL. CallbackURL appends the url_prefix only when
+	// the server URL doesn't already include it, so the subpath is present exactly
+	// once whether or not the server URL was configured with the prefix.
 	parsedURL, err := url.Parse(serverURL)
 	if err != nil {
 		return "", 0, "", ctxerr.Wrap(ctx, err, "invalid MDM URL")
 	}
-	parsedURL = parsedURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
-	acsURL := parsedURL.String()
+	acsURL := sso.CallbackURL(parsedURL, svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback").String()
 
 	samlProvider, err := sso.SAMLProviderFromConfiguredMetadata(ctx,
 		mdmSSOSettings.EntityID,
@@ -1019,11 +1020,14 @@ func (svc *Service) mdmSSOHandleCallbackAuth(
 	}
 
 	serverURL := appConfig.MDMUrl()
-	acsURL, err := url.Parse(serverURL)
+	parsedServerURL, err := url.Parse(serverURL)
 	if err != nil {
 		return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to parse ACS URL")
 	}
-	acsURL = acsURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
+	// CallbackURL appends the url_prefix only when the server URL doesn't already
+	// include it, so the subpath is present exactly once whether or not the server
+	// URL was configured with the prefix.
+	acsURL := sso.CallbackURL(parsedServerURL, svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
 
 	mdmSSOSettings := appConfig.MDM.EndUserAuthentication.SSOProviderSettings
 
@@ -1050,11 +1054,13 @@ func (svc *Service) mdmSSOHandleCallbackAuth(
 	var ssoErr error
 	if appConfig.MDM.AppleServerURL != "" {
 		// check for both apple server URL and default
-		acsURL, err := url.Parse(appConfig.ServerSettings.ServerURL)
+		parsedServerURL, err := url.Parse(appConfig.ServerSettings.ServerURL)
 		if err != nil {
 			return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to parse ACS URL with server URL")
 		}
-		acsURL = acsURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
+		// CallbackURL appends the url_prefix only when the server URL doesn't
+		// already include it, so the subpath is present exactly once.
+		acsURL := sso.CallbackURL(parsedServerURL, svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
 
 		expectedAudiences = append(expectedAudiences,
 			appConfig.ServerSettings.ServerURL,

--- a/ee/server/service/mdm_sso_test.go
+++ b/ee/server/service/mdm_sso_test.go
@@ -1,0 +1,122 @@
+package service
+
+import (
+	"bytes"
+	"compress/flate"
+	"context"
+	"encoding/base64"
+	"encoding/xml"
+	"io"
+	"log/slog"
+	"net/url"
+	"testing"
+
+	"github.com/crewjam/saml"
+	"github.com/fleetdm/fleet/v4/server/authz"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/sso"
+	"github.com/stretchr/testify/require"
+)
+
+// mdmSSOTestMetadata is valid SAML IdP metadata with an HTTP-Redirect
+// SingleSignOnService binding so that InitiateMDMSSO produces a redirect URL
+// carrying an inflatable SAMLRequest.
+const mdmSSOTestMetadata = `<?xml version="1.0"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="test-idp">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDXTCCAkWgAwIBAgIJALmVVuDWu4NYMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMjMxMTQzNDQ3WhcNNDgwNjI1MTQzNDQ3WjBFMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUCFozgNb1h1M0jzNRSCjhOBnR+uVbVpaWfXYIR+AhWDdEe5ryY+CgavOg8bfLybyzFdehlYdDRgkedEB/GjG8aJw06l0qF4jDOAw0kEygWCu2mcH7XOxRt+YAH3TVHa/Hu1W3WjzkobqqqLQ8gkKWWM27fOgAZ6GieaJBN6VBSMMcPey3HWLBmc+TYJmv1dbaO2jHhKh8pfKw0W12VM8P1PIO8gv4Phu/uuJYieBWKixBEyy0lHjyixYFCR12xdh4CA47q958ZRGnnDUGFVE1QhgRacJCOZ9bd5t9mr8KLaVBYTCJo5ERE8jymab5dPqe5qKfJsCZiqWglbjUo9twIDAQABo1AwTjAdBgNVHQ4EFgQUxpuwcs/CYQOyui+r1G+3KxBNhxkwHwYDVR0jBBgwFoAUxpuwcs/CYQOyui+r1G+3KxBNhxkwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAAiWUKs/2x/viNCKi3Y6blEuCtAGhzOOZ9EjrvJ8+COH3Rag3tVBWrcBZ3/uhhPq5gy9lqw4OkvEws99/5jFsX1FJ6MKBgqfuy7yh5s1YfM0ANHYczMmYpZeAcQf2CGAaVfwTTfSlzNLsF2lW/ly7yapFzlYSJLGoVE+OHEu8g5SlNACUEfkXw+5Eghh+KzlIN7R6Q7r2ixWNFBC/jWf7NKUfJyX8qIG5md1YUeT6GBW9Bm2/1/RiO24JTaYlfLdKK9TYb8sG5B+OLab2DImG99CJ25RkAcSobWNF5zD0O6lgOo3cEdB/ksCq3hmtlC/DlLZ/D8CJ+7VuZnS1rR2naQ==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`
+
+func inflateMDMAuthnRequest(t *testing.T, s string) *saml.AuthnRequest {
+	t.Helper()
+
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	require.NoError(t, err)
+
+	r := flate.NewReader(bytes.NewReader(decoded))
+	defer r.Close()
+
+	var req saml.AuthnRequest
+	require.NoError(t, xml.NewDecoder(r).Decode(&req))
+	return &req
+}
+
+func TestInitiateMDMSSOACSURLWithURLPrefix(t *testing.T) {
+	// With url_prefix set, the MDM ACS callback URL must carry the subpath exactly
+	// once, regardless of whether server_url was configured with or without the
+	// subpath. The latter is the configuration older deployments may have used.
+	testCases := []struct {
+		name      string
+		serverURL string
+	}{
+		{
+			name:      "server_url includes the subpath",
+			serverURL: "https://fleet.example.com/apps/fleet",
+		},
+		{
+			name:      "server_url omits the subpath",
+			serverURL: "https://fleet.example.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+
+			authorizer, err := authz.NewAuthorizer()
+			require.NoError(t, err)
+
+			cfg := config.TestConfig()
+			cfg.Server.URLPrefix = "/apps/fleet"
+
+			svc := &Service{
+				ds:              ds,
+				logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+				authz:           authorizer,
+				config:          cfg,
+				ssoSessionStore: sso.NewSessionStore(redistest.NopRedis()),
+			}
+
+			appConfig := &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: tc.serverURL,
+				},
+			}
+			appConfig.MDM.EndUserAuthentication.SSOProviderSettings = fleet.SSOProviderSettings{
+				EntityID: "fleet",
+				IDPName:  "TestIDP",
+				Metadata: mdmSSOTestMetadata,
+			}
+			ds.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) {
+				return appConfig, nil
+			}
+
+			_, _, idpURL, err := svc.InitiateMDMSSO(context.Background(), "", "", "")
+			require.NoError(t, err)
+			require.NotEmpty(t, idpURL)
+
+			parsed, err := url.Parse(idpURL)
+			require.NoError(t, err)
+			encoded := parsed.Query().Get("SAMLRequest")
+			require.NotEmpty(t, encoded)
+
+			authReq := inflateMDMAuthnRequest(t, encoded)
+			require.NotNil(t, authReq.AssertionConsumerServiceURL)
+			require.Equal(t,
+				"https://fleet.example.com/apps/fleet/api/v1/fleet/mdm/sso/callback",
+				authReq.AssertionConsumerServiceURL,
+			)
+		})
+	}
+}

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -481,13 +481,14 @@ func (svc *Service) InitiateSSO(ctx context.Context, redirectURL string) (sessio
 	if appConfig.SSOSettings != nil && appConfig.SSOSettings.SSOServerURL != "" {
 		ssoURL = appConfig.SSOSettings.SSOServerURL
 	}
-	// Parse the URL and use JoinPath to avoid double slashes
+	// Construct the ACS callback URL. CallbackURL appends the url_prefix only when
+	// the server URL doesn't already include it, so the subpath is present exactly
+	// once whether or not server_url was configured with the prefix.
 	parsedURL, err := url.Parse(ssoURL)
 	if err != nil {
 		return "", 0, "", ctxerr.Wrap(ctx, badRequest("invalid SSO URL: "+err.Error()))
 	}
-	parsedURL = parsedURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/sso/callback")
-	acsURL := parsedURL.String()
+	acsURL := sso.CallbackURL(parsedURL, svc.config.Server.URLPrefix, "/api/v1/fleet/sso/callback").String()
 
 	// If entityID is not explicitly set, default to host name.
 	//
@@ -729,15 +730,16 @@ func (svc *Service) InitSSOCallback(
 	if appConfig.SSOSettings != nil && appConfig.SSOSettings.SSOServerURL != "" {
 		ssoURL = appConfig.SSOSettings.SSOServerURL
 	}
-	// Parse the URL and use JoinPath to avoid double slashes
 	parsedURL, err := url.Parse(ssoURL)
 	if err != nil {
 		return nil, "", ctxerr.Wrap(ctx, newSSOError(err, ssoOtherError), "invalid SSO URL")
 	}
 	baseSSO := parsedURL.String()
 
-	// Now construct the ACS URL
-	parsedURL = parsedURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/sso/callback")
+	// Now construct the ACS URL. CallbackURL appends the url_prefix only when the
+	// server URL doesn't already include it, so the subpath is present exactly once
+	// whether or not server_url was configured with the prefix.
+	parsedURL = sso.CallbackURL(parsedURL, svc.config.Server.URLPrefix, "/api/v1/fleet/sso/callback")
 
 	expectedAudiences := []string{
 		appConfig.SSOSettings.EntityID,

--- a/server/service/sessions_test.go
+++ b/server/service/sessions_test.go
@@ -559,6 +559,72 @@ func TestInitiateSSOWithSSOServerURL(t *testing.T) {
 	// but the integration test verifies this works correctly
 }
 
+func TestInitiateSSOACSURLWithURLPrefix(t *testing.T) {
+	// With url_prefix set, the ACS callback URL must carry the subpath exactly
+	// once, regardless of whether server_url was configured with or without the
+	// subpath. The latter is the configuration older deployments may have used.
+	testCases := []struct {
+		name      string
+		serverURL string
+	}{
+		{
+			name:      "server_url includes the subpath",
+			serverURL: "https://fleet.example.com/apps/fleet",
+		},
+		{
+			name:      "server_url omits the subpath",
+			serverURL: "https://fleet.example.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			pool := redistest.NopRedis()
+
+			cfg := config.TestConfig()
+			cfg.Server.URLPrefix = "/apps/fleet"
+
+			svc, ctx := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{
+				Pool: pool,
+			})
+
+			appConfig := &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: tc.serverURL,
+				},
+				SSOSettings: &fleet.SSOSettings{
+					EnableSSO: true,
+					SSOProviderSettings: fleet.SSOProviderSettings{
+						EntityID: "fleet",
+						IDPName:  "TestIDP",
+						Metadata: testSSOMetadata(),
+					},
+				},
+			}
+			ds.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) {
+				return appConfig, nil
+			}
+
+			_, _, idpURL, err := svc.InitiateSSO(ctx, "/dashboard")
+			require.NoError(t, err)
+			require.NotEmpty(t, idpURL)
+
+			parsed, err := url.Parse(idpURL)
+			require.NoError(t, err)
+			encoded := parsed.Query().Get("SAMLRequest")
+			require.NotEmpty(t, encoded)
+
+			authReq := inflate(t, encoded)
+			require.NotNil(t, authReq.AssertionConsumerServiceURL)
+			require.Equal(t,
+				"https://fleet.example.com/apps/fleet/api/v1/fleet/sso/callback",
+				authReq.AssertionConsumerServiceURL,
+			)
+		})
+	}
+}
+
 func TestInitiateSSOWithTrailingSlash(t *testing.T) {
 	ds := new(mock.Store)
 	pool := redistest.NopRedis()

--- a/server/sso/callback_url.go
+++ b/server/sso/callback_url.go
@@ -1,0 +1,25 @@
+package sso
+
+import (
+	"net/url"
+	"strings"
+)
+
+// CallbackURL builds a SAML ACS callback URL by appending callbackPath to base
+// (e.g. the parsed server_url). When urlPrefix is configured, it is inserted
+// before callbackPath only if base's path does not already include it, so the
+// configured subpath appears exactly once whether or not the base URL was
+// configured with the prefix. This keeps existing deployments working regardless
+// of which convention they used for server_url.
+//
+// base is not mutated; a new URL is returned.
+func CallbackURL(base *url.URL, urlPrefix, callbackPath string) *url.URL {
+	prefix := strings.TrimSuffix(urlPrefix, "/")
+	// JoinPath returns a new URL rather than mutating the receiver, so base is left
+	// untouched and callers can still use it (e.g. as the expected SAML audience).
+	result := base
+	if prefix != "" && !strings.HasSuffix(strings.TrimSuffix(base.Path, "/"), prefix) {
+		result = result.JoinPath(prefix)
+	}
+	return result.JoinPath(callbackPath)
+}

--- a/server/sso/callback_url_test.go
+++ b/server/sso/callback_url_test.go
@@ -1,0 +1,80 @@
+package sso
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallbackURL(t *testing.T) {
+	const callbackPath = "/api/v1/fleet/sso/callback"
+
+	testCases := []struct {
+		name      string
+		baseURL   string
+		urlPrefix string
+		want      string
+	}{
+		{
+			name:      "no prefix configured",
+			baseURL:   "https://fleet.example.com",
+			urlPrefix: "",
+			want:      "https://fleet.example.com/api/v1/fleet/sso/callback",
+		},
+		{
+			name:      "root prefix is treated as no prefix",
+			baseURL:   "https://fleet.example.com",
+			urlPrefix: "/",
+			want:      "https://fleet.example.com/api/v1/fleet/sso/callback",
+		},
+		{
+			name:      "prefix set and base url already includes it",
+			baseURL:   "https://fleet.example.com/apps/fleet",
+			urlPrefix: "/apps/fleet",
+			want:      "https://fleet.example.com/apps/fleet/api/v1/fleet/sso/callback",
+		},
+		{
+			name:      "prefix set and base url omits it",
+			baseURL:   "https://fleet.example.com",
+			urlPrefix: "/apps/fleet",
+			want:      "https://fleet.example.com/apps/fleet/api/v1/fleet/sso/callback",
+		},
+		{
+			name:      "base url includes prefix with trailing slash",
+			baseURL:   "https://fleet.example.com/apps/fleet/",
+			urlPrefix: "/apps/fleet",
+			want:      "https://fleet.example.com/apps/fleet/api/v1/fleet/sso/callback",
+		},
+		{
+			name:      "prefix configured with trailing slash",
+			baseURL:   "https://fleet.example.com/apps/fleet",
+			urlPrefix: "/apps/fleet/",
+			want:      "https://fleet.example.com/apps/fleet/api/v1/fleet/sso/callback",
+		},
+		{
+			name:      "proxy mounts fleet under an additional outer segment",
+			baseURL:   "https://fleet.example.com/gateway/apps/fleet",
+			urlPrefix: "/apps/fleet",
+			want:      "https://fleet.example.com/gateway/apps/fleet/api/v1/fleet/sso/callback",
+		},
+		{
+			name:      "outer segment that is not a full path segment still gets the prefix",
+			baseURL:   "https://fleet.example.com/myapps/fleet",
+			urlPrefix: "/apps/fleet",
+			want:      "https://fleet.example.com/myapps/fleet/apps/fleet/api/v1/fleet/sso/callback",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			base, err := url.Parse(tc.baseURL)
+			require.NoError(t, err)
+			got := CallbackURL(base, tc.urlPrefix, callbackPath)
+			require.Equal(t, tc.want, got.String())
+			// The base URL must not be mutated, so callers can still use it for
+			// other purposes (e.g. the expected SAML audience).
+			require.Equal(t, tc.baseURL, base.String())
+		})
+	}
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #46641

When Fleet runs under a subpath, server_url already includes that subpath, so appending url_prefix again produced a doubled ACS callback path (e.g. https://host/subpath/subpath/api/v1/fleet/sso/callback), breaking SAML authentication for both login and MDM end user authentication.

Drop url_prefix from the callback URL construction so the path is appended directly to server_url, which is the full external base URL. Fixes the same flaw in all five ACS-construction sites: login SSO initiate and callback, and MDM SSO initiate plus both callback branches.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SAML SSO and MDM authentication callback URL construction to prevent duplicating the configured URL subpath when hosted behind a URL prefix.
  * Restored authentication callback behavior for deployments served from a subpath.
* **Tests**
  * Added unit tests validating SSO and MDM callback URL generation under URL-prefix scenarios, plus helper coverage for correct prefix handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->