### PR TITLE
Fleet UI: Contain page-area overflow on narrow viewports

### DIFF
--- a/frontend/components/MainContent/_styles.scss
+++ b/frontend/components/MainContent/_styles.scss
@@ -3,6 +3,10 @@
   margin: 0 auto;
   padding: $pad-page;
   flex-grow: 1;
+  // min-width: 0 lets this flex item shrink below its content's intrinsic
+  // min size so wide descendants stay inside main-content's own overflow
+  // instead of pushing the document past the viewport — see #47029.
+  min-width: 0;
   // overflow: auto allows for horizontal scrolling
   // of the main-content when there is a banner. (e.g. sandbox mode)
   // Without it the main content pushes the banner off the page.


### PR DESCRIPTION
## Issue
Closes #47029

## Description
- Bug fix (root cause): `.main-content` is a flex item of `.core-wrapper` (`display: flex`). With no explicit `min-width`, it defaulted to `min-width: auto`, which resolves to the content's intrinsic min-content size. When a descendant had a high intrinsic min-width (e.g. the IdP empty state's 3-column ghost table at narrow viewports), main-content inflated to fit it and pushed the document past the viewport — so its existing `overflow: auto` (added for the banner case) never got a chance to fire. The Variables/Cert Authorities pages didn't show the bug because their empty states use the single-column `header-list` variant, whose lone `flex: 1 1 100%` column shrinks cleanly.
- Global fix: added `min-width: 0` to `.main-content`. Every page wrapped by `MainContent` (i.e. all of them) is now allowed to shrink with the viewport, and any descendant wider than the page area scrolls inside main-content's existing `overflow: auto` instead of pushing the document. Prevents this whole class of "narrow-viewport horizontal overflow" bug for any future component too, not just the IdP empty state.

## Screenrecording
- IdP empty state at ~768px viewport, before vs after


  

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page layout so wide content no longer causes the main area to overflow the viewport.
  * The content area now shrinks more reliably within flexible layouts, helping keep horizontal scrolling under control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->