### PR TITLE
Fleet UI: Add software progress bar stops jittering as percentage digits change

### DIFF
--- a/frontend/components/FileDetails/_styles.scss
+++ b/frontend/components/FileDetails/_styles.scss
@@ -43,10 +43,11 @@
 
   &__progress-wrapper {
     display: flex;
-    width: 184px; // using fixed width to prevent jitter when text changes: 144px + $pad-medium + 24px for text
+    width: 184px; // 144px bar + $pad-medium gap + 32px text
+    flex-shrink: 0; // don't let the sibling __info collapse this wrapper to its min-content (#47539)
     justify-content: space-between;
     align-items: center;
-    gap: $pad-small; // shouldn't be necessary, but just in case
+    gap: $pad-small;
   }
 
   &__progress-bar {
@@ -64,6 +65,9 @@
   }
 
   &__progress-text {
+    width: 32px; // fixed width so "1%" → "100%" doesn't shift the bar (#47539)
+    flex-shrink: 0;
+    text-align: right;
     font-size: $x-small;
     color: $ui-fleet-black-50;
   }

--- a/frontend/components/FileDetails/_styles.scss
+++ b/frontend/components/FileDetails/_styles.scss
@@ -43,7 +43,7 @@
 
   &__progress-wrapper {
     display: flex;
-    width: 184px; // 144px bar + $pad-medium gap + 32px text
+    width: 184px; // 144px bar + $pad-small gap + 32px text
     flex-shrink: 0; // don't let the sibling __info collapse this wrapper to its min-content (#47539)
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
## Issue
Closes #47539

## Description
- Bug fix (root cause): `.file-details__progress-wrapper` had `width: 184px`, but its sibling `.file-details__info` has `width: 100%`, so flexbox shrunk the wrapper down to its min-content. As the percentage text grew from "1%" to "100%", the wrapper width oscillated 169–183px, shifting the bar's left edge by ~9px during an upload.
- Fix: added `flex-shrink: 0` to the progress wrapper so it stays at 184px regardless of its sibling's demand for space.
- UX: also fixed the percentage text to `width: 32px; text-align: right` so the `%` glyph stays anchored and digits grow leftward — matches numeric-counter UX and prevents micro-jitter inside the wrapper.

## Screenrecording
- Add software → custom package upload of a large file, percentage climbs 1% → 100%, bar's left edge stays put.



https://github.com/user-attachments/assets/e5e23e5d-745c-477a-b7b9-26af28ec1ebb


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the file details progress display to keep the progress bar and percentage text stable during updates.
  * Reduced layout shifting by preventing the progress wrapper and percentage text from shrinking and preserving consistent right-aligned alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->