### PR TITLE
Handbook: shift product group rollout for mid-cycle 4.88.0 release

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -292,14 +292,15 @@ At the end of every three-week release cycle, the working group holds a 30-minut
 
 ### Working group rollout
 
-The transition to working groups happens over the next three release cycles, following a buffer cycle in 4.87.0 to give everyone time to absorb the handbook change before any team changes:
+The transition to working groups happens over the following release cycles, following a buffer cycle in 4.87.0 to give everyone time to absorb the handbook change before any team changes:
 
 | Release | Change |
 |:---|:---|
 | 4.87.0 | Handbook change published. No team changes this cycle (buffer/ramp-up). |
-| 4.88.0 | First Impressions pauses. Scott Gress joins Konstantin Sykulev on Power to the PC. |
-| 4.89.0 | Konstantin spins out to lead BYOD with Andrew Mellor. MDM becomes Apple @ Work. Software becomes Auto Patching. |
-| 4.90.0 | Orchestration product group becomes Digital Employee Experience (DEX). Security & Compliance product group becomes Supply Chain. Both become working groups. |
+| 4.89.0 | First Impressions pauses. Power to the PC continues with Konstantin Sykulev and Victor Lyuboslavsky, and continues to own Android. |
+| 4.90.0 | MDM becomes Apple @ Work. Software becomes Auto Patching. |
+| 4.91.0 | Orchestration product group becomes Digital Employee Experience (DEX). Security & Compliance product group becomes Supply Chain. Both become working groups. |
+| TBD | BYOD group spins out from Power to the PC to lead Android device management. |
 
 > When an engineer moves into a new area of the code, allocate one release cycle for ramp-up. Reduced output during that cycle is expected and planned for.
 
@@ -319,7 +320,7 @@ The goal of the website group is to increase and exceed Fleet's product maturity
 
 
 <!--
-Paused as of the 4.88.0 release cycle.
+Paused as of the 4.89.0 release cycle.
 
 ### First Impressions group
 
@@ -330,7 +331,7 @@ The goal of the First Impressions working group is to make changes to the core F
 | Product Designer                  | [Noah Talerman](https://www.linkedin.com/in/noah-talerman/) _([@noahtalerman](https://github.com/noahtalerman))_, [Mike McNeil](https://www.linkedin.com/in/mikermcneil/) _([@mikermcneil](https://github.com/mikermcneil))_
 | Engineering Manager               | [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
 | Quality Assurance                 | [Andrey Kizimenko](https://www.linkedin.com/in/andrey-kizimenko-988900214/) _([@AndreyKizimenko](https://github.com/AndreyKizimenko))_
-| Software Engineer                 | [Scott Gress](https://www.linkedin.com/in/scottgress/) _([@sgress454](https://github.com/sgress454))_, [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
+| Software Engineer                 | [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
 
 > The [Slack channel](https://fleetdm.slack.com/archives/C0ACJ8L1FD0), [kanban board](https://github.com/orgs/fleetdm/projects/105/), and [GitHub label](https://github.com/fleetdm/fleet/labels?q=%23g-first-impressions) for this working group is `#g-first-impressions`.
 -->
@@ -339,7 +340,7 @@ The goal of the First Impressions working group is to make changes to the core F
 
 ### Power to the PC group
 
-The goal of the Power to the PC working group is to empower Windows users to fully leverage Fleet as an MDM.
+The goal of the Power to the PC working group is to empower Windows users to fully leverage Fleet as an MDM. This group also owns Android device management for the time being, until the BYOD group spins out.
 
 | Responsibility                    | Human(s)                  |
 |:----------------------------------|:--------------------------|
@@ -353,7 +354,7 @@ The goal of the Power to the PC working group is to empower Windows users to ful
 
 
 <!--
-Planned for the 4.89.0 release cycle. See the working group rollout above.
+Planned for the 4.90.0 release cycle. See the working group rollout above.
 
 ### Apple @ Work group
 
@@ -365,7 +366,7 @@ The goal of the Apple @ Work working group is to increase the number of Apple de
 | Engineering Manager               | [George Karr](https://www.linkedin.com/in/george-karr-4977b441/) _([@georgekarrv](https://github.com/georgekarrv))_
 | Tech Lead                         | [Jordan Montgomery](https://www.linkedin.com/in/jordan-montgomery-54553651/) _([@JordanMontgomery](https://github.com/JordanMontgomery))_
 | Quality Assurance                 | [Christopher Noel](https://www.linkedin.com/in/chrstphr/) _([@chrstphr84](https://github.com/chrstphr84))_
-| Software Engineer                 | [Magnus Jensen](https://linkedin.com/in/magnus-holm-jensen) _([@MagnusHJensen](https://github.com/magnushjensen))_
+| Software Engineer                 | [Magnus Jensen](https://linkedin.com/in/magnus-holm-jensen) _([@MagnusHJensen](https://github.com/magnushjensen))_, Andrew Mellor _([@andymFleet](https://github.com/andymFleet))_
 
 **Areas of expertise**:
 - Apple MDM protocol & configuration
@@ -399,7 +400,11 @@ The goal of the Auto Patching working group is to reduce the amount of time befo
 - Scripts
 
 > The [Slack channel](https://fleetdm.slack.com/archives/C086V2QK76X), [kanban board](https://github.com/orgs/fleetdm/projects/70), and [GitHub label](https://github.com/fleetdm/fleet/labels?q=%23g-software) for this working group is `#g-software`.
+-->
 
+
+<!--
+Spin-out date TBD. The BYOD group will spin out from Power to the PC, which owns Android device management in the meantime. See the working group rollout above.
 
 ### BYOD group
 
@@ -418,7 +423,7 @@ The goal of the BYOD working group is to enable Fleet to manage personally-owned
 
 
 <!--
-Planned for the 4.90.0 release cycle. See the working group rollout above. Inherits from the Orchestration product group.
+Planned for the 4.91.0 release cycle. See the working group rollout above. Inherits from the Orchestration product group.
 
 ### Digital Employee Experience (DEX) group
 
@@ -524,7 +529,7 @@ When a new feature is introduced it may be labeled as experimental. Experimental
 2. Set the optional `isExperimental` property to "yes" in [pricing-features-table.yml](https://github.com/fleetdm/fleet/blob/main/handbook/company/pricing-features-table.yml).
 3. Make sure all API endpoints and configuration surface documentation contains the following message (including the anticipated version it will be marked stable):
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows. This feature's experimental status will be reevaluated in Fleet 4.89.0.
+> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows. This feature's experimental status will be reevaluated in Fleet 4.90.0.
 
 
 ### Breaking changes


### PR DESCRIPTION
**Related issue:** NA

Handbook-only change to `handbook/company/product-groups.md` reflecting the mid-release-cycle 4.88.0 minor release and team changes.

- **Version shift:** A mid-cycle 4.88.0 release was issued, so every rollout target of 4.88.0 or later is incremented by one (4.89.0, 4.90.0, 4.91.0). This includes the experimental-feature reevaluation reference in the "Experimental features" section.
- **First Impressions paused:** Scott Gress has left the company; removed him from the (paused) roster and reworded the rollout row.
- **BYOD spin-out delayed (date TBD):** Konstantin Sykulev and Victor Lyuboslavsky stay on Power to the PC, which continues to own Android in the meantime. BYOD moved to its own commented block with a TBD date.
- **Apple @ Work / Auto Patching:** unchanged transitions, now targeted at 4.90.0. Andrew Mellor stays on MDM/Apple @ Work for now.

# Checklist for submitter

- [x] Changes are documentation/handbook only; no code, tests, migrations, config, or fleetd impact.
