### PR TITLE
Add onTargetEarnings field to open APAC CSE position

### DIFF
--- a/handbook/company/open-positions.yml
+++ b/handbook/company/open-positions.yml
@@ -235,6 +235,7 @@
   hiringManagerName: Zay Hanlon
   hiringManagerGithubUsername: zayhanlon
   hiringManagerLinkedInUrl: https://www.linkedin.com/in/zayhanlon/
+  onTargetEarnings: "$30,000 - $80,000"
   responsibilities: |
     - 🏋🏻 Train under our customer support and engineering team to learn the ins and outs of Fleet, frequently asked customer questions, develop an understanding of our troubleshooting guide, and learn how to search through documentation and Fleet repo.
     - 🚀 Deploy Fleet on your own to better understand the customer experience and how the product works.


### PR DESCRIPTION
The APAC CSE role didn’t include an `onTargetEarnings` property, so it was displaying on our website as $48k-$480k.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit on-target earnings range to the Customer Support Engineer (APAC) job posting, making compensation details clearer for candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->