### PR TITLE
Show individual settings sections in user menu

### DIFF
--- a/changes/37972-improve-settings-subnav
+++ b/changes/37972-improve-settings-subnav
@@ -1,1 +1,2 @@
 - Improved the user menu to show individual settings sections for admins.
+- Fixed sorting of fleets on certain pages with non-global admins.

--- a/changes/37972-improve-settings-subnav
+++ b/changes/37972-improve-settings-subnav
@@ -1,0 +1,1 @@
+- Improved the user menu to show individual settings sections for admins.

--- a/changes/37972-improve-settings-subnav
+++ b/changes/37972-improve-settings-subnav
@@ -1,2 +1,1 @@
 - Improved the user menu to show individual settings sections for admins.
-- Fixed sorting of fleets on certain pages with non-global admins.

--- a/changes/37972-improve-settings-subnav
+++ b/changes/37972-improve-settings-subnav
@@ -1,1 +1,2 @@
 - Improved the user menu to show individual settings sections for admins.
+- Fixed sorting of fleets for fleet-level users.

--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tests.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tests.tsx
@@ -17,7 +17,7 @@ const urlLocation = {
 };
 
 describe("SiteTopNav - component", () => {
-  it("renders correct navigation for free global admin", async () => {
+  it("renders correct navigation for free global admin", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -27,7 +27,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser()}
@@ -37,31 +37,14 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/controls/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /settings/i })
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole("menuitem", { name: /users/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
   });
-  it("renders correct navigation for free global maintainer", async () => {
+
+  it("renders correct navigation for free global maintainer", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -71,7 +54,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser({
@@ -84,27 +67,14 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/controls/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
-
-    expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
-  it("renders correct navigation for free global observer", async () => {
+
+  it("renders correct navigation for free global observer", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -113,7 +83,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser({
@@ -126,27 +96,15 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
 
     expect(screen.queryByText(/controls/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
-  it("renders correct navigation for premium global admin", async () => {
+
+  it("renders correct navigation for premium global admin", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -156,7 +114,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser()}
@@ -166,30 +124,14 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/controls/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /settings/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /users/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
   });
-  it("renders correct navigation for premium global maintainer", async () => {
+
+  it("renders correct navigation for premium global maintainer", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -199,7 +141,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser({
@@ -212,27 +154,14 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/controls/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
-
-    expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
-  it("renders correct navigation for premium global observer", async () => {
+
+  it("renders correct navigation for premium global observer", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -241,7 +170,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser({
@@ -254,27 +183,15 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
 
     expect(screen.queryByText(/controls/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
-  it("renders correct navigation for premium team admin", async () => {
+
+  it("renders correct navigation for premium team admin", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -284,7 +201,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser({
@@ -297,29 +214,14 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/controls/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /settings/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
-
-    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
-  it("renders correct navigation for premium team maintainer", async () => {
+
+  it("renders correct navigation for premium team maintainer", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -329,7 +231,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser({
@@ -342,27 +244,14 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/controls/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
-
-    expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
-  it("renders correct navigation for premium team observer", async () => {
+
+  it("renders correct navigation for premium team observer", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -371,7 +260,7 @@ describe("SiteTopNav - component", () => {
       },
     });
 
-    const { user } = render(
+    render(
       <SiteTopNav
         config={createMockConfig()}
         currentUser={createMockUser({
@@ -384,25 +273,11 @@ describe("SiteTopNav - component", () => {
       />
     );
 
-    await user.click(screen.getByTestId("user-avatar"));
-
     expect(screen.getByText(/hosts/i)).toBeInTheDocument();
     expect(screen.getByText(/software/i)).toBeInTheDocument();
     expect(screen.getByText(/reports/i)).toBeInTheDocument();
     expect(screen.getByText(/policies/i)).toBeInTheDocument();
 
-    expect(
-      screen.getByRole("menuitem", { name: /my account/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /documentation/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /sign out/i })
-    ).toBeInTheDocument();
-
     expect(screen.queryByText(/controls/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/top_nav/UserMenu/UserMenu.tests.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tests.tsx
@@ -1,0 +1,222 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+
+import { noop } from "lodash";
+
+import createMockUser from "__mocks__/userMock";
+import createMockTeam, { createMockTeamSummary } from "__mocks__/teamMock";
+
+import UserMenu from ".";
+
+describe("UserMenu - component", () => {
+  it("renders correct menu items for a global admin on the free tier", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: false,
+          isSandboxMode: false,
+        },
+      },
+    });
+
+    const { user } = render(
+      <UserMenu
+        onLogout={noop}
+        onUserMenuItemClick={noop}
+        isGlobalAdmin
+        isAnyTeamAdmin={false}
+        currentUser={createMockUser()}
+        currentTeam={undefined}
+      />
+    );
+
+    await user.click(screen.getByTestId("user-avatar"));
+
+    expect(
+      screen.getByRole("menuitem", { name: /labels/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /organization settings/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /integrations/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /users/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /my account/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /documentation/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /sign out/i })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("menuitem", { name: /fleets/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders correct menu items for a global admin on the premium tier", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isSandboxMode: false,
+        },
+      },
+    });
+
+    const { user } = render(
+      <UserMenu
+        onLogout={noop}
+        onUserMenuItemClick={noop}
+        isGlobalAdmin
+        isAnyTeamAdmin={false}
+        currentUser={createMockUser()}
+        currentTeam={undefined}
+      />
+    );
+
+    await user.click(screen.getByTestId("user-avatar"));
+
+    expect(
+      screen.getByRole("menuitem", { name: /labels/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /organization settings/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /integrations/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /users/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /fleets/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /my account/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /documentation/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /sign out/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders correct menu items for a fleet-level admin", async () => {
+    const mockTeam = createMockTeam({ role: "admin" });
+
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isSandboxMode: false,
+        },
+      },
+    });
+
+    const { user } = render(
+      <UserMenu
+        onLogout={noop}
+        onUserMenuItemClick={noop}
+        isGlobalAdmin={false}
+        isAnyTeamAdmin
+        currentUser={createMockUser({ global_role: null, teams: [mockTeam] })}
+        currentTeam={createMockTeamSummary({ id: mockTeam.id })}
+      />
+    );
+
+    await user.click(screen.getByTestId("user-avatar"));
+
+    expect(
+      screen.getByRole("menuitem", { name: /labels/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /users/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /agent options/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /settings/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /my account/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /documentation/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /sign out/i })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("menuitem", { name: /organization settings/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /integrations/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /fleets/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders correct menu items for a non-admin", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isSandboxMode: false,
+        },
+      },
+    });
+
+    const { user } = render(
+      <UserMenu
+        onLogout={noop}
+        onUserMenuItemClick={noop}
+        isGlobalAdmin={false}
+        isAnyTeamAdmin={false}
+        currentUser={createMockUser({ global_role: "observer" })}
+        currentTeam={undefined}
+      />
+    );
+
+    await user.click(screen.getByTestId("user-avatar"));
+
+    expect(
+      screen.getByRole("menuitem", { name: /labels/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /my account/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /documentation/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /sign out/i })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("menuitem", { name: /organization settings/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /integrations/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /users/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /agent options/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /fleets/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/top_nav/UserMenu/UserMenu.tests.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tests.tsx
@@ -167,6 +167,53 @@ describe("UserMenu - component", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders correct menu items for a global admin in sandbox mode", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isSandboxMode: true,
+        },
+      },
+    });
+
+    const { user } = render(
+      <UserMenu
+        onLogout={noop}
+        onUserMenuItemClick={noop}
+        isGlobalAdmin
+        isAnyTeamAdmin={false}
+        currentUser={createMockUser()}
+        currentTeam={undefined}
+      />
+    );
+
+    await user.click(screen.getByTestId("user-avatar"));
+
+    expect(
+      screen.getByRole("menuitem", { name: /labels/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /integrations/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /my account/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /documentation/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /sign out/i })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("menuitem", { name: /organization settings/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /users/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("renders correct menu items for a non-admin", async () => {
     const render = createCustomRenderer({
       context: {

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -11,9 +11,8 @@ import { IUser } from "interfaces/user";
 import { ITeam, ITeamSummary } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import PATHS from "router/paths";
-
+import { getSortedTeamOptions } from "utilities/helpers";
 import { AppContext } from "context/app";
-import { preferredOrLowestIdFleet } from "hooks/useTeamIdParam";
 
 import { PADDING } from "styles/var/padding";
 import { COLORS } from "styles/var/colors";
@@ -178,7 +177,7 @@ const UserMenu = ({
     // to the first team the user is an admin of.
     const targetTeamId = currentTeamIsAdmin
       ? currentTeam.id
-      : preferredOrLowestIdFleet(userAdminTeams)?.id;
+      : getSortedTeamOptions(userAdminTeams)[0].value;
 
     dropdownItems.push({
       label: "Users",

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Select, {
   components,
   DropdownIndicatorProps,
@@ -12,6 +12,7 @@ import { ITeam, ITeamSummary } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import PATHS from "router/paths";
 import { getSortedTeamOptions } from "utilities/helpers";
+import { AppContext } from "context/app";
 
 import { PADDING } from "styles/var/padding";
 import { COLORS } from "styles/var/colors";
@@ -61,20 +62,29 @@ const CustomOption: React.FC<
   const { innerRef, data, isFocused, isKeyboardFocus } = props;
 
   return (
-    <components.Option
-      {...props}
-      isFocused={isKeyboardFocus ? isFocused : false} // work around to not preselect first option unless keyboarding
-    >
-      <div
-        className={`${baseClass}__option`}
-        ref={innerRef}
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-        tabIndex={0}
-        role="menuitem"
+    <>
+      {data.hasDividerBefore && (
+        <div
+          className={`${baseClass}__divider`}
+          aria-hidden="true"
+          role="presentation"
+        />
+      )}
+      <components.Option
+        {...props}
+        isFocused={isKeyboardFocus ? isFocused : false} // work around to not preselect first option unless keyboarding
       >
-        {data.label}
-      </div>
-    </components.Option>
+        <div
+          className={`${baseClass}__option`}
+          ref={innerRef}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex={0}
+          role="menuitem"
+        >
+          {data.label}
+        </div>
+      </components.Option>
+    </>
   );
 };
 
@@ -86,6 +96,8 @@ const UserMenu = ({
   currentUser,
   currentTeam,
 }: IUserMenuProps): JSX.Element => {
+  const { isPremiumTier, isSandboxMode } = useContext(AppContext);
+
   // Work around for react-select-5 not having :focus-visible pseudo class that can style dropdown on keyboard tab only
   // Work around preventing react-select-5 from auto focusing first option unless using keyboard
   const [isKeyboardFocus, setIsKeyboardFocus] = useState(false);
@@ -110,70 +122,95 @@ const UserMenu = ({
     };
   }, []);
 
-  const dropdownItems = [
+  const dropdownItems: IDropdownOption[] = [
     {
-      label: "My account",
-      value: "my-account",
-      onClick: () => onUserMenuItemClick(PATHS.ACCOUNT),
-    },
-    {
-      label: "Documentation",
-      value: "documentation",
-      onClick: () => {
-        window.open("https://fleetdm.com/docs", "_blank");
-      },
-    },
-    {
-      label: "Sign out",
-      value: "sign-out",
-      onClick: onLogout,
+      label: "Labels",
+      value: "labels",
+      onClick: () => onUserMenuItemClick(PATHS.MANAGE_LABELS),
     },
   ];
 
   if (isGlobalAdmin) {
-    const manageUserNavItem = {
-      label: "Users",
-      value: "manage-users",
-      onClick: () => onUserMenuItemClick(PATHS.ADMIN_USERS),
-    };
-    dropdownItems.unshift(manageUserNavItem);
-  }
-
-  const manageLabelsMenuItem = {
-    label: "Labels",
-    value: "labels",
-    onClick: () => onUserMenuItemClick(PATHS.MANAGE_LABELS),
-  };
-  dropdownItems.unshift(manageLabelsMenuItem);
-
-  if (currentUser && (isAnyTeamAdmin || isGlobalAdmin)) {
-    let clickHandler = () => onUserMenuItemClick(PATHS.ADMIN_ORGANIZATION);
-    if (currentUser.global_role !== "admin") {
-      const userAdminTeams = currentUser.teams.filter(
-        (thisTeam: ITeam) => thisTeam.role === "admin"
-      );
-      clickHandler = () => {
-        const currentTeamIsAdmin =
-          currentTeam && userAdminTeams.some((t) => t.id === currentTeam.id);
-        if (currentTeamIsAdmin) {
-          onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(currentTeam.id));
-        } else {
-          // Not an admin of the current team — redirect to the first team the
-          // user is an admin of.
-          const targetTeam = getSortedTeamOptions(userAdminTeams)[0];
-          onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeam.value));
-        }
-      };
+    if (!isSandboxMode) {
+      dropdownItems.push({
+        label: "Organization settings",
+        value: "organization-settings",
+        hasDividerBefore: true,
+        onClick: () => onUserMenuItemClick(PATHS.ADMIN_ORGANIZATION),
+      });
+    } else {
+      dropdownItems.push({
+        label: "Integrations",
+        value: "integrations",
+        hasDividerBefore: true,
+        onClick: () => onUserMenuItemClick(PATHS.ADMIN_INTEGRATIONS),
+      });
     }
 
-    const adminMenuItem = {
-      label: "Settings",
-      value: "settings",
-      onClick: clickHandler,
+    if (!isSandboxMode) {
+      dropdownItems.push({
+        label: "Integrations",
+        value: "integrations",
+        onClick: () => onUserMenuItemClick(PATHS.ADMIN_INTEGRATIONS),
+      });
+      dropdownItems.push({
+        label: "Users",
+        value: "users",
+        onClick: () => onUserMenuItemClick(PATHS.ADMIN_USERS),
+      });
+    }
+
+    if (isPremiumTier) {
+      dropdownItems.push({
+        label: "Fleets",
+        value: "fleets",
+        onClick: () => onUserMenuItemClick(PATHS.ADMIN_FLEETS),
+      });
+    }
+  } else if (currentUser && isAnyTeamAdmin) {
+    const userAdminTeams = currentUser.teams.filter(
+      (thisTeam: ITeam) => thisTeam.role === "admin"
+    );
+    const settingsClickHandler = () => {
+      const currentTeamIsAdmin =
+        currentTeam && userAdminTeams.some((t) => t.id === currentTeam.id);
+      if (currentTeamIsAdmin) {
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(currentTeam.id));
+      } else {
+        // Not an admin of the current team — redirect to the first team the
+        // user is an admin of.
+        const targetTeam = getSortedTeamOptions(userAdminTeams)[0];
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeam.value));
+      }
     };
 
-    dropdownItems.unshift(adminMenuItem);
+    dropdownItems.push({
+      label: "Settings",
+      value: "settings",
+      hasDividerBefore: true,
+      onClick: settingsClickHandler,
+    });
   }
+
+  dropdownItems.push({
+    label: "My account",
+    value: "my-account",
+    hasDividerBefore: true,
+    onClick: () => onUserMenuItemClick(PATHS.ACCOUNT),
+  });
+  dropdownItems.push({
+    label: "Documentation",
+    value: "documentation",
+    onClick: () => {
+      window.open("https://fleetdm.com/docs", "_blank");
+    },
+  });
+  dropdownItems.push({
+    label: "Sign out",
+    value: "sign-out",
+    hasDividerBefore: true,
+    onClick: onLogout,
+  });
 
   const customStyles: StylesConfig<IDropdownOption, false> = {
     control: (provided, state) => ({
@@ -243,9 +280,6 @@ const UserMenu = ({
       whiteSpace: "nowrap",
       "&:hover": {
         backgroundColor: COLORS["ui-fleet-black-5"],
-      },
-      "&:last-child, &:nth-last-of-type(2)": {
-        borderTop: `1px solid ${COLORS["ui-fleet-black-10"]}`,
       },
     }),
   };

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -11,8 +11,9 @@ import { IUser } from "interfaces/user";
 import { ITeam, ITeamSummary } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import PATHS from "router/paths";
-import { getSortedTeamOptions } from "utilities/helpers";
+
 import { AppContext } from "context/app";
+import { preferredOrLowestIdFleet } from "hooks/useTeamIdParam";
 
 import { PADDING } from "styles/var/padding";
 import { COLORS } from "styles/var/colors";
@@ -177,7 +178,7 @@ const UserMenu = ({
     // to the first team the user is an admin of.
     const targetTeamId = currentTeamIsAdmin
       ? currentTeam.id
-      : getSortedTeamOptions(userAdminTeams)[0].value;
+      : preferredOrLowestIdFleet(userAdminTeams)?.id;
 
     dropdownItems.push({
       label: "Users",

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -8,10 +8,10 @@ import Select, {
 } from "react-select-5";
 
 import { IUser } from "interfaces/user";
-import { ITeam, ITeamSummary } from "interfaces/team";
+import { ITeamSummary } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import PATHS from "router/paths";
-import { getSortedTeamOptions } from "utilities/helpers";
+import permissions from "utilities/permissions";
 import { AppContext } from "context/app";
 
 import { PADDING } from "styles/var/padding";
@@ -96,7 +96,9 @@ const UserMenu = ({
   currentUser,
   currentTeam,
 }: IUserMenuProps): JSX.Element => {
-  const { isPremiumTier, isSandboxMode } = useContext(AppContext);
+  const { availableTeams, isPremiumTier, isSandboxMode } = useContext(
+    AppContext
+  );
 
   // Work around for react-select-5 not having :focus-visible pseudo class that can style dropdown on keyboard tab only
   // Work around preventing react-select-5 from auto focusing first option unless using keyboard
@@ -168,16 +170,15 @@ const UserMenu = ({
       });
     }
   } else if (currentUser && isAnyTeamAdmin) {
-    const userAdminTeams = currentUser.teams.filter(
-      (thisTeam: ITeam) => thisTeam.role === "admin"
-    );
     const currentTeamIsAdmin =
-      currentTeam && userAdminTeams.some((t) => t.id === currentTeam.id);
+      currentTeam && permissions.isTeamAdmin(currentUser, currentTeam.id);
     // Use the current team if the user is an admin of it, otherwise fall back
-    // to the first team the user is an admin of.
+    // to the first team (alphabetical) the user is an admin of.
+    // availableTeams is pre-sorted alphabetically by AppContext.
     const targetTeamId = currentTeamIsAdmin
       ? currentTeam.id
-      : getSortedTeamOptions(userAdminTeams)[0].value;
+      : availableTeams?.find((t) => permissions.isTeamAdmin(currentUser, t.id))
+          ?.id;
 
     dropdownItems.push({
       label: "Users",

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -170,34 +170,38 @@ const UserMenu = ({
       });
     }
   } else if (currentUser && isAnyTeamAdmin) {
-    const currentTeamIsAdmin =
-      currentTeam && permissions.isTeamAdmin(currentUser, currentTeam.id);
-    // Use the current team if the user is an admin of it, otherwise fall back
-    // to the first team (alphabetical) the user is an admin of.
-    // availableTeams is pre-sorted alphabetically by AppContext.
-    const targetTeamId = currentTeamIsAdmin
-      ? currentTeam.id
-      : availableTeams?.find((t) => permissions.isTeamAdmin(currentUser, t.id))
-          ?.id;
+    // Resolved at click time so availableTeams is guaranteed to be loaded.
+    const getTargetTeamId = () => {
+      const currentTeamIsAdmin =
+        currentTeam && permissions.isTeamAdmin(currentUser, currentTeam.id);
+      // Use the current team if the user is an admin of it, otherwise fall back
+      // to the first team (alphabetical) the user is an admin of.
+      // availableTeams is pre-sorted alphabetically by AppContext.
+      return currentTeamIsAdmin
+        ? currentTeam.id
+        : availableTeams?.find((t) =>
+            permissions.isTeamAdmin(currentUser, t.id)
+          )?.id;
+    };
 
     dropdownItems.push({
       label: "Users",
       value: "team-users",
       hasDividerBefore: true,
       onClick: () =>
-        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeamId)),
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(getTargetTeamId())),
     });
     dropdownItems.push({
       label: "Agent options",
       value: "team-agent-options",
       onClick: () =>
-        onUserMenuItemClick(PATHS.FLEET_DETAILS_OPTIONS(targetTeamId)),
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_OPTIONS(getTargetTeamId())),
     });
     dropdownItems.push({
       label: "Settings",
       value: "team-settings",
       onClick: () =>
-        onUserMenuItemClick(PATHS.FLEET_DETAILS_SETTINGS(targetTeamId)),
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_SETTINGS(getTargetTeamId())),
     });
   }
 

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -171,24 +171,32 @@ const UserMenu = ({
     const userAdminTeams = currentUser.teams.filter(
       (thisTeam: ITeam) => thisTeam.role === "admin"
     );
-    const settingsClickHandler = () => {
-      const currentTeamIsAdmin =
-        currentTeam && userAdminTeams.some((t) => t.id === currentTeam.id);
-      if (currentTeamIsAdmin) {
-        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(currentTeam.id));
-      } else {
-        // Not an admin of the current team — redirect to the first team the
-        // user is an admin of.
-        const targetTeam = getSortedTeamOptions(userAdminTeams)[0];
-        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeam.value));
-      }
-    };
+    const currentTeamIsAdmin =
+      currentTeam && userAdminTeams.some((t) => t.id === currentTeam.id);
+    // Use the current team if the user is an admin of it, otherwise fall back
+    // to the first team the user is an admin of.
+    const targetTeamId = currentTeamIsAdmin
+      ? currentTeam.id
+      : getSortedTeamOptions(userAdminTeams)[0].value;
 
     dropdownItems.push({
-      label: "Settings",
-      value: "settings",
+      label: "Users",
+      value: "team-users",
       hasDividerBefore: true,
-      onClick: settingsClickHandler,
+      onClick: () =>
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeamId)),
+    });
+    dropdownItems.push({
+      label: "Agent options",
+      value: "team-agent-options",
+      onClick: () =>
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_OPTIONS(targetTeamId)),
+    });
+    dropdownItems.push({
+      label: "Settings",
+      value: "team-settings",
+      onClick: () =>
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_SETTINGS(targetTeamId)),
     });
   }
 

--- a/frontend/components/top_nav/UserMenu/_styles.scss
+++ b/frontend/components/top_nav/UserMenu/_styles.scss
@@ -1,1 +1,8 @@
-// Styles for user-menu are defined inline via react-select's `styles` prop.
+// Most styles for user-menu are defined inline via react-select's `styles` prop.
+
+.user-menu {
+  &__divider {
+    border-top: 1px solid $ui-fleet-black-10;
+    margin: $pad-xsmall 0;
+  }
+}

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -157,15 +157,13 @@ const filterUserTeamsByRole = (
   userTeams: ITeam[],
   permittedAccessByUserRole?: Record<IUserRole, boolean>
 ) => {
-  if (!permittedAccessByUserRole) {
-    return userTeams;
-  }
+  const filtered = permittedAccessByUserRole
+    ? userTeams.filter(
+        ({ role }) => role && !!permittedAccessByUserRole[role as IUserRole]
+      )
+    : [...userTeams];
 
-  return userTeams
-    .filter(
-      ({ role }) => role && !!permittedAccessByUserRole[role as IUserRole]
-    )
-    .sort((a, b) => sort.caseInsensitiveAsc(a.name, b.name));
+  return filtered.sort((a, b) => sort.caseInsensitiveAsc(a.name, b.name));
 };
 
 const getUserTeams = ({

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -15,7 +15,6 @@ import {
 } from "interfaces/team";
 import { IUser, IUserRole } from "interfaces/user";
 import permissions from "utilities/permissions";
-import sort from "utilities/sort";
 
 type OnTeamChangeFuncShouldStripParam = (
   teamIdForApi: number | undefined
@@ -165,7 +164,7 @@ const filterUserTeamsByRole = (
     .filter(
       ({ role }) => role && !!permittedAccessByUserRole[role as IUserRole]
     )
-    .sort((a, b) => sort.caseInsensitiveAsc(a.name, b.name));
+    .sort((a, b) => a.id - b.id);
 };
 
 const getUserTeams = ({

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -15,6 +15,7 @@ import {
 } from "interfaces/team";
 import { IUser, IUserRole } from "interfaces/user";
 import permissions from "utilities/permissions";
+import sort from "utilities/sort";
 
 type OnTeamChangeFuncShouldStripParam = (
   teamIdForApi: number | undefined
@@ -164,7 +165,7 @@ const filterUserTeamsByRole = (
     .filter(
       ({ role }) => role && !!permittedAccessByUserRole[role as IUserRole]
     )
-    .sort((a, b) => a.id - b.id);
+    .sort((a, b) => sort.caseInsensitiveAsc(a.name, b.name));
 };
 
 const getUserTeams = ({

--- a/frontend/interfaces/dropdownOption.ts
+++ b/frontend/interfaces/dropdownOption.ts
@@ -11,6 +11,7 @@ export type TooltipContent = ReactNode;
 
 export interface IDropdownOption {
   disabled?: boolean;
+  hasDividerBefore?: boolean;
   label: string | JSX.Element;
   value: string | number;
   helpText?: ReactNode;

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -4,7 +4,6 @@ import {
   flatMap,
   omit,
   pick,
-  memoize,
   reduce,
   trim,
   trimEnd,
@@ -43,7 +42,6 @@ import { ITeam } from "interfaces/team";
 import { UserRole } from "interfaces/user";
 
 import stringUtils from "utilities/strings";
-import sortUtils from "utilities/sort";
 import {
   DEFAULT_EMPTY_CELL_VALUE,
   DEFAULT_GRAVATAR_LINK,
@@ -826,18 +824,6 @@ export const tooltipTextWithLineBreaks = (lines: string[]) => {
     );
   });
 };
-
-export const getSortedTeamOptions = memoize((teams: ITeam[]) =>
-  teams
-    .map((team) => {
-      return {
-        disabled: false,
-        label: team.name,
-        value: team.id,
-      };
-    })
-    .sort((a, b) => sortUtils.caseInsensitiveAsc(a.label, b.label))
-);
 
 // returns a mixture of props from host
 export const normalizeEmptyValues = (

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -4,6 +4,7 @@ import {
   flatMap,
   omit,
   pick,
+  memoize,
   reduce,
   trim,
   trimEnd,
@@ -42,6 +43,7 @@ import { ITeam } from "interfaces/team";
 import { UserRole } from "interfaces/user";
 
 import stringUtils from "utilities/strings";
+import sortUtils from "utilities/sort";
 import {
   DEFAULT_EMPTY_CELL_VALUE,
   DEFAULT_GRAVATAR_LINK,
@@ -824,6 +826,18 @@ export const tooltipTextWithLineBreaks = (lines: string[]) => {
     );
   });
 };
+
+export const getSortedTeamOptions = memoize((teams: ITeam[]) =>
+  teams
+    .map((team) => {
+      return {
+        disabled: false,
+        label: team.name,
+        value: team.id,
+      };
+    })
+    .sort((a, b) => sortUtils.caseInsensitiveAsc(a.label, b.label))
+);
 
 // returns a mixture of props from host
 export const normalizeEmptyValues = (


### PR DESCRIPTION
**Related issue:** Resolves #37972

This also fixes the sort order of fleets for flee-level users.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the user menu to show the correct settings sections based on account type and access level, with clearer separation between sections.

* **Bug Fixes**
  * Fixed fleet sorting for fleet-level users.
  * Corrected top navigation behavior so the menu only shows role/tier-appropriate items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->