### PR TITLE
Update claude rules to allow server/ptr non deprecated functions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,7 +39,7 @@ The following terms were recently renamed. Use the new terms in conversation and
 - **Endpoint registration**: `ue.POST("/api/_version_/fleet/resource", fn, reqType{})`
 - **Authorization**: `svc.authz.Authorize(ctx, entity, fleet.ActionX)` at start of service methods
 - **Logging**: slog with `DebugContext/InfoContext/WarnContext/ErrorContext` — never bare slog.Debug/Info/Warn/Error
-- **Pointers**: Use Go 1.26 `new(expression)` for pointer values (e.g., `new("value")`, `new(true)`, `new(42)`). Do NOT use the legacy `server/ptr` package in new code — it exists throughout the codebase but is superseded by `new(expr)`.
+- **Pointers**: Use Go 1.26 `new(expression)` (e.g., `new("value")`, `new(true)`, `new(42)`) — not `server/ptr`'s deprecated constructors. Non-deprecated helpers (e.g., `ptr.ValOrZero`) are still fine.
 - **Reference example**: `server/service/vulnerabilities.go`
 
 ## Before writing a fix

--- a/.claude/rules/fleet-go-backend.md
+++ b/.claude/rules/fleet-go-backend.md
@@ -74,7 +74,7 @@ paths:
 ## Imports & Utilities
 - Internal packages: `github.com/fleetdm/fleet/v4/server/` prefix
 - **HTTP clients**: Use `fleethttp.NewClient()` — never `http.Client{}` or `new(http.Client)` directly (custom linter rule)
-- **Pointers (Go 1.26+)**: Use `new(expression)` for pointer values: `new("value")`, `new(true)`, `new(yearsSince(born))`. Do NOT use the `server/ptr` package (`ptr.String()`, `ptr.Uint()`, etc.) in new code — it's legacy. You'll see it throughout the existing codebase but should not follow that pattern.
+- **Pointers**: Use Go 1.26 `new(expression)` (e.g., `new("value")`, `new(true)`, `new(42)`) — not `server/ptr`'s deprecated constructors. Non-deprecated helpers are still fine: `ptr.ValOrZero` (deref-or-zero), `ptr.Equal` (nil-safe equality), `ptr.UintOrNilIfZero` (nil for `0`).
 - **Random numbers**: use `math/rand/v2` instead of `math/rand`
 - Sets: use `map[T]struct{}`, convert to slice with `slices.Collect(maps.Keys(m))`
 - Flexible JSON: use `json.RawMessage` for configs stored as JSON blobs


### PR DESCRIPTION
Updates the claude backend rules to still allow some functions from the server/ptr package. The constructor functions are deprecated but not all the functions in the package are. For example: UintOrNilIfZero, Equal and ValOrZero are still fine. 