### PR TITLE
Fleet UI: Browser Back no longer trapped on script batch progress page

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -66,6 +66,7 @@ Use the `useTeamIdParam` hook for team-scoped pages:
 Use react-router, not `window.location` / `window.history`. Direct window mutation desyncs react-router's location state.
 - Read query params from `location.query`, not `URLSearchParams(window.location.search)`.
 - Mutate the URL with `router.replace`/`router.push` or `browserHistory.replace`/`.push`, not `window.history.replaceState`.
+- Auto-correcting a missing/invalid query param inside a `useEffect` MUST use `router.replace`, not `router.push`, so browser Back isn't trapped.
 - Internal `<CustomLink>` (and any `router.push` / `<Link>`) to a fleet-scoped route MUST preserve the current fleet via `getPathWithQueryParams(PATHS.X, { fleet_id: teamId })`. Linking to the bare path drops fleet context and lands the user on the wrong fleet. Applies to any path that reads `fleet_id` from the query string (most `/software`, `/hosts`, `/policies`, `/queries`, `/controls` routes). `getPathWithQueryParams` filters undefined/null, so pass `teamId` directly — `fleet_id=0` (No team) is a valid, intentional value and must be preserved.
 
 ## Notifications

--- a/changes/47019-script-batch-back-button
+++ b/changes/47019-script-batch-back-button
@@ -1,0 +1,1 @@
+- Fixed browser Back button being trapped on the script batch progress and details pages.

--- a/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/ScriptBatchDetailsPage.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/ScriptBatchDetailsPage.tsx
@@ -172,9 +172,7 @@ const ScriptBatchDetailsPage = ({
   );
 
   useEffect(() => {
-    // Replace (don't push) when defaulting an invalid/missing status — pushing
-    // here gets re-pushed by this same effect on browser Back, trapping the
-    // user on this page (#47019).
+    // replace (not push) — pushing re-fires this effect on browser Back
     if (!isValidScriptBatchHostStatus(selectedHostStatus)) {
       router.replace(buildTabPath(0));
     }

--- a/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/ScriptBatchDetailsPage.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/ScriptBatchDetailsPage.tsx
@@ -146,7 +146,7 @@ const ScriptBatchDetailsPage = ({
     }
   }, [batchExecutionId, pathToProgress, router]);
 
-  const handleTabChange = useCallback(
+  const buildTabPath = useCallback(
     (index: number) => {
       const newHostsStatus = HOSTS_STATUS_BY_INDEX[index];
 
@@ -155,22 +155,30 @@ const ScriptBatchDetailsPage = ({
       newParams.set("page", "0");
       const newQuery = newParams.toString();
 
-      router.push(
-        paths
-          .CONTROLS_SCRIPTS_BATCH_DETAILS(batchExecutionId)
-          .concat(newQuery ? `?${newQuery}` : "")
-      );
+      return paths
+        .CONTROLS_SCRIPTS_BATCH_DETAILS(batchExecutionId)
+        .concat(newQuery ? `?${newQuery}` : "");
+    },
+    [batchExecutionId, location?.search]
+  );
+
+  const handleTabChange = useCallback(
+    (index: number) => {
+      router.push(buildTabPath(index));
       // update page's summary data (e.g. pct hosts responded) whenever changing tabs
       refetchBatchDetails();
     },
-    [batchExecutionId, location?.search, refetchBatchDetails, router]
+    [buildTabPath, refetchBatchDetails, router]
   );
 
   useEffect(() => {
+    // Replace (don't push) when defaulting an invalid/missing status — pushing
+    // here gets re-pushed by this same effect on browser Back, trapping the
+    // user on this page (#47019).
     if (!isValidScriptBatchHostStatus(selectedHostStatus)) {
-      handleTabChange(0);
+      router.replace(buildTabPath(0));
     }
-  }, [handleTabChange, selectedHostStatus]);
+  }, [buildTabPath, router, selectedHostStatus]);
 
   const renderTabContent = ([hostStatus, hostStatusCount]: [
     ScriptBatchHostStatus,

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tests.tsx
@@ -246,4 +246,59 @@ describe("ScriptBatchProgress", () => {
       expect(screen.getByText(/20\s+\/\s+50/m)).toBeInTheDocument();
     });
   });
+
+  // Regression coverage for #47019: the auto-correction effect for an
+  // invalid/missing ?status must use router.replace, not router.push, so the
+  // browser Back button isn't trapped.
+  it("Replaces (does not push) the URL with ?status=started when status is invalid", async () => {
+    mockServer.use(emptyTeamBatchSummariesHandler);
+
+    const router = createMockRouter();
+    const render = createCustomRenderer({ withBackendMock: true });
+
+    render(
+      <ScriptBatchProgress
+        router={router}
+        teamId={1}
+        location={{
+          pathname: "/controls/scripts/progress",
+          query: { status: "bogus" },
+          search: "?status=bogus",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(
+        "/controls/scripts/progress?status=started"
+      );
+    });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it("Replaces (does not push) the URL with ?status=started when status is missing", async () => {
+    mockServer.use(emptyTeamBatchSummariesHandler);
+
+    const router = createMockRouter();
+    const render = createCustomRenderer({ withBackendMock: true });
+
+    render(
+      <ScriptBatchProgress
+        router={router}
+        teamId={1}
+        location={{
+          pathname: "/controls/scripts/progress",
+          query: {},
+          search: "",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(
+        "/controls/scripts/progress?status=started"
+      );
+    });
+    expect(router.push).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -184,8 +184,7 @@ const ScriptBatchProgress = ({
     );
   };
 
-  // Reset to first tab if status is invalid. Replace (don't push) so browser
-  // Back doesn't re-trigger this effect and trap the user (#47019).
+  // replace (not push) — pushing re-fires this effect on browser Back
   useEffect(() => {
     if (!isValidScriptBatchStatus(statusParam)) {
       router.replace(buildTabPath(0));

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -105,7 +105,7 @@ const ScriptBatchProgress = ({
     keepPreviousData: true,
   });
 
-  const handleTabChange = useCallback(
+  const buildTabPath = useCallback(
     (index: number) => {
       const newStatus = STATUS_BY_INDEX[index];
 
@@ -113,14 +113,19 @@ const ScriptBatchProgress = ({
       newParams.set("status", newStatus);
       const newQuery = newParams.toString();
 
-      router.push(
-        PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS.concat(
-          newQuery ? `?${newQuery}` : ""
-        )
+      return PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS.concat(
+        newQuery ? `?${newQuery}` : ""
       );
+    },
+    [location?.search]
+  );
+
+  const handleTabChange = useCallback(
+    (index: number) => {
+      router.push(buildTabPath(index));
       setPageNumber(0);
     },
-    [location?.search, router]
+    [buildTabPath, router]
   );
 
   const onClickRow = (r: IScriptBatchSummaryV2) => {
@@ -179,12 +184,14 @@ const ScriptBatchProgress = ({
     );
   };
 
-  // Reset to first tab if status is invalid.
+  // Reset to first tab if status is invalid. Replace (don't push) so browser
+  // Back doesn't re-trigger this effect and trap the user (#47019).
   useEffect(() => {
     if (!isValidScriptBatchStatus(statusParam)) {
-      handleTabChange(0);
+      router.replace(buildTabPath(0));
+      setPageNumber(0);
     }
-  }, [statusParam, handleTabChange]);
+  }, [buildTabPath, router, statusParam]);
 
   const renderTabContent = (status: ScriptBatchStatus) => {
     // If we're switching to a new tab, show the loading spinner


### PR DESCRIPTION
## Issue
Closes #47019

## Description
- Bug fix (root cause): The script batch progress and details pages auto-corrected a missing `?status=...` URL param via `router.push` inside a `useEffect`. Pressing browser Back returned to the un-corrected URL, the same effect re-fired, and pushed forward again — looping the user on the page.
- Swapped the auto-correction `router.push` for `router.replace` in both pages. User-initiated tab clicks still `push` so the in-page tab history works as before. Extracted a small `buildTabPath` helper so the push and replace call sites share the URL-building logic.

## Screenrecording
- Browser Back from the script batch details page now returns to the dashboard (or wherever the user came from).



## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the browser Back button getting trapped on script batch progress and script batch details pages.
  * Improved tab navigation so invalid or missing status query values restore the correct tab using replace navigation (avoids extra history entries).
  * Reset pagination when switching tabs and refreshed batch summary data for accurate tab details.
* **Tests**
  * Added regression tests to verify replace vs push routing for invalid or missing status query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->