### PR TITLE
Restrict authorization for team membership operations

### DIFF
--- a/changes/fix-team-member-authorization.md
+++ b/changes/fix-team-member-authorization.md
@@ -1,0 +1,1 @@
+- Restricted authorization for team membership management operations.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -691,7 +691,7 @@ func (svc *Service) ModifyTeamAgentOptions(ctx context.Context, teamID uint, tea
 }
 
 func (svc *Service) AddTeamUsers(ctx context.Context, teamID uint, users []fleet.TeamUser) (*fleet.Team, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.Team{ID: teamID}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.Authorize(ctx, &fleet.Team{ID: teamID}, fleet.ActionWriteMembers); err != nil {
 		return nil, err
 	}
 
@@ -736,7 +736,7 @@ func (svc *Service) AddTeamUsers(ctx context.Context, teamID uint, users []fleet
 }
 
 func (svc *Service) DeleteTeamUsers(ctx context.Context, teamID uint, users []fleet.TeamUser) (*fleet.Team, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.Team{ID: teamID}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.Authorize(ctx, &fleet.Team{ID: teamID}, fleet.ActionWriteMembers); err != nil {
 		return nil, err
 	}
 

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -19,6 +19,7 @@ cancel_host_activity := "cancel_host_activity"
 transfer_host := "transfer_host"
 resend := "resend" # only for profiles, and to a single host
 read_secrets := "read_secrets"
+write_members := "write_members"
 
 # User specific actions
 write_role := "write_role"
@@ -136,6 +137,22 @@ allow {
   object.type == "team"
   team_role(subject, object.id) == [admin, gitops][_]
   action == write
+}
+
+# Global admins can manage team membership.
+allow {
+  object.type == "team"
+  object.id != 0
+  subject.global_role == admin
+  action == write_members
+}
+
+# Team admins can manage membership of their teams.
+allow {
+  object.type == "team"
+  object.id != 0
+  team_role(subject, object.id) == admin
+  action == write_members
 }
 
 ##

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -32,6 +32,7 @@ const (
 	transferHost       = fleet.ActionTransferHost
 	create             = fleet.ActionCreate
 	readSecrets        = fleet.ActionReadSecrets
+	writeMembers       = fleet.ActionWriteMembers
 )
 
 var auth *Authorizer
@@ -584,6 +585,49 @@ func TestAuthorizeTeam(t *testing.T) {
 		{user: test.UserTeamTechnicianTeam1, object: team1, action: write, allow: false},
 		{user: test.UserTeamTechnicianTeam1, object: team2, action: read, allow: false},
 		{user: test.UserTeamTechnicianTeam1, object: team2, action: write, allow: false},
+
+		// write_members action
+		{user: nil, object: team1, action: writeMembers, allow: false},
+		{user: nil, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserNoRoles, object: team1, action: writeMembers, allow: false},
+		{user: test.UserNoRoles, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserAdmin, object: team1, action: writeMembers, allow: true},
+		{user: test.UserAdmin, object: team2, action: writeMembers, allow: true},
+
+		{user: test.UserMaintainer, object: team1, action: writeMembers, allow: false},
+		{user: test.UserMaintainer, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserObserver, object: team1, action: writeMembers, allow: false},
+		{user: test.UserObserver, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserObserverPlus, object: team1, action: writeMembers, allow: false},
+		{user: test.UserObserverPlus, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserTechnician, object: team1, action: writeMembers, allow: false},
+		{user: test.UserTechnician, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserGitOps, object: team1, action: writeMembers, allow: false},
+		{user: test.UserGitOps, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserTeamAdminTeam1, object: team1, action: writeMembers, allow: true},
+		{user: test.UserTeamAdminTeam1, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserTeamMaintainerTeam1, object: team1, action: writeMembers, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserTeamObserverTeam1, object: team1, action: writeMembers, allow: false},
+		{user: test.UserTeamObserverTeam1, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserTeamObserverPlusTeam1, object: team1, action: writeMembers, allow: false},
+		{user: test.UserTeamObserverPlusTeam1, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserTeamGitOpsTeam1, object: team1, action: writeMembers, allow: false},
+		{user: test.UserTeamGitOpsTeam1, object: team2, action: writeMembers, allow: false},
+
+		{user: test.UserTeamTechnicianTeam1, object: team1, action: writeMembers, allow: false},
+		{user: test.UserTeamTechnicianTeam1, object: team2, action: writeMembers, allow: false},
 	})
 }
 

--- a/server/fleet/authz.go
+++ b/server/fleet/authz.go
@@ -21,6 +21,9 @@ const (
 	ActionResend = "resend"
 	// ActionReadSecrets refers to reading secrets/credentials of an entity (e.g. CA private keys, API tokens).
 	ActionReadSecrets = "read_secrets"
+	// ActionWriteMembers refers to adding/removing members of a team.
+	// This is more restrictive than ActionWrite to prevent non-admin roles from managing team membership.
+	ActionWriteMembers = "write_members"
 
 	//
 	// User specific actions

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -7357,7 +7357,7 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 	// Attempt to delete a user, should fail.
 	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/users/%d", admin.ID), deleteUserRequest{}, http.StatusForbidden, &deleteUserResponse{})
 
-	// Attempt to add users to team, should allow.
+	// Attempt to add users to team, should fail (gitops cannot manage team membership).
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/users", t1.ID), modifyTeamUsersRequest{
 		Users: []fleet.TeamUser{
 			{
@@ -7365,9 +7365,9 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 				Role: "admin",
 			},
 		},
-	}, http.StatusOK, &teamResponse{})
+	}, http.StatusForbidden, &teamResponse{})
 
-	// Attempt to delete users from team, should allow.
+	// Attempt to delete users from team, should fail (gitops cannot manage team membership).
 	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/teams/%d/users", t1.ID), modifyTeamUsersRequest{
 		Users: []fleet.TeamUser{
 			{
@@ -7375,7 +7375,7 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 				Role: "admin",
 			},
 		},
-	}, http.StatusOK, &teamResponse{})
+	}, http.StatusForbidden, &teamResponse{})
 
 	// Attempt to create a team, should allow.
 	tr := teamResponse{}
@@ -7634,7 +7634,7 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 		}
 	}`), http.StatusForbidden, &teamResponse{})
 
-	// Attempt to add users from team it owns to another team it owns, should allow.
+	// Attempt to add users from team it owns to another team it owns, should fail (gitops cannot manage team membership).
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/users", t3.ID), modifyTeamUsersRequest{
 		Users: []fleet.TeamUser{
 			{
@@ -7642,16 +7642,16 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 				Role: "maintainer",
 			},
 		},
-	}, http.StatusOK, &teamResponse{})
+	}, http.StatusForbidden, &teamResponse{})
 
-	// Attempt to delete users from team it owns, should allow.
+	// Attempt to delete users from team it owns, should fail (gitops cannot manage team membership).
 	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/teams/%d/users", t3.ID), modifyTeamUsersRequest{
 		Users: []fleet.TeamUser{
 			{
 				User: *u3,
 			},
 		},
-	}, http.StatusOK, &teamResponse{})
+	}, http.StatusForbidden, &teamResponse{})
 
 	// Attempt to add users to another team it doesn't own, should fail.
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/users", t2.ID), modifyTeamUsersRequest{

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -184,6 +184,15 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailTeamMemberWrite:  true,
 		},
 		{
+			name:                       "global gitops",
+			user:                       &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
+			shouldFailTeamWrite:        false,
+			shouldFailGlobalWrite:      false,
+			shouldFailRead:             true,
+			shouldFailTeamSecretsWrite: true,
+			shouldFailTeamMemberWrite:  true,
+		},
+		{
 			name:                       "team gitops, belongs to team",
 			user:                       &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}},
 			shouldFailTeamWrite:        false,

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -100,6 +100,7 @@ func TestTeamAuth(t *testing.T) {
 		shouldFailGlobalWrite      bool
 		shouldFailRead             bool
 		shouldFailTeamSecretsWrite bool
+		shouldFailTeamMemberWrite  bool
 	}{
 		{
 			name:                       "global admin",
@@ -108,6 +109,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      false,
 			shouldFailRead:             false,
 			shouldFailTeamSecretsWrite: false,
+			shouldFailTeamMemberWrite:  false,
 		},
 		{
 			name:                       "global maintainer",
@@ -116,6 +118,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             false,
 			shouldFailTeamSecretsWrite: false,
+			shouldFailTeamMemberWrite:  true,
 		},
 		{
 			name:                       "global observer",
@@ -124,6 +127,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             false,
 			shouldFailTeamSecretsWrite: true,
+			shouldFailTeamMemberWrite:  true,
 		},
 		{
 			name:                       "team admin, belongs to team",
@@ -132,6 +136,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             false,
 			shouldFailTeamSecretsWrite: false,
+			shouldFailTeamMemberWrite:  false,
 		},
 		{
 			name:                       "team maintainer, belongs to team",
@@ -140,6 +145,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             false,
 			shouldFailTeamSecretsWrite: false,
+			shouldFailTeamMemberWrite:  true,
 		},
 		{
 			name:                       "team observer, belongs to team",
@@ -148,6 +154,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             false,
 			shouldFailTeamSecretsWrite: true,
+			shouldFailTeamMemberWrite:  true,
 		},
 		{
 			name:                       "team admin, DOES NOT belong to team",
@@ -156,6 +163,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             true,
 			shouldFailTeamSecretsWrite: true,
+			shouldFailTeamMemberWrite:  true,
 		},
 		{
 			name:                       "team maintainer, DOES NOT belong to team",
@@ -164,6 +172,7 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             true,
 			shouldFailTeamSecretsWrite: true,
+			shouldFailTeamMemberWrite:  true,
 		},
 		{
 			name:                       "team observer, DOES NOT belong to team",
@@ -172,6 +181,16 @@ func TestTeamAuth(t *testing.T) {
 			shouldFailGlobalWrite:      true,
 			shouldFailRead:             true,
 			shouldFailTeamSecretsWrite: true,
+			shouldFailTeamMemberWrite:  true,
+		},
+		{
+			name:                       "team gitops, belongs to team",
+			user:                       &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}},
+			shouldFailTeamWrite:        false,
+			shouldFailGlobalWrite:      true,
+			shouldFailRead:             true,
+			shouldFailTeamSecretsWrite: true,
+			shouldFailTeamMemberWrite:  true,
 		},
 	}
 	for _, tt := range testCases {
@@ -188,10 +207,10 @@ func TestTeamAuth(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 
 			_, err = svc.AddTeamUsers(ctx, 1, []fleet.TeamUser{})
-			checkAuthErr(t, tt.shouldFailTeamWrite, err)
+			checkAuthErr(t, tt.shouldFailTeamMemberWrite, err)
 
 			_, err = svc.DeleteTeamUsers(ctx, 1, []fleet.TeamUser{})
-			checkAuthErr(t, tt.shouldFailTeamWrite, err)
+			checkAuthErr(t, tt.shouldFailTeamMemberWrite, err)
 
 			_, err = svc.ListTeamUsers(ctx, 1, fleet.ListOptions{})
 			checkAuthErr(t, tt.shouldFailRead, err)

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -186,7 +186,7 @@ func TestTeamAuth(t *testing.T) {
 		},
 		{
 			name:                       "global gitops",
-			user:                       &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
+			user:                       &fleet.User{GlobalRole: new(fleet.RoleGitOps)},
 			shouldFailTeamWrite:        false,
 			shouldFailGlobalWrite:      false,
 			shouldFailRead:             true,

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
+	"github.com/fleetdm/fleet/v4/server/authz"
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -243,6 +244,66 @@ func TestTeamAuth(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 		})
 	}
+}
+
+// TestGitOpsCannotManageTeamMembers verifies that a team gitops user cannot
+// add or remove team members (including self-promotion to admin).
+func TestGitOpsCannotManageTeamMembers(t *testing.T) {
+	ds := new(mock.Store)
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+
+	ds.TeamWithExtrasFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
+		return &fleet.Team{ID: tid}, nil
+	}
+	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		return team, nil
+	}
+	ds.UserByIDFunc = func(ctx context.Context, id uint) (*fleet.User, error) {
+		return &fleet.User{ID: id}, nil
+	}
+
+	teamID := uint(1)
+	gitopsUserID := uint(42)
+
+	// Simulate a team gitops user.
+	gitopsUser := &fleet.User{
+		ID:    gitopsUserID,
+		Teams: []fleet.UserTeam{{Team: fleet.Team{ID: teamID}, Role: fleet.RoleGitOps}},
+	}
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: gitopsUser})
+
+	// Attempt self-promotion: gitops user tries to make themselves a team admin.
+	_, err := svc.AddTeamUsers(ctx, teamID, []fleet.TeamUser{
+		{User: fleet.User{ID: gitopsUserID}, Role: fleet.RoleAdmin},
+	})
+	require.Error(t, err, "team gitops user should not be able to add team members")
+	var forbidden *authz.Forbidden
+	require.ErrorAs(t, err, &forbidden, "expected authorization error, got: %v", err)
+
+	// Also verify gitops cannot remove team members.
+	_, err = svc.DeleteTeamUsers(ctx, teamID, []fleet.TeamUser{
+		{User: fleet.User{ID: 99}},
+	})
+	require.Error(t, err, "team gitops user should not be able to remove team members")
+	require.ErrorAs(t, err, &forbidden, "expected authorization error, got: %v", err)
+
+	// Verify that a team admin CAN still manage members (not broken for legitimate users).
+	adminUser := &fleet.User{
+		ID:    uint(10),
+		Teams: []fleet.UserTeam{{Team: fleet.Team{ID: teamID}, Role: fleet.RoleAdmin}},
+	}
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: adminUser})
+
+	_, err = svc.AddTeamUsers(ctx, teamID, []fleet.TeamUser{
+		{User: fleet.User{ID: gitopsUserID}, Role: fleet.RoleObserver},
+	})
+	require.NoError(t, err, "team admin should be able to add team members")
+
+	_, err = svc.DeleteTeamUsers(ctx, teamID, []fleet.TeamUser{
+		{User: fleet.User{ID: gitopsUserID}},
+	})
+	require.NoError(t, err, "team admin should be able to remove team members")
 }
 
 func TestApplyTeamSpecs(t *testing.T) {


### PR DESCRIPTION
**Related issue:** N/A

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] Reproduced the issue and verified the fix
- [x] QA'd all new/changed functionality manually

## Summary

- Introduced a more granular authorization action for team membership management
- Updated OPA policy and service-layer authorization accordingly
- Added comprehensive authorization test coverage

Verified that team membership operations now enforce correct authorization checks. Admin users retain full access to manage team membership.