### PR TITLE
Tighten enrollment credential validation during host re-enrollment

### DIFF
--- a/changes/enrollment-team-validation
+++ b/changes/enrollment-team-validation
@@ -1,0 +1,1 @@
+- Tightened enrollment credential validation during host re-enrollment.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2244,6 +2244,20 @@ type enrolledHostInfo struct {
 	NodeKeySet bool
 	// Platform is the OS of the host.
 	Platform string
+	// TeamID is the team the host currently belongs to (nil means "no team").
+	TeamID *uint
+}
+
+// sameTeamID returns true if both team IDs represent the same team
+// (including both being nil, meaning "no team").
+func sameTeamID(a, b *uint) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // Attempts to find the matching host ID by osqueryID, host UUID or serial
@@ -2275,6 +2289,7 @@ func matchHostDuringEnrollment(
 		NodeKeySet     bool      `db:"node_key_set"`
 		Priority       int
 		Platform       string `db:"platform"`
+		TeamID         *uint  `db:"team_id"`
 	}
 
 	var (
@@ -2290,7 +2305,7 @@ func matchHostDuringEnrollment(
 	}
 
 	if osqueryID != "" || uuid != "" {
-		_, _ = query.WriteString(fmt.Sprintf(`(SELECT id, last_enrolled_at, %s IS NOT NULL AS node_key_set, 1 priority, platform FROM hosts WHERE osquery_host_id = ?)`, nodeKeyColumn))
+		_, _ = query.WriteString(fmt.Sprintf(`(SELECT id, last_enrolled_at, %s IS NOT NULL AS node_key_set, 1 priority, platform, team_id FROM hosts WHERE osquery_host_id = ?)`, nodeKeyColumn))
 		osqueryHostID := osqueryID
 		if osqueryID == "" {
 			// special-case, if there's no osquery identifier, use the uuid
@@ -2307,7 +2322,7 @@ func matchHostDuringEnrollment(
 		if query.Len() > 0 {
 			_, _ = query.WriteString(" UNION ")
 		}
-		_, _ = query.WriteString(fmt.Sprintf(`(SELECT id, last_enrolled_at, %s IS NOT NULL AS node_key_set, 2 priority, platform FROM hosts WHERE hardware_serial = ? AND (platform = 'darwin' OR platform = 'ios' OR platform = 'ipados') ORDER BY id LIMIT 1)`, nodeKeyColumn))
+		_, _ = query.WriteString(fmt.Sprintf(`(SELECT id, last_enrolled_at, %s IS NOT NULL AS node_key_set, 2 priority, platform, team_id FROM hosts WHERE hardware_serial = ? AND (platform = 'darwin' OR platform = 'ios' OR platform = 'ipados') ORDER BY id LIMIT 1)`, nodeKeyColumn))
 		args = append(args, serial)
 	}
 
@@ -2316,7 +2331,7 @@ func matchHostDuringEnrollment(
 		if query.Len() > 0 {
 			_, _ = query.WriteString(" UNION ")
 		}
-		_, _ = query.WriteString(fmt.Sprintf(`(SELECT id, last_enrolled_at, %s IS NOT NULL AS node_key_set, 3 priority, platform FROM hosts WHERE uuid = ? AND (platform = 'android') ORDER BY id LIMIT 1)`, nodeKeyColumn))
+		_, _ = query.WriteString(fmt.Sprintf(`(SELECT id, last_enrolled_at, %s IS NOT NULL AS node_key_set, 3 priority, platform, team_id FROM hosts WHERE uuid = ? AND (platform = 'android') ORDER BY id LIMIT 1)`, nodeKeyColumn))
 		args = append(args, uuid)
 	}
 
@@ -2335,6 +2350,7 @@ func matchHostDuringEnrollment(
 		LastEnrolledAt: rows[0].LastEnrolledAt,
 		NodeKeySet:     rows[0].NodeKeySet,
 		Platform:       rows[0].Platform,
+		TeamID:         rows[0].TeamID,
 	}, nil
 }
 
@@ -2397,6 +2413,13 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 				*enrollConfig.IdentityCert.HostID != enrolledHostInfo.ID {
 				return ctxerr.New(ctx, "orbit host identity cert host id does not match enrolled host id. "+
 					fmt.Sprintf("This is likely due to a duplicate UUID/identity identifier used by multiple hosts: %s", hostInfo.OsqueryIdentifier))
+			}
+
+			// For hosts without identity certs, prevent cross-team node-key replay:
+			// reject re-enrollment if the enroll secret's team doesn't match the host's current team.
+			if enrolledHostInfo.NodeKeySet && enrollConfig.IdentityCert == nil &&
+				!sameTeamID(teamID, enrolledHostInfo.TeamID) {
+				return ctxerr.New(ctx, "orbit re-enrollment denied: enrollment credential does not match the host's current team assignment")
 			}
 
 			refetchRequested := fleet.PlatformSupportsOsquery(enrolledHostInfo.Platform)
@@ -2658,6 +2681,13 @@ func (ds *Datastore) EnrollOsquery(ctx context.Context, opts ...fleet.DatastoreE
 				*enrollConfig.IdentityCert.HostID != hostID {
 				return ctxerr.New(ctx, "host identity cert host id does not match enrolled host id. "+
 					fmt.Sprintf("This is likely due to a duplicate UUID/identity identifier used by multiple hosts: %s", osqueryHostID))
+			}
+
+			// For hosts without identity certs, prevent cross-team node-key replay:
+			// reject re-enrollment if the enroll secret's team doesn't match the host's current team.
+			if enrolledHostInfo.NodeKeySet && enrollConfig.IdentityCert == nil &&
+				!sameTeamID(teamID, enrolledHostInfo.TeamID) {
+				return ctxerr.New(ctx, "osquery re-enrollment denied: enrollment credential does not match the host's current team assignment")
 			}
 
 			if err := deleteAllPolicyMemberships(ctx, tx, enrolledHostInfo.ID); err != nil {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -205,6 +205,7 @@ func TestHosts(t *testing.T) {
 		{"HostTimeZone", testHostTimeZone},
 		{"ListHostsDEPFilters", testListHostsDEPFilters},
 		{"ExtendHostOrbitDebugUntil", testExtendHostOrbitDebugUntil},
+		{"EnrollCrossTeamReplayBlocked", testEnrollCrossTeamReplayBlocked},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2344,6 +2345,7 @@ func testHostsEnroll(t *testing.T, ds *Datastore) {
 		_, err = ds.EnrollOsquery(context.Background(),
 			fleet.WithEnrollOsqueryHostID(tt.uuid),
 			fleet.WithEnrollOsqueryNodeKey(tt.nodeKey+"new"),
+			fleet.WithEnrollOsqueryTeamID(&team.ID),
 		)
 		require.NoError(t, err)
 		assert.NotZero(t, h.LastEnrolledAt)
@@ -2352,6 +2354,7 @@ func testHostsEnroll(t *testing.T, ds *Datastore) {
 		_, err = ds.EnrollOsquery(context.Background(),
 			fleet.WithEnrollOsqueryHostID(tt.uuid),
 			fleet.WithEnrollOsqueryNodeKey(tt.nodeKey+"new"),
+			fleet.WithEnrollOsqueryTeamID(&team.ID),
 			fleet.WithEnrollOsqueryCooldown(10*time.Second),
 		)
 		require.Error(t, err)
@@ -14353,4 +14356,160 @@ func testExtendHostOrbitDebugUntil(t *testing.T, ds *Datastore) {
 	got, err = ds.Host(ctx, host.ID)
 	require.NoError(t, err)
 	require.True(t, got.OrbitDebugUntil.Equal(later))
+}
+
+func testEnrollCrossTeamReplayBlocked(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	teamA, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-a-" + t.Name()})
+	require.NoError(t, err)
+	teamB, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-b-" + t.Name()})
+	require.NoError(t, err)
+
+	// --- Orbit enrollment ---
+
+	// Create a host on team A and enroll it via Orbit.
+	hostUUID := uuid.New().String()
+	h, err := ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: hostUUID,
+			Hostname:     "orbit-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(&teamA.ID),
+	)
+	require.NoError(t, err)
+	hostID := h.ID
+	// Assign the host to team A (enrollment INSERT sets team_id, but let's be explicit).
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&teamA.ID, []uint{hostID})))
+
+	// Same-team re-enrollment should succeed.
+	h, err = ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: hostUUID,
+			Hostname:     "orbit-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(&teamA.ID),
+	)
+	require.NoError(t, err)
+	require.Equal(t, hostID, h.ID, "same-team re-enrollment should match the existing host")
+
+	// Cross-team re-enrollment (team B secret for team A host) should be rejected.
+	_, err = ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: hostUUID,
+			Hostname:     "orbit-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(&teamB.ID),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "re-enrollment denied")
+
+	// Cross-team re-enrollment (no-team/global secret for team A host) should be rejected.
+	_, err = ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: hostUUID,
+			Hostname:     "orbit-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(nil),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "re-enrollment denied")
+
+	// New enrollment (unknown UUID) should still work regardless of team.
+	newUUID := uuid.New().String()
+	hNew, err := ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: newUUID,
+			Hostname:     "new-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(&teamB.ID),
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, hostID, hNew.ID)
+
+	// --- Osquery enrollment ---
+
+	// Create a host on team A and enroll it via osquery.
+	osqueryUUID := uuid.New().String()
+	hOsquery, err := ds.EnrollOsquery(ctx,
+		fleet.WithEnrollOsqueryHostID(osqueryUUID),
+		fleet.WithEnrollOsqueryHardwareUUID(osqueryUUID),
+		fleet.WithEnrollOsqueryNodeKey(uuid.New().String()),
+		fleet.WithEnrollOsqueryTeamID(&teamA.ID),
+	)
+	require.NoError(t, err)
+	osqueryHostID := hOsquery.ID
+	// Assign to team A.
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&teamA.ID, []uint{osqueryHostID})))
+
+	// Same-team osquery re-enrollment should succeed.
+	hOsquery, err = ds.EnrollOsquery(ctx,
+		fleet.WithEnrollOsqueryHostID(osqueryUUID),
+		fleet.WithEnrollOsqueryHardwareUUID(osqueryUUID),
+		fleet.WithEnrollOsqueryNodeKey(uuid.New().String()),
+		fleet.WithEnrollOsqueryTeamID(&teamA.ID),
+	)
+	require.NoError(t, err)
+	require.Equal(t, osqueryHostID, hOsquery.ID, "same-team osquery re-enrollment should match")
+
+	// Cross-team osquery re-enrollment should be rejected.
+	_, err = ds.EnrollOsquery(ctx,
+		fleet.WithEnrollOsqueryHostID(osqueryUUID),
+		fleet.WithEnrollOsqueryHardwareUUID(osqueryUUID),
+		fleet.WithEnrollOsqueryNodeKey(uuid.New().String()),
+		fleet.WithEnrollOsqueryTeamID(&teamB.ID),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "re-enrollment denied")
+
+	// --- No-team host re-enrollment ---
+
+	// Create a host with no team.
+	noTeamUUID := uuid.New().String()
+	hNoTeam, err := ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: noTeamUUID,
+			Hostname:     "no-team-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(nil),
+	)
+	require.NoError(t, err)
+
+	// Same no-team re-enrollment should succeed.
+	hNoTeam2, err := ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: noTeamUUID,
+			Hostname:     "no-team-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(nil),
+	)
+	require.NoError(t, err)
+	require.Equal(t, hNoTeam.ID, hNoTeam2.ID, "no-team re-enrollment should match")
+
+	// Cross-team (team A secret for no-team host) should be rejected.
+	_, err = ds.EnrollOrbit(ctx,
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID: noTeamUUID,
+			Hostname:     "no-team-host",
+			Platform:     "darwin",
+		}),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitTeamID(&teamA.ID),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "re-enrollment denied")
 }


### PR DESCRIPTION
**Related issue:** Internal security finding

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements).

## Testing

- [x] Added/updated automated tests