### PR TITLE
Fleet UI: Stop query-param URL replace from dismissing newly-landed toasts

### DIFF
--- a/frontend/components/ToastNotification/ToastNotification.tsx
+++ b/frontend/components/ToastNotification/ToastNotification.tsx
@@ -31,12 +31,20 @@ const ToastNotification = ({
     : `${baseClass} ${baseClass}__wrapper`;
 
   // Dismiss visible toasts on route change, matching 4.86 flash behavior.
-  // The listener fires synchronously during router.push; because `notify`
-  // defers creation by a tick (see below), a toast triggered alongside a
-  // navigation is created afterward and lands on the destination page.
+  // Only fires when the pathname actually changes — query-param `replace`s
+  // (e.g. TableContainer's onQueryChange URL sync on initial render) are
+  // ignored so they don't kill a toast that just landed on the destination
+  // page (#48180). The listener fires synchronously during router.push;
+  // because `notify` defers creation by a tick (see below), a toast
+  // triggered alongside a navigation is created afterward and lands on the
+  // destination page.
   useEffect(() => {
-    const unlisten = browserHistory.listen(() => {
-      toast.dismiss();
+    let prevPathname = window.location.pathname;
+    const unlisten = browserHistory.listen((location) => {
+      if (location.pathname !== prevPathname) {
+        prevPathname = location.pathname;
+        toast.dismiss();
+      }
     });
     return unlisten;
   }, []);


### PR DESCRIPTION
## Issue
Closes #48180

## Description
- Bug fix (root cause): the route-change listener in `ToastNotification` fired on every `browserHistory` event, including `router.replace` calls that only change query params. `SoftwareLibraryTable` (and other `TableContainer` pages) runs an `onQueryChange`-driven `router.replace` on initial render to sync sort/page/filter into the URL — that fired immediately after the freshly-landed success toast and dismissed it, well under the 5s window.
- Fix: track the previous pathname in the listener and only call `toast.dismiss()` when the pathname actually changes. Query-param-only `replace`s no longer kill the toast; real page navigations still do.
- Behavior change to watch: fleet switches via `?fleet_id=` no longer dismiss toasts (same pathname). Hash changes likewise no longer dismiss. Pathname-level navigation behaves exactly as before.

## Screenrecording

https://github.com/user-attachments/assets/9a4d084c-61d9-439f-b5e5-2b20b74091e2

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now stay visible during URL updates that don’t change the page, such as query-string-only changes.
  * Toasts are dismissed only when the page path actually changes, reducing unexpected disappearance after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->