### PR TITLE
Use full-depth checkout in snapshot image build for correct build-info version

### DIFF
--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -50,6 +50,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Full history + tags so the Go toolchain embeds a real build-info
+          # version (e.g. v4.87.1-0.<commit>) instead of the v4.0.0 module base
+          # that a shallow clone produces. Matches the release workflow.
+          fetch-depth: 0
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
           # Full history + tags so the Go toolchain embeds a real build-info
-          # version (e.g. v4.87.1-0.<commit>) instead of the v4.0.0 module base
+          # version (e.g. v4.87.1-0.<timestamp>-<commit>) instead of the v4.0.0 module base
           # that a shallow clone produces. Matches the release workflow.
           fetch-depth: 0
 


### PR DESCRIPTION
**Related issue:** Resolves fleetdm/confidential#16551

## What changed

Use a full-depth git checkout in the snapshot/edge Fleet image build so the compiled binary carries a correct Go build-info module version.

`.github/workflows/goreleaser-snapshot-fleet.yaml` checked out the repo with the default `fetch-depth` (shallow, depth 1). With no reachable semver tag in a shallow clone, the Go toolchain stamps the binary's build-info module version with the `v4.0.0` base of the `github.com/fleetdm/fleet/v4` module (rendered by scanners as the pseudo-version `v4.0.0-<timestamp>-<commit>`).

Container vulnerability scanners (AWS Inspector, Trivy, Grype, etc.) read that build-info version, see `4.0.0`, and report every Fleet advisory fixed after 4.0.0 as present, even though the edge image is built from current `main` and already contains those fixes. This produces persistent false positives on edge images that recur on every rebuild.

The release workflow (`goreleaser-fleet.yaml`) already uses `fetch-depth: 0` ("Needed for goreleaser"), which is why tagged release images report the correct version. This brings the snapshot build in line. With full history, an untagged `main` build embeds a tag-based version (e.g. `v4.87.1-0.<timestamp>-<commit>`) whose base is above the latest release, so scanners no longer match already-fixed Fleet CVEs.

# Checklist for submitter

- [ ] CI snapshot image build succeeds with the full-depth checkout.

## Testing

- [ ] After merge, pull the rebuilt edge image and confirm `go version -m /usr/bin/fleet` reports a `v4.87.x`-based module version (not `v4.0.0-...`), and that scanners no longer report already-fixed Fleet CVEs against it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version reporting for published Docker images and binaries by using accurate tag/commit-derived release information instead of a fallback from shallow clones.
  * Updated the snapshot publish workflow to match the main release workflow’s versioning behavior for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->