### PR TITLE
Upgrade OpenSSL in mdmproxy image to clear CVE-2026-34182

### DIFF
--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -5,8 +5,8 @@ RUN go install github.com/fleetdm/fleet/v4/tools/mdm/migration/mdmproxy@${TAG}
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 LABEL maintainer="Fleet Developers"
 
-RUN apk update && apk add --no-cache tini
-RUN apk --no-cache upgrade openssl libcrypto3 libssl3
+RUN apk --no-cache upgrade openssl libcrypto3 libssl3 \
+    && apk add --no-cache tini
 COPY --from=0 /go/bin/mdmproxy /usr/bin/mdmproxy
 ADD --chmod=0755 ./entrypoint.sh /usr/bin/entrypoint.sh
 

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -6,6 +6,7 @@ FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 LABEL maintainer="Fleet Developers"
 
 RUN apk update && apk add --no-cache tini
+RUN apk --no-cache upgrade openssl libcrypto3 libssl3
 COPY --from=0 /go/bin/mdmproxy /usr/bin/mdmproxy
 ADD --chmod=0755 ./entrypoint.sh /usr/bin/entrypoint.sh
 


### PR DESCRIPTION
## What changed

Upgrade the OpenSSL libraries in the `mdmproxy` runtime image so it picks up the patched Alpine packages, matching what the main `fleet` image already does (`tools/fleet-docker/Dockerfile`).

`tools/mdm/migration/mdmproxy/Dockerfile` builds on `alpine:3.23.4`, whose bundled OpenSSL (3.5.6) is flagged for CVE-2026-34182 (critical) by container scanners. The `fleet` image already runs `apk --no-cache upgrade openssl libcrypto3 libssl3`; this brings the mdmproxy image in line so the same finding clears on rebuild instead of persisting.

```dockerfile
RUN apk update && apk add --no-cache tini
RUN apk --no-cache upgrade openssl libcrypto3 libssl3   # <-- added
COPY --from=0 /go/bin/mdmproxy /usr/bin/mdmproxy
```

# Checklist for submitter

- [ ] mdmproxy image builds with the added upgrade step.

## Testing

- [ ] After rebuild, confirm the image's `openssl`/`libssl3`/`libcrypto3` packages are >= 3.5.7-r0 (`apk info -v | grep -E 'openssl|libssl|libcrypto'`) and that scanners no longer report CVE-2026-34182 against the mdmproxy asset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the build environment to apply targeted Alpine security upgrades for OpenSSL-related libraries during image creation.
  - Streamlined the initialization tooling installation as part of the Docker image build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->