### PR TITLE
Docs: correct custom variables permissions in RBAC guide

### DIFF
--- a/articles/role-based-access.md
+++ b/articles/role-based-access.md
@@ -122,8 +122,8 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | Turn off MDM for specific hosts                                                                                                            |          |            |            | ✅         | ✅    |         |
 | Configure Microsoft Entra conditional access integration                                                                                   |          |            |            |            | ✅    |         |
 | Add Microsoft Entra tenant                                                                                                                 |          |            |            |            | ✅    |         |
-| View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                                  | ✅       | ✅         | ✅         | ✅         | ✅    |         |
-| Create, edit, and delete custom variables                                                                                                  | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                                  | ✅       | ✅         | ✅         | ✅         | ✅    | ✅      |
+| Create, edit, and delete custom variables                                                                                                  |          |            |            | ✅         | ✅    | ✅      |
 
 \* Applies only to Fleet Premium
 


### PR DESCRIPTION
## What & why

The [role-based access guide](https://fleetdm.com/guides/role-based-access) listed custom-variables permissions that don't match what Fleet actually enforces in `server/authz/policy.rego` (the "Secret variables" rules):

- **Write** (create/edit/delete) is allowed for global **Admin, Maintainer, and GitOps** only — the guide incorrectly granted it to **Observer, Observer+, and Technician**, and omitted **GitOps**.
- **Read** (view) is allowed for **all global roles, including GitOps** — the guide omitted GitOps.

This updates the two rows in the global permissions table so they match enforcement (and mirror the existing "queries" rows, which share the same role logic).

### Source of truth

`server/authz/policy.rego` — Secret variables:

```rego
# Global admins, maintainers, and gitops can write secret variables.
subject.global_role == [admin, maintainer, gitops][_]   # action == write

# Any global user can read secret variables.
subject.global_role == [admin, maintainer, gitops, technician, observer_plus, observer][_]   # action == read
```

### Notes

- Found during a QA chaos-engineering review (originally reported 2026-03-25): the docs implied read-only roles like Observer could create/edit/delete custom variables, which the UI/API don't allow.
- The separate "the RBAC guide calls the Reports page the Query page" terminology cleanup is **not** included here — it overlaps the in-flight Query → Report rename (#41419) and is better handled there.
- Docs/article-only change; no `changes/` entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
