### PR TITLE
Fix dogfood-deploy DOCKER_IMAGE guidance (tags + digest) and make geolite2 tag digest-safe

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       DOCKER_IMAGE:
-        description: "The full name of the docker image to be deployed. (e.g. fleetdm/fleet:v4.30.0). Note: do not use fleetdm/fleet:main directly.  Use the short hash instead.  If pull-rate limited, try using the quay.io/fleetdm/fleet mirror."
+        description: "The full image reference to deploy. Usually a tag: an RC branch tag (e.g. fleetdm/fleet:rc-minor-fleet-v4.90.0) or a release tag (e.g. fleetdm/fleet:v4.87.0). To deploy from main, do not use the floating fleetdm/fleet:main tag; pin the immutable digest instead (e.g. fleetdm/fleet@sha256:<digest>, from the main tag on Docker Hub) since per-commit hash tags are no longer published. If pull-rate limited, try the quay.io/fleetdm/fleet mirror."
         required: true
       dry_run:
         description: Dry run only? No "terraform apply"

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -59,7 +59,8 @@ locals {
   fleet_image    = var.fleet_image # Set this to the version of fleet to be deployed
   # Tag component for the geolite2 image. Handle both ":tag" and "@sha256:digest" refs
   # so deploying a digest-pinned image (e.g. from main) yields a clean tag, not a 64-char hex.
-  fleet_image_tag = strcontains(var.fleet_image, "@sha256:") ? "sha256-${substr(split("@sha256:", var.fleet_image)[1], 0, 12)}" : split(":", var.fleet_image)[1]
+  # For tag refs, take the last ":" segment so registries with a port (host:5000/repo:tag) still resolve to the tag.
+  fleet_image_tag = strcontains(var.fleet_image, "@sha256:") ? "sha256-${substr(split("@sha256:", var.fleet_image)[1], 0, 12)}" : reverse(split(":", var.fleet_image))[0]
   geolite2_image  = "${aws_ecr_repository.fleet.repository_url}:${local.fleet_image_tag}-geolite2-${formatdate("YYYYMMDDhhmm", timestamp())}"
   extra_environment_variables = {
     FLEET_LICENSE_KEY             = var.fleet_license

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -57,7 +57,10 @@ data "aws_caller_identity" "current" {}
 locals {
   customer       = "fleet-dogfood"
   fleet_image    = var.fleet_image # Set this to the version of fleet to be deployed
-  geolite2_image = "${aws_ecr_repository.fleet.repository_url}:${split(":", var.fleet_image)[1]}-geolite2-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  # Tag component for the geolite2 image. Handle both ":tag" and "@sha256:digest" refs
+  # so deploying a digest-pinned image (e.g. from main) yields a clean tag, not a 64-char hex.
+  fleet_image_tag = strcontains(var.fleet_image, "@sha256:") ? "sha256-${substr(split("@sha256:", var.fleet_image)[1], 0, 12)}" : split(":", var.fleet_image)[1]
+  geolite2_image  = "${aws_ecr_repository.fleet.repository_url}:${local.fleet_image_tag}-geolite2-${formatdate("YYYYMMDDhhmm", timestamp())}"
   extra_environment_variables = {
     FLEET_LICENSE_KEY             = var.fleet_license
     FLEET_LOGGING_DEBUG           = "true"


### PR DESCRIPTION
**Related issue:** Resolves NA

## What changed

Updates the `Deploy Dogfood Environment` workflow's `DOCKER_IMAGE` input guidance and makes the geolite2 tag derivation digest-safe.

**Why:** The input help text said "use the short hash," but per-commit hash tags are no longer published, that was removed intentionally in #42693 ("Cleanup docker publish") for registry hygiene. The snapshot build now publishes only branch-name tags. So the instruction was stale and there was no immutable tag to pin when deploying from `main`.

**Changes:**
- **`.github/workflows/dogfood-deploy.yml`** — rewrite the `DOCKER_IMAGE` description: the usual input is a tag (an RC branch tag, e.g. `fleetdm/fleet:rc-minor-fleet-v4.90.0`, or a release tag, e.g. `fleetdm/fleet:v4.87.0`); to deploy from `main`, pin the immutable digest (`fleetdm/fleet@sha256:<digest>`) rather than the floating `:main` tag.
- **`infrastructure/dogfood/terraform/aws-tf-module/main.tf`** — `local.geolite2_image` derived its tag via `split(":", var.fleet_image)[1]`, which assumes a `:tag` ref. With a digest ref that yields a 64-char hex tag. Added `local.fleet_image_tag` that handles both `:tag` and `@sha256:digest` refs (digest → `sha256-<12 hex>`), so digest-pinned deploys produce a clean ECR tag.

# Checklist for submitter

- [ ] `terraform validate` / plan succeeds for the dogfood module with both a `:tag` and an `@sha256:` image input.

## Testing

- [ ] Confirm `local.geolite2_image` resolves to `…:<tag>-geolite2-<ts>` for a tag input and `…:sha256-<12hex>-geolite2-<ts>` for a digest input (e.g. via `terraform console`).
- [ ] Workflow input description renders as intended in the Actions "Run workflow" form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of container image references so digest-pinned images work cleanly and no longer produce overly long tag strings.
* **Documentation**
  * Updated deployment guidance for the dogfood Docker image workflow, clarifying preferred pinned immutable digests for deployments from `main` and the currently supported tag formats (including RC/release patterns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->