### PR TITLE
Check if host is still on script's team before executing batch

### DIFF
--- a/changes/batch-script-team-check
+++ b/changes/batch-script-team-check
@@ -1,0 +1,1 @@
+* Fixed a bug where a script executed in a scheduled batch would still execute on hosts that had been transferred to a different fleet between the time the batch was scheduled and the time it later executed

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -2633,6 +2633,16 @@ func (ds *Datastore) batchExecuteScript(ctx context.Context, userID *uint, scrip
 				continue
 			}
 
+			// The host may have moved to a different team since the batch was
+			// scheduled, so re-check it still matches the script's team before running.
+			if !teamIDEq(host.TeamID, script.TeamID) {
+				executions = append(executions, fleet.BatchExecutionHost{
+					HostID: host.ID,
+					Error:  &fleet.BatchExecuteIncompatibleTeam,
+				})
+				continue
+			}
+
 			// Non-orbit-enrolled host (iOS, android)
 			noNodeKey := host.OrbitNodeKey == nil || *host.OrbitNodeKey == ""
 			// Scripts disabled on host

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -50,6 +50,7 @@ func TestScripts(t *testing.T) {
 		{"BatchExecute", testBatchExecute},
 		{"BatchExecuteWithStatus", testBatchExecuteWithStatus},
 		{"BatchScriptSchedule", testBatchScriptSchedule},
+		{"BatchScriptScheduleTeamTransfer", testBatchScriptScheduleTeamTransfer},
 		{"BatchScriptCancel", testBatchScriptCancel},
 		{"TestMarkActivitiesAsCompleted", testMarkActivitiesAsCompleted},
 		{"DeleteScriptActivatesNextActivity", testDeleteScriptActivatesNextActivity},
@@ -2338,7 +2339,7 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 	require.Len(t, executions, 1)
-	require.Equal(t, uint(3), *executions[0].NumIncompatible)
+	require.Equal(t, uint(4), *executions[0].NumIncompatible)
 
 	hostResults, err = ds.GetBatchActivityHostResults(ctx, execID)
 	require.NoError(t, err)
@@ -2361,9 +2362,10 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 			require.NotNil(t, hostResult.Error)
 			require.Equal(t, fleet.BatchExecuteIncompatiblePlatform, *hostResult.Error)
 		case hostTeam1.ID:
-			// Bad team
-			require.Len(t, upcomingScripts, 1)
-			require.Nil(t, hostResult.Error)
+			// Host is on a team that no longer matches the script's team
+			require.Len(t, upcomingScripts, 0)
+			require.NotNil(t, hostResult.Error)
+			require.Equal(t, fleet.BatchExecuteIncompatibleTeam, *hostResult.Error)
 		case hostNoScripts.ID:
 			// Host doesn't support scripts
 			require.Len(t, upcomingScripts, 0)
@@ -2399,6 +2401,78 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 	require.Equal(t, *summary.NumErrored, uint(0))
 	require.Equal(t, *summary.NumRan, uint(0))
 	require.Equal(t, *summary.NumCanceled, uint(5))
+}
+
+func testBatchScriptScheduleTeamTransfer(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	user := test.NewUser(t, ds, "user1", "user@example.com", true)
+
+	teamA, err := ds.NewTeam(ctx, &fleet.Team{Name: "teamA"})
+	require.NoError(t, err)
+	teamB, err := ds.NewTeam(ctx, &fleet.Team{Name: "teamB"})
+	require.NoError(t, err)
+
+	// Both hosts start on team A, matching the script's team.
+	hostStays := test.NewHost(t, ds, "hostStays", "10.0.0.1", "hoststayskey", "hoststaysuuid", time.Now(), test.WithTeamID(teamA.ID))
+	hostMoved := test.NewHost(t, ds, "hostMoved", "10.0.0.2", "hostmovedkey", "hostmoveduuid", time.Now(), test.WithTeamID(teamA.ID))
+	test.SetOrbitEnrollment(t, hostStays, ds)
+	test.SetOrbitEnrollment(t, hostMoved, ds)
+
+	script, err := ds.NewScript(ctx, &fleet.Script{
+		Name:           "script1.sh",
+		ScriptContents: "echo hi",
+		TeamID:         &teamA.ID,
+	})
+	require.NoError(t, err)
+
+	scheduledTime := time.Now().Add(10 * time.Hour).Truncate(time.Second).UTC()
+	execID, err := ds.BatchScheduleScript(ctx, &user.ID, script.ID, []uint{hostStays.ID, hostMoved.ID}, scheduledTime)
+	require.NoError(t, err)
+	require.NotEmpty(t, execID)
+
+	// Move one host to a different team after scheduling but before the batch fires.
+	err = ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&teamB.ID, []uint{hostMoved.ID}))
+	require.NoError(t, err)
+	movedHost, err := ds.Host(ctx, hostMoved.ID)
+	require.NoError(t, err)
+	require.Equal(t, teamB.ID, *movedHost.TeamID)
+
+	// Fire the scheduled batch as the worker would.
+	err = ds.RunScheduledBatchActivity(ctx, execID)
+	require.NoError(t, err)
+
+	hostResults, err := ds.GetBatchActivityHostResults(ctx, execID)
+	require.NoError(t, err)
+	require.Len(t, hostResults, 2)
+	for _, hostResult := range hostResults {
+		upcomingScripts, err := ds.ListPendingHostScriptExecutions(ctx, hostResult.HostID, false)
+		require.NoError(t, err)
+		switch hostResult.HostID {
+		case hostStays.ID:
+			// Still on the script's team, so it runs.
+			require.NotNil(t, hostResult.HostExecutionID)
+			require.Nil(t, hostResult.Error)
+			require.Len(t, upcomingScripts, 1)
+		case hostMoved.ID:
+			// Moved off the script's team, so it is skipped.
+			require.Nil(t, hostResult.HostExecutionID)
+			require.NotNil(t, hostResult.Error)
+			require.Equal(t, fleet.BatchExecuteIncompatibleTeam, *hostResult.Error)
+			require.Len(t, upcomingScripts, 0)
+		default:
+			require.Failf(t, "unexpected host in batch", "host_id: %d", hostResult.HostID)
+		}
+	}
+
+	executions, err := ds.ListBatchScriptExecutions(ctx, fleet.BatchExecutionStatusFilter{
+		ExecutionID: &execID,
+	})
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+	require.Equal(t, uint(2), *executions[0].NumTargeted)
+	require.Equal(t, uint(1), *executions[0].NumIncompatible)
+	require.Equal(t, uint(1), *executions[0].NumPending)
 }
 
 func testMarkActivitiesAsCompleted(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -2362,7 +2362,7 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 			require.NotNil(t, hostResult.Error)
 			require.Equal(t, fleet.BatchExecuteIncompatiblePlatform, *hostResult.Error)
 		case hostTeam1.ID:
-			// Host is on a team that no longer matches the script's team
+			// Host is on a different team than the script
 			require.Empty(t, upcomingScripts)
 			require.NotNil(t, hostResult.Error)
 			require.Equal(t, fleet.BatchExecuteIncompatibleTeam, *hostResult.Error)

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -2358,17 +2358,17 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 			require.Len(t, upcomingScripts, 1)
 		case hostWindows.ID:
 			// Bad platform
-			require.Len(t, upcomingScripts, 0)
+			require.Empty(t, upcomingScripts)
 			require.NotNil(t, hostResult.Error)
 			require.Equal(t, fleet.BatchExecuteIncompatiblePlatform, *hostResult.Error)
 		case hostTeam1.ID:
 			// Host is on a team that no longer matches the script's team
-			require.Len(t, upcomingScripts, 0)
+			require.Empty(t, upcomingScripts)
 			require.NotNil(t, hostResult.Error)
 			require.Equal(t, fleet.BatchExecuteIncompatibleTeam, *hostResult.Error)
 		case hostNoScripts.ID:
 			// Host doesn't support scripts
-			require.Len(t, upcomingScripts, 0)
+			require.Empty(t, upcomingScripts)
 			require.NotNil(t, hostResult.Error)
 			require.Equal(t, fleet.BatchExecuteIncompatibleFleetd, *hostResult.Error)
 		case 0xbeef:
@@ -2459,7 +2459,7 @@ func testBatchScriptScheduleTeamTransfer(t *testing.T, ds *Datastore) {
 			require.Nil(t, hostResult.HostExecutionID)
 			require.NotNil(t, hostResult.Error)
 			require.Equal(t, fleet.BatchExecuteIncompatibleTeam, *hostResult.Error)
-			require.Len(t, upcomingScripts, 0)
+			require.Empty(t, upcomingScripts)
 		default:
 			require.Failf(t, "unexpected host in batch", "host_id: %d", hostResult.HostID)
 		}

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -833,6 +833,7 @@ var (
 	BatchExecuteIncompatiblePlatform = "incompatible-platform"
 	BatchExecuteIncompatibleFleetd   = "incompatible-fleetd"
 	BatchExecuteInvalidHost          = "invalid-host"
+	BatchExecuteIncompatibleTeam     = "incompatible-team"
 )
 
 type BatchExecutionStatusFilter struct {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled batch script execution now re-checks host team membership at execution time, skipping any hosts moved to a different team before the batch runs.
  * Added a clear “team mismatch” incompatibility outcome and ensured incompatible hosts are not queued for execution.
* **Tests**
  * Expanded script scheduling tests to cover host-to-team transfers between scheduling and execution, including updated incompatibility counts and per-host expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->