### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/acorn/darwin.json
+++ b/ee/maintained-apps/outputs/acorn/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.5.1",
+      "version": "8.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8' AND version_compare(bundle_short_version, '8.5.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8' AND version_compare(bundle_short_version, '8.6') < 0);"
       },
-      "installer_url": "https://flyingmeat.com/download/Acorn-8.5.1.zip",
+      "installer_url": "https://flyingmeat.com/download/Acorn-8.6.zip",
       "install_script_ref": "299f47da",
       "uninstall_script_ref": "d8d84d04",
-      "sha256": "95f140cda6e7e13ba1d881e2add2bbff2aaa8dabdc74d96c7536205454e94a77",
+      "sha256": "9dc6541b417ac48f0328eecac6d8cf256d4cf90365bfa7baefc6473c6dac30e3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.598",
+      "version": "6.606",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.598') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.606') < 0);"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.598-2026062303.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.606-2026062402.zip",
       "install_script_ref": "920c563d",
       "uninstall_script_ref": "b0dc7152",
-      "sha256": "87c447fdbf8600559426317630e52b921679fee571d9a55b49901bac1dcceca7",
+      "sha256": "e7be72c697125b23d36b9add3b232b6ab80a6d429a13857403ab3596b6f85ec5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.1.91.175",
+      "version": "149.1.91.178",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '149.1.91.175') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '149.1.91.178') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/191.175/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/191.178/Brave-Browser-arm64.dmg",
       "install_script_ref": "013e53e8",
       "uninstall_script_ref": "9a376609",
-      "sha256": "f62869227d5649cd0ef4c52382f5c580cf47b5e57774893d87ba0b9582f68506",
+      "sha256": "0c188b587ab9a056961798e97a46b5560075217972f53a70b05e90f4b4e9cb84",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/insomnia/darwin.json
+++ b/ee/maintained-apps/outputs/insomnia/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "13.0.1",
+      "version": "13.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '13.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.insomnia.app' AND version_compare(bundle_short_version, '13.0.2') < 0);"
       },
-      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4013.0.1/Insomnia.Core-13.0.1.dmg",
+      "installer_url": "https://github.com/Kong/insomnia/releases/download/core%4013.0.2/Insomnia.Core-13.0.2.dmg",
       "install_script_ref": "80491bd1",
       "uninstall_script_ref": "093d2a58",
-      "sha256": "bdc06eb2131ee7d8c366920cc84e6a1f70f40e0af4fc9080568c33b72a9d8520",
+      "sha256": "4af7e5a14c241b28a2c16370bb6cb0b53c4a9fb00c4814a95e413a2c67a584d7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17.9",
+      "version": "1.17.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.10') < 0);"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.9/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.10/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "727dc41e",
       "uninstall_script_ref": "ad62b190",
-      "sha256": "edcc148f2d2f78932e7edd5ea7a5ffd6cc9aa0280a53de686f7cd88e63d737c4",
+      "sha256": "e119d14a2680cac8b0e8321f73608496bf345036e87325509ed0373d34b9df0e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/processing/darwin.json
+++ b/ee/maintained-apps/outputs/processing/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.5.4",
+      "version": "4.5.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.processing.four';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.processing.four' AND version_compare(bundle_short_version, '4.5.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.processing.four' AND version_compare(bundle_short_version, '4.5.5') < 0);"
       },
-      "installer_url": "https://github.com/processing/processing4/releases/download/processing-1432-4.5.4/processing-4.5.4-macos-aarch64.dmg",
+      "installer_url": "https://github.com/processing/processing4/releases/download/processing-1433-4.5.5/processing-4.5.5-macos-aarch64.dmg",
       "install_script_ref": "c22623fc",
       "uninstall_script_ref": "b69978e7",
-      "sha256": "26cfbdd9401dc254bd812def60033267b1c872abe2420ec10dc91b3699dcd8d0",
+      "sha256": "5bd8e6ad2b9250921cc5d85f9dae16b1eed109ba278976da3e4f96e81d81ef48",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.15.0",
+      "version": "8.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.16.0') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.15.0.zip",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.16.0.zip",
       "install_script_ref": "fac7f399",
       "uninstall_script_ref": "c0c94e32",
-      "sha256": "9808321a58815bb6c5612a2ba80fd751599ff86a4dfb8eda818853ae93617d4c",
+      "sha256": "52556e29e384fda79f56a50bc6db783802136b36c847bfc63454cc79d88b18b9",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for several maintained macOS apps, including Acorn, BetterTouchTool, Brave Browser, Insomnia, opencode desktop, Processing, and Signal.
  * These updates point installers to the latest available versions and refresh download checksums for safer installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->