### PR TITLE
[YAML] Add multiple custom packages for the same software title in the same fleet

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -620,7 +620,7 @@ You can add multiple packages for the same software in a package YAML file. This
 
 If multiple packages target the same host, Fleet will install the one that was added first.
 
-> In GitOps, the first package added is the first one in the package YAML file's list on the run that first adds the title's packages. Reordering the list on a later run doesn't change which package was added first. 
+> In GitOps, the first package added is the first one in the package YAML file's list on the initial run that adds the title's packages. Reordering the list on a later run doesn't change the order.
 >
 > You can preview the order of the packages in the UI. The first package in the list is always a fallback in case of a conflict.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -612,6 +612,46 @@ software:
 
 #### Example
 
+##### Multiple versions of the same software
+
+You can add multiple packages for the same software in a package YAML file. This enables staged rollouts and support of architecture-specific installers.
+
+`self_service`, `categories`, and labels are defined per package. `setup_experience` is defined on the fleet-level.
+
+If multiple packages target the same host, Fleet will install the one that was added first.
+
+> In GitOps, the first package added is the first one in the package YAML file's list on the run that first adds the title's packages. Reordering the list on a later run doesn't change which package was added first. 
+>
+> You can preview the order of the packages in the UI. The first package in the list is always a fallback in case of a conflict.
+
+`fleets/fleet-name.yml`, or `fleets/unassigned.yml`
+
+```yaml
+software:
+  packages:
+    - path: ../lib/software/santa.package.yml
+```
+
+`lib/software/santa.package.yml`
+
+```yaml
+- url: https://github.com/northpolesec/santa/releases/download/2026.2/santa-2026.2.pkg
+  install_script:
+    path: ../lib/software/santa-install-script.sh
+  self_service: true
+  labels_include_all:
+    - macOS
+- url: https://github.com/northpolesec/santa/releases/download/2026.4/santa-2026.4.pkg
+  install_script:
+    path: ../lib/software/santa-install-script.sh
+  self_service: true
+  categories:
+    - "💻 Productivity"
+  labels_include_all:
+    - macOS
+    - IT test team
+```
+
 ##### URL
 
 `lib/software-name.package.yml`:
@@ -665,46 +705,6 @@ software:
       labels_include_any:
       - Engineering
       - Customer Support
-```
-
-##### Multiple versions of the same software
-
-You can add multiple packages for the same software in a package YAML file. This enables staged rollouts and support of architecture-specific installers.
-
-`self_service`, `categories`, and labels are defined per package inside the package YAML file.
-
-If multiple packages target the same host, Fleet will install the one that was added first.
-
-In GitOps, the first package added is the first one in the package YAML file's list on the run that first adds the title's packages. Reordering the list on a later run doesn't change which package was added first. To change it, remove the package from the YAML and re-add it on a later run.
-
-You can always preview the order of the packages in the UI. The first package in the list is always a fallback in case of a conflict.
-
-`fleets/fleet-name.yml`, or `fleets/unassigned.yml`
-
-```yaml
-software:
-  packages:
-    - path: ../lib/software/santa.package.yml
-```
-
-`lib/software/santa.package.yml`
-
-```yaml
-- url: https://github.com/northpolesec/santa/releases/download/2026.2/santa-2026.2.pkg
-  install_script:
-    path: ../lib/software/santa-install-script.sh
-  self_service: true
-  labels_include_all:
-    - macOS
-- url: https://github.com/northpolesec/santa/releases/download/2026.4/santa-2026.4.pkg
-  install_script:
-    path: ../lib/software/santa-install-script.sh
-  self_service: true
-  categories:
-    - "💻 Productivity"
-  labels_include_all:
-    - macOS
-    - IT test team
 ```
 
 ### app_store_apps

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -703,6 +703,10 @@ software:
     - IT test team
 ```
 
+If multiple packages target the same host, Fleet will install the one that was added first.
+
+The first package added to a title is also returned in the `software_package` field of the API for backwards compatibility. For GitOps, the first package added is the first one in the package YAML file's list on the run that first adds the title's packages. Reordering the list on a later run does _not_ change which package was added first, because existing packages keep their original order. To change it, remove the package from the YAML and re-add it on a later run.
+
 ### app_store_apps
 
 - `app_store_id` is the ID of the Apple App Store or Android Play Store app. You can find this ID at the end of the app's URL. For example, "Bear - Markdown Notes" URL is "https://apps.apple.com/us/app/bear-markdown-notes/id1016366447" making the `app_store_id` is "1016366447". Similarly, the URL for "Google Chrome" on Android is "https://play.google.com/store/apps/details?id=com.android.chrome," so the `app_store_id` is "com.android.chrome."

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -674,6 +674,12 @@ You can add multiple packages for the same software in a package YAML file. This
 
 `self_service`, `categories`, and labels are defined per package inside the package YAML file.
 
+If multiple packages target the same host, Fleet will install the one that was added first.
+
+In GitOps, the first package added is the first one in the package YAML file's list on the run that first adds the title's packages. Reordering the list on a later run doesn't change which package was added first. To change it, remove the package from the YAML and re-add it on a later run.
+
+You can always preview the order of the packages in the UI. The first package in the list is always a fallback in case of a conflict.
+
 `fleets/fleet-name.yml`, or `fleets/unassigned.yml`
 
 ```yaml
@@ -701,10 +707,6 @@ software:
     - macOS
     - IT test team
 ```
-
-If multiple packages target the same host, Fleet will install the one that was added first.
-
-The first package added to a title is also returned in the `software_package` field of the API for backwards compatibility. For GitOps, the first package added is the first one in the package YAML file's list on the run that first adds the title's packages. Reordering the list on a later run does _not_ change which package was added first, because existing packages keep their original order. To change it, remove the package from the YAML and re-add it on a later run.
 
 ### app_store_apps
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -672,7 +672,7 @@ software:
 
 You can add multiple packages for the same software in a package YAML file. This enables staged rollouts and support of architecture-specific installers.
 
-`self_service`, `categories`, and labels are defined per package inside the package YAML file, not on the fleet-level YAML file.
+`self_service`, `categories`, and labels are defined per package inside the package YAML file.
 
 `fleets/fleet-name.yml`, or `fleets/unassigned.yml`
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -591,7 +591,6 @@ software:
 
 #### self_service, labels, categories, and setup_experience
 
-When adding [multiple packages](#multiple-versions-of-the-same-software) for the same software title, `self_service`, `categories`, and labels must be specified for each package inside the package YAML file, not on the fleet-level YAML file.
 
 - `self_service` specifies whether end users can install from **Fleet Desktop > Self-service** (default: `false`) on macOS or [self-service web app](https://fleetdm.com/learn-more-about/deploy-self-service-to-ios) on iOS/iPadOS.
 - `labels_include_all` targets hosts that **have all** of the specified labels. `labels_include_any` targets hosts that **have any** of the specified labels. `labels_exclude_any` targets hosts that **have none** of the specified labels. Only one of these fields can be set. If none are set, all hosts are targeted.
@@ -671,7 +670,7 @@ software:
 
 ##### Multiple versions of the same software
 
-You can add multiple packages for the same software title by pointing a single `packages` entry at a package YAML file that lists more than one package. This way you can do a staged rollout of a new version or target different architectures (e.g. Arm vs. Intel) using labels.
+You can add multiple packages for the same software in a package YAML file. This enables staged rollouts and support of architecture-specific installers.
 
 `self_service`, `categories`, and labels are defined per package inside the package YAML file, not on the fleet-level YAML file.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -590,7 +590,9 @@ software:
 ```
 
 #### self_service, labels, categories, and setup_experience
-  
+
+When adding [multiple packages](#multiple-versions-of-the-same-software) for the same software title, `self_service`, `categories`, and labels must be specified for each package inside the package YAML file, not on the fleet-level YAML file.
+
 - `self_service` specifies whether end users can install from **Fleet Desktop > Self-service** (default: `false`) on macOS or [self-service web app](https://fleetdm.com/learn-more-about/deploy-self-service-to-ios) on iOS/iPadOS.
 - `labels_include_all` targets hosts that **have all** of the specified labels. `labels_include_any` targets hosts that **have any** of the specified labels. `labels_exclude_any` targets hosts that **have none** of the specified labels. Only one of these fields can be set. If none are set, all hosts are targeted.
 - `categories` is a list of self-service category names. Categories group self-service software on your end users' **Fleet Desktop > My device** page so that end users can filter by category and install all software in a category at once.
@@ -665,6 +667,40 @@ software:
       labels_include_any:
       - Engineering
       - Customer Support
+```
+
+##### Multiple versions of the same software
+
+You can add multiple packages for the same software title by pointing a single `packages` entry at a package YAML file that lists more than one package. This way you can do a staged rollout of a new version or target different architectures (e.g. Arm vs. Intel) using labels.
+
+`self_service`, `categories`, and labels are defined per package inside the package YAML file, not on the fleet-level YAML file.
+
+`fleets/fleet-name.yml`, or `fleets/unassigned.yml`
+
+```yaml
+software:
+  packages:
+    - path: ../lib/software/santa.package.yml
+```
+
+`lib/software/santa.package.yml`
+
+```yaml
+- url: https://github.com/northpolesec/santa/releases/download/2026.2/santa-2026.2.pkg
+  install_script:
+    path: ../lib/software/santa-install-script.sh
+  self_service: true
+  labels_include_all:
+    - macOS
+- url: https://github.com/northpolesec/santa/releases/download/2026.4/santa-2026.4.pkg
+  install_script:
+    path: ../lib/software/santa-install-script.sh
+  self_service: true
+  categories:
+    - "💻 Productivity"
+  labels_include_all:
+    - macOS
+    - IT test team
 ```
 
 ### app_store_apps

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -591,7 +591,6 @@ software:
 
 #### self_service, labels, categories, and setup_experience
 
-
 - `self_service` specifies whether end users can install from **Fleet Desktop > Self-service** (default: `false`) on macOS or [self-service web app](https://fleetdm.com/learn-more-about/deploy-self-service-to-ios) on iOS/iPadOS.
 - `labels_include_all` targets hosts that **have all** of the specified labels. `labels_include_any` targets hosts that **have any** of the specified labels. `labels_exclude_any` targets hosts that **have none** of the specified labels. Only one of these fields can be set. If none are set, all hosts are targeted.
 - `categories` is a list of self-service category names. Categories group self-service software on your end users' **Fleet Desktop > My device** page so that end users can filter by category and install all software in a category at once.


### PR DESCRIPTION
Related:

- #28108

Documents the GitOps YAML changes for supporting multiple custom packages on the same software title in the same fleet.

- Adds a **Multiple versions of the same software** section under `software.packages`, showing how a single `packages` entry can point at a package YAML file that lists more than one package (e.g. for a staged rollout or architecture targeting).
- Clarifies that `self_service`, `categories`, and labels are defined per package inside the package YAML file, not on the fleet-level YAML file.