### PR TITLE
Enable refetchOnWindowFocus and set refetchInterval to 5s when no report results are available

### DIFF
--- a/changes/48192-refetch-report-results
+++ b/changes/48192-refetch-report-results
@@ -1,0 +1,1 @@
+- Enabled automatic refetching when refocusing the window set a 5-second refetch interval for the report results page.

--- a/changes/48192-refetch-report-results
+++ b/changes/48192-refetch-report-results
@@ -1,1 +1,1 @@
-- Enabled automatic refetching when refocusing the window set a 5-second refetch interval for the report results page.
+- Enabled automatic refreshing of report results when the window is refocused and every 5 seconds while waiting for results to arrive (skipped when report caching is disabled).

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tests.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor, act } from "@testing-library/react";
+import { focusManager } from "react-query";
 import { http, HttpResponse } from "msw";
 
 import {
@@ -12,6 +13,7 @@ import createMockUser from "__mocks__/userMock";
 import createMockConfig from "__mocks__/configMock";
 import createMockSchedulableQuery from "__mocks__/scheduleableQueryMock";
 import createMockQueryReport from "__mocks__/queryReportMock";
+import { IQueryReportResultRow } from "interfaces/query_report";
 
 import QueryDetailsPage from "./QueryDetailsPage";
 
@@ -245,5 +247,123 @@ describe("QueryDetailsPage - back navigation", () => {
     const back = await renderPage(app, hostId);
     expect(back).toHaveTextContent(expectText);
     expect(back.getAttribute("data-path")).toContain(expectPathContains);
+  });
+});
+
+const RESULT_ROW: IQueryReportResultRow = {
+  host_id: 1,
+  host_name: "alpha-host",
+  last_fetched: "2024-01-01T00:00:00Z",
+  columns: { model: "WIDGET-XYZ" },
+};
+
+// Sets up the metadata + report handlers, with the report results determined by
+// `reportSequence(callIndex)` so a test can return different results per fetch
+// (e.g. empty first, then populated).
+const setupReportHandlers = ({
+  queryOverrides = {},
+  reportSequence,
+}: {
+  queryOverrides?: Parameters<typeof createMockSchedulableQuery>[0];
+  reportSequence: (callIndex: number) => IQueryReportResultRow[];
+}) => {
+  let reportCalls = 0;
+  let metadataCalls = 0;
+  mockServer.use(
+    http.get(baseUrl(`/reports/${QUERY_ID}`), () => {
+      metadataCalls += 1;
+      return HttpResponse.json({
+        query: createMockSchedulableQuery({
+          id: QUERY_ID,
+          team_id: null,
+          ...queryOverrides,
+        }),
+      });
+    }),
+    http.get(baseUrl(`/reports/${QUERY_ID}/report`), () => {
+      const results = reportSequence(reportCalls);
+      reportCalls += 1;
+      return HttpResponse.json(
+        createMockQueryReport({ query_id: QUERY_ID, results })
+      );
+    })
+  );
+  return {
+    getReportCalls: () => reportCalls,
+    getMetadataCalls: () => metadataCalls,
+  };
+};
+
+const renderReportPage = () => {
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: { app: baseAppContext },
+  });
+  return render(<QueryDetailsPage {...createProps()} />);
+};
+
+describe("QueryDetailsPage - report results states", () => {
+  it("shows the no-results empty state when the report has no results", async () => {
+    setupReportHandlers({ reportSequence: () => [] });
+    renderReportPage();
+
+    expect(await screen.findByTestId("no-results")).toBeInTheDocument();
+    expect(screen.queryByText("WIDGET-XYZ")).not.toBeInTheDocument();
+  });
+
+  it("shows the results table when the report has results", async () => {
+    setupReportHandlers({ reportSequence: () => [RESULT_ROW] });
+    renderReportPage();
+
+    expect(await screen.findByText("WIDGET-XYZ")).toBeInTheDocument();
+    expect(screen.queryByTestId("no-results")).not.toBeInTheDocument();
+  });
+});
+
+describe("QueryDetailsPage - report refetching", () => {
+  afterEach(() => {
+    focusManager.setFocused(undefined);
+  });
+
+  it("shows results after a refetch when a previously-empty report returns rows", async () => {
+    // Empty on first load, populated on the second fetch.
+    setupReportHandlers({
+      reportSequence: (callIndex) => (callIndex === 0 ? [] : [RESULT_ROW]),
+    });
+    renderReportPage();
+
+    // Initially empty.
+    expect(await screen.findByTestId("no-results")).toBeInTheDocument();
+
+    // Trigger a window focus refetch.
+    act(() => {
+      focusManager.setFocused(true);
+    });
+
+    expect(await screen.findByText("WIDGET-XYZ")).toBeInTheDocument();
+    expect(screen.queryByTestId("no-results")).not.toBeInTheDocument();
+  });
+
+  it("does not refetch the report when caching is disabled (discard_data = true)", async () => {
+    // With caching disabled the report can never populate, so we must not keep
+    // hitting the report endpoint even though the next fetch would return rows.
+    const handlers = setupReportHandlers({
+      queryOverrides: { discard_data: true },
+      reportSequence: (callIndex) => (callIndex === 0 ? [] : [RESULT_ROW]),
+    });
+    renderReportPage();
+
+    expect(await screen.findByTestId("no-results")).toBeInTheDocument();
+    expect(handlers.getReportCalls()).toBe(1);
+
+    act(() => {
+      focusManager.setFocused(true);
+    });
+
+    await waitFor(() =>
+      expect(handlers.getMetadataCalls()).toBeGreaterThanOrEqual(2)
+    );
+    expect(handlers.getReportCalls()).toBe(1);
+    expect(screen.getByTestId("no-results")).toBeInTheDocument();
   });
 });

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -128,7 +128,6 @@ const QueryDetailsPage = ({
     () => queryAPI.load(queryId),
     {
       enabled: !!queryId,
-      refetchOnWindowFocus: false,
       select: (data) => data.query,
       onError: (error) => handlePageError(error),
     }
@@ -170,7 +169,7 @@ const QueryDetailsPage = ({
       }),
     {
       enabled: !!queryId,
-      refetchOnWindowFocus: false,
+      refetchInterval: (data) => (data?.results?.length === 0 ? 5000 : false),
       onError: (error) => handlePageError(error),
     }
   );

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -153,6 +153,11 @@ const QueryDetailsPage = ({
     );
   }
 
+  const discardData = !!storedQuery?.discard_data;
+  const loggingSnapshot = storedQuery?.logging === "snapshot";
+  const reportCachingDisabled =
+    disabledCachingGlobally || discardData || !loggingSnapshot;
+
   const {
     isLoading: isQueryReportLoading,
     data: queryReport,
@@ -169,7 +174,9 @@ const QueryDetailsPage = ({
       }),
     {
       enabled: !!queryId,
-      refetchInterval: (data) => (data?.results?.length === 0 ? 5000 : false),
+      refetchOnWindowFocus: !reportCachingDisabled,
+      refetchInterval: (data) =>
+        !reportCachingDisabled && data?.results?.length === 0 ? 5000 : false,
       onError: (error) => handlePageError(error),
     }
   );
@@ -377,10 +384,6 @@ const QueryDetailsPage = ({
   );
 
   const renderReport = () => {
-    const discardData = !!storedQuery?.discard_data;
-    const loggingSnapshot = storedQuery?.logging === "snapshot";
-    const disabledCaching =
-      disabledCachingGlobally || discardData || !loggingSnapshot;
     const emptyCache = (queryReport?.results?.length ?? 0) === 0;
 
     if (isLoading) {
@@ -398,7 +401,7 @@ const QueryDetailsPage = ({
           queryId={queryId}
           queryInterval={storedQuery?.interval}
           queryUpdatedAt={storedQuery?.updated_at}
-          disabledCaching={disabledCaching}
+          disabledCaching={reportCachingDisabled}
           disabledCachingGlobally={disabledCachingGlobally}
           discardDataEnabled={discardData}
           loggingSnapshot={loggingSnapshot}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48192

- Deleted `refetchOnWindowFocus: false` so that users get fresh data if they navigate away and come back to the report results page (IMHO this should be the behavior across all Fleet's UI).
- Set a refetch interval of 5s when no report results are available.

^ is gated to the report bringing back results (i.e. `discard_data = false` and `logging = snapshot`).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/13513f37-8634-4c22-95cc-c0b2e9128058


https://github.com/user-attachments/assets/ae30640a-d0cb-4d93-a0f3-058650895959


https://github.com/user-attachments/assets/54a46634-fbca-4a7a-a75e-36b73370c9a0





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report results now refresh automatically when you return to the browser window.
  * Empty report results are checked again every 5 seconds until data appears.

* **Bug Fixes**
  * Improved handling of report caching settings so refresh behavior is skipped when caching is disabled.
  * The empty-state view now stays in sync with whether report caching is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->