### PR TITLE
Tighten certificate renewal validation in host identity SCEP service

### DIFF
--- a/changes/scep-renewal-validation
+++ b/changes/scep-renewal-validation
@@ -1,0 +1,1 @@
+- Improved certificate renewal validation in the host identity SCEP service.

--- a/ee/server/service/hostidentity/scep.go
+++ b/ee/server/service/hostidentity/scep.go
@@ -192,6 +192,13 @@ func renewalMiddleware(ds fleet.Datastore, logger *slog.Logger, next scepserver.
 			return nil, errors.New("invalid renewal signature")
 		}
 
+		// Enforce that the CSR's CN matches the original certificate's CN.
+		// Without this check, a host with a valid cert could submit a CSR
+		// with a different CN and obtain a certificate for another identity.
+		if m.CSR.Subject.CommonName != oldCertData.CommonName {
+			return nil, errors.New("renewal CSR common name does not match original certificate")
+		}
+
 		logger.InfoContext(ctx, "renewal signature verified", "serial", renewalData.SerialNumber, "cn", oldCertData.CommonName)
 
 		// Issue the new certificate

--- a/ee/server/service/hostidentity/scep_test.go
+++ b/ee/server/service/hostidentity/scep_test.go
@@ -1,0 +1,134 @@
+package hostidentity
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"context"
+	"log/slog"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/ee/pkg/hostidentity/types"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	scepserver "github.com/fleetdm/fleet/v4/server/mdm/scep/server"
+	"github.com/smallstep/scep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenewalMiddleware_CNMismatchRejected(t *testing.T) {
+	ctx := t.Context()
+
+	// Generate a key pair for the "old" certificate
+	oldKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	oldPubKeyRaw, err := types.CreateECDSAPublicKeyRaw(&oldKey.PublicKey)
+	require.NoError(t, err)
+
+	const originalCN = "original-host-identity"
+	const serialNumber uint64 = 12345
+
+	ds := new(mock.Store)
+	ds.GetHostIdentityCertBySerialNumberFunc = func(_ context.Context, _ uint64) (*types.HostIdentityCertificate, error) {
+		return &types.HostIdentityCertificate{
+			SerialNumber:  serialNumber,
+			CommonName:    originalCN,
+			HostID:        new(uint),
+			NotValidAfter: time.Now().Add(24 * time.Hour),
+			PublicKeyRaw:  oldPubKeyRaw,
+		}, nil
+	}
+
+	// The next signer should NOT be called when CN mismatches
+	nextSignerCalled := false
+	nextSigner := scepserver.CSRSignerContextFunc(func(_ context.Context, _ *scep.CSRReqMessage) (*x509.Certificate, error) {
+		nextSignerCalled = true
+		return &x509.Certificate{SerialNumber: big.NewInt(99999)}, nil
+	})
+
+	logger := slog.Default()
+	middleware := renewalMiddleware(ds, logger, nextSigner)
+
+	// Build renewal data signed by the old key
+	serialHex := "0xc"
+	hash := sha256.Sum256([]byte(serialHex))
+	sig, err := ecdsa.SignASN1(rand.Reader, oldKey, hash[:])
+	require.NoError(t, err)
+
+	renewalData := types.RenewalData{
+		SerialNumber: serialHex,
+		Signature:    base64.StdEncoding.EncodeToString(sig),
+	}
+	renewalJSON, err := json.Marshal(renewalData)
+	require.NoError(t, err)
+
+	t.Run("mismatched CN is rejected", func(t *testing.T) {
+		// Create a CSR with a DIFFERENT CN
+		attackerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		csrTemplate := &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: "attacker-identity",
+			},
+			SignatureAlgorithm: x509.ECDSAWithSHA256,
+			ExtraExtensions: []pkix.Extension{
+				{
+					Id:    types.RenewalExtensionOID,
+					Value: renewalJSON,
+				},
+			},
+		}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, attackerKey)
+		require.NoError(t, err)
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		require.NoError(t, err)
+
+		msg := &scep.CSRReqMessage{CSR: csr}
+		_, err = middleware.SignCSRContext(ctx, msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "common name does not match")
+		assert.False(t, nextSignerCalled, "next signer should not be called when CN mismatches")
+	})
+
+	t.Run("matching CN is accepted", func(t *testing.T) {
+		nextSignerCalled = false
+
+		newKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		csrTemplate := &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: originalCN,
+			},
+			SignatureAlgorithm: x509.ECDSAWithSHA256,
+			ExtraExtensions: []pkix.Extension{
+				{
+					Id:    types.RenewalExtensionOID,
+					Value: renewalJSON,
+				},
+			},
+		}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, newKey)
+		require.NoError(t, err)
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		require.NoError(t, err)
+
+		ds.UpdateHostIdentityCertHostIDBySerialFunc = func(_ context.Context, _ uint64, _ uint) error {
+			return nil
+		}
+
+		msg := &scep.CSRReqMessage{CSR: csr}
+		_, err = middleware.SignCSRContext(ctx, msg)
+		require.NoError(t, err)
+		assert.True(t, nextSignerCalled, "next signer should be called when CN matches")
+	})
+}

--- a/ee/server/service/hostidentity/scep_test.go
+++ b/ee/server/service/hostidentity/scep_test.go
@@ -1,6 +1,7 @@
 package hostidentity
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -9,7 +10,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
-	"context"
 	"log/slog"
 	"math/big"
 	"testing"

--- a/ee/server/service/hostidentity/scep_test.go
+++ b/ee/server/service/hostidentity/scep_test.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/ee/pkg/hostidentity/types"
-	"github.com/fleetdm/fleet/v4/server/mock"
 	scepserver "github.com/fleetdm/fleet/v4/server/mdm/scep/server"
+	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/smallstep/scep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
**Related issue:** N/A (internal security hardening)

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Summary

Tightened validation in the host identity SCEP certificate renewal flow to ensure the renewed certificate matches the original certificate's identity.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

### Unit tests

- Verified that renewal requests with mismatched identity are rejected
- Verified that renewal requests with matching identity succeed

### Integration tests

Ran the full `TestHostIdentity` suite against a local MySQL instance (`MYSQL_TEST=1 REDIS_TEST=1`). All 28 subtests pass.

Linter passes (`make lint-go-incremental` -- 0 issues).