### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/clop/darwin.json
+++ b/ee/maintained-apps/outputs/clop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lowtechguys.Clop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lowtechguys.Clop' AND version_compare(bundle_short_version, '3.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lowtechguys.Clop' AND version_compare(bundle_short_version, '3.2.0') < 0);"
       },
-      "installer_url": "https://files.lowtechguys.com/releases/Clop-3.1.0.dmg",
+      "installer_url": "https://files.lowtechguys.com/releases/Clop-3.2.0.dmg",
       "install_script_ref": "76fb9b1b",
       "uninstall_script_ref": "3712ca1f",
-      "sha256": "1665073b52fdfc571acd1544595fbd5d076515f327d6dd7862fb33adf73dbf15",
+      "sha256": "f6316e7313afca0a8a64baa0cf916b5eee3421486763323e1ae25a106d5c2872",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.8.23",
+      "version": "3.8.24",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.8.23') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.8.24') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/7cf19b7482706625cdb70db3211b7dd035b7aa35/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/cf80f4b937f3b9c48070d7085129a838ce7876a3/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "76911e3cc7e61ee63253afef49a4d37dae52b085a78ed5d5faaf264c4c57b2fb",
+      "sha256": "c2283792d91f83408a4837b455a5e2e543358d90d4ffc411e81fc03b71e3d07b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/nordvpn/darwin.json
+++ b/ee/maintained-apps/outputs/nordvpn/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "10.4.0",
+      "version": "10.5.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos' AND version_compare(bundle_short_version, '10.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordvpn.macos' AND version_compare(bundle_short_version, '10.5.1') < 0);"
       },
-      "installer_url": "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/10.4.0/NordVPN.pkg",
+      "installer_url": "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/10.5.1/NordVPN.pkg",
       "install_script_ref": "60b24e24",
       "uninstall_script_ref": "c0f6be08",
-      "sha256": "8cf675f2c680e707554cc3849f3c6b7e414f1f61020fdf77ee70bade1dc8e7bb",
+      "sha256": "7eaa613fa6fedc8e4df39e3d5c825389c08620e3270ec9aa64cb5c71b293f91e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notchnook/darwin.json
+++ b/ee/maintained-apps/outputs/notchnook/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.5",
+      "version": "1.6.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'lo.cafe.NotchNook';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'lo.cafe.NotchNook' AND version_compare(bundle_short_version, '1.5.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'lo.cafe.NotchNook' AND version_compare(bundle_short_version, '1.6.2') < 0);"
       },
-      "installer_url": "https://lo.cafe/notchnook-files/NotchNook-1.5.5.zip",
+      "installer_url": "https://lo.cafe/notchnook-files/NotchNook-1.6.2.zip",
       "install_script_ref": "f99dc21b",
       "uninstall_script_ref": "2b68da1f",
-      "sha256": "11d03f16e8de481a1ee7bc910736ef67df2922ab8a1cb823d0e4f502b29fe527",
+      "sha256": "4f5023cc25567000d1e054aa3d24387fa576c3ffe738e864bc03ecf78d61dc9b",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17.10",
+      "version": "1.17.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.11') < 0);"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.10/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.11/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "727dc41e",
       "uninstall_script_ref": "ad62b190",
-      "sha256": "e119d14a2680cac8b0e8321f73608496bf345036e87325509ed0373d34b9df0e",
+      "sha256": "1a4ac035af9e3f31216569b6722998147f2f237189afafb33399f6b6c0aadab5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.16.2",
+      "version": "12.16.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.16.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.16.3') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.16.2/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.16.3/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "8f566623eb13ca5e11cc3546c9216241a6137eceb7dda8adfc9f96fe467491f5",
+      "sha256": "0a4a08fe9668cdb406c76ca9328ab92cf16b0e793ca2822bef0697a03f0ccda3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rive/darwin.json
+++ b/ee/maintained-apps/outputs/rive/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.8.5103",
+      "version": "0.8.5113",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5103') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5113') < 0);"
       },
-      "installer_url": "https://releases.rive.app/macos/0.8.5103/Rive.dmg",
+      "installer_url": "https://releases.rive.app/macos/0.8.5113/Rive.dmg",
       "install_script_ref": "2bbfee4e",
       "uninstall_script_ref": "8f862785",
-      "sha256": "2126058481e67be58c677a90d2e2ab3fa88436c401eb1789ba1542778be8363f",
+      "sha256": "2a4fb2cad3a54d886bbbd3a08c2703e2f396ee97d04bb1e4fc673ea44f7f40cb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/shapr3d/darwin.json
+++ b/ee/maintained-apps/outputs/shapr3d/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.110.0.11116",
+      "version": "26.111.0.11141",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr' AND version_compare(bundle_short_version, '26.110.0.11116') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr' AND version_compare(bundle_short_version, '26.111.0.11141') < 0);"
       },
-      "installer_url": "https://download.shapr3d.com/mac/Shapr3D-26.110.0.11116.dmg",
+      "installer_url": "https://download.shapr3d.com/mac/Shapr3D-26.111.0.11141.dmg",
       "install_script_ref": "f6e027de",
       "uninstall_script_ref": "261544b8",
-      "sha256": "fb0d772b543032df6621b5c9b679bac6dd4e6a74d3f706b5b1c5a8d0c01a9fd6",
+      "sha256": "663a7764bb1bbd26df646e178cec17fdd62bb55cd26101f2cbc5fbeb8aa04901",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "46.6.0.35178",
+      "version": "46.6.1.35236",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.0.35178') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.1.35236') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "d105863f",

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.25.15",
+      "version": "26.25.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.25.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.25.20') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated macOS app metadata for several maintained apps to reflect newer releases.
  * Included version bumps for Clop, Cursor, NordVPN, NotchNook, OpenCode Desktop, Postman, Rive, Shapr3D, Webex, and WhatsApp.

* **Bug Fixes**
  * Installer checks now point to the latest available downloads and matching integrity hashes.
  * Version detection logic was refreshed so supported installs are recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->