### PR TITLE
Rename "Create" buttons and links to "Add" across the Fleet UI

### DIFF
--- a/changes/48177-rename-create-buttons-to-add
+++ b/changes/48177-rename-create-buttons-to-add
@@ -1,0 +1,1 @@
+- Renamed "Create" buttons and links to "Add" across the Fleet UI for consistency.

--- a/frontend/components/CommandPalette/groups/commands.ts
+++ b/frontend/components/CommandPalette/groups/commands.ts
@@ -34,14 +34,14 @@ const buildCommandsItems = (
   } = derived;
 
   return [
-    // Create new pack — companion to the "Packs" page in pages.ts. Shares
+    // Add new pack — companion to the "Packs" page in pages.ts. Shares
     // the same search-regex condition. Kept here so the Commands group
     // stays self-contained.
     ...(/packs|create new pack|add new pack/.test(search.toLowerCase())
       ? [
           {
             id: "new-pack",
-            label: "Create new pack",
+            label: "Add new pack",
             group: "Commands" as const,
             path: paths.NEW_PACK,
             keywords: ["packs", "add new pack", "create new pack"],
@@ -470,14 +470,14 @@ const buildCommandsItems = (
                     "create user",
                   ],
                 },
-                // Create fleet — Premium-only, hidden in Primo Mode, and
+                // Add fleet — Premium-only, hidden in Primo Mode, and
                 // hidden in GitOps Mode (ManageFleetsPage disables the
                 // primary action in all three states).
                 ...(isPremiumTier && !isPrimoMode && !isGitOpsMode
                   ? [
                       {
                         id: "create-fleet",
-                        label: "Create fleet",
+                        label: "Add fleet",
                         group: "Commands" as const,
                         path: `${paths.ADMIN_FLEETS}?create_fleet=1`,
                         keywords: [

--- a/frontend/components/CommandPalette/groups/derivations.ts
+++ b/frontend/components/CommandPalette/groups/derivations.ts
@@ -42,7 +42,7 @@ export const deriveContext = (ctx: ICommandPaletteContext): IDerivedContext => {
   const isAbmConfigured = config?.mdm?.apple_bm_enabled_and_configured ?? false;
 
   // GitOps mode disables write actions in the UI; mirrors the predicate
-  // ManageFleetsPage uses to disable its Create fleet button.
+  // ManageFleetsPage uses to disable its Add fleet button.
   const isGitOpsMode = !!(
     config?.gitops?.gitops_mode_enabled && config?.gitops?.repository_url
   );

--- a/frontend/components/CommandPalette/groups/pages.ts
+++ b/frontend/components/CommandPalette/groups/pages.ts
@@ -159,7 +159,7 @@ const buildPagesItems = (
     },
 
     // Packs page — only visible when searching for "packs" or similar.
-    // The companion "Create new pack" item lives in commands.ts.
+    // The companion "Add new pack" item lives in commands.ts.
     ...(/packs|create new pack|add new pack/.test(search.toLowerCase())
       ? [
           {

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -591,7 +591,7 @@ describe("CommandPalette helpers", () => {
       expect(items.map((i) => i.id)).toContain("manage-report-automations");
     });
 
-    it("shows Create fleet only for admins", () => {
+    it("shows Add fleet only for admins", () => {
       const adminItems = buildPaletteItems(BASE_CONTEXT);
       expect(adminItems.map((i) => i.id)).toContain("create-fleet");
 

--- a/frontend/pages/admin/ManageFleetsPage/ManageFleetsPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/ManageFleetsPage.tsx
@@ -64,7 +64,7 @@ const ManageFleetsPage = ({
   const [isUpdatingFleets, setIsUpdatingFleets] = useState(false);
   const [showCreateFleetModal, setShowCreateFleetModal] = useState(false);
 
-  // Mirror the gate used by the in-page "Create fleet" button:
+  // Mirror the gate used by the in-page "Add fleet" button:
   // Primo mode and GitOps mode both disable creation.
   const isCreateFleetDisabled =
     !!config?.partnerships?.enable_primo ||
@@ -344,7 +344,7 @@ const ManageFleetsPage = ({
           defaultSortDirection="asc"
           actionButton={{
             name: "create fleet",
-            buttonText: "Create fleet",
+            buttonText: "Add fleet",
             variant: "default",
             onClick: toggleCreateFleetModal,
             hideButton: false,
@@ -358,7 +358,7 @@ const ManageFleetsPage = ({
                 onClick={toggleCreateFleetModal}
                 className={`${noFleetsClass}__create-button`}
               >
-                Create fleet
+                Add fleet
               </Button>
             );
             const primaryButton = disabledPrimaryActionTooltip ? (
@@ -377,7 +377,7 @@ const ManageFleetsPage = ({
             return (
               <EmptyState
                 header="No fleets yet"
-                info="Create a fleet to add hosts and assign users."
+                info="Add a fleet to add hosts and assign users."
                 primaryButton={primaryButton}
               />
             );

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
@@ -396,7 +396,7 @@ const UsersPage = ({ location, router }: ITeamSubnavProps): JSX.Element => {
           defaultSortHeader="name"
           defaultSortDirection="asc"
           actionButton={{
-            name: isGlobalAdmin ? "add user" : "add user",
+            name: "add user",
             buttonText: isGlobalAdmin ? "Add users" : "Add user",
             variant: "default",
             onClick: isGlobalAdmin ? toggleAddUserModal : toggleCreateUserModal,

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
@@ -396,8 +396,8 @@ const UsersPage = ({ location, router }: ITeamSubnavProps): JSX.Element => {
           defaultSortHeader="name"
           defaultSortDirection="asc"
           actionButton={{
-            name: isGlobalAdmin ? "add user" : "create user",
-            buttonText: isGlobalAdmin ? "Add users" : "Create user",
+            name: isGlobalAdmin ? "add user" : "add user",
+            buttonText: isGlobalAdmin ? "Add users" : "Add user",
             variant: "default",
             onClick: isGlobalAdmin ? toggleAddUserModal : toggleCreateUserModal,
             hideButton: userIds.length === 0 && searchString === "",

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/components/AddUsersModal/AddUsersModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/components/AddUsersModal/AddUsersModal.tsx
@@ -63,7 +63,7 @@ const AddUsersModal = ({
         <p>
           User not here?&nbsp;
           <Button onClick={onCreateNewTeamUser} variant="link">
-            Create a user
+            Add a user
           </Button>
         </p>
         <div className="modal-cta-wrap">

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/components/EmptyUsersTable.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/components/EmptyUsersTable.tsx
@@ -53,7 +53,7 @@ const CreateUserButton = ({
       onClick={toggleCreateMemberModal}
       disabled={disabled}
     >
-      Create user
+      Add user
     </Button>
   );
 };

--- a/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
@@ -50,7 +50,7 @@ const CreateFleetModal = ({
   );
 
   return (
-    <Modal title="Create fleet" onExit={onCancel} className={baseClass}>
+    <Modal title="Add fleet" onExit={onCancel} className={baseClass}>
       <form
         className={`${baseClass}__form`}
         onSubmit={onFormSubmit}

--- a/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tsx
@@ -448,7 +448,7 @@ const UserForm = ({
           <div className="form-field__label">Account</div>
           <Radio
             className={`${baseClass}__radio-input`}
-            label="Create user"
+            label="Add user"
             id="create-user"
             checked={formData.newUserType !== NewUserType.AdminInvited}
             value={NewUserType.AdminCreated}

--- a/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tests.tsx
+++ b/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tests.tsx
@@ -53,16 +53,16 @@ describe("TransferHostModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows Create a fleet link when user is global admin", () => {
+  it("shows Add a fleet link when user is global admin", () => {
     setup({ isGlobalAdmin: true });
 
-    expect(screen.getByText(/Create a fleet/i)).toBeInTheDocument();
+    expect(screen.getByText(/Add a fleet/i)).toBeInTheDocument();
   });
 
-  it("does not show Create a fleet link when not global admin", () => {
+  it("does not show Add a fleet link when not global admin", () => {
     setup({ isGlobalAdmin: false });
 
-    expect(screen.queryByText(/Create a fleet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Add a fleet/i)).not.toBeInTheDocument();
   });
 
   it("disables Transfer button until a team is selected", () => {

--- a/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tsx
@@ -111,7 +111,7 @@ const TransferHostModal = ({
             <CustomLink
               url={PATHS.ADMIN_FLEETS}
               className={`${baseClass}__team-link`}
-              text="Create a fleet"
+              text="Add a fleet"
             />
           </p>
         ) : null}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tests.tsx
@@ -28,7 +28,7 @@ const baseProps = {
 };
 
 describe("SelectReportModal", () => {
-  it("renders empty state with Create a report link when user can create", async () => {
+  it("renders empty state with Add a report link when user can create", async () => {
     mockServer.use(createReportsHandler([]));
     const render = createCustomRenderer({
       withBackendMock: true,
@@ -43,11 +43,11 @@ describe("SelectReportModal", () => {
     render(<SelectReportModal {...baseProps} />);
 
     expect(await screen.findByText("No saved reports")).toBeInTheDocument();
-    expect(screen.getByText("Create a report")).toBeInTheDocument();
+    expect(screen.getByText("Add a report")).toBeInTheDocument();
     expect(screen.getByText(/to run\./)).toBeInTheDocument();
   });
 
-  it("renders empty state without Create a report link for observer-only users", async () => {
+  it("renders empty state without Add a report link for observer-only users", async () => {
     mockServer.use(createReportsHandler([]));
     const render = createCustomRenderer({
       withBackendMock: true,
@@ -65,7 +65,7 @@ describe("SelectReportModal", () => {
     expect(
       screen.getByText("No reports are available to run.")
     ).toBeInTheDocument();
-    expect(screen.queryByText("Create a report")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add a report")).not.toBeInTheDocument();
   });
 
   it("renders report list when reports exist", async () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tsx
@@ -173,7 +173,7 @@ const SelectReportModal = ({
             canCreateReport ? (
               <>
                 <Button variant="link" onClick={onRunCustomReport}>
-                  Create a report
+                  Add a report
                 </Button>{" "}
                 to run.
               </>

--- a/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
+++ b/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
@@ -169,7 +169,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
                 className={`${baseClass}__create-button`}
                 onClick={onCreatePackClick}
               >
-                Create new pack
+                Add new pack
               </Button>
             </div>
           )}

--- a/frontend/pages/packs/ManagePacksPage/components/PacksTable/PacksTable.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksTable/PacksTable.tsx
@@ -68,7 +68,7 @@ const PacksTable = ({
           className={`${baseClass}__create-button`}
           onClick={onCreatePackClick}
         >
-          Create new pack
+          Add new pack
         </Button>
       ),
     };


### PR DESCRIPTION
**Related issue:** Resolves #48177

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized action wording across the UI from “Create” to “Add” for fleets, packs, users, and reports.
  * Updated related labels in command palette items, empty states, buttons, links, and modal titles to match the new terminology.

* **Tests**
  * Updated UI tests to assert the revised button and link text in affected fleet, host, and report flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->