### PR TITLE
Fix required password reset logging users out

### DIFF
--- a/changes/16292-password-reset-clear-sessions
+++ b/changes/16292-password-reset-clear-sessions
@@ -1,1 +1,1 @@
-* Improved session handling during password reset flows.
+* Fixed a regression where completing a required password reset would log the user out.

--- a/changes/16292-password-reset-clear-sessions
+++ b/changes/16292-password-reset-clear-sessions
@@ -1,1 +1,1 @@
-* Fixed a regression where completing a required password reset would log the user out.
+* Improved session handling during password reset flows.

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -1382,9 +1382,23 @@ func (svc *Service) PerformRequiredPasswordReset(ctx context.Context, password s
 	}
 
 	user.AdminForcedPasswordReset = false
-	err := svc.setNewPassword(ctx, user, password, true)
+	err := svc.setNewPassword(ctx, user, password, false)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "setting new password")
+	}
+
+	// Destroy all other sessions but keep the current one so the user
+	// completing the reset is not logged out.
+	sessions, err := svc.ds.ListSessionsForUser(ctx, user.ID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing user sessions")
+	}
+	for _, s := range sessions {
+		if s.ID != vc.Session.ID {
+			if err := svc.ds.DestroySession(ctx, s); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "destroying session")
+			}
+		}
 	}
 
 	return user, nil

--- a/server/service/users_test.go
+++ b/server/service/users_test.go
@@ -1854,7 +1854,7 @@ func TestPasswordChangeClearsTokensAndSessions(t *testing.T) {
 		assert.Equal(t, targetUser.ID, destroyedSessionsForUserID, "should destroy sessions for the correct user")
 	})
 
-	t.Run("PerformRequiredPasswordReset clears reset tokens and sessions", func(t *testing.T) {
+	t.Run("PerformRequiredPasswordReset clears other sessions but keeps current", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc, ctx := newTestService(t, ds, nil, nil)
 
@@ -1866,10 +1866,13 @@ func TestPasswordChangeClearsTokensAndSessions(t *testing.T) {
 		err := targetUser.SetPassword(test.GoodPassword, 10, 10)
 		require.NoError(t, err)
 
+		currentSession := &fleet.Session{ID: 1, UserID: targetUser.ID}
+		otherSession := &fleet.Session{ID: 2, UserID: targetUser.ID}
+
 		// CanPerformPasswordReset requires a session to be present.
 		ctx = viewer.NewContext(ctx, viewer.Viewer{
 			User:    targetUser,
-			Session: &fleet.Session{ID: 1, UserID: targetUser.ID},
+			Session: currentSession,
 		})
 
 		ds.SaveUserFunc = func(ctx context.Context, u *fleet.User) error {
@@ -1882,9 +1885,13 @@ func TestPasswordChangeClearsTokensAndSessions(t *testing.T) {
 			return nil
 		}
 
-		var destroyedSessionsForUserID uint
-		ds.DestroyAllSessionsForUserFunc = func(ctx context.Context, userID uint) error {
-			destroyedSessionsForUserID = userID
+		ds.ListSessionsForUserFunc = func(ctx context.Context, userID uint) ([]*fleet.Session, error) {
+			return []*fleet.Session{currentSession, otherSession}, nil
+		}
+
+		var destroyedSessionIDs []uint
+		ds.DestroySessionFunc = func(ctx context.Context, s *fleet.Session) error {
+			destroyedSessionIDs = append(destroyedSessionIDs, s.ID)
 			return nil
 		}
 
@@ -1894,7 +1901,9 @@ func TestPasswordChangeClearsTokensAndSessions(t *testing.T) {
 		assert.True(t, ds.DeletePasswordResetRequestsForUserFuncInvoked, "DeletePasswordResetRequestsForUser should be called")
 		assert.Equal(t, targetUser.ID, deletedPasswordResetForUserID, "should delete password reset tokens for the correct user")
 
-		assert.True(t, ds.DestroyAllSessionsForUserFuncInvoked, "DestroyAllSessionsForUser should be called for required password reset")
-		assert.Equal(t, targetUser.ID, destroyedSessionsForUserID, "should destroy sessions for the correct user")
+		assert.False(t, ds.DestroyAllSessionsForUserFuncInvoked, "DestroyAllSessionsForUser should NOT be called")
+		assert.True(t, ds.ListSessionsForUserFuncInvoked, "ListSessionsForUser should be called")
+		assert.True(t, ds.DestroySessionFuncInvoked, "DestroySession should be called")
+		assert.Equal(t, []uint{otherSession.ID}, destroyedSessionIDs, "should only destroy the other session, not the current one")
 	})
 }


### PR DESCRIPTION
# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Summary

Fixes a regression from #47860 where completing a required password reset caused the user's own active session to be invalidated, logging them out immediately after resetting their password.

The fix preserves the user's current session while correctly invalidating other sessions.

## Reproduction

1. Create a new user (admin_forced_password_reset defaults to true)
2. Log in as the new user
3. Complete the required password reset
4. **Before fix:** User gets a 401 error and is logged out
5. **After fix:** User lands on the home screen normally

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- [x] Confirmed that the fix is not expected to adversely impact load test results