### PR TITLE
Adding changes for Fleet v4.87.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Fleet 4.87.1 (Jun 25, 2026)
+
+### Bug fixes
+
+- Fixed a bug where an Apple SCEP certificate profile backed by NDES could be marked "failed" and consume one of the host's limited profile retry attempts when its challenge password expired, instead of being automatically resent with a fresh challenge.
+- Fixed GitOps runs failing with a `software_categories` duplicate-entry error when a software category's name differed only by characters MySQL's collation treats as equal (such as the Unicode variation selector in default categories like "🖥️ Productivity").
+- Fixed the **My device > Software** tab appending a `macos_applications` query parameter to the URL when paginating, even though that page has no /Applications filter.
+
 ## Fleet 4.87.0 (Jun 19, 2026)
 
 ### IT Admins

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v7.0.8
+version: v7.0.9
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -8,7 +8,7 @@ version: v7.0.8
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.87.0
+appVersion: v4.87.1
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.87.0 # Version of Fleet to deploy
+imageTag: v4.87.1 # Version of Fleet to deploy
 # imagePullPolicy is optional. If unset, Kubernetes defaults to IfNotPresent
 # for tagged images and Always for the :latest tag. Valid values: Always,
 # IfNotPresent, Never.

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.87.0"
+  default     = "fleetdm/fleet:v4.87.1"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.87.0"
+  default = "fleetdm/fleet:v4.87.1"
 }
 
 variable "software_installers_bucket_name" {

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.87.0",
+  "version": "v4.87.1",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/hangar/internal/gitrepo/git_test.go
+++ b/tools/hangar/internal/gitrepo/git_test.go
@@ -125,7 +125,7 @@ func TestParseBranchesRCGrouping(t *testing.T) {
 	raw := strings.Join([]string{
 		ref("rc-minor-fleet-v4.88.0", "a", "s", "me", "1d", "refs/heads/rc-minor-fleet-v4.88.0"),
 		ref("rc-patch-fleet-v4.88.1", "a", "s", "me", "2d", "refs/heads/rc-patch-fleet-v4.88.1"),
-		ref("rc-minor-fleet-v4.87.1", "a", "s", "me", "3d", "refs/heads/rc-minor-fleet-v4.87.1"),
+		ref("rc-minor-fleet-v4.87.0", "a", "s", "me", "3d", "refs/heads/rc-minor-fleet-v4.87.0"),
 		ref("rc-minor-fleet-v4.86.0", "a", "s", "me", "4d", "refs/heads/rc-minor-fleet-v4.86.0"), // current
 		ref("rc-minor-fleet-v4.85.0", "a", "s", "me", "5d", "refs/heads/rc-minor-fleet-v4.85.0"),
 	}, "\n")

--- a/tools/hangar/internal/gitrepo/git_test.go
+++ b/tools/hangar/internal/gitrepo/git_test.go
@@ -138,7 +138,7 @@ func TestParseBranchesRCGrouping(t *testing.T) {
 	}
 	// Keep 2 most-recent minor lines (4.88, 4.87) incl. the patch on 4.88,
 	// plus the current branch (4.86). Drop 4.85.
-	for _, want := range []string{"rc-minor-fleet-v4.88.0", "rc-patch-fleet-v4.88.1", "rc-minor-fleet-v4.87.1", "rc-minor-fleet-v4.86.0"} {
+	for _, want := range []string{"rc-minor-fleet-v4.88.0", "rc-patch-fleet-v4.88.1", "rc-minor-fleet-v4.87.0", "rc-minor-fleet-v4.86.0"} {
 		if !names[want] {
 			t.Errorf("expected %q in RC result, got %v", want, names)
 		}

--- a/tools/hangar/internal/gitrepo/git_test.go
+++ b/tools/hangar/internal/gitrepo/git_test.go
@@ -125,7 +125,7 @@ func TestParseBranchesRCGrouping(t *testing.T) {
 	raw := strings.Join([]string{
 		ref("rc-minor-fleet-v4.88.0", "a", "s", "me", "1d", "refs/heads/rc-minor-fleet-v4.88.0"),
 		ref("rc-patch-fleet-v4.88.1", "a", "s", "me", "2d", "refs/heads/rc-patch-fleet-v4.88.1"),
-		ref("rc-minor-fleet-v4.87.0", "a", "s", "me", "3d", "refs/heads/rc-minor-fleet-v4.87.0"),
+		ref("rc-minor-fleet-v4.87.1", "a", "s", "me", "3d", "refs/heads/rc-minor-fleet-v4.87.1"),
 		ref("rc-minor-fleet-v4.86.0", "a", "s", "me", "4d", "refs/heads/rc-minor-fleet-v4.86.0"), // current
 		ref("rc-minor-fleet-v4.85.0", "a", "s", "me", "5d", "refs/heads/rc-minor-fleet-v4.85.0"),
 	}, "\n")
@@ -138,7 +138,7 @@ func TestParseBranchesRCGrouping(t *testing.T) {
 	}
 	// Keep 2 most-recent minor lines (4.88, 4.87) incl. the patch on 4.88,
 	// plus the current branch (4.86). Drop 4.85.
-	for _, want := range []string{"rc-minor-fleet-v4.88.0", "rc-patch-fleet-v4.88.1", "rc-minor-fleet-v4.87.0", "rc-minor-fleet-v4.86.0"} {
+	for _, want := range []string{"rc-minor-fleet-v4.88.0", "rc-patch-fleet-v4.88.1", "rc-minor-fleet-v4.87.1", "rc-minor-fleet-v4.86.0"} {
 		if !names[want] {
 			t.Errorf("expected %q in RC result, got %v", want, names)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Fleet to version **v4.87.1** across Helm, Terraform, and the npm package.
  * Updated deployment image tags so environments using the chart or infrastructure defaults will pick up the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->