### PR TITLE
Restrict conditional access Okta IdP asset endpoints to privileged roles

### DIFF
--- a/changes/16288-conditional-access-authz
+++ b/changes/16288-conditional-access-authz
@@ -1,0 +1,1 @@
+- Restricted authorization for conditional access Okta IdP asset endpoints so that observer and observer+ roles can no longer read them.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -89,10 +89,10 @@ allow {
   action == write
 }
 
-# Global admin, gitops, maintainer, technician, observer_plus and observer can read Okta IdP assets.
+# Global admin, gitops, maintainer, and technician can read Okta IdP assets.
 allow {
   object.type == "conditional_access_idp_assets"
-  subject.global_role == [admin, gitops, maintainer, technician, observer_plus, observer][_]
+  subject.global_role == [admin, gitops, maintainer, technician][_]
   action == read
 }
 

--- a/server/service/conditional_access_idp_test.go
+++ b/server/service/conditional_access_idp_test.go
@@ -44,8 +44,8 @@ func TestConditionalAccessGetIdPSigningCertAuth(t *testing.T) {
 	}{
 		{"global admin", test.UserAdmin, false},
 		{"global maintainer", test.UserMaintainer, false},
-		{"global observer", test.UserObserver, false},
-		{"global observer+", test.UserObserverPlus, false},
+		{"global observer", test.UserObserver, true},
+		{"global observer+", test.UserObserverPlus, true},
 		{"global gitops", test.UserGitOps, false},
 		{"team admin", test.UserTeamAdminTeam1, true},
 		{"team maintainer", test.UserTeamMaintainerTeam1, true},
@@ -131,8 +131,8 @@ func TestConditionalAccessGetIdPAppleProfileAuth(t *testing.T) {
 	}{
 		{"global admin", test.UserAdmin, false},
 		{"global maintainer", test.UserMaintainer, false},
-		{"global observer", test.UserObserver, false},
-		{"global observer+", test.UserObserverPlus, false},
+		{"global observer", test.UserObserver, true},
+		{"global observer+", test.UserObserverPlus, true},
 		{"global gitops", test.UserGitOps, false},
 		{"team admin", test.UserTeamAdminTeam1, true},
 		{"team maintainer", test.UserTeamMaintainerTeam1, true},


### PR DESCRIPTION
# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated (authorization policy change only).

## Testing

- [x] Added/updated automated tests — the role matrix in `TestConditionalAccessGetIdPSigningCertAuth` and `TestConditionalAccessGetIdPAppleProfileAuth` now asserts observer and observer+ are denied; `go test ./server/authz/` confirms the policy compiles.
- [x] QA'd all new/changed functionality manually — covered by the automated role-matrix tests for this authz-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened access to conditional access identity provider assets so only higher-privilege roles can read them.
  * Users with observer and observer+ roles can no longer access these endpoints.
  * Updated validation coverage to reflect the revised access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->