### PR TITLE
Fleet UI: Activity feed outline only on keyboard focus

### DIFF
--- a/changes/47685-activity-outline
+++ b/changes/47685-activity-outline
@@ -1,0 +1,1 @@
+- Fixed the activity feed showing a focus outline when an activity was clicked. The outline now appears only when tabbing to an activity with the keyboard, matching the focus behavior used elsewhere in the UI.

--- a/frontend/components/FeedListItem/_styles.scss
+++ b/frontend/components/FeedListItem/_styles.scss
@@ -46,7 +46,7 @@
     padding: $pad-small;
     margin-bottom: $pad-large;
 
-    &:focus {
+    &:focus-visible {
       outline: 2px solid $ui-fleet-black-75;
     }
 


### PR DESCRIPTION
## Issue
Closes #47685

## Description
- Bug fix (root cause): Activity feed rows used `:focus`, which fires on mouse click — leaving a black outline around the activity after clicking. Switched to `:focus-visible` so the outline only appears when the user reaches an activity via keyboard navigation, matching the focus pattern used elsewhere in the UI.

## Screenrecording


https://github.com/user-attachments/assets/83ee97bc-e88a-4aac-97b4-1be3c093b719


## Testing

- [x] QA'd all new/changed functionality manually