### PR TITLE
fix: remove as a custom MDM command text from MDM command list view

### DIFF
--- a/changes/48297-fix-mdm-command-list-custom-label
+++ b/changes/48297-fix-mdm-command-list-custom-label
@@ -1,0 +1,1 @@
+* Fixed a bug where all MDM commands in the command list were incorrectly displayed as "custom MDM command". Only commands run via the custom MDM command API now display this label.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1859,26 +1859,6 @@ const HostDetailsPage = ({
           {!!mdmCommandDetails && (
             <CommandResultsModal
               command={mdmCommandDetails}
-              contentBody={
-                mdmCommandDetails.name === null
-                  ? (cls, result) => (
-                      <IconStatusMessage
-                        className={`${cls}__status-message`}
-                        iconName={getIconName(result.status)}
-                        message={
-                          <span>
-                            {formatMdmCommandNameForActivityItem(
-                              result.request_type
-                            )}
-                            {" on "}
-                            <b>{result.hostname}</b>
-                            {"."}
-                          </span>
-                        }
-                      />
-                    )
-                  : undefined
-              }
               onDone={onCancelMdmCommandDetailsModal}
             />
           )}


### PR DESCRIPTION
**Related issue:** Resolves #48297

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MDM command labeling in host details so only commands run through the custom MDM command API appear as “custom MDM command.”
  * Improved command details display for MDM items to show the appropriate label instead of applying the custom label broadly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->