### PR TITLE
Replace duplicate code with existing getDisplayedSoftwareName helper

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -336,9 +336,6 @@ type IInstallStatusCellProps = {
   isHostOnline?: boolean;
 };
 
-const getSoftwarePackageName = (software: IHostSoftware) =>
-  software.display_name || software.name;
-
 const resolveDisplayText = (
   displayText: IStatusDisplayConfig["displayText"],
   isSelfService: boolean,
@@ -403,7 +400,10 @@ const InstallStatusCell = ({
     !!software.app_store_app && isAndroid(software.app_store_app.platform);
   const lastInstall = getLastInstall(software); // TODO (back end bug fix) - `software.app_store_app.last_install sometimes coming back `null` for VPP apps, currently falls back to displaying the `InventoryVersionsModal`
   const lastUninstall = getLastUninstall(software);
-  const softwarePackageName = getSoftwarePackageName(software);
+  const softwarePackageName = getDisplayedSoftwareName(
+    software.name,
+    software.display_name
+  );
   const displayStatus = software.ui_status;
 
   if (displayStatus === "uninstalled" || displayStatus === "never_ran_script") {


### PR DESCRIPTION
Follow-up to https://github.com/fleetdm/fleet/pull/46839#discussion_r3475389665.

Related to #46921.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how software names are shown in install status views, so the displayed name now better matches the preferred label.
  * Added support for host online status when determining install status display and tooltip text, improving the accuracy of status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->