### PR TITLE
Website: Add FAQ to security and control page's header

### DIFF
--- a/website/api/controllers/view-security-and-control.js
+++ b/website/api/controllers/view-security-and-control.js
@@ -62,95 +62,79 @@ module.exports = {
 
     // Build a JSON FAQ to insert into this page's header.
     let pageFaqForSeo = {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      'mainEntity': [
         {
-          "@type": "Question",
-          "name": "What can Fleet detect on a device?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Fleet inventories more than installed applications. It reports on browser extensions across Chrome, Firefox, Safari, and Edge, IDE plugins, AI tools and MCP connectors, package manager installs like Homebrew and NPM, Python libraries, and operating system versions, across macOS, Windows, Linux, and more."
+          '@type': 'Question',
+          'name': 'What can Fleet detect on a device?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'Fleet inventories more than installed applications. It reports on browser extensions across Chrome, Firefox, Safari, and Edge, IDE plugins, AI tools and MCP connectors, package manager installs like Homebrew and NPM, Python libraries, and operating system versions, across macOS, Windows, Linux, and more.'
           }
         },
         {
-          "@type": "Question",
-          "name": "Can Fleet see browser extensions across my fleet?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Yes. Fleet reports every extension installed across Chrome, Firefox, Safari, and Edge, so you can find extensions that haven't been vetted or approved."
+          '@type': 'Question',
+          'name': 'Can Fleet see browser extensions across my fleet?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'Yes. Fleet reports every extension installed across Chrome, Firefox, Safari, and Edge, so you can find extensions that haven\'t been vetted or approved.'
           }
         },
         {
-          "@type": "Question",
-          "name": "How does Fleet block or remove unauthorized software?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "You set policies for what software is approved across your fleet. Fleet can block, remove, or allowlist software automatically. When it detects something unauthorized, Fleet can remove it or notify the user, depending on how your team prefers to work."
+          '@type': 'Question',
+          'name': 'How does Fleet block or remove unauthorized software?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'You set policies for what software is approved across your fleet. Fleet can block, remove, or allowlist software automatically. When it detects something unauthorized, Fleet can remove it or notify the user, depending on how your team prefers to work.'
           }
         },
         {
-          "@type": "Question",
-          "name": "How does Fleet prioritize vulnerabilities?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Not every CVE is equal. Fleet uses CISA Known Exploited Vulnerabilities (KEV) and EPSS data so your team focuses on vulnerabilities that are actually being exploited, not just those with high CVSS scores."
+          '@type': 'Question',
+          'name': 'How does Fleet prioritize vulnerabilities?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'Not every CVE is equal. Fleet uses CISA Known Exploited Vulnerabilities (KEV) and EPSS data so your team focuses on vulnerabilities that are actually being exploited, not just those with high CVSS scores.'
           }
         },
         {
-          "@type": "Question",
-          "name": "Does Fleet require network vulnerability scans?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "No. Fleet uses a lightweight agent instead of network scans, so you get up-to-date data from on-premises and remote devices without clogging your network."
+          '@type': 'Question',
+          'name': 'Does Fleet require network vulnerability scans?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'No. Fleet uses a lightweight agent instead of network scans, so you get up-to-date data from on-premises and remote devices without clogging your network.'
           }
         },
         {
-          "@type": "Question",
-          "name": "Can Fleet remediate vulnerabilities automatically?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Yes. When a device has vulnerable software, Fleet can install the correct version automatically, with no ticket and no manual intervention. When an update isn't available, Fleet can uninstall old versions, apply a workaround, or remove stale apps."
+          '@type': 'Question',
+          'name': 'Can Fleet remediate vulnerabilities automatically?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'Yes. When a device has vulnerable software, Fleet can install the correct version automatically, with no ticket and no manual intervention. When an update isn\'t available, Fleet can uninstall old versions, apply a workaround, or remove stale apps.'
           }
         },
         {
-          "@type": "Question",
-          "name": "Which operating systems does Fleet support?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Fleet manages and reports across macOS, Windows, Linux, iOS, iPadOS, Android, and ChromeOS from one place, so you spend less time reconciling data from multiple tools."
+          '@type': 'Question',
+          'name': 'Which operating systems does Fleet support?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'Fleet manages and reports across macOS, Windows, Linux, iOS, iPadOS, Android, and ChromeOS from one place, so you spend less time reconciling data from multiple tools.'
           }
         },
         {
-          "@type": "Question",
-          "name": "How does Fleet track AI tools and MCP connectors?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Fleet reports on which AI tools, MCP connectors, and IDE extensions are in use across your organization, so you can track adoption and identify unsanctioned tools."
+          '@type': 'Question',
+          'name': 'How does Fleet track AI tools and MCP connectors?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'Fleet reports on which AI tools, MCP connectors, and IDE extensions are in use across your organization, so you can track adoption and identify unsanctioned tools.'
           }
         },
         {
-          "@type": "Question",
-          "name": "How does Fleet keep changes reviewed and auditable?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Every change goes through a pull request that you review and approve from Slack or the Fleet UI. Fleet tracks who proposed each change, who approved it, and when it shipped, giving your security team a full audit trail."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Can changes in Fleet be rolled back?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Yes. You can roll back any change with a single revert, so changes become less risky instead of more work."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "How does Fleet patch software without disrupting users?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Fleet installs updates when apps are idle and notifies users before a reboot. You can exempt specific devices or people when needed."
+          '@type': 'Question',
+          'name': 'How does Fleet patch software without disrupting users?',
+          'acceptedAnswer': {
+            '@type': 'Answer',
+            'text': 'Fleet installs updates when apps are idle and notifies users before a reboot. You can exempt specific devices or people when needed.'
           }
         }
       ]

--- a/website/api/controllers/view-security-and-control.js
+++ b/website/api/controllers/view-security-and-control.js
@@ -60,10 +60,107 @@ module.exports = {
       });
     }//ﬁ
 
+    // Build a JSON FAQ to insert into this page's header.
+    let pageFaqForSeo = {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What can Fleet detect on a device?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Fleet inventories more than installed applications. It reports on browser extensions across Chrome, Firefox, Safari, and Edge, IDE plugins, AI tools and MCP connectors, package manager installs like Homebrew and NPM, Python libraries, and operating system versions, across macOS, Windows, Linux, and more."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can Fleet see browser extensions across my fleet?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Fleet reports every extension installed across Chrome, Firefox, Safari, and Edge, so you can find extensions that haven't been vetted or approved."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does Fleet block or remove unauthorized software?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "You set policies for what software is approved across your fleet. Fleet can block, remove, or allowlist software automatically. When it detects something unauthorized, Fleet can remove it or notify the user, depending on how your team prefers to work."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does Fleet prioritize vulnerabilities?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Not every CVE is equal. Fleet uses CISA Known Exploited Vulnerabilities (KEV) and EPSS data so your team focuses on vulnerabilities that are actually being exploited, not just those with high CVSS scores."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Fleet require network vulnerability scans?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. Fleet uses a lightweight agent instead of network scans, so you get up-to-date data from on-premises and remote devices without clogging your network."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can Fleet remediate vulnerabilities automatically?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. When a device has vulnerable software, Fleet can install the correct version automatically, with no ticket and no manual intervention. When an update isn't available, Fleet can uninstall old versions, apply a workaround, or remove stale apps."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Which operating systems does Fleet support?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Fleet manages and reports across macOS, Windows, Linux, iOS, iPadOS, Android, and ChromeOS from one place, so you spend less time reconciling data from multiple tools."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does Fleet track AI tools and MCP connectors?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Fleet reports on which AI tools, MCP connectors, and IDE extensions are in use across your organization, so you can track adoption and identify unsanctioned tools."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does Fleet keep changes reviewed and auditable?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Every change goes through a pull request that you review and approve from Slack or the Fleet UI. Fleet tracks who proposed each change, who approved it, and when it shipped, giving your security team a full audit trail."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can changes in Fleet be rolled back?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. You can roll back any change with a single revert, so changes become less risky instead of more work."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does Fleet patch software without disrupting users?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Fleet installs updates when apps are idle and notifies users before a reboot. You can exempt specific devices or people when needed."
+          }
+        }
+      ]
+    };
+
 
     // Respond with view.
     return {
       testimonialsForScrollableTweets,
+      pageFaqForSeo: JSON.stringify(pageFaqForSeo),
     };
 
 

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -149,7 +149,7 @@
     /* Otherwise, any such scripts are excluded, and we instead inject a
     robots/noindex meta tag to help prevent any unwanted visits from search engines. */
     else { %>
-
+    <meta name="robots" content="noindex">
     <% } %>
     <% /*
         Stylesheets

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -34,6 +34,11 @@
     <meta property="og:image" content="<%= typeof pageImageForMeta !== 'undefined' ? 'https://fleetdm.com' + pageImageForMeta : 'https://fleetdm.com/images/fleet-cloud-city-1200x627@2x.png' %>" />
     <meta property="og:title" content="Fleet | <% if (typeof pageTitleForMeta !== 'undefined') { %><%= pageTitleForMeta %><% } else { %><%- partial('../partials/primary-tagline.partial.ejs') %><% } %>" />
     <meta property="og:description" content="<%= typeof pageDescriptionForMeta !== 'undefined' ? pageDescriptionForMeta : defaultMetaDescription %>" />
+    <% if(typeof pageFaqForSeo !== 'undefined'){ %>
+    <script type="application/ld+json">
+      <%- pageFaqForSeo %>
+    </script>
+    <% } %>
     <% if (sails.config.environment === 'production') { %>
     <% /* ConsentMode */ %>
     <script>
@@ -144,7 +149,7 @@
     /* Otherwise, any such scripts are excluded, and we instead inject a
     robots/noindex meta tag to help prevent any unwanted visits from search engines. */
     else { %>
-    <meta name="robots" content="noindex">
+
     <% } %>
     <% /*
         Stylesheets


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/48052

Changes:
- Added a JSON FAQ to the security and control pages header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FAQ structured data (JSON-LD) to the “Security and control” page to enhance search engine understanding and visibility.
  * The page layout now conditionally renders the FAQ JSON-LD script in the document head when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->