### PR TITLE
Fix spacing around icons and add missing

### DIFF
--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -26,6 +26,7 @@ import useTeamIdParam from "hooks/useTeamIdParam";
 import BackButton from "components/BackButton";
 import Button from "components/buttons/Button";
 import DataSet from "components/DataSet";
+import Graphic from "components/Graphic";
 import Icon from "components/Icon";
 import MainContent from "components/MainContent";
 import PageDescription from "components/PageDescription";
@@ -342,12 +343,24 @@ const PolicyDetailsPage = ({
         title="Automations"
         value={
           <Button variant="link" onClick={openAutomationsModal}>
-            {firstAutomation.isSoftware && (
+            {firstAutomation.isSoftware ? (
               <SoftwareIcon
                 name={firstAutomation.iconName ?? firstAutomation.name}
                 url={firstAutomation.iconUrl}
                 size="small"
               />
+            ) : (
+              firstAutomation.graphicName && (
+                <Graphic
+                  name={firstAutomation.graphicName}
+                  className={
+                    firstAutomation.graphicName === "file-sh" ||
+                    firstAutomation.graphicName === "file-ps1"
+                      ? "scale-40-24"
+                      : ""
+                  }
+                />
+              )
             )}
             {firstAutomation.name}
             {moreCount > 0 && ` + ${moreCount} more`}

--- a/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
@@ -62,6 +62,13 @@
     gap: $pad-xsmall;
   }
 
+  &__automations {
+    .software-icon,
+    .graphic {
+      margin-right: $pad-xsmall;
+    }
+  }
+
   &__resolve dd {
     white-space: normal;
   }


### PR DESCRIPTION
Relates to #38670

Fix padding issue around automation icons and
add missing automation icons.
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy details now display the appropriate icon or graphic for automation entries beyond software automations.
  * Special styling is applied for certain file-related graphics to keep the layout aligned.
  * The automation name and “+ more” indicator continue to display as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->