### PR TITLE
Parse both date formats while parsing macos profiles for verification

### DIFF
--- a/changes/45947-fix-macos-profiles-stuck-verifying
+++ b/changes/45947-fix-macos-profiles-stuck-verifying
@@ -1,0 +1,1 @@
+- Fixed macOS configuration profiles getting stuck in "Verifying" when a host reported a profile install date in a 12-hour time format.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3020,12 +3020,14 @@ func buildConfigProfilesMacOSQuery(ctx context.Context, logger *slog.Logger, hos
 
 // parseMacOSProfileInstallDate parses the install_date reported by the
 // macos_profiles and macos_user_profiles tables. The value comes straight from
-// `/usr/bin/profiles -o stdout-xml`, which formats it using the host's locale.
+// `/usr/bin/profiles -o stdout-xml`, which seemingly formats it using the host's
+// locale in certain cases which have been observed but unfortunately not reproduced.
 // Depending on region and macOS version the time portion can be 24-hour
 // (NSDate.description, the common case) or 12-hour with an AM/PM marker, and on
 // macOS 14+ (CLDR 42) the AM/PM marker is preceded by a narrow no-break space
 // (U+202F) instead of an ASCII space.
 func parseMacOSProfileInstallDate(installDate string) (time.Time, error) {
+	// Replace narrow and standard-no-break spaces with a common ' ' space
 	normalized := strings.NewReplacer("\u202f", " ", "\u00a0", " ").Replace(installDate)
 	for _, layout := range []string{
 		"2006-01-02 15:04:05 -0700",   // 24-hour
@@ -3058,7 +3060,7 @@ func directIngestMacOSProfiles(
 	for _, row := range rows {
 		installDate, err := parseMacOSProfileInstallDate(row["install_date"])
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "directIngestMacOSProfiles")
+			return ctxerr.Wrap(ctx, err, "directIngestMacOSProfiles parse install_date")
 		}
 		if installDate.IsZero() {
 			// this should never happen, but if it does, we should log it

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3018,6 +3018,26 @@ func buildConfigProfilesMacOSQuery(ctx context.Context, logger *slog.Logger, hos
 	return query, true
 }
 
+// parseMacOSProfileInstallDate parses the install_date reported by the
+// macos_profiles and macos_user_profiles tables. The value comes straight from
+// `/usr/bin/profiles -o stdout-xml`, which formats it using the host's locale.
+// Depending on region and macOS version the time portion can be 24-hour
+// (NSDate.description, the common case) or 12-hour with an AM/PM marker, and on
+// macOS 14+ (CLDR 42) the AM/PM marker is preceded by a narrow no-break space
+// (U+202F) instead of an ASCII space.
+func parseMacOSProfileInstallDate(installDate string) (time.Time, error) {
+	normalized := strings.NewReplacer("\u202f", " ", "\u00a0", " ").Replace(installDate)
+	for _, layout := range []string{
+		"2006-01-02 15:04:05 -0700",   // 24-hour
+		"2006-01-02 3:04:05 PM -0700", // 12-hour with AM/PM
+	} {
+		if t, err := time.Parse(layout, normalized); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported install_date format %q", installDate)
+}
+
 func directIngestMacOSProfiles(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -3036,9 +3056,9 @@ func directIngestMacOSProfiles(
 
 	installed := make(map[string]*fleet.HostMacOSProfile, len(rows))
 	for _, row := range rows {
-		installDate, err := time.Parse("2006-01-02 15:04:05 -0700", row["install_date"])
+		installDate, err := parseMacOSProfileInstallDate(row["install_date"])
 		if err != nil {
-			return err
+			return ctxerr.Wrap(ctx, err, "directIngestMacOSProfiles")
 		}
 		if installDate.IsZero() {
 			// this should never happen, but if it does, we should log it

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -2502,9 +2502,109 @@ func TestDirectIngestHostMacOSProfiles(t *testing.T) {
 	// expect no error: empty rows
 	require.NoError(t, directIngestMacOSProfiles(ctx, logger, h, ds, []map[string]string{}))
 
-	// expect error: install date format is not "2006-01-02 15:04:05 -0700"
+	// expect no error: locale-formatted install dates (12-hour with AM/PM and a
+	// narrow no-break space) as emitted by `/usr/bin/profiles` on macOS 14+
+	fixedInstall := time.Date(2026, 4, 10, 16, 25, 20, 0, time.UTC)
+	for i := range installedProfiles {
+		installedProfiles[i].InstallDate = fixedInstall
+	}
+	rows = toRows(installedProfiles)
+	for _, row := range rows {
+		row["install_date"] = "2026-04-10 4:25:20\u202fPM +0000"
+	}
+	require.NoError(t, directIngestMacOSProfiles(ctx, logger, h, ds, rows))
+
+	// expect error: unrecognized install date format
 	rows[0]["install_date"] = time.Now().Format(time.UnixDate)
-	require.ErrorContains(t, directIngestMacOSProfiles(ctx, logger, h, ds, rows), "parsing time")
+	require.ErrorContains(t, directIngestMacOSProfiles(ctx, logger, h, ds, rows), "unsupported install_date format")
+}
+
+func TestParseMacOSProfileInstallDate(t *testing.T) {
+	const (
+		nnbsp = "\u202f" // narrow no-break space (U+202F), emitted by macOS 14+ before AM/PM
+		nbsp  = "\u00a0" // no-break space (U+00A0)
+	)
+
+	mustUTC := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:  "24-hour NSDate.description (common case)",
+			input: "2026-04-10 16:25:38 +0000",
+			want:  mustUTC("2026-04-10T16:25:38Z"),
+		},
+		{
+			// verbatim from a customer's `SELECT * FROM macos_profiles` output
+			name:  "12-hour PM with narrow no-break space (macOS 14+)",
+			input: "2026-04-10 4:25:20" + nnbsp + "PM +0000",
+			want:  mustUTC("2026-04-10T16:25:20Z"),
+		},
+		{
+			// verbatim from the same customer output
+			name:  "12-hour AM with narrow no-break space",
+			input: "2024-09-25 8:53:53" + nnbsp + "AM +0000",
+			want:  mustUTC("2024-09-25T08:53:53Z"),
+		},
+		{
+			name:  "12-hour with regular space (macOS 13 and earlier)",
+			input: "2026-04-10 4:25:20 PM +0000",
+			want:  mustUTC("2026-04-10T16:25:20Z"),
+		},
+		{
+			name:  "12-hour with no-break space",
+			input: "2026-04-10 4:25:20" + nbsp + "PM +0000",
+			want:  mustUTC("2026-04-10T16:25:20Z"),
+		},
+		{
+			name:  "noon",
+			input: "2026-04-10 12:00:00" + nnbsp + "PM +0000",
+			want:  mustUTC("2026-04-10T12:00:00Z"),
+		},
+		{
+			name:  "after midnight",
+			input: "2026-04-10 12:30:00" + nnbsp + "AM +0000",
+			want:  mustUTC("2026-04-10T00:30:00Z"),
+		},
+		{
+			name:  "two-digit 12-hour",
+			input: "2026-04-10 11:05:00" + nnbsp + "PM +0000",
+			want:  mustUTC("2026-04-10T23:05:00Z"),
+		},
+		{
+			name:  "non-UTC offset",
+			input: "2026-04-10 4:25:20" + nnbsp + "PM -0700",
+			want:  mustUTC("2026-04-10T23:25:20Z"),
+		},
+		{
+			name:    "unsupported format",
+			input:   "Fri Apr 10 16:25:38 PDT 2026",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMacOSProfileInstallDate(tc.input)
+			if tc.wantErr {
+				require.ErrorContains(t, err, "unsupported install_date format")
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, got.Equal(tc.want), "got %s, want %s", got.UTC(), tc.want)
+		})
+	}
 }
 
 func TestDirectIngestMDMDeviceIDWindows(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45947

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

We do not know how to repro the customer issue and I spent about 6 hours across a couple of days throwing everything I could at it so testing was limited to macos profile verification smoke testing and unit tests to confirm the time we see from customer logs and queries is now supported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where macOS configuration profiles could get stuck in “Verifying” when the reported install date uses a 12-hour time format.
  * Improved parsing of locale-formatted install dates, including handling of special spacing characters found on newer macOS versions.
  * Enhanced validation so unsupported or empty install date formats return clearer error messages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->