### PR TITLE
Fix policy selection resetting pagination to first page

### DIFF
--- a/changes/47246-policy-selection-pagination-reset
+++ b/changes/47246-policy-selection-pagination-reset
@@ -1,0 +1,1 @@
+- Fixed a bug where selecting a policy on the host details or self-service policies page reset the list back to the first page.

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -171,6 +171,11 @@ describe("HostPolicies", () => {
     expect(policyRow).not.toBeNull();
     await user.click(policyRow as HTMLElement);
 
+    // Confirm the click actually selected the policy and opened the modal —
+    // otherwise the page-retention assertions below could pass trivially.
+    // "Resolve:" only renders inside PolicyDetailsModal.
+    expect(screen.getByText("Resolve:")).toBeInTheDocument();
+
     // The table should still be on page 2 — Policy 21 belongs to page 2 and
     // is not rendered by the modal.
     expect(screen.queryAllByText("Policy 21").length).toBeGreaterThan(0);

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tests.tsx
@@ -120,6 +120,63 @@ describe("HostPolicies", () => {
     expect(screen.queryByText("No policies checked")).not.toBeInTheDocument();
   });
 
+  it("keeps the current pagination page when a policy is selected after first page", async () => {
+    const policies = Array.from({ length: 25 }, (_, i) =>
+      createMockHostPolicy({ id: i + 1, name: `Policy ${i + 1}` })
+    );
+
+    const Wrapper = () => {
+      const [selectedPolicy, setSelectedPolicy] = useState<IHostPolicy | null>(
+        null
+      );
+
+      const openModal = useCallback((p: IHostPolicy) => {
+        setSelectedPolicy(p);
+      }, []);
+
+      const closeModal = useCallback(() => {
+        setSelectedPolicy(null);
+      }, []);
+
+      return (
+        <>
+          <HostPolicies
+            {...baseProps}
+            policies={policies}
+            togglePolicyDetailsModal={openModal}
+            closePolicyDetailsModal={closeModal}
+          />
+          {selectedPolicy && (
+            <PolicyDetailsModal onCancel={closeModal} policy={selectedPolicy} />
+          )}
+        </>
+      );
+    };
+
+    const { user } = renderWithSetup(<Wrapper />);
+
+    // Each policy name renders twice (visible cell + truncation tooltip).
+    // Page 1 shows the first 20 policies.
+    expect(screen.queryAllByText("Policy 1").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Policy 21")).toHaveLength(0);
+
+    // Go to page 2.
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(screen.queryAllByText("Policy 1")).toHaveLength(0);
+    expect(screen.queryAllByText("Policy 21").length).toBeGreaterThan(0);
+
+    // Select a policy on page 2 (opens the details modal). Click the row
+    // rather than the name cell, which is a router Link.
+    const policyRow = screen.getAllByText("Policy 25")[0].closest("tr");
+    expect(policyRow).not.toBeNull();
+    await user.click(policyRow as HTMLElement);
+
+    // The table should still be on page 2 — Policy 21 belongs to page 2 and
+    // is not rendered by the modal.
+    expect(screen.queryAllByText("Policy 21").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Policy 1")).toHaveLength(0);
+  });
+
   it("closes the policy details modal when HostPolicies unmounts", async () => {
     // Simulates the policies tab unmounting (e.g. the user presses the
     // browser back button from /hosts/:id/policies to /hosts/:id, or

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 
 import { Row } from "react-table";
 
@@ -73,6 +73,13 @@ const Policies = ({
     [togglePolicyDetailsModal]
   );
 
+  // Memoize the table data so its reference stays stable across re-renders
+  // that don't change the policies.
+  const tableData = useMemo(
+    () => generatePolicyDataSet(policies, !!conditionalAccessEnabled),
+    [policies, conditionalAccessEnabled]
+  );
+
   const renderBanner = () => {
     if (!failingResponses?.length) {
       return null;
@@ -143,7 +150,7 @@ const Policies = ({
         {renderBanner()}
         <TableContainer
           columnConfigs={tableHeaders}
-          data={generatePolicyDataSet(policies, !!conditionalAccessEnabled)}
+          data={tableData}
           isLoading={isLoading}
           defaultSortHeader="status"
           resultsTitle="policies"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #47246

https://github.com/user-attachments/assets/411e9314-8390-4db5-b967-df9f8440a2b9

On the host details policies tab and the device user self-service policies page, clicking a policy while on any page other than the first reset the list back to page 1. To fix this, Memoize the data set so its reference stays stable across re-renders that don't change the policies.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where selecting a policy on the host details or self-service policies pages could reset the policy list pagination back to the first page.
* **Tests**
  * Added a test to confirm pagination state is retained when navigating to policy details from a non-first page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->