### PR TITLE
Pin-cleanup on FMA delete

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1056,6 +1056,12 @@ func (svc *Service) deleteSoftwareInstaller(ctx context.Context, meta *fleet.Sof
 					return ctxerr.Wrap(ctx, err, "deleting cached FMA version")
 				}
 			}
+			// The pin row is keyed by (team, title) and is not cascade-deleted when
+			// installer rows go away (only when the title row is deleted), so clear
+			// it explicitly to avoid a stale pin surviving a delete + re-add.
+			if err := svc.ds.DeletePinnedVersion(ctx, meta.TeamID, *meta.TitleID); err != nil {
+				return ctxerr.Wrap(ctx, err, "deleting pinned version after FMA removal")
+			}
 		}
 	default:
 		if err := svc.ds.DeleteSoftwareInstaller(ctx, meta.InstallerID); err != nil {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2609,6 +2609,14 @@ WHERE
   title_id NOT IN (?)
 `
 
+	// Fleet-maintained app pins are keyed by (team, title) and are not
+	// cascade-deleted when installer rows go away (the FK cascades only on title
+	// deletion, which BatchSet doesn't do), so clear pins for removed titles
+	// explicitly. Reused with a sentinel 0 to clear all pins for the team.
+	const deletePinnedVersionsNotInList = `
+DELETE FROM software_title_team_pins WHERE team_id = ? AND title_id NOT IN (?)
+`
+
 	// ORDER BY is_active DESC, id DESC makes existing[0] the previously-active row.
 	const checkExistingInstaller = `
 SELECT
@@ -2869,6 +2877,11 @@ WHERE
 				return ctxerr.Wrap(ctx, err, "delete obsolete software installers")
 			}
 
+			// reuse the NOT IN query with sentinel 0 to clear all FMA pins for the team
+			if _, err := tx.ExecContext(ctx, deletePinnedVersionsNotInList, globalOrTeamID, 0); err != nil {
+				return ctxerr.Wrap(ctx, err, "delete all FMA version pins")
+			}
+
 			return nil
 		}
 
@@ -3033,6 +3046,14 @@ WHERE
 		}
 		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete obsolete software installers")
+		}
+
+		stmt, args, err = sqlx.In(deletePinnedVersionsNotInList, globalOrTeamID, titleIDs)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "build statement to delete obsolete FMA pins")
+		}
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete obsolete FMA version pins")
 		}
 
 		// Fill a map of title IDs for this team that have a display name

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -33501,6 +33501,30 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 		"version": {"1.0"},
 	})
 	s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", customTitleID), body.Bytes(), http.StatusBadRequest, headers)
+
+	// --- Deleting an FMA clears its pin row ---
+
+	// The pin row is keyed on (team, title); the title row outlives the installer
+	// rows, so without explicit cleanup a stale pin would resurface on re-add.
+	pinRowCount := func() int {
+		var n int
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &n,
+				"SELECT COUNT(*) FROM software_title_team_pins WHERE team_id = ? AND title_id = ?", team.ID, titleID)
+		})
+		return n
+	}
+	patchVersion("10.0")
+	require.Equal(t, new("10.0"), getPkg().PinnedVersion)
+	require.Equal(t, 1, pinRowCount())
+
+	// The policies attached above block a delete, so remove them first.
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/policies/delete", team.ID),
+		fleet.DeleteTeamPoliciesRequest{IDs: []uint{installPol.Policy.ID, patchPol.Policy.ID}},
+		http.StatusOK, &fleet.DeleteTeamPoliciesResponse{})
+
+	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", fmt.Sprint(team.ID))
+	require.Equal(t, 0, pinRowCount(), "deleting an FMA must delete its pin row")
 }
 
 func (s *integrationEnterpriseTestSuite) TestResetPolicy() {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -33525,6 +33525,35 @@ func (s *integrationEnterpriseTestSuite) TestFleetMaintainedAppVersionPin() {
 
 	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", fmt.Sprint(team.ID))
 	require.Equal(t, 0, pinRowCount(), "deleting an FMA must delete its pin row")
+
+	// --- GitOps removal also clears the pin ---
+
+	// Re-add zoom (deleted above) and pin it via GitOps.
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows")}})
+	batchSet([]*fleet.SoftwareInstallerPayload{{Slug: new("zoom/windows"), RollbackVersion: "10.0"}})
+	require.Equal(t, 1, pinRowCount())
+
+	// Dropping zoom from the config (chrome stays) clears its pin via the
+	// title_id-NOT-IN removal path.
+	batchSet([]*fleet.SoftwareInstallerPayload{})
+	require.Equal(t, 0, pinRowCount(), "removing an FMA via GitOps must delete its pin row")
+
+	// An empty config (remove all software) clears every pin for the team,
+	// including chrome's "^149", via the delete-all path.
+	teamPinCount := func() int {
+		var n int
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &n, "SELECT COUNT(*) FROM software_title_team_pins WHERE team_id = ?", team.ID)
+		})
+		return n
+	}
+	require.NotZero(t, teamPinCount()) // chrome's "^149" pin is present
+	var emptyResp batchSetSoftwareInstallersResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/batch",
+		batchSetSoftwareInstallersRequest{Software: []*fleet.SoftwareInstallerPayload{}, TeamName: team.Name},
+		http.StatusAccepted, &emptyResp, "team_name", team.Name)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, emptyResp.RequestUUID)
+	require.Zero(t, teamPinCount(), "removing all software via GitOps must delete all team pins")
 }
 
 func (s *integrationEnterpriseTestSuite) TestResetPolicy() {


### PR DESCRIPTION
**Related issue:** Resolves #48309

  Deleting a Fleet-maintained app from a team now also deletes its `software_title_team_pins` row. Previously the pin survived the delete (the FK cascades only on title deletion, and the title row outlives the installer rows), so re-adding the app resurfaced a stale pin pointing at a version no longer cached.

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually
