### PR TITLE
Return per-version filename in fleet_maintained_versions

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -119,6 +119,7 @@ export interface ISoftwareAppStoreAppStatus {
 export interface IFleetMaintainedVersion {
   id: number;
   version: string;
+  filename: string;
   uploaded_at: string;
 }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -299,7 +299,7 @@ const SoftwareTitleDetailsPage = ({
           {rows.map((row) => (
             <LibraryItemAccordion
               key={row.id}
-              filename={pkg.name}
+              filename={row.filename ?? pkg.name}
               version={row.version}
               addedAt={row.uploaded_at}
               installerType="package"

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/VersionsModal.tests.tsx
@@ -27,8 +27,18 @@ const fmaPackage = (overrides?: Partial<ISoftwarePackage>) =>
     fleet_maintained_app_id: 5,
     version: "149.0.2",
     fleet_maintained_versions: [
-      { id: 1, version: "149.0.2", uploaded_at: "2026-01-02T00:00:00Z" },
-      { id: 2, version: "148.0.1", uploaded_at: "2026-01-01T00:00:00Z" },
+      {
+        id: 1,
+        version: "149.0.2",
+        filename: "installer-149.0.2.pkg",
+        uploaded_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: 2,
+        version: "148.0.1",
+        filename: "installer-148.0.1.pkg",
+        uploaded_at: "2026-01-01T00:00:00Z",
+      },
     ],
     ...overrides,
   });
@@ -84,8 +94,18 @@ describe("VersionsModal", () => {
     renderModal({
       pinned_version: "^149",
       fleet_maintained_versions: [
-        { id: 1, version: "149.0.2", uploaded_at: "2026-01-02T00:00:00Z" },
-        { id: 2, version: "149.0.1", uploaded_at: "2026-01-01T00:00:00Z" },
+        {
+          id: 1,
+          version: "149.0.2",
+          filename: "installer-149.0.2.pkg",
+          uploaded_at: "2026-01-02T00:00:00Z",
+        },
+        {
+          id: 2,
+          version: "149.0.1",
+          filename: "installer-149.0.1.pkg",
+          uploaded_at: "2026-01-01T00:00:00Z",
+        },
       ],
     });
     expect(
@@ -99,7 +119,12 @@ describe("VersionsModal", () => {
     renderModal({
       pinned_version: "^148",
       fleet_maintained_versions: [
-        { id: 1, version: "149.0.2", uploaded_at: "2026-01-02T00:00:00Z" },
+        {
+          id: 1,
+          version: "149.0.2",
+          filename: "installer-149.0.2.pkg",
+          uploaded_at: "2026-01-02T00:00:00Z",
+        },
       ],
     });
     expect(

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/VersionsModal/helpers.tests.ts
@@ -7,6 +7,7 @@ import {
 const v = (id: number, version: string) => ({
   id,
   version,
+  filename: `installer-${version}.pkg`,
   uploaded_at: "2026-01-01T00:00:00Z",
 });
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
@@ -4,6 +4,7 @@ import { buildLibraryVersionRows, getInstallerCardInfo } from "./helpers";
 const v = (id: number, version: string) => ({
   id,
   version,
+  filename: `installer-${version}.pkg`,
   uploaded_at: "2026-01-01T00:00:00Z",
 });
 
@@ -41,6 +42,22 @@ describe("SoftwareTitleDetailsPage helpers", () => {
       expect(rows.map((r) => [r.version, r.isActive, r.badgeState])).toEqual([
         ["149.0.7827.54", true, "latest"],
         ["148.0.7778.179", false, undefined],
+      ]);
+    });
+
+    it("carries each version's own filename through to its row", () => {
+      const rows = buildLibraryVersionRows({
+        fleetMaintainedVersions: [
+          v(1, "149.0.7827.54"),
+          v(2, "148.0.7778.179"),
+        ],
+        activeVersion: "149.0.7827.54",
+        pinnedVersion: null,
+        addedTimestamp: "x",
+      });
+      expect(rows.map((r) => r.filename)).toEqual([
+        "installer-149.0.7827.54.pkg",
+        "installer-148.0.7778.179.pkg",
       ]);
     });
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
@@ -36,6 +36,7 @@ export interface InstallerCardInfo {
 export interface ILibraryVersionRow {
   id: number;
   version: string;
+  filename?: string;
   uploaded_at: string;
   isActive: boolean;
   badgeState?: LibraryItemBadgeState;

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -6262,7 +6262,7 @@ func testSetFleetMaintainedAppActiveInstallerPin(t *testing.T, ds *Datastore) {
 			INSERT INTO software_installers
 				(team_id, global_or_team_id, storage_id, filename, extension, version, platform, title_id,
 				 fleet_maintained_app_id, install_script_content_id, uninstall_script_content_id, is_active, package_ids, patch_query)
-			SELECT team_id, global_or_team_id, 'storageid2', filename, extension, '2.0', platform, title_id,
+			SELECT team_id, global_or_team_id, 'storageid2', 'test2.pkg', extension, '2.0', platform, title_id,
 				fleet_maintained_app_id, install_script_content_id, uninstall_script_content_id, 0, package_ids, patch_query
 			FROM software_installers WHERE id = ?
 		`, v1ID)
@@ -6272,6 +6272,15 @@ func testSetFleetMaintainedAppActiveInstallerPin(t *testing.T, ds *Datastore) {
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		return sqlx.GetContext(ctx, q, &v2ID, `SELECT id FROM software_installers WHERE title_id=? AND global_or_team_id=0 AND version='2.0'`, titleID)
 	})
+
+	// GetFleetMaintainedVersionsByTitleID returns each cached version's own filename.
+	fmaVersions, err := ds.GetFleetMaintainedVersionsByTitleID(ctx, nil, titleID, false)
+	require.NoError(t, err)
+	gotFilenames := map[string]string{}
+	for _, fv := range fmaVersions {
+		gotFilenames[fv.Version] = fv.Filename
+	}
+	require.Equal(t, map[string]string{"1.0": "test.pkg", "2.0": "test2.pkg"}, gotFilenames)
 
 	activeID := func() uint {
 		var id uint

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -1010,7 +1010,7 @@ func (ds *Datastore) getFleetMaintainedVersionsByTitleIDs(ctx context.Context, q
 	}
 
 	query := `
-		SELECT si.id, si.version, si.title_id, si.uploaded_at
+		SELECT si.id, si.version, si.filename, si.title_id, si.uploaded_at
 			FROM software_installers si
 		WHERE si.title_id IN (?) AND si.global_or_team_id = ? AND si.fleet_maintained_app_id IS NOT NULL
 		ORDER BY si.title_id, si.uploaded_at DESC

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -380,6 +380,8 @@ type FleetMaintainedVersion struct {
 	ID uint `json:"id" db:"id"`
 	// Version is the version string.
 	Version string `json:"version" db:"version"`
+	// Filename is the installer filename for this version.
+	Filename string `json:"filename" db:"filename"`
 	// UploadedAt is when this version was added to the database.
 	UploadedAt time.Time `json:"uploaded_at" db:"uploaded_at"`
 }


### PR DESCRIPTION
**Related issue:** Resolves #48334

  The software title response now returns a per-version `filename` in `fleet_maintained_versions`, and the Library version rows render each version's own filename instead of the active installer's. Previously, every cached-version row showed the active installer's filename because the array didn't include one.

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually
