### PR TITLE
Fixing android tests

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -5651,6 +5651,9 @@ func setupAndroidCertificatesTestMocks(t *testing.T, ds *mock.Store) []*fleet.Ce
 	ds.CreatePendingCertificateTemplatesForExistingHostsFunc = func(ctx context.Context, certificateTemplateID uint, teamID uint) (int64, error) {
 		return 0, nil
 	}
+	ds.SetCertificateTemplateVariablesFunc = func(ctx context.Context, certTemplateID uint, fleetVars []fleet.FleetVarName) error {
+		return nil
+	}
 
 	// Mock for looking up certificate template by team ID and name
 	var templateIDCounter uint

--- a/cmd/fleetctl/fleetctl/testing_utils_test.go
+++ b/cmd/fleetctl/fleetctl/testing_utils_test.go
@@ -289,6 +289,9 @@ func setupEmptyGitOpsMocks(ds *mock.Store) {
 	ds.CreatePendingCertificateTemplatesForExistingHostsFunc = func(ctx context.Context, certificateTemplateID uint, teamID uint) (int64, error) {
 		return 0, nil
 	}
+	ds.SetCertificateTemplateVariablesFunc = func(ctx context.Context, certTemplateID uint, fleetVars []fleet.FleetVarName) error {
+		return nil
+	}
 	ds.SetHostCertificateTemplatesToPendingRemoveFunc = func(ctx context.Context, certTmplID uint) error {
 		return nil
 	}


### PR DESCRIPTION


https://github.com/fleetdm/fleet/actions/runs/28218912241/job/83595668272

`cmd/fleetctl/fleetctl TestGitOpsAndroidCertificatesAdd`
`cmd/fleetctl/fleetctl TestGitOpsAndroidCertificatesChange`
`cmd/fleetctl/fleetctl TestGitOpsAndroidCertificatesDeleteOne`

Panic triggered due to missing mock
```
created by net/http.(*Server).Serve in goroutine 1296276
	/opt/hostedtoolcache/go/1.26.4/x64/src/net/http/server.go:3464 +0x88a
    gitops_test.go:6099: 
        	Error Trace:	/home/runner/work/fleet/fleet/cmd/fleetctl/fleetctl/gitops_test.go:6099
        	Error:      	Received unexpected error:
        	            	applying Android certificates: POST /api/latest/fleet/spec/certificates: do request: Post "http://127.0.0.1:39447/api/latest/fleet/spec/certificates": EOF (API time: 4ms)
        	Test:       	TestGitOpsAndroidCertificatesDeleteOne
```

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Updated the test mocks used for GitOps and fleetctl scenarios to support certificate template variable updates.
  * Prevents failures when certificate template variable setting is invoked during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->