### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/inputs/winget/vnc-viewer.json
+++ b/ee/maintained-apps/inputs/winget/vnc-viewer.json
@@ -8,6 +8,7 @@
   "installer_arch": "x64",
   "installer_type": "zip",
   "installer_scope": "machine",
+  "frozen": true,
   "default_categories": ["Productivity"],
   "exists_query": "SELECT 1 FROM programs WHERE (name LIKE 'RealVNC Viewer %' OR name LIKE 'RealVNC Connect Viewer %') AND publisher = 'RealVNC';"
 }

--- a/ee/maintained-apps/outputs/alcove/darwin.json
+++ b/ee/maintained-apps/outputs/alcove/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.7.5",
+      "version": "1.7.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.henrikruscon.Alcove';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.henrikruscon.Alcove' AND version_compare(bundle_short_version, '1.7.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.henrikruscon.Alcove' AND version_compare(bundle_short_version, '1.7.7') < 0);"
       },
       "installer_url": "https://download.tryalcove.com/Alcove.dmg",
       "install_script_ref": "a58c1d28",

--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.606",
+      "version": "6.609",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.606') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.609') < 0);"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.606-2026062402.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.609-2026062603.zip",
       "install_script_ref": "920c563d",
       "uninstall_script_ref": "b0dc7152",
-      "sha256": "e7be72c697125b23d36b9add3b232b6ab80a6d429a13857403ab3596b6f85ec5",
+      "sha256": "b0770364a91d968a3f3916bd88f9e1f331d8cda8f2848ef21a9130dd9ae43477",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/drawio/darwin.json
+++ b/ee/maintained-apps/outputs/drawio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "30.2.4",
+      "version": "30.2.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '30.2.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '30.2.6') < 0);"
       },
-      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.2.4/draw.io-arm64-30.2.4.dmg",
+      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.2.6/draw.io-arm64-30.2.6.dmg",
       "install_script_ref": "1f3003b7",
       "uninstall_script_ref": "19c87f7a",
-      "sha256": "c3aad06da601d40b4a7842a8d51b414038e312b4a5c66a05a6a022952b25e423",
+      "sha256": "259117e3b04ac93fb175268e127896a6cfbdc451fe1edea0dc33121aaaff9a54",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.372.1",
+      "version": "7.372.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.372.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.372.2') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.372.1/Granola-7.372.1-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.372.2/Granola-7.372.2-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "92742c1e32d760304d8e214d2cd0562458cfe2dbb25dc5a55d4545b8bee3c040",
+      "sha256": "66def0f75334af1a6fc21d068f7744a1bd6c1caaa12a001a2fa173fb952e2283",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/lens/darwin.json
+++ b/ee/maintained-apps/outputs/lens/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.6.231104-latest",
+      "version": "2026.6.260931-latest",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens' AND version_compare(bundle_short_version, '2026.6.231104-latest') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.kontena-lens' AND version_compare(bundle_short_version, '2026.6.260931-latest') < 0);"
       },
-      "installer_url": "https://api.k8slens.dev/binaries/Lens-2026.6.231104-latest-arm64.dmg",
+      "installer_url": "https://api.k8slens.dev/binaries/Lens-2026.6.260931-latest-arm64.dmg",
       "install_script_ref": "e8691291",
       "uninstall_script_ref": "ea665c04",
-      "sha256": "8a01626fb62009a77718adcaa063063957b7061c5070c785f64568452fce684f",
+      "sha256": "b30b9266baf85485e42acc819e838b202cbeb8b6c03a1a295453547aa548abdc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/lens/windows.json
+++ b/ee/maintained-apps/outputs/lens/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.6.231104-latest",
+      "version": "2026.6.260931-latest",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Lens %' AND publisher = 'Mirantis, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Lens %' AND publisher = 'Mirantis, Inc.' AND version_compare(version, '2026.6.231104-latest') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Lens %' AND publisher = 'Mirantis, Inc.' AND version_compare(version, '2026.6.260931-latest') < 0);"
       },
-      "installer_url": "https://downloads.k8slens.dev/ide/Lens%20Setup%202026.6.231104-latest.exe",
+      "installer_url": "https://downloads.k8slens.dev/ide/Lens%20Setup%202026.6.260931-latest.exe",
       "install_script_ref": "c6fa52b0",
       "uninstall_script_ref": "415f448d",
-      "sha256": "8c2746f1e1a50c0b83054474e119134bfcc46cd0c938ba6035b39306f605f064",
+      "sha256": "3a6d9f8b2fb1ba2d2962f1779b046810d63489b9aad264622119b81e3fb30afc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.39",
+      "version": "3.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.0.39') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.0') < 0);"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.0.39.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.0.zip",
       "install_script_ref": "c6782863",
       "uninstall_script_ref": "9e4b9fca",
-      "sha256": "6d60c9e84c1662fc73a9b450ca9d0d04398987b2f5499d3af9853a0aa8ebbb08",
+      "sha256": "193ec49325928839b8c72fbffba128ffa4cddb478527c1dd774115ea0b670251",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.80",
+      "version": "149.0.4022.96",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '149.0.4022.80') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '149.0.4022.96') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/8c19fadc-2e0b-4e3c-97a8-b33956b14985/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/96f71ebf-d93a-4a10-80af-5c5380af81f5/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "94b9340286cf255aea188b7977e2574a42f5dcdb4a73d1aa90b292f9cc850d40",
+      "sha256": "793f753122566fe30e1382b148725a4fedfeeb79732608e2fba78b498166aeb3",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/vnc-viewer/windows.json
+++ b/ee/maintained-apps/outputs/vnc-viewer/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.15.1.18",
+      "version": "8.4.1.10",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE (name LIKE 'RealVNC Viewer %' OR name LIKE 'RealVNC Connect Viewer %') AND publisher = 'RealVNC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE ((name LIKE 'RealVNC Viewer %' OR name LIKE 'RealVNC Connect Viewer %') AND publisher = 'RealVNC') AND version_compare(version, '7.15.1.18') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE ((name LIKE 'RealVNC Viewer %' OR name LIKE 'RealVNC Connect Viewer %') AND publisher = 'RealVNC') AND version_compare(version, '8.4.1.10') < 0);"
       },
-      "installer_url": "https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-7.15.1-Windows-msi.zip",
+      "installer_url": "https://downloads.realvnc.com/download/file/realvnc-connect-viewer/RealVNC-Connect-Viewer-8.4.1-Windows.msi.zip",
       "install_script_ref": "74f06b30",
       "uninstall_script_ref": "4f8e8fe6",
-      "sha256": "87d11921ca0256587c73a47b61b53faca752fd76752bb9701e1670855f57e40e",
+      "sha256": "84cd9dec42215217ad36fb4d2f905afc146bd2a6fcc42bd85981464ee13ff353",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/vnc-viewer/windows.json
+++ b/ee/maintained-apps/outputs/vnc-viewer/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.4.1.10",
+      "version": "7.15.1.18",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE (name LIKE 'RealVNC Viewer %' OR name LIKE 'RealVNC Connect Viewer %') AND publisher = 'RealVNC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE ((name LIKE 'RealVNC Viewer %' OR name LIKE 'RealVNC Connect Viewer %') AND publisher = 'RealVNC') AND version_compare(version, '8.4.1.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE ((name LIKE 'RealVNC Viewer %' OR name LIKE 'RealVNC Connect Viewer %') AND publisher = 'RealVNC') AND version_compare(version, '7.15.1.18') < 0);"
       },
-      "installer_url": "https://downloads.realvnc.com/download/file/realvnc-connect-viewer/RealVNC-Connect-Viewer-8.4.1-Windows.msi.zip",
+      "installer_url": "https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-7.15.1-Windows-msi.zip",
       "install_script_ref": "74f06b30",
       "uninstall_script_ref": "4f8e8fe6",
-      "sha256": "84cd9dec42215217ad36fb4d2f905afc146bd2a6fcc42bd85981464ee13ff353",
+      "sha256": "87d11921ca0256587c73a47b61b53faca752fd76752bb9701e1670855f57e40e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wechat/darwin.json
+++ b/ee/maintained-apps/outputs/wechat/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.1.11.21",
+      "version": "4.1.11.23",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.11.21') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.11.23') < 0);"
       },
-      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.11.21_40446.dmg",
+      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.11.23_40493.dmg",
       "install_script_ref": "57f30b74",
       "uninstall_script_ref": "18d6be1e",
-      "sha256": "a229eece2bc260f70e1618c59051f6f1abb2c3e9473929f8cbf6b2c7f9462bcc",
+      "sha256": "ebda8533ec85c9f92741d1178ac197efbec9856cae056842e7521b2bf6685e62",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/xnviewmp/windows.json
+++ b/ee/maintained-apps/outputs/xnviewmp/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.11.2.0",
+      "version": "1.11.4.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'XnView MP' AND publisher = 'Pierre-e Gougelet';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'XnView MP' AND publisher = 'Pierre-e Gougelet' AND version_compare(version, '1.11.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'XnView MP' AND publisher = 'Pierre-e Gougelet' AND version_compare(version, '1.11.4.0') < 0);"
       },
-      "installer_url": "https://download.xnview.com/old_versions/XnView_MP/XnView_MP-1.11.2-win-x64.exe",
+      "installer_url": "https://download.xnview.com/old_versions/XnView_MP/XnView_MP-1.11.4-win-x64.exe",
       "install_script_ref": "7eb6b47e",
       "uninstall_script_ref": "bfabc3a8",
-      "sha256": "b98de5ad8b3d02e9d92496420cc290196540970b8a8fefa1b0394b129a31e594",
+      "sha256": "a3c362df7d1589d1e1cee4cdac052e86479f4152cafe3e10acc9d58aafc00991",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated version information, download links, and package checksums for several managed apps, including Alcove, BetterTouchTool, draw.io, Granola, Lens, Marked, Microsoft Edge, WeChat, and XnView MP.
  * Added an update lock for VNC Viewer to keep its current package version fixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->