### PR TITLE
Left-align Advanced options toggle in vuln exposure chart filter

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
@@ -162,6 +162,7 @@ const SoftwareFilters = ({
       </div>
 
       <RevealButton
+        className={`${baseClass}__advanced-toggle`}
         isShowing={showAdvanced}
         showText="Advanced options"
         hideText="Advanced options"

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/_styles.scss
@@ -33,6 +33,10 @@
     gap: $pad-small;
   }
 
+  &__advanced-toggle {
+    align-self: flex-start;
+  }
+
   &__advanced {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Visual polish for the unreleased Vulnerability Exposure chart filter (part of #47674 / #44746)

Left-aligns the "Advanced options" reveal toggle in the chart filter modal's Software tab so it matches the design. Previously the toggle stretched to the full width of the column-flex container and its content was centered; this adds `align-self: flex-start` so it hugs the left edge.

## Before / After
- **Before:** "Advanced options" toggle centered in the panel.
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/b4cbe5fc-832e-415b-af31-bfd3ca14085d" />

- **After:** Left-aligned, matching the Figma design.
<img width="400" alt="CleanShot 2026-06-26 at 12 20 50@2x" src="https://github.com/user-attachments/assets/6204bc50-eb1a-4abc-bee6-45f6bb161bb2" />

# Checklist for submitter

- [x] QA'd all new/changed functionality manually

<!-- Frontend-only CSS alignment fix on an unreleased feature — DB/config/orbit/changes-file sections below are N/A and removed per template instructions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the alignment of the “Advanced options” toggle in the software filters panel for a cleaner layout.
* **Bug Fixes**
  * Improved the positioning of the toggle button so it aligns consistently within the filter section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->