### PR TITLE
Use active custom script if available

### DIFF
--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -283,6 +283,35 @@ func downloadNewVersionIfEligible(
 		InstallerFile:   tfr,
 	}
 
+	// Preserve admin-customized scripts across auto-updates. The active installer
+	// (still the previous version here; promotion happens later) is the one to
+	// carry forward from. Detect customization per-script by comparing against the
+	// manifest: the install script is a version-independent template (direct
+	// compare), but the uninstall script is version-specific after $PACKAGE_ID /
+	// $UPGRADE_CODE substitution, so compare against the manifest template
+	// substituted with the active version's package IDs.
+	active, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, c.TeamID, c.TitleID, true)
+	if err != nil && !fleet.IsNotFound(err) {
+		return ctxerr.Wrap(ctx, err, "getting active installer to preserve custom scripts")
+	}
+	if active != nil {
+		if strings.TrimSpace(active.InstallScript) != strings.TrimSpace(app.InstallScript) {
+			payload.InstallScript = active.InstallScript
+		}
+		defaultUninstall := &fleet.UploadSoftwareInstallerPayload{
+			UninstallScript: app.UninstallScript,
+			PackageIDs:      active.PackageIDs(),
+			UpgradeCode:     active.UpgradeCode,
+			Extension:       active.Extension,
+		}
+		if err := preProcessUninstallScript(defaultUninstall); err != nil {
+			return ctxerr.Wrap(ctx, err, "computing manifest uninstall script for comparison")
+		}
+		if strings.TrimSpace(active.UninstallScript) != strings.TrimSpace(defaultUninstall.UninstallScript) {
+			payload.UninstallScript = active.UninstallScript
+		}
+	}
+
 	// Substitute $PACKAGE_ID / $UPGRADE_CODE in the uninstall script, matching the
 	// GitOps materialization path (no-op when there are no package IDs).
 	if err := preProcessUninstallScript(payload); err != nil {

--- a/ee/server/service/maintained_apps_auto_update_download_test.go
+++ b/ee/server/service/maintained_apps_auto_update_download_test.go
@@ -140,6 +140,12 @@ func baseDownloadStore(t *testing.T, activeVersion string, activeID uint) *mock.
 		return nil
 	}
 	ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, a, b bool) error { return nil }
+	// By default the active installer has no custom scripts to carry forward, so the
+	// cron keeps the manifest scripts. nil signals "nothing to preserve". Tests that
+	// exercise custom-script carry-forward override this.
+	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+		return nil, nil
+	}
 	return ds
 }
 
@@ -258,6 +264,9 @@ func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
 		return nil
 	}
 	ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, a, b bool) error { return nil }
+	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+		return nil, nil
+	}
 
 	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
 
@@ -342,4 +351,29 @@ func TestAutoUpdateUnsubstitutedUninstallSkipsInsert(t *testing.T) {
 	// and the $PACKAGE_ID placeholder survives — the candidate must be skipped.
 	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
 	require.False(t, ds.InsertFleetMaintainedAppVersionFuncInvoked)
+}
+
+// When the active installer has admin-customized scripts (differ from the
+// manifest defaults), the cron carries them forward to the newly downloaded
+// version instead of reverting to the manifest scripts.
+func TestAutoUpdatePreservesCustomScripts(t *testing.T) {
+	newFakeManifestServer(t)
+	ds := baseDownloadStore(t, "149.0.0", 9)
+	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{
+			InstallScript:   "echo CUSTOM install",
+			UninstallScript: "echo CUSTOM uninstall",
+			Extension:       "pkg",
+		}, nil
+	}
+	var gotPayload *fleet.UploadSoftwareInstallerPayload
+	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		gotPayload = payload
+		return 13, nil
+	}
+
+	require.NoError(t, AutoUpdateFleetMaintainedApps(context.Background(), ds, memStore(), discardLogger()))
+	require.NotNil(t, gotPayload)
+	require.Equal(t, "echo CUSTOM install", gotPayload.InstallScript, "custom install script carried forward")
+	require.Equal(t, "echo CUSTOM uninstall", gotPayload.UninstallScript, "custom uninstall script carried forward")
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -27339,6 +27339,21 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
 		})
 		return ss
 	}
+	activeScripts := func(teamID, titleID uint) (install, uninstall string) {
+		var row struct {
+			Install   string `db:"install_script"`
+			Uninstall string `db:"uninstall_script"`
+		}
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &row, `
+				SELECT inst.contents AS install_script, COALESCE(uninst.contents, '') AS uninstall_script
+				FROM software_installers si
+				LEFT JOIN script_contents inst ON inst.id = si.install_script_content_id
+				LEFT JOIN script_contents uninst ON uninst.id = si.uninstall_script_content_id
+				WHERE si.global_or_team_id = ? AND si.title_id = ? AND si.is_active = 1`, teamID, titleID)
+		})
+		return row.Install, row.Uninstall
+	}
 	setPin := func(teamID, titleID uint, pin string) {
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 			_, err := q.ExecContext(ctx,
@@ -27423,6 +27438,30 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
 	// === Section D: a re-run with nothing new is a no-op ===
 	runCron()
 	require.Equal(t, "3.1", activeTitle(team.ID).SoftwarePackage.Version)
+
+	// === Section E: admin-customized scripts are carried forward on auto-update ===
+	clearPin(team.ID, titleID)
+	const customInstall = "echo custom-install"
+	const customUninstall = "echo custom-uninstall"
+	var batchRespE batchSetSoftwareInstallersResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/batch",
+		batchSetSoftwareInstallersRequest{Software: []*fleet.SoftwareInstallerPayload{
+			{Slug: new(slug), SelfService: true, InstallScript: customInstall, UninstallScript: customUninstall},
+		}, TeamName: team.Name},
+		http.StatusAccepted, &batchRespE, "team_name", team.Name, "team_id", fmt.Sprint(team.ID))
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, batchRespE.RequestUUID)
+
+	gotInstall, gotUninstall := activeScripts(team.ID, titleID)
+	require.Equal(t, customInstall, gotInstall)
+	require.Equal(t, customUninstall, gotUninstall)
+
+	// A newly published version must keep the custom scripts, not revert to the manifest's.
+	setManifest("5.0", []byte("v50"))
+	runCron()
+	require.Equal(t, "5.0", activeTitle(team.ID).SoftwarePackage.Version)
+	gotInstall, gotUninstall = activeScripts(team.ID, titleID)
+	require.Equal(t, customInstall, gotInstall, "custom install script must survive auto-update")
+	require.Equal(t, customUninstall, gotUninstall, "custom uninstall script must survive auto-update")
 }
 
 func (s *integrationEnterpriseTestSuite) TestFMAVersionRollback() {


### PR DESCRIPTION
**Related issue:** Resolves #48301

  When the auto-update cron downloads a new Fleet-maintained app version, it now carries forward the previously-active install/uninstall scripts when they were customized (e.g. via GitOps), instead of overwriting them with the manifest defaults. Customization is detected per-script by comparing the active scripts against the manifest (the uninstall script is compared against the manifest template substituted with the active version's package IDs, since it's version-specific). When the active scripts match the manifest, the new version's manifest scripts are used as before.

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually
