### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/chatwise/darwin.json
+++ b/ee/maintained-apps/outputs/chatwise/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.5.3",
+      "version": "26.6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.5.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.6.0') < 0);"
       },
-      "installer_url": "https://releases.chatwise.app/26.5.3/ChatWise-26.5.3-arm64.dmg",
+      "installer_url": "https://releases.chatwise.app/26.6.0/ChatWise-26.6.0-arm64.dmg",
       "install_script_ref": "b3b382a0",
       "uninstall_script_ref": "da509fe4",
-      "sha256": "cdcebed8bd51e4e97aea7fba216e932500f122749bfc1de3c7eb425fa234eb1d",
+      "sha256": "a9fcde761816ba3d3d8b2577687ff1621bd34af95b7b7b5bbbd470377a1cd4ac",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Chatwise macOS app entry to version 26.6.0.
  * Refreshed the download package and checksum to match the latest installer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->