### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/vimcal/darwin.json
+++ b/ee/maintained-apps/outputs/vimcal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.46",
+      "version": "1.0.48",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.vimcal.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vimcal.app' AND version_compare(bundle_short_version, '1.0.46') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vimcal.app' AND version_compare(bundle_short_version, '1.0.48') < 0);"
       },
-      "installer_url": "https://vimcal-m1.s3.amazonaws.com/Vimcal-1.0.46-arm64.dmg",
+      "installer_url": "https://vimcal-m1.s3.amazonaws.com/Vimcal-1.0.48-arm64.dmg",
       "install_script_ref": "4a38f0a5",
       "uninstall_script_ref": "7f3d36b8",
-      "sha256": "f15a308db275cedb42e32897d85ec91a39d134407a11295169c4577f71b9aadc",
+      "sha256": "f77489563c93c56a98c78040b85883690711efb17b58c654291f4a6e06f64fe7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.25.20",
+      "version": "26.25.22",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.25.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.25.22') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS installer details for Vimcal to the latest available release, including version info, download link, and checksum.
  * Adjusted WhatsApp’s patched eligibility check to recognize the newer app version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->