### PR TITLE
Style inline article CTA button links

### DIFF
--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -494,6 +494,20 @@
       color: #515774;
       margin-bottom: 32px;
     }
+    p a[purpose='cta-button'] { // Green Fleet CTA button authored inline in article markdown (e.g. under "Key takeaways")
+      .cta-button(); // Reuse the homepage's brand button styling
+      display: inline-flex; // Override the mixin's full-width `display: flex` so the button hugs its label
+      width: fit-content;
+      height: auto;
+      padding: 12px 24px;
+      margin: 8px 0 32px; // Space it from the content above and the next heading below
+      font-size: 16px;
+      font-weight: 700;
+      text-decoration: none;
+      &:hover {
+        text-decoration: none;
+      }
+    }
     img + em { // Image captions
       position: relative;
       top: -12px;


### PR DESCRIPTION
Add targeted styling for `p a[purpose='cta-button']` in basic article pages so markdown-authored CTA links render as branded Fleet buttons. It reuses the existing `.cta-button()` mixin while overriding layout details (inline-flex, fit-content width, padding, spacing, and hover text decoration) so the button sizes to its label and fits article flow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance of inline “Green Fleet” call-to-action links in article content.
  * Buttons now display inline, size more naturally with the text, and have updated spacing for better readability.
  * Hover behavior has been kept clean by preventing unwanted text decoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->