### PR TITLE
Fix gitops leaving temporary url for script-only package in datastore

### DIFF
--- a/changes/47947-script-only-gitops-url
+++ b/changes/47947-script-only-gitops-url
@@ -1,1 +1,1 @@
-* Fixed a bug where adding a script-only package via path in GitOps stored a temporary URL that made fleetctl generate-gitops produce an invalid file.
+* Fixed a bug where adding a script-only package via path in GitOps made fleetctl generate-gitops produce an invalid file.

--- a/changes/47947-script-only-gitops-url
+++ b/changes/47947-script-only-gitops-url
@@ -1,0 +1,1 @@
+* Fixed a bug where adding a script-only package via path in GitOps stored a temporary URL that made fleetctl generate-gitops produce an invalid file.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1943,8 +1943,10 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			continue
 		}
 
-		// Script packages (.sh/.ps1) have no version, and their script fields aren't
-		// user-configurable, so neither is written to the generated yaml.
+		// Detect if this is a script package (.sh or .ps1 file)
+		// Script packages have the file contents as the install script internally,
+		// but these fields should NOT be exposed in GitOps YAML as they are not
+		// user-configurable for script packages.
 		isScriptPackage := sw.SoftwarePackage != nil &&
 			fleet.IsScriptPackage(strings.ToLower(filepath.Ext(sw.SoftwarePackage.Name)))
 

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1943,6 +1943,11 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			continue
 		}
 
+		// Script packages (.sh/.ps1) have no version, and their script fields aren't
+		// user-configurable, so neither is written to the generated yaml.
+		isScriptPackage := sw.SoftwarePackage != nil &&
+			fleet.IsScriptPackage(strings.ToLower(filepath.Ext(sw.SoftwarePackage.Name)))
+
 		softwareSpec := make(map[string]interface{})
 		switch {
 		case sw.SoftwarePackage != nil:
@@ -1950,7 +1955,12 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			if sw.SoftwarePackage.Name != "" {
 				pkgName = fmt.Sprintf(" (%s)", sw.SoftwarePackage.Name)
 			}
-			comment := cmd.AddComment(filePath, fmt.Sprintf("%s%s version %s", sw.Name, pkgName, sw.SoftwarePackage.Version))
+			var comment string
+			if isScriptPackage {
+				comment = cmd.AddComment(filePath, fmt.Sprintf("%s%s", sw.Name, pkgName))
+			} else {
+				comment = cmd.AddComment(filePath, fmt.Sprintf("%s%s version %s", sw.Name, pkgName, sw.SoftwarePackage.Version))
+			}
 			if sw.HashSHA256 == nil {
 				cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
 					Filename: filePath,
@@ -1994,14 +2004,6 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 
 		if softwareTitle.SoftwarePackage != nil {
 			filenamePrefix := generateFilename(sw.Name) + "-" + sw.SoftwarePackage.Platform
-
-			// Detect if this is a script package (.sh or .ps1 file)
-			// Script packages have the file contents as the install script internally,
-			// but these fields should NOT be exposed in GitOps YAML as they are not
-			// user-configurable for script packages.
-			isScriptPackage := sw.SoftwarePackage != nil && sw.SoftwarePackage.Name != "" &&
-				(strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".sh") ||
-					strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".ps1"))
 
 			var fmaInstallScriptModified, fmaUninstallScriptModified bool
 			if softwareTitle.SoftwarePackage.FleetMaintainedAppID != nil {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1813,6 +1813,21 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 	require.Contains(t, regularPkg, "uninstall_script", "regular package should have uninstall_script")
 	require.Contains(t, regularPkg, "pre_install_query", "regular package should have pre_install_query")
 
+	// Script packages have no version, so their comment drops it while regular packages
+	// keep it. The comment is stored as a token on hash_sha256.
+	commentByToken := make(map[string]string)
+	for _, c := range cmd.Comments {
+		commentByToken[c.Token] = c.Comment
+	}
+	commentFor := func(pkg map[string]any) string {
+		fields := strings.Fields(pkg["hash_sha256"].(string))
+		require.NotEmpty(t, fields, "hash_sha256 should carry a comment token")
+		return commentByToken[fields[len(fields)-1]]
+	}
+	require.NotContains(t, commentFor(shScriptPkg), "version", ".sh script package comment should not mention version")
+	require.NotContains(t, commentFor(ps1ScriptPkg), "version", ".ps1 script package comment should not mention version")
+	require.Contains(t, commentFor(regularPkg), "version", "regular package comment should still mention version")
+
 	for filename := range cmd.FilesToWrite {
 		require.NotContains(t, filename, "my-script-linux-install", "should not write install script file for .sh script package")
 		require.NotContains(t, filename, "my-script-linux-postinstall", "should not write post-install script file for .sh script package")

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1813,20 +1813,18 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 	require.Contains(t, regularPkg, "uninstall_script", "regular package should have uninstall_script")
 	require.Contains(t, regularPkg, "pre_install_query", "regular package should have pre_install_query")
 
-	// Script packages have no version, so their comment drops it while regular packages
-	// keep it. The comment is stored as a token on hash_sha256.
-	commentByToken := make(map[string]string)
-	for _, c := range cmd.Comments {
-		commentByToken[c.Token] = c.Comment
+	// Only the regular package keeps a version in its generated comment.
+	commentFor := func(name string) string {
+		for _, c := range cmd.Comments {
+			if strings.Contains(c.Comment, name) {
+				return c.Comment
+			}
+		}
+		return ""
 	}
-	commentFor := func(pkg map[string]any) string {
-		fields := strings.Fields(pkg["hash_sha256"].(string))
-		require.NotEmpty(t, fields, "hash_sha256 should carry a comment token")
-		return commentByToken[fields[len(fields)-1]]
-	}
-	require.NotContains(t, commentFor(shScriptPkg), "version", ".sh script package comment should not mention version")
-	require.NotContains(t, commentFor(ps1ScriptPkg), "version", ".ps1 script package comment should not mention version")
-	require.Contains(t, commentFor(regularPkg), "version", "regular package comment should still mention version")
+	require.NotContains(t, commentFor("my-script.sh"), "version", ".sh script package comment should not mention version")
+	require.NotContains(t, commentFor("setup.ps1"), "version", ".ps1 script package comment should not mention version")
+	require.Contains(t, commentFor("regular-package.deb"), "version", "regular package comment should still mention version")
 
 	for filename := range cmd.FilesToWrite {
 		require.NotContains(t, filename, "my-script-linux-install", "should not write install script file for .sh script package")

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3179,6 +3179,11 @@ func (svc *Service) softwareBatchUpload(
 				installer.PostInstallScript = ""
 				installer.UninstallScript = ""
 				installer.PreInstallQuery = ""
+				// Path-based script packages carry their filename in a "script://" url.
+				// It's an internal placeholder, not a real download url, so don't keep it.
+				if strings.HasPrefix(installer.URL, "script://") {
+					installer.URL = ""
+				}
 
 			case installer.Extension != "exe":
 				// custom scripts only for exe installers and non-script packages

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -17002,6 +17002,40 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploads() {
 	require.Empty(t, scriptContents.UninstallScript, "uninstall_script should still be empty")
 	require.Empty(t, scriptContents.PostInstallScript, "post_install_script should still be empty")
 	require.Empty(t, scriptContents.PreInstallQuery, "pre_install_query should still be empty")
+
+	// GitOps adds a path-based script package by sending a "script://filename" placeholder
+	// url plus the script hash. The placeholder must not be persisted.
+	installScript := "echo 'hello world'"
+	scriptSum := sha256.Sum256([]byte(installScript))
+	scriptPkg := []*fleet.SoftwareInstallerPayload{
+		{URL: "script://hello world.sh", SHA256: hex.EncodeToString(scriptSum[:]), InstallScript: installScript},
+	}
+
+	// First apply: no matching installer yet, so this exercises the download path.
+	var batchResp batchSetSoftwareInstallersResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: scriptPkg}, http.StatusAccepted, &batchResp, "team_name", team.Name)
+	packages := waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, batchResp.RequestUUID)
+	require.Len(t, packages, 1)
+
+	var storedURL string
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &storedURL, `SELECT url FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, &team.ID, "hello world.sh")
+	})
+	require.Empty(t, storedURL, "script:// placeholder url must not be persisted")
+
+	// Seed a stale placeholder url like an older Fleet would, then re-apply. The hash and
+	// url now match an existing installer, so this hits the cache-hit path, which must
+	// also drop the placeholder.
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE software_installers SET url = ? WHERE global_or_team_id = ? AND filename = ?`, "script://hello world.sh", &team.ID, "hello world.sh")
+		return err
+	})
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: scriptPkg}, http.StatusAccepted, &batchResp, "team_name", team.Name)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, batchResp.RequestUUID)
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &storedURL, `SELECT url FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, &team.ID, "hello world.sh")
+	})
+	require.Empty(t, storedURL, "cache-hit re-apply must drop the placeholder url too")
 }
 
 // 1. host reports software


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47947 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitOps generation for script-only packages added by path so it no longer creates invalid output files.
  * Script package entries now use cleaner comments, while regular packages still show version details.
  * Placeholder `script://` installer URLs are now cleared properly and won’t remain stored after processing.
* **Tests**
  * Added coverage for script package comment formatting and for clearing placeholder installer URLs during GitOps workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->