### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.153.0",
+      "version": "1.153.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.153.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.153.1') < 0);"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.153.0-82581.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.153.1-82775.zip",
       "install_script_ref": "bb0dd542",
       "uninstall_script_ref": "a19b04fa",
-      "sha256": "186ebad1925a4869530bf6de30a44f3f5fe2834c1c22ea0e6f7a946826c3993b",
+      "sha256": "1510785c7a4b45beef59b3ee39c3e0875c6d1c1279288de2ffd993f99902eb5a",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/arc/windows.json
+++ b/ee/maintained-apps/outputs/arc/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.112.0.332",
+      "version": "1.112.1.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York' AND version_compare(version, '1.112.0.332') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York' AND version_compare(version, '1.112.1.2') < 0);"
       },
-      "installer_url": "https://releases.arc.net/windows/prod/1.112.0.332/Arc.x64.msix",
+      "installer_url": "https://releases.arc.net/windows/prod/1.112.1.2/Arc.x64.msix",
       "install_script_ref": "d2d5c7dc",
       "uninstall_script_ref": "ebcac670",
-      "sha256": "e215351e2c6c6f79ca17701f59d1b19189f48d82520a9a0939606f3497eebade",
+      "sha256": "6a90a95a4e7c973a948663aefbdaf9550b3595c00bd119948511f7ca5f07d354",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.1.91.178",
+      "version": "149.1.91.180",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '149.1.91.178') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '149.1.91.180') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.91.178/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.91.180/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "a0e4c616aa45b4a2ea150c34d80d298ccf8928daf3e59c432bfa5587f37e90ca",
+      "sha256": "aca365fb42fcc09f3c13358743790e9b23e237f626eb0f91b686bbd4c00aea40",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.15962.0",
+      "version": "1.15962.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.15962.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.15962.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.15962.0/Claude-039543c96f820be3f47c6a5bcdb32d7278724ef1.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.15962.1/Claude-1e236d9fa9efd21a5a0a66a7b70c028f48848604.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "7fafab165cdf66834af243836a5f98495be985fca647bb732c87c0f9c99ae195",
+      "sha256": "b6db28e229c79a5c90c385f0658fd04f58ece23877d48fba80a49c761d49dfe9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dockside/darwin.json
+++ b/ee/maintained-apps/outputs/dockside/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.9.16",
+      "version": "2.9.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.17') < 0);"
       },
-      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.16/Dockside.dmg",
+      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.17/Dockside.dmg",
       "install_script_ref": "11c3511b",
       "uninstall_script_ref": "262fd2cc",
-      "sha256": "d8fd00a87b3a9bf14cf6a9c64f9e2016e639756888fd2b2b475ebc91375fc31f",
+      "sha256": "f4cee84e466ff795a8478c1b8c7b61d770439e98756413128956bd8562026a5e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/emclient/windows.json
+++ b/ee/maintained-apps/outputs/emclient/windows.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "10.4.5600.0",
+      "version": "10.4.5600",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'eM Client' AND publisher = 'eM Client s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'eM Client' AND publisher = 'eM Client s.r.o.' AND version_compare(version, '10.4.5600.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'eM Client' AND publisher = 'eM Client s.r.o.' AND version_compare(version, '10.4.5600') < 0);"
       },
-      "installer_url": "https://cdn-dist.emclient.com/dist/v10.4.5600/setup.msi",
+      "installer_url": "https://www.emclient.com/dist/v10.4.5600/setup.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "04c930bd",
       "sha256": "d31b75ec085a595a3c3fd1a6f7f0a6b62c6d4e7abcfd8f9db163014d3eb4152d",

--- a/ee/maintained-apps/outputs/fantastical/darwin.json
+++ b/ee/maintained-apps/outputs/fantastical/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.1.15",
+      "version": "4.1.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.flexibits.fantastical';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flexibits.fantastical' AND version_compare(bundle_short_version, '4.1.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flexibits.fantastical' AND version_compare(bundle_short_version, '4.1.16') < 0);"
       },
-      "installer_url": "https://cdn.flexibits.com/Fantastical_4.1.15.zip",
+      "installer_url": "https://cdn.flexibits.com/Fantastical_4.1.16.zip",
       "install_script_ref": "0da19afb",
       "uninstall_script_ref": "846b1a5a",
-      "sha256": "d5b12100dbf59148cabb64ac75799d227b592afcbabc2b0d40e54aa39930864b",
+      "sha256": "1960ad78d1bb2b774d970f40259f36e5e0f3c36c698a9f8d11c82fde1eb2c85f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/figma/darwin.json
+++ b/ee/maintained-apps/outputs/figma/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "126.6.9",
+      "version": "126.6.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.6.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.6.11') < 0);"
       },
-      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.6.9.zip",
+      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.6.11.zip",
       "install_script_ref": "f0952230",
       "uninstall_script_ref": "7dcd0304",
-      "sha256": "b3fb9f51dfdd8acbb116a1be93e0bc572438a96a84f42f014708485eac3e4f5c",
+      "sha256": "3b8dc1044290eb7b461f0c9f7209e127cd7bad56e746be1b315f310b50e6c3b1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/figma/windows.json
+++ b/ee/maintained-apps/outputs/figma/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "126.6.9",
+      "version": "126.6.11",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.6.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.6.11') < 0);"
       },
-      "installer_url": "https://desktop.figma.com/win/build/Figma-126.6.9.exe",
+      "installer_url": "https://desktop.figma.com/win/build/Figma-126.6.11.exe",
       "install_script_ref": "442d71b3",
       "uninstall_script_ref": "e33afd6b",
-      "sha256": "0812132b74f21b674b11b0cc5ec4043891dd3060cc8e5110fadb18083420d7c7",
+      "sha256": "aff43c97fb99df1d66c78d690b4b7638615d89358f92282c6f7783a09da2c529",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/funter/darwin.json
+++ b/ee/maintained-apps/outputs/funter/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.1.1",
+      "version": "7.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nektony.Funter-SIII';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nektony.Funter-SIII' AND version_compare(bundle_short_version, '7.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nektony.Funter-SIII' AND version_compare(bundle_short_version, '7.1.2') < 0);"
       },
-      "installer_url": "https://download.nektony.com/download/funter/Funter.dmg?build=374",
+      "installer_url": "https://download.nektony.com/download/funter/Funter.dmg?build=377",
       "install_script_ref": "1cb99628",
       "uninstall_script_ref": "0088be9f",
-      "sha256": "8a8f8784ef3042106ff1f776803d96682f079c175e21a63d8f42568205e1081c",
+      "sha256": "8f160d43fb50191b4e1bc9fe74a6c979a1be14faff9b8c2ce564506e75e8844f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/gather/darwin.json
+++ b/ee/maintained-apps/outputs/gather/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.37.1",
+      "version": "1.39.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.gather.Gather';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.gather.Gather' AND version_compare(bundle_short_version, '1.37.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.gather.Gather' AND version_compare(bundle_short_version, '1.39.2') < 0);"
       },
-      "installer_url": "https://github.com/gathertown/gather-town-desktop-releases/releases/download/v1.37.1/Gather-1.37.1-arm64-mac.zip",
+      "installer_url": "https://github.com/gathertown/gather-town-desktop-releases/releases/download/v1.39.2/Gather-1.39.2-arm64-mac.zip",
       "install_script_ref": "e494e208",
       "uninstall_script_ref": "b64dd64c",
-      "sha256": "50ba0fb5fc81ac1ff5b15d383f253a7693cf32d9dc96ffd5896e78e2666e9ee0",
+      "sha256": "292a6f5d7f20a865218055fd3de75f2facc4ce07ca8a35854e348ec069b7cd2f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.96",
+      "version": "149.0.4022.98",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.96') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.98') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/0269fe29-f4d9-4f21-9a92-a88ede10d84a/MicrosoftEdge-149.0.4022.96.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/739ebe4c-478b-4726-9c65-8dc694d4b5ed/MicrosoftEdge-149.0.4022.98.dmg",
       "install_script_ref": "caf6f785",
       "uninstall_script_ref": "3b06f51c",
-      "sha256": "3f6b900466674c867d089d766dc82e41063d8f546a218aafd98767fbcd8bc8bf",
+      "sha256": "cc07d415520f1d6b356d3db62c821b5075901af04f6749b43049ad15494b904b",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.96",
+      "version": "149.0.4022.98",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '149.0.4022.96') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '149.0.4022.98') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/96f71ebf-d93a-4a10-80af-5c5380af81f5/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/82374039-b772-4d0a-a9a9-ee311dabec12/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "793f753122566fe30e1382b148725a4fedfeeb79732608e2fba78b498166aeb3",
+      "sha256": "d026379848222d1e32800a1ff4268b9f5252a9d50f98819768ba54662f27979e",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/ocenaudio/darwin.json
+++ b/ee/maintained-apps/outputs/ocenaudio/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.19.4",
+      "version": "3.19.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.19.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.19.5') < 0);"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg",
       "install_script_ref": "0c2240cf",

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.30.10",
+      "version": "0.30.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.30.11') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.10/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.30.11/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "bf40e2d5",
-      "sha256": "18ff2fd66e141595edbb79fa6887806ed2fe6e08fdfe8b91ecc9376a6bfcb29f",
+      "sha256": "8fe6681bdf3ffd850c2728b578555908c71db2f33bd77c36e2023b967719703a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/p4v/windows.json
+++ b/ee/maintained-apps/outputs/p4v/windows.json
@@ -6,7 +6,7 @@
         "exists": "SELECT 1 FROM programs WHERE name = 'P4 Apps' AND publisher = 'Perforce Software';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'P4 Apps' AND publisher = 'Perforce Software' AND version_compare(version, '242.62.2') < 0);"
       },
-      "installer_url": "https://www.perforce.com/downloads/perforce/r26.2/bin.ntx64/p4vinst64.msi",
+      "installer_url": "https://filehost.perforce.com/perforce/r26.2/bin.ntx64/p4vinst64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "030745cd",
       "sha256": "e6bc46b18a3b20431610c45019664b5fb9c85ff44585135ac8fc1be6fe86ce6d",

--- a/ee/maintained-apps/outputs/quip/darwin.json
+++ b/ee/maintained-apps/outputs/quip/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.48.0",
+      "version": "9.54.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.quip.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.quip.Desktop' AND version_compare(bundle_short_version, '9.48.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.quip.Desktop' AND version_compare(bundle_short_version, '9.54.0') < 0);"
       },
-      "installer_url": "https://quip-clients.com/macosx_9.48.0.dmg",
+      "installer_url": "https://quip-clients.com/macosx_9.54.0.dmg",
       "install_script_ref": "e420c1cc",
       "uninstall_script_ref": "fe098197",
-      "sha256": "efaf12227392381b142480d55237e7459e6faf2a2c626eb160cfa4ddc00b52f7",
+      "sha256": "b36753df589115466268738dfbcb7da4cd98a591fc7f67a212700ecdb0004bdb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/r/windows.json
+++ b/ee/maintained-apps/outputs/r/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.0",
+      "version": "4.6.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'R for Windows %' AND publisher = 'R Core Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'R for Windows %' AND publisher = 'R Core Team' AND version_compare(version, '4.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'R for Windows %' AND publisher = 'R Core Team' AND version_compare(version, '4.6.1') < 0);"
       },
-      "installer_url": "https://cloud.r-project.org/bin/windows/base/old/4.6.0/R-4.6.0-win.exe",
+      "installer_url": "https://cloud.r-project.org/bin/windows/base/old/4.6.1/R-4.6.1-win.exe",
       "install_script_ref": "1c98e2a1",
       "uninstall_script_ref": "76fa8c37",
-      "sha256": "ca14dd6c39cdacee0b2bc7702c4335f6b34e40ab5cf5f55f71428ebf5bc368ca",
+      "sha256": "c5424c40cd70ef85765a55d2ff96bb602b5f30ed536938ff004f14db5db3c2df",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/tuple/darwin.json
+++ b/ee/maintained-apps/outputs/tuple/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.8",
+      "version": "3.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app' AND version_compare(bundle_short_version, '3.0.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app' AND version_compare(bundle_short_version, '3.1.0') < 0);"
       },
-      "installer_url": "https://d32ifkf9k9ezcg.cloudfront.net/production/sparkle/tuple-3.0.8-2026-06-22-7ab704b60a.zip",
+      "installer_url": "https://d32ifkf9k9ezcg.cloudfront.net/production/sparkle/tuple-3.1.0-2026-06-26-bf7997a186.zip",
       "install_script_ref": "ff9821fc",
       "uninstall_script_ref": "03815558",
-      "sha256": "bf289935a02c3194381b0e59efa1e0318ddcb65abd47a209323eb8ad4a5e2984",
+      "sha256": "f55a911bfc4459f66daaa13903011743883e18211790791d9d47a53f5796ad79",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.06.17.09.49.02",
+      "version": "0.2026.06.24.09.19.02",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.17.09.49.02') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.24.09.19.02') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.17.09.49.stable_02/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.24.09.19.stable_02/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated maintained app definitions so installs and update checks recognize the latest releases for Arc, Brave, Claude, Dockside, eM Client, Fantastical, Figma, Funter, Gather, Microsoft Edge, Ocenaudio, Ollama, P4V, Quip, R for Windows, Tuple, and Warp.
  * Refreshed download links and package checksums to match the newest installers, improving update reliability across macOS and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->