### PR TITLE
Redirect to software inventory on 404 when switching fleets on title

### DIFF
--- a/changes/48252-redirect-software-title-404-on-fleet-switch
+++ b/changes/48252-redirect-software-title-404-on-fleet-switch
@@ -1,0 +1,1 @@
+- Fixed a bug where switching fleets on a software title detail page redirected to an empty "Software not detected" state instead of the software inventory page when the title didn't exist in the new fleet.

--- a/changes/48252-redirect-software-title-404-on-fleet-switch
+++ b/changes/48252-redirect-software-title-404-on-fleet-switch
@@ -1,1 +1,1 @@
-- Fixed a bug where switching fleets on a software title detail page redirected to an empty "Software not detected" state instead of the software inventory page when the title didn't exist in the new fleet.
+* Improved empty state copy on software title detail page when the software is not found in the selected fleet.

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -160,7 +160,7 @@ const SoftwareTitleDetailsPage = ({
       select: (data) => data.software_title,
       onError: (error) => {
         if (error.status === 404) {
-          router.push(
+          router.replace(
             getPathWithQueryParams(paths.SOFTWARE, {
               fleet_id: teamIdForApi,
             })

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -159,15 +159,7 @@ const SoftwareTitleDetailsPage = ({
       retry: false,
       select: (data) => data.software_title,
       onError: (error) => {
-        if (error.status === 404) {
-          router.replace(
-            getPathWithQueryParams(paths.SOFTWARE, {
-              fleet_id: teamIdForApi,
-            })
-          );
-          return;
-        }
-        if (!ignoreAxiosError(error, [403])) {
+        if (!ignoreAxiosError(error, [403, 404])) {
           handlePageError(error);
         }
       },
@@ -673,7 +665,7 @@ const SoftwareTitleDetailsPage = ({
     if (isSoftwareTitleError) {
       return (
         <DetailsNoHosts
-          header="Software not detected"
+          header="Software not found in this fleet"
           details="Expecting to see software? Check back later."
         />
       );

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -159,7 +159,15 @@ const SoftwareTitleDetailsPage = ({
       retry: false,
       select: (data) => data.software_title,
       onError: (error) => {
-        if (!ignoreAxiosError(error, [403, 404])) {
+        if (error.status === 404) {
+          router.push(
+            getPathWithQueryParams(paths.SOFTWARE, {
+              fleet_id: teamIdForApi,
+            })
+          );
+          return;
+        }
+        if (!ignoreAxiosError(error, [403])) {
           handlePageError(error);
         }
       },

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -23,7 +23,10 @@ import {
   MAX_PACKAGES_PER_TITLE,
   NO_VERSION_OR_HOST_DATA_SOURCES,
 } from "interfaces/software";
-import { APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
+import {
+  APP_CONTEXT_NO_TEAM_ID,
+  APP_CONTEXT_ALL_TEAMS_ID,
+} from "interfaces/team";
 import {
   canDownloadSoftwareInstaller,
   canWriteSoftware,
@@ -665,7 +668,11 @@ const SoftwareTitleDetailsPage = ({
     if (isSoftwareTitleError) {
       return (
         <DetailsNoHosts
-          header="Software not found in this fleet"
+          header={
+            currentTeamId === APP_CONTEXT_ALL_TEAMS_ID
+              ? "Software not found"
+              : "Software not found in this fleet"
+          }
           details="Expecting to see software? Check back later."
         />
       );


### PR DESCRIPTION
**Related issue:** Resolves #48252

Screenshot demonstrating the fix

<img width="1894" height="465" alt="image" src="https://github.com/user-attachments/assets/685122d0-d8ef-4400-a943-9d8de07309b1" />

 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the software title detail page’s empty-state messaging when the software isn’t available in the selected fleet, making the 404 experience clearer.
  * The header now reflects the viewing scope: “Software not found” for **All teams**, or “Software not found in this fleet” for a specific fleet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->