### PR TITLE
Fix Redis MOVED errors from query results counts in cluster mode

### DIFF
--- a/changes/47303-redis-moved-errors-query-results-counts
+++ b/changes/47303-redis-moved-errors-query-results-counts
@@ -1,0 +1,1 @@
+- Fixed recurring Redis `MOVED` errors and silently-dropped report result-count increments on Redis Cluster deployments by grouping `query_results_count` keys by hash slot before pipelining.

--- a/server/live_query/live_query_test.go
+++ b/server/live_query/live_query_test.go
@@ -20,6 +20,7 @@ var testFunctions = [...]func(*testing.T, fleet.LiveQueryStore){
 	testLiveQueryOnlyExpired,
 	testLiveQueryCleanupInactive,
 	testLiveQuerySetBitOnlyIfKeyExists,
+	testLiveQueryResultsCounts,
 }
 
 func testLiveQuery(t *testing.T, store fleet.LiveQueryStore) {
@@ -263,4 +264,66 @@ func testLiveQuerySetBitOnlyIfKeyExists(t *testing.T, store fleet.LiveQueryStore
 	n, err := redigo.Int(conn.Do("EXISTS", queryKeyPrefix+"{test-2}"))
 	require.NoError(t, err)
 	require.Zero(t, n)
+}
+
+func testLiveQueryResultsCounts(t *testing.T, store fleet.LiveQueryStore) {
+	// Use many query IDs so that, in cluster mode, their keys spread across
+	// multiple hash slots - exercising the split-by-slot pipelining.
+	queryIDs := []uint{1, 2, 3, 4, 5, 10, 42, 100, 250, 999}
+
+	// The query_results_count keys are not covered by the test cleanup key
+	// prefix, so clear any leftover state from previous runs and after this one.
+	cleanup := func() {
+		for _, id := range append(append([]uint{}, queryIDs...), 123456) {
+			require.NoError(t, store.DeleteQueryResultsCount(id))
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// counts for never-incremented queries default to 0
+	counts, err := store.GetQueryResultsCounts(queryIDs)
+	require.NoError(t, err)
+	for _, id := range queryIDs {
+		require.Zero(t, counts[id])
+	}
+
+	// increment each query by a distinct amount
+	increments := make(map[uint]int, len(queryIDs))
+	for i, id := range queryIDs {
+		increments[id] = i + 1
+	}
+	err = store.IncrQueryResultsCounts(increments)
+	require.NoError(t, err)
+
+	counts, err = store.GetQueryResultsCounts(queryIDs)
+	require.NoError(t, err)
+	for _, id := range queryIDs {
+		require.Equal(t, increments[id], counts[id])
+	}
+
+	// incrementing again accumulates
+	err = store.IncrQueryResultsCounts(increments)
+	require.NoError(t, err)
+
+	counts, err = store.GetQueryResultsCounts(queryIDs)
+	require.NoError(t, err)
+	for _, id := range queryIDs {
+		require.Equal(t, 2*increments[id], counts[id])
+	}
+
+	// a query that was never incremented is explicitly populated with 0 in the
+	// returned map, mixed with ones that were incremented
+	counts, err = store.GetQueryResultsCounts([]uint{queryIDs[0], 123456})
+	require.NoError(t, err)
+	require.Equal(t, 2*increments[queryIDs[0]], counts[queryIDs[0]])
+	require.Contains(t, counts, uint(123456))
+	require.Zero(t, counts[123456])
+
+	// empty inputs are no-ops
+	err = store.IncrQueryResultsCounts(nil)
+	require.NoError(t, err)
+	counts, err = store.GetQueryResultsCounts(nil)
+	require.NoError(t, err)
+	require.Empty(t, counts)
 }

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -777,36 +777,57 @@ func (r *redisLiveQuery) GetQueryResultsCounts(queryIDs []uint) (map[uint]int, e
 		return make(map[uint]int), nil
 	}
 
+	// The query_results_count keys have no hash tag, so they may live on
+	// different slots in a Redis Cluster. Group them by slot so that each
+	// pipelined request only touches keys that hash to the same slot, avoiding
+	// MOVED redirects.
+	keys := make([]string, 0, len(queryIDs))
+	keyToID := make(map[string]uint, len(queryIDs))
+	for _, queryID := range queryIDs {
+		key := queryResultsCountKey(queryID)
+		keys = append(keys, key)
+		keyToID[key] = queryID
+	}
+
+	results := make(map[uint]int, len(queryIDs))
+	for _, slotKeys := range redis.SplitKeysBySlot(r.pool, keys...) {
+		if err := r.collectBatchResultsCounts(slotKeys, keyToID, results); err != nil {
+			return nil, err
+		}
+	}
+
+	return results, nil
+}
+
+func (r *redisLiveQuery) collectBatchResultsCounts(keys []string, keyToID map[string]uint, results map[uint]int) error {
 	conn := redis.ReadOnlyConn(r.pool, r.pool.Get())
 	defer conn.Close()
 
-	// Pipeline GET requests for all query IDs
-	for _, queryID := range queryIDs {
-		key := queryResultsCountKey(queryID)
+	// Pipeline GET requests for all keys in this slot.
+	for _, key := range keys {
 		if err := conn.Send("GET", key); err != nil {
-			return nil, fmt.Errorf("send get query results count: %w", err)
+			return fmt.Errorf("send get query results count: %w", err)
 		}
 	}
 
 	if err := conn.Flush(); err != nil {
-		return nil, fmt.Errorf("flush pipeline: %w", err)
+		return fmt.Errorf("flush pipeline: %w", err)
 	}
 
-	// Receive results and build the map
-	results := make(map[uint]int, len(queryIDs))
-	for _, queryID := range queryIDs {
+	// Receive results in order and build the map.
+	for _, key := range keys {
 		count, err := redigo.Int(conn.Receive())
 		if err != nil {
 			if err == redigo.ErrNil {
-				results[queryID] = 0
+				results[keyToID[key]] = 0
 				continue
 			}
-			return nil, fmt.Errorf("receive query results count: %w", err)
+			return fmt.Errorf("receive query results count: %w", err)
 		}
-		results[queryID] = count
+		results[keyToID[key]] = count
 	}
 
-	return results, nil
+	return nil
 }
 
 // IncrQueryResultsCounts increments the query results counts by the given amounts.
@@ -816,13 +837,38 @@ func (r *redisLiveQuery) IncrQueryResultsCounts(queryIDsToAmounts map[uint]int) 
 		return nil
 	}
 
-	conn := redis.ConfigureDoer(r.pool, r.pool.Get())
-	defer conn.Close()
-
-	// Pipeline INCRBY requests for all query IDs
+	// The query_results_count keys have no hash tag, so they may live on
+	// different slots in a Redis Cluster. Group them by slot so that each
+	// pipelined request only touches keys that hash to the same slot, avoiding
+	// MOVED redirects.
+	keys := make([]string, 0, len(queryIDsToAmounts))
+	amountByKey := make(map[string]int, len(queryIDsToAmounts))
 	for queryID, amount := range queryIDsToAmounts {
 		key := queryResultsCountKey(queryID)
-		if err := conn.Send("INCRBY", key, amount); err != nil {
+		keys = append(keys, key)
+		amountByKey[key] = amount
+	}
+
+	for _, slotKeys := range redis.SplitKeysBySlot(r.pool, keys...) {
+		if err := r.incrBatchResultsCounts(slotKeys, amountByKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *redisLiveQuery) incrBatchResultsCounts(keys []string, amountByKey map[string]int) error {
+	// Use a plain connection rather than redis.ConfigureDoer: the latter wraps
+	// the connection in a redisc.RetryConn, whose Send method is unsupported, so
+	// the pipeline below would fail. All keys in this batch hash to the same
+	// slot, so no redirection handling is needed.
+	conn := r.pool.Get()
+	defer conn.Close()
+
+	// Pipeline INCRBY requests for all keys in this slot.
+	for _, key := range keys {
+		if err := conn.Send("INCRBY", key, amountByKey[key]); err != nil {
 			return fmt.Errorf("send incrby query results count: %w", err)
 		}
 	}
@@ -831,8 +877,8 @@ func (r *redisLiveQuery) IncrQueryResultsCounts(queryIDsToAmounts map[uint]int) 
 		return fmt.Errorf("flush pipeline: %w", err)
 	}
 
-	// Receive all results to complete the pipeline (we don't need the values)
-	for range queryIDsToAmounts {
+	// Receive all results to complete the pipeline (we don't need the values).
+	for range keys {
 		if _, err := conn.Receive(); err != nil {
 			return fmt.Errorf("receive incrby result: %w", err)
 		}


### PR DESCRIPTION
Fixes #47303

GetQueryResultsCounts and IncrQueryResultsCounts pipelined commands across multiple query_results_count:<id> keys on a single connection. These keys have no hash tag, so in a Redis Cluster they scatter across hash slots. A pipelined connection binds to the first key's slot, so every other key returned a MOVED redirect, producing recurring error log noise on host check-ins. IncrQueryResultsCounts additionally used ConfigureDoer, whose RetryConn does not support Send, so increments failed entirely in cluster mode.

Group the keys by hash slot with redis.SplitKeysBySlot and run one pipeline per slot group, mirroring the existing QueriesForHost and CleanupInactiveQueries patterns in the same file. The write path uses a plain pooled connection (not ConfigureDoer) since all keys in a slot group share a slot and no redirect handling is needed.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recurring Redis `MOVED` errors in live-query result counting on Redis Cluster.
  * Ensured `query_results_count` updates aren’t silently dropped by batching operations per Redis hash slot.
  * Missing count entries now correctly return `0` instead of being omitted.

* **Tests**
  * Added coverage for live-query result counting, including zero counts, repeated increments, mixed query sets, and empty/nil inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->