### PR TITLE
Fleet UI: New user role dropdown weird scrollbar

### DIFF
--- a/frontend/components/MainContent/_styles.scss
+++ b/frontend/components/MainContent/_styles.scss
@@ -4,13 +4,10 @@
   padding: $pad-page;
   flex-grow: 1;
   // min-width: 0 lets this flex item shrink below its content's intrinsic
-  // min size so wide descendants stay inside main-content's own overflow
-  // instead of pushing the document past the viewport — see #47029.
+  // min size so wide descendants don't push the document past the viewport.
+  // Pages with intrinsically wide content (data tables, etc.) must handle
+  // their own horizontal overflow scoped to that content — see #47029.
   min-width: 0;
-  // overflow: auto allows for horizontal scrolling
-  // of the main-content when there is a banner. (e.g. sandbox mode)
-  // Without it the main content pushes the banner off the page.
-  overflow: auto;
 
   > :not(.main-content--animation-disabled) {
     animation: fade-in 250ms ease-out;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -13,6 +13,10 @@ $shadow-transition-width: 16px;
       border-radius: 6px;
       flex-grow: 1;
       width: 100%;
+      // Wide tables scroll horizontally within the table wrapper rather than
+      // pushing the document past the viewport. The shadow backgrounds below
+      // were already engineered for horizontal scrolling.
+      overflow-x: auto;
 
       // Shadow
       background-image:

--- a/frontend/pages/DashboardPage/_styles.scss
+++ b/frontend/pages/DashboardPage/_styles.scss
@@ -1,5 +1,4 @@
 .dashboard-page {
-  overflow: initial; // auto causes double scroll bar  but still needed for other pages .main-content div
   @include vertical-page-layout;
 
   h2 {

--- a/frontend/pages/DashboardPage/cards/Munki/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Munki/_styles.scss
@@ -2,9 +2,6 @@
   margin-top: $pad-large;
   position: relative;
 
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
   .tab-nav .table-container__header {
     display: none;
   }

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/_styles.scss
@@ -2,10 +2,6 @@
   margin-top: $pad-large;
   position: relative;
 
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
-
   .hosts-cell__wrapper {
     display: flex;
     align-items: center;

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -12,9 +12,6 @@
       outline: 1px solid $core-focused-outline;
     }
   }
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
   .form-field--dropdown {
     margin: 0;
   }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/_styles.scss
@@ -15,8 +15,6 @@
 
   .data-table {
     &__wrapper {
-      // Keeps table data within the table container at smaller screen sizes
-      overflow-x: auto;
       // Prevent border from causing .side-nav__card-container horizontal scroll
       box-sizing: border-box;
     }

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/_styles.scss
@@ -98,12 +98,6 @@
     }
   }
 
-  // needed to handle overflow of the table data on small screens
-  .data-table {
-    &__wrapper {
-      overflow-x: auto;
-    }
-  }
   .view-all-hosts {
     &__cell {
       display: flex;

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/_styles.scss
@@ -78,13 +78,6 @@
     }
   }
 
-  // needed to handle overflow of the table data on small screens
-  .data-table {
-    &__wrapper {
-      overflow-x: auto;
-    }
-  }
-
   .view-all-hosts {
     &__cell {
       display: flex;

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/_styles.scss
@@ -33,9 +33,6 @@
     &__data-table-block {
       .data-table-block {
         .data-table {
-          &__wrapper {
-            overflow-x: auto;
-          }
           &__table {
             tbody {
               .name_only__cell {

--- a/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/_styles.scss
@@ -1,8 +1,2 @@
 .software-vulnerabilities-table {
-  // keeps table data within the table container at smaller screen sizes
-  .data-table {
-    &__wrapper {
-      overflow-x: auto;
-    }
-  }
 }

--- a/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/_styles.scss
@@ -1,11 +1,4 @@
 .software-vulnerabilities-table {
-  // keeps table data within the table container at smaller screen sizes
-  .data-table {
-    &__wrapper {
-      overflow-x: auto;
-    }
-  }
-
   // used to position header text with premium icon correctly
   .column-header {
     display: flex;

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -178,9 +178,6 @@
     .table-container__data-table-block {
       .data-table-block {
         .data-table {
-          &__wrapper {
-            overflow-x: auto;
-          }
           &__table {
             tbody {
               .issues {

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/_styles.scss
@@ -1,8 +1,4 @@
 .certificates-table {
-  .data-table-block .data-table__wrapper {
-    overflow-x: auto;
-  }
-
   .cert-table__status-indicator {
     min-width: 160px;
   }

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
@@ -35,16 +35,6 @@
     width: 100%;
   }
 
-  .table-container__data-table-block {
-    .data-table-block {
-      .data-table {
-        &__wrapper {
-          overflow-x: auto;
-        }
-      }
-    }
-  }
-
   &__item-actions {
     display: flex;
     flex-direction: row;

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -1,13 +1,3 @@
-// Sandbox mode was removed years ago but .main-content still carries
-// `overflow: auto` for it. On the self-service page, that overflow
-// container catches the absolutely-positioned category dropdown when it
-// extends past the page bottom, producing an inner scrollbar instead of
-// the document scrollbar at the viewport edge. TODO: revisit removing
-// overflow: auto from .main-content globally.
-.main-content:has(.software-self-service) {
-  overflow: initial;
-}
-
 .software-self-service {
   @include vertical-page-tab-panel-layout;
 

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -19,16 +19,6 @@
     width: 100%;
   }
 
-  .table-container__data-table-block {
-    .data-table-block {
-      .data-table {
-        &__wrapper {
-          overflow-x: auto;
-        }
-      }
-    }
-  }
-
   .host-software-table {
     // When the macOS /Applications dropdown is shown, lay the controls out as
     // search (left) ... dropdown, filters button (right). The dropdown and

--- a/frontend/pages/packs/EditPackPage/_styles.scss
+++ b/frontend/pages/packs/EditPackPage/_styles.scss
@@ -1,6 +1,5 @@
 .edit-pack-page {
   @include vertical-page-layout;
-  overflow: initial; // Removes weird overflow auto second scrollbar when select targets dropdown is open
 
   @at-root .has-sidebar > &__content {
     display: flex;

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/_styles.scss
@@ -1,10 +1,6 @@
 .policies-table {
   border-collapse: collapse;
 
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
-
   thead {
     th {
       &.passing_host_count__header,

--- a/frontend/pages/policies/edit/components/PolicyResults/_styles.scss
+++ b/frontend/pages/policies/edit/components/PolicyResults/_styles.scss
@@ -3,10 +3,6 @@
     margin: 2rem auto 1.25rem;
   }
 
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
-
   .data-table-block .data-table thead th {
     min-width: 140px;
     padding-left: 0px;

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -53,7 +53,6 @@
     .data-table-block {
       .data-table {
         &__wrapper {
-          overflow-x: auto;
           overflow-y: hidden;
         }
         &__table {

--- a/frontend/pages/queries/details/components/QueryReport/_styles.scss
+++ b/frontend/pages/queries/details/components/QueryReport/_styles.scss
@@ -13,10 +13,6 @@
     .last_fetched__cell {
       white-space: nowrap; // Prevent timestamp wrapping on multiple lines
     }
-
-    .data-table__wrapper {
-      overflow-x: auto;
-    }
   }
 
   &__results-cta {

--- a/frontend/pages/queries/edit/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/edit/components/QueryResults/_styles.scss
@@ -8,10 +8,6 @@
     margin-right: $pad-medium;
   }
 
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
-
   .data-table-block .data-table thead th {
     min-width: 140px;
     padding-left: 0px;


### PR DESCRIPTION
## Issue
Closes #47960

## Description
- Bug fix (root cause): `.main-content { overflow: auto }` existed only to allow horizontal scrolling under the sandbox-mode banner. Sandbox mode was removed years ago, but the overflow stayed and made `.main-content` a scroll container — so any absolutely-positioned descendant that extended past its content box (here, an open react-select menu near the bottom of the page) inflated its scrollHeight and produced a second scrollbar next to the page scrollbar. The new user Role dropdown was just the latest instance; the same family of bugs had already been worked around piecemeal on the dashboard, self-service, queries, policies, packs, and software pages.
- Removed the obsolete `overflow: auto` from `.main-content` and moved horizontal-table scrolling into the shared `.data-table__wrapper`. The wrapper already had shadow gradients engineered for horizontal scrolling — they only worked on the ~18 pages that had each pasted `overflow-x: auto` locally. Now every TableContainer-backed table gets correct scoped horizontal scrolling and shadows for free.
- UX (slight upgrade everywhere): wide tables now scroll horizontally inside the table itself with the page header / filters / search staying put — previously the whole `.main-content` scrolled.
- Cleanup: deleted the 16 redundant `overflow-x: auto` page overrides on `.data-table__wrapper` and the 3 `overflow: initial` workarounds explicitly tied to this bug (Dashboard root, EditPackPage root, and the recent `.main-content:has(.software-self-service)` :has() fix from #47913). Kept the 4 `overflow: initial` uses that aren't related (badges, definition list, cell `children-wrapper` for tooltips) and the 2 `overflow-x: auto` overrides that target a different element (ChartCard's `&__scroll-wrapper`, HostQueryReport's `.data-table`).

## Screenrecording
- New user Role dropdown opening on a short window — one scrollbar, no second bar.

https://github.com/user-attachments/assets/2220e47c-8ad7-42ef-b0a4-f1949eb3638d


https://github.com/user-attachments/assets/2809258d-332a-4fc8-b21b-d665af007253


https://github.com/user-attachments/assets/bf7dfe0d-81c0-4a79-bbca-4ad58c6205ed


https://github.com/user-attachments/assets/ab5d8788-dfb8-484b-8431-af35201b15bf


https://github.com/user-attachments/assets/4f90485d-57d8-4e12-b75d-96716f8debcc


https://github.com/user-attachments/assets/095623f4-63a1-46bf-b08c-01a36b8bc165




## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

### QA checklist

**Primary repro (the closed bug):**
- [x] Settings → Users → Add user → Regular user → Global user → open the **Role** dropdown on a short window. One page scrollbar, no second bar.

**Wide-table behavior (global change — scrollbar should now sit at the bottom of the table, not the page; header/filters/search stay put):**
- [x] Hosts page (narrow viewport / many columns)
- [x] Software → Inventory / Library / OS
- [x] Queries → list, individual report, edit results
- [ ] Policies → list, individual policy edit results
- [x] Dashboard cards: Software, Munki, Operating systems
- [x] Host details → Software library, Certificates, Software card
- [ ] Controls → Disk encryption

**Pages where workarounds were removed (no visible regression):**
- [x] Dashboard (`.dashboard-page { overflow: initial }` removed)
- [x] Edit Pack page (root `overflow: initial` removed, plus dropdown opens with no second scrollbar)
- [x] Device self-service (`:has(.software-self-service)` workaround removed; category dropdown opens with no second scrollbar)

**Special-case overrides kept — confirm these still behave correctly:**
- [x] ManageQueriesPage table: no vertical scrollbar inside the wrapper (the `overflow-y: hidden` is still there)
- [ ] Dashboard ChartCard horizontal scroll-wrapper still scrolls
- [x] HostQueryReport table still scrolls horizontally
- [ ] DiskEncryption table border doesn't cause the side-nav card container to horizontally scroll

**Dropdowns + modals:**
- [x] Opening a dropdown inside a modal (e.g., Hosts → Transfer host, Software → Filters, Policies → Install software) — no double scrollbar
- [x] Any dropdown opened near the bottom of any page — no double scrollbar

**Sanity:**
- [x] Long content pages (Settings, GitOps mode, host details) still vertically scroll cleanly