### PR TITLE
Fix orbit nudge test mdm connection fidelity

### DIFF
--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -500,9 +500,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		ds.ListReadyToExecuteSoftwareInstallsFunc = func(ctx context.Context, hostID uint) ([]string, error) {
 			return nil, nil
 		}
-		// GetOrbitConfig derives the Fleet-MDM connection state from GetHostMDM
-		// (ConnectedToFleet), not a separate IsHostConnectedToFleetMDM call, so the
-		// variations below are driven through GetHostMDM.
+		// GetOrbitConfig derives the Fleet-MDM connection state from GetHostMDM (ConnectedToFleet)
 		var connectedToFleetMDM bool
 		ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
 			if connectedToFleetMDM {

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -500,13 +500,11 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		ds.ListReadyToExecuteSoftwareInstallsFunc = func(ctx context.Context, hostID uint) ([]string, error) {
 			return nil, nil
 		}
-		// GetOrbitConfig derives the Fleet-MDM connection state from GetHostMDM (ConnectedToFleet)
+		// GetOrbitConfig derives the Fleet-MDM connection state from GetHostMDM
+		// (ConnectedToFleet).
 		var connectedToFleetMDM bool
 		ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
-			if connectedToFleetMDM {
-				return &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet, ConnectedToFleet: true}, nil
-			}
-			return nil, newNotFoundError()
+			return &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet, ConnectedToFleet: connectedToFleetMDM}, nil
 		}
 
 		ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -500,12 +500,15 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		ds.ListReadyToExecuteSoftwareInstallsFunc = func(ctx context.Context, hostID uint) ([]string, error) {
 			return nil, nil
 		}
+		// GetOrbitConfig derives the Fleet-MDM connection state from GetHostMDM
+		// (ConnectedToFleet), not a separate IsHostConnectedToFleetMDM call, so the
+		// variations below are driven through GetHostMDM.
+		var connectedToFleetMDM bool
 		ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+			if connectedToFleetMDM {
+				return &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet, ConnectedToFleet: true}, nil
+			}
 			return nil, newNotFoundError()
-		}
-		var isHostConnectedToFleet bool
-		ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, h *fleet.Host) (bool, error) {
-			return isHostConnectedToFleet, nil
 		}
 
 		ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
@@ -525,12 +528,12 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		}
 
 		checkHostVariations := func(h *fleet.Host) {
-			// host is not connected to fleet
-			isHostConnectedToFleet = false
+			// host is osquery-enrolled but not connected to Fleet MDM
+			connectedToFleetMDM = false
 			checkEmptyNudgeConfig(h)
 
-			// host has MDM turned on but is not enrolled
-			isHostConnectedToFleet = true
+			// host is connected to Fleet MDM but not osquery-enrolled
+			connectedToFleetMDM = true
 			h.OsqueryHostID = nil
 			checkEmptyNudgeConfig(h)
 		}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44629

Test fix only. Test now distinguishes between being connected to Fleet MDM and being connected but not osquery-enrolled.

[ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved validation of host configuration nudge behavior by refining how Fleet MDM connection states are simulated.
  * Test scenarios now better cover: enrolled but not connected to Fleet MDM, and connected to Fleet MDM without enrollment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->