### PR TITLE
Add "DRIs" to managed Chrome bookmarks

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -325,6 +325,12 @@
                         </dict>
                         <dict>
                             <key>name</key>
+                            <string>Directly responsible individuals (DRIs)</string>
+                            <key>url</key>
+                            <string>https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris</string>
+                        </dict>
+                        <dict>
+                            <key>name</key>
                             <string>📈 OKRs (quarterly goals) + KPIs (everyday metrics)</string>
                             <key>url</key>
                             <string>https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0</string>


### PR DESCRIPTION
- Useful for quickly knowing who owns what


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new managed Chrome bookmark for “Directly responsible individuals (DRIs)” in the Fleeties bookmarks section.
  * The bookmark now links directly to the Fleet handbook page for DRIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->