### PR TITLE
Fix IdP name overflowing button in login page

### DIFF
--- a/changes/42473-sso-button-overflow
+++ b/changes/42473-sso-button-overflow
@@ -1,0 +1,1 @@
+* Fixed the SSO sign-on button text overflowing by using a fixed "Sign in with SSO" label and showing the configured IdP name in a tooltip.

--- a/frontend/components/forms/LoginForm/LoginForm.tests.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tests.tsx
@@ -160,7 +160,7 @@ describe("LoginForm - component", () => {
     expect(screen.getByText("Log in").parentElement).toHaveFocus();
     await user.tab();
     expect(
-      screen.getByText("Sign in with Test IdP").parentElement
+      screen.getByRole("button", { name: /sign in with sso/i })
     ).toHaveFocus();
     await user.tab();
     expect(screen.getByText("Forgot password?")).toHaveFocus();

--- a/frontend/components/forms/LoginForm/LoginForm.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tsx
@@ -88,7 +88,6 @@ const LoginForm = ({
       <Button
         className={`${baseClass}__sso-btn`}
         type="button"
-        title="Single sign-on"
         variant="inverse"
         onClick={handleSSOSignOn}
         tabIndex={0}

--- a/frontend/components/forms/LoginForm/LoginForm.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tsx
@@ -6,6 +6,7 @@ import { ILoginUserData } from "interfaces/user";
 import CustomLink from "components/CustomLink";
 import Icon from "components/Icon";
 import Button from "components/buttons/Button";
+import TooltipWrapper from "components/TooltipWrapper";
 // @ts-ignore
 import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
 import paths from "router/paths";
@@ -82,34 +83,8 @@ const LoginForm = ({
     return false;
   };
 
-  const showLegendWithImage = () => {
-    let legend = "Single sign-on";
-    if (idpName) {
-      legend = `Sign in with ${idpName}`;
-    }
-
-    return (
-      <>
-        <img
-          src={imageURL}
-          alt={idpName}
-          className={`${baseClass}__sso-image`}
-        />
-        <span className={`${baseClass}__sso-legend`}>{legend}</span>
-      </>
-    );
-  };
-
   const renderSingleSignOnButton = () => {
-    let legend: string | JSX.Element = "Single sign-on";
-    if (idpName) {
-      legend = `Sign in with ${idpName}`;
-    }
-    if (imageURL) {
-      legend = showLegendWithImage();
-    }
-
-    return (
+    const button = (
       <Button
         className={`${baseClass}__sso-btn`}
         type="button"
@@ -118,8 +93,29 @@ const LoginForm = ({
         onClick={handleSSOSignOn}
         tabIndex={0}
       >
-        {legend}
+        {imageURL && (
+          <img src={imageURL} alt="" className={`${baseClass}__sso-image`} />
+        )}
+        <span className={`${baseClass}__sso-legend`}>Sign in with SSO</span>
       </Button>
+    );
+
+    // The label is always the generic "Sign in with SSO"; the configured IdP's
+    // name is surfaced only on hover so a long name can't overflow the button.
+    if (!idpName) {
+      return button;
+    }
+
+    return (
+      <TooltipWrapper
+        className={`${baseClass}__sso-tooltip`}
+        tipContent={`Sign in with ${idpName}`}
+        position="top"
+        showArrow
+        underline={false}
+      >
+        {button}
+      </TooltipWrapper>
     );
   };
 

--- a/frontend/components/forms/LoginForm/_styles.scss
+++ b/frontend/components/forms/LoginForm/_styles.scss
@@ -9,7 +9,6 @@
     vertical-align: middle;
     height: 20px;
     width: 20px;
-    margin-right: 10px;
     border-radius: 20%;
   }
 
@@ -43,7 +42,17 @@
     align-self: flex-start;
   }
 
-  &__sso-btn.button {
+  &__sso-tooltip.component__tooltip-wrapper {
+    display: block;
+    width: 100%;
+
+    .component__tooltip-wrapper__element {
+      width: 100%;
+    }
+  }
+
+  &__sso-tooltip.component__tooltip-wrapper .component__tooltip-wrapper__element &__sso-btn.button {
+    width: 100%;
     border: 1px solid $core-fleet-black;
     white-space: nowrap;
   }

--- a/frontend/components/forms/LoginForm/_styles.scss
+++ b/frontend/components/forms/LoginForm/_styles.scss
@@ -42,21 +42,23 @@
     align-self: flex-start;
   }
 
+  &__sso-btn.button {
+    border: 1px solid $core-fleet-black;
+    white-space: nowrap;
+  }
+
   &__sso-tooltip.component__tooltip-wrapper {
     display: block;
     width: 100%;
 
     .component__tooltip-wrapper__element {
-      width: 100%;
+      display: flex;
+
+      > .button {
+        flex: 1;
+      }
     }
   }
-
-  &__sso-tooltip.component__tooltip-wrapper .component__tooltip-wrapper__element &__sso-btn.button {
-    width: 100%;
-    border: 1px solid $core-fleet-black;
-    white-space: nowrap;
-  }
-  // End login button styles
 }
 
 .two-factor-check-email {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42473

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

With image URL set:
<img width="598" height="476" alt="Screenshot 2026-06-29 at 1 48 45 PM" src="https://github.com/user-attachments/assets/9e10c92d-57ce-448e-94c8-01cf852550a9" />

Without image:
<img width="598" height="507" alt="Screenshot 2026-06-29 at 1 49 13 PM" src="https://github.com/user-attachments/assets/782324e9-ffd3-459f-85ea-6bece16b8ce5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented SSO sign-in button text from overflowing by standardizing the visible label to **“Sign in with SSO”**.
  * Show the configured identity provider name in a **hover tooltip**, instead of altering the button label.
  * Improved SSO button/tooltip layout and spacing, including refined icon spacing and better button sizing within the tooltip.
* **Tests**
  * Updated LoginForm focus assertions to match the revised SSO button labeling and accessibility name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->