### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bezel/darwin.json
+++ b/ee/maintained-apps/outputs/bezel/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.5.0",
+      "version": "4.6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct' AND version_compare(bundle_short_version, '4.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nonstrict.Bezel-direct' AND version_compare(bundle_short_version, '4.6.0') < 0);"
       },
-      "installer_url": "https://download.nonstrict.eu/bezel/Bezel-4.5.0.zip",
+      "installer_url": "https://download.nonstrict.eu/bezel/Bezel-4.6.0.zip",
       "install_script_ref": "6ddd4f59",
       "uninstall_script_ref": "539e1578",
-      "sha256": "6961f17c7b97af9117af1679b959f4d59a64b744ef58f7c004a5e73995ab98be",
+      "sha256": "d321447352ee3ed786207901a9d83ab414fab4c8200a4cc041add6a2a5e89c66",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/clipbook/darwin.json
+++ b/ee/maintained-apps/outputs/clipbook/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.35.0",
+      "version": "1.36.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ikryanov.clipbook';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ikryanov.clipbook' AND version_compare(bundle_short_version, '1.35.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ikryanov.clipbook' AND version_compare(bundle_short_version, '1.36.0') < 0);"
       },
-      "installer_url": "https://f005.backblazeb2.com/file/clipbook/ClipBook-1.35.0-arm64.dmg",
+      "installer_url": "https://f005.backblazeb2.com/file/clipbook/ClipBook-1.36.0-arm64.dmg",
       "install_script_ref": "c4fc5697",
       "uninstall_script_ref": "ac8f913f",
-      "sha256": "31de4c4cd1a1a2f6e79fbb04f2ef6d6e8df172d3a2c251a2960d2b9720e6f580",
+      "sha256": "d59ad57f6bb8026c026e392e996eea2523fc8c9180e6a48be4981a491764d767",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/cryptomator/darwin.json
+++ b/ee/maintained-apps/outputs/cryptomator/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.19.2",
+      "version": "1.19.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.cryptomator';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cryptomator' AND version_compare(bundle_short_version, '1.19.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cryptomator' AND version_compare(bundle_short_version, '1.19.3') < 0);"
       },
-      "installer_url": "https://github.com/cryptomator/cryptomator/releases/download/1.19.2/Cryptomator-1.19.2-arm64.dmg",
+      "installer_url": "https://github.com/cryptomator/cryptomator/releases/download/1.19.3/Cryptomator-1.19.3-arm64.dmg",
       "install_script_ref": "04e0f825",
       "uninstall_script_ref": "68dd4a14",
-      "sha256": "e978a2da545d8aaca1192faf6dadf4c51bdf5e9bdc232a227618401c0b833f9a",
+      "sha256": "0bfe8c6aeb97acf638810e3e576016db510bc7bf71366dc00f3c7eea9a314f23",
       "default_categories": [
         "Security"
       ]

--- a/ee/maintained-apps/outputs/downie/darwin.json
+++ b/ee/maintained-apps/outputs/downie/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.12.8",
+      "version": "4.12.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.9') < 0);"
       },
-      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5197.dmg",
+      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5205.dmg",
       "install_script_ref": "1468a553",
       "uninstall_script_ref": "24e71e3c",
-      "sha256": "27b76527dc168501c944e940708c2ddf085fe4d2267262832c0bfbb426a7cdd8",
+      "sha256": "e8d52f5c96440ce52c49960751af0252f5700a2bf2d92a1c7998a970e91d8f68",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/duckduckgo/darwin.json
+++ b/ee/maintained-apps/outputs/duckduckgo/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.195.0",
+      "version": "1.196.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.duckduckgo.macos.browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.duckduckgo.macos.browser' AND version_compare(bundle_short_version, '1.195.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.duckduckgo.macos.browser' AND version_compare(bundle_short_version, '1.196.0') < 0);"
       },
-      "installer_url": "https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo-1.195.0.743.dmg",
+      "installer_url": "https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo-1.196.0.751.dmg",
       "install_script_ref": "c6bf9cce",
       "uninstall_script_ref": "b6f097db",
-      "sha256": "8e395284e403d697b14c70b60c0d3b9b702d8f6f91f4c2a80921bbb6ed6977fa",
+      "sha256": "4960923e78442485f18b57642406b4ad137b21c2fd15dacb7e3f198cd3704ca2",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/genesys-cloud/windows.json
+++ b/ee/maintained-apps/outputs/genesys-cloud/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.51.912.0",
+      "version": "2.51.916.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GenesysCloud' AND publisher = 'Genesys Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GenesysCloud' AND publisher = 'Genesys Inc.' AND version_compare(version, '2.51.912.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GenesysCloud' AND publisher = 'Genesys Inc.' AND version_compare(version, '2.51.916.0') < 0);"
       },
-      "installer_url": "https://app.mypurecloud.com/directory-windows/build-assets/2.51.912-245/genesys-cloud-windows-2.51.912-x86.msi",
+      "installer_url": "https://app.mypurecloud.com/directory-windows/build-assets/2.51.916-248/genesys-cloud-windows-2.51.916-x86.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "3d56a699",
-      "sha256": "8b00d99a1545d7ca21209e6642de26540cc863ca1f3ffff40b4e971821e6dab1",
+      "sha256": "4c63a4b793684eb1d061ee46b82ca80442bd61f5118ea90cea86f3c1164ac3bb",
       "default_categories": [
         "Communication"
       ],

--- a/ee/maintained-apps/outputs/macwhisper/darwin.json
+++ b/ee/maintained-apps/outputs/macwhisper/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "13.22.0",
+      "version": "13.23.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.goodsnooze.MacWhisper';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.goodsnooze.MacWhisper' AND version_compare(bundle_short_version, '13.22.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.goodsnooze.MacWhisper' AND version_compare(bundle_short_version, '13.23.0') < 0);"
       },
-      "installer_url": "https://cdn.macwhisper.com/macwhisper/MacWhisper-1432.zip",
+      "installer_url": "https://cdn.macwhisper.com/macwhisper/MacWhisper-1436.zip",
       "install_script_ref": "cf608a83",
       "uninstall_script_ref": "fc63912f",
-      "sha256": "c1b9c112c2371ea9489da0c5de54de9835d48881a546c79ea918b6aadf832644",
+      "sha256": "1753fdb2214571e74a3663a84eb66b24c688894f8b103008eb9c75e53cb236dc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/miro/windows.json
+++ b/ee/maintained-apps/outputs/miro/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.11.144",
+      "version": "0.11.154",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Miro' AND publisher = 'Miro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Miro' AND publisher = 'Miro' AND version_compare(version, '0.11.144') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Miro' AND publisher = 'Miro' AND version_compare(version, '0.11.154') < 0);"
       },
       "installer_url": "https://desktop.miro.com/platforms/win32-nsis-pu/Miro-setup.exe",
       "install_script_ref": "c9d9747e",
       "uninstall_script_ref": "66f6a4de",
-      "sha256": "24da9d6b31fd5429a773f1e30d7fb2b16ba789330201289f45920babf8fb0704",
+      "sha256": "0191332d9a1ed8e470552adbc752d71c7da0d21172223369ac18cb37ff9c89a1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nextcloud/windows.json
+++ b/ee/maintained-apps/outputs/nextcloud/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "33.0.6",
+      "version": "33.0.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Nextcloud' AND publisher = 'Nextcloud GmbH';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Nextcloud' AND publisher = 'Nextcloud GmbH' AND version_compare(version, '33.0.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Nextcloud' AND publisher = 'Nextcloud GmbH' AND version_compare(version, '33.0.7') < 0);"
       },
-      "installer_url": "https://github.com/nextcloud-releases/desktop/releases/download/v33.0.6/Nextcloud-33.0.6-x64.msi",
+      "installer_url": "https://github.com/nextcloud-releases/desktop/releases/download/v33.0.7/Nextcloud-33.0.7-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "625d37ef",
-      "sha256": "74aad01a110f3277f39a2e87ed18cb3126ee0beaee7b56205ad953da83e614c3",
+      "sha256": "88d47f551082e6284d5c0845261a8110e361b6d9ce3fe805af6bec711514a34e",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.1893",
+      "version": "1.4.1901",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1893') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1901') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1893/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1901/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "15f099ed23a2bc72fb92bb7d34fd4f219954f09e0e40e02378373f81c54746ce",
+      "sha256": "adf8c530653a9aaff2b518ac14f9f1badddcb4d5c15639b795d5c0ce732a3559",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "132.0",
+      "version": "133.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '132.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '133.0') < 0);"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/132.0.5905.102/mac/Opera_132.0.5905.102_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/133.0.5932.10/mac/Opera_133.0.5932.10_Setup.dmg",
       "install_script_ref": "e9e947a7",
       "uninstall_script_ref": "566d9846",
-      "sha256": "72a774d6c2306fd1a54cfcaddd82e2c2582bd49031299e5ce8c8a2f4c6eaf4a4",
+      "sha256": "a668091faf85e3c263e91046e17bcd81619bef590d1db7ce9a7bb662df7808b9",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/proton-drive/windows.json
+++ b/ee/maintained-apps/outputs/proton-drive/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG' AND version_compare(version, '3.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG' AND version_compare(version, '3.0.2') < 0);"
       },
-      "installer_url": "https://proton.me/download/drive/windows/3.0.1/x64/Proton%20Drive%20Setup%203.0.1.exe",
+      "installer_url": "https://proton.me/download/drive/windows/3.0.2/x64/Proton%20Drive%20Setup%203.0.2.exe",
       "install_script_ref": "0bff62f0",
       "uninstall_script_ref": "7491c781",
-      "sha256": "2277df8023f69d3454d605e6980367145885544d3d94f7b1d4370c6a466b9b13",
+      "sha256": "5d12341e356eb32ff0675eb73caed3e128aeb16fb780aeb53c677fc9d6bcae14",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/reqable/darwin.json
+++ b/ee/maintained-apps/outputs/reqable/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.3",
+      "version": "3.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.0') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.1.3/reqable-app-macos-arm64.dmg",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.0/reqable-app-macos-arm64.dmg",
       "install_script_ref": "5d84816f",
       "uninstall_script_ref": "3319d75e",
-      "sha256": "c186aad60848d7ba89a19b5991a8d94832d0fe720565d9d42d5b13aaadd9bb81",
+      "sha256": "5f8e711f9f2ec519739d3f308e10f6f3ddf6845111d1957ce9ce6f795b776fad",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/reqable/windows.json
+++ b/ee/maintained-apps/outputs/reqable/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.1') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.0/reqable-app-windows-x86_64.exe",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.1/reqable-app-windows-x86_64.exe",
       "install_script_ref": "d2ffec58",
       "uninstall_script_ref": "b33fc442",
-      "sha256": "8c3a7193ac5eb0ecb3ea6686c999f78be61ce72943757fe85d5b0332c6ee183f",
+      "sha256": "c6ce26f99e70dba18179fee91323942469462a61c52f0d782980c1f2c032f75b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.25.22",
+      "version": "26.26.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.25.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.26.12') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",

--- a/ee/maintained-apps/outputs/wins/darwin.json
+++ b/ee/maintained-apps/outputs/wins/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.4",
+      "version": "3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main' AND version_compare(bundle_short_version, '3.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main' AND version_compare(bundle_short_version, '3.3') < 0);"
       },
       "installer_url": "https://winswebsite.s3.us-east-005.backblazeb2.com/Wins.zip",
       "install_script_ref": "16e109de",

--- a/ee/maintained-apps/outputs/wins/darwin.json
+++ b/ee/maintained-apps/outputs/wins/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.3",
+      "version": "3.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main' AND version_compare(bundle_short_version, '3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main' AND version_compare(bundle_short_version, '3.4') < 0);"
       },
       "installer_url": "https://winswebsite.s3.us-east-005.backblazeb2.com/Wins.zip",
       "install_script_ref": "16e109de",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated app release metadata for multiple macOS and Windows apps so users get the latest available installers.
  * Bumped versions for Bezel, ClipBook, Cryptomator, Downie, DuckDuckGo, Genesys Cloud, MacWhisper, Miro, Nextcloud, Notepad.exe, Opera, Proton Drive, Reqable, WhatsApp, and Wins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->