### PR TITLE
Fleet UI: Stop clipping action dropdown menus inside scrollable tables

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tests.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tests.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
 
+import TableLayoutContext from "components/TableContainer/TableLayoutContext";
 import ActionsDropdown from "./ActionsDropdown";
 
 const DROPDOWN_OPTIONS = [
@@ -72,6 +73,28 @@ describe("Actions dropdown", () => {
     const deleteOption = screen.getByText("Delete");
 
     expect(deleteOption).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("portals menu and fires onChange on option click when insideTable", async () => {
+    const mockOnChange = jest.fn();
+    const { user } = renderWithSetup(
+      <TableLayoutContext.Provider value={{ insideTable: true }}>
+        <ActionsDropdown
+          options={DROPDOWN_OPTIONS}
+          placeholder={PLACEHOLDER}
+          onChange={mockOnChange}
+        />
+      </TableLayoutContext.Provider>
+    );
+
+    await user.click(screen.getByText("Actions"));
+    // Menu portals to a sibling of body, not inside the wrapper div.
+    expect(
+      document.querySelector(".actions-dropdown-select__menu-portal")
+    ).not.toBeNull();
+    await user.click(screen.getByText("Edit"));
+
+    expect(mockOnChange).toHaveBeenCalledWith("edit-query");
   });
 
   it("closes the dropdown when clicking outside", async () => {

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -343,7 +343,11 @@ const ActionsDropdown = ({
         classNamePrefix={`${baseClass}-select`}
         isOptionDisabled={(option) => !!option.disabled}
         menuPlacement={menuPlacement}
-        menuPortalTarget={document.body}
+        // Skip the portal for brand-button: it nulls out Control, and
+        // react-select's MenuPortal bails when controlElement is missing,
+        // leaving no menu to render. Brand-button is only used outside the
+        // data-table wrapper anyway, so it doesn't need the portal.
+        menuPortalTarget={isBrandButton ? undefined : document.body}
         {...{ variant }} // Allows CustomDropdownIndicator to be ui-fleet-black-75 for variant: "button"
       />
     </div>

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -135,14 +135,18 @@ const ActionsDropdown = ({
   // Close on outside click
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      // If click was outside wrapper, close menu
+      if (!menuIsOpen || !wrapperRef.current) return;
+      const target = event.target as Element | null;
+      // Trigger button (wrapper) or portaled menu both count as "inside" —
+      // since menuPortalTarget renders the menu in document.body, a contains()
+      // check on wrapperRef alone would treat option clicks as outside.
       if (
-        menuIsOpen &&
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
+        wrapperRef.current.contains(target) ||
+        target?.closest(`.${baseClass}-select__menu-portal`)
       ) {
-        setMenuIsOpen(false);
+        return;
       }
+      setMenuIsOpen(false);
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => {
@@ -267,6 +271,12 @@ const ActionsDropdown = ({
       right: getRightMenuAlign(menuAlign),
       animation: "fade-in 150ms ease-out",
     }),
+    // Portal the menu to document.body so it isn't clipped by a scrollable
+    // ancestor (notably .data-table__wrapper's overflow-x: auto).
+    menuPortal: (provided) => ({
+      ...provided,
+      zIndex: 6,
+    }),
     menuList: (provided) => ({
       ...provided,
       padding: PADDING["pad-small"],
@@ -329,6 +339,7 @@ const ActionsDropdown = ({
         classNamePrefix={`${baseClass}-select`}
         isOptionDisabled={(option) => !!option.disabled}
         menuPlacement={menuPlacement}
+        menuPortalTarget={document.body}
         {...{ variant }} // Allows CustomDropdownIndicator to be ui-fleet-black-75 for variant: "button"
       />
     </div>

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -136,13 +136,15 @@ const ActionsDropdown = ({
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (!menuIsOpen || !wrapperRef.current) return;
-      const target = event.target as Element | null;
+      const target = event.target;
+      if (!(target instanceof Node)) return;
       // Trigger button (wrapper) or portaled menu both count as "inside" —
       // since menuPortalTarget renders the menu in document.body, a contains()
       // check on wrapperRef alone would treat option clicks as outside.
+      if (wrapperRef.current.contains(target)) return;
       if (
-        wrapperRef.current.contains(target) ||
-        target?.closest(`.${baseClass}-select__menu-portal`)
+        target instanceof Element &&
+        target.closest(`.${baseClass}-select__menu-portal`)
       ) {
         return;
       }
@@ -272,10 +274,12 @@ const ActionsDropdown = ({
       animation: "fade-in 150ms ease-out",
     }),
     // Portal the menu to document.body so it isn't clipped by a scrollable
-    // ancestor (notably .data-table__wrapper's overflow-x: auto).
+    // ancestor (notably .data-table__wrapper's overflow-x: auto). zIndex must
+    // clear .site-nav-container (100) and Modal (101) since ActionsDropdown
+    // can render inside a modal (e.g. ScriptDetailsModal).
     menuPortal: (provided) => ({
       ...provided,
-      zIndex: 6,
+      zIndex: 999,
     }),
     menuList: (provided) => ({
       ...provided,

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import Select, {
   components,
   DropdownIndicatorProps,
@@ -16,6 +16,7 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import DropdownOptionTooltipWrapper from "components/forms/fields/Dropdown/DropdownOptionTooltipWrapper";
+import TableLayoutContext from "components/TableContainer/TableLayoutContext";
 
 const baseClass = "actions-dropdown";
 
@@ -126,6 +127,13 @@ const ActionsDropdown = ({
   buttonLabel,
 }: IActionsDropdownProps): JSX.Element => {
   const dropdownClassnames = classnames(baseClass, className);
+
+  // Portal the menu only when rendered inside a TableContainer's data-table
+  // block, where .data-table__wrapper's overflow-x: auto would otherwise clip
+  // the menu vertically. The brand-button variant nulls out react-select's
+  // Control, and MenuPortal bails when controlElement is missing — so don't
+  // use brand-button inside a table cell.
+  const { insideTable } = useContext(TableLayoutContext);
 
   // Used for brand Action button
   const [menuIsOpen, setMenuIsOpen] = useState(false);
@@ -273,10 +281,9 @@ const ActionsDropdown = ({
       right: getRightMenuAlign(menuAlign),
       animation: "fade-in 150ms ease-out",
     }),
-    // Portal the menu to document.body so it isn't clipped by a scrollable
-    // ancestor (notably .data-table__wrapper's overflow-x: auto). zIndex must
-    // clear .site-nav-container (100) and Modal (101) since ActionsDropdown
-    // can render inside a modal (e.g. ScriptDetailsModal).
+    // zIndex 999 (document-portal tier) so the portaled menu clears
+    // .site-nav-container and Modal — ActionsDropdown can render inside a
+    // TableContainer that lives inside a modal (e.g. ScriptDetailsModal).
     menuPortal: (provided) => ({
       ...provided,
       zIndex: 999,
@@ -343,11 +350,7 @@ const ActionsDropdown = ({
         classNamePrefix={`${baseClass}-select`}
         isOptionDisabled={(option) => !!option.disabled}
         menuPlacement={menuPlacement}
-        // Skip the portal for brand-button: it nulls out Control, and
-        // react-select's MenuPortal bails when controlElement is missing,
-        // leaving no menu to render. Brand-button is only used outside the
-        // data-table wrapper anyway, so it doesn't need the portal.
-        menuPortalTarget={isBrandButton ? undefined : document.body}
+        menuPortalTarget={insideTable ? document.body : undefined}
         {...{ variant }} // Allows CustomDropdownIndicator to be ui-fleet-black-75 for variant: "button"
       />
     </div>

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -12,6 +12,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 
 import DataTable from "./DataTable/DataTable";
 import { IActionButtonProps } from "./DataTable/ActionButton/ActionButton";
+import TableLayoutContext from "./TableLayoutContext";
 
 export interface ITableQueryData {
   pageIndex: number;
@@ -511,91 +512,99 @@ const TableContainer = <T,>({
   return (
     <div className={wrapperClasses}>
       {renderFilters()}
-      <div className={`${baseClass}__data-table-block`}>
-        {/* No entities for this result. */}
-        {(!isLoading && data.length === 0 && !isMultiColumnFilter) ||
-        (searchQuery.length &&
-          data.length === 0 &&
-          !isMultiColumnFilter &&
-          !isLoading) ? (
-          <>
-            <EmptyComponent pageIndex={currentPageIndex} />
-            {/* This UI only shows if a user navigates to a table page with a URL page param that is outside the # of pages available */}
-            {currentPageIndex !== 0 && (
-              <div className={`${baseClass}__empty-page`}>
-                <div className={`${baseClass}__previous-button`}>
-                  <Pagination
-                    disableNext
-                    onNextPage={() => onPaginationChange(currentPageIndex + 1)}
-                    onPrevPage={() => onPaginationChange(currentPageIndex - 1)}
-                  />
-                </div>
-              </div>
-            )}
-          </>
-        ) : (
-          <>
-            {/* TODO: Fix this hacky solution to clientside search being 0 rendering emptycomponent but
-            no longer accesses rows.length because DataTable is not rendered */}
-            {!isLoading && clientFilterCount === 0 && !isMultiColumnFilter && (
+      <TableLayoutContext.Provider value={{ insideTable: true }}>
+        <div className={`${baseClass}__data-table-block`}>
+          {/* No entities for this result. */}
+          {(!isLoading && data.length === 0 && !isMultiColumnFilter) ||
+          (searchQuery.length &&
+            data.length === 0 &&
+            !isMultiColumnFilter &&
+            !isLoading) ? (
+            <>
               <EmptyComponent pageIndex={currentPageIndex} />
-            )}
-            <div
-              className={
-                isClientSideFilter && !isMultiColumnFilter
-                  ? `client-result-count-${clientFilterCount}`
-                  : ""
-              }
-            >
-              <DataTable
-                isLoading={isLoading}
-                columns={columnConfigs}
-                data={data}
-                filters={filters}
-                manualSortBy={manualSortBy}
-                sortHeader={sortHeader}
-                sortDirection={sortDirection}
-                onSort={onSortChange}
-                disableMultiRowSelect={disableMultiRowSelect}
-                showMarkAllPages={showMarkAllPages}
-                isAllPagesSelected={isAllPagesSelected}
-                toggleAllPagesSelected={toggleAllPagesSelected}
-                totalCount={totalCount}
-                resultsTitle={resultsTitle}
-                defaultPageSize={pageSize}
-                defaultPageIndex={pageIndex}
-                defaultSelectedRows={defaultSelectedRows}
-                autoResetPage={!disableAutoResetPage}
-                primarySelectAction={primarySelectAction}
-                secondarySelectActions={secondarySelectActions}
-                onSelectSingleRow={onSelectSingleRow}
-                onClickRow={onClickRow}
-                keyboardSelectableRows={keyboardSelectableRows}
-                onResultsCountChange={setClientFilterCount}
-                isClientSidePagination={isClientSidePagination}
-                onClientSidePaginationChange={onClientSidePaginationChange}
-                isClientSideFilter={isClientSideFilter}
-                disableHighlightOnHover={disableHighlightOnHover}
-                searchQuery={searchQuery}
-                searchQueryColumn={searchQueryColumn}
-                selectedDropdownFilter={selectedDropdownFilter}
-                renderTableHelpText={renderTableHelpText}
-                renderPagination={
-                  isClientSidePagination
-                    ? undefined
-                    : renderServersidePagination
+              {/* This UI only shows if a user navigates to a table page with a URL page param that is outside the # of pages available */}
+              {currentPageIndex !== 0 && (
+                <div className={`${baseClass}__empty-page`}>
+                  <div className={`${baseClass}__previous-button`}>
+                    <Pagination
+                      disableNext
+                      onNextPage={() =>
+                        onPaginationChange(currentPageIndex + 1)
+                      }
+                      onPrevPage={() =>
+                        onPaginationChange(currentPageIndex - 1)
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              {/* TODO: Fix this hacky solution to clientside search being 0 rendering emptycomponent but
+            no longer accesses rows.length because DataTable is not rendered */}
+              {!isLoading &&
+                clientFilterCount === 0 &&
+                !isMultiColumnFilter && (
+                  <EmptyComponent pageIndex={currentPageIndex} />
+                )}
+              <div
+                className={
+                  isClientSideFilter && !isMultiColumnFilter
+                    ? `client-result-count-${clientFilterCount}`
+                    : ""
                 }
-                setExportRows={setExportRows}
-                onClearSelection={onClearSelection}
-                suppressHeaderActions={suppressHeaderActions}
-                getRowId={getRowId}
-                persistSelectedRows={persistSelectedRows}
-                hideFooter={hideFooter}
-              />
-            </div>
-          </>
-        )}
-      </div>
+              >
+                <DataTable
+                  isLoading={isLoading}
+                  columns={columnConfigs}
+                  data={data}
+                  filters={filters}
+                  manualSortBy={manualSortBy}
+                  sortHeader={sortHeader}
+                  sortDirection={sortDirection}
+                  onSort={onSortChange}
+                  disableMultiRowSelect={disableMultiRowSelect}
+                  showMarkAllPages={showMarkAllPages}
+                  isAllPagesSelected={isAllPagesSelected}
+                  toggleAllPagesSelected={toggleAllPagesSelected}
+                  totalCount={totalCount}
+                  resultsTitle={resultsTitle}
+                  defaultPageSize={pageSize}
+                  defaultPageIndex={pageIndex}
+                  defaultSelectedRows={defaultSelectedRows}
+                  autoResetPage={!disableAutoResetPage}
+                  primarySelectAction={primarySelectAction}
+                  secondarySelectActions={secondarySelectActions}
+                  onSelectSingleRow={onSelectSingleRow}
+                  onClickRow={onClickRow}
+                  keyboardSelectableRows={keyboardSelectableRows}
+                  onResultsCountChange={setClientFilterCount}
+                  isClientSidePagination={isClientSidePagination}
+                  onClientSidePaginationChange={onClientSidePaginationChange}
+                  isClientSideFilter={isClientSideFilter}
+                  disableHighlightOnHover={disableHighlightOnHover}
+                  searchQuery={searchQuery}
+                  searchQueryColumn={searchQueryColumn}
+                  selectedDropdownFilter={selectedDropdownFilter}
+                  renderTableHelpText={renderTableHelpText}
+                  renderPagination={
+                    isClientSidePagination
+                      ? undefined
+                      : renderServersidePagination
+                  }
+                  setExportRows={setExportRows}
+                  onClearSelection={onClearSelection}
+                  suppressHeaderActions={suppressHeaderActions}
+                  getRowId={getRowId}
+                  persistSelectedRows={persistSelectedRows}
+                  hideFooter={hideFooter}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </TableLayoutContext.Provider>
     </div>
   );
 };

--- a/frontend/components/TableContainer/TableLayoutContext.tsx
+++ b/frontend/components/TableContainer/TableLayoutContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+// Signals to descendants that they're rendered inside a TableContainer's
+// data-table block — which has overflow-x: auto on its wrapper. Popup
+// components (e.g. ActionsDropdown) read this to decide whether to portal
+// their menu to document.body so the wrapper's overflow doesn't clip it.
+const TableLayoutContext = createContext<{ insideTable: boolean }>({
+  insideTable: false,
+});
+
+export default TableLayoutContext;


### PR DESCRIPTION
## Issue
Closes #47960 

Unreleased bug introduced in #48419 — that PR moved horizontal table scrolling into `.data-table__wrapper` via `overflow-x: auto`. Per CSS spec, setting either overflow axis to non-`visible` coerces the other axis too, so the wrapper now clips action dropdown menus vertically. Most visible on tables where the actions cell is in the last visible row.

## Description

Introduced `TableLayoutContext` (`frontend/components/TableContainer/TableLayoutContext.tsx`) — a small React context that `TableContainer` wraps around its `data-table-block` div, signaling `insideTable: true` to descendants. `ActionsDropdown` reads the context via `useContext` and sets `menuPortalTarget={document.body}` only when inside a TableContainer's data-table block. Action buttons rendered in TableContainer's header (`customControl`, `actionButton`) sit *outside* the provider, so the brand-button "Add user" / "Actions" buttons stay un-portaled and continue to work — react-select's `MenuPortal` bails when `controlElement` is null, which is the case for `variant="brand-button"`.

Portal styling:
- `menuPortal` z-index uses the document-portal tier (`999`) so the menu clears `.site-nav-container` (100) and `Modal` (101). `ActionsDropdown` can render inside a `TableContainer` nested in a modal (e.g. `ScriptDetailsModal`).

Click-outside handler:
- Treats the portaled menu as "inside" by checking `target.closest('.actions-dropdown-select__menu-portal')`. Without this, an option mousedown would close the menu before the option's click registered.
- Narrows `event.target` separately for `Node` (the `contains` path) and `Element` (the `closest` path) — Text nodes have no `closest()`.

Added a Jest test that mounts `ActionsDropdown` inside `<TableLayoutContext.Provider value={{ insideTable: true }}>`, opens the menu, asserts the portal element exists on `document`, clicks an option, and asserts `onChange` fires. This locks the regression that bit us mid-review (brand-button-with-portal rendered nothing because Control was nulled out).

## Screen recording


https://github.com/user-attachments/assets/a67eecd3-35da-49b4-ab2f-2afc5a008914

- [x] QA'd all new/changed functionality manually

## Testing

- [x] Open Hosts → Manage labels: row actions dropdown is fully visible, including on the bottom row of a short table.
- [x] Click an option in a row's actions dropdown and confirm the action fires (regression check on the click-outside handler).
- [x] Confirm `menuAlign="right"` still aligns the menu's right edge with the trigger.
- [ ] Hosts → host details → Activities → script row → `ScriptDetailsModal` "More actions" dropdown still opens and selects (regression check — this one is *not* portaled, since it renders directly inside a Modal, not inside a `TableContainer`).
- [x] Settings → Users → "Add user" brand-button dropdown still opens and works (this one is *not* portaled — uses `customControl`, lives outside the data-table-block).
- [x] Hosts → Host details → host-page Actions brand-button dropdown still opens and works (also outside any TableContainer).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropdown menus now stay open when interacting with the menu itself, including when it appears outside the table area.
  * Table views now support better layering for dropdown menus so they display above other content.

* **Bug Fixes**
  * Fixed dropdowns closing unexpectedly on valid clicks inside the menu.
  * Improved menu behavior in tables to avoid clipping and interaction issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->