### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/beyond-compare/darwin.json
+++ b/ee/maintained-apps/outputs/beyond-compare/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.2.2.32209",
+      "version": "5.2.3.32296",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ScooterSoftware.BeyondCompare';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ScooterSoftware.BeyondCompare' AND version_compare(bundle_short_version, '5.2.2.32209') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ScooterSoftware.BeyondCompare' AND version_compare(bundle_short_version, '5.2.3.32296') < 0);"
       },
-      "installer_url": "https://www.scootersoftware.com/files/BCompareOSX-5.2.2.32209.zip",
+      "installer_url": "https://www.scootersoftware.com/files/BCompareOSX-5.2.3.32296.zip",
       "install_script_ref": "5fca1cb5",
       "uninstall_script_ref": "1360661e",
-      "sha256": "3432647d13d81054b37b85bd111adc35cf49988d17d737a073d3a96377112709",
+      "sha256": "7693708616951be361c660dae4c64b5579914edc59a86a06f3791f60002b04f7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/docker-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/docker-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.79.0",
+      "version": "4.80.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '4.79.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '4.80.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/mac/main/arm64/230596/Docker.dmg",
+      "installer_url": "https://desktop.docker.com/mac/main/arm64/232116/Docker.dmg",
       "install_script_ref": "2c3a200a",
       "uninstall_script_ref": "dd14c72d",
-      "sha256": "43930db6d7cf6fd34a563c9489d40f733d62d1e32a48221428f26a68697b7782",
+      "sha256": "41d0e5c61327a877f229a1e1158d056d37f003902189fd5e0ba8629619c1819f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/wins/darwin.json
+++ b/ee/maintained-apps/outputs/wins/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.3",
+      "version": "3.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main' AND version_compare(bundle_short_version, '3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cools.wins.main' AND version_compare(bundle_short_version, '3.4') < 0);"
       },
       "installer_url": "https://winswebsite.s3.us-east-005.backblazeb2.com/Wins.zip",
       "install_script_ref": "16e109de",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS package metadata for Beyond Compare and Docker Desktop to point to the latest available versions and installer downloads.
  * Refined version matching for WINS on macOS so the app is detected more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->