### PR TITLE
Website: Fix failing deploy

### DIFF
--- a/articles/block-and-monitor-edr-freeze-on-macos-with-santa-and-fleet.md
+++ b/articles/block-and-monitor-edr-freeze-on-macos-with-santa-and-fleet.md
@@ -181,4 +181,4 @@ With Fleet, blocking and monitoring the attack is a reviewed, version-controlled
 <meta name="authorGitHubUsername" value="karmine05">
 <meta name="category" value="articles">
 <meta name="publishedOn" value="2026-06-29">
-<meta name="description" value="Learn how EDR Freeze works on macOS, how Santa 2026.3 blocks it with AntiSuspendSigningIDs, and how to monitor for it using Fleet's Santa osquery tables.">
+<meta name="description" value="Learn how EDR Freeze works on macOS, how Santa 2026.3 blocks it with AntiSuspendSigningIDs, and using Fleet's Santa osquery tables to monitor it.">

--- a/handbook/engineering/engineering.rituals.yml
+++ b/handbook/engineering/engineering.rituals.yml
@@ -16,7 +16,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/engineering#renew-mdm-certificate-signing-request-csr"
   dri: "georgekarrv"
   autoIssue: 
-    labels: [ "#g-mdm", "P2"]
+    labels: [ "#g-apple-at-work", "P2"]
     repo: "fleet"
 -
   task: "Renew Apple developer account"
@@ -26,7 +26,7 @@
   moreInfoUrl: https://fleetdm.com/handbook/engineering#accept-new-apple-developer-account-terms
   dri: "georgekarrv"
   autoIssue: 
-    labels: [ "#g-mdm", "P2"]
+    labels: [ "#g-apple-at-work", "P2"]
     repo: "fleet"
 - 
   task: "Oncall handoff"

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1674,7 +1674,9 @@ module.exports = {
           });
           // Get the latest "complete" release to use.
           let latestCompleteRelease = _.last(_.sortBy(completeReleases, (release)=>{ return new Date(release.published_at).getTime(); }));
-
+          if(!latestCompleteRelease) {
+            throw new Error(`When getting information about recent Fleet releases to find installers for the download page, no release containing macOS, Windows (amd64), and Windows (arm64) installers was found in the GitHub API response.`);
+          }
           if(!macOsInstaller) {
             sails.log.warn(`When getting information about the latest release (${latestFleetReleaseDetails.name}) to get installer links for the download page, no installer for macOS was found in the release assets. The download page will link to an older version (${latestCompleteRelease.name}) for macOS.`);
             macOsInstaller = _.find(latestCompleteRelease.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_mac.pkg');});

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1666,7 +1666,7 @@ module.exports = {
             return new Error(`When sending a request to the GitHub API to get links for the latest released fleetctl installers, an error occurred. Full error: ${util.inspect(err)}`);
           });
 
-          // Find all relases that contains all three installer assets.
+          // Find all releases that contains all three installer assets.
           let completeReleases = _.filter(otherRecentFleetReleases, (release)=>{
             return _.some(release.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_mac.pkg');}) &&
               _.some(release.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_windows_amd64.msi');}) &&

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1656,16 +1656,37 @@ module.exports = {
         });
         let downloadAssets = latestFleetReleaseDetails.assets;
         let macOsInstaller = _.find(downloadAssets, (asset)=> { return  _.endsWith(asset.browser_download_url, '_mac.pkg');});
-        if(!macOsInstaller) {
-          throw new Error(`When getting information about the latest release (${latestFleetReleaseDetails.name}) to get installer links for the download page, no installer for macOS was found in the release assets.`);
-        }
         let windowsInstaller = _.find(downloadAssets, (asset)=> { return _.endsWith(asset.browser_download_url, '_windows_amd64.msi');});
-        if(!windowsInstaller) {
-          throw new Error(`When getting information about the latest release (${latestFleetReleaseDetails.name}) to get installer links for the download page, no installer for Windows (amd64) was found in the release assets.`);
-        }
         let windowsArmInstaller = _.find(downloadAssets, (asset)=> { return _.endsWith(asset.browser_download_url, '_windows_arm64.msi');});
-        if(!windowsArmInstaller) {
-          throw new Error(`When getting information about the latest release (${latestFleetReleaseDetails.name}) to get installer links for the download page, no installer for Windows (arm64) was found in the release assets.`);
+        if(!macOsInstaller || !windowsInstaller || !windowsArmInstaller) {
+          let otherRecentFleetReleases = await sails.helpers.http.get.with({
+            url: 'https://api.github.com/repos/fleetdm/fleet/releases',
+            headers: baseHeadersForGithubRequests,
+          }).intercept((err) =>{
+            return new Error(`When sending a request to the GitHub API to get links for the latest released fleetctl installers, an error occurred. Full error: ${util.inspect(err)}`);
+          });
+
+          // Find all relases that contains all three installer assets.
+          let completeReleases = _.filter(otherRecentFleetReleases, (release)=>{
+            return _.some(release.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_mac.pkg');}) &&
+              _.some(release.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_windows_amd64.msi');}) &&
+              _.some(release.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_windows_arm64.msi');});
+          });
+          // Get the latest "complete" release to use.
+          let latestCompleteRelease = _.last(_.sortBy(completeReleases, (release)=>{ return new Date(release.published_at).getTime(); }));
+
+          if(!macOsInstaller) {
+            sails.log.warn(`When getting information about the latest release (${latestFleetReleaseDetails.name}) to get installer links for the download page, no installer for macOS was found in the release assets. The download page will link to an older version (${latestCompleteRelease.name}) for macOS.`);
+            macOsInstaller = _.find(latestCompleteRelease.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_mac.pkg');});
+          }
+          if(!windowsInstaller) {
+            sails.log.warn(`When getting information about the latest release (${latestFleetReleaseDetails.name}) to get installer links for the download page, no installer for Windows (amd64) was found in the release assets. The download page will link to an older version (${latestCompleteRelease.name}) for Windows (amd64).`);
+            windowsInstaller = _.find(latestCompleteRelease.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_windows_amd64.msi');});
+          }
+          if(!windowsArmInstaller) {
+            sails.log.warn(`When getting information about the latest release (${latestFleetReleaseDetails.name}) to get installer links for the download page, no installer for Windows (arm64) was found in the release assets. The download page will link to an older version (${latestCompleteRelease.name}) for Windows (arm64).`);
+            windowsArmInstaller = _.find(latestCompleteRelease.assets, (asset)=> { return _.endsWith(asset.browser_download_url, '_windows_arm64.msi');});
+          }
         }
         builtStaticContent.fleetctlDownloadUrls = {
           macOs: macOsInstaller.browser_download_url,


### PR DESCRIPTION
Changes:
- Updated the website's build-static-content script to use download URLs from the next latest released version of Fleet when the latest release does not contain installers for a platform in its release assets.
- Reduced the length of the description meta tag value in the "Block and monitor EDR Freeze on macOS with Santa and Fleet" article
- Updated the labels values for two engineering rituals (The old label was removed from the GH repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when generating fleetctl download links if the latest GitHub release is missing one or more required platform installer assets.
  * The system now looks for the most recent release that contains the complete installer set, warns for any missing platform, and fails only if no complete set is available.

* **Documentation**
  * Updated labels for two Apple-related engineering rituals to use the correct label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->