### PR TITLE
Fleet UI: Lock labels table column widths to prevent reflow on sort

### DIFF
--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/_styles.scss
@@ -1,33 +1,26 @@
-// Selectors nest under .data-table-block to outrank the global rule
-// `.data-table-block .data-table tbody td { max-width: 500px }`, which
-// otherwise wins on a class-vs-element specificity tie. `width: 100%;
-// max-width: 0` is the table idiom for "absorb the remaining row width
-// and let TooltipTruncatedTextCell truncate the overflow."
+// table-layout: fixed locks column widths to the declared values; without it
+// the browser auto-sizes columns to content and the layout shifts each time
+// sorting brings differently-sized values into view. Widths are set on both
+// the header and cell selectors because fixed layout reads widths from the
+// first row of cells (typically the header row).
 .labels-table {
+  .data-table-block .data-table__table {
+    table-layout: fixed;
+  }
+
+  .data-table-block .name__header,
   .data-table-block .name__cell {
-    width: $col-lg;
-    max-width: $col-lg;
+    width: 30%;
   }
 
-  // Description flexes so it can't push the table past the viewport; name
-  // stays at $col-lg.
+  .data-table-block .description__header,
   .data-table-block .description__cell {
-    width: 100%;
-    max-width: 0;
+    width: 40%;
   }
 
-  // Roles swap at the narrowest viewport: description locks small so it
-  // stays readable, name takes whatever's left.
-  @media (max-width: $break-sm) {
-    .data-table-block .description__cell {
-      width: 185px;
-      min-width: 185px;
-      max-width: 185px;
-    }
-
-    .data-table-block .name__cell {
-      width: 100%;
-      max-width: 0;
-    }
+  .data-table-block .label_membership_type__header,
+  .data-table-block .label_membership_type__cell {
+    width: 100px;
+    max-width: 100px;
   }
 }


### PR DESCRIPTION
## Issue

Resolves #48130

## Description

Apply `table-layout: fixed` to the Manage labels table and lock the column widths so they no longer auto-size to the content of the currently visible page:

- Name: 30%
- Description: 40%
- Type: 100px
- Actions: untouched (uses the base data-table 99px header rule)

Long values truncate via the existing `TooltipTruncatedTextCell` instead of pushing the column wider. The sort-header click target stays under the cursor across pages and sorts.

Scoped intentionally to the labels table. The same `table-layout: auto` + auto-sized columns pattern exists across many other tables in the app (#48130 calls out labels because it's the most obvious offender, but the underlying behavior is global). Overhauling every table to use fixed layout is a larger initiative — picking the right widths per column requires per-table design judgment, regression QA across responsive breakpoints, and coordination with PD on which columns can truncate. That should be scoped, prioritized, and tracked as its own piece of work rather than smuggled into a single-table bug fix.

## Screen recording



https://github.com/user-attachments/assets/4ee152c1-38bb-4d81-baac-9dbeefbf0a5f


## Testing

- [x] QA'd all new/changed functionality manually
- [x] Hosts → Manage labels: sort by Name, Description, and Type across multiple pages — column widths stay constant, sort-header click target doesn't move.
- [x] Long label name or description: truncates with a hover tooltip showing the full value.
- [x] Narrow viewport: table scrolls horizontally inside the wrapper instead of pushing the page out.