### PR TITLE
Controls > OS settings > Certificates: View certificates

### DIFF
--- a/changes/39346-certificates-list
+++ b/changes/39346-certificates-list
@@ -1,0 +1,2 @@
+- Added a "View certificate" modal to Controls > OS settings > Certificates so admins can inspect and copy an existing certificate's details.
+- Added a "no custom SCEP CA configured" empty state to the certificates card.

--- a/frontend/__mocks__/certificatesMock.ts
+++ b/frontend/__mocks__/certificatesMock.ts
@@ -68,6 +68,7 @@ export const createMockCertificateAuthorityPartial = (
 const DEFAULT_ANDROID_CERT_MOCK: ICertificate = {
   id: 1,
   name: "Test Android Certificate",
+  subject_name: "CN=test@example.com, O=Test Inc.",
   certificate_authority_id: 1,
   certificate_authority_name: "Test CA",
   created_at: "2021-08-19T02:02:17Z",

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -5,13 +5,16 @@ import { formatDistanceToNow } from "date-fns";
 
 import { AppContext } from "context/app";
 import PATHS from "router/paths";
+import useGitOpsMode from "hooks/useGitOpsMode";
+import { getGitOpsModeTipContent } from "utilities/helpers";
+
+import { IDropdownOption } from "interfaces/dropdownOption";
 
 import UploadList from "components/UploadList";
 import UploadListHeading from "pages/ManageControlsPage/components/UploadListHeading";
 
-import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+import ActionsDropdown from "components/ActionsDropdown";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import ListItem from "components/ListItem";
 import Pagination from "components/Pagination";
 import CustomLink from "components/CustomLink";
@@ -36,8 +39,10 @@ import certAPI, {
 
 import { IOSSettingsCommonProps } from "../../OSSettingsNavItems";
 import AddCertCard from "./components/AddCertificateCard/AddCertificateCard";
+import AddCertAuthorityCard from "./components/AddCertAuthorityCard";
 import DeleteCertModal from "./components/DeleteCertificateModal";
 import AddCertModal from "./components/AddCertificateModal";
+import ViewCertModal from "./components/ViewCertificateModal";
 
 const baseClass = "certificates";
 
@@ -52,8 +57,10 @@ const Certificates = ({
   onMutation,
 }: ICertificatesProps) => {
   const [showAddCertModal, setShowAddCertModal] = useState(false);
+  const [certToView, setCertToView] = useState<null | ICertificate>(null);
   const [certToDelete, setCertToDelete] = useState<null | ICertificate>(null);
   const { config, isPremiumTier } = useContext(AppContext);
+  const { gitOpsModeEnabled, repoURL } = useGitOpsMode();
 
   const androidMdmEnabled = !!config?.mdm.android_enabled_and_configured;
 
@@ -83,6 +90,27 @@ const Certificates = ({
     }
   );
 
+  // Certificates require a custom SCEP CA to be configured. We fetch the list
+  // of certificate authorities to decide whether to prompt the admin to add a
+  // CA before they can add certificates.
+  const {
+    data: certAuthorities,
+    isLoading: isLoadingCAs,
+    isError: isErrorCAs,
+  } = useQuery(
+    ["certAuthorities"],
+    () => certAPI.getCertificateAuthoritiesList(),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: isPremiumTier && androidMdmEnabled,
+      select: (data) => data.certificate_authorities,
+    }
+  );
+
+  const hasCustomScepCA = (certAuthorities ?? []).some(
+    (ca) => ca.type === "custom_scep_proxy"
+  );
+
   const certs = certsResp?.certificates || [];
   const { has_next_results: hasNext, has_previous_results: hasPrev } =
     certsResp?.meta || {};
@@ -104,6 +132,19 @@ const Certificates = ({
     router.push(path.concat(`${queryString}page=${currentPage + 1}`));
   }, [router, path, currentPage, queryString]);
 
+  const onSelectCertAction = (action: string, cert: ICertificate) => {
+    switch (action) {
+      case "view":
+        setCertToView(cert);
+        break;
+      case "delete":
+        setCertToDelete(cert);
+        break;
+      default:
+        break;
+    }
+  };
+
   const renderContent = () => {
     if (!isPremiumTier) {
       return <PremiumFeatureMessage />;
@@ -122,12 +163,16 @@ const Certificates = ({
         />
       );
     }
-    if (isLoadingCerts) {
+    if (isLoadingCerts || isLoadingCAs) {
       return <Spinner />;
     }
 
-    if (isErrorCerts) {
+    if (isErrorCerts || isErrorCAs) {
       return <DataError />;
+    }
+
+    if (!hasCustomScepCA) {
+      return <AddCertAuthorityCard router={router} />;
     }
 
     if (!certs.length) {
@@ -155,27 +200,37 @@ const Certificates = ({
 
             const details = (
               <>
-                {caName} &bull; Added{" "}
+                {caName} &bull; Updated{" "}
                 {formatDistanceToNow(new Date(created_at))} ago
               </>
             );
+
+            const certActions: IDropdownOption[] = [
+              { label: "View certificate", value: "view" },
+              {
+                label: "Delete",
+                value: "delete",
+                disabled: gitOpsModeEnabled,
+                tooltipContent:
+                  gitOpsModeEnabled && repoURL
+                    ? getGitOpsModeTipContent(repoURL)
+                    : undefined,
+              },
+            ];
+
             return (
               <ListItem
                 graphic="file-certificate"
                 title={<TooltipTruncatedText value={name} />}
                 details={details}
                 actions={
-                  <GitOpsModeTooltipWrapper
-                    renderChildren={(disableChildren) => (
-                      <Button
-                        disabled={disableChildren}
-                        className={`${baseClass}__delete-button`}
-                        variant="icon"
-                        onClick={() => setCertToDelete(listItem)}
-                      >
-                        <Icon name="trash" />
-                      </Button>
-                    )}
+                  <ActionsDropdown
+                    options={certActions}
+                    placeholder="Actions"
+                    variant="small-button"
+                    menuAlign="right"
+                    menuPlacement="auto"
+                    onChange={(action) => onSelectCertAction(action, listItem)}
                   />
                 }
               />
@@ -218,6 +273,9 @@ const Certificates = ({
           onSuccess={onUpdateSuccess}
           currentTeamId={currentTeamId}
         />
+      )}
+      {certToView && (
+        <ViewCertModal cert={certToView} onExit={() => setCertToView(null)} />
       )}
       {certToDelete && (
         <DeleteCertModal

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -90,9 +90,6 @@ const Certificates = ({
     }
   );
 
-  // Certificates require a custom SCEP CA to be configured. We fetch the list
-  // of certificate authorities to decide whether to prompt the admin to add a
-  // CA before they can add certificates.
   const {
     data: certAuthorities,
     isLoading: isLoadingCAs,

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -160,20 +160,26 @@ const Certificates = ({
         />
       );
     }
-    if (isLoadingCerts || isLoadingCAs) {
+    if (isLoadingCerts) {
       return <Spinner />;
     }
 
-    if (isErrorCerts || isErrorCAs) {
+    if (isErrorCerts) {
       return <DataError />;
     }
 
-    if (!hasCustomScepCA) {
-      return <AddCertAuthorityCard router={router} />;
-    }
-
     if (!certs.length) {
-      return <AddCertCard setShowModal={setShowAddCertModal} />;
+      if (isLoadingCAs) {
+        return <Spinner />;
+      }
+      if (isErrorCAs) {
+        return <DataError />;
+      }
+      return hasCustomScepCA ? (
+        <AddCertCard setShowModal={setShowAddCertModal} />
+      ) : (
+        <AddCertAuthorityCard router={router} />
+      );
     }
 
     return (

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/AddCertAuthorityCard.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/AddCertAuthorityCard.tests.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { screen } from "@testing-library/react";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import PATHS from "router/paths";
+
+import AddCertAuthorityCard from "./AddCertAuthorityCard";
+
+describe("AddCertAuthorityCard", () => {
+  it("renders the empty-state copy and Add CA button", () => {
+    const router = createMockRouter();
+    const render = createCustomRenderer();
+    render(<AddCertAuthorityCard router={router} />);
+
+    expect(screen.getByText("Add certificate authority")).toBeInTheDocument();
+    expect(
+      screen.getByText(/custom SCEP certificate authority must be configured/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add CA" })).toBeInTheDocument();
+  });
+
+  it("routes to the certificate authorities settings page when Add CA is clicked", async () => {
+    const router = createMockRouter();
+    const render = createCustomRenderer();
+    const { user } = render(<AddCertAuthorityCard router={router} />);
+
+    await user.click(screen.getByRole("button", { name: "Add CA" }));
+
+    expect(router.push).toHaveBeenCalledWith(
+      PATHS.ADMIN_INTEGRATIONS_CERTIFICATE_AUTHORITIES
+    );
+  });
+});

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/AddCertAuthorityCard.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/AddCertAuthorityCard.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import PATHS from "router/paths";
+import { InjectedRouter } from "react-router";
+
+import Card from "components/Card";
+import Button from "components/buttons/Button";
+
+const baseClass = "add-cert-authority-card";
+
+interface IAddCertAuthorityCardProps {
+  router: InjectedRouter;
+}
+
+const AddCertAuthorityCard = ({ router }: IAddCertAuthorityCardProps) => (
+  <Card className={baseClass}>
+    <div className={`${baseClass}__content-wrap`}>
+      <div className={`${baseClass}__text`}>
+        <b>Add certificate authority</b>
+        <p>
+          To add certificates, a custom SCEP certificate authority must be
+          configured in organization settings.
+        </p>
+      </div>
+      <Button
+        className={`${baseClass}__add-button`}
+        type="button"
+        onClick={() =>
+          router.push(PATHS.ADMIN_INTEGRATIONS_CERTIFICATE_AUTHORITIES)
+        }
+      >
+        Add CA
+      </Button>
+    </div>
+  </Card>
+);
+
+export default AddCertAuthorityCard;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/_styles.scss
@@ -15,7 +15,7 @@
     gap: $pad-small;
     text-align: center;
     b {
-      font-size: px-to-rem(16);
+      font-size: $small;
     }
     p {
       margin: 0;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/_styles.scss
@@ -1,4 +1,4 @@
-.add-cert-card {
+.add-cert-authority-card {
   height: px-to-rem(160);
   &__content-wrap {
     height: 100%;
@@ -13,11 +13,13 @@
     flex-direction: column;
     align-items: center;
     gap: $pad-small;
+    text-align: center;
     b {
       font-size: px-to-rem(16);
     }
     p {
       margin: 0;
+      max-width: px-to-rem(450);
     }
   }
 }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/index.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertAuthorityCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddCertAuthorityCard";

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateCard/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateCard/_styles.scss
@@ -14,7 +14,7 @@
     align-items: center;
     gap: $pad-small;
     b {
-      font-size: px-to-rem(16);
+      font-size: $small;
     }
     p {
       margin: 0;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
@@ -98,8 +98,6 @@ describe("AddCertModal", () => {
     await renderModal();
     const caLabel = screen.getByText("Certificate authority (CA)");
     const nameLabel = screen.getByText("Name");
-    // The two labels are cousins (neither contains the other), so comparing
-    // them yields exactly DOCUMENT_POSITION_FOLLOWING when Name comes after CA.
     expect(caLabel.compareDocumentPosition(nameLabel)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
@@ -94,6 +94,17 @@ describe("AddCertModal", () => {
     expect(screen.getByPlaceholderText(SAN_PLACEHOLDER)).toBeInTheDocument();
   });
 
+  it("renders the Certificate authority field above the Name field", async () => {
+    await renderModal();
+    const caLabel = screen.getByText("Certificate authority (CA)");
+    const nameLabel = screen.getByText("Name");
+    // The two labels are cousins (neither contains the other), so comparing
+    // them yields exactly DOCUMENT_POSITION_FOLLOWING when Name comes after CA.
+    expect(caLabel.compareDocumentPosition(nameLabel)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+  });
+
   it("clicking Add with all required fields empty shows three inline errors and does not call the API", async () => {
     const { user } = await renderModal();
     await user.click(screen.getByRole("button", { name: /Add/i }));

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
@@ -170,17 +170,6 @@ const AddCertModal = ({
     }
     return (
       <form className={baseClass} onSubmit={onSubmitForm}>
-        <InputField
-          name="name"
-          label="Name"
-          value={formData.name}
-          onChange={onInputChange}
-          error={serverErrors.name ?? formValidation.name?.message}
-          helpText="Letters, numbers, spaces, dashes, and underscores only. Name can be used as certificate alias to reference in configuration profiles."
-          parseTarget
-          placeholder="VPN certificate"
-          autofocus
-        />
         <DropdownWrapper
           label="Certificate authority (CA)"
           name="certificateAuthority"
@@ -201,6 +190,16 @@ const AddCertModal = ({
             </>
           }
           error={formValidation.certAuthorityId?.message}
+        />
+        <InputField
+          name="name"
+          label="Name"
+          value={formData.name}
+          onChange={onInputChange}
+          error={serverErrors.name ?? formValidation.name?.message}
+          helpText="Letters, numbers, spaces, dashes, and underscores only. Name can be used as certificate alias to reference in configuration profiles."
+          parseTarget
+          placeholder="VPN certificate"
         />
         <InputField
           name="subjectName"

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/ViewCertificateModal.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/ViewCertificateModal.tests.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+import { screen } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+import { createMockAndroidCert } from "__mocks__/certificatesMock";
+
+import ViewCertificateModal from "./ViewCertificateModal";
+
+const mockOnExit = jest.fn();
+
+const renderModal = (cert = createMockAndroidCert()) => {
+  const render = createCustomRenderer();
+  return render(<ViewCertificateModal cert={cert} onExit={mockOnExit} />);
+};
+
+describe("ViewCertificateModal", () => {
+  beforeEach(() => {
+    mockOnExit.mockClear();
+  });
+
+  it("renders the certificate name, CA, added time, and subject name", () => {
+    const cert = createMockAndroidCert({
+      name: "Zero trust certificate",
+      certificate_authority_name: "PRODUCTION_SCEP_SERVER",
+      subject_name: "CN=test@example.com, O=Example Inc.",
+    });
+    renderModal(cert);
+
+    expect(screen.getByText("Zero trust certificate")).toBeInTheDocument();
+    expect(screen.getByText("Certificate authority")).toBeInTheDocument();
+    expect(screen.getByText("PRODUCTION_SCEP_SERVER")).toBeInTheDocument();
+    expect(screen.getByText("Added")).toBeInTheDocument();
+    expect(screen.getByText("Subject name (SN)")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("CN=test@example.com, O=Example Inc.")
+    ).toBeInTheDocument();
+  });
+
+  it("hides the SAN section when the certificate has no subject alternative name", () => {
+    renderModal(createMockAndroidCert({ subject_alternative_name: undefined }));
+    expect(
+      screen.queryByText("Subject alternative name (SAN)")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the SAN section when present", () => {
+    renderModal(
+      createMockAndroidCert({
+        subject_alternative_name:
+          "UPN=test@example.com, EMAIL=test@example.com",
+      })
+    );
+    expect(
+      screen.getByText("Subject alternative name (SAN)")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("UPN=test@example.com, EMAIL=test@example.com")
+    ).toBeInTheDocument();
+  });
+
+  it("calls onExit when Done is clicked", async () => {
+    const { user } = renderModal();
+    await user.click(screen.getByRole("button", { name: "Done" }));
+    expect(mockOnExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/ViewCertificateModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/ViewCertificateModal.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { formatDistanceToNow } from "date-fns";
+
+import { ICertificate } from "services/entities/certificates";
+
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+import DataSet from "components/DataSet";
+import InputField from "components/forms/fields/InputField";
+
+const baseClass = "view-certificate-modal";
+
+interface IViewCertificateModalProps {
+  cert: ICertificate;
+  onExit: () => void;
+}
+
+const ViewCertificateModal = ({ cert, onExit }: IViewCertificateModalProps) => {
+  const {
+    name,
+    certificate_authority_name: caName,
+    subject_name: subjectName,
+    subject_alternative_name: subjectAlternativeName,
+    created_at,
+  } = cert;
+
+  return (
+    <Modal className={baseClass} title={name} width="large" onExit={onExit}>
+      <>
+        <div className={`${baseClass}__content`}>
+          <div className={`${baseClass}__summary`}>
+            <DataSet title="Certificate authority" value={caName} />
+            <DataSet
+              title="Added"
+              value={`${formatDistanceToNow(new Date(created_at))} ago`}
+            />
+          </div>
+          <InputField
+            label="Subject name (SN)"
+            name="subjectName"
+            type="textarea"
+            value={subjectName}
+            readOnly
+          />
+          {subjectAlternativeName && (
+            <InputField
+              label="Subject alternative name (SAN)"
+              name="subjectAlternativeName"
+              type="textarea"
+              value={subjectAlternativeName}
+              readOnly
+            />
+          )}
+        </div>
+        <div className="modal-cta-wrap">
+          <Button onClick={onExit}>Done</Button>
+        </div>
+      </>
+    </Modal>
+  );
+};
+
+export default ViewCertificateModal;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/_styles.scss
@@ -1,8 +1,6 @@
 .view-certificate-modal {
   &__content {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-large;
+    @include vertical-modal-layout;
   }
 
   &__summary {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/_styles.scss
@@ -1,0 +1,18 @@
+.view-certificate-modal {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-large;
+  }
+
+  &__summary {
+    display: flex;
+    gap: $pad-xxlarge;
+  }
+
+  // Match Fleet's code-box treatment (Textarea, SQLEditor, etc.) so the
+  // subject fields render in SourceCodePro as designed.
+  textarea {
+    font-family: "SourceCodePro", $monospace;
+  }
+}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/_styles.scss
@@ -10,8 +10,6 @@
     gap: $pad-xxlarge;
   }
 
-  // Match Fleet's code-box treatment (Textarea, SQLEditor, etc.) so the
-  // subject fields render in SourceCodePro as designed.
   textarea {
     font-family: "SourceCodePro", $monospace;
   }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/index.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ViewCertificateModal";

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -56,6 +56,7 @@ export interface IQueryKeyGetCerts extends IGetCertsParams {
 export interface ICertificate {
   id: number;
   name: string;
+  subject_name: string;
   certificate_authority_id: number;
   certificate_authority_name: string;
   subject_alternative_name?: string;


### PR DESCRIPTION
**Related issue:** Resolves #39346

Adds a **View certificate** modal to Controls > OS settings > Certificates so admins can inspect (and copy) an existing certificate's details. Also adds a "no custom SCEP CA configured" empty state, switches each row to an Actions dropdown (View/Delete), and moves the CA field to the top of the Add form. Frontend-only; no API changes.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented, JS inline code is prevented, and untrusted data interpolated into shell scripts/commands is validated.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

https://claude.ai/code/session_01J77VQSSuPptxpoZDrFQxdj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “View certificate” option to inspect certificate details in a modal.
  * Added a new empty state for environments without a custom SCEP certificate authority, with a shortcut to add one.

* **Improvements**
  * Certificate actions are now shown in a dropdown, with delete disabled in GitOps mode.
  * Certificate lists now display updated-time information and handle loading or error states more clearly.
  * The add-certificate form now shows the certificate authority field before the name field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->