### PR TITLE
Website: update report details page

### DIFF
--- a/website/views/pages/docs/report-details.ejs
+++ b/website/views/pages/docs/report-details.ejs
@@ -20,10 +20,10 @@
           </div>
           <p purpose="report-description"><%- report.description %></p>
           <div purpose="report-check">
-            <p>To learn more about queries, <a href="/guides/queries">check this guide</a>.</p>
+            <p>To learn more about reports, <a href="/guides/reports">check this guide</a>.</p>
             <div purpose="codeblock">
               <div purpose="codeblock-tabs" >
-                <a purpose="codeblock-tab" :class="[ selectedTab === 'sql' ? 'selected' : '']" @click="selectedTab = 'sql'">report</a>
+                <a purpose="codeblock-tab" :class="[ selectedTab === 'sql' ? 'selected' : '']" @click="selectedTab = 'sql'">Query</a>
                 <a purpose="codeblock-tab" :class="[ selectedTab === 'ps' ? 'selected' : '']"  @click="selectedTab = 'ps'" v-if="report.powershell">PowerShell<span purpose="new-badge">NEW</span></a>
                 <a purpose="codeblock-tab" :class="[ selectedTab === 'bash' ? 'selected' : '']"  @click="selectedTab = 'bash'" v-if="report.bash">Bash<span purpose="new-badge">NEW</span></a>
                 <div purpose="copy-button-tab">


### PR DESCRIPTION
Changes:
- Updated the query tab on the report details page to say "Query" instead of report, and updated the link to the reports guide to not say queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the “learn more” link text so report guidance now points to the reports guide.
  * Updated the visible label in the SQL tab area to show “Query” for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->