### PR TITLE
Limit lint concurrency to half CPUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,17 @@ else
 	NOW	= $(shell powershell Get-Date -format "yyy-MM-dd")
 endif
 
+# Cap lint concurrency at half the logical CPUs (rounded up) so the incremental
+# linters (modernize, nilaway) don't saturate the machine. Override with LINT_CONCURRENCY=N.
+ifndef LINT_CONCURRENCY
+	ifeq ($(OS), Windows_NT)
+		LINT_NPROC := $(NUMBER_OF_PROCESSORS)
+	else
+		LINT_NPROC := $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 2)
+	endif
+	LINT_CONCURRENCY := $(shell echo $$(( ($(LINT_NPROC) + 1) / 2 )))
+endif
+
 ifndef CIRCLE_PR_NUMBER
 	DOCKER_IMAGE_TAG = ${REVSHORT}
 else
@@ -244,7 +255,7 @@ check-no-testing-in-prod:
 .help-short--lint-go-incremental:
 	@echo "Run the incremental Go linters"
 lint-go-incremental: custom-gcl
-	./custom-gcl run --allow-serial-runners -c .golangci-incremental.yml --new-from-merge-base=origin/main --timeout 15m ./...
+	GOMAXPROCS=$(LINT_CONCURRENCY) ./custom-gcl run --allow-serial-runners --concurrency=$(LINT_CONCURRENCY) -c .golangci-incremental.yml --new-from-merge-base=origin/main --timeout 15m ./...
 
 custom-gcl:
 	golangci-lint custom


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48470

I've seen a Linux dev machine become unusable when custom-gcl is running, so this aims to fix this developer experience issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvement**
  * Linting now uses a smarter default concurrency limit, reducing CPU contention during checks.
  * The concurrency limit can now be overridden when needed for faster or lighter runs.
  * Incremental Go linting now applies the same concurrency cap consistently, helping keep local and CI runs more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->