### PR TITLE
Add tech leads to CODEOWNERS for .claude directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -156,5 +156,12 @@ go.mod @fleetdm/go
 # 🚀 GitHub workflows
 ##############################################################################################
 /.github/workflows/ @georgekarrv @sharon-fdm @lukeheath @lucasmrod @getvictor
+
+##############################################################################################
+# 🤖 Claude Code configuration (agents, skills, rules, settings).
+# (Reviewed by the product group tech leads.)
+##############################################################################################
+/.claude/ @JordanMontgomery @cdcme @lucasmrod @mostlikelee
+
 # ℹ️ But wait, there's more!
 # See the comments up top to learn where else DRIs and maintainers are configured.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -161,7 +161,7 @@ go.mod @fleetdm/go
 # 🤖 Claude Code configuration (agents, skills, rules, settings).
 # (Reviewed by the product group tech leads.)
 ##############################################################################################
-/.claude/ @JordanMontgomery @cdcme @lucasmrod @mostlikelee
+/.claude/ @JordanMontgomery @cdcme @lucasmrod @mostlikelee @getvictor 
 
 # ℹ️ But wait, there's more!
 # See the comments up top to learn where else DRIs and maintainers are configured.


### PR DESCRIPTION
**Related issue:** NA

# Checklist for submitter

Adds the four current product group tech leads as required reviewers (CODEOWNERS) for the `.claude/` directory.

- MDM → @JordanMontgomery
- Software → @cdcme
- Orchestration → @lucasmrod
- Security & Compliance → @mostlikelee

## Testing

- [x] QA'd all new/changed functionality manually

CODEOWNERS-only change; no code, tests, migrations, config settings, or fleetd changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit ownership and review coverage for the Claude Code configuration area.
  * Changes within the configuration directory now require designated reviewers before being merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->