### PR TITLE
"Filtered" badge is vertically misaligned in dashabord chart headers

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -11,6 +11,16 @@
     display: flex;
     align-items: center;
     gap: $pad-small;
+
+    .component__tooltip-wrapper {
+      align-items: center;
+      line-height: 1;
+
+      &__element {
+        display: flex;
+        align-items: center;
+      }
+    }
   }
 
   &__description-tooltip {


### PR DESCRIPTION
Resolves: #48487
- [x] QA'd all new/changed functionality manually

For the following bug:
- https://github.com/fleetdm/fleet/issues/48487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard chart card header tooltip styling for better alignment and cleaner vertical centering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->