### PR TITLE
Fix WhatsApp version check in maintained apps ingestion

### DIFF
--- a/changes/fix-whatsapp-version-check
+++ b/changes/fix-whatsapp-version-check
@@ -1,0 +1,1 @@
+- Fixed maintained apps ingestion failing due to WhatsApp version scheme change.

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/whats_app_version_shortener.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/whats_app_version_shortener.go
@@ -1,7 +1,6 @@
 package externalrefs
 
 import (
-	"fmt"
 	"strings"
 
 	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
@@ -10,10 +9,11 @@ import (
 func WhatsAppVersionShortener(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {
 	homebrewVersion := app.Version
 
+	// Legacy WhatsApp versions used a "2." prefix added by Homebrew that
+	// needed to be stripped (e.g. "2.25.16.81" -> "25.16.81").
+	// Newer versions (e.g. "26.26.12") no longer carry this prefix.
 	if strings.HasPrefix(homebrewVersion, "2.") {
 		app.Version = strings.TrimPrefix(homebrewVersion, "2.")
-	} else {
-		return app, fmt.Errorf("Expected WhatsApp version to start with '2.' but found '%s'", homebrewVersion)
 	}
 
 	return app, nil

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/whats_app_version_shortener_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/whats_app_version_shortener_test.go
@@ -18,13 +18,13 @@ func TestWhatsAppVersionShortener(t *testing.T) {
 		assert.Equal(t, "25.16.81", result.Version)
 	})
 
-	t.Run("unexpected version format", func(t *testing.T) {
+	t.Run("new version scheme without 2. prefix", func(t *testing.T) {
 		app := &maintained_apps.FMAManifestApp{
 			UniqueIdentifier: "whatsapp/darwin",
-			Version:          "3.25.16.81",
+			Version:          "26.26.12",
 		}
 		result, err := WhatsAppVersionShortener(app)
-		assert.Error(t, err)
-		assert.Equal(t, "3.25.16.81", result.Version)
+		assert.NoError(t, err)
+		assert.Equal(t, "26.26.12", result.Version)
 	})
 }

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/whats_app_version_shortener_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/whats_app_version_shortener_test.go
@@ -5,6 +5,7 @@ import (
 
 	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWhatsAppVersionShortener(t *testing.T) {
@@ -14,7 +15,7 @@ func TestWhatsAppVersionShortener(t *testing.T) {
 			Version:          "2.25.16.81",
 		}
 		result, err := WhatsAppVersionShortener(app)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "25.16.81", result.Version)
 	})
 
@@ -24,7 +25,7 @@ func TestWhatsAppVersionShortener(t *testing.T) {
 			Version:          "26.26.12",
 		}
 		result, err := WhatsAppVersionShortener(app)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "26.26.12", result.Version)
 	})
 }


### PR DESCRIPTION
## Summary
- WhatsApp changed their version scheme from `2.x.y.z` to `26.x.y`
- The `WhatsAppVersionShortener` was erroring on versions without the legacy `2.` prefix, causing the maintained apps ingestion workflow to panic and fail on main
- Fix: pass through versions that don't have the `2.` prefix instead of erroring

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)