### PR TITLE
Small UI tweaks for the Policy details page

### DIFF
--- a/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
@@ -90,6 +90,7 @@
   &__properties {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: $pad-xlarge;
   }
 }

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTableConfig.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTableConfig.tsx
@@ -98,7 +98,7 @@ const generateColumnConfigs = (
           onClick={() => onShowDetails(activity)}
         >
           <span className={`${baseClass}__details-text`}>
-            {primaryText ? <TooltipTruncatedText value={primaryText} /> : "---"}
+            {primaryText || "---"}
           </span>
           <Icon
             name="info-outline"

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/_styles.scss
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/_styles.scss
@@ -89,10 +89,7 @@
     flex: 1;
     min-width: 0;
     text-align: left;
-
-    .tooltip-truncated-text {
-      max-width: 100%;
-    }
+    @include ellipse-text;
   }
 
   // Info icon sits at the right edge of the Details column, shown on row hover


### PR DESCRIPTION
Related to #38670

Implement UI tweaks based on feedback.

<img width="1619" height="647" alt="Screenshot 2026-06-30 at 2 31 17 PM" src="https://github.com/user-attachments/assets/b3f04ec2-ccf0-4f94-bb20-f56ca05838d3" />

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated spacing and alignment in the policy details page for a cleaner layout.
  * Improved the policy automations activities table so the Details column displays more consistently with ellipsis handling.
* **Bug Fixes**
  * Simplified empty-state display in the Details column, showing a clear placeholder when no text is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->