### PR TITLE
Handbook: reduce thread juggling in support escalations

### DIFF
--- a/handbook/company/go-to-market-operations.md
+++ b/handbook/company/go-to-market-operations.md
@@ -461,6 +461,7 @@ Even if you never show these decks on a screenshare, use them to keep the conver
 - [Fleet for IT engineers and IT admins](https://docs.google.com/presentation/d/1WTyGrmA4pSB7H8BeT14BF7peozBceToW8TK__doyQTg/edit?slide=id.g3d7b8aeb1bc_1_182#slide=id.g3d7b8aeb1bc_1_182)
 - [Fleet for digital workplace leaders](https://drive.google.com/file/d/1JlIV1PY5lECQQmq2H_eR35haeKefHXIf/view?usp=sharing)
 - [Fleet for partners](https://docs.google.com/presentation/d/1iNvn5EYnkklKxguYzrOh6ZNvZee53OqAlF3rc_Da_Us/edit?slide=id.g3871afd58d8_0_0#slide=id.g3871afd58d8_0_0)
+
 <!--
 - [Fleet for digital workplace leaders](https://docs.google.com/presentation/d/1G8BtuhYRX92He3AifA5TAW4YlZO3jlcj8OeCqcSHmOM/edit?slide=id.g3d28ee536a1_2_37#slide=id.g3d28ee536a1_2_37)
 - [Fleet for CISOs](https://docs.google.com/presentation/d/17PUAqa63jTb5yFT3hGg3F5mgGyPtUmg8OlTGyxS6vLI/edit?slide=id.g3d28ee536a1_2_0#slide=id.g3d28ee536a1_2_0)

--- a/handbook/customer-success/README.md
+++ b/handbook/customer-success/README.md
@@ -231,6 +231,14 @@ During the window of time available to investigate an issue, use the resources a
 
 Note: For non-CSA engaged customer requests, CSE's are responsible for escalations to a CSA as needed. 
 
+### Keep support conversations in one thread
+
+A single issue can sprawl across the customer channel, #help-customers, #help-engineering, and a product group channel, making it hard to track. To keep full context in one place:
+
+- **Talk to the customer** in the customer channel thread.
+- **Coordinate internally** in a single #help-customers thread. This is the source of truth for the issue.
+- **When asking for help** in any channel other than #help-customers (e.g., #help-engineering or a product group channel), keep the post short: summarize the ask and link to the #help-customers thread. Ask responders to reply in the #help-customers thread, not in the post, so everyone has the most context at all times.
+
 ### Troubleshooting a managed cloud or self-hosted customer suspected infrastructure issue
 
 ##### For managed cloud customers, CSE is responsible for doing an initial check on logs. Timebox 10 minutes to do the following: 


### PR DESCRIPTION
**Related issue:** Resolves #41847

# Checklist for submitter

Handbook recommendation to reduce "thread juggling" — one support issue today can span the customer channel, #help-customers, #help-engineering, and a product group channel.

Adds a concise subsection to the Customer Success handbook recommending:
- Direct customer communication stays in the customer channel thread.
- A single #help-customers thread is the internal source of truth.
- Requests for help in any other channel should be a short post linking back to the #help-customers thread, with responders asked to reply there rather than in the post — so everyone keeps full context.

Handbook-only change; no code, tests, or migrations.
