### PR TITLE
For R.C. - Fleet UI: Stop clipping action dropdown menus inside scrollable tables (#48430)

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tests.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tests.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
 
+import TableLayoutContext from "components/TableContainer/TableLayoutContext";
 import ActionsDropdown from "./ActionsDropdown";
 
 const DROPDOWN_OPTIONS = [
@@ -72,6 +73,28 @@ describe("Actions dropdown", () => {
     const deleteOption = screen.getByText("Delete");
 
     expect(deleteOption).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("portals menu and fires onChange on option click when insideTable", async () => {
+    const mockOnChange = jest.fn();
+    const { user } = renderWithSetup(
+      <TableLayoutContext.Provider value={{ insideTable: true }}>
+        <ActionsDropdown
+          options={DROPDOWN_OPTIONS}
+          placeholder={PLACEHOLDER}
+          onChange={mockOnChange}
+        />
+      </TableLayoutContext.Provider>
+    );
+
+    await user.click(screen.getByText("Actions"));
+    // Menu portals to a sibling of body, not inside the wrapper div.
+    expect(
+      document.querySelector(".actions-dropdown-select__menu-portal")
+    ).not.toBeNull();
+    await user.click(screen.getByText("Edit"));
+
+    expect(mockOnChange).toHaveBeenCalledWith("edit-query");
   });
 
   it("closes the dropdown when clicking outside", async () => {

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import Select, {
   components,
   DropdownIndicatorProps,
@@ -16,6 +16,7 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import DropdownOptionTooltipWrapper from "components/forms/fields/Dropdown/DropdownOptionTooltipWrapper";
+import TableLayoutContext from "components/TableContainer/TableLayoutContext";
 
 const baseClass = "actions-dropdown";
 
@@ -127,6 +128,13 @@ const ActionsDropdown = ({
 }: IActionsDropdownProps): JSX.Element => {
   const dropdownClassnames = classnames(baseClass, className);
 
+  // Portal the menu only when rendered inside a TableContainer's data-table
+  // block, where .data-table__wrapper's overflow-x: auto would otherwise clip
+  // the menu vertically. The brand-button variant nulls out react-select's
+  // Control, and MenuPortal bails when controlElement is missing — so don't
+  // use brand-button inside a table cell.
+  const { insideTable } = useContext(TableLayoutContext);
+
   // Used for brand Action button
   const [menuIsOpen, setMenuIsOpen] = useState(false);
   const selectRef = useRef<SelectInstance<IDropdownOption, false>>(null);
@@ -135,14 +143,20 @@ const ActionsDropdown = ({
   // Close on outside click
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      // If click was outside wrapper, close menu
+      if (!menuIsOpen || !wrapperRef.current) return;
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      // Trigger button (wrapper) or portaled menu both count as "inside" —
+      // since menuPortalTarget renders the menu in document.body, a contains()
+      // check on wrapperRef alone would treat option clicks as outside.
+      if (wrapperRef.current.contains(target)) return;
       if (
-        menuIsOpen &&
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
+        target instanceof Element &&
+        target.closest(`.${baseClass}-select__menu-portal`)
       ) {
-        setMenuIsOpen(false);
+        return;
       }
+      setMenuIsOpen(false);
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => {
@@ -267,6 +281,13 @@ const ActionsDropdown = ({
       right: getRightMenuAlign(menuAlign),
       animation: "fade-in 150ms ease-out",
     }),
+    // zIndex 999 (document-portal tier) so the portaled menu clears
+    // .site-nav-container and Modal — ActionsDropdown can render inside a
+    // TableContainer that lives inside a modal (e.g. ScriptDetailsModal).
+    menuPortal: (provided) => ({
+      ...provided,
+      zIndex: 999,
+    }),
     menuList: (provided) => ({
       ...provided,
       padding: PADDING["pad-small"],
@@ -329,6 +350,7 @@ const ActionsDropdown = ({
         classNamePrefix={`${baseClass}-select`}
         isOptionDisabled={(option) => !!option.disabled}
         menuPlacement={menuPlacement}
+        menuPortalTarget={insideTable ? document.body : undefined}
         {...{ variant }} // Allows CustomDropdownIndicator to be ui-fleet-black-75 for variant: "button"
       />
     </div>

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -12,6 +12,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 
 import DataTable from "./DataTable/DataTable";
 import { IActionButtonProps } from "./DataTable/ActionButton/ActionButton";
+import TableLayoutContext from "./TableLayoutContext";
 
 export interface ITableQueryData {
   pageIndex: number;
@@ -511,91 +512,99 @@ const TableContainer = <T,>({
   return (
     <div className={wrapperClasses}>
       {renderFilters()}
-      <div className={`${baseClass}__data-table-block`}>
-        {/* No entities for this result. */}
-        {(!isLoading && data.length === 0 && !isMultiColumnFilter) ||
-        (searchQuery.length &&
-          data.length === 0 &&
-          !isMultiColumnFilter &&
-          !isLoading) ? (
-          <>
-            <EmptyComponent pageIndex={currentPageIndex} />
-            {/* This UI only shows if a user navigates to a table page with a URL page param that is outside the # of pages available */}
-            {currentPageIndex !== 0 && (
-              <div className={`${baseClass}__empty-page`}>
-                <div className={`${baseClass}__previous-button`}>
-                  <Pagination
-                    disableNext
-                    onNextPage={() => onPaginationChange(currentPageIndex + 1)}
-                    onPrevPage={() => onPaginationChange(currentPageIndex - 1)}
-                  />
-                </div>
-              </div>
-            )}
-          </>
-        ) : (
-          <>
-            {/* TODO: Fix this hacky solution to clientside search being 0 rendering emptycomponent but
-            no longer accesses rows.length because DataTable is not rendered */}
-            {!isLoading && clientFilterCount === 0 && !isMultiColumnFilter && (
+      <TableLayoutContext.Provider value={{ insideTable: true }}>
+        <div className={`${baseClass}__data-table-block`}>
+          {/* No entities for this result. */}
+          {(!isLoading && data.length === 0 && !isMultiColumnFilter) ||
+          (searchQuery.length &&
+            data.length === 0 &&
+            !isMultiColumnFilter &&
+            !isLoading) ? (
+            <>
               <EmptyComponent pageIndex={currentPageIndex} />
-            )}
-            <div
-              className={
-                isClientSideFilter && !isMultiColumnFilter
-                  ? `client-result-count-${clientFilterCount}`
-                  : ""
-              }
-            >
-              <DataTable
-                isLoading={isLoading}
-                columns={columnConfigs}
-                data={data}
-                filters={filters}
-                manualSortBy={manualSortBy}
-                sortHeader={sortHeader}
-                sortDirection={sortDirection}
-                onSort={onSortChange}
-                disableMultiRowSelect={disableMultiRowSelect}
-                showMarkAllPages={showMarkAllPages}
-                isAllPagesSelected={isAllPagesSelected}
-                toggleAllPagesSelected={toggleAllPagesSelected}
-                totalCount={totalCount}
-                resultsTitle={resultsTitle}
-                defaultPageSize={pageSize}
-                defaultPageIndex={pageIndex}
-                defaultSelectedRows={defaultSelectedRows}
-                autoResetPage={!disableAutoResetPage}
-                primarySelectAction={primarySelectAction}
-                secondarySelectActions={secondarySelectActions}
-                onSelectSingleRow={onSelectSingleRow}
-                onClickRow={onClickRow}
-                keyboardSelectableRows={keyboardSelectableRows}
-                onResultsCountChange={setClientFilterCount}
-                isClientSidePagination={isClientSidePagination}
-                onClientSidePaginationChange={onClientSidePaginationChange}
-                isClientSideFilter={isClientSideFilter}
-                disableHighlightOnHover={disableHighlightOnHover}
-                searchQuery={searchQuery}
-                searchQueryColumn={searchQueryColumn}
-                selectedDropdownFilter={selectedDropdownFilter}
-                renderTableHelpText={renderTableHelpText}
-                renderPagination={
-                  isClientSidePagination
-                    ? undefined
-                    : renderServersidePagination
+              {/* This UI only shows if a user navigates to a table page with a URL page param that is outside the # of pages available */}
+              {currentPageIndex !== 0 && (
+                <div className={`${baseClass}__empty-page`}>
+                  <div className={`${baseClass}__previous-button`}>
+                    <Pagination
+                      disableNext
+                      onNextPage={() =>
+                        onPaginationChange(currentPageIndex + 1)
+                      }
+                      onPrevPage={() =>
+                        onPaginationChange(currentPageIndex - 1)
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              {/* TODO: Fix this hacky solution to clientside search being 0 rendering emptycomponent but
+            no longer accesses rows.length because DataTable is not rendered */}
+              {!isLoading &&
+                clientFilterCount === 0 &&
+                !isMultiColumnFilter && (
+                  <EmptyComponent pageIndex={currentPageIndex} />
+                )}
+              <div
+                className={
+                  isClientSideFilter && !isMultiColumnFilter
+                    ? `client-result-count-${clientFilterCount}`
+                    : ""
                 }
-                setExportRows={setExportRows}
-                onClearSelection={onClearSelection}
-                suppressHeaderActions={suppressHeaderActions}
-                getRowId={getRowId}
-                persistSelectedRows={persistSelectedRows}
-                hideFooter={hideFooter}
-              />
-            </div>
-          </>
-        )}
-      </div>
+              >
+                <DataTable
+                  isLoading={isLoading}
+                  columns={columnConfigs}
+                  data={data}
+                  filters={filters}
+                  manualSortBy={manualSortBy}
+                  sortHeader={sortHeader}
+                  sortDirection={sortDirection}
+                  onSort={onSortChange}
+                  disableMultiRowSelect={disableMultiRowSelect}
+                  showMarkAllPages={showMarkAllPages}
+                  isAllPagesSelected={isAllPagesSelected}
+                  toggleAllPagesSelected={toggleAllPagesSelected}
+                  totalCount={totalCount}
+                  resultsTitle={resultsTitle}
+                  defaultPageSize={pageSize}
+                  defaultPageIndex={pageIndex}
+                  defaultSelectedRows={defaultSelectedRows}
+                  autoResetPage={!disableAutoResetPage}
+                  primarySelectAction={primarySelectAction}
+                  secondarySelectActions={secondarySelectActions}
+                  onSelectSingleRow={onSelectSingleRow}
+                  onClickRow={onClickRow}
+                  keyboardSelectableRows={keyboardSelectableRows}
+                  onResultsCountChange={setClientFilterCount}
+                  isClientSidePagination={isClientSidePagination}
+                  onClientSidePaginationChange={onClientSidePaginationChange}
+                  isClientSideFilter={isClientSideFilter}
+                  disableHighlightOnHover={disableHighlightOnHover}
+                  searchQuery={searchQuery}
+                  searchQueryColumn={searchQueryColumn}
+                  selectedDropdownFilter={selectedDropdownFilter}
+                  renderTableHelpText={renderTableHelpText}
+                  renderPagination={
+                    isClientSidePagination
+                      ? undefined
+                      : renderServersidePagination
+                  }
+                  setExportRows={setExportRows}
+                  onClearSelection={onClearSelection}
+                  suppressHeaderActions={suppressHeaderActions}
+                  getRowId={getRowId}
+                  persistSelectedRows={persistSelectedRows}
+                  hideFooter={hideFooter}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </TableLayoutContext.Provider>
     </div>
   );
 };

--- a/frontend/components/TableContainer/TableLayoutContext.tsx
+++ b/frontend/components/TableContainer/TableLayoutContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+// Signals to descendants that they're rendered inside a TableContainer's
+// data-table block — which has overflow-x: auto on its wrapper. Popup
+// components (e.g. ActionsDropdown) read this to decide whether to portal
+// their menu to document.body so the wrapper's overflow doesn't clip it.
+const TableLayoutContext = createContext<{ insideTable: boolean }>({
+  insideTable: false,
+});
+
+export default TableLayoutContext;


### PR DESCRIPTION
## Issue
Closes #47960
Unreleased bug introduced by #48419

## Description
- Previously merged into `main` with #48430
- This is for the 4.89.0 R.C.

- [x] QA'd all new/changed functionality manually