### PR TITLE
Update Release QA issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -700,12 +700,11 @@ Perform a quick visual scan of the UI and confirm:
 
 <tr>
 <td>Release-critical issues (Ready for release)</td>
-<td>Verify every release-critical issue has been driven to "Ready for release": open <code>~unreleased bug</code> issues (regressions introduced during this release cycle — the most critical to clear) and open <code>~release blocker</code> tickets.</td>
+<td>Verify no open <code>~unreleased bug</code> or <code>~release blocker</code> issue is still in the works — all should be "Ready for release".</td>
 <td>
 
-1. Review **every** open issue under the [`~unreleased bug`](https://github.com/fleetdm/fleet/labels/~unreleased%20bug) and [`~release blocker`](https://github.com/fleetdm/fleet/labels/~release%20blocker) label filters.
-2. Confirm each one has a milestone, an owner (assignee), and has been moved to **"Ready for release"** on its product group's project board (Status lives on the group board, not on the issue itself).
-3. All of these must be "Ready for release" before the release can proceed. If any is missing a milestone/owner or is not yet "Ready for release", raise an alarm in the `#help-engineering` and the relevant product group channel and drive it to resolution.
+1. Check the [`~unreleased bug`](https://github.com/fleetdm/fleet/labels/~unreleased%20bug) and [`~release blocker`](https://github.com/fleetdm/fleet/labels/~release%20blocker) filters and confirm every open issue is "Ready for release" on its product group board.
+2. If any is not, raise an alarm in the `#help-engineering` and the relevant product group channel.
 
 </td>
 </tr>

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -11,7 +11,7 @@ assignees: 'xpkoala,andreykizimenko,chrstphr84,Brajim20'
 
 Easy-to-follow test steps for checking a release manually.
 
-> **How to check off:** Tick the checkbox in each **Progress** list as a test passes. GitHub tracks completion ("X of Y tasks") at the top of the issue. The tables below each list hold the step instructions and expected results for reference. For a **failure**, leave the box unchecked and record the details under [Notes](#notes).
+> **How to check off:** Tick the checkbox in each **Progress** list as a test passes. GitHub tracks completion ("X of Y tasks") at the top of the issue. The tables below each list hold the step instructions and expected results for reference. For a **failure**, leave the box unchecked and record the details under the **Notes** section at the bottom of this issue.
 
 # Important reference data
 
@@ -173,12 +173,14 @@ Perform a quick visual scan of the UI and confirm:
 
 </table>
 
-### MDM
+### Apple at Work
 
 **Progress**
 - [ ] MDM enrollment flow
 - [ ] MDM migration flow
 - [ ] OS settings
+- [ ] Disk encryption
+- [ ] OS updates
 - [ ] Setup experience
 - [ ] iOS/iPadOS
 - [ ] Token & Certificate Renewals
@@ -218,6 +220,28 @@ Perform a quick visual scan of the UI and confirm:
 
 1. Verify Profiles upload/download/delete.
 2. Verify Profiles are delivered to host and applied.
+
+</td>
+</tr>
+
+<tr>
+<td>Disk encryption</td>
+<td>Verify disk encryption functionality (macOS).</td>
+<td>
+
+1. Verify able to configure Disk encryption (macOS).
+2. Verify host enrolled with Disk encryption enforced successfully encrypts.
+
+</td>
+</tr>
+
+<tr>
+<td>OS updates</td>
+<td>Verify OS updates flow (macOS).</td>
+<td>
+
+1. Configure OS updates (macOS).
+2. Verify enforce minimumOS occurs during enrollment (macOS 14+).
 
 </td>
 </tr>
@@ -279,6 +303,8 @@ Run basic checks for the product group area while using a Fleet Free license.
    - Configuration profile delivery
    - APNs Certificate renewal
 - Premium features are correctly restricted or hidden:
+   - Disk encryption
+   - OS updates
    - Setup experience
 - No UI, API, or workflow errors occur when using Free-only functionality.
 
@@ -310,6 +336,8 @@ Perform a quick visual scan of the UI and confirm:
 - [ ] MDM enrollment flow
 - [ ] MDM migration flow
 - [ ] OS settings
+- [ ] Disk encryption
+- [ ] OS updates
 - [ ] Setup Experience
 - [ ] Fleet Free
 - [ ] UI / UX
@@ -351,6 +379,27 @@ Perform a quick visual scan of the UI and confirm:
 </tr>
 
 <tr>
+<td>Disk encryption</td>
+<td>Verify disk encryption functionality (Windows).</td>
+<td>
+
+1. Verify able to configure Disk encryption (Windows).
+2. Verify host enrolled with Disk encryption enforced successfully encrypts.
+
+</td>
+</tr>
+
+<tr>
+<td>OS updates</td>
+<td>Verify OS updates flow (Windows).</td>
+<td>
+
+1. Configure OS updates (Windows).
+
+</td>
+</tr>
+
+<tr>
 <td>Setup Experience</td>
 <td>Verify Windows Setup experience.</td>
 <td>
@@ -374,6 +423,8 @@ Run basic checks for the product group area while using a Fleet Free license.
    - Configuration profile delivery
 - Premium features are correctly restricted or hidden:
    - Automatic MDM migration
+   - Disk encryption
+   - OS updates
 - No UI, API, or workflow errors occur when using Free-only functionality.
 
 Reference: https://fleetdm.com/pricing
@@ -398,7 +449,7 @@ Perform a quick visual scan of the UI and confirm:
 
 </table>
 
-### Software
+### Auto Patching
 
 **Progress**
 - [ ] Report flow
@@ -521,11 +572,10 @@ Perform a quick visual scan of the UI and confirm:
 ### Security & Compliance
 
 **Progress**
-- [ ] Disk encryption
+- [ ] Disk encryption (Linux)
 - [ ] Vulnerabilities
 - [ ] Certificate Authorities
 - [ ] Android
-- [ ] OS updates
 - [ ] Lock & Wipe
 - [ ] Fleet Free
 - [ ] UI / UX
@@ -534,11 +584,11 @@ Perform a quick visual scan of the UI and confirm:
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
 
 <tr>
-<td>Disk encryption</td>
-<td>Verify disk encryption functionality.</td>
+<td>Disk encryption (Linux)</td>
+<td>Verify disk encryption functionality (Linux).</td>
 <td>
 
-1. Verify able to configure Disk encryption (macOS, Windows, & Linux).
+1. Verify able to configure Disk encryption (Linux).
 2. Verify host enrolled with Disk encryption enforced successfully encrypts.
 
 </td>
@@ -584,17 +634,6 @@ Perform a quick visual scan of the UI and confirm:
 </tr>
 
 <tr>
-<td>OS updates</td>
-<td>Verify OS updates flow.</td>
-<td>
-
-1. Configure OS updates (macOS & Windows).
-2. Verify enforce minimumOS occurs during enrollment (macOS 14+).
-
-</td>
-</tr>
-
-<tr>
 <td>Lock & Wipe</td>
 <td>Verify hosts can be locked & wiped.</td>
 <td>
@@ -618,8 +657,7 @@ Run basic checks for the product group area while using a Fleet Free license.
    - Vulnerability detection
    - Individual CVE page
 - Premium features are correctly restricted or hidden:
-   - Disk encryption
-   - OS Updates
+   - Disk encryption (Linux)
    - Lock / Wipe
    - Certificate authorities
 - No UI, API, or workflow errors occur when using Free-only functionality.
@@ -649,7 +687,7 @@ Perform a quick visual scan of the UI and confirm:
 ### All product groups
 
 **Progress**
-- [ ] Release blockers
+- [ ] Release-critical issues (Ready for release)
 - [ ] Baseline loadtest (minor releases only)
 - [ ] Migration loadtest (minor releases only)
 - [ ] Helm chart
@@ -661,12 +699,13 @@ Perform a quick visual scan of the UI and confirm:
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
 
 <tr>
-<td>Release blockers</td>
-<td>Verify there are no outstanding release blocking tickets.</td>
+<td>Release-critical issues (Ready for release)</td>
+<td>Verify every release-critical issue has been driven to "Ready for release": open <code>~unreleased bug</code> issues (regressions introduced during this release cycle — the most critical to clear) and open <code>~release blocker</code> tickets.</td>
 <td>
 
-1. Check [this](https://github.com/fleetdm/fleet/labels/~release%20blocker) filter to view all open `~release blocker` tickets.
-2. If any are found raise an alarm in the `#help-engineering` and `#g-mdm` (or `#g-endpoint-ops`) channels.
+1. Review **every** open issue under the [`~unreleased bug`](https://github.com/fleetdm/fleet/labels/~unreleased%20bug) and [`~release blocker`](https://github.com/fleetdm/fleet/labels/~release%20blocker) label filters.
+2. Confirm each one has a milestone, an owner (assignee), and has been moved to **"Ready for release"** on its product group's project board (Status lives on the group board, not on the issue itself).
+3. All of these must be "Ready for release" before the release can proceed. If any is missing a milestone/owner or is not yet "Ready for release", raise an alarm in the `#help-engineering` and the relevant product group channel and drive it to resolution.
 
 </td>
 </tr>


### PR DESCRIPTION
**Related issue:** N/A — internal update to the release-QA issue template

# Description

Updates the **Release QA** issue template (`.github/ISSUE_TEMPLATE/release-qa.md`) to match current product group naming and to tighten the release-critical issue gate.

Changes:

- **Renamed product group sections** to match the working-group names in `handbook/company/product-groups.md`: **MDM → Apple at Work** and **Software → Auto Patching**.
- **Moved OS updates and disk encryption checks** out of Security & Compliance to the platform-owning groups:
  - macOS OS updates + disk encryption → **Apple at Work**
  - Windows OS updates + disk encryption → **Power to PC**
  - Linux disk encryption stays in **Security & Compliance**
  - Per-section Fleet Free premium-gating lists updated to follow the moves.
- **Consolidated the release-critical issue check** into a single "Ready for release" gate covering both `~unreleased bug` (regressions introduced during the cycle — the most critical to clear) and `~release blocker` labels. Every such issue must have a milestone, an owner, and be moved to "Ready for release" on its product group board before the release can proceed.
- **Removed non-functional in-issue anchor links.** GitHub only generates heading anchors when rendering Markdown as a repo file/wiki/Discussion, not inside issue bodies, so the previous `#notes`-style links silently did nothing once the template became an issue.

# Checklist for submitter

- [ ] ~Changes file added for user-visible changes~ — N/A, internal QA issue template only (no user-visible product change).

## Testing

This is a docs-only change to a GitHub issue template; no code paths are affected.

- [x] QA'd all new/changed functionality manually (verified rendered Markdown, section structure, and label-filter links).
