### PR TITLE
Revert "[YAML] Add multiple custom packages for the same software title in the same fleet" from docs-v4.89.0

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -590,7 +590,7 @@ software:
 ```
 
 #### self_service, labels, categories, and setup_experience
-
+  
 - `self_service` specifies whether end users can install from **Fleet Desktop > Self-service** (default: `false`) on macOS or [self-service web app](https://fleetdm.com/learn-more-about/deploy-self-service-to-ios) on iOS/iPadOS.
 - `labels_include_all` targets hosts that **have all** of the specified labels. `labels_include_any` targets hosts that **have any** of the specified labels. `labels_exclude_any` targets hosts that **have none** of the specified labels. Only one of these fields can be set. If none are set, all hosts are targeted.
 - `categories` is a list of self-service category names. Categories group self-service software on your end users' **Fleet Desktop > My device** page so that end users can filter by category and install all software in a category at once.
@@ -611,46 +611,6 @@ software:
 - `icon.path` is a relative path to the PNG icon that will be displayed in Fleet and on **Fleet Desktop > Self-service** instead of the default icon built into Fleet. It must be a square PNG with dimensions between 120x120 px and 1024x1024 px. Custom icons will only override the icon for the software title and fleet where they are added.
 
 #### Example
-
-##### Multiple versions of the same software
-
-You can add multiple packages for the same software in a package YAML file. This enables staged rollouts and support of architecture-specific installers.
-
-`self_service`, `categories`, and labels are defined per package. `setup_experience` is defined on the fleet-level.
-
-If multiple packages target the same host, Fleet will install the one that was added first.
-
-> In GitOps, the first package added is the first one in the package YAML file's list on the initial run that adds the title's packages. Reordering the list on a later run doesn't change the order.
->
-> You can preview the order of the packages in the UI. The first package in the list is always a fallback in case of a conflict.
-
-`fleets/fleet-name.yml`, or `fleets/unassigned.yml`
-
-```yaml
-software:
-  packages:
-    - path: ../lib/software/santa.package.yml
-```
-
-`lib/software/santa.package.yml`
-
-```yaml
-- url: https://github.com/northpolesec/santa/releases/download/2026.2/santa-2026.2.pkg
-  install_script:
-    path: ../lib/software/santa-install-script.sh
-  self_service: true
-  labels_include_all:
-    - macOS
-- url: https://github.com/northpolesec/santa/releases/download/2026.4/santa-2026.4.pkg
-  install_script:
-    path: ../lib/software/santa-install-script.sh
-  self_service: true
-  categories:
-    - "💻 Productivity"
-  labels_include_all:
-    - macOS
-    - IT test team
-```
 
 ##### URL
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -590,7 +590,6 @@ software:
 ```
 
 #### self_service, labels, categories, and setup_experience
-  
 - `self_service` specifies whether end users can install from **Fleet Desktop > Self-service** (default: `false`) on macOS or [self-service web app](https://fleetdm.com/learn-more-about/deploy-self-service-to-ios) on iOS/iPadOS.
 - `labels_include_all` targets hosts that **have all** of the specified labels. `labels_include_any` targets hosts that **have any** of the specified labels. `labels_exclude_any` targets hosts that **have none** of the specified labels. Only one of these fields can be set. If none are set, all hosts are targeted.
 - `categories` is a list of self-service category names. Categories group self-service software on your end users' **Fleet Desktop > My device** page so that end users can filter by category and install all software in a category at once.


### PR DESCRIPTION
Reverts #48266 from `docs-v4.89.0`. Feature is moving to `docs-v4.90.0`.

**Related:** #48266