### PR TITLE
Update Chrome managed bookmarks

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -506,15 +506,21 @@
                         </dict>
                         <dict>
                             <key>name</key>
-                            <string>💻 Current sprint (#g-mdm)</string>
+                            <string>🍎 Kanban board (#g-apple-at-work)</string>
                             <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/58</string>
+                            <string>https://github.com/orgs/fleetdm/projects/108</string>
                         </dict>
                         <dict>
                             <key>name</key>
-                            <string>📦 Current sprint (#g-software)</string>
+                            <string>❤️‍🩹 Kanban board (#g-auto-patching)</string>
                             <key>url</key>
-                            <string>https://github.com/orgs/fleetdm/projects/70</string>
+                            <string>https://github.com/orgs/fleetdm/projects/109</string>
+                        </dict>
+                        <dict>
+                            <key>name</key>
+                            <string>⚡ Kanban board (#g-power-to-pc)</string>
+                            <key>url</key>
+                            <string>https://github.com/orgs/fleetdm/projects/106</string>
                         </dict>
                         <dict>
                             <key>name</key>


### PR DESCRIPTION
- #g-mdm => #g-apple-at-work
- #g-software => #g-auto-patching
- Add #g-power-to-pc
- These teams now use ["continuous flow"](https://fleetdm.com/handbook/company/product-groups#continuous-flow) instead of scum so updated language from "Current sprint" to "Kanban board"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Chrome managed bookmarks for the Engineering section with new kanban board links.
  * Added bookmarks for `#g-apple-at-work`, `#g-auto-patching`, and `#g-power-to-pc`.
* **Bug Fixes**
  * Removed outdated sprint bookmarks from the managed bookmarks list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->