### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aptakube/windows.json
+++ b/ee/maintained-apps/outputs/aptakube/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.18.0",
+      "version": "1.18.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL' AND version_compare(version, '1.18.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL' AND version_compare(version, '1.18.1') < 0);"
       },
-      "installer_url": "https://releases.aptakube.com/Aptakube_1.18.0_x64_en-US.msi",
+      "installer_url": "https://releases.aptakube.com/Aptakube_1.18.1_x64_en-US.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "d2281ec5",
-      "sha256": "dfdf077f3d215e1c3d4028bc39955d0461b4275a507dca1635fc31bb1bc210ee",
+      "sha256": "4e509d38970e8fc77247d3a9af189526cf1d842fd7fe0fd4b4bc29d58d7079d9",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/bluej/darwin.json
+++ b/ee/maintained-apps/outputs/bluej/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.5.0",
+      "version": "6.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.bluej.BlueJ';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.bluej.BlueJ' AND version_compare(bundle_short_version, '5.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.bluej.BlueJ' AND version_compare(bundle_short_version, '6.0.0') < 0);"
       },
-      "installer_url": "https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-5.5.0/BlueJ-mac-aarch64-5.5.0.dmg",
+      "installer_url": "https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-6.0.0/BlueJ-mac-aarch64-6.0.0.dmg",
       "install_script_ref": "fa50ccec",
       "uninstall_script_ref": "f69f658d",
-      "sha256": "206c4b329f8b47e84b547a4f8fa5afdc9e143a803717cd47f2a1a2cacf183546",
+      "sha256": "2151ec9e1ce8d49e80c58267e5691aa71ac638997d338ecf2ea1f134da12d542",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/chatwise/darwin.json
+++ b/ee/maintained-apps/outputs/chatwise/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.6.0",
+      "version": "26.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.0') < 0);"
       },
-      "installer_url": "https://releases.chatwise.app/26.6.0/ChatWise-26.6.0-arm64.dmg",
+      "installer_url": "https://releases.chatwise.app/26.7.0/ChatWise-26.7.0-arm64.dmg",
       "install_script_ref": "b3b382a0",
       "uninstall_script_ref": "da509fe4",
-      "sha256": "a9fcde761816ba3d3d8b2577687ff1621bd34af95b7b7b5bbbd470377a1cd4ac",
+      "sha256": "e39f496c8592a1c5cfad2891e26ca217a27e0cd08c568c04706da9ca7c2c84cf",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/clop/darwin.json
+++ b/ee/maintained-apps/outputs/clop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.1",
+      "version": "3.2.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lowtechguys.Clop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lowtechguys.Clop' AND version_compare(bundle_short_version, '3.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lowtechguys.Clop' AND version_compare(bundle_short_version, '3.2.2') < 0);"
       },
-      "installer_url": "https://files.lowtechguys.com/releases/Clop-3.2.1.dmg",
+      "installer_url": "https://files.lowtechguys.com/releases/Clop-3.2.2.dmg",
       "install_script_ref": "76fb9b1b",
       "uninstall_script_ref": "3712ca1f",
-      "sha256": "0b71db037665fdc615ab351c8e4aca3ddc21723efe97e2866d6800242d07cdd9",
+      "sha256": "e07a369ecac6ec36b9fc1baaab92175232a3701fd5dcb7835f32682f5e490943",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/daisydisk/darwin.json
+++ b/ee/maintained-apps/outputs/daisydisk/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "4.33.3",
+      "version": "4.34",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.daisydiskapp.DaisyDiskStandAlone';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.daisydiskapp.DaisyDiskStandAlone' AND version_compare(bundle_short_version, '4.33.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.daisydiskapp.DaisyDiskStandAlone' AND version_compare(bundle_short_version, '4.34') < 0);"
       },
       "installer_url": "https://daisydiskapp.com/download/DaisyDisk.zip",
       "install_script_ref": "af1b217c",

--- a/ee/maintained-apps/outputs/druva-insync/windows.json
+++ b/ee/maintained-apps/outputs/druva-insync/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.5.7",
+      "version": "8.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Druva inSync %' AND publisher = 'Druva Technologies Pte. Ltd.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Druva inSync %' AND publisher = 'Druva Technologies Pte. Ltd.' AND version_compare(version, '7.5.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Druva inSync %' AND publisher = 'Druva Technologies Pte. Ltd.' AND version_compare(version, '8.1.3') < 0);"
       },
-      "installer_url": "https://downloads.druva.com/downloads/inSync/Windows/7.5.7/inSync7.5.7r110923.msi",
+      "installer_url": "https://downloads.druva.com/downloads/inSync/Windows/8.1.3/inSync8.1.3r111021.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "3c11d43f",
-      "sha256": "44e7295a0efba9e386e5dc24fa1e024e84b14d5e70f290ddd4389da5c5e5c96e",
+      "sha256": "f4ec7f458762a76b758de4daa68b5f697c1dab0a38d64d20297ec4826f985ac4",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/firefox/windows.json
+++ b/ee/maintained-apps/outputs/firefox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "152.0.3",
+      "version": "152.0.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '152.0.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '152.0.4') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/152.0.3/win64/en-US/Firefox%20Setup%20152.0.3.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/152.0.4/win64/en-US/Firefox%20Setup%20152.0.4.exe",
       "install_script_ref": "80fb9175",
       "uninstall_script_ref": "8b5e20e4",
-      "sha256": "c0824d81db60a834ff647ca50f078c9c78f932d7e758855668fc24587f94a3d8",
+      "sha256": "a1cd9b563a1c084db7e77f6e2a7e1f07876d8e58e4e33463052d53cc0a5d7069",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/git/windows.json
+++ b/ee/maintained-apps/outputs/git/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.54.0",
+      "version": "2.55.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Git %' AND publisher = 'The Git Development Community';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Git %' AND publisher = 'The Git Development Community' AND version_compare(version, '2.54.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Git %' AND publisher = 'The Git Development Community' AND version_compare(version, '2.55.0') < 0);"
       },
-      "installer_url": "https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/Git-2.54.0-64-bit.exe",
+      "installer_url": "https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.1/Git-2.55.0-64-bit.exe",
       "install_script_ref": "64df8252",
       "uninstall_script_ref": "3233086c",
-      "sha256": "2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983",
+      "sha256": "0c66e4a5875da5a74f9754386de7555ba301503b03bbdcdbafa69dc6464e548d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/jamovi/darwin.json
+++ b/ee/maintained-apps/outputs/jamovi/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.7.36.0",
+      "version": "2.7.37.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.jamovi.jamovi';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jamovi.jamovi' AND version_compare(bundle_short_version, '2.7.36.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jamovi.jamovi' AND version_compare(bundle_short_version, '2.7.37.0') < 0);"
       },
-      "installer_url": "https://www.jamovi.org/downloads/jamovi-2.7.36.0-macos-arm64.dmg",
+      "installer_url": "https://www.jamovi.org/downloads/jamovi-2.7.37.0-macos-arm64.dmg",
       "install_script_ref": "1df03dad",
       "uninstall_script_ref": "f35082d0",
-      "sha256": "d281b893f74686ed2e951a0cee5c96c5d81cbf4f52cb65f20eaf39c2b2c3d276",
+      "sha256": "9010ab2e19b6bd30669aa757224a664dd14bf7c6201e0acdd1ace93b8a650b70",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-teams/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-teams/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26149.1804.4788.5681",
+      "version": "26163.407.4839.8659",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2' AND version_compare(bundle_short_version, '26149.1804.4788.5681') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2' AND version_compare(bundle_short_version, '26163.407.4839.8659') < 0);"
       },
-      "installer_url": "https://statics.teams.cdn.office.net/production-osx/26149.1804.4788.5681/MicrosoftTeams.pkg",
+      "installer_url": "https://statics.teams.cdn.office.net/production-osx/26163.407.4839.8659/MicrosoftTeams.pkg",
       "install_script_ref": "9842434b",
       "uninstall_script_ref": "1fbcf592",
-      "sha256": "bcf6d54723446063e3b37c5a03bbd5c9f5f8e7bf5e7517d6db2676fc0e684e0b",
+      "sha256": "ea55e7b683cf606f1642597f35441068dd553db1cafa827927c3f7a04e57b980",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/notesnook/darwin.json
+++ b/ee/maintained-apps/outputs/notesnook/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.1",
+      "version": "3.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook' AND version_compare(bundle_short_version, '3.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook' AND version_compare(bundle_short_version, '3.4.2') < 0);"
       },
-      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.4.1/notesnook_mac_arm64.dmg",
+      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.4.2/notesnook_mac_arm64.dmg",
       "install_script_ref": "458f8fba",
       "uninstall_script_ref": "181a288a",
-      "sha256": "44b84fe7603196bd0a93d5eff614dd6a6a21cefd91fd55d0a30c50e724e65669",
+      "sha256": "300a9e515ab2dcc21ccc1033ec37a4d677892662c205625ce1e98a1dfa99ccf9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notesnook/windows.json
+++ b/ee/maintained-apps/outputs/notesnook/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.1",
+      "version": "3.4.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Notesnook %' AND publisher = 'Streetwriters';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Notesnook %' AND publisher = 'Streetwriters' AND version_compare(version, '3.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Notesnook %' AND publisher = 'Streetwriters' AND version_compare(version, '3.4.2') < 0);"
       },
-      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.4.1/notesnook_win_x64.exe",
+      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.4.2/notesnook_win_x64.exe",
       "install_script_ref": "fae91a29",
       "uninstall_script_ref": "83cee2d6",
-      "sha256": "3e23f06ef7fa9c2674b4cce42f958654bfa8c6ee60444e36ec789fdc66984c1b",
+      "sha256": "ce4013647c105f9a7a9cb47c7d4d266a05cb9459e962bb5e9f8d11abeec0c542",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/onedrive/darwin.json
+++ b/ee/maintained-apps/outputs/onedrive/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.098.0524.0004",
+      "version": "26.106.0603.0003",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.098.0524.0004') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.106.0603.0003') < 0);"
       },
-      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.098.0524.0004/universal/OneDrive.pkg",
+      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.106.0603.0003/universal/OneDrive.pkg",
       "install_script_ref": "1e78de1c",
       "uninstall_script_ref": "e2151a4d",
-      "sha256": "85dfbe556b09a8e287186bed4a61d05a8a04350a0f669d99a3ed3e0396ae85ef",
+      "sha256": "22278b574099df8b2e556d1061f5e024a576e3cefa21d8780717c769e1fbebf5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rive/darwin.json
+++ b/ee/maintained-apps/outputs/rive/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.8.5117",
+      "version": "0.8.5134",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5117') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5134') < 0);"
       },
-      "installer_url": "https://releases.rive.app/macos/0.8.5117/Rive.dmg",
+      "installer_url": "https://releases.rive.app/macos/0.8.5134/Rive.dmg",
       "install_script_ref": "2bbfee4e",
       "uninstall_script_ref": "8f862785",
-      "sha256": "38f5b32caa16a3e544de17a3105d5fb3271cfd0e318059ee28448b4848ab8bdf",
+      "sha256": "6a750c7caa03d93e967a0fafb57a771517469af127a9e61a03fd5f3174198d86",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.23.5",
+      "version": "2.23.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.23.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.23.6') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.23.5.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.23.6.dmg",
       "install_script_ref": "5f8295ce",
       "uninstall_script_ref": "a5d6883d",
-      "sha256": "d379c2436eb9761abe82922f10860b33af4edddd8a642beba72d87bf28f182ed",
+      "sha256": "90fda3e334e121edc9fe3728e4731706a10eafc396cb815a263a3879bbeb084d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "1.126.0",
+      "version": "1.127.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.126.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.127.0') < 0);"
       },
-      "installer_url": "https://update.code.visualstudio.com/1.126.0/darwin-universal/stable",
+      "installer_url": "https://update.code.visualstudio.com/1.127.0/darwin-universal/stable",
       "install_script_ref": "e6d54100",
       "uninstall_script_ref": "c6e93467",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/winlogbeat/windows.json
+++ b/ee/maintained-apps/outputs/winlogbeat/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.4.2",
+      "version": "9.4.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Beats winlogbeat % (x86_64)' AND publisher = 'Elastic';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Beats winlogbeat % (x86_64)' AND publisher = 'Elastic' AND version_compare(version, '9.4.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Beats winlogbeat % (x86_64)' AND publisher = 'Elastic' AND version_compare(version, '9.4.3') < 0);"
       },
-      "installer_url": "https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-9.4.2-windows-x86_64.msi",
+      "installer_url": "https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-9.4.3-windows-x86_64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "641d45e4",
-      "sha256": "190d8307f3feab0daacbe215766527969687bc0d23db15abf8cc47893aa8b9de",
+      "sha256": "8027ef46abfcf32fb2c074fbb1e081151a0e1e93d468c58da642a99f58030c78",
       "default_categories": [
         "Security"
       ],


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated available installers for several apps, including Firefox, Visual Studio Code, Git for Windows, OneDrive, Microsoft Teams, and others.
  * Bumped multiple macOS and Windows app entries to newer releases, such as BlueJ 6.0.0, Notesnook 3.4.2, and ChatWise 26.7.0.
  * Improved version detection so installed apps are recognized correctly against the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->