### PR TITLE
Add VEX exclusions for wix and fleetctl image scans

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -316,6 +316,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:35:00
 
+### [CVE-2026-54513](https://nvd.nist.gov/vuln/detail/CVE-2026-54513)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use Java.
+- **Products:** `fleetctl`,`pkg:maven/com.fasterxml.jackson.core/jackson-databind`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-01 13:33:33
+
+### [CVE-2026-54512](https://nvd.nist.gov/vuln/detail/CVE-2026-54512)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use Java.
+- **Products:** `fleetctl`,`pkg:maven/com.fasterxml.jackson.core/jackson-databind`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-01 13:33:33
+
 ### [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -666,6 +682,38 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Timestamp:** 2025-04-10 14:46:52
 
 ## `fleetdm/wix` docker image
+
+### [CVE-2026-8461](https://nvd.nist.gov/vuln/detail/CVE-2026-8461)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process media files when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libavcodec61`,`pkg:deb/debian/libavformat61`,`pkg:deb/debian/libavutil59`,`pkg:deb/debian/libswresample5`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-01 13:31:34
+
+### [CVE-2026-7598](https://nvd.nist.gov/vuln/detail/CVE-2026-7598)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh2-1t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-01 13:31:34
+
+### [CVE-2026-55200](https://nvd.nist.gov/vuln/detail/CVE-2026-55200)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh2-1t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-01 13:31:34
+
+### [CVE-2026-55199](https://nvd.nist.gov/vuln/detail/CVE-2026-55199)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh2-1t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-01 13:31:34
 
 ### [CVE-2026-5201](https://nvd.nist.gov/vuln/detail/CVE-2026-5201)
 - **Author:** @lucasmrod

--- a/security/vex/fleetctl/CVE-2026-54512.vex.json
+++ b/security/vex/fleetctl/CVE-2026-54512.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-05da424665ca49da6e9f325673ee41f8f1b67c50f8168b8e43ec1a19acd120df",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-01T13:33:33.000000Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54512"
+      },
+      "timestamp": "2026-07-01T13:33:33.000000Z",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:maven/com.fasterxml.jackson.core/jackson-databind"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use Java",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2026-54513.vex.json
+++ b/security/vex/fleetctl/CVE-2026-54513.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-bada5d9be976526ff12bc9318f990ed8f3a5947ecf7f0e0a240ffc0e1cfdd594",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-01T13:33:33.000000Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54513"
+      },
+      "timestamp": "2026-07-01T13:33:33.000000Z",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:maven/com.fasterxml.jackson.core/jackson-databind"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use Java",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-55199.vex.json
+++ b/security/vex/wix/CVE-2026-55199.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-86decdb74ba4b83a5eb9ea6520f82cc11ac449cfe25a85d5a1a5e2050d0912c8",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-01T13:31:34.000000Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-55199"
+      },
+      "timestamp": "2026-07-01T13:31:34.000000Z",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh2-1t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-55200.vex.json
+++ b/security/vex/wix/CVE-2026-55200.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-22fdb7aa971182cdb35c73e8754ec638f7dc53f10d186b9207f2d07b7af960fd",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-01T13:31:34.000000Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-55200"
+      },
+      "timestamp": "2026-07-01T13:31:34.000000Z",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh2-1t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-7598.vex.json
+++ b/security/vex/wix/CVE-2026-7598.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-ccc71c73913ec518997e2bd0c52cd797fac1c28816454b95cec444be76b2a656",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-01T13:31:34.000000Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-7598"
+      },
+      "timestamp": "2026-07-01T13:31:34.000000Z",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh2-1t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/wix/CVE-2026-8461.vex.json
+++ b/security/vex/wix/CVE-2026-8461.vex.json
@@ -1,0 +1,35 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-2d9d8148f396e6c596de8889f34477b4ec2fdf1b5267c8404323a227aa5a67d5",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-01T13:31:34.000000Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8461"
+      },
+      "timestamp": "2026-07-01T13:31:34.000000Z",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libavcodec61"
+        },
+        {
+          "@id": "pkg:deb/debian/libavformat61"
+        },
+        {
+          "@id": "pkg:deb/debian/libavutil59"
+        },
+        {
+          "@id": "pkg:deb/debian/libswresample5"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process media files when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Failures: 
- WiX: https://github.com/fleetdm/fleet/actions/runs/28500663153
- fleetctl: https://github.com/fleetdm/fleet/actions/runs/28501229768

New runs:
- WiX: https://github.com/fleetdm/fleet/actions/runs/28521840457
- fleetctl: https://github.com/fleetdm/fleet/actions/runs/28521833124

Adds VEX exclusions for false-positive vulnerabilities flagged by the scheduled Trivy scans of the `fleetdm/wix` and `fleetdm/fleetctl` images.

**wix** ([run](https://github.com/fleetdm/fleet/actions/runs/28500663153)):
- `CVE-2026-8461` — ffmpeg libs (libavcodec61, libavformat61, libavutil59, libswresample5); fleetctl does not process media files when using fleetdm/wix.
- `CVE-2026-55199`, `CVE-2026-55200`, `CVE-2026-7598` — libssh2-1t64; fleetctl does not establish SSH connections when generating MSI packages.

**fleetctl** ([run](https://github.com/fleetdm/fleet/actions/runs/28501229768)):
- `CVE-2026-54512`, `CVE-2026-54513` — com.fasterxml.jackson.core:jackson-databind; fleetctl does not use Java.

All statements are `not_affected` / `vulnerable_code_not_in_execute_path`, consistent with existing VEX entries in these directories. The scan workflows auto-glob the VEX directories, so no workflow changes are needed.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (validated JSON; mirrors existing VEX statements picked up by the scan workflow)