### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/timing/darwin.json
+++ b/ee/maintained-apps/outputs/timing/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.4",
+      "version": "2026.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'info.eurocomp.Timing2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'info.eurocomp.Timing2' AND version_compare(bundle_short_version, '2026.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'info.eurocomp.Timing2' AND version_compare(bundle_short_version, '2026.4.1') < 0);"
       },
-      "installer_url": "https://updates.timingapp.com/download/Timing-2026.4.dmg",
+      "installer_url": "https://updates.timingapp.com/download/Timing-2026.4.1.dmg",
       "install_script_ref": "a3717392",
       "uninstall_script_ref": "c2ba8bc0",
-      "sha256": "31cc8dcaf4f6a907ed924458514124574b6186a8c3847016db7822d68261bfae",
+      "sha256": "43f74cd2010b89e4864be9a845528455ddb936bdafc905131af6474b0adcad79",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.26.12",
+      "version": "26.26.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.26.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.26.15') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the macOS app entries for Timing and WhatsApp to newer versions.
  * Refreshed the Timing download link and checksum to match the latest release.
  * Adjusted version checks so the apps are recognized correctly when determining whether they need updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->