### PR TITLE
Product design sprint kickoff ritual: Remove retro

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Product design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "1. Pull up all contributors' calendars to review time off and, if needed, update design review calendar events. 2. Create reference docs release branches for any milestones newly added to the drafting board 3. For feature requests prioritized during feature fest, add user stories to the drafing and release planning boards, add milestones to the stories, confirm available capacity in targeted release, and align on priorities. Retro last sprint: What went well? What could go better? What to remember for next time? Pick one improvement to implement next sprint."
+  description: "1. Pull up all contributors' calendars to review time off and, if needed, update design review calendar events. 2. Create reference docs release branches for any milestones newly added to the drafting board 3. For feature requests prioritized during feature fest, add user stories to the drafing and release planning boards, add milestones to the stories, confirm available capacity in targeted release, and align on priorities."
   moreInfoUrl: 
   dri: "noahtalerman"
 -


### PR DESCRIPTION
- Product Designers attend respective product group retros instead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Product design sprint kickoff guidance to include clearer steps for planning and capturing prioritized requests.
  * Removed the end-of-sprint retro reminder from this ritual description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->