### PR TITLE
Fix panic in GetClientConfig with null agent options config (#47388)

### DIFF
--- a/changes/47388-getclientconfig-nil-map-panic
+++ b/changes/47388-getclientconfig-nil-map-panic
@@ -1,0 +1,1 @@
+- Fixed a server panic ("assignment to entry in nil map") when a host checked in for its osquery config while its agent options had a null `config`.

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -420,7 +420,7 @@ func (svc *Service) GetClientConfig(ctx context.Context) (map[string]interface{}
 			// "config": null) sets the map to nil rather than leaving it empty.
 			// Re-initialize so later assignments (e.g. config["packs"]) don't
 			// panic with "assignment to entry in nil map".
-			config = make(map[string]interface{})
+			config = make(map[string]any)
 		}
 	}
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -415,6 +415,13 @@ func (svc *Service) GetClientConfig(ctx context.Context) (map[string]interface{}
 		if err != nil {
 			return nil, newOsqueryError("internal error: parse base configuration: " + err.Error())
 		}
+		if config == nil {
+			// Unmarshaling the JSON literal `null` (e.g. agent options with
+			// "config": null) sets the map to nil rather than leaving it empty.
+			// Re-initialize so later assignments (e.g. config["packs"]) don't
+			// panic with "assignment to entry in nil map".
+			config = make(map[string]interface{})
+		}
 	}
 
 	packConfig := fleet.Packs{}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -215,6 +215,53 @@ func TestGetClientConfig(t *testing.T) {
 	)
 }
 
+// TestGetClientConfigNullConfig is a regression test for a panic
+// ("assignment to entry in nil map") that occurred when a host's agent options
+// had a null "config" and the host also had packs/scheduled queries. See
+// https://github.com/fleetdm/fleet/issues/47388.
+func TestGetClientConfigNullConfig(t *testing.T) {
+	ds := new(mock.Store)
+
+	ds.TeamAgentOptionsFunc = func(ctx context.Context, teamID uint) (*json.RawMessage, error) {
+		return nil, nil
+	}
+	ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Pack, error) {
+		return []*fleet.Pack{{ID: 1, Name: "pack_by_label"}}, nil
+	}
+	ds.ListScheduledQueriesInPackFunc = func(ctx context.Context, pid uint) (fleet.ScheduledQueryList, error) {
+		fals := false
+		return []*fleet.ScheduledQuery{
+			{Name: "time", Query: "select * from time", Interval: 30, Removed: &fals},
+		}, nil
+	}
+	ds.ListScheduledQueriesForAgentsFunc = func(ctx context.Context, teamID *uint, hostID *uint, queryReportsDisabled bool) ([]*fleet.Query, error) {
+		return nil, nil
+	}
+	// Global agent options with a null config. This unmarshals into a nil map,
+	// which previously caused a panic once packs were added to the config.
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{AgentOptions: ptr.RawMessage(json.RawMessage(`{"config":null}`))}, nil
+	}
+	ds.UpdateHostFunc = func(ctx context.Context, host *fleet.Host) error {
+		return nil
+	}
+
+	svc, ctx := newTestService(t, ds, nil, nil)
+	ctx = hostctx.NewContext(ctx, &fleet.Host{ID: 1})
+
+	conf, err := svc.GetClientConfig(ctx)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"pack_by_label": {
+			"queries":{
+				"time":{"query":"select * from time","interval":30,"removed":false}
+			}
+		}
+	}`,
+		string(conf["packs"].(json.RawMessage)),
+	)
+}
+
 func TestAgentOptionsForHost(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -229,9 +229,8 @@ func TestGetClientConfigNullConfig(t *testing.T) {
 		return []*fleet.Pack{{ID: 1, Name: "pack_by_label"}}, nil
 	}
 	ds.ListScheduledQueriesInPackFunc = func(ctx context.Context, pid uint) (fleet.ScheduledQueryList, error) {
-		fals := false
 		return []*fleet.ScheduledQuery{
-			{Name: "time", Query: "select * from time", Interval: 30, Removed: &fals},
+			{Name: "time", Query: "select * from time", Interval: 30, Removed: new(false)},
 		}, nil
 	}
 	ds.ListScheduledQueriesForAgentsFunc = func(ctx context.Context, teamID *uint, hostID *uint, queryReportsDisabled bool) ([]*fleet.Query, error) {
@@ -240,7 +239,7 @@ func TestGetClientConfigNullConfig(t *testing.T) {
 	// Global agent options with a null config. This unmarshals into a nil map,
 	// which previously caused a panic once packs were added to the config.
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{AgentOptions: ptr.RawMessage(json.RawMessage(`{"config":null}`))}, nil
+		return &fleet.AppConfig{AgentOptions: new(json.RawMessage(`{"config":null}`))}, nil
 	}
 	ds.UpdateHostFunc = func(ctx context.Context, host *fleet.Host) error {
 		return nil


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47388

I'll be doing some separate research on how agent options ends up as `null` in the first place.
Obviously you can set `config:` in the agent options and hit `Save` and the issue is reproduced but seems unlikely (one theory is GitOps doing some overriding).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Summary

`GetClientConfig` (`server/service/osquery.go`) panicked with `assignment to entry in nil map` (returning 5XX on `/api/v1/osquery/config`) when a host's resolved agent options had a null `config`.

Root cause: `config` is initialized as an empty map, but `json.Unmarshal([]byte("null"), &config)` silently sets the map to `nil` (no error). When the host also had packs or scheduled queries, the later `config["packs"] = ...` assignment panicked.

This adds a nil-guard that re-initializes the map after the unmarshal.

## Testing

- [x] Added/updated automated tests

Added `TestGetClientConfigNullConfig`, which sets `{"config":null}` agent options plus a pack and asserts no panic/error and that `packs` still serialize correctly.

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a server crash that could occur when generating osquery configuration for hosts with a null agent config.
  * Improved config handling so hosts with packs and scheduled queries now receive their configuration reliably, even when the base config is empty.
  * Added regression coverage to help prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->