### PR TITLE
Auto-install 1Password patches on Workstations

### DIFF
--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -8,11 +8,10 @@
     - Macs with Google Chrome installed
 - name: macOS - 1Password up to date
   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+  resolution: "1Password is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
   fleet_maintained_app_slug: 1password/darwin
-  install_software: false
-  calendar_events_enabled: true
+  install_software: true
   labels_include_any:
     - Macs with 1Password installed
 - name: macOS - Brave Browser up to date

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -8,11 +8,10 @@
     - x86 Windows hosts with Slack installed
 - name: Windows - 1Password up to date
   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+  resolution: "1Password is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
   fleet_maintained_app_slug: 1password/windows
-  install_software: false
-  calendar_events_enabled: true
+  install_software: true
   labels_include_any:
     - x86 Windows hosts with 1Password installed
 - name: Windows - Claude up to date


### PR DESCRIPTION
**Related issue:** N/A — dogfood GitOps configuration change

# What & why

Changes the 1Password patch automation on the **💻 Workstations** fleet from calendar-event-driven remediation to **forced install**, on both macOS and Windows.

For both `1password/darwin` and `1password/windows` patch policies in `it-and-security/`:
- `install_software: false` → `install_software: true`
- Removed `calendar_events_enabled: true`
- Updated the `resolution` text to drop the "scheduled maintenance window / check your calendar" language, matching the wording used by the other IT-managed forced-install policies (Okta Verify, Adobe Acrobat, etc.).

When a host now fails either 1Password patch policy, Fleet automatically installs the latest Fleet-maintained 1Password with no end-user calendar interaction. The fleet's `google_calendar` integration is left in place since other policies (e.g. Firefox) still use calendar events.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (GitOps config only; no code change)

Note: This is a dogfood GitOps config change only — no user-visible product change, no code, no migrations, no new settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 1Password updates are now managed automatically on macOS and Windows.
  * Devices that need 1Password installed can receive it automatically.
* **Bug Fixes**
  * Updated policy guidance explains what to do if 1Password remains out of date, including retrying the check and contacting IT support when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->