### PR TITLE
Website: add link on software management page

### DIFF
--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -162,6 +162,7 @@
             <p>
               Deploy software to macOS, Windows, and Linux devices through the UI, API, or <a href="/infrastructure-as-code">GitOps</a>. Choose the method that fits your team and the source that fits your needs.
             </p>
+            <animated-arrow-button href="/software-catalog">View software</animated-arrow-button>
           </div>
           <div purpose="feature-image">
             <img alt="Deploy software your own way" src="/images/mdm-software-management-800x600@2x.png">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/16603

Changes:
- Added a link going to the software catalog in the "Deploy software your own way" section of the /software-management page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “View software” call-to-action on the software management page, giving users a direct link to the software catalog.
  * Updated the “Deploy software your own way” section to include an additional way to explore available software options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->