### PR TITLE
[API] Add 'ab_source' field to REST API documentation

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3741,6 +3741,7 @@ Returns the information of the specified host.
     "disk_encryption_enabled": true,
     "status": "online",
     "display_text": "Annas-MacBook-Pro.local",
+    "ab_source": "Apple",
     "additional": {},
     "issues": {
       "failing_policies_count": 1,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3741,7 +3741,7 @@ Returns the information of the specified host.
     "disk_encryption_enabled": true,
     "status": "online",
     "display_text": "Annas-MacBook-Pro.local",
-    "ab_source": "Apple",
+    "apple_business_source": "Apple",
     "additional": {},
     "issues": {
       "failing_policies_count": 1,


### PR DESCRIPTION
Corrected the API endpoint for resending certificates and added a new field for 'ab_source'.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43478