### PR TITLE
Fix CPE matching for python3-prefixed packages on Ubuntu/Debian

### DIFF
--- a/changes/43328-python3-prefix-cpe
+++ b/changes/43328-python3-prefix-cpe
@@ -1,0 +1,1 @@
+- Fixed vulnerability detection for Python packages on Ubuntu/Debian devices by stripping the "python3-" name prefix during CPE matching.

--- a/server/vulnerabilities/nvd/sanitize.go
+++ b/server/vulnerabilities/nvd/sanitize.go
@@ -92,13 +92,6 @@ func sanitizeSoftwareName(s *fleet.Software) string {
 	r := strings.ToLower(s.Name)
 	r = strings.TrimSuffix(r, ".app")
 
-	// Strip "python3-" prefix from python_packages names for CPE matching.
-	// On Ubuntu/Debian, pythonPackageFilter prepends "python3-" to match OVAL definitions,
-	// but the CPE database uses the bare package name (e.g. "geopandas" not "python3-geopandas").
-	if s.Source == "python_packages" {
-		r = strings.TrimPrefix(r, "python3-")
-	}
-
 	// Remove vendor, for 'apps' the vendor name is usually after the top level domain part.
 	r = strings.ReplaceAll(r, strings.ToLower(s.Vendor), "")
 	bundleParts := strings.Split(s.BundleIdentifier, ".")
@@ -164,6 +157,26 @@ func productVariations(s *fleet.Software) []string {
 		parts := strings.SplitN(s.Name, ".", 2)
 		if len(parts) == 2 && parts[1] != "" {
 			r = append(r, parts[1])
+		}
+	}
+
+	// On Ubuntu/Debian/RHEL, pythonPackageFilter prepends "python3-" to python_packages names
+	// to match OVAL definitions. The CPE database uses bare package names (e.g. "geopandas"
+	// not "python3-geopandas"), so we add the stripped name as an additional variation.
+	// We keep the original name too in case a PyPI package genuinely starts with "python3-"
+	// (e.g. python3-openid, python3-saml).
+	if s.Source == "python_packages" {
+		stripped := strings.TrimPrefix(sn, "python3-")
+		if stripped != sn {
+			for _, v := range []string{
+				strings.ReplaceAll(stripped, " ", ""),
+				strings.ReplaceAll(stripped, " ", "_"),
+			} {
+				if !rSet[v] {
+					rSet[v] = true
+					r = append(r, v)
+				}
+			}
 		}
 	}
 

--- a/server/vulnerabilities/nvd/sanitize.go
+++ b/server/vulnerabilities/nvd/sanitize.go
@@ -92,6 +92,13 @@ func sanitizeSoftwareName(s *fleet.Software) string {
 	r := strings.ToLower(s.Name)
 	r = strings.TrimSuffix(r, ".app")
 
+	// Strip "python3-" prefix from python_packages names for CPE matching.
+	// On Ubuntu/Debian, pythonPackageFilter prepends "python3-" to match OVAL definitions,
+	// but the CPE database uses the bare package name (e.g. "geopandas" not "python3-geopandas").
+	if s.Source == "python_packages" {
+		r = strings.TrimPrefix(r, "python3-")
+	}
+
 	// Remove vendor, for 'apps' the vendor name is usually after the top level domain part.
 	r = strings.ReplaceAll(r, strings.ToLower(s.Vendor), "")
 	bundleParts := strings.Split(s.BundleIdentifier, ".")

--- a/server/vulnerabilities/nvd/sanitize.go
+++ b/server/vulnerabilities/nvd/sanitize.go
@@ -160,11 +160,11 @@ func productVariations(s *fleet.Software) []string {
 		}
 	}
 
-	// On Ubuntu/Debian/RHEL, pythonPackageFilter prepends "python3-" to python_packages names
-	// to match OVAL definitions. The CPE database uses bare package names (e.g. "geopandas"
-	// not "python3-geopandas"), so we add the stripped name as an additional variation.
-	// We keep the original name too in case a PyPI package genuinely starts with "python3-"
-	// (e.g. python3-openid, python3-saml).
+	// pythonPackageFilter (osquery.go) prepends "python3-" to python_packages names on
+	// Ubuntu/Debian/RHEL to match OVAL definitions. The CPE database uses bare package names
+	// (e.g. "geopandas" not "python3-geopandas"), so we add the stripped name as an additional
+	// variation. We keep the original name too so packages whose real PyPI name starts with
+	// "python3-" (e.g. python3-openid, python3-saml) still match on any platform.
 	if s.Source == "python_packages" {
 		stripped := strings.TrimPrefix(sn, "python3-")
 		if stripped != sn {

--- a/server/vulnerabilities/nvd/sanitize_test.go
+++ b/server/vulnerabilities/nvd/sanitize_test.go
@@ -162,6 +162,14 @@ func TestVariations(t *testing.T) {
 			vendorVariations:  []string{"microsoft", "ms-python"},
 			productVariations: []string{"python", "ms-python.python"},
 		},
+		{
+			software:          fleet.Software{Name: "python3-geopandas", Version: "1.0.1", Source: "python_packages"},
+			productVariations: []string{"geopandas"},
+		},
+		{
+			software:          fleet.Software{Name: "python3-django", Version: "3.2.12", Source: "python_packages"},
+			productVariations: []string{"django"},
+		},
 	}
 
 	for _, tc := range variationsTestCases {
@@ -372,6 +380,54 @@ func TestSanitizedSoftwareName(t *testing.T) {
 				expected: "firefox",
 			},
 		}
+		for _, tc := range testCases {
+			tc := tc
+			actual := sanitizeSoftwareName(&tc.software)
+			require.Equal(t, tc.expected, actual)
+		}
+	})
+
+	t.Run("strips python3- prefix from python_packages", func(t *testing.T) {
+		testCases := []struct {
+			software fleet.Software
+			expected string
+		}{
+			{
+				software: fleet.Software{
+					Name:    "python3-geopandas",
+					Version: "1.0.1",
+					Source:  "python_packages",
+				},
+				expected: "geopandas",
+			},
+			{
+				software: fleet.Software{
+					Name:    "python3-django",
+					Version: "3.2.12",
+					Source:  "python_packages",
+				},
+				expected: "django",
+			},
+			{
+				// python_packages without the prefix should not be affected
+				software: fleet.Software{
+					Name:    "requests",
+					Version: "2.28.0",
+					Source:  "python_packages",
+				},
+				expected: "requests",
+			},
+			{
+				// deb_packages with python3- prefix should NOT be stripped
+				software: fleet.Software{
+					Name:    "python3-geopandas",
+					Version: "1.0.1",
+					Source:  "deb_packages",
+				},
+				expected: "python3-geopandas",
+			},
+		}
+
 		for _, tc := range testCases {
 			tc := tc
 			actual := sanitizeSoftwareName(&tc.software)

--- a/server/vulnerabilities/nvd/sanitize_test.go
+++ b/server/vulnerabilities/nvd/sanitize_test.go
@@ -164,11 +164,16 @@ func TestVariations(t *testing.T) {
 		},
 		{
 			software:          fleet.Software{Name: "python3-geopandas", Version: "1.0.1", Source: "python_packages"},
-			productVariations: []string{"geopandas"},
+			productVariations: []string{"python3-geopandas", "geopandas"},
 		},
 		{
 			software:          fleet.Software{Name: "python3-django", Version: "3.2.12", Source: "python_packages"},
-			productVariations: []string{"django"},
+			productVariations: []string{"python3-django", "django"},
+		},
+		{
+			// python_packages without the prefix should not get extra variations
+			software:          fleet.Software{Name: "requests", Version: "2.28.0", Source: "python_packages"},
+			productVariations: []string{"requests"},
 		},
 	}
 
@@ -387,53 +392,6 @@ func TestSanitizedSoftwareName(t *testing.T) {
 		}
 	})
 
-	t.Run("strips python3- prefix from python_packages", func(t *testing.T) {
-		testCases := []struct {
-			software fleet.Software
-			expected string
-		}{
-			{
-				software: fleet.Software{
-					Name:    "python3-geopandas",
-					Version: "1.0.1",
-					Source:  "python_packages",
-				},
-				expected: "geopandas",
-			},
-			{
-				software: fleet.Software{
-					Name:    "python3-django",
-					Version: "3.2.12",
-					Source:  "python_packages",
-				},
-				expected: "django",
-			},
-			{
-				// python_packages without the prefix should not be affected
-				software: fleet.Software{
-					Name:    "requests",
-					Version: "2.28.0",
-					Source:  "python_packages",
-				},
-				expected: "requests",
-			},
-			{
-				// deb_packages with python3- prefix should NOT be stripped
-				software: fleet.Software{
-					Name:    "python3-geopandas",
-					Version: "1.0.1",
-					Source:  "deb_packages",
-				},
-				expected: "python3-geopandas",
-			},
-		}
-
-		for _, tc := range testCases {
-			tc := tc
-			actual := sanitizeSoftwareName(&tc.software)
-			require.Equal(t, tc.expected, actual)
-		}
-	})
 }
 
 func TestParseUpdateFromVersion(t *testing.T) {


### PR DESCRIPTION
Closes #43328

## Summary

- On Ubuntu/Debian/RHEL, `pythonPackageFilter` in osquery.go prepends `python3-` to Python package names (e.g., `geopandas` becomes `python3-geopandas`) to match OVAL definitions
- However, the CPE database uses the bare package name (e.g., `geopandas`, not `python3-geopandas`), so CPE matching fails and no vulnerabilities are reported
- This fix adds the stripped name (without `python3-` prefix) as an additional product variation during CPE lookup, so both `python3-geopandas` and `geopandas` are tried
- The original prefixed name is preserved so packages genuinely named `python3-*` on PyPI (e.g., `python3-openid`, `python3-saml`) still match correctly on non-Ubuntu platforms

## How I reproduced

Used the `nvdvuln` tool to simulate CPE matching:

**Before fix** (on main branch):
```
$ go run --tags=fts5 tools/nvd/nvdvuln/nvdvuln.go \
    --software_name python3-geopandas \
    --software_source python_packages \
    --software_version 1.0.1
Translating software to CPE...
Unable to match a CPE for the software...
```

**After fix:**
```
$ go run --tags=fts5 tools/nvd/nvdvuln/nvdvuln.go \
    --software_name python3-geopandas \
    --software_source python_packages \
    --software_version 1.0.1
Translating software to CPE...
Matched CPE: 0: cpe:2.3:a:geopandas:geopandas:1.0.1:*:*:*:*:python:*:*
Translating CPEs to CVEs...
CVEs found for python3-geopandas (1.0.1): CVE-2025-69662
```

Also verified with `python3-django` (version 3.2.12) -- correctly finds CVE-2024-24680 and other CVEs.

## How I tested

- Unit tests: added test cases for `productVariations` covering:
  - `python3-geopandas` (source: `python_packages`) -> produces both `python3-geopandas` and `geopandas` variations
  - `python3-django` (source: `python_packages`) -> produces both `python3-django` and `django` variations
  - `requests` (source: `python_packages`, no prefix) -> no extra variations added
- Manual: ran `nvdvuln` tool for both packages from the issue, confirmed CPE match and CVE detection
- Lint: `make lint-go-incremental` passes clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability detection for Python packages on Ubuntu/Debian by handling package names with or without the `python3-` prefix.
  * Added additional matching variations derived from sanitized names, ensuring both full and stripped forms are considered.
  * Ensured existing non-Python package matching behavior remains unchanged.
* **Tests**
  * Expanded NVD sanitization and product variation test coverage for `python_packages` scenarios (including cases with and without the `python3-` prefix).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->