### PR TITLE
Sort host device_mapping emails deterministically

### DIFF
--- a/changes/device-mapping-order
+++ b/changes/device-mapping-order
@@ -1,0 +1,1 @@
+- Made the order of a host's `device_mapping` emails deterministic (sorted by email) in host list and label host list responses.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1167,7 +1167,7 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
 		// idx_host_emails_host_id_email.
 		sql += fmt.Sprintf(`,
     COALESCE((
-        SELECT CONCAT('[', GROUP_CONCAT(JSON_OBJECT('email', he.email, 'source', %s)), ']')
+        SELECT CONCAT('[', GROUP_CONCAT(JSON_OBJECT('email', he.email, 'source', %s) ORDER BY he.email, he.source), ']')
         FROM host_emails he
         WHERE he.host_id = h.id
     ), 'null') as device_mapping

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1234,7 +1234,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 	deviceMappingJoin := fmt.Sprintf(`LEFT JOIN (
 	SELECT
 		host_id,
-		CONCAT('[', GROUP_CONCAT(JSON_OBJECT('email', email, 'source', %s)), ']') AS device_mapping
+		CONCAT('[', GROUP_CONCAT(JSON_OBJECT('email', email, 'source', %s) ORDER BY email, source), ']') AS device_mapping
 	FROM
 		host_emails
 	GROUP BY

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6149,12 +6149,13 @@ func (s *integrationTestSuite) TestListHostsByLabel() {
 		),
 	)
 
-	// Add device mapping
+	// Add device mapping, inserted out of order to verify the response is
+	// sorted by email
 	require.NoError(
 		t, s.ds.ReplaceHostDeviceMapping(
 			context.Background(), host.ID, []*fleet.HostDeviceMapping{
-				{HostID: hosts[0].ID, Email: "a@b.c", Source: fleet.DeviceMappingGoogleChromeProfiles},
 				{HostID: hosts[0].ID, Email: "b@b.c", Source: fleet.DeviceMappingGoogleChromeProfiles},
+				{HostID: hosts[0].ID, Email: "a@b.c", Source: fleet.DeviceMappingGoogleChromeProfiles},
 			}, fleet.DeviceMappingGoogleChromeProfiles,
 		),
 	)
@@ -10542,10 +10543,11 @@ func (s *integrationTestSuite) TestHostsReportDownload() {
 	err = s.ds.RecordPolicyQueryExecutions(ctx, hosts[1], map[uint]*bool{pol.ID: new(false)}, time.Now(), false, nil)
 	require.NoError(t, err)
 
-	// create some device mappings for host[2]
+	// create some device mappings for host[2], inserted out of order to verify
+	// the response is sorted by email
 	err = s.ds.ReplaceHostDeviceMapping(ctx, hosts[2].ID, []*fleet.HostDeviceMapping{
-		{HostID: hosts[2].ID, Email: "a@b.c", Source: "google_chrome_profiles"},
 		{HostID: hosts[2].ID, Email: "b@b.c", Source: "google_chrome_profiles"},
+		{HostID: hosts[2].ID, Email: "a@b.c", Source: "google_chrome_profiles"},
 	}, "google_chrome_profiles")
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Related issue:** NA

The `device_mapping` `GROUP_CONCAT` in the host list (`hosts.go`) and label host list (`labels.go`) queries had no `ORDER BY`, so a host's emails came back in an unspecified order that varied between query executions. This produced inconsistent API output and flaky integration test failures (`TestHostsReportDownload`, `TestListHostsByLabel`). Emails are now sorted by `email, source`, matching the single-host `ListHostDeviceMapping` query.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device mapping emails now appear in a consistent, sorted order in host and label host responses.
  * Host report CSV output now lists device mapping emails deterministically.
  * Updated validation coverage to reflect the stable ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->