### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aldente/darwin.json
+++ b/ee/maintained-apps/outputs/aldente/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.37.3",
+      "version": "1.38",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.apphousekitchen.aldente-pro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apphousekitchen.aldente-pro' AND version_compare(bundle_short_version, '1.37.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apphousekitchen.aldente-pro' AND version_compare(bundle_short_version, '1.38') < 0);"
       },
-      "installer_url": "https://apphousekitchen.com/aldente/AlDente1.37.3.dmg",
+      "installer_url": "https://apphousekitchen.com/aldente/AlDente1.38.dmg",
       "install_script_ref": "5e5ca0a4",
       "uninstall_script_ref": "c2d64a5f",
-      "sha256": "468ac2c11f1d3310e4e9a3c68d32bc8d514282c63d6d2e189f469415a468bdee",
+      "sha256": "5e079f1ce5614a76cf4fab6cc7d1b40cc95dc63e5ab217a777602bf2d5cce9e7",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.35.13",
+      "version": "2.35.14",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.13') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.14') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.13.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.14.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "7b5c11d2b2b3464b307ac99cc1ce25633c14188781d6e6b326337c0cbbc84f45",
+      "sha256": "cf20a3addc418334e9f926416ad8f4d749c35f1a615bdf5d1e8f19eb29318eeb",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/chatwise/darwin.json
+++ b/ee/maintained-apps/outputs/chatwise/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.7.0",
+      "version": "26.7.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.1') < 0);"
       },
-      "installer_url": "https://releases.chatwise.app/26.7.0/ChatWise-26.7.0-arm64.dmg",
+      "installer_url": "https://releases.chatwise.app/26.7.1/ChatWise-26.7.1-arm64.dmg",
       "install_script_ref": "b3b382a0",
       "uninstall_script_ref": "da509fe4",
-      "sha256": "e39f496c8592a1c5cfad2891e26ca217a27e0cd08c568c04706da9ca7c2c84cf",
+      "sha256": "cfa40ef35e1c2091391321d97ea6a1401189620759ed12d14ef6c8699df5a950",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17377.1",
+      "version": "1.17377.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.17377.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.17377.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.17377.1/Claude-2b3ab429b13f2c904d7552b7ca82a0d2a22af52f.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.17377.2/Claude-e0ea9e9df1d5a7e3848ea088cc6b1863adc020b9.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "573fdef6f098dc7bc461db69ff83272cdb00113ed955d93637cdf676d7b7c4e9",
+      "sha256": "21c22ce4bad2a6d43c2872c8c953a8a8cb1b4e5ace7fcc4bb2bc54f2eae49894",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dfu-blaster-pro/darwin.json
+++ b/ee/maintained-apps/outputs/dfu-blaster-pro/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.2",
+      "version": "5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.twocanoes.DFU-Blaster-Pro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.twocanoes.DFU-Blaster-Pro' AND version_compare(bundle_short_version, '4.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.twocanoes.DFU-Blaster-Pro' AND version_compare(bundle_short_version, '5.0') < 0);"
       },
-      "installer_url": "https://twocanoes-software-updates.s3.amazonaws.com/DFU_Blaster_Pro_Build-3282_Version-4.2.dmg",
+      "installer_url": "https://twocanoes-software-updates.s3.amazonaws.com/DFU_Blaster_Pro_Build-3567_Version-5.0.dmg",
       "install_script_ref": "98616873",
       "uninstall_script_ref": "e818d04f",
-      "sha256": "69a4eae2a7a6fb23be29c6f7a7c9540fbb8063a0b1993a9ca74365e23a25d07e",
+      "sha256": "9084c38301beb24a232377984f9f0f909f91c8f79c10f09c6e1c100ede2a2cf9",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/franz/darwin.json
+++ b/ee/maintained-apps/outputs/franz/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.4.0",
+      "version": "6.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.meetfranz.franz';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.meetfranz.franz' AND version_compare(bundle_short_version, '6.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.meetfranz.franz' AND version_compare(bundle_short_version, '6.4.1') < 0);"
       },
-      "installer_url": "https://github.com/meetfranz/franz-6/releases/download/v6.4.0/Franz-arm64.dmg",
+      "installer_url": "https://github.com/meetfranz/franz-6/releases/download/v6.4.1/Franz-arm64.dmg",
       "install_script_ref": "8c009aad",
       "uninstall_script_ref": "acd2d9b1",
-      "sha256": "a8cf46e9b2f5904e62d9e9e06ccaad00df0bd249a8104923e421fc33abd07c38",
+      "sha256": "473baf26b35990815e499e73726626207f8d3ef9fa50766d7eb7280899a07368",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/github/darwin.json
+++ b/ee/maintained-apps/outputs/github/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.6.1",
+      "version": "3.6.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.6.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient' AND version_compare(bundle_short_version, '3.6.2') < 0);"
       },
-      "installer_url": "https://desktop.githubusercontent.com/releases/3.6.1-8fa814ac/GitHubDesktop-arm64.zip",
+      "installer_url": "https://desktop.githubusercontent.com/releases/3.6.2-57f0b637/GitHubDesktop-arm64.zip",
       "install_script_ref": "98ab6ed8",
       "uninstall_script_ref": "642b60ca",
-      "sha256": "d02a33ab60168e4978a3f18fadfef2bdf51df881e5613c550cc2b91c8dac9539",
+      "sha256": "d0f0e30d5191846581c89c7719dc49f20599184488e8dab64d15fd66d644007c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/google-gemini/darwin.json
+++ b/ee/maintained-apps/outputs/google-gemini/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.80.15.516",
+      "version": "1.80.15.522",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.15.516') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.15.522') < 0);"
       },
       "installer_url": "https://dl.google.com/release2/j33ro/release/Gemini.dmg",
       "install_script_ref": "d6aaaffc",

--- a/ee/maintained-apps/outputs/google-gemini/darwin.json
+++ b/ee/maintained-apps/outputs/google-gemini/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.80.15.522",
+      "version": "1.80.18.522",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.15.522') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.18.522') < 0);"
       },
       "installer_url": "https://dl.google.com/release2/j33ro/release/Gemini.dmg",
       "install_script_ref": "d6aaaffc",

--- a/ee/maintained-apps/outputs/google-gemini/darwin.json
+++ b/ee/maintained-apps/outputs/google-gemini/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.80.18.522",
+      "version": "1.80.15.516",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.18.522') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.15.516') < 0);"
       },
       "installer_url": "https://dl.google.com/release2/j33ro/release/Gemini.dmg",
       "install_script_ref": "d6aaaffc",

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.357.1",
+      "version": "0.358.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.357.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.358.1') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.357.1-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.358.1-arm64.dmg",
       "install_script_ref": "bd0f7905",
       "uninstall_script_ref": "f408ec47",
-      "sha256": "0511e9a79a63db511c90f9e1e5d31329477329025c1addb0622fb173d5517f17",
+      "sha256": "a47262cca7fef4b082427f78406cc6d8ed8b8fb7f8e513bd55346620457f7078",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/windows.json
+++ b/ee/maintained-apps/outputs/loom/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.357.1",
+      "version": "0.358.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.357.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.358.1') < 0);"
       },
-      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.357.1.exe",
+      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.358.1.exe",
       "install_script_ref": "77327cbf",
       "uninstall_script_ref": "b012f1e7",
-      "sha256": "001d9fa6d78f2922f74a8d224dfa8aba2becd68424379af6d70adae66242c8fd",
+      "sha256": "227c855a5048b54f08defa2dd4c40d4a6e77ee01874af25e050d1737081738e9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17.12",
+      "version": "1.17.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.13') < 0);"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.12/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.13/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "727dc41e",
       "uninstall_script_ref": "ad62b190",
-      "sha256": "a6cd85c685ac295dfe6e15c313e24c36a2e1126c9eb9c03ba83b14cbafa80aa8",
+      "sha256": "db8e9159ec9d8615d9cce0a72dca107b43d643a7fdc63664d4b5d28e6c8e7ed9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.16.0",
+      "version": "8.17.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.16.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.17.0') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.16.0.zip",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.17.0.zip",
       "install_script_ref": "fac7f399",
       "uninstall_script_ref": "c0c94e32",
-      "sha256": "52556e29e384fda79f56a50bc6db783802136b36c847bfc63454cc79d88b18b9",
+      "sha256": "7aa9ca3c7d864c671cf08dd68a866c6bff3a41ac5f55851c6b62a3ca653b32da",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/signal/windows.json
+++ b/ee/maintained-apps/outputs/signal/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.16.0",
+      "version": "8.17.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Signal' AND publisher = 'Signal Messenger, LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Signal' AND publisher = 'Signal Messenger, LLC' AND version_compare(version, '8.16.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Signal' AND publisher = 'Signal Messenger, LLC' AND version_compare(version, '8.17.0') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-win-8.16.0.exe",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-win-8.17.0.exe",
       "install_script_ref": "06366bfb",
       "uninstall_script_ref": "8c3c10d6",
-      "sha256": "750812f794c5de74e5b544e797f3a6a84ae8eeca23ae34c8cfc4696c97b5e60e",
+      "sha256": "ee8fa68bad3d9fc100fa98862634fcc825c2224be267767b6e8b72c195a80708",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/unity-hub/darwin.json
+++ b/ee/maintained-apps/outputs/unity-hub/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.19.1",
+      "version": "3.19.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.19.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.19.2') < 0);"
       },
       "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-arm64.dmg",
       "install_script_ref": "c26804cb",

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.26.15",
+      "version": "26.26.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.26.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.26.17') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8.2",
+      "version": "1.9.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.8.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.9.0') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.8.2/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.9.0/Zed-aarch64.dmg",
       "install_script_ref": "ad597b79",
       "uninstall_script_ref": "2a2c7eb8",
-      "sha256": "a4cacbc3a0fa84ff6c414d975bb173fc27c8a1cf8e3bca865d9473307e7b49e7",
+      "sha256": "0dc8abf9948eaa3e3e5e76ff75bf537d93bb6f1d2a57fbda2f7cc73bf8d28055",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8.2",
+      "version": "1.9.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.8.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.9.0') < 0);"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.8.2/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.9.0/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "147744ba96840924606345d4e7417fc53df77a5fb809a6bece053037378a2fd3",
+      "sha256": "1485f50a93d451074e063b57c383d21a04a2b16cf51d19046eb4f51508366fcd",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated package metadata for several maintained apps so the latest versions are available on macOS and Windows.
* **Bug Fixes**
  * Refreshed version checks, download links, and checksums across multiple app entries to match newer releases.
  * Included updates for AlDente, AWS CLI, ChatWise, Claude Desktop, DFU Blaster Pro, Franz, GitHub Desktop, Google Gemini, Loom, OpenCode Desktop, Signal, Unity Hub, WhatsApp, and Zed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->