### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bluej/windows.json
+++ b/ee/maintained-apps/outputs/bluej/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.5.0",
+      "version": "6.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'BlueJ' AND publisher = 'BlueJ Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'BlueJ' AND publisher = 'BlueJ Team' AND version_compare(version, '5.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'BlueJ' AND publisher = 'BlueJ Team' AND version_compare(version, '6.0.0') < 0);"
       },
-      "installer_url": "https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-5.5.0/BlueJ-windows-5.5.0.msi",
+      "installer_url": "https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-6.0.0/BlueJ-windows-6.0.0.msi",
       "install_script_ref": "29a9338f",
       "uninstall_script_ref": "d85b3e22",
-      "sha256": "697404b7f704235878861bd4133e24480e17e74942f0a9d31db08ddfe4ee21c0",
+      "sha256": "4383dae085447d55672f9521320bd60f23fd3cf7d88e219c17a4731dad665528",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/google-gemini/darwin.json
+++ b/ee/maintained-apps/outputs/google-gemini/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.80.18.522",
+      "version": "1.80.15.516",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.18.522') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.80.15.516') < 0);"
       },
       "installer_url": "https://dl.google.com/release2/j33ro/release/Gemini.dmg",
       "install_script_ref": "d6aaaffc",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * BlueJ for Windows was updated to version 6.0.0, including the latest installer and checksum.
  * Google Gemini for macOS was adjusted to use the new target version 1.80.15.516 for version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->