### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-sam-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-sam-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.162.1",
+      "version": "1.163.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.162.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.163.0') < 0);"
       },
-      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.162.1/AWS_SAM_CLI_64_PY3.msi",
+      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.163.0/AWS_SAM_CLI_64_PY3.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "a3074b39",
-      "sha256": "a2e5b3e077b984fe66887a717e0561dc8c4c206a9e12cb578c2c10244c35e7e4",
+      "sha256": "1127a4d176fa155e046090f39c7355cca2a7c657c3c748f6a0f6ade2e482135d",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/badgeify/darwin.json
+++ b/ee/maintained-apps/outputs/badgeify/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.2",
+      "version": "1.13.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'studio.techflow.badgeify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'studio.techflow.badgeify' AND version_compare(bundle_short_version, '1.13.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'studio.techflow.badgeify' AND version_compare(bundle_short_version, '1.13.3') < 0);"
       },
-      "installer_url": "https://api.badgeify.app/release/download/darwin/universal/1.13.2",
+      "installer_url": "https://api.badgeify.app/release/download/darwin/universal/1.13.3",
       "install_script_ref": "c91686bf",
       "uninstall_script_ref": "9d0f29ae",
-      "sha256": "d6aec4dbed547e5a9e5f864a698c7f98ac4cf30f87d1ae6b08d557e90d9466cb",
+      "sha256": "58b624948611e3d78425d03a3f16757148cf28fc841610ba633748fadd9c7d8c",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/bluej/windows.json
+++ b/ee/maintained-apps/outputs/bluej/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.5.0",
+      "version": "6.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'BlueJ' AND publisher = 'BlueJ Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'BlueJ' AND publisher = 'BlueJ Team' AND version_compare(version, '5.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'BlueJ' AND publisher = 'BlueJ Team' AND version_compare(version, '6.0.0') < 0);"
       },
-      "installer_url": "https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-5.5.0/BlueJ-windows-5.5.0.msi",
+      "installer_url": "https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-6.0.0/BlueJ-windows-6.0.0.msi",
       "install_script_ref": "29a9338f",
       "uninstall_script_ref": "d85b3e22",
-      "sha256": "697404b7f704235878861bd4133e24480e17e74942f0a9d31db08ddfe4ee21c0",
+      "sha256": "4383dae085447d55672f9521320bd60f23fd3cf7d88e219c17a4731dad665528",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/bruno/darwin.json
+++ b/ee/maintained-apps/outputs/bruno/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.0",
+      "version": "3.5.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '3.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '3.5.1') < 0);"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.0/bruno_3.5.0_arm64_mac.dmg",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.1/bruno_3.5.1_arm64_mac.dmg",
       "install_script_ref": "6aa1c49e",
       "uninstall_script_ref": "14f6d5fd",
-      "sha256": "11490cd4d9ebdf3853371a3905129ad6628a88f23e9905fb0ec1d350bec58a2d",
+      "sha256": "8cf286597e7eb055f7edc24b8181930c381842fd3e923744870b1d2c94ce146e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17377.1",
+      "version": "1.17377.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.17377.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.17377.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.17377.1/Claude-2b3ab429b13f2c904d7552b7ca82a0d2a22af52f.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.17377.2/Claude-e0ea9e9df1d5a7e3848ea088cc6b1863adc020b9.msix",
       "install_script_ref": "16c020cc",
       "uninstall_script_ref": "03f72055",
-      "sha256": "553b9161d1913ed38dd2990d3d0ed9ce9cfbda2a2167dc17b9966e7ea809fb16",
+      "sha256": "b071b480bd8547ae6a4f8dd0b8598bd1c675fd72886a3576e4a266060c9ff4e4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cmake-app/windows.json
+++ b/ee/maintained-apps/outputs/cmake-app/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.3",
+      "version": "4.3.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware' AND version_compare(version, '4.3.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware' AND version_compare(version, '4.3.4') < 0);"
       },
-      "installer_url": "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-windows-x86_64.msi",
+      "installer_url": "https://github.com/Kitware/CMake/releases/download/v4.3.4/cmake-4.3.4-windows-x86_64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "6ac3efbc",
-      "sha256": "b6c50584847f02fe7f11d94ad1d99d592b5b371c476e2de3770ae3ee823b2638",
+      "sha256": "6f54ab92a19bf7d6695a40f3a774a8d1a54e90730c726fad8afb44544db892da",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/cyberduck/darwin.json
+++ b/ee/maintained-apps/outputs/cyberduck/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.5.0",
+      "version": "9.5.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck' AND version_compare(bundle_short_version, '9.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.sudo.cyberduck' AND version_compare(bundle_short_version, '9.5.2') < 0);"
       },
-      "installer_url": "https://update.cyberduck.io/Cyberduck-9.5.0.45237.zip",
+      "installer_url": "https://update.cyberduck.io/Cyberduck-9.5.2.45323.zip",
       "install_script_ref": "3390ca0f",
       "uninstall_script_ref": "8d609003",
-      "sha256": "c35aea13bf617b1fbc66030c7978ded1360ea1ac67b2ab057492ac3dc961bc1d",
+      "sha256": "5664ed7c06be260e236128f5e14d5187b58dadf00e86876a98ca49f048407fc5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/github-desktop/windows.json
+++ b/ee/maintained-apps/outputs/github-desktop/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.6.1",
+      "version": "3.6.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.' AND version_compare(version, '3.6.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND publisher = 'GitHub, Inc.' AND version_compare(version, '3.6.2') < 0);"
       },
-      "installer_url": "https://desktop.githubusercontent.com/releases/3.6.1-8fa814ac/GitHubDesktopSetup-x64.msi",
+      "installer_url": "https://desktop.githubusercontent.com/releases/3.6.2-57f0b637/GitHubDesktopSetup-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "cfc2b24c",
-      "sha256": "767c25addc1e75d1fbaa235055a4c45172dcb82056327c710e5314537f210b61",
+      "sha256": "36a7a7faf601f0726214d14ddaaf2ea9ae1c39d3526b1f4b7c8c432fd8e770b8",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/google-chrome/darwin.json
+++ b/ee/maintained-apps/outputs/google-chrome/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "149.0.7827.201",
+      "version": "150.0.7871.47",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '149.0.7827.201') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '150.0.7871.47') < 0);"
       },
       "installer_url": "https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg",
       "install_script_ref": "6981ff84",

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '133.0') < 0);"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/133.0.5932.10/mac/Opera_133.0.5932.10_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/133.0.5932.20/mac/Opera_133.0.5932.20_Setup.dmg",
       "install_script_ref": "e9e947a7",
       "uninstall_script_ref": "566d9846",
-      "sha256": "a668091faf85e3c263e91046e17bcd81619bef590d1db7ce9a7bb662df7808b9",
+      "sha256": "6ddef0c233d970ad0e9572aaa68b2ad08bf9f601e7c55042cbffaeba784a9e24",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.17.2",
+      "version": "12.17.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.17.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.17.3') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.17.2/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.17.3/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "b5cf5c153394eee792194a7a01fb676fee967494b8752928499447ad3463bb17",
+      "sha256": "772c120afd7bac082ac38037db355987dda2f441ac64b1902beea801558c9946",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.17.2",
+      "version": "12.17.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.17.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.17.3') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.17.2/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.17.3/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "938a103d30919f4462f18f7da8f4d8b8656722f7f70052c20c198dd5b13c517b",
+      "sha256": "cab550ba27bc1ef428cfefee2e7d467209b25750a7bd7750b0cc0c990cf86570",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/reqable/darwin.json
+++ b/ee/maintained-apps/outputs/reqable/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.3",
+      "version": "3.2.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.4') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.3/reqable-app-macos-arm64.dmg",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.4/reqable-app-macos-arm64.dmg",
       "install_script_ref": "5d84816f",
       "uninstall_script_ref": "3319d75e",
-      "sha256": "7b978605659da36d9186b083846a34dc7465145157a32fad4d58e37b8dd52a9c",
+      "sha256": "66893081800f4d22b96ef585fd57f6de807c38374722f293ea4009a7a36ffb87",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/reqable/windows.json
+++ b/ee/maintained-apps/outputs/reqable/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.3",
+      "version": "3.2.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.4') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.3/reqable-app-windows-x86_64.exe",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.4/reqable-app-windows-x86_64.exe",
       "install_script_ref": "d2ffec58",
       "uninstall_script_ref": "b33fc442",
-      "sha256": "040ec6c2e138e7b20090acd487e9cae7ca987a1463925c28b49320531e7dee24",
+      "sha256": "e3e1cd0e67449b39ace002b979b286b08ab09774cea0209bc695496b50673a0a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rocket-chat/darwin.json
+++ b/ee/maintained-apps/outputs/rocket-chat/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.15.0",
+      "version": "4.15.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.1') < 0);"
       },
-      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.0/rocketchat-4.15.0-mac.dmg",
+      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.1/rocketchat-4.15.1-mac.dmg",
       "install_script_ref": "8a2921c9",
       "uninstall_script_ref": "36b46743",
-      "sha256": "ec38748565dad8fd44edb216f054ce7aa4dbab9a9ebf4ef1ee6b774a6e439b04",
+      "sha256": "66ba0a5b949dc9b6be1cac267657877716ded158bffd739a52d9d82b04d2c540",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/splashtop-streamer/darwin.json
+++ b/ee/maintained-apps/outputs/splashtop-streamer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.8.4.0",
+      "version": "3.8.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer' AND version_compare(bundle_short_version, '3.8.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.splashtop.Splashtop-Streamer' AND version_compare(bundle_short_version, '3.8.4.1') < 0);"
       },
-      "installer_url": "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v3.8.4.0.dmg",
+      "installer_url": "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v3.8.4.1.dmg",
       "install_script_ref": "de170a2c",
       "uninstall_script_ref": "4cb9c2d4",
-      "sha256": "3d19bb58d48f2e1305cbf46fd09124d1004eb6b92c1e1d84a5e808fd7f326398",
+      "sha256": "b2430af88c682f831068e771214d435aaaa52a2d0813b346fa0565114b0f42f6",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installer metadata and version checks for several maintained apps on macOS and Windows.
  * Refreshed download links and checksums to match the latest released installers.
  * Included version updates for AWS SAM CLI, Badgeify, BlueJ, Bruno, Claude, CMake, Cyberduck, GitHub Desktop, Google Chrome, Opera, Postman, Reqable, Rocket.Chat, and Splashtop Streamer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->