### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bruno/windows.json
+++ b/ee/maintained-apps/outputs/bruno/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.0",
+      "version": "3.5.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '3.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '3.5.1') < 0);"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.0/bruno_3.5.0_x64_win.msi",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.1/bruno_3.5.1_x64_win.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "bfadc5e4",
-      "sha256": "cf9db7c903c302863ceb6ee5ad82f0f36830e3eb734ef0df5e7999aeabfc0132",
+      "sha256": "e38ff57fc95bfa773d9cbc12666353977f744c2fff20b7361f56d838b21609d3",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/clion/darwin.json
+++ b/ee/maintained-apps/outputs/clion/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.4-aarch64.dmg",
       "install_script_ref": "0eea3e67",
       "uninstall_script_ref": "efb3480e",
-      "sha256": "4073f514213ffcaf785dd6036d07f740feaadfd6a0efcb57c862ac54fbe7953f",
+      "sha256": "8b7b2d5fb77246048e264153303f7f864c3a7b698636a9f5dd2ed7fef27ae914",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dangerzone/darwin.json
+++ b/ee/maintained-apps/outputs/dangerzone/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'press.freedom.dangerzone';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'press.freedom.dangerzone' AND version_compare(bundle_short_version, '0.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'press.freedom.dangerzone' AND version_compare(bundle_short_version, '0.11.0') < 0);"
       },
-      "installer_url": "https://github.com/freedomofpress/dangerzone/releases/download/v0.10.0/Dangerzone-0.10.0-arm64.dmg",
+      "installer_url": "https://github.com/freedomofpress/dangerzone/releases/download/v0.11.0/Dangerzone-0.11.0-arm64.dmg",
       "install_script_ref": "8137ce83",
       "uninstall_script_ref": "0a2d2e93",
-      "sha256": "20b0b32d30b46c53907b7d8543091c7d31cf02dc8bd1ee1ae67f7469ac001821",
+      "sha256": "406c3e87cd7c01fbc2b5911eb67937213ac721b0d928297c445bd2045654f0e6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dot/darwin.json
+++ b/ee/maintained-apps/outputs/dot/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.3.0') < 0);"
       },
-      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.2.0/Dot-2.2.0.dmg",
+      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.3.0/Dot-2.3.0.dmg",
       "install_script_ref": "2fd2fbc1",
       "uninstall_script_ref": "3e5c7f37",
-      "sha256": "7338ea500dd253b2767bfb5a95dc76b0ea291b512cb162497cf80f3b2edd2baf",
+      "sha256": "8bfd5fea433d4f399cf183f5fcdfcd33dae632d4d692a2dfd5a1916358960f4a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/intellij-idea/darwin.json
+++ b/ee/maintained-apps/outputs/intellij-idea/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/idea/ideaIU-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/idea/ideaIU-2026.1.4-aarch64.dmg",
       "install_script_ref": "6e3c7555",
       "uninstall_script_ref": "188d226d",
-      "sha256": "2d1ca0d832e64e00a1745291f0d3061a35836530169e3429a13a7734806f62b2",
+      "sha256": "5c804affe2f16b3f5d5fe2f197b1d7b25f99dd9ec60734ae0f136cb1bff8036b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.104.20",
+      "version": "1.104.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.21') < 0);"
       },
-      "installer_url": "https://releases.raycast.com/releases/1.104.20/download?build=arm",
+      "installer_url": "https://releases.raycast.com/releases/1.104.21/download?build=arm",
       "install_script_ref": "ee3bb800",
       "uninstall_script_ref": "cb893329",
-      "sha256": "294091342c42a007ad1035c83c1b0370c067baba411f71a74b4319fb8aca09f0",
+      "sha256": "89e3eaf7ade7c4b3bb441b2acbdceb3f3673e94dd509bb7df909854f57853837",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated package metadata for several maintained apps to newer releases on Windows and macOS.
  * Includes version bumps for Bruno, CLion, Dangerzone, dot, IntelliJ IDEA, and Raycast.
  * Refreshed download links and checksums to match the latest installer artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->