### PR TITLE
Add apple_hardware_info table to include hardware_marketing_name

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -1040,6 +1040,25 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/new/main/schema?filename=tables%2Fappcompat_shims.yml&value=name%3A%20appcompat_shims%0Adescription%3A%20%7C-%20%23%20(required)%20string%20-%20The%20description%20for%20this%20table.%20Note%3A%20this%20field%20supports%20Markdown%0A%09%23%20Add%20description%20here%0Aexamples%3A%20%7C-%20%23%20(optional)%20string%20-%20An%20example%20query%20for%20this%20table.%20Note%3A%20This%20field%20supports%20Markdown%0A%09%23%20Add%20examples%20here%0Anotes%3A%20%7C-%20%23%20(optional)%20string%20-%20Notes%20about%20this%20table.%20Note%3A%20This%20field%20supports%20Markdown.%0A%09%23%20Add%20notes%20here%0Acolumns%3A%20%23%20(required)%0A%09-%20name%3A%20%23%20(required)%20string%20-%20The%20name%20of%20the%20column%0A%09%20%20description%3A%20%23%20(required)%20string%20-%20The%20column's%20description.%20Note%3A%20this%20field%20supports%20Markdown%0A%09%20%20type%3A%20%23%20(required)%20string%20-%20the%20column's%20data%20type%0A%09%20%20required%3A%20%23%20(required)%20boolean%20-%20whether%20or%20not%20this%20column%20is%20required%20to%20query%20this%20table."
   },
   {
+    "name": "apple_hardware_info",
+    "platforms": [
+      "darwin"
+    ],
+    "description": "Hardware marketing name for macOS hosts.",
+    "columns": [
+      {
+        "name": "hardware_marketing_name",
+        "type": "text",
+        "required": true,
+        "description": "Hardware marketing name, e.g. \"MacBook Air (13-inch, M5)\"."
+      }
+    ],
+    "notes": "This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).",
+    "evented": false,
+    "url": "https://fleetdm.com/tables/apple_hardware_info",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/apple_hardware_info.yml"
+  },
+  {
     "name": "apps",
     "description": "macOS applications installed in known search paths (e.g., /Applications).",
     "url": "https://fleetdm.com/tables/apps",

--- a/schema/tables/apple_hardware_info.yml
+++ b/schema/tables/apple_hardware_info.yml
@@ -1,0 +1,11 @@
+name: apple_hardware_info
+platforms:
+  - darwin
+description: Hardware marketing name for macOS hosts.
+columns:
+  - name: hardware_marketing_name
+    type: text
+    required: true
+    description: Hardware marketing name, e.g. "MacBook Air (13-inch, M5)".
+notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+evented: false

--- a/schema/tables/system_info.yml
+++ b/schema/tables/system_info.yml
@@ -73,7 +73,7 @@ columns:
   - name: hardware_marketing_name
     type: text
     description: Hardware marketing name, e.g. "MacBook Air (13-inch, M5)".
-    - platforms:
+    platforms:
       - darwin
   - name: cpu_brand
     type: text

--- a/schema/tables/system_info.yml
+++ b/schema/tables/system_info.yml
@@ -70,11 +70,6 @@ columns:
   - name: hardware_model
     type: text
     description: Hardware model. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
-  - name: hardware_marketing_name
-    type: text
-    description: Hardware marketing name, e.g. "MacBook Air (13-inch, M5)".
-    platforms:
-      - darwin
   - name: cpu_brand
     type: text
   - name: cpu_type

--- a/schema/tables/system_info.yml
+++ b/schema/tables/system_info.yml
@@ -70,6 +70,9 @@ columns:
   - name: hardware_model
     type: text
     description: Hardware model. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
+  - name: hardware_marketing_name
+    type: text
+    description: Hardware marketing name. Currently only supported for Apple devices.
   - name: cpu_brand
     type: text
   - name: cpu_type

--- a/schema/tables/system_info.yml
+++ b/schema/tables/system_info.yml
@@ -72,7 +72,9 @@ columns:
     description: Hardware model. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
   - name: hardware_marketing_name
     type: text
-    description: Hardware marketing name. Currently only supported for Apple devices.
+    description: Hardware marketing name, e.g. "MacBook Air (13-inch, M5)".
+    - platforms:
+      - darwin
   - name: cpu_brand
     type: text
   - name: cpu_type


### PR DESCRIPTION
**Related issue:** Resolves #48524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new system information field for hardware marketing names on macOS devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->