### PR TITLE
[Guide] Add default team configuration for Autopilot hosts

### DIFF
--- a/articles/windows-mdm-setup.md
+++ b/articles/windows-mdm-setup.md
@@ -215,6 +215,28 @@ Testing automatic enrollment requires creating a test user in Microsoft Entra ID
 
 2. After it's been wiped, open your workstation and follow the setup steps. On the screen in which you're asked to sign in, you should see the title "Welcome to [your organization]!" next to the logo you uploaded in step 4.
 
+### Set a default team for Autopilot-enrolled hosts
+
+_Available in Fleet Premium_
+
+By default, Windows hosts enrolled via Autopilot are added to "No team." You can configure a default team so that Autopilot-enrolled hosts are automatically assigned to a specific team — similar to how [Apple Business Manager default teams](https://fleetdm.com/guides/macos-mdm-setup#set-a-default-team-for-hosts-enrolled-via-abm) work.
+
+#### In the UI
+
+1. Head to **Settings > Integrations > MDM > Windows MDM**.
+
+2. Under **Automatic enrollment**, use the **Default team** dropdown to select the team that automatically enrolled (Windows Autopilot) hosts should be assigned to.
+
+3. Select **Save**.
+
+#### Via GitOps (YAML)
+
+Add the `windows_autopilot_default_team` key under `mdm` in your global (org) settings YAML file:
+
+```yaml
+  controls:
+  windows_automatic_enrollment: "💻 Workstations"
+```
 
 ## Automatic Windows MDM migration
 


### PR DESCRIPTION
Added instructions for setting a default team for Autopilot-enrolled hosts in Windows MDM setup.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41787