### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/7-zip/windows.json
+++ b/ee/maintained-apps/outputs/7-zip/windows.json
@@ -6,7 +6,7 @@
         "exists": "SELECT 1 FROM programs WHERE name LIKE '7-Zip %' AND publisher = 'Igor Pavlov';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE '7-Zip %' AND publisher = 'Igor Pavlov' AND version_compare(version, '26.02') < 0);"
       },
-      "installer_url": "https://7-zip.org/a/7z2602-x64.msi",
+      "installer_url": "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "cd80dc1f",
       "sha256": "db407a4f6d4999e5c7bc00ce8a882be94717b56e7fa68140fe3f12605d91643e",

--- a/ee/maintained-apps/outputs/actual/darwin.json
+++ b/ee/maintained-apps/outputs/actual/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.6.0",
+      "version": "26.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual' AND version_compare(bundle_short_version, '26.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual' AND version_compare(bundle_short_version, '26.7.0') < 0);"
       },
-      "installer_url": "https://github.com/actualbudget/actual/releases/download/v26.6.0/Actual-mac-arm64.dmg",
+      "installer_url": "https://github.com/actualbudget/actual/releases/download/v26.7.0/Actual-mac-arm64.dmg",
       "install_script_ref": "631bbb42",
       "uninstall_script_ref": "27bb5492",
-      "sha256": "32f6893b599e8408b21e9cfe4b0d2530f41951c31100a41d0585b815691c577f",
+      "sha256": "7e9b5be9d3d1a78de6a7a625717dd0e31ccfb2f79f9718f761726925dac44ece",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/alt-tab/darwin.json
+++ b/ee/maintained-apps/outputs/alt-tab/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.3.1",
+      "version": "11.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos' AND version_compare(bundle_short_version, '11.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos' AND version_compare(bundle_short_version, '11.4.0') < 0);"
       },
-      "installer_url": "https://github.com/lwouis/alt-tab-macos/releases/download/v11.3.1/AltTab-11.3.1.zip",
+      "installer_url": "https://github.com/lwouis/alt-tab-macos/releases/download/v11.4.0/AltTab-11.4.0.zip",
       "install_script_ref": "b04664c1",
       "uninstall_script_ref": "2cc2914b",
-      "sha256": "5f9f6c1505ae4fdcb7fd819f1bf945a179a8795fc18c73e788365ecb93e16f8c",
+      "sha256": "10362bd9c120b2c32ffc63eb558698f9bac123a1833e2a8247050914d19840c5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.2.948",
+      "version": "4.2.957",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.2.948') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.2.957') < 0);"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.2.948-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.2.957-arm64-mac.zip",
       "install_script_ref": "a73050ea",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "63bb5f5d4749b988a7fd9b8f5cf21f9c202840f9aacf5e3c6679534ce669661e",
+      "sha256": "8ca0aad017a425fd6ea47448bd90244df42630a90cbdf56bf30da35c3223ad5d",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.1.91.180",
+      "version": "150.1.92.134",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '149.1.91.180') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '150.1.92.134') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/191.180/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/192.134/Brave-Browser-arm64.dmg",
       "install_script_ref": "013e53e8",
       "uninstall_script_ref": "9a376609",
-      "sha256": "fda09d6ef2d2b16b2cbfc0c71e58b2e0d3781441bab511c67c82f69cdfa33323",
+      "sha256": "7fa772713526d51ceb8f45c89d334d05100a1fa036b6b98dfadc2df4ba5998da",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.1.91.180",
+      "version": "150.1.92.134",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '149.1.91.180') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.134') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.91.180/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.134/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "aca365fb42fcc09f3c13358743790e9b23e237f626eb0f91b686bbd4c00aea40",
+      "sha256": "4726e28a23da1b0b253efb63736efc9b20a580f26017f93f72ebdacf471c657a",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/bruno/windows.json
+++ b/ee/maintained-apps/outputs/bruno/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.0",
+      "version": "3.5.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '3.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '3.5.1') < 0);"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.0/bruno_3.5.0_x64_win.msi",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.1/bruno_3.5.1_x64_win.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "bfadc5e4",
-      "sha256": "cf9db7c903c302863ceb6ee5ad82f0f36830e3eb734ef0df5e7999aeabfc0132",
+      "sha256": "e38ff57fc95bfa773d9cbc12666353977f744c2fff20b7361f56d838b21609d3",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17377.2",
+      "version": "1.18286.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.17377.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.18286.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.17377.2/Claude-e0ea9e9df1d5a7e3848ea088cc6b1863adc020b9.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.18286.0/Claude-259c3fc2a647e4222ca15e99bba9b2649f31f051.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "21c22ce4bad2a6d43c2872c8c953a8a8cb1b4e5ace7fcc4bb2bc54f2eae49894",
+      "sha256": "80a74053d52f478d447f10b48af6ac840c1b6dd172b3354b43107ff6d3bcc3b4",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/clion/darwin.json
+++ b/ee/maintained-apps/outputs/clion/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.4-aarch64.dmg",
       "install_script_ref": "0eea3e67",
       "uninstall_script_ref": "efb3480e",
-      "sha256": "4073f514213ffcaf785dd6036d07f740feaadfd6a0efcb57c862ac54fbe7953f",
+      "sha256": "8b7b2d5fb77246048e264153303f7f864c3a7b698636a9f5dd2ed7fef27ae914",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dangerzone/darwin.json
+++ b/ee/maintained-apps/outputs/dangerzone/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'press.freedom.dangerzone';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'press.freedom.dangerzone' AND version_compare(bundle_short_version, '0.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'press.freedom.dangerzone' AND version_compare(bundle_short_version, '0.11.0') < 0);"
       },
-      "installer_url": "https://github.com/freedomofpress/dangerzone/releases/download/v0.10.0/Dangerzone-0.10.0-arm64.dmg",
+      "installer_url": "https://github.com/freedomofpress/dangerzone/releases/download/v0.11.0/Dangerzone-0.11.0-arm64.dmg",
       "install_script_ref": "8137ce83",
       "uninstall_script_ref": "0a2d2e93",
-      "sha256": "20b0b32d30b46c53907b7d8543091c7d31cf02dc8bd1ee1ae67f7469ac001821",
+      "sha256": "406c3e87cd7c01fbc2b5911eb67937213ac721b0d928297c445bd2045654f0e6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dialpad/darwin.json
+++ b/ee/maintained-apps/outputs/dialpad/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2605.1.0",
+      "version": "2606.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2605.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2606.1.1') < 0);"
       },
       "installer_url": "https://download.dialpad.com/osx/arm64/dialpad.pkg",
       "install_script_ref": "49548b01",

--- a/ee/maintained-apps/outputs/dot/darwin.json
+++ b/ee/maintained-apps/outputs/dot/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.3.0') < 0);"
       },
-      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.2.0/Dot-2.2.0.dmg",
+      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.3.0/Dot-2.3.0.dmg",
       "install_script_ref": "2fd2fbc1",
       "uninstall_script_ref": "3e5c7f37",
-      "sha256": "7338ea500dd253b2767bfb5a95dc76b0ea291b512cb162497cf80f3b2edd2baf",
+      "sha256": "8bfd5fea433d4f399cf183f5fcdfcd33dae632d4d692a2dfd5a1916358960f4a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/egnyte/windows.json
+++ b/ee/maintained-apps/outputs/egnyte/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.31.1.179",
+      "version": "4.4.1.198",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.' AND version_compare(version, '3.31.1.179') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.' AND version_compare(version, '4.4.1.198') < 0);"
       },
-      "installer_url": "https://egnyte-cdn.egnyte.com/egnytedrive/win/en-us/3.31.1/EgnyteDesktopApp_3.31.1_179.msi",
+      "installer_url": "https://egnyte-cdn.egnyte.com/egnytedrive/win/en-us/4.4.1/EgnyteDesktopApp_4.4.1_198.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "70b84d4a",
-      "sha256": "aca64bfeacb23e4edfae7f33a831deb003da3788035dd49e8ff866afccadad85",
+      "sha256": "fed541b65a0194e828762617c8c12ff72f0f67acf9b1b67e59deb58f98a3a181",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/goland/darwin.json
+++ b/ee/maintained-apps/outputs/goland/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/go/goland-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/go/goland-2026.1.4-aarch64.dmg",
       "install_script_ref": "1d48cff5",
       "uninstall_script_ref": "c7ca278d",
-      "sha256": "3f1aeac0fb13999b70f6815522c06589d9fdd0dc38a91b18b9690ed81498e746",
+      "sha256": "cbb98491ed33d0cbd0b3e90cb6b9ababb11e02d2546e0a3ab0666b381d0cada3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.373.2",
+      "version": "7.386.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.373.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.386.3') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.373.2/Granola-7.373.2-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.386.3/Granola-7.386.3-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "00af10c973264087dd6c5d74a085338cd041405f6f77ef77314b3cfb3ca0ab7b",
+      "sha256": "ec04257770ecf1195e1838f0ee2aa721ebeaea723b4735736cb5af1b20ebed0f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.373.2",
+      "version": "7.386.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.373.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.386.3') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.373.2/Granola-7.373.2-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.386.3/Granola-7.386.3-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "c540dfc763288b706717b3a9d55aa5cc641149ee7fb083520b2603c09673f6e6",
+      "sha256": "81ee1e935dfb184190130ce90e2f0ab1a7843944e36598f2c91a2e23b0846051",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/intellij-idea/darwin.json
+++ b/ee/maintained-apps/outputs/intellij-idea/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/idea/ideaIU-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/idea/ideaIU-2026.1.4-aarch64.dmg",
       "install_script_ref": "6e3c7555",
       "uninstall_script_ref": "188d226d",
-      "sha256": "2d1ca0d832e64e00a1745291f0d3061a35836530169e3429a13a7734806f62b2",
+      "sha256": "5c804affe2f16b3f5d5fe2f197b1d7b25f99dd9ec60734ae0f136cb1bff8036b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5",
+      "version": "3.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.6') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.5.0.84344-arm64.dmg",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.0.85549-arm64.dmg",
       "install_script_ref": "9dbacbdd",
       "uninstall_script_ref": "276d8363",
-      "sha256": "0c31a81cc96d6565bfecbb4774388cc12ec7120b3c88fac9a9cd170ba6289696",
+      "sha256": "128a8580fee1cbbafe8fbcbe96e0d013ad7d1ce4548aa05ed876606484151773",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.0.0",
+      "version": "3.6.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.5.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.6.0.0') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.5.0.84344.exe",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.0.85549.exe",
       "install_script_ref": "f635418b",
       "uninstall_script_ref": "a6821d8b",
-      "sha256": "c4dc5d95a76bf2c0365e1dfb5ed7c76e80c1d3319e2467d18ec9af2ac1520ccf",
+      "sha256": "5b83c3c3c83163c214552061a1e9a684a52088157536d05b39c9ff2a885b4b2a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/kiro-cli/darwin.json
+++ b/ee/maintained-apps/outputs/kiro-cli/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.10.0",
+      "version": "2.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.11.0') < 0);"
       },
-      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.10.0/Kiro%20CLI.dmg",
+      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.11.0/Kiro%20CLI.dmg",
       "install_script_ref": "7bf3d706",
       "uninstall_script_ref": "31b59062",
-      "sha256": "3437b25d03bd341b0adf1a8011c3b58069fdb5af99550d4637067885b1947b74",
+      "sha256": "3dd3a3e4e6616b742c70ee836d31419cdf74130130139f6139742f330308cd3e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/lookaway/darwin.json
+++ b/ee/maintained-apps/outputs/lookaway/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mysticalbits.lookaway';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mysticalbits.lookaway' AND version_compare(bundle_short_version, '2.2.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mysticalbits.lookaway' AND version_compare(bundle_short_version, '2.2.3') < 0);"
       },
-      "installer_url": "https://github.com/mysticalbits/lookaway-releases/releases/download/2.2.2/LookAway.dmg",
+      "installer_url": "https://github.com/mysticalbits/lookaway-releases/releases/download/2.2.3/LookAway.dmg",
       "install_script_ref": "8e23d582",
       "uninstall_script_ref": "edb6da69",
-      "sha256": "087ccff385bc885cc3345500b62fcbb0298e54681260cec9cb1937ed0b10d51d",
+      "sha256": "cdb5106d5faecb4fec403582ab8a9871f038b9fe3bfaab8333c8406ad4b08cda",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.6",
+      "version": "3.1.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.7') < 0);"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.6.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.7.zip",
       "install_script_ref": "c6782863",
       "uninstall_script_ref": "9e4b9fca",
-      "sha256": "be794d5115c6da4e7566bacba1f3c22680d57a561ed8a010810abf8f91ab5d2a",
+      "sha256": "ba5ab5f2903154cb2770a0f7f1f344fdf06069ba9c89910429f647197a3da567",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/merlin-project/darwin.json
+++ b/ee/maintained-apps/outputs/merlin-project/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "9.1.2",
+      "version": "9.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.projectwizards.merlinproject';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.projectwizards.merlinproject' AND version_compare(bundle_short_version, '9.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.projectwizards.merlinproject' AND version_compare(bundle_short_version, '9.2.0') < 0);"
       },
       "installer_url": "https://www.projectwizards.net/downloads/MerlinProject.zip",
       "install_script_ref": "d1bfdbd8",

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.104.20",
+      "version": "1.104.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.21') < 0);"
       },
-      "installer_url": "https://releases.raycast.com/releases/1.104.20/download?build=arm",
+      "installer_url": "https://releases.raycast.com/releases/1.104.21/download?build=arm",
       "install_script_ref": "ee3bb800",
       "uninstall_script_ref": "cb893329",
-      "sha256": "294091342c42a007ad1035c83c1b0370c067baba411f71a74b4319fb8aca09f0",
+      "sha256": "89e3eaf7ade7c4b3bb441b2acbdceb3f3673e94dd509bb7df909854f57853837",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rider/darwin.json
+++ b/ee/maintained-apps/outputs/rider/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.4-aarch64.dmg",
       "install_script_ref": "b5794400",
       "uninstall_script_ref": "c52dae57",
-      "sha256": "cd0400cffcd8c7e1a4e7a8f6bd90387a822f94aa1953e117228b12d726ea3c16",
+      "sha256": "71fc13db604dd63cca673ad91cc42a60524f1ae470b5afecaa83893a9f8f7c11",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rubymine/darwin.json
+++ b/ee/maintained-apps/outputs/rubymine/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1.4-aarch64.dmg",
       "install_script_ref": "da6b418a",
       "uninstall_script_ref": "1464e3dd",
-      "sha256": "96a6b72feac18841ff84f98571ebd606e9afbf2041ce8511dedb6f03cb34b93d",
+      "sha256": "e30127c1c3d1b70a74c3178f50c88ba30eac3318abc2775131d9892fc2c187d9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/super-productivity/darwin.json
+++ b/ee/maintained-apps/outputs/super-productivity/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "18.12.0",
+      "version": "18.13.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.super-productivity.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.super-productivity.app' AND version_compare(bundle_short_version, '18.12.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.super-productivity.app' AND version_compare(bundle_short_version, '18.13.1') < 0);"
       },
-      "installer_url": "https://github.com/super-productivity/super-productivity/releases/download/v18.12.0/superProductivity-arm64.dmg",
+      "installer_url": "https://github.com/super-productivity/super-productivity/releases/download/v18.13.1/superProductivity-arm64.dmg",
       "install_script_ref": "149e0795",
       "uninstall_script_ref": "98941c96",
-      "sha256": "1d15de1322b6efc2833bd7496186f5d9ce3dcdb58a09c9e4d33e71f5131c3ccc",
+      "sha256": "a70c00abb327acc83acd62f52c6c5e7544da46f7b205164da382208c5937816e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webstorm/darwin.json
+++ b/ee/maintained-apps/outputs/webstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4-aarch64.dmg",
       "install_script_ref": "cd510d61",
       "uninstall_script_ref": "c0791a1f",
-      "sha256": "d4dd51b4dd502efb89d502fc8db3794dd6ce1c01d237ce16f5710ad8f10f8a32",
+      "sha256": "6587a7e84c341986c1026b860830023c1b3283167ab13efcee8ea0a85f43273c",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed release information for several maintained apps on macOS and Windows, including newer installer links and checksums.
  * Bumped version targets for apps such as 7-Zip, Actual, AltTab, Beeper, Brave, Claude, Dialpad, Egnyte, JetBrains Toolbox, Raycast, and multiple JetBrains IDEs.
  * Improved install availability for the latest app releases across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->