### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/7-zip/windows.json
+++ b/ee/maintained-apps/outputs/7-zip/windows.json
@@ -6,7 +6,7 @@
         "exists": "SELECT 1 FROM programs WHERE name LIKE '7-Zip %' AND publisher = 'Igor Pavlov';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE '7-Zip %' AND publisher = 'Igor Pavlov' AND version_compare(version, '26.02') < 0);"
       },
-      "installer_url": "https://7-zip.org/a/7z2602-x64.msi",
+      "installer_url": "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "cd80dc1f",
       "sha256": "db407a4f6d4999e5c7bc00ce8a882be94717b56e7fa68140fe3f12605d91643e",

--- a/ee/maintained-apps/outputs/actual/darwin.json
+++ b/ee/maintained-apps/outputs/actual/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.6.0",
+      "version": "26.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual' AND version_compare(bundle_short_version, '26.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual' AND version_compare(bundle_short_version, '26.7.0') < 0);"
       },
-      "installer_url": "https://github.com/actualbudget/actual/releases/download/v26.6.0/Actual-mac-arm64.dmg",
+      "installer_url": "https://github.com/actualbudget/actual/releases/download/v26.7.0/Actual-mac-arm64.dmg",
       "install_script_ref": "631bbb42",
       "uninstall_script_ref": "27bb5492",
-      "sha256": "32f6893b599e8408b21e9cfe4b0d2530f41951c31100a41d0585b815691c577f",
+      "sha256": "7e9b5be9d3d1a78de6a7a625717dd0e31ccfb2f79f9718f761726925dac44ece",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/alt-tab/darwin.json
+++ b/ee/maintained-apps/outputs/alt-tab/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.3.1",
+      "version": "11.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos' AND version_compare(bundle_short_version, '11.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos' AND version_compare(bundle_short_version, '11.4.0') < 0);"
       },
-      "installer_url": "https://github.com/lwouis/alt-tab-macos/releases/download/v11.3.1/AltTab-11.3.1.zip",
+      "installer_url": "https://github.com/lwouis/alt-tab-macos/releases/download/v11.4.0/AltTab-11.4.0.zip",
       "install_script_ref": "b04664c1",
       "uninstall_script_ref": "2cc2914b",
-      "sha256": "5f9f6c1505ae4fdcb7fd819f1bf945a179a8795fc18c73e788365ecb93e16f8c",
+      "sha256": "10362bd9c120b2c32ffc63eb558698f9bac123a1833e2a8247050914d19840c5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/arc/windows.json
+++ b/ee/maintained-apps/outputs/arc/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.112.1.2",
+      "version": "1.113.0.288",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York' AND version_compare(version, '1.112.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Arc' AND publisher = 'The Browser Company of New York' AND version_compare(version, '1.113.0.288') < 0);"
       },
-      "installer_url": "https://releases.arc.net/windows/prod/1.112.1.2/Arc.x64.msix",
+      "installer_url": "https://releases.arc.net/windows/prod/1.113.0.288/Arc.x64.msix",
       "install_script_ref": "d2d5c7dc",
       "uninstall_script_ref": "ebcac670",
-      "sha256": "6a90a95a4e7c973a948663aefbdaf9550b3595c00bd119948511f7ca5f07d354",
+      "sha256": "f5678e13210fb10bbe4b812d80a59834b934aa0f1f7055ab89093fc3e16c11c6",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.35.14",
+      "version": "2.35.15",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.35.15') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.14.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.35.15.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "cf20a3addc418334e9f926416ad8f4d749c35f1a615bdf5d1e8f19eb29318eeb",
+      "sha256": "83f49dd966ed7a5f6ecc437d60b1ecfda1339482582572dd54b10e050842daa4",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.2.948",
+      "version": "4.2.957",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.2.948') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.2.957') < 0);"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.2.948-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.2.957-arm64-mac.zip",
       "install_script_ref": "a73050ea",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "63bb5f5d4749b988a7fd9b8f5cf21f9c202840f9aacf5e3c6679534ce669661e",
+      "sha256": "8ca0aad017a425fd6ea47448bd90244df42630a90cbdf56bf30da35c3223ad5d",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.1.91.180",
+      "version": "150.1.92.134",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '149.1.91.180') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '150.1.92.134') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/191.180/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/192.134/Brave-Browser-arm64.dmg",
       "install_script_ref": "013e53e8",
       "uninstall_script_ref": "9a376609",
-      "sha256": "fda09d6ef2d2b16b2cbfc0c71e58b2e0d3781441bab511c67c82f69cdfa33323",
+      "sha256": "7fa772713526d51ceb8f45c89d334d05100a1fa036b6b98dfadc2df4ba5998da",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.1.91.180",
+      "version": "150.1.92.134",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '149.1.91.180') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.134') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.91.180/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.134/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "aca365fb42fcc09f3c13358743790e9b23e237f626eb0f91b686bbd4c00aea40",
+      "sha256": "4726e28a23da1b0b253efb63736efc9b20a580f26017f93f72ebdacf471c657a",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/calibre/darwin.json
+++ b/ee/maintained-apps/outputs/calibre/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.10.0",
+      "version": "9.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre' AND version_compare(bundle_short_version, '9.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre' AND version_compare(bundle_short_version, '9.11.0') < 0);"
       },
-      "installer_url": "https://download.calibre-ebook.com/9.10.0/calibre-9.10.0.dmg",
+      "installer_url": "https://download.calibre-ebook.com/9.11.0/calibre-9.11.0.dmg",
       "install_script_ref": "02b09c17",
       "uninstall_script_ref": "1945fe9a",
-      "sha256": "68a091a4207351842da509fba0abec9afbb832499f8752e6fcd996425b2da882",
+      "sha256": "300c1acf1f8b941e265d0f8c39fc608c3cfea865a31702e084643d536b78c951",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/calibre/windows.json
+++ b/ee/maintained-apps/outputs/calibre/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.10.0",
+      "version": "9.11.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'calibre %' AND publisher = 'Kovid Goyal';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'calibre %' AND publisher = 'Kovid Goyal' AND version_compare(version, '9.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'calibre %' AND publisher = 'Kovid Goyal' AND version_compare(version, '9.11.0') < 0);"
       },
-      "installer_url": "https://download.calibre-ebook.com/9.10.0/calibre-64bit-9.10.0.msi",
+      "installer_url": "https://download.calibre-ebook.com/9.11.0/calibre-64bit-9.11.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "3ae8dcd8",
-      "sha256": "8a69cca7be43e3bb0202c60bdbbf855e3614b2295b82f33a67d308eec83d5255",
+      "sha256": "59bd2a7fb7978665e16b7f94218479d64ddedc80ec7fccb47a6768ae348ceb3d",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17377.2",
+      "version": "1.18286.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.17377.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.18286.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.17377.2/Claude-e0ea9e9df1d5a7e3848ea088cc6b1863adc020b9.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.18286.0/Claude-259c3fc2a647e4222ca15e99bba9b2649f31f051.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "21c22ce4bad2a6d43c2872c8c953a8a8cb1b4e5ace7fcc4bb2bc54f2eae49894",
+      "sha256": "80a74053d52f478d447f10b48af6ac840c1b6dd172b3354b43107ff6d3bcc3b4",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17377.2",
+      "version": "1.18286.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.17377.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.18286.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.17377.2/Claude-e0ea9e9df1d5a7e3848ea088cc6b1863adc020b9.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.18286.0/Claude-259c3fc2a647e4222ca15e99bba9b2649f31f051.msix",
       "install_script_ref": "16c020cc",
       "uninstall_script_ref": "03f72055",
-      "sha256": "b071b480bd8547ae6a4f8dd0b8598bd1c675fd72886a3576e4a266060c9ff4e4",
+      "sha256": "7927bafc45478d87d3213d9b9afb27bba58bc32b4fe9aa58a106cbfc139d0d3c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/clion/windows.json
+++ b/ee/maintained-apps/outputs/clion/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.137') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.26222.59') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.3.exe",
+      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.4.exe",
       "install_script_ref": "f1faeca2",
       "uninstall_script_ref": "7da7c7ff",
-      "sha256": "f5fb5b7aae35c6498040a9b3aab8ce4481417d6561bba8566c5cbe2ed7bcc337",
+      "sha256": "7f5cfcf37cbf659d70ecf5844b7d7ed32755e6f580199549ae605b936b14f83b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/codex-app/darwin.json
+++ b/ee/maintained-apps/outputs/codex-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.623.81905",
+      "version": "26.623.101652",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.623.81905') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.623.101652') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.623.81905.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.623.101652.zip",
       "install_script_ref": "5e3efa57",
       "uninstall_script_ref": "a2b5ee81",
-      "sha256": "3be3f9f46e2d3168e3df3bc404e2cdbf2bb8a80012fb6d3a8643adf9e110a646",
+      "sha256": "3283ebded45412c46810c5cbca2e3ab4fc36a735b79e531c182b7c35ca069bba",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dialpad/darwin.json
+++ b/ee/maintained-apps/outputs/dialpad/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2605.1.0",
+      "version": "2606.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2605.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2606.1.1') < 0);"
       },
       "installer_url": "https://download.dialpad.com/osx/arm64/dialpad.pkg",
       "install_script_ref": "49548b01",

--- a/ee/maintained-apps/outputs/egnyte/windows.json
+++ b/ee/maintained-apps/outputs/egnyte/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.31.1.179",
+      "version": "4.4.1.198",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.' AND version_compare(version, '3.31.1.179') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.' AND version_compare(version, '4.4.1.198') < 0);"
       },
-      "installer_url": "https://egnyte-cdn.egnyte.com/egnytedrive/win/en-us/3.31.1/EgnyteDesktopApp_3.31.1_179.msi",
+      "installer_url": "https://egnyte-cdn.egnyte.com/egnytedrive/win/en-us/4.4.1/EgnyteDesktopApp_4.4.1_198.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "70b84d4a",
-      "sha256": "aca64bfeacb23e4edfae7f33a831deb003da3788035dd49e8ff866afccadad85",
+      "sha256": "fed541b65a0194e828762617c8c12ff72f0f67acf9b1b67e59deb58f98a3a181",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/goland/darwin.json
+++ b/ee/maintained-apps/outputs/goland/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/go/goland-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/go/goland-2026.1.4-aarch64.dmg",
       "install_script_ref": "1d48cff5",
       "uninstall_script_ref": "c7ca278d",
-      "sha256": "3f1aeac0fb13999b70f6815522c06589d9fdd0dc38a91b18b9690ed81498e746",
+      "sha256": "cbb98491ed33d0cbd0b3e90cb6b9ababb11e02d2546e0a3ab0666b381d0cada3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.373.2",
+      "version": "7.386.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.373.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.386.3') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.373.2/Granola-7.373.2-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.386.3/Granola-7.386.3-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "00af10c973264087dd6c5d74a085338cd041405f6f77ef77314b3cfb3ca0ab7b",
+      "sha256": "ec04257770ecf1195e1838f0ee2aa721ebeaea723b4735736cb5af1b20ebed0f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.373.2",
+      "version": "7.386.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.373.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.386.3') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.373.2/Granola-7.373.2-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.386.3/Granola-7.386.3-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "c540dfc763288b706717b3a9d55aa5cc641149ee7fb083520b2603c09673f6e6",
+      "sha256": "81ee1e935dfb184190130ce90e2f0ab1a7843944e36598f2c91a2e23b0846051",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/huly/darwin.json
+++ b/ee/maintained-apps/outputs/huly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.7.423",
+      "version": "0.7.426",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'hc.hcengineering.Huly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'hc.hcengineering.Huly' AND version_compare(bundle_short_version, '0.7.423') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'hc.hcengineering.Huly' AND version_compare(bundle_short_version, '0.7.426') < 0);"
       },
-      "installer_url": "https://dist.huly.io/Huly-macos-0.7.423-arm64.zip",
+      "installer_url": "https://dist.huly.io/Huly-macos-0.7.426-arm64.zip",
       "install_script_ref": "fc10469f",
       "uninstall_script_ref": "367bd3f8",
-      "sha256": "e3721316549ecc2f5097607eeec67d33f2e47eacbc2665db748a258ec41a2d73",
+      "sha256": "1965a7f09dff166586f3675aded9a9b53e1733096beacbc87967ab3b4f82a926",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5",
+      "version": "3.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.6') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.5.0.84344-arm64.dmg",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.0.85549-arm64.dmg",
       "install_script_ref": "9dbacbdd",
       "uninstall_script_ref": "276d8363",
-      "sha256": "0c31a81cc96d6565bfecbb4774388cc12ec7120b3c88fac9a9cd170ba6289696",
+      "sha256": "128a8580fee1cbbafe8fbcbe96e0d013ad7d1ce4548aa05ed876606484151773",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.0.0",
+      "version": "3.6.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.5.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.6.0.0') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.5.0.84344.exe",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.0.85549.exe",
       "install_script_ref": "f635418b",
       "uninstall_script_ref": "a6821d8b",
-      "sha256": "c4dc5d95a76bf2c0365e1dfb5ed7c76e80c1d3319e2467d18ec9af2ac1520ccf",
+      "sha256": "5b83c3c3c83163c214552061a1e9a684a52088157536d05b39c9ff2a885b4b2a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/kiro-cli/darwin.json
+++ b/ee/maintained-apps/outputs/kiro-cli/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.10.0",
+      "version": "2.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.11.0') < 0);"
       },
-      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.10.0/Kiro%20CLI.dmg",
+      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.11.0/Kiro%20CLI.dmg",
       "install_script_ref": "7bf3d706",
       "uninstall_script_ref": "31b59062",
-      "sha256": "3437b25d03bd341b0adf1a8011c3b58069fdb5af99550d4637067885b1947b74",
+      "sha256": "3dd3a3e4e6616b742c70ee836d31419cdf74130130139f6139742f330308cd3e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/lookaway/darwin.json
+++ b/ee/maintained-apps/outputs/lookaway/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mysticalbits.lookaway';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mysticalbits.lookaway' AND version_compare(bundle_short_version, '2.2.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mysticalbits.lookaway' AND version_compare(bundle_short_version, '2.2.3') < 0);"
       },
-      "installer_url": "https://github.com/mysticalbits/lookaway-releases/releases/download/2.2.2/LookAway.dmg",
+      "installer_url": "https://github.com/mysticalbits/lookaway-releases/releases/download/2.2.3/LookAway.dmg",
       "install_script_ref": "8e23d582",
       "uninstall_script_ref": "edb6da69",
-      "sha256": "087ccff385bc885cc3345500b62fcbb0298e54681260cec9cb1937ed0b10d51d",
+      "sha256": "cdb5106d5faecb4fec403582ab8a9871f038b9fe3bfaab8333c8406ad4b08cda",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.6",
+      "version": "3.1.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.7') < 0);"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.6.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.7.zip",
       "install_script_ref": "c6782863",
       "uninstall_script_ref": "9e4b9fca",
-      "sha256": "be794d5115c6da4e7566bacba1f3c22680d57a561ed8a010810abf8f91ab5d2a",
+      "sha256": "ba5ab5f2903154cb2770a0f7f1f344fdf06069ba9c89910429f647197a3da567",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.98",
+      "version": "150.0.4078.50",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '149.0.4022.98') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '150.0.4078.50') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/739ebe4c-478b-4726-9c65-8dc694d4b5ed/MicrosoftEdge-149.0.4022.98.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/d269d021-b72c-4afd-9486-41bec03d66fb/MicrosoftEdge-150.0.4078.50.dmg",
       "install_script_ref": "caf6f785",
       "uninstall_script_ref": "afe8f338",
-      "sha256": "cc07d415520f1d6b356d3db62c821b5075901af04f6749b43049ad15494b904b",
+      "sha256": "7b1febf17546e623ce6a08b50526f2a00931817399ff8af590170c41344c984b",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.4022.98",
+      "version": "150.0.4078.48",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '149.0.4022.98') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '150.0.4078.48') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/82374039-b772-4d0a-a9a9-ee311dabec12/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/6476e2cb-803c-4ed9-b91f-60caaa21dbfd/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "d026379848222d1e32800a1ff4268b9f5252a9d50f98819768ba54662f27979e",
+      "sha256": "94a406cdc1ab9c1c8ac8aa48b42d89e4e35cee68622cda718b301e5e3ed93b49",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/phpstorm/darwin.json
+++ b/ee/maintained-apps/outputs/phpstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1.4-aarch64.dmg",
       "install_script_ref": "a85d5737",
       "uninstall_script_ref": "bdde2409",
-      "sha256": "628e741215500e0edcfc2dc967dbad671a6c398d03b997e063362d04df4d9b09",
+      "sha256": "5c671f1161c778bba0be44ff5a5403b1544ddf7178e9bd4f08d8483508ada926",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rancher/windows.json
+++ b/ee/maintained-apps/outputs/rancher/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.22.3",
+      "version": "1.23.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Rancher Desktop' AND publisher = 'SUSE';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Rancher Desktop' AND publisher = 'SUSE' AND version_compare(version, '1.22.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Rancher Desktop' AND publisher = 'SUSE' AND version_compare(version, '1.23.1') < 0);"
       },
-      "installer_url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.22.3/Rancher.Desktop.Setup.1.22.3.msi",
+      "installer_url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.23.1/Rancher.Desktop.Setup.1.23.1.msi",
       "install_script_ref": "5189ac09",
       "uninstall_script_ref": "da741b06",
-      "sha256": "d0918c3e99d2918d84d739e47df12964b2d75ccdf3f9da769b6d4b47ede187cf",
+      "sha256": "65c2daa6e7d6b5dbd172d51f9eb72d4a318869deb722a99decc82e87ae068102",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/rider/windows.json
+++ b/ee/maintained-apps/outputs/rider/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'JetBrains Rider %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'JetBrains Rider %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.25134.178') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'JetBrains Rider %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.26222.60') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.3.exe",
+      "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.4.exe",
       "install_script_ref": "d65fe1de",
       "uninstall_script_ref": "c5bf08c9",
-      "sha256": "41ed77cd74466cdcc906f3a6c5792f6d414cc01c48b58181fa82f7205d0bb70d",
+      "sha256": "403218ce37b7cb0f1ffbc0106d1fba016e372e9ab6bae6315095a89cd052528a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rocket-chat/darwin.json
+++ b/ee/maintained-apps/outputs/rocket-chat/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.15.1",
+      "version": "4.15.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.2') < 0);"
       },
-      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.1/rocketchat-4.15.1-mac.dmg",
+      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.2/rocketchat-4.15.2-mac.dmg",
       "install_script_ref": "8a2921c9",
       "uninstall_script_ref": "36b46743",
-      "sha256": "66ba0a5b949dc9b6be1cac267657877716ded158bffd739a52d9d82b04d2c540",
+      "sha256": "4c74d234fbda7711551aaecb6bfda12d76984c1a8123d2bab831f9e6e742ffc9",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/rsyncui/darwin.json
+++ b/ee/maintained-apps/outputs/rsyncui/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'no.blogspot.RsyncUI';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'no.blogspot.RsyncUI' AND version_compare(bundle_short_version, '3.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'no.blogspot.RsyncUI' AND version_compare(bundle_short_version, '3.0.2') < 0);"
       },
-      "installer_url": "https://github.com/rsyncOSX/RsyncUI/releases/download/v3.0.0/RsyncUI.3.0.0.dmg",
+      "installer_url": "https://github.com/rsyncOSX/RsyncUI/releases/download/v3.0.2/RsyncUI.3.0.2.dmg",
       "install_script_ref": "18009020",
       "uninstall_script_ref": "71459de0",
-      "sha256": "62810f5852358a2e85008baefb45b0fbb1c6273d3eecbceb256c768c90175c2a",
+      "sha256": "21f40b2c389be6530a53a2a6a2b981f6c76a73d84492cbe2909519f9bdb885b4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/super-productivity/darwin.json
+++ b/ee/maintained-apps/outputs/super-productivity/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "18.12.0",
+      "version": "18.13.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.super-productivity.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.super-productivity.app' AND version_compare(bundle_short_version, '18.12.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.super-productivity.app' AND version_compare(bundle_short_version, '18.13.1') < 0);"
       },
-      "installer_url": "https://github.com/super-productivity/super-productivity/releases/download/v18.12.0/superProductivity-arm64.dmg",
+      "installer_url": "https://github.com/super-productivity/super-productivity/releases/download/v18.13.1/superProductivity-arm64.dmg",
       "install_script_ref": "149e0795",
       "uninstall_script_ref": "98941c96",
-      "sha256": "1d15de1322b6efc2833bd7496186f5d9ce3dcdb58a09c9e4d33e71f5131c3ccc",
+      "sha256": "a70c00abb327acc83acd62f52c6c5e7544da46f7b205164da382208c5937816e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tower/windows.json
+++ b/ee/maintained-apps/outputs/tower/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.2.562",
+      "version": "12.3.563",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Tower %' AND publisher = 'SaaS.Group';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Tower %' AND publisher = 'SaaS.Group' AND version_compare(version, '12.2.562') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Tower %' AND publisher = 'SaaS.Group' AND version_compare(version, '12.3.563') < 0);"
       },
-      "installer_url": "https://www.git-tower.com/apps/tower3-win/562-2f47fd7a/Tower-12.2.562.msi",
+      "installer_url": "https://www.git-tower.com/apps/tower3-win/563-51cf3efc/Tower-12.3.563.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "8940833c",
-      "sha256": "3642d08d018d59c1bbf5b43c1c02c975f599c26fcd76adb739cc33826edbb673",
+      "sha256": "d4cdae41fffb64f44568a34c4daf0105cdf1976df1cf3edf586d09776ebb2aab",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/webstorm/darwin.json
+++ b/ee/maintained-apps/outputs/webstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4-aarch64.dmg",
       "install_script_ref": "cd510d61",
       "uninstall_script_ref": "c0791a1f",
-      "sha256": "d4dd51b4dd502efb89d502fc8db3794dd6ce1c01d237ce16f5710ad8f10f8a32",
+      "sha256": "6587a7e84c341986c1026b860830023c1b3283167ab13efcee8ea0a85f43273c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/wispr-flow/darwin.json
+++ b/ee/maintained-apps/outputs/wispr-flow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.980",
+      "version": "1.5.1095",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.5.980') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.5.1095') < 0);"
       },
-      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.5.980.dmg",
+      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.5.1095.dmg",
       "install_script_ref": "3a49fcfd",
       "uninstall_script_ref": "e0cf2e96",
-      "sha256": "b546e0c3ccbb390991c8780140ef8b7cf6aca439a13be51255f1c0742a3e7132",
+      "sha256": "2c1c20e4b331f24944521a1d07ac5f4c827c9bd77a025764774ac8c9b7acb36d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zen/darwin.json
+++ b/ee/maintained-apps/outputs/zen/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.21.4b",
+      "version": "1.21.5b",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.21.4b') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.21.5b') < 0);"
       },
-      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.21.4b/zen.macos-universal.dmg",
+      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.21.5b/zen.macos-universal.dmg",
       "install_script_ref": "fd25a9c8",
       "uninstall_script_ref": "6fa48a6f",
-      "sha256": "40a708776e8f251859a4fa73ed485f862eb5e1b97be356bfe014b414504fdb4a",
+      "sha256": "e6ab356ede41d6973f2f3c165edf974dd04d94b497aad0132f80d1aa25d4a566",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installer metadata and version checks for multiple maintained apps on Windows and macOS.
  * Bumped several apps to newer releases, including Brave, Microsoft Edge, Calibre, Claude, JetBrains Toolbox, GoLand, PhpStorm, WebStorm, and others.
  * Refreshed download links and checksums so installs and updates use the latest available packages.
  * Included smaller version updates for tools like 7-Zip, AWS CLI, Alt-Tab, Granola, Huly, Kiro CLI, LookAway, Tower, and Zen Browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->