### PR TITLE
Cherry-pick #48651: Google Workspace settings: page description instead of instructions card

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/GoogleWorkspaceSection/GoogleWorkspaceSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/GoogleWorkspaceSection/GoogleWorkspaceSection.tsx
@@ -10,7 +10,7 @@ import { notify } from "components/ToastNotification";
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
 import Card from "components/Card";
-import InfoBanner from "components/InfoBanner";
+import PageDescription from "components/PageDescription";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import SettingsSection from "pages/admin/components/SettingsSection";
 
@@ -185,11 +185,16 @@ const GoogleWorkspaceSection = ({
 
   return (
     <SettingsSection title="Google Workspace" className={baseClass}>
-      <InfoBanner>
-        Connecting Google Workspace populates IdP host vitals directly from your
-        directory. While Google Workspace is connected, SCIM provisioning (Okta,
-        Entra ID, etc.) is ignored — configure one or the other, not both.
-      </InfoBanner>
+      <PageDescription
+        content={
+          <>
+            Configure these settings to populate IdP host vitals from Google
+            Workspace. When Google Workspace is connected, Fleet ignores SCIM
+            provisioning from other IdPs (e.g Okta, Entra ID).
+          </>
+        }
+        variant="right-panel"
+      />
       <form onSubmit={onFormSubmit} autoComplete="off">
         <Card>
           <InputField

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/GoogleWorkspaceSection/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/GoogleWorkspaceSection/_styles.scss
@@ -3,10 +3,9 @@
 
   form {
     .card {
-      // The generic `.card` is content-box (only `.info-banner` gets the global
-      // border-box override), so its `width: 100%` plus padding/border renders
-      // ~50px wider than the section, overflowing past the InfoBanner above.
-      // border-box makes its total width equal the section width, like the banner.
+      // The generic `.card` is content-box, so its `width: 100%` plus
+      // padding/border renders ~50px wider than the section and overflows.
+      // border-box makes its total width equal the section width.
       box-sizing: border-box;
 
       // Stack the fields with consistent vertical spacing so each field's help


### PR DESCRIPTION
Cherry-pick of #48651 into the RC branch.