### PR TITLE
Fix nondeterministic device_mapping order in ListHosts

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1165,9 +1165,12 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
 		// LEFT JOIN with GROUP BY) so the aggregation over host_emails is evaluated only
 		// for the rows actually returned by the outer query, each as an indexed lookup on
 		// idx_host_emails_host_id_email.
+		// GROUP_CONCAT without ORDER BY has no guaranteed order; sort to match
+		// listHostDeviceMappingDB so all endpoints return device_mapping in the
+		// same order.
 		sql += fmt.Sprintf(`,
     COALESCE((
-        SELECT CONCAT('[', GROUP_CONCAT(JSON_OBJECT('email', he.email, 'source', %s)), ']')
+        SELECT CONCAT('[', GROUP_CONCAT(JSON_OBJECT('email', he.email, 'source', %s) ORDER BY he.email, he.source), ']')
         FROM host_emails he
         WHERE he.host_id = h.id
     ), 'null') as device_mapping

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -149,6 +149,7 @@ func TestHosts(t *testing.T) {
 		{"ReplaceHostDeviceMapping", testHostsReplaceHostDeviceMapping},
 		{"CustomHostDeviceMapping", testHostsCustomHostDeviceMapping},
 		{"IDPHostDeviceMapping", testIDPHostDeviceMapping},
+		{"ListHostsDeviceMappingOrder", testHostsListDeviceMappingOrder},
 		{"HostMDMAndMunki", testHostMDMAndMunki},
 		{"AggregatedHostMDMAndMunki", testAggregatedHostMDMAndMunki},
 		{"MunkiIssuesBatchSize", testMunkiIssuesBatchSize},
@@ -7865,6 +7866,50 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 
 	require.Len(t, mappings, 1)
 	require.Equal(t, mappings[0].Source, fleet.DeviceMappingCustomReplacement)
+}
+
+func testHostsListDeviceMappingOrder(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   ptr.String("dm-order-host"),
+		NodeKey:         ptr.String("dm-order-host"),
+		Platform:        "linux",
+		Hostname:        "dm-order-host",
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Insert the google_chrome_profiles rows first so they get lower ids: with
+	// ORDER BY (email, source), "b@example.com"/custom_installer sorts before
+	// "b@example.com"/google_chrome_profiles even though it was inserted last,
+	// so an accidental id-ordered read cannot pass this test.
+	require.NoError(t, ds.ReplaceHostDeviceMapping(ctx, host.ID, []*fleet.HostDeviceMapping{
+		{HostID: host.ID, Email: "z@example.com", Source: fleet.DeviceMappingGoogleChromeProfiles},
+		{HostID: host.ID, Email: "b@example.com", Source: fleet.DeviceMappingGoogleChromeProfiles},
+	}, fleet.DeviceMappingGoogleChromeProfiles))
+	_, err = ds.SetOrUpdateCustomHostDeviceMapping(ctx, host.ID, "b@example.com", fleet.DeviceMappingCustomInstaller)
+	require.NoError(t, err)
+
+	filter := fleet.TeamFilter{User: test.UserAdmin}
+	gotHosts := listHostsCheckCount(t, ds, filter, fleet.HostListOptions{DeviceMapping: true}, 1)
+	require.NotNil(t, gotHosts[0].DeviceMapping)
+
+	var dm []*fleet.HostDeviceMapping
+	require.NoError(t, json.Unmarshal(*gotHosts[0].DeviceMapping, &dm))
+
+	// ListHosts must return device_mapping ordered by (email, source), matching
+	// ListHostDeviceMapping, so all endpoints agree regardless of insertion order.
+	require.Len(t, dm, 3)
+	assert.Equal(t, "b@example.com", dm[0].Email)
+	assert.Equal(t, fleet.DeviceMappingCustomReplacement, dm[0].Source)
+	assert.Equal(t, "b@example.com", dm[1].Email)
+	assert.Equal(t, fleet.DeviceMappingGoogleChromeProfiles, dm[1].Source)
+	assert.Equal(t, "z@example.com", dm[2].Email)
+	assert.Equal(t, fleet.DeviceMappingGoogleChromeProfiles, dm[2].Source)
 }
 
 func testHostMDMAndMunki(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -7872,8 +7872,8 @@ func testHostsListDeviceMappingOrder(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
 	host, err := ds.NewHost(ctx, &fleet.Host{
-		OsqueryHostID:   ptr.String("dm-order-host"),
-		NodeKey:         ptr.String("dm-order-host"),
+		OsqueryHostID:   new("dm-order-host"),
+		NodeKey:         new("dm-order-host"),
 		Platform:        "linux",
 		Hostname:        "dm-order-host",
 		DetailUpdatedAt: time.Now(),


### PR DESCRIPTION
Fixes the `device_mapping` ordering flake in `TestIntegrations/TestListHostsByLabel` and `TestIntegrations/TestHostsReportDownload`, seen across integration-core jobs on `main` since July 1 (e.g. [this run](https://github.com/fleetdm/fleet/actions/runs/28567132474)).

#48488 replaced the derived-table `GROUP_CONCAT` join in `ListHosts` with a correlated subquery, but the `GROUP_CONCAT` has no `ORDER BY`, so MySQL returns `device_mapping` entries in arbitrary order. The old plan happened to read `idx_host_emails_host_id_email` in index order, which masked this; the new access path doesn't, so the order now varies between endpoints and runs — the tests compare `GET /hosts` output against `GET /labels/{id}/hosts` (and CSV report) output for the same host and intermittently see `[b@b.c, a@b.c]` vs `[a@b.c, b@b.c]`.

This adds `ORDER BY he.email, he.source` inside the `GROUP_CONCAT`, matching the ordering of the single-host `listHostDeviceMappingDB` query. The sort applies only within each host's few email rows, so it doesn't affect the perf improvement from #48488.

No changes file: #48488 is unreleased (not in any RC branch), so this is a fix to an unreleased change.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Covered by existing tests: `TestIntegrations/TestListHostsByLabel` and `TestIntegrations/TestHostsReportDownload` assert the (now deterministic) ordering. Ran both 4× locally with `MYSQL_TEST=1 REDIS_TEST=1`, plus the `TestHosts` device-mapping/ListHosts datastore tests — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of host device mapping results by making the ordering deterministic.
  * Fixed an issue where device mapping entries could appear in different orders between requests.
* **Tests**
  * Added coverage to verify the device mapping order remains stable and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->