### PR TITLE
Add host name template types, activity, and validation

### DIFF
--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
@@ -50,6 +50,7 @@
           "minimum_version": null,
           "update_new_hosts": null
         },
+        "name_template": "",
         "setup_experience": {
           "apple_enable_release_device_manually": false,
           "apple_setup_assistant": null,
@@ -148,6 +149,7 @@
           "minimum_version": null,
           "update_new_hosts": null
         },
+        "name_template": "",
         "windows_require_bitlocker_pin": false,
         "windows_settings": {
           "custom_settings": null
@@ -239,6 +241,7 @@
           "minimum_version": "12.3.1",
           "update_new_hosts": null
         },
+        "name_template": "",
         "setup_experience": {
           "apple_enable_release_device_manually": false,
           "apple_setup_assistant": null,
@@ -352,6 +355,7 @@
           "minimum_version": "12.3.1",
           "update_new_hosts": null
         },
+        "name_template": "",
         "windows_require_bitlocker_pin": false,
         "windows_settings": {
           "custom_settings": null

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
@@ -18,6 +18,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_updates:
         update_new_hosts: null
@@ -76,6 +77,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_updates:
         update_new_hosts: null
@@ -147,6 +149,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: true
+      name_template: null
       windows_require_bitlocker_pin: null
       ios_updates:
         minimum_version: "17.5"
@@ -206,6 +209,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: true
+      name_template: null
       windows_require_bitlocker_pin: null
       ios_updates:
         minimum_version: "17.5"

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -18,6 +18,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
@@ -76,6 +77,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
@@ -138,6 +140,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
@@ -189,6 +192,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -18,6 +18,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
@@ -76,6 +77,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
@@ -138,6 +140,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
@@ -190,6 +193,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -18,6 +18,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
@@ -76,6 +77,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
@@ -17,6 +17,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
@@ -75,6 +76,7 @@ spec:
     mdm:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
+      name_template: null
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -654,6 +654,16 @@ func (a ActivityTypeDisabledRecoveryLockPasswords) ActivityName() string {
 	return "disabled_recovery_lock_passwords"
 }
 
+type ActivityTypeEditedHostNameTemplate struct {
+	TeamID       *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName     *string `json:"team_name" renameto:"fleet_name"`
+	NameTemplate *string `json:"name_template"` // nil when the template was cleared
+}
+
+func (a ActivityTypeEditedHostNameTemplate) ActivityName() string {
+	return "edited_host_name_template"
+}
+
 type ActivityTypeCreatedManagedLocalAccount struct {
 	HostID          uint   `json:"host_id"`
 	HostDisplayName string `json:"host_display_name"`

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -655,8 +655,8 @@ func (a ActivityTypeDisabledRecoveryLockPasswords) ActivityName() string {
 }
 
 type ActivityTypeEditedHostNameTemplate struct {
-	TeamID       *uint   `json:"team_id" renameto:"fleet_id"`
-	TeamName     *string `json:"team_name" renameto:"fleet_name"`
+	FleetID      *uint   `json:"fleet_id"`
+	FleetName    *string `json:"fleet_name"`
 	NameTemplate *string `json:"name_template"` // nil when the template was cleared
 }
 

--- a/server/fleet/name_template.go
+++ b/server/fleet/name_template.go
@@ -1,0 +1,104 @@
+package fleet
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/fleetdm/fleet/v4/server/variables"
+)
+
+const maxHostNameTemplateLength = 255
+
+// fleetVarsSupportedInNameTemplates is the allow-list of Fleet variables that
+// may be used in a host name template.
+var fleetVarsSupportedInNameTemplates = []FleetVarName{
+	FleetVarHostHardwareSerial,
+	FleetVarHostUUID,
+	FleetVarHostPlatform,
+}
+
+// nameTemplateVarRegexp matches every supported name-template variable in both
+// its $FLEET_VAR_NAME and ${FLEET_VAR_NAME} forms, in a single pattern. It is
+// derived from fleetVarsSupportedInNameTemplates so it stays in sync with the
+// allow-list. The unbraced form uses a trailing word boundary so that an
+// unsupported longer name (e.g. HOST_UUID_EXTRA) is not partially matched.
+var nameTemplateVarRegexp = func() *regexp.Regexp {
+	alts := make([]string, len(fleetVarsSupportedInNameTemplates))
+	for i, v := range fleetVarsSupportedInNameTemplates {
+		alts[i] = regexp.QuoteMeta(string(v))
+	}
+	alt := strings.Join(alts, "|")
+	return regexp.MustCompile(fmt.Sprintf(`\$FLEET_VAR_(%[1]s)\b|\$\{FLEET_VAR_(%[1]s)\}`, alt))
+}()
+
+// ValidateHostNameTemplate validates a host name template and returns the
+// normalized (trimmed) template that callers should persist.
+func ValidateHostNameTemplate(tmpl string) (string, error) {
+	tmpl = strings.TrimSpace(tmpl)
+	if tmpl == "" {
+		return "", NewInvalidArgumentError("name_template", "Host name template can't be empty.")
+	}
+	if !utf8.ValidString(tmpl) {
+		return "", NewInvalidArgumentError("name_template", "Host name template must be valid UTF-8.")
+	}
+	if utf8.RuneCountInString(tmpl) > maxHostNameTemplateLength {
+		return "", NewInvalidArgumentError("name_template", "Host name template can't be longer than 255 characters.")
+	}
+	for _, r := range tmpl {
+		// Reject C0/C1 control characters (Cc) as well as Unicode "format"
+		// characters (Cf, e.g. bidi overrides and zero-width joiners) that can be
+		// used to spoof a name displayed to admins in the UI.
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			return "", NewInvalidArgumentError("name_template", "Host name template can't contain control characters.")
+		}
+	}
+
+	// Secret variables ($FLEET_SECRET_*) are never allowed in name templates.
+	if len(ContainsPrefixVars(tmpl, ServerSecretPrefix)) > 0 {
+		return "", NewInvalidArgumentError("name_template", "Secret variables aren't supported in host name templates.")
+	}
+
+	// Every Fleet variable used must be in the allow-list.
+	for _, v := range variables.Find(tmpl) {
+		if !slices.Contains(fleetVarsSupportedInNameTemplates, FleetVarName(v)) {
+			return "", NewInvalidArgumentError("name_template",
+				"Fleet variable $FLEET_VAR_"+v+" is not supported in host name templates.")
+		}
+	}
+
+	return tmpl, nil
+}
+
+// ResolveHostNameTemplate resolves a host name template against a host by
+// substituting the supported host-identity Fleet variables with the host's
+// values.
+func ResolveHostNameTemplate(tmpl string, host *Host) string {
+	if host == nil {
+		return tmpl
+	}
+
+	platform := host.Platform
+	if platform == "darwin" {
+		platform = "macos"
+	}
+
+	values := map[FleetVarName]string{
+		FleetVarHostHardwareSerial: host.HardwareSerial,
+		FleetVarHostUUID:           host.UUID,
+		FleetVarHostPlatform:       platform,
+	}
+
+	return nameTemplateVarRegexp.ReplaceAllStringFunc(tmpl, func(match string) string {
+		groups := nameTemplateVarRegexp.FindStringSubmatch(match)
+		// Exactly one of the two capture groups (unbraced/braced) is populated.
+		name := groups[1]
+		if name == "" {
+			name = groups[2]
+		}
+		return values[FleetVarName(name)]
+	})
+}

--- a/server/fleet/name_template.go
+++ b/server/fleet/name_template.go
@@ -73,6 +73,17 @@ func ValidateHostNameTemplate(tmpl string) (string, error) {
 	return tmpl, nil
 }
 
+// hostNameTemplatePlatformDisplayNames maps a host's osquery platform to the
+// display name shown when $FLEET_VAR_HOST_PLATFORM is resolved in a host name
+// template. Host name templates only apply to Apple devices, so only the Apple
+// platforms are mapped here; it mirrors the frontend's
+// APPLE_PLATFORM_DISPLAY_NAMES. Any other platform resolves to its raw value.
+var hostNameTemplatePlatformDisplayNames = map[string]string{
+	"darwin": "macOS",
+	"ios":    "iOS",
+	"ipados": "iPadOS",
+}
+
 // ResolveHostNameTemplate resolves a host name template against a host by
 // substituting the supported host-identity Fleet variables with the host's
 // values.
@@ -82,8 +93,8 @@ func ResolveHostNameTemplate(tmpl string, host *Host) string {
 	}
 
 	platform := host.Platform
-	if platform == "darwin" {
-		platform = "macos"
+	if display, ok := hostNameTemplatePlatformDisplayNames[platform]; ok {
+		platform = display
 	}
 
 	values := map[FleetVarName]string{

--- a/server/fleet/name_template_test.go
+++ b/server/fleet/name_template_test.go
@@ -2,7 +2,6 @@ package fleet
 
 import (
 	"encoding/json"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -55,8 +54,8 @@ func TestValidateHostNameTemplate(t *testing.T) {
 			wantErr: "Secret variables aren't supported in host name templates.",
 		},
 		{name: "tab control char", tmpl: "bad\tname", wantErr: "control characters"},
-		{name: "rtl override format char", tmpl: "bad‮name", wantErr: "control characters"},
-		{name: "zero-width joiner format char", tmpl: "bad‍name", wantErr: "control characters"},
+		{name: "rtl override format char", tmpl: "bad\u202ename", wantErr: "control characters"},
+		{name: "zero-width joiner format char", tmpl: "bad\u200dname", wantErr: "control characters"},
 		{name: "invalid utf-8", tmpl: "bad\xff\xfename", wantErr: "valid UTF-8"},
 		{name: "too long", tmpl: strings.Repeat("a", 256), wantErr: "255 characters"},
 		{name: "max length ok", tmpl: strings.Repeat("a", 255), wantNorm: strings.Repeat("a", 255)},
@@ -96,15 +95,29 @@ func TestResolveHostNameTemplate(t *testing.T) {
 		{name: "no vars", tmpl: "workstation", host: host, want: "workstation"},
 		{name: "serial", tmpl: "$FLEET_VAR_HOST_HARDWARE_SERIAL", host: host, want: "C02ABC123"},
 		{name: "uuid braced", tmpl: "${FLEET_VAR_HOST_UUID}", host: host, want: "1234-5678"},
-		{name: "platform darwin maps to macos", tmpl: "$FLEET_VAR_HOST_PLATFORM", host: host, want: "macos"},
+		{name: "platform darwin maps to macOS", tmpl: "$FLEET_VAR_HOST_PLATFORM", host: host, want: "macOS"},
+		{
+			name: "platform ios maps to iOS",
+			tmpl: "$FLEET_VAR_HOST_PLATFORM",
+			host: &Host{Platform: "ios"},
+			want: "iOS",
+		},
+		{
+			name: "platform ipados maps to iPadOS",
+			tmpl: "$FLEET_VAR_HOST_PLATFORM",
+			host: &Host{Platform: "ipados"},
+			want: "iPadOS",
+		},
 		{
 			name: "mixed and repeated",
 			tmpl: "$FLEET_VAR_HOST_PLATFORM-$FLEET_VAR_HOST_HARDWARE_SERIAL-${FLEET_VAR_HOST_HARDWARE_SERIAL}",
 			host: host,
-			want: "macos-C02ABC123-C02ABC123",
+			want: "macOS-C02ABC123-C02ABC123",
 		},
 		{
-			name: "non-darwin platform unchanged",
+			// Non-Apple platforms fall back to the raw value (the feature only
+			// applies to Apple devices, so this is defensive).
+			name: "non-apple platform falls back to raw value",
 			tmpl: "$FLEET_VAR_HOST_PLATFORM",
 			host: &Host{Platform: "windows"},
 			want: "windows",
@@ -201,38 +214,28 @@ func TestActivityTypeEditedHostNameTemplate(t *testing.T) {
 	t.Run("marshal with template", func(t *testing.T) {
 		tmpl := "$FLEET_VAR_HOST_HARDWARE_SERIAL"
 		b, err := json.Marshal(ActivityTypeEditedHostNameTemplate{
-			TeamID:       new(uint(1)),
-			TeamName:     new("Workstations"),
+			FleetID:      new(uint(1)),
+			FleetName:    new("Workstations"),
 			NameTemplate: &tmpl,
 		})
 		require.NoError(t, err)
 		require.JSONEq(t, `{
-			"team_id": 1,
-			"team_name": "Workstations",
+			"fleet_id": 1,
+			"fleet_name": "Workstations",
 			"name_template": "$FLEET_VAR_HOST_HARDWARE_SERIAL"
 		}`, string(b))
 	})
 
 	t.Run("marshal cleared template is null", func(t *testing.T) {
 		b, err := json.Marshal(ActivityTypeEditedHostNameTemplate{
-			TeamID:   new(uint(1)),
-			TeamName: new("Workstations"),
+			FleetID:   new(uint(1)),
+			FleetName: new("Workstations"),
 		})
 		require.NoError(t, err)
 		require.JSONEq(t, `{
-			"team_id": 1,
-			"team_name": "Workstations",
+			"fleet_id": 1,
+			"fleet_name": "Workstations",
 			"name_template": null
 		}`, string(b))
-	})
-
-	t.Run("team_id and team_name are renamed in HTTP responses", func(t *testing.T) {
-		// The rename to fleet_id/fleet_name happens at the HTTP layer via the
-		// renameto struct tags; assert the tags are wired here.
-		typ := reflect.TypeFor[ActivityTypeEditedHostNameTemplate]()
-		teamID, _ := typ.FieldByName("TeamID")
-		teamName, _ := typ.FieldByName("TeamName")
-		require.Equal(t, "fleet_id", teamID.Tag.Get("renameto"))
-		require.Equal(t, "fleet_name", teamName.Tag.Get("renameto"))
 	})
 }

--- a/server/fleet/name_template_test.go
+++ b/server/fleet/name_template_test.go
@@ -1,0 +1,238 @@
+package fleet
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateHostNameTemplate(t *testing.T) {
+	cases := []struct {
+		name     string
+		tmpl     string
+		wantNorm string // expected normalized template on success
+		wantErr  string
+	}{
+		{name: "plain string", tmpl: "workstation", wantNorm: "workstation"},
+		{name: "hardware serial", tmpl: "$FLEET_VAR_HOST_HARDWARE_SERIAL", wantNorm: "$FLEET_VAR_HOST_HARDWARE_SERIAL"},
+		{name: "uuid braced", tmpl: "${FLEET_VAR_HOST_UUID}", wantNorm: "${FLEET_VAR_HOST_UUID}"},
+		{name: "platform", tmpl: "$FLEET_VAR_HOST_PLATFORM", wantNorm: "$FLEET_VAR_HOST_PLATFORM"},
+		{
+			name:     "mixed",
+			tmpl:     "mac-$FLEET_VAR_HOST_HARDWARE_SERIAL-${FLEET_VAR_HOST_UUID}",
+			wantNorm: "mac-$FLEET_VAR_HOST_HARDWARE_SERIAL-${FLEET_VAR_HOST_UUID}",
+		},
+		{
+			name:     "surrounding whitespace is trimmed in the returned value",
+			tmpl:     "  serial-$FLEET_VAR_HOST_HARDWARE_SERIAL  ",
+			wantNorm: "serial-$FLEET_VAR_HOST_HARDWARE_SERIAL",
+		},
+
+		{name: "empty", tmpl: "", wantErr: "can't be empty"},
+		{name: "whitespace only", tmpl: "   ", wantErr: "can't be empty"},
+		{
+			name:    "unsupported var",
+			tmpl:    "$FLEET_VAR_HOST_END_USER_IDP_GROUPS",
+			wantErr: "Fleet variable $FLEET_VAR_HOST_END_USER_IDP_GROUPS is not supported in host name templates.",
+		},
+		{
+			name:    "supported var with unsupported suffix",
+			tmpl:    "$FLEET_VAR_HOST_UUID_EXTRA",
+			wantErr: "Fleet variable $FLEET_VAR_HOST_UUID_EXTRA is not supported in host name templates.",
+		},
+		{
+			name:    "secret var",
+			tmpl:    "$FLEET_SECRET_FOO",
+			wantErr: "Secret variables aren't supported in host name templates.",
+		},
+		{
+			name:    "secret var braced",
+			tmpl:    "${FLEET_SECRET_FOO}",
+			wantErr: "Secret variables aren't supported in host name templates.",
+		},
+		{name: "tab control char", tmpl: "bad\tname", wantErr: "control characters"},
+		{name: "rtl override format char", tmpl: "bad‮name", wantErr: "control characters"},
+		{name: "zero-width joiner format char", tmpl: "bad‍name", wantErr: "control characters"},
+		{name: "invalid utf-8", tmpl: "bad\xff\xfename", wantErr: "valid UTF-8"},
+		{name: "too long", tmpl: strings.Repeat("a", 256), wantErr: "255 characters"},
+		{name: "max length ok", tmpl: strings.Repeat("a", 255), wantNorm: strings.Repeat("a", 255)},
+		// The limit is 255 characters, not bytes: 255 multi-byte runes must pass.
+		{name: "255 multi-byte runes ok", tmpl: strings.Repeat("é", 255), wantNorm: strings.Repeat("é", 255)},
+		{name: "256 multi-byte runes too long", tmpl: strings.Repeat("é", 256), wantErr: "255 characters"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			norm, err := ValidateHostNameTemplate(c.tmpl)
+			if c.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, c.wantNorm, norm)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), c.wantErr)
+			require.Empty(t, norm)
+		})
+	}
+}
+
+func TestResolveHostNameTemplate(t *testing.T) {
+	host := &Host{
+		HardwareSerial: "C02ABC123",
+		UUID:           "1234-5678",
+		Platform:       "darwin",
+	}
+
+	cases := []struct {
+		name string
+		tmpl string
+		host *Host
+		want string
+	}{
+		{name: "no vars", tmpl: "workstation", host: host, want: "workstation"},
+		{name: "serial", tmpl: "$FLEET_VAR_HOST_HARDWARE_SERIAL", host: host, want: "C02ABC123"},
+		{name: "uuid braced", tmpl: "${FLEET_VAR_HOST_UUID}", host: host, want: "1234-5678"},
+		{name: "platform darwin maps to macos", tmpl: "$FLEET_VAR_HOST_PLATFORM", host: host, want: "macos"},
+		{
+			name: "mixed and repeated",
+			tmpl: "$FLEET_VAR_HOST_PLATFORM-$FLEET_VAR_HOST_HARDWARE_SERIAL-${FLEET_VAR_HOST_HARDWARE_SERIAL}",
+			host: host,
+			want: "macos-C02ABC123-C02ABC123",
+		},
+		{
+			name: "non-darwin platform unchanged",
+			tmpl: "$FLEET_VAR_HOST_PLATFORM",
+			host: &Host{Platform: "windows"},
+			want: "windows",
+		},
+		{
+			name: "empty host field resolves to empty string",
+			tmpl: "serial=$FLEET_VAR_HOST_HARDWARE_SERIAL",
+			host: &Host{},
+			want: "serial=",
+		},
+		{
+			// A host value that itself contains variable syntax must not be
+			// re-substituted by a later pass (single-pass replacement).
+			name: "host value containing variable syntax is not re-substituted",
+			tmpl: "$FLEET_VAR_HOST_HARDWARE_SERIAL",
+			host: &Host{HardwareSerial: "$FLEET_VAR_HOST_UUID", UUID: "real-uuid"},
+			want: "$FLEET_VAR_HOST_UUID",
+		},
+		{
+			name: "unsupported longer variable name is left untouched",
+			tmpl: "$FLEET_VAR_HOST_UUID_EXTRA",
+			host: host,
+			want: "$FLEET_VAR_HOST_UUID_EXTRA",
+		},
+		{name: "nil host leaves template unchanged", tmpl: "$FLEET_VAR_HOST_UUID", host: nil, want: "$FLEET_VAR_HOST_UUID"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, ResolveHostNameTemplate(c.tmpl, c.host))
+		})
+	}
+}
+
+func TestTeamNameTemplateRoundTrip(t *testing.T) {
+	t.Run("TeamMDM", func(t *testing.T) {
+		in := TeamMDM{NameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}
+		b, err := json.Marshal(in)
+		require.NoError(t, err)
+		require.Contains(t, string(b), `"name_template":"$FLEET_VAR_HOST_HARDWARE_SERIAL"`)
+
+		var out TeamMDM
+		require.NoError(t, json.Unmarshal(b, &out))
+		require.Equal(t, in.NameTemplate, out.NameTemplate)
+	})
+
+	t.Run("TeamSpecMDM", func(t *testing.T) {
+		in := TeamSpecMDM{NameTemplate: optjson.SetString("$FLEET_VAR_HOST_UUID")}
+		b, err := json.Marshal(in)
+		require.NoError(t, err)
+		require.Contains(t, string(b), `"name_template":"$FLEET_VAR_HOST_UUID"`)
+
+		var out TeamSpecMDM
+		require.NoError(t, json.Unmarshal(b, &out))
+		require.True(t, out.NameTemplate.Set)
+		require.True(t, out.NameTemplate.Valid)
+		require.Equal(t, "$FLEET_VAR_HOST_UUID", out.NameTemplate.Value)
+	})
+
+	t.Run("TeamSpecMDM absent", func(t *testing.T) {
+		var out TeamSpecMDM
+		require.NoError(t, json.Unmarshal([]byte(`{}`), &out))
+		require.False(t, out.NameTemplate.Set)
+	})
+
+	t.Run("TeamPayloadMDM", func(t *testing.T) {
+		in := TeamPayloadMDM{NameTemplate: optjson.SetString("$FLEET_VAR_HOST_PLATFORM")}
+		b, err := json.Marshal(in)
+		require.NoError(t, err)
+		require.Contains(t, string(b), `"name_template":"$FLEET_VAR_HOST_PLATFORM"`)
+
+		var out TeamPayloadMDM
+		require.NoError(t, json.Unmarshal(b, &out))
+		require.True(t, out.NameTemplate.Set)
+		require.Equal(t, "$FLEET_VAR_HOST_PLATFORM", out.NameTemplate.Value)
+	})
+
+	t.Run("TeamConfig storage round-trip", func(t *testing.T) {
+		// name_template rides in the teams.config JSON blob (no dedicated
+		// column), so verify it survives the actual SQL Value()/Scan() boundary.
+		in := TeamConfig{MDM: TeamMDM{NameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}}
+		val, err := in.Value()
+		require.NoError(t, err)
+
+		var out TeamConfig
+		require.NoError(t, out.Scan(val))
+		require.Equal(t, "$FLEET_VAR_HOST_HARDWARE_SERIAL", out.MDM.NameTemplate)
+	})
+}
+
+func TestActivityTypeEditedHostNameTemplate(t *testing.T) {
+	require.Equal(t, "edited_host_name_template", ActivityTypeEditedHostNameTemplate{}.ActivityName())
+
+	t.Run("marshal with template", func(t *testing.T) {
+		tmpl := "$FLEET_VAR_HOST_HARDWARE_SERIAL"
+		b, err := json.Marshal(ActivityTypeEditedHostNameTemplate{
+			TeamID:       new(uint(1)),
+			TeamName:     new("Workstations"),
+			NameTemplate: &tmpl,
+		})
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"team_id": 1,
+			"team_name": "Workstations",
+			"name_template": "$FLEET_VAR_HOST_HARDWARE_SERIAL"
+		}`, string(b))
+	})
+
+	t.Run("marshal cleared template is null", func(t *testing.T) {
+		b, err := json.Marshal(ActivityTypeEditedHostNameTemplate{
+			TeamID:   new(uint(1)),
+			TeamName: new("Workstations"),
+		})
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"team_id": 1,
+			"team_name": "Workstations",
+			"name_template": null
+		}`, string(b))
+	})
+
+	t.Run("team_id and team_name are renamed in HTTP responses", func(t *testing.T) {
+		// The rename to fleet_id/fleet_name happens at the HTTP layer via the
+		// renameto struct tags; assert the tags are wired here.
+		typ := reflect.TypeFor[ActivityTypeEditedHostNameTemplate]()
+		teamID, _ := typ.FieldByName("TeamID")
+		teamName, _ := typ.FieldByName("TeamName")
+		require.Equal(t, "fleet_id", teamID.Tag.Get("renameto"))
+		require.Equal(t, "fleet_name", teamName.Tag.Get("renameto"))
+	})
+}

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -96,7 +96,8 @@ type TeamPayloadMDM struct {
 	// WindowsUpdates defines the OS update settings for Windows devices.
 	WindowsUpdates *WindowsUpdates `json:"windows_updates"`
 
-	MacOSSetup *MacOSSetup `json:"macos_setup"`
+	MacOSSetup   *MacOSSetup    `json:"macos_setup"`
+	NameTemplate optjson.String `json:"name_template"`
 }
 
 // Team is the data representation for the "Team" concept (group of hosts and
@@ -335,6 +336,10 @@ type TeamMDM struct {
 	WindowsSettings WindowsSettings `json:"windows_settings"`
 
 	AndroidSettings AndroidSettings `json:"android_settings"`
+
+	// NameTemplate is the template used to compute a host's display name from
+	// host-identity Fleet variables (e.g. $FLEET_VAR_HOST_HARDWARE_SERIAL).
+	NameTemplate string `json:"name_template"`
 	// NOTE: TeamSpecMDM must be kept in sync with TeamMDM.
 
 	/////////////////////////////////////////////////////////////////
@@ -421,6 +426,7 @@ type TeamSpecMDM struct {
 	WindowsSettings WindowsSettings `json:"windows_settings"`
 
 	AndroidSettings AndroidSettings `json:"android_settings"`
+	NameTemplate    optjson.String  `json:"name_template"`
 
 	// NOTE: TeamMDM must be kept in sync with TeamSpecMDM.
 }

--- a/server/fleet/teams_test.go
+++ b/server/fleet/teams_test.go
@@ -302,6 +302,16 @@ func TestTeamMDMCopy(t *testing.T) {
 		)
 		require.NotSame(t, tm.MacOSSettings.DeprecatedEnableDiskEncryption, clone.MacOSSettings.DeprecatedEnableDiskEncryption)
 	})
+
+	t.Run("copy NameTemplate", func(t *testing.T) {
+		tm := &TeamMDM{NameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}
+		clone := tm.Copy()
+		require.Equal(t, tm.NameTemplate, clone.NameTemplate)
+
+		// mutating the copy must not affect the original (plain-string value copy)
+		clone.NameTemplate = "changed"
+		require.Equal(t, "$FLEET_VAR_HOST_HARDWARE_SERIAL", tm.NameTemplate)
+	})
 }
 
 func TestTeamConfigCopy(t *testing.T) {

--- a/tools/cloner-check/generated_files/teamconfig.txt
+++ b/tools/cloner-check/generated_files/teamconfig.txt
@@ -90,6 +90,7 @@ github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	Name	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	CertificateAuthorityName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectAlternativeName	string
+github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	NameTemplate	string
 github.com/fleetdm/fleet/v4/server/fleet/TeamConfig	Features	fleet.Features
 github.com/fleetdm/fleet/v4/server/fleet/Features	EnableHostUsers	bool
 github.com/fleetdm/fleet/v4/server/fleet/Features	EnableSoftwareInventory	bool

--- a/tools/cloner-check/generated_files/teammdm.txt
+++ b/tools/cloner-check/generated_files/teammdm.txt
@@ -61,3 +61,4 @@ github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	Name	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	CertificateAuthorityName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectAlternativeName	string
+github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	NameTemplate	string

--- a/tools/dibble/pkg/seed/activities.go
+++ b/tools/dibble/pkg/seed/activities.go
@@ -273,6 +273,7 @@ var activityTemplatesByCategory = map[string][]fleet.ActivityDetails{
 		fleet.ActivityTypeDisabledMacosDiskEncryption{},
 		fleet.ActivityTypeEnabledRecoveryLockPasswords{},
 		fleet.ActivityTypeDisabledRecoveryLockPasswords{},
+		fleet.ActivityTypeEditedHostNameTemplate{},
 		fleet.ActivityTypeEnabledGitOpsMode{},
 		fleet.ActivityTypeDisabledGitOpsMode{},
 		fleet.ActivityTypeEnabledGitOpsException{},


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #48621

- Add name_template to TeamMDM, TeamSpecMDM and TeamPayloadMDM.
- Add the edited_host_name_template activity type.
- Add ValidateHostNameTemplate and ResolveHostNameTemplate in server/fleet/name_template.go.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a host display name template for fleet-managed devices.
  * Host name templates now accept approved variables and can be previewed from host data.

* **Bug Fixes**
  * Improved validation to reject invalid, empty, overlong, or unsafe templates.
  * Clearing a template is now handled cleanly and shown correctly in activity history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->