### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/alt-tab/darwin.json
+++ b/ee/maintained-apps/outputs/alt-tab/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.4.0",
+      "version": "11.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos' AND version_compare(bundle_short_version, '11.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lwouis.alt-tab-macos' AND version_compare(bundle_short_version, '11.4.1') < 0);"
       },
-      "installer_url": "https://github.com/lwouis/alt-tab-macos/releases/download/v11.4.0/AltTab-11.4.0.zip",
+      "installer_url": "https://github.com/lwouis/alt-tab-macos/releases/download/v11.4.1/AltTab-11.4.1.zip",
       "install_script_ref": "b04664c1",
       "uninstall_script_ref": "2cc2914b",
-      "sha256": "10362bd9c120b2c32ffc63eb558698f9bac123a1833e2a8247050914d19840c5",
+      "sha256": "867520b3f9af65603dd6da29a98dbb9c421036ddefe601186f985ae38bad1c65",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/aptakube/windows.json
+++ b/ee/maintained-apps/outputs/aptakube/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.18.1",
+      "version": "1.18.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL' AND version_compare(version, '1.18.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL' AND version_compare(version, '1.18.3') < 0);"
       },
-      "installer_url": "https://releases.aptakube.com/Aptakube_1.18.1_x64_en-US.msi",
+      "installer_url": "https://releases.aptakube.com/Aptakube_1.18.3_x64_en-US.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "d2281ec5",
-      "sha256": "4e509d38970e8fc77247d3a9af189526cf1d842fd7fe0fd4b4bc29d58d7079d9",
+      "sha256": "ce6e89abfa4edf3c5ab2a717bc83860a7ee10c20ebd71e37feb4e17b9e8479f6",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.37.2",
+      "version": "0.38.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.37.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.38.0') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.37.2/CodexBar-macos-universal-0.37.2.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.38.0/CodexBar-macos-universal-0.38.0.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "dc8f7c3c7fde007d46f6ea7ed408b05ec8711a865135fddb171b31e56df6ba77",
+      "sha256": "a5c6040e1fe469724a0236b05c8c720c44128c04693bd8617c88c235ff69be15",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/deezer/darwin.json
+++ b/ee/maintained-apps/outputs/deezer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.1.260",
+      "version": "7.1.270",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop' AND version_compare(bundle_short_version, '7.1.260') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop' AND version_compare(bundle_short_version, '7.1.270') < 0);"
       },
-      "installer_url": "https://www.deezer.com/desktop/download/artifact-darwin-x64-7.1.260",
+      "installer_url": "https://www.deezer.com/desktop/download/artifact-darwin-x64-7.1.270",
       "install_script_ref": "17993903",
       "uninstall_script_ref": "7a7ca836",
-      "sha256": "92932eac27d3874e2d7f0aacb31039d1fade14c80c1ef0570345fb5357b8a409",
+      "sha256": "1713256fce054b97568db11ad160ea9cc682015651cff7385830987611188e06",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/egnyte/windows.json
+++ b/ee/maintained-apps/outputs/egnyte/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.31.1.179",
+      "version": "4.4.1.198",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.' AND version_compare(version, '3.31.1.179') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Egnyte Desktop App' AND publisher = 'Egnyte, Inc.' AND version_compare(version, '4.4.1.198') < 0);"
       },
-      "installer_url": "https://egnyte-cdn.egnyte.com/egnytedrive/win/en-us/3.31.1/EgnyteDesktopApp_3.31.1_179.msi",
+      "installer_url": "https://egnyte-cdn.egnyte.com/egnytedrive/win/en-us/4.4.1/EgnyteDesktopApp_4.4.1_198.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "70b84d4a",
-      "sha256": "aca64bfeacb23e4edfae7f33a831deb003da3788035dd49e8ff866afccadad85",
+      "sha256": "fed541b65a0194e828762617c8c12ff72f0f67acf9b1b67e59deb58f98a3a181",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/free-download-manager/darwin.json
+++ b/ee/maintained-apps/outputs/free-download-manager/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "6.34.1",
+      "version": "6.34.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.freedownloadmanager.fdm6';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.freedownloadmanager.fdm6' AND version_compare(bundle_short_version, '6.34.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.freedownloadmanager.fdm6' AND version_compare(bundle_short_version, '6.34.2') < 0);"
       },
       "installer_url": "https://files2.freedownloadmanager.org/6/latest/fdm.dmg",
       "install_script_ref": "231b7da2",

--- a/ee/maintained-apps/outputs/home-assistant/darwin.json
+++ b/ee/maintained-apps/outputs/home-assistant/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.4.1",
+      "version": "2026.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant' AND version_compare(bundle_short_version, '2026.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant' AND version_compare(bundle_short_version, '2026.7.0') < 0);"
       },
-      "installer_url": "https://github.com/home-assistant/iOS/releases/download/release%2F2026.4.1%2F2026.1904/home-assistant-mac.zip",
+      "installer_url": "https://github.com/home-assistant/iOS/releases/download/release%2F2026.7.0%2F2026.2208/home-assistant-mac.zip",
       "install_script_ref": "8e645b2e",
       "uninstall_script_ref": "b46351a1",
-      "sha256": "286ff6deb0b9f5f0017984cee7c0ae5bfc2113e8bf6dd43ea85b596ee588b93b",
+      "sha256": "35aebe979ccbf477dd7afc2d752c11b6b505dea1f9f01a5e7167b71563af429a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/mountain-duck/darwin.json
+++ b/ee/maintained-apps/outputs/mountain-duck/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.3.0",
+      "version": "5.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.mountainduck';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.mountainduck' AND version_compare(bundle_short_version, '5.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.mountainduck' AND version_compare(bundle_short_version, '5.3.1') < 0);"
       },
-      "installer_url": "https://dist.mountainduck.io/Mountain%20Duck-5.3.0.29446.zip",
+      "installer_url": "https://dist.mountainduck.io/Mountain%20Duck-5.3.1.29526.zip",
       "install_script_ref": "6ff201d4",
       "uninstall_script_ref": "9229a596",
-      "sha256": "279a70ed6a5e948eb83129d227cc55966f1a78112d71d39c81e15f8baf5adc72",
+      "sha256": "b224d053f47d30253e0b7b86a19018f94496dc06246f1ff6b79fe3717764936d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '133.0') < 0);"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/133.0.5932.20/mac/Opera_133.0.5932.20_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/133.0.5932.24/mac/Opera_133.0.5932.24_Setup.dmg",
       "install_script_ref": "e9e947a7",
       "uninstall_script_ref": "566d9846",
-      "sha256": "6ddef0c233d970ad0e9572aaa68b2ad08bf9f601e7c55042cbffaeba784a9e24",
+      "sha256": "48d2d64725521fd6d194decdf1d931752526d4ec2f99cf44d2e0c0720aff5c24",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/proxyman/windows.json
+++ b/ee/maintained-apps/outputs/proxyman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.15.0",
+      "version": "3.16.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Proxyman' AND publisher = 'Proxyman LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proxyman' AND publisher = 'Proxyman LLC' AND version_compare(version, '3.15.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proxyman' AND publisher = 'Proxyman LLC' AND version_compare(version, '3.16.0') < 0);"
       },
-      "installer_url": "https://assets.proxyman.com/windows/3.15.0/build/Proxyman%20Setup%203.15.0.exe",
+      "installer_url": "https://assets.proxyman.com/windows/3.16.0/build/Proxyman%20Setup%203.16.0.exe",
       "install_script_ref": "46c673e8",
       "uninstall_script_ref": "d1d99ad9",
-      "sha256": "b9deac46b34313bf896f3b76e99a88d44e82be1627d1a085deceac16a0f6d142",
+      "sha256": "fa25ae25eaaaf72a76c11bdc13b8de3a4a5b7dda2df268b067ee6c482ee3ca7c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rustrover/darwin.json
+++ b/ee/maintained-apps/outputs/rustrover/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/rustrover/RustRover-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/rustrover/RustRover-2026.1.4-aarch64.dmg",
       "install_script_ref": "250e5b10",
       "uninstall_script_ref": "bfcf7fb3",
-      "sha256": "9dd8a9313cedad8794768e0c7ce1e32479379621eeb5698c8fe27a1bcc63b560",
+      "sha256": "1e5cb8341bfd9a0fd1326c4233a9bdc39792fc243bc9cc69ed5d95419c321901",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.23.6",
+      "version": "2.24.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.23.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.24.1') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.23.6.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.24.1.dmg",
       "install_script_ref": "5f8295ce",
       "uninstall_script_ref": "a5d6883d",
-      "sha256": "90fda3e334e121edc9fe3728e4731706a10eafc396cb815a263a3879bbeb084d",
+      "sha256": "ee93ac489152e9ae763c82357c456f6f14aa9aa826d5906f242321f6a3b9dafc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spotify/windows.json
+++ b/ee/maintained-apps/outputs/spotify/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.92.148.g882cc571",
+      "version": "1.2.93.667.g7b5cc0ce",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB' AND version_compare(version, '1.2.92.148.g882cc571') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB' AND version_compare(version, '1.2.93.667.g7b5cc0ce') < 0);"
       },
       "installer_url": "https://download.scdn.co/SpotifyFullSetupX64.exe",
       "install_script_ref": "7e4727ac",
       "uninstall_script_ref": "48d55e3d",
-      "sha256": "2cd6bb280e9728b27b12044e4a277f7754145287882fb112e8bb495726fff616",
+      "sha256": "614741858a7def3fb21da385312fe7b114dd2873f6d79fb3d980a979af560ba0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/surfshark/darwin.json
+++ b/ee/maintained-apps/outputs/surfshark/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.28.0",
+      "version": "4.28.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct' AND version_compare(bundle_short_version, '4.28.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct' AND version_compare(bundle_short_version, '4.28.1') < 0);"
       },
-      "installer_url": "https://downloads.surfshark.com/macOS/stable/4.28.0/4370/Surfshark.dmg",
+      "installer_url": "https://downloads.surfshark.com/macOS/stable/4.28.1/4373/Surfshark.dmg",
       "install_script_ref": "7a06e80c",
       "uninstall_script_ref": "4f050417",
-      "sha256": "62d09a025a8cf3da97f32f9fa4d9986fe2860d6d0520407e5a9c29988576b32e",
+      "sha256": "19e25c9886717646a5047cbd283c300c0002c5c102d3970177a451734952ae71",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/vivaldi/darwin.json
+++ b/ee/maintained-apps/outputs/vivaldi/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "8.0.4033.54",
+      "version": "8.0.4033.57",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi' AND version_compare(bundle_short_version, '8.0.4033.54') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi' AND version_compare(bundle_short_version, '8.0.4033.57') < 0);"
       },
-      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.0.4033.54.universal.dmg",
+      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.0.4033.57.universal.dmg",
       "install_script_ref": "6a60dca7",
       "uninstall_script_ref": "7c1876ca",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.06.24.09.19.03",
+      "version": "0.2026.07.01.09.21.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.06.24.09.19.03') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.01.09.21.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.06.24.09.19.stable_03/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.01.09.21.stable_01/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/yacreader/darwin.json
+++ b/ee/maintained-apps/outputs/yacreader/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "10.0.0.260501214",
+      "version": "10.1.0.260703260",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.yacreader.YACReader';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.yacreader.YACReader' AND version_compare(bundle_short_version, '10.0.0.260501214') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.yacreader.YACReader' AND version_compare(bundle_short_version, '10.1.0.260703260') < 0);"
       },
-      "installer_url": "https://github.com/YACReader/yacreader/releases/download/10.0.0/YACReader-10.0.0.260501214.MacOSX-U.Qt6.dmg",
+      "installer_url": "https://github.com/YACReader/yacreader/releases/download/10.1.0/YACReader-10.1.0.260703260.MacOSX-U.Qt6.dmg",
       "install_script_ref": "390de351",
       "uninstall_script_ref": "3ff4171c",
-      "sha256": "41db0506e405bab7ff1ae0ec209cb06b858823cdadcb34967208532d827a7bf5",
+      "sha256": "ae1b1886987b6f7e3af84cf9c155f69804f801cb6b51f0383708257e230ae71f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zappy/darwin.json
+++ b/ee/maintained-apps/outputs/zappy/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.9.8",
+      "version": "4.9.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.blackbeltlabs.Zappy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.blackbeltlabs.Zappy' AND version_compare(bundle_short_version, '4.9.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.blackbeltlabs.Zappy' AND version_compare(bundle_short_version, '4.9.9') < 0);"
       },
-      "installer_url": "https://zappy.zapier.com/releases/zappy-4.9.8.dmg",
+      "installer_url": "https://zappy.zapier.com/releases/zappy-4.9.9.dmg",
       "install_script_ref": "5aa8d307",
       "uninstall_script_ref": "b8dddbb7",
-      "sha256": "baed6731bb88adf1913d243abbfca0e265ae951fefac53cb5d58b221c3fc56f0",
+      "sha256": "e7b323657c331f58fe740370ad8274d52c50296dfe78017572adc594f515403a",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated availability metadata for multiple apps on macOS and Windows, including AltTab, Aptakube, CodexBar, Deezer, Egnyte, Free Download Manager, Home Assistant, Mountain Duck, Opera, Proxyman, RustRover, Spokenly, Spotify, Surfshark, Vivaldi, Warp, YACReader, and Zappy.
  * These entries now point to the latest released installers and version checks, helping keep app update status accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->