### PR TITLE
Fix live results error page from browser auto-translate (#48277)

### DIFF
--- a/changes/fix-48277-live-results-translate-crash
+++ b/changes/fix-48277-live-results-translate-crash
@@ -1,0 +1,1 @@
+* Fixed Google Translate extension causing a 500-page when running live reports.

--- a/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
@@ -238,7 +238,11 @@ const PolicyResults = ({
   });
 
   return (
-    <div className={baseClass}>
+    // `notranslate`: Chrome's auto-translate wraps text nodes in <font> elements,
+    // detaching nodes React holds refs to. As live results stream in and cells
+    // unmount, React's removeChild throws NotFoundError and error-boundaries the
+    // page (#48277). Excluding this streaming subtree from translation avoids it.
+    <div className={`${baseClass} notranslate`}>
       <LiveResultsHeading
         numHostsTargeted={targetsTotalCount}
         numHostsResponded={uiHostCounts.total}

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -273,7 +273,11 @@ const QueryResults = ({
   });
 
   return (
-    <div className={baseClass}>
+    // `notranslate`: Chrome's auto-translate wraps text nodes in <font> elements,
+    // detaching nodes React holds refs to. As live results stream in and cells
+    // unmount, React's removeChild throws NotFoundError and error-boundaries the
+    // page (#48277). Excluding this streaming subtree from translation avoids it.
+    <div className={`${baseClass} notranslate`}>
       <LiveResultsHeading
         numHostsTargeted={targetsTotalCount}
         numHostsResponded={uiHostCounts.total}


### PR DESCRIPTION
**Related issue:** Resolves #48277

## What & why

Running a live report/query (or live policy) on some machines throws a full error page once results start streaming in:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

**Root cause:** Chrome's built-in auto-translate (Google Translate) wraps text nodes in `<font>` elements, detaching the original DOM nodes React holds references to. As live results stream in over the websocket, table cells (and the responded-count heading) unmount rapidly; React then calls `parentNode.removeChild(node)` on a node Translate has already moved, throwing `NotFoundError`. The app's error boundary catches it and renders the error page (facebook/react#11538).

This is why it's machine-dependent: it only reproduces when Chrome is translating the page. It surfaces on live results specifically because that's one of the few surfaces that unmounts DOM rapidly while displaying translatable text.

**Fix:** Exclude the live-results subtrees from translation via the `notranslate` class on the top-level containers of `QueryResults` (live report/query) and `PolicyResults` (live policy). These wrappers cover the `LiveResultsHeading` counts, the results table, and (policy) the errors table. Translation stays enabled everywhere else in the app.

## How to reproduce / QA

1. In Chrome, enable translation of the live results page (right-click → Translate to English, or set a non-English preferred language so the Translate banner activates and choose "Always translate").
2. Run a live query/report or live policy targeting several hosts so results stream in.
3. Before the fix: error page appears after a few results. After the fix: results render normally.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented browser auto-translation from modifying live results areas in the policy and query editors.
  * Reduces the chance of display errors during live streaming/remounting of results.
  * Addressed a related Google Translate browser extension issue that could lead to incorrect live-run behavior.
* **Chores**
  * Added a changelog entry for the live results translation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->