### PR TITLE
Multiple packages: install-time precedence and setup experience

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1404,6 +1404,60 @@ func (svc *Service) getSoftwareInstallerBinary(ctx context.Context, storageID st
 	}, nil
 }
 
+// resolveFirstAddedInScopeInstaller returns the first-added (smallest installer_id) package of the
+// title that host is in label scope for — and, when requireSelfService is set, that is self-service
+// enabled. This is the install-time precedence rule now that a title can hold multiple packages:
+// admins scope labels to avoid overlap, but when a host still matches more than one package Fleet
+// installs the first-added one. anyPackages reports whether the title has any active packages at all,
+// so callers can distinguish "no package for this title" (fall through to VPP/in-house) from
+// "packages exist but none is a match for this host" (reject).
+func (svc *Service) resolveFirstAddedInScopeInstaller(ctx context.Context, host *fleet.Host, titleID uint, requireSelfService bool) (installer *fleet.SoftwareInstaller, anyPackages bool, err error) {
+	pkgs, err := svc.ds.GetSoftwarePackagesByTeamAndTitleID(ctx, host.TeamID, titleID)
+	if err != nil {
+		return nil, false, ctxerr.Wrap(ctx, err, "listing packages for install precedence")
+	}
+	anyPackages = len(pkgs) > 0
+
+	// pkgs are ordered installer_id ASC (first-added first). Prefer the first-added package the host
+	// can actually install (in scope and platform-compatible). Keep the first-added in-scope package
+	// of any platform as a fallback so a cross-platform title with no compatible package still hits
+	// the downstream platform error (matching single-package behavior).
+	var fallback *fleet.SoftwareInstaller
+	for _, pkg := range pkgs {
+		if requireSelfService && !pkg.SelfService {
+			continue
+		}
+		scoped, err := svc.ds.IsSoftwareInstallerLabelScoped(ctx, pkg.InstallerID, host.ID)
+		if err != nil {
+			return nil, anyPackages, ctxerr.Wrap(ctx, err, "checking label scoping during software install attempt")
+		}
+		if !scoped {
+			continue
+		}
+		if fallback == nil {
+			fallback = pkg
+		}
+		if installerCompatibleWithHost(pkg, host) {
+			return pkg, anyPackages, nil
+		}
+	}
+
+	return fallback, anyPackages, nil
+}
+
+// installerCompatibleWithHost reports whether the installer's package can run on the host's platform.
+// Mirrors the platform gate in installSoftwareTitleUsingInstaller (.sh runs on any unix-like host).
+func installerCompatibleWithHost(installer *fleet.SoftwareInstaller, host *fleet.Host) bool {
+	ext, requiredPlatform := installerRequiredPlatform(installer)
+	if requiredPlatform == "" {
+		return false
+	}
+	if host.FleetPlatform() == requiredPlatform {
+		return true
+	}
+	return ext == ".sh" && fleet.IsUnixLike(host.Platform)
+}
+
 func (svc *Service) InstallSoftwareTitle(ctx context.Context, hostID uint, softwareTitleID uint) error {
 	// we need to use ds.Host because ds.HostLite doesn't return the orbit
 	// node key
@@ -1472,28 +1526,22 @@ func (svc *Service) InstallSoftwareTitle(ctx context.Context, hostID uint, softw
 	}
 
 	if !mobileAppleDevice {
-		installer, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, host.TeamID, softwareTitleID, false)
+		// Resolve the first-added package the host is in label scope for (first-added-wins when the
+		// host matches more than one package of the title).
+		installer, anyPackages, err := svc.resolveFirstAddedInScopeInstaller(ctx, host, softwareTitleID, false)
 		if err != nil {
-			if !fleet.IsNotFound(err) {
-				return ctxerr.Wrap(ctx, err, "finding software installer for title")
-			}
-			installer = nil
+			return err
 		}
 
-		// if we found an installer, use that
+		// The title has packages but the host isn't in scope for any of them.
+		if installer == nil && anyPackages {
+			return &fleet.BadRequestError{
+				Message: "Couldn't install. Host isn't member of the labels defined for this software title.",
+			}
+		}
+
+		// if we resolved an installer, use that
 		if installer != nil {
-			// check the label scoping for this installer and host
-			scoped, err := svc.ds.IsSoftwareInstallerLabelScoped(ctx, installer.InstallerID, hostID)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "checking label scoping during software install attempt")
-			}
-
-			if !scoped {
-				return &fleet.BadRequestError{
-					Message: "Couldn't install. Host isn't member of the labels defined for this software title.",
-				}
-			}
-
 			lastInstallRequest, err := svc.ds.GetHostLastInstallData(ctx, host.ID, installer.InstallerID)
 			if err != nil {
 				return ctxerr.Wrapf(ctx, err, "getting last install data for host %d and installer %d", host.ID, installer.InstallerID)
@@ -3585,16 +3633,22 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 	// self-service. The downstream VPP install flow handles user-scoped
 	// licensing via clientUserIds. End-to-end success still depends on the
 	// main install-gate removal landing (#31138 subtask 01).
-	installer, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, host.TeamID, softwareTitleID, false)
+	// Resolve the first-added self-service package the host is in label scope for (first-added-wins
+	// when the host matches more than one self-service package of the title).
+	installer, anyPackages, err := svc.resolveFirstAddedInScopeInstaller(ctx, host, softwareTitleID, true)
 	if err != nil {
-		if !fleet.IsNotFound(err) {
-			return ctxerr.Wrap(ctx, err, "finding software installer for title")
-		}
-		installer = nil
+		return err
 	}
 
-	if installer != nil {
-		if !installer.SelfService {
+	if installer == nil && anyPackages {
+		// The title has packages but none is available to this host through self-service. Distinguish
+		// "in scope but not self-service enabled" from "not a label member" to preserve the existing
+		// error messages.
+		inScopeInstaller, _, err := svc.resolveFirstAddedInScopeInstaller(ctx, host, softwareTitleID, false)
+		if err != nil {
+			return err
+		}
+		if inScopeInstaller != nil {
 			return &fleet.BadRequestError{
 				Message: "Software title is not available through self-service",
 				InternalErr: ctxerr.NewWithData(
@@ -3603,18 +3657,12 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 				),
 			}
 		}
-
-		scoped, err := svc.ds.IsSoftwareInstallerLabelScoped(ctx, installer.InstallerID, host.ID)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "checking label scoping during software install attempt")
+		return &fleet.BadRequestError{
+			Message: "Couldn't install. Host isn't member of the labels defined for this software title.",
 		}
+	}
 
-		if !scoped {
-			return &fleet.BadRequestError{
-				Message: "Couldn't install. Host isn't member of the labels defined for this software title.",
-			}
-		}
-
+	if installer != nil {
 		ext, requiredPlatform := installerRequiredPlatform(installer)
 		if requiredPlatform == "" {
 			// this should never happen

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -261,6 +261,7 @@ func TestInstallUninstallAuth(t *testing.T) {
 			TeamID:   ptr.Uint(1),
 		}, nil
 	}
+	mockSoftwarePackagesFromMetadata(ds)
 	ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID uint, installerID uint) (*fleet.HostLastInstallData, error) {
 		return nil, nil
 	}
@@ -726,6 +727,19 @@ func newTestService(t *testing.T, ds fleet.Datastore) *Service {
 	return svc
 }
 
+// mockSoftwarePackagesFromMetadata wires GetSoftwarePackagesByTeamAndTitleID (used by the install
+// precedence resolver) to return the single installer that GetSoftwareInstallerMetadataByTeamAndTitleID
+// yields, so install-path unit tests keep their installer defined in one place.
+func mockSoftwarePackagesFromMetadata(ds *mock.Store) {
+	ds.GetSoftwarePackagesByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) ([]*fleet.SoftwareInstaller, error) {
+		si, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, teamID, titleID, false)
+		if err != nil {
+			return nil, err
+		}
+		return []*fleet.SoftwareInstaller{si}, nil
+	}
+}
+
 func newTestServiceWithMock(t *testing.T, ds fleet.Datastore) (*Service, *svcmock.Service) {
 	t.Helper()
 	authorizer, err := authz.NewAuthorizer()
@@ -986,6 +1000,7 @@ func TestInstallShScriptOnDarwin(t *testing.T) {
 			SelfService: false,
 		}, nil
 	}
+	mockSoftwarePackagesFromMetadata(ds)
 
 	// Label scoping check passes
 	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
@@ -1049,6 +1064,7 @@ func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {
 			SelfService: false,
 		}, nil
 	}
+	mockSoftwarePackagesFromMetadata(ds)
 
 	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
 		return true, nil
@@ -1145,6 +1161,7 @@ func TestSelfServiceInstallZipInstallerUsesStoredPlatform(t *testing.T) {
 			SelfService: true,
 		}, nil
 	}
+	mockSoftwarePackagesFromMetadata(ds)
 
 	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
 		return true, nil
@@ -1203,6 +1220,7 @@ func TestInstallShScriptOnWindowsFails(t *testing.T) {
 			SelfService: false,
 		}, nil
 	}
+	mockSoftwarePackagesFromMetadata(ds)
 
 	// Label scoping check passes
 	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
@@ -1241,6 +1259,11 @@ func TestSelfServiceInstallSoftwareTitleAllowsPersonallyEnrolledDevices(t *testi
 	// got past the old gate without entangling this test in the install flow.
 	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(_ context.Context, _ *uint, _ uint, _ bool) (*fleet.SoftwareInstaller, error) {
 		return nil, &notFoundError{}
+	}
+	// The title has no packages, so the precedence resolver returns none and the flow falls through
+	// to the VPP/in-house lookups (both not found) — the same "not available" path as before.
+	ds.GetSoftwarePackagesByTeamAndTitleIDFunc = func(_ context.Context, _ *uint, _ uint) ([]*fleet.SoftwareInstaller, error) {
+		return nil, nil
 	}
 	ds.GetVPPAppByTeamAndTitleIDFunc = func(_ context.Context, _ *uint, _ uint) (*fleet.VPPApp, error) {
 		return nil, &notFoundError{}
@@ -1584,6 +1607,14 @@ func TestSelfServiceInstallAllSoftwareTitles(t *testing.T) {
 				return nil, fail.installTitle
 			}
 			return &fleet.SoftwareInstaller{InstallerID: 1, SelfService: true, Name: "foo.pkg"}, nil
+		}
+		// The per-title self-service install now resolves the package via the precedence resolver,
+		// so the per-title failure injection lives on this read.
+		ds.GetSoftwarePackagesByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) ([]*fleet.SoftwareInstaller, error) {
+			if fail.installTitle != nil {
+				return nil, fail.installTitle
+			}
+			return []*fleet.SoftwareInstaller{{InstallerID: 1, SelfService: true, Name: "foo.pkg"}}, nil
 		}
 		ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID uint, hostID uint) (bool, error) {
 			return true, nil

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1588,13 +1588,19 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 			SoftwareInstallerID *uint `db:"si_id"`
 			VPPAppsTeamsID      *uint `db:"vat_id"`
 		}
+		// A title can hold several active packages; pin the policy to the first-added one
+		// (smallest installer_id) so GitOps re-links deterministically to the first-added-wins
+		// package. si_id IS NULL orders the VPP branch last (a title is single-regime, so only
+		// one branch returns rows).
 		err := sqlx.GetContext(ctx, queryerContext, &ids,
 			`SELECT id si_id, NULL vat_id FROM software_installers
 				WHERE global_or_team_id = ? AND title_id = ? AND is_active = 1
 				UNION
 				SELECT NULL si_id, vat.id vat_id FROM vpp_apps_teams vat
 				JOIN vpp_apps va ON va.adam_id = vat.adam_id AND va.platform = vat.platform
-				WHERE global_or_team_id = ? AND title_id = ?`,
+				WHERE global_or_team_id = ? AND title_id = ?
+				ORDER BY si_id IS NULL, si_id ASC
+				LIMIT 1`,
 			teamNameToID[spec.Team], spec.SoftwareTitleID, teamNameToID[spec.Team], spec.SoftwareTitleID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -75,6 +75,7 @@ func TestPolicies(t *testing.T) {
 		{"TestPoliciesTeamPoliciesWithInstaller", testTeamPoliciesWithInstaller},
 		{"TestPoliciesTeamPoliciesWithVPP", testTeamPoliciesWithVPP},
 		{"ApplyPolicySpecWithInstallers", testApplyPolicySpecWithInstallers},
+		{"ApplyPolicySpecFirstAddedInstaller", testApplyPolicySpecFirstAddedInstaller},
 		{"TestPoliciesNewGlobalPolicyWithScript", testNewGlobalPolicyWithScript},
 		{"TestPoliciesTeamPoliciesWithScript", testTeamPoliciesWithScript},
 		{"TeamPoliciesNoTeam", testTeamPoliciesNoTeam},
@@ -8821,4 +8822,55 @@ func testResetPolicy(t *testing.T, ds *Datastore) {
 			`SELECT attempt_number FROM host_script_results WHERE execution_id = 'other-script-1'`)
 	})
 	require.Equal(t, 3, attemptNum, "other policy attempt_number must be untouched")
+}
+
+// testApplyPolicySpecFirstAddedInstaller verifies that GitOps policy application resolves a title with
+// multiple active packages to the first-added package (smallest installer_id) deterministically.
+func testApplyPolicySpecFirstAddedInstaller(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Spec First Added", "spec-first-added@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "spec-first-added-team"})
+	require.NoError(t, err)
+
+	var titleID uint
+	newPkg := func(storage, filename string) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello-"+storage), t.TempDir)
+		require.NoError(t, err)
+		id, tID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         filename,
+			Title:            "SpecMultiPkg",
+			Version:          "1.0",
+			Source:           "apps",
+			BundleIdentifier: "com.example.specmultipkg",
+			UserID:           user.ID,
+			TeamID:           &team.ID,
+			Platform:         "darwin",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+		titleID = tID
+		return id
+	}
+	installerA := newPkg("spec-a", "pkgA.pkg")
+	installerB := newPkg("spec-b", "pkgB.pkg")
+	require.Less(t, installerA, installerB)
+
+	err = ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{
+		{
+			Name:            "spec multi-package policy",
+			Query:           "SELECT 1;",
+			Team:            team.Name,
+			SoftwareTitleID: &titleID,
+		},
+	})
+	require.NoError(t, err)
+
+	policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "")
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	require.NotNil(t, policies[0].SoftwareInstallerID)
+	require.Equal(t, installerA, *policies[0].SoftwareInstallerID, "GitOps must resolve to the first-added package")
 }

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -210,7 +210,8 @@ SELECT
 		FROM policies p
 		WHERE p.software_installer_id = si.id
 		AND ? IN ('windows', 'linux')) AS policy_gated,
-	COALESCE(stdn.display_name, st.name) AS sort_name
+	COALESCE(stdn.display_name, st.name) AS sort_name,
+	st.id AS software_title_id
 FROM software_installers si
 INNER JOIN software_titles st
 	ON si.title_id = st.id
@@ -267,7 +268,8 @@ SELECT
 	si.id AS software_installer_id,
 	NULL AS vpp_app_team_id,
 	FALSE AS policy_gated,
-	COALESCE(stdn.display_name, st.name) AS sort_name
+	COALESCE(stdn.display_name, st.name) AS sort_name,
+	st.id AS software_title_id
 FROM software_installers si
 INNER JOIN software_titles st
 	ON si.title_id = st.id
@@ -302,7 +304,8 @@ SELECT
 	NULL AS software_installer_id,
 	vat.id AS vpp_app_team_id,
 	FALSE AS policy_gated,
-	COALESCE(stdn.display_name, st.name) AS sort_name
+	COALESCE(stdn.display_name, st.name) AS sort_name,
+	st.id AS software_title_id
 FROM vpp_apps va
 INNER JOIN vpp_apps_teams vat
 	ON vat.adam_id = va.adam_id
@@ -329,6 +332,9 @@ AND %s`
 
 	var stmtSoftwareCombined string
 	if len(softwareUnionParts) > 0 {
+		// A title can now hold several packages, and more than one can be flagged for setup. Queue only
+		// the first-added (smallest installer_id) package per title so setup doesn't double-queue; labels
+		// don't apply during setup. VPP apps are single-package per title, so they pass through untouched.
 		stmtSoftwareCombined = fmt.Sprintf(`
 INSERT INTO setup_experience_status_results (
 	host_uuid,
@@ -339,8 +345,14 @@ INSERT INTO setup_experience_status_results (
 	policy_gated
 )
 SELECT host_uuid, name, status, software_installer_id, vpp_app_team_id, policy_gated FROM (
-	%s
-) AS combined
+	SELECT combined.*, ROW_NUMBER() OVER (
+		PARTITION BY software_title_id
+		ORDER BY (software_installer_id IS NULL), software_installer_id ASC
+	) AS first_added_rank FROM (
+		%s
+	) AS combined
+) AS deduped
+WHERE software_installer_id IS NULL OR first_added_rank = 1
 ORDER BY sort_name ASC, COALESCE(software_installer_id, vpp_app_team_id, 0)`, strings.Join(softwareUnionParts, " UNION ALL "))
 	}
 

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -41,6 +41,7 @@ func TestSetupExperience(t *testing.T) {
 		{"PolicyGate", testSetupExperiencePolicyGate},
 		{"PolicyGateResultLookups", testSetupExperiencePolicyGateResultLookups},
 		{"CrossPlatformShScripts", testSetupExperienceCrossPlatformShScripts},
+		{"FirstAddedPerTitleNoDoubleQueue", testEnqueueSetupExperienceFirstAddedPerTitle},
 	}
 
 	for _, c := range cases {
@@ -2742,4 +2743,79 @@ func testSetupExperienceCrossPlatformShScripts(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		assert.False(t, enrolled)
 	})
+}
+
+// testEnqueueSetupExperienceFirstAddedPerTitle verifies that when a title has more than one active
+// package flagged for setup experience, only the first-added package is queued (no double-queue).
+func testEnqueueSetupExperienceFirstAddedPerTitle(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "se-multi-pkg"})
+	require.NoError(t, err)
+	user := test.NewUser(t, ds, "SE Admin", "se-admin@example.com", true)
+
+	newPkg := func(storage, filename string) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
+		require.NoError(t, err)
+		id, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         filename,
+			Title:            "MultiPkgTitle",
+			Version:          "1.0",
+			Source:           "apps",
+			BundleIdentifier: "com.example.multipkg",
+			UserID:           user.ID,
+			TeamID:           &team.ID,
+			Platform:         string(fleet.MacOSPlatform),
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+		return id
+	}
+
+	// Two packages under the same title (same bundle id, different content hash), both flagged for setup.
+	firstAddedID := newPkg("storage-a", "pkgA.pkg")
+	secondID := newPkg("storage-b", "pkgB.pkg")
+	require.Less(t, firstAddedID, secondID)
+
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, "UPDATE software_installers SET install_during_setup = 1 WHERE id IN (?, ?)", firstAddedID, secondID)
+		return err
+	})
+
+	hostUUID := "multi-pkg-host"
+	_, err = ds.NewHost(ctx, &fleet.Host{
+		Hostname:       "macos-multi-pkg",
+		OsqueryHostID:  new("osquery-multi-pkg"),
+		NodeKey:        new("node-key-multi-pkg"),
+		UUID:           hostUUID,
+		Platform:       "darwin",
+		HardwareSerial: "multi-pkg-serial",
+	})
+	require.NoError(t, err)
+
+	assertSinglePackageQueued := func() {
+		results, err := ds.ListSetupExperienceResultsByHostUUID(ctx, hostUUID, team.ID)
+		require.NoError(t, err)
+		var installerResults []*fleet.SetupExperienceStatusResult
+		for _, r := range results {
+			if r.SoftwareInstallerID != nil {
+				installerResults = append(installerResults, r)
+			}
+		}
+		require.Len(t, installerResults, 1, "a multi-package title should queue exactly one package during setup")
+		require.Equal(t, firstAddedID, *installerResults[0].SoftwareInstallerID, "the first-added package should be queued")
+	}
+
+	enqueued, err := ds.EnqueueSetupExperienceItems(ctx, "darwin", "darwin", hostUUID, team.ID)
+	require.NoError(t, err)
+	require.True(t, enqueued)
+	assertSinglePackageQueued()
+
+	// Re-enqueue stays a single row (idempotent, still no double-queue).
+	enqueued, err = ds.EnqueueSetupExperienceItems(ctx, "darwin", "darwin", hostUUID, team.ID)
+	require.NoError(t, err)
+	require.True(t, enqueued)
+	assertSinglePackageQueued()
 }

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3652,6 +3652,13 @@ func hostSoftwareInstalls(ds *Datastore, ctx context.Context, hostID uint) ([]*h
 			software_installers ON software_installers.title_id = recorded_si.title_id
 				AND software_installers.global_or_team_id = recorded_si.global_or_team_id
 				AND software_installers.is_active = 1
+				-- collapse to the first-added active package so multiple active packages don't fan out rows
+				AND software_installers.id = (
+					SELECT MIN(si_first.id) FROM software_installers si_first
+					WHERE si_first.title_id = recorded_si.title_id
+						AND si_first.global_or_team_id = recorded_si.global_or_team_id
+						AND si_first.is_active = 1
+				)
     `
 	var softwareInstalls []*hostSoftware
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &softwareInstalls, softwareInstallsStmt, hostID, hostID)
@@ -3738,6 +3745,13 @@ func hostSoftwareUninstalls(ds *Datastore, ctx context.Context, hostID uint) ([]
 			software_installers ON software_installers.title_id = recorded_si.title_id
 				AND software_installers.global_or_team_id = recorded_si.global_or_team_id
 				AND software_installers.is_active = 1
+				-- collapse to the first-added active package so multiple active packages don't fan out rows
+				AND software_installers.id = (
+					SELECT MIN(si_first.id) FROM software_installers si_first
+					WHERE si_first.title_id = recorded_si.title_id
+						AND si_first.global_or_team_id = recorded_si.global_or_team_id
+						AND si_first.is_active = 1
+				)
 		LEFT OUTER JOIN
 			host_script_results ON host_script_results.host_id = ? AND host_script_results.execution_id = lsua.last_uninstall_script_execution_id
     `
@@ -3750,172 +3764,268 @@ func hostSoftwareUninstalls(ds *Datastore, ctx context.Context, hostID uint) ([]
 	return softwareUninstalls, nil
 }
 
+// resolvedInstaller is the package the host software read should display and act on for a title.
+type resolvedInstaller struct {
+	ID          uint
+	SelfService bool
+}
+
+// resolveFirstAddedInstallersForHost resolves, for each of the given titles, the package to display
+// and install for this host: the first-added (smallest installer_id) active package the host is in
+// label scope for. When the host is in scope for no package of a title, it falls back to the
+// first-added active package so the display stays deterministic. inScope holds the titles for which
+// the host is in scope for at least one package (those the title is actually available to install
+// on). This is the read-side counterpart of the service-layer install precedence resolver, so the
+// list, the install, and policy defaults all point at the same package.
+func (ds *Datastore) resolveFirstAddedInstallersForHost(ctx context.Context, host *fleet.Host, titleIDs []uint) (resolved map[uint]resolvedInstaller, inScope map[uint]struct{}, err error) {
+	resolved = make(map[uint]resolvedInstaller, len(titleIDs))
+	inScope = make(map[uint]struct{}, len(titleIDs))
+	if len(titleIDs) == 0 {
+		return resolved, inScope, nil
+	}
+
+	globalOrTeamID := ptr.ValOrZero(host.TeamID)
+
+	// The four label-scope CTEs are the same ones used to gate a single installer; here they run
+	// over every active package of the titles so a title isn't hidden just because its first-added
+	// package is out of scope while a sibling is in scope (e.g. an Intel host and an Arm-first title).
+	stmt := `
+		WITH no_labels AS (
+			SELECT
+				software_installers.id AS installer_id,
+				0 AS count_installer_labels,
+				0 AS count_host_labels,
+				0 AS count_host_updated_after_labels
+			FROM
+				software_installers
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM software_installer_labels
+				WHERE software_installer_labels.software_installer_id = software_installers.id
+			)
+		),
+		include_any AS (
+			SELECT
+				software_installers.id AS installer_id,
+				COUNT(*) AS count_installer_labels,
+				COUNT(label_membership.label_id) AS count_host_labels,
+				0 AS count_host_updated_after_labels
+			FROM
+				software_installers
+			INNER JOIN software_installer_labels
+				ON software_installer_labels.software_installer_id = software_installers.id
+					AND software_installer_labels.exclude = 0
+					AND software_installer_labels.require_all = 0
+			LEFT JOIN label_membership
+				ON label_membership.label_id = software_installer_labels.label_id
+				AND label_membership.host_id = :host_id
+			GROUP BY
+				software_installers.id
+			HAVING
+				count_installer_labels > 0 AND count_host_labels > 0
+		),
+		exclude_any AS (
+			SELECT
+				software_installers.id AS installer_id,
+				COUNT(software_installer_labels.label_id) AS count_installer_labels,
+				COUNT(label_membership.label_id) AS count_host_labels,
+				SUM(
+					CASE
+						WHEN labels.created_at IS NOT NULL AND (
+							labels.label_membership_type = 1 OR
+							(labels.label_membership_type = 0 AND :host_label_updated_at >= labels.created_at)
+						) THEN 1
+						ELSE 0
+					END
+				) AS count_host_updated_after_labels
+			FROM
+				software_installers
+			INNER JOIN software_installer_labels
+				ON software_installer_labels.software_installer_id = software_installers.id
+					AND software_installer_labels.exclude = 1
+					AND software_installer_labels.require_all = 0
+			INNER JOIN labels
+				ON labels.id = software_installer_labels.label_id
+			LEFT JOIN label_membership
+				ON label_membership.label_id = software_installer_labels.label_id
+				AND label_membership.host_id = :host_id
+			GROUP BY
+				software_installers.id
+			HAVING
+				count_installer_labels > 0
+				AND count_installer_labels = count_host_updated_after_labels
+				AND count_host_labels = 0
+		),
+		include_all AS (
+			SELECT
+				software_installers.id AS installer_id,
+				COUNT(*) AS count_installer_labels,
+				COUNT(label_membership.label_id) AS count_host_labels,
+				0 AS count_host_updated_after_labels
+			FROM
+				software_installers
+			INNER JOIN software_installer_labels
+				ON software_installer_labels.software_installer_id = software_installers.id
+					AND software_installer_labels.exclude = 0
+					AND software_installer_labels.require_all = 1
+			LEFT JOIN label_membership
+				ON label_membership.label_id = software_installer_labels.label_id
+				AND label_membership.host_id = :host_id
+			GROUP BY
+				software_installers.id
+			HAVING
+				count_installer_labels > 0
+				AND count_host_labels = count_installer_labels
+		)
+		SELECT
+			software_installers.id AS installer_id,
+			software_installers.title_id AS title_id,
+			software_installers.self_service AS self_service,
+			software_installers.platform AS platform,
+			software_installers.extension AS extension,
+			(
+				no_labels.installer_id IS NOT NULL
+				OR include_any.installer_id IS NOT NULL
+				OR exclude_any.installer_id IS NOT NULL
+				OR include_all.installer_id IS NOT NULL
+			) AS in_scope
+		FROM
+			software_installers
+		LEFT JOIN no_labels
+			ON no_labels.installer_id = software_installers.id
+		LEFT JOIN include_any
+			ON include_any.installer_id = software_installers.id
+		LEFT JOIN exclude_any
+			ON exclude_any.installer_id = software_installers.id
+		LEFT JOIN include_all
+			ON include_all.installer_id = software_installers.id
+		WHERE
+			software_installers.global_or_team_id = :global_or_team_id
+			AND software_installers.is_active = 1
+			AND software_installers.title_id IN (:title_ids)
+		ORDER BY software_installers.title_id ASC, software_installers.id ASC
+	`
+
+	stmt, args, err := sqlx.Named(stmt, map[string]any{
+		"host_id":               host.ID,
+		"host_label_updated_at": host.LabelUpdatedAt,
+		"global_or_team_id":     globalOrTeamID,
+		"title_ids":             titleIDs,
+	})
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "resolveFirstAddedInstallersForHost building named query args")
+	}
+	stmt, args, err = sqlx.In(stmt, args...)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "resolveFirstAddedInstallersForHost building in query args")
+	}
+	stmt = ds.reader(ctx).Rebind(stmt)
+
+	var rows []struct {
+		InstallerID uint   `db:"installer_id"`
+		TitleID     uint   `db:"title_id"`
+		SelfService bool   `db:"self_service"`
+		Platform    string `db:"platform"`
+		Extension   string `db:"extension"`
+		InScope     bool   `db:"in_scope"`
+	}
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...); err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "resolveFirstAddedInstallersForHost executing query")
+	}
+
+	hostPlatform := host.FleetPlatform()
+	// Per title, rank candidate packages so the resolved (displayed/installed) package matches what the
+	// install path would pick: platform-compatible + in-scope first, then in-scope, then compatible,
+	// then any active package (a deterministic fallback so display never goes empty). Rows are ordered
+	// installer_id ASC, so within each tier the first-added package wins. inScope marks titles the host
+	// is label-in-scope for (independent of platform, matching the prior label-only availability gate).
+	type candidate struct {
+		both, inScopeAny, compatAny, any *resolvedInstaller
+	}
+	byTitle := make(map[uint]*candidate, len(titleIDs))
+	for _, r := range rows {
+		compat := r.Platform == hostPlatform || (r.Extension == "sh" && r.Platform == "linux" && fleet.IsUnixLike(host.Platform))
+		pkg := resolvedInstaller{ID: r.InstallerID, SelfService: r.SelfService}
+		c := byTitle[r.TitleID]
+		if c == nil {
+			c = &candidate{}
+			byTitle[r.TitleID] = c
+		}
+		if c.any == nil {
+			c.any = &pkg
+		}
+		if compat && c.compatAny == nil {
+			c.compatAny = &pkg
+		}
+		if r.InScope {
+			inScope[r.TitleID] = struct{}{}
+			if c.inScopeAny == nil {
+				c.inScopeAny = &pkg
+			}
+			if compat && c.both == nil {
+				c.both = &pkg
+			}
+		}
+	}
+
+	for titleID, c := range byTitle {
+		switch {
+		case c.both != nil:
+			resolved[titleID] = *c.both
+		case c.inScopeAny != nil:
+			resolved[titleID] = *c.inScopeAny
+		case c.compatAny != nil:
+			resolved[titleID] = *c.compatAny
+		default:
+			resolved[titleID] = *c.any
+		}
+	}
+
+	return resolved, inScope, nil
+}
+
 func filterSoftwareInstallersByLabel(
 	ds *Datastore,
 	ctx context.Context,
 	host *fleet.Host,
 	bySoftwareTitleID map[uint]*hostSoftware,
-) (map[uint]*hostSoftware, error) {
+) (map[uint]*hostSoftware, map[uint]resolvedInstaller, error) {
 	if len(bySoftwareTitleID) == 0 {
-		return bySoftwareTitleID, nil
+		return bySoftwareTitleID, map[uint]resolvedInstaller{}, nil
+	}
+
+	titleIDsToCheck := make([]uint, 0, len(bySoftwareTitleID))
+	for titleID, st := range bySoftwareTitleID {
+		if st.InstallerID != nil {
+			titleIDsToCheck = append(titleIDsToCheck, titleID)
+		}
 	}
 
 	filteredbySoftwareTitleID := make(map[uint]*hostSoftware, len(bySoftwareTitleID))
-	softwareInstallersIDsToCheck := make([]uint, 0, len(bySoftwareTitleID))
-
-	for _, st := range bySoftwareTitleID {
-		if st.InstallerID != nil {
-			softwareInstallersIDsToCheck = append(softwareInstallersIDsToCheck, *st.InstallerID)
-		}
+	if len(titleIDsToCheck) == 0 {
+		return filteredbySoftwareTitleID, map[uint]resolvedInstaller{}, nil
 	}
 
-	if len(softwareInstallersIDsToCheck) > 0 {
-		globalOrTeamID := ptr.ValOrZero(host.TeamID)
-
-		labelSqlFilter := `
-			WITH no_labels AS (
-				SELECT
-					software_installers.id AS installer_id,
-					0 AS count_installer_labels,
-					0 AS count_host_labels,
-					0 AS count_host_updated_after_labels
-				FROM
-					software_installers
-				WHERE NOT EXISTS (
-					SELECT 1
-					FROM software_installer_labels
-					WHERE software_installer_labels.software_installer_id = software_installers.id
-				)
-			),
-			include_any AS (
-				SELECT
-					software_installers.id AS installer_id,
-					COUNT(*) AS count_installer_labels,
-					COUNT(label_membership.label_id) AS count_host_labels,
-					0 AS count_host_updated_after_labels
-				FROM
-					software_installers
-				INNER JOIN software_installer_labels
-					ON software_installer_labels.software_installer_id = software_installers.id
-						AND software_installer_labels.exclude = 0
-						AND software_installer_labels.require_all = 0
-				LEFT JOIN label_membership
-					ON label_membership.label_id = software_installer_labels.label_id
-					AND label_membership.host_id = :host_id
-				GROUP BY
-					software_installers.id
-				HAVING
-					count_installer_labels > 0 AND count_host_labels > 0
-			),
-			exclude_any AS (
-				SELECT
-					software_installers.id AS installer_id,
-					COUNT(software_installer_labels.label_id) AS count_installer_labels,
-					COUNT(label_membership.label_id) AS count_host_labels,
-					SUM(
-						CASE
-							WHEN labels.created_at IS NOT NULL AND (
-								labels.label_membership_type = 1 OR
-								(labels.label_membership_type = 0 AND :host_label_updated_at >= labels.created_at)
-							) THEN 1
-							ELSE 0
-						END
-					) AS count_host_updated_after_labels
-				FROM
-					software_installers
-				INNER JOIN software_installer_labels
-					ON software_installer_labels.software_installer_id = software_installers.id
-						AND software_installer_labels.exclude = 1
-						AND software_installer_labels.require_all = 0
-				INNER JOIN labels
-					ON labels.id = software_installer_labels.label_id
-				LEFT JOIN label_membership
-					ON label_membership.label_id = software_installer_labels.label_id
-					AND label_membership.host_id = :host_id
-				GROUP BY
-					software_installers.id
-				HAVING
-					count_installer_labels > 0
-					AND count_installer_labels = count_host_updated_after_labels
-					AND count_host_labels = 0
-			),
-			include_all AS (
-				SELECT
-					software_installers.id AS installer_id,
-					COUNT(*) AS count_installer_labels,
-					COUNT(label_membership.label_id) AS count_host_labels,
-					0 AS count_host_updated_after_labels
-				FROM
-					software_installers
-				INNER JOIN software_installer_labels
-					ON software_installer_labels.software_installer_id = software_installers.id
-						AND software_installer_labels.exclude = 0
-						AND software_installer_labels.require_all = 1
-				LEFT JOIN label_membership
-					ON label_membership.label_id = software_installer_labels.label_id
-					AND label_membership.host_id = :host_id
-				GROUP BY
-					software_installers.id
-				HAVING
-					count_installer_labels > 0
-					AND count_host_labels = count_installer_labels
-			)
-			SELECT
-				software_installers.id AS id,
-				software_installers.title_id AS title_id
-			FROM
-				software_installers
-			LEFT JOIN no_labels
-				ON no_labels.installer_id = software_installers.id
-			LEFT JOIN include_any
-				ON include_any.installer_id = software_installers.id
-			LEFT JOIN exclude_any
-				ON exclude_any.installer_id = software_installers.id
-			LEFT JOIN include_all
-				ON include_all.installer_id = software_installers.id
-			WHERE
-				software_installers.global_or_team_id = :global_or_team_id
-				AND software_installers.id IN (:software_installer_ids)
-				AND (
-					no_labels.installer_id IS NOT NULL
-					OR include_any.installer_id IS NOT NULL
-					OR exclude_any.installer_id IS NOT NULL
-					OR include_all.installer_id IS NOT NULL
-				)
-		`
-		labelSqlFilter, args, err := sqlx.Named(labelSqlFilter, map[string]any{
-			"host_id":                host.ID,
-			"host_label_updated_at":  host.LabelUpdatedAt,
-			"software_installer_ids": softwareInstallersIDsToCheck,
-			"global_or_team_id":      globalOrTeamID,
-		})
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "filterSoftwareInstallersByLabel building named query args")
-		}
-
-		labelSqlFilter, args, err = sqlx.In(labelSqlFilter, args...)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "filterSoftwareInstallersByLabel building in query args")
-		}
-
-		labelSqlFilter = ds.reader(ctx).Rebind(labelSqlFilter)
-
-		var validSoftwareInstallers []struct {
-			Id      uint `db:"id"`
-			TitleId uint `db:"title_id"`
-		}
-		err = sqlx.SelectContext(ctx, ds.reader(ctx), &validSoftwareInstallers, labelSqlFilter, args...)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "filterSoftwareInstallersByLabel executing query")
-		}
-
-		// go through the returned list of validSoftwareInstaller and add all the titles that meet the label criteria to be returned
-		for _, validSoftwareInstaller := range validSoftwareInstallers {
-			filteredbySoftwareTitleID[validSoftwareInstaller.TitleId] = bySoftwareTitleID[validSoftwareInstaller.TitleId]
-		}
+	resolved, inScope, err := ds.resolveFirstAddedInstallersForHost(ctx, host, titleIDsToCheck)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return filteredbySoftwareTitleID, nil
+	// Point each in-scope title at its resolved first-added in-scope package so downstream
+	// self-service and inventory decisions match what the install path would do.
+	for titleID := range inScope {
+		st := bySoftwareTitleID[titleID]
+		if st == nil {
+			continue
+		}
+		if r, ok := resolved[titleID]; ok {
+			st.InstallerID = &r.ID
+			st.PackageSelfService = &r.SelfService
+		}
+		filteredbySoftwareTitleID[titleID] = st
+	}
+
+	return filteredbySoftwareTitleID, resolved, nil
 }
 
 func filterVPPAppsByLabel(
@@ -5739,6 +5849,14 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				  AND software_installers.platform = ?
 				  AND software_installers.global_or_team_id = ?
 				  AND software_installers.is_active = 1
+				  -- collapse to the first-added active package per title/platform to avoid duplicate rows
+				  AND software_installers.id = (
+					SELECT MIN(si_first.id) FROM software_installers si_first
+					WHERE si_first.title_id = software.title_id
+						AND si_first.platform = software_installers.platform
+						AND si_first.global_or_team_id = software_installers.global_or_team_id
+						AND si_first.is_active = 1
+				  )
 			WHERE host_software.host_id = ?
 			`
 		type InstalledSoftwareTitle struct {
@@ -5966,8 +6084,10 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 		}
 	}
 
-	// filter out software installers due to label scoping
-	filteredBySoftwareTitleID, err := filterSoftwareInstallersByLabel(
+	// filter out software installers due to label scoping. resolvedInstallers maps each title with a
+	// package to the first-added in-scope installer (first-added active as a deterministic fallback),
+	// used to display a single deterministic package per title in the final query below.
+	filteredBySoftwareTitleID, resolvedInstallers, err := filterSoftwareInstallersByLabel(
 		ds,
 		ctx,
 		host,
@@ -6112,6 +6232,20 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 		softwareTitleIDs = append(softwareTitleIDs, softwareTitleID)
 	}
 
+	// A title can hold several active packages; pin the final query to the one resolved package per
+	// title (first-added in-scope) so the list shows a single deterministic software_package and does
+	// not emit duplicate title rows. Titles with no installer (VPP/in-house/inventory-only) have no
+	// entry, so they keep a NULL installer via the LEFT JOIN. Sentinel 0 keeps the IN() list valid.
+	displayInstallerIDs := make([]uint, 0, len(softwareTitleIDs))
+	for _, titleID := range softwareTitleIDs {
+		if r, ok := resolvedInstallers[titleID]; ok {
+			displayInstallerIDs = append(displayInstallerIDs, r.ID)
+		}
+	}
+	if len(displayInstallerIDs) == 0 {
+		displayInstallerIDs = []uint{0}
+	}
+
 	var softwareIDs []uint
 	for softwareID := range bySoftwareID {
 		softwareIDs = append(softwareIDs, softwareID)
@@ -6239,9 +6373,11 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 			FROM
 				software_titles
 			LEFT JOIN
+				-- Pin to the resolved first-added in-scope package per title so a multi-package title
+				-- yields one deterministic row (no duplicate titles, no arbitrary sibling).
 				software_installers ON software_titles.id = software_installers.title_id
 				AND software_installers.global_or_team_id = :global_or_team_id
-				AND software_installers.is_active = true
+				AND software_installers.id IN (?)
 			LEFT JOIN
 				software ON software_titles.id = software.title_id ` + installedSoftwareJoinsCondition + `
 			WHERE
@@ -6254,9 +6390,9 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 
 			var softwareTitleArgs []interface{}
 			if len(softwareIDs) > 0 {
-				softwareTitleStatement, softwareTitleArgs, err = sqlx.In(softwareTitleStatement, softwareIDs, softwareTitleIDs)
+				softwareTitleStatement, softwareTitleArgs, err = sqlx.In(softwareTitleStatement, displayInstallerIDs, softwareIDs, softwareTitleIDs)
 			} else {
-				softwareTitleStatement, softwareTitleArgs, err = sqlx.In(softwareTitleStatement, softwareTitleIDs)
+				softwareTitleStatement, softwareTitleArgs, err = sqlx.In(softwareTitleStatement, displayInstallerIDs, softwareTitleIDs)
 			}
 			if err != nil {
 				return nil, nil, ctxerr.Wrap(ctx, err, "expand IN query for software titles")

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3771,12 +3771,14 @@ type resolvedInstaller struct {
 }
 
 // resolveFirstAddedInstallersForHost resolves, for each of the given titles, the package to display
-// and install for this host: the first-added (smallest installer_id) active package the host is in
-// label scope for. When the host is in scope for no package of a title, it falls back to the
-// first-added active package so the display stays deterministic. inScope holds the titles for which
-// the host is in scope for at least one package (those the title is actually available to install
-// on). This is the read-side counterpart of the service-layer install precedence resolver, so the
-// list, the install, and policy defaults all point at the same package.
+// for this host: the first-added (smallest installer_id) active package the host is in label scope
+// for. When the host is in scope for no package of a title, it falls back to the first-added active
+// package so the inventory row still shows a deterministic package — this happens for a title the
+// host already has installed but whose labels changed so the host no longer matches any package
+// (matching the pre-multi-package behavior of showing the active installer regardless of scope).
+// The fallback is display-only: availability and install decisions use inScope (below) and never the
+// fallback, so a host is never offered or sent a package it isn't scoped for. inScope holds the
+// titles the host is in scope for at least one package of.
 func (ds *Datastore) resolveFirstAddedInstallersForHost(ctx context.Context, host *fleet.Host, titleIDs []uint) (resolved map[uint]resolvedInstaller, inScope map[uint]struct{}, err error) {
 	resolved = make(map[uint]resolvedInstaller, len(titleIDs))
 	inScope = make(map[uint]struct{}, len(titleIDs))
@@ -3913,11 +3915,11 @@ func (ds *Datastore) resolveFirstAddedInstallersForHost(ctx context.Context, hos
 		"title_ids":             titleIDs,
 	})
 	if err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "resolveFirstAddedInstallersForHost building named query args")
+		return nil, nil, ctxerr.Wrap(ctx, err, "build named query for scoped installers")
 	}
 	stmt, args, err = sqlx.In(stmt, args...)
 	if err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "resolveFirstAddedInstallersForHost building in query args")
+		return nil, nil, ctxerr.Wrap(ctx, err, "build IN query for scoped installers")
 	}
 	stmt = ds.reader(ctx).Rebind(stmt)
 
@@ -3930,7 +3932,7 @@ func (ds *Datastore) resolveFirstAddedInstallersForHost(ctx context.Context, hos
 		InScope     bool   `db:"in_scope"`
 	}
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...); err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "resolveFirstAddedInstallersForHost executing query")
+		return nil, nil, ctxerr.Wrap(ctx, err, "select scoped installers for host")
 	}
 
 	hostPlatform := host.FleetPlatform()

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1198,7 +1198,12 @@ SELECT
 FROM
 	software_installers si
 WHERE
-  si.title_id = ? AND si.global_or_team_id = ?
+  si.title_id = ? AND si.global_or_team_id = ? AND si.is_active = 1
+  -- A title can hold several packages; report the first-added (smallest id) deterministically.
+  AND si.id = (
+    SELECT MIN(si2.id) FROM software_installers si2
+    WHERE si2.title_id = si.title_id AND si2.global_or_team_id = si.global_or_team_id AND si2.is_active = 1
+  )
 
 UNION ALL
 
@@ -1534,6 +1539,30 @@ func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error
 				WHERE other.title_id = si.title_id AND other.global_or_team_id = si.global_or_team_id AND other.id != si.id
 			)`, id); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete software title display name for installer being deleted")
+		}
+
+		// If install-automation policies reference this package and the title has other active
+		// packages, re-point those policies to the first-added surviving package (first-added-wins),
+		// so deleting one package of several keeps the automation working. When this is the last
+		// package there is no survivor: the delete below then hits the policies FK (RESTRICT) and
+		// returns the 409 that tells the admin to disable the automation first.
+		var survivorID *uint
+		if err := sqlx.GetContext(ctx, tx, &survivorID, `
+			SELECT MIN(other.id)
+			FROM software_installers other
+			JOIN software_installers deleted ON deleted.id = ?
+			WHERE other.title_id = deleted.title_id
+				AND other.global_or_team_id = deleted.global_or_team_id
+				AND other.id != deleted.id
+				AND other.is_active = 1`, id); err != nil {
+			return ctxerr.Wrap(ctx, err, "find surviving package to re-point policies")
+		}
+		if survivorID != nil {
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE policies SET software_installer_id = ? WHERE software_installer_id = ?`,
+				*survivorID, id); err != nil {
+				return ctxerr.Wrap(ctx, err, "re-point policies to surviving package before delete")
+			}
 		}
 
 		// allow delete only if not selected for setup experience (natively or cross-platform)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -43,6 +43,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"GetSoftwarePackagesByTeamAndTitleID", testGetSoftwarePackagesByTeamAndTitleID},
 		{"HasSelfServiceSoftwareInstallers", testHasSelfServiceSoftwareInstallers},
 		{"DeleteSoftwareInstallers", testDeleteSoftwareInstallers},
+		{"DeleteSoftwareInstallerRepointsPolicies", testDeleteSoftwareInstallerRepointsPolicies},
 		{"testDeletePendingSoftwareInstallsForPolicy", testDeletePendingSoftwareInstallsForPolicy},
 		{"GetHostLastInstallData", testGetHostLastInstallData},
 		{"GetOrGenerateSoftwareInstallerTitleID", testGetOrGenerateSoftwareInstallerTitleID},
@@ -6577,4 +6578,63 @@ VALUES (?, ?, ?)`, uaID, installerID, titleID)
 	require.NoError(t, err)
 	// The host must be counted exactly once (not dropped, not double-counted).
 	require.Equal(t, fleet.SoftwareInstallerStatusSummary{PendingInstall: 1}, *summary)
+}
+
+// testDeleteSoftwareInstallerRepointsPolicies verifies that deleting one package of several re-points
+// install-automation policies to the first-added surviving package, while deleting the last package a
+// policy references still returns the 409 telling the admin to disable the automation first.
+func testDeleteSoftwareInstallerRepointsPolicies(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Delete Repoint", "delete-repoint@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "delete-repoint-team"})
+	require.NoError(t, err)
+
+	newPkg := func(storage, filename string) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello-"+storage), t.TempDir)
+		require.NoError(t, err)
+		id, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         filename,
+			Title:            "RepointApp",
+			Version:          "1.0",
+			Source:           "apps",
+			BundleIdentifier: "com.example.repoint",
+			UserID:           user.ID,
+			TeamID:           &team.ID,
+			Platform:         "darwin",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+		return id
+	}
+	installerA := newPkg("repoint-a", "pkgA.pkg")
+	installerB := newPkg("repoint-b", "pkgB.pkg")
+	require.Less(t, installerA, installerB)
+
+	pol, err := ds.NewTeamPolicy(ctx, team.ID, &user.ID, fleet.PolicyPayload{
+		Name:                "repoint policy",
+		Query:               "SELECT 1;",
+		SoftwareInstallerID: &installerA,
+	})
+	require.NoError(t, err)
+
+	// Deleting the referenced package while a sibling remains re-points the policy to the survivor.
+	require.NoError(t, ds.DeleteSoftwareInstaller(ctx, installerA))
+	got, err := ds.Policy(ctx, pol.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.SoftwareInstallerID)
+	require.Equal(t, installerB, *got.SoftwareInstallerID)
+
+	// Deleting the last package the policy references is refused (disable automation first).
+	err = ds.DeleteSoftwareInstaller(ctx, installerB)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errDeleteInstallerWithAssociatedInstallPolicy)
+
+	// The policy still points at the (undeleted) package.
+	got, err = ds.Policy(ctx, pol.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.SoftwareInstallerID)
+	require.Equal(t, installerB, *got.SoftwareInstallerID)
 }

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -106,6 +106,7 @@ func TestSoftware(t *testing.T) {
 		{"ListHostSoftwareInstallThenDeleteInstallers", testListHostSoftwareInstallThenDeleteInstallers},
 		{"ListSoftwareVersionsVulnerabilityFilters", testListSoftwareVersionsVulnerabilityFilters},
 		{"TestListHostSoftwareWithLabelScoping", testListHostSoftwareWithLabelScoping},
+		{"ListHostSoftwareMultiplePackagesPrecedence", testListHostSoftwareMultiplePackagesPrecedence},
 		{"TestListHostSoftwareVulnerableAndVPP", testListHostSoftwareVulnerableAndVPP},
 		{"TestListHostSoftwareQuerySearching", testListHostSoftwareQuerySearching},
 		{"TestListHostSoftwareWithLabelScopingVPP", testListHostSoftwareWithLabelScopingVPP},
@@ -13565,4 +13566,113 @@ func testCreateIntermediateInstallFailureRecordAfterDeletion(t *testing.T, ds *D
 	require.Equal(t, fleet.SoftwareInstallFailed, batchPendingResult.Status)
 	require.Equal(t, "batch-pending-app", batchPendingResult.SoftwareTitle)
 	require.Equal(t, "batch-pending.pkg", batchPendingResult.SoftwarePackage)
+}
+
+// testListHostSoftwareMultiplePackagesPrecedence verifies that when a title holds multiple
+// label-scoped packages, ListHostSoftware deterministically shows the first-added in-scope package
+// as software_package (matching the install-time precedence resolver) and does not emit duplicate
+// title rows.
+func testListHostSoftwareMultiplePackagesPrecedence(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Alice", "alice-multipkg@example.com", true)
+
+	hostBoth := test.NewHost(t, ds, "h-both", "", "h-both-key", "h-both-uuid", time.Now(), test.WithPlatform("darwin"))
+	nanoEnroll(t, ds, hostBoth, false)
+	hostSecondOnly := test.NewHost(t, ds, "h-second", "", "h-second-key", "h-second-uuid", time.Now(), test.WithPlatform("darwin"))
+	nanoEnroll(t, ds, hostSecondOnly, false)
+	hostNeither := test.NewHost(t, ds, "h-none", "", "h-none-key", "h-none-uuid", time.Now(), test.WithPlatform("darwin"))
+	nanoEnroll(t, ds, hostNeither, false)
+
+	time.Sleep(time.Second) // ensure labels_updated_at is before label creation
+
+	var titleID uint
+	newPkg := func(storage, filename string) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
+		require.NoError(t, err)
+		id, tID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         filename,
+			Title:            "ArchTargetedApp",
+			Version:          "1.0",
+			Source:           "apps",
+			BundleIdentifier: "com.example.archapp",
+			UserID:           user.ID,
+			Platform:         "darwin",
+			SelfService:      true,
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+		titleID = tID
+		return id
+	}
+
+	// Two packages under one title (e.g. Arm vs Intel builds): pkgA is first-added.
+	firstAddedID := newPkg("storage-a", "pkgA.pkg")
+	secondID := newPkg("storage-b", "pkgB.pkg")
+	require.Less(t, firstAddedID, secondID)
+
+	labelA, err := ds.NewLabel(ctx, &fleet.Label{Name: "labelA" + t.Name()})
+	require.NoError(t, err)
+	labelB, err := ds.NewLabel(ctx, &fleet.Label{Name: "labelB" + t.Name()})
+	require.NoError(t, err)
+
+	// hostBoth matches both packages, hostSecondOnly only pkgB, hostNeither none.
+	require.NoError(t, ds.AddLabelsToHost(ctx, hostBoth.ID, []uint{labelA.ID, labelB.ID}))
+	require.NoError(t, ds.AddLabelsToHost(ctx, hostSecondOnly.ID, []uint{labelB.ID}))
+	for _, h := range []*fleet.Host{hostBoth, hostSecondOnly, hostNeither} {
+		h.LabelUpdatedAt = time.Now()
+		require.NoError(t, ds.UpdateHost(ctx, h))
+	}
+	time.Sleep(time.Second)
+
+	// Scope each package to its label (include-any).
+	require.NoError(t, setOrUpdateSoftwareInstallerLabelsDB(ctx, ds.writer(ctx), firstAddedID, fleet.LabelIdentsWithScope{
+		LabelScope: fleet.LabelScopeIncludeAny,
+		ByName:     map[string]fleet.LabelIdent{labelA.Name: {LabelName: labelA.Name, LabelID: labelA.ID}},
+	}, softwareTypeInstaller))
+	require.NoError(t, setOrUpdateSoftwareInstallerLabelsDB(ctx, ds.writer(ctx), secondID, fleet.LabelIdentsWithScope{
+		LabelScope: fleet.LabelScopeIncludeAny,
+		ByName:     map[string]fleet.LabelIdent{labelB.Name: {LabelName: labelB.Name, LabelID: labelB.ID}},
+	}, softwareTypeInstaller))
+
+	opts := fleet.HostSoftwareTitleListOptions{
+		ListOptions:                fleet.ListOptions{PerPage: 20, IncludeMetadata: true, OrderKey: "name"},
+		IncludeAvailableForInstall: true,
+		OnlyAvailableForInstall:    true,
+	}
+
+	// hostBoth matches pkgA and pkgB → first-added (pkgA) wins, exactly one row for the title.
+	sw, _, err := ds.ListHostSoftware(ctx, hostBoth, opts)
+	require.NoError(t, err)
+	rowsForTitle := 0
+	for _, s := range sw {
+		if s.ID == titleID {
+			rowsForTitle++
+			require.NotNil(t, s.SoftwarePackage)
+			require.Equal(t, "pkgA.pkg", s.SoftwarePackage.Name)
+		}
+	}
+	require.Equal(t, 1, rowsForTitle, "multi-package title must appear exactly once")
+
+	// hostSecondOnly matches only pkgB → the in-scope sibling is shown (title not hidden).
+	sw, _, err = ds.ListHostSoftware(ctx, hostSecondOnly, opts)
+	require.NoError(t, err)
+	rowsForTitle = 0
+	for _, s := range sw {
+		if s.ID == titleID {
+			rowsForTitle++
+			require.NotNil(t, s.SoftwarePackage)
+			require.Equal(t, "pkgB.pkg", s.SoftwarePackage.Name)
+		}
+	}
+	require.Equal(t, 1, rowsForTitle, "title with an in-scope sibling must not be hidden")
+
+	// hostNeither matches no package → title is not available for install.
+	sw, _, err = ds.ListHostSoftware(ctx, hostNeither, opts)
+	require.NoError(t, err)
+	for _, s := range sw {
+		require.NotEqual(t, titleID, s.ID, "title should not be available when the host is in scope for no package")
+	}
 }

--- a/server/fleet/api_policies.go
+++ b/server/fleet/api_policies.go
@@ -175,6 +175,9 @@ type TeamPolicyRequest struct {
 	Critical                     bool     `json:"critical" premium:"true"`
 	CalendarEventsEnabled        bool     `json:"calendar_events_enabled"`
 	SoftwareTitleID              *uint    `json:"software_title_id"`
+	// SoftwareInstallerID optionally selects which package of the title to install on failure.
+	// When omitted, the policy defaults to the title's first-added package.
+	SoftwareInstallerID          *uint    `json:"software_installer_id"`
 	ScriptID                     *uint    `json:"script_id"`
 	LabelsIncludeAny             []string `json:"labels_include_any" premium:"true"`
 	LabelsIncludeAll             []string `json:"labels_include_all" premium:"true"`

--- a/server/fleet/api_policies.go
+++ b/server/fleet/api_policies.go
@@ -165,16 +165,16 @@ func (r AutofillPoliciesResponse) Error() error { return r.Err }
 /////////////////////////////////////////////////////////////////////////////////
 
 type TeamPolicyRequest struct {
-	TeamID                       uint     `url:"fleet_id"`
-	QueryID                      *uint    `json:"query_id" renameto:"report_id"`
-	Query                        string   `json:"query"`
-	Name                         string   `json:"name"`
-	Description                  string   `json:"description"`
-	Resolution                   string   `json:"resolution"`
-	Platform                     string   `json:"platform"`
-	Critical                     bool     `json:"critical" premium:"true"`
-	CalendarEventsEnabled        bool     `json:"calendar_events_enabled"`
-	SoftwareTitleID              *uint    `json:"software_title_id"`
+	TeamID                uint   `url:"fleet_id"`
+	QueryID               *uint  `json:"query_id" renameto:"report_id"`
+	Query                 string `json:"query"`
+	Name                  string `json:"name"`
+	Description           string `json:"description"`
+	Resolution            string `json:"resolution"`
+	Platform              string `json:"platform"`
+	Critical              bool   `json:"critical" premium:"true"`
+	CalendarEventsEnabled bool   `json:"calendar_events_enabled"`
+	SoftwareTitleID       *uint  `json:"software_title_id"`
 	// SoftwareInstallerID optionally selects which package of the title to install on failure.
 	// When omitted, the policy defaults to the title's first-added package.
 	SoftwareInstallerID          *uint    `json:"software_installer_id"`

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -105,6 +105,9 @@ type NewTeamPolicyPayload struct {
 	CalendarEventsEnabled bool
 	// SoftwareTitleID is the ID of the software title that will be installed if the policy fails.
 	SoftwareTitleID *uint
+	// SoftwareInstallerID optionally selects which package of the title to install on failure.
+	// When nil, the policy defaults to the title's first-added package.
+	SoftwareInstallerID *uint
 	// ScriptID is the ID of the script that will be executed if the policy fails.
 	ScriptID *uint
 	// LabelsIncludeAny scopes the policy to hosts that are members of ANY of the listed labels.
@@ -300,6 +303,11 @@ type ModifyPolicyPayload struct {
 	//
 	// Only applies to team policies.
 	SoftwareTitleID optjson.Any[uint] `json:"software_title_id" premium:"true"`
+	// SoftwareInstallerID optionally selects which package of the title to install on failure.
+	// When omitted (or 0), the policy defaults to the title's first-added package.
+	//
+	// Only applies to team policies.
+	SoftwareInstallerID optjson.Any[uint] `json:"software_installer_id" premium:"true"`
 	// ScriptID is the ID of the script that will be executed if the policy fails.
 	// Value 0 will unset the current script from the policy.
 	//

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -34109,3 +34109,191 @@ func (s *integrationEnterpriseTestSuite) TestResetPolicy() {
 	// 404 for a nonexistent policy.
 	s.Do("POST", "/api/latest/fleet/policies/999999/reset", nil, http.StatusNotFound)
 }
+
+// TestSoftwareMultiplePackagesInstallPrecedence verifies install-time first-added precedence when a
+// title holds multiple label-scoped packages: a host matching more than one package installs the
+// first-added one, while a host matching only a later package installs that one (correct scoping).
+func (s *integrationEnterpriseTestSuite) TestSoftwareMultiplePackagesInstallPrecedence() {
+	t := s.T()
+	ctx := context.Background()
+
+	var createTeamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &fleet.Team{Name: t.Name()}, http.StatusOK, &createTeamResp)
+	teamID := createTeamResp.Team.ID
+	user := s.users["admin1@example.com"]
+
+	labelA, err := s.ds.NewLabel(ctx, &fleet.Label{Name: "labelA_" + t.Name()})
+	require.NoError(t, err)
+	labelB, err := s.ds.NewLabel(ctx, &fleet.Label{Name: "labelB_" + t.Name()})
+	require.NoError(t, err)
+
+	// Two packages under one title (same bundle id, different content hash), each scoped to one label.
+	newPkg := func(storage, filename, version string, label *fleet.Label) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello-"+storage), t.TempDir)
+		require.NoError(t, err)
+		id, _, err := s.ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			UninstallScript:  "uninstall",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         filename,
+			Title:            "MultiPkgApp",
+			Version:          version,
+			Source:           "deb_packages",
+			Extension:        "deb",
+			BundleIdentifier: "com.example.multipkgapp",
+			UserID:           user.ID,
+			TeamID:           &teamID,
+			Platform:         "linux",
+			ValidatedLabels: &fleet.LabelIdentsWithScope{
+				LabelScope: fleet.LabelScopeIncludeAny,
+				ByName:     map[string]fleet.LabelIdent{label.Name: {LabelName: label.Name, LabelID: label.ID}},
+			},
+		})
+		require.NoError(t, err)
+		return id
+	}
+	installerA := newPkg("storage-a", "pkgA.deb", "1.0", labelA)
+	installerB := newPkg("storage-b", "pkgB.deb", "2.0", labelB)
+	require.Less(t, installerA, installerB)
+
+	titleID := getSoftwareTitleID(t, s.ds, "MultiPkgApp", "deb_packages")
+
+	newLinuxHost := func(suffix string, labelIDs []uint) *fleet.Host {
+		h, err := s.ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			OsqueryHostID:   new(t.Name() + suffix + uuid.New().String()),
+			NodeKey:         new(t.Name() + suffix + uuid.New().String()),
+			Hostname:        fmt.Sprintf("%s-%s.local", t.Name(), suffix),
+			Platform:        "ubuntu",
+		})
+		require.NoError(t, err)
+		require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&teamID, []uint{h.ID})))
+		if len(labelIDs) > 0 {
+			require.NoError(t, s.ds.AddLabelsToHost(ctx, h.ID, labelIDs))
+		}
+		h.LabelUpdatedAt = time.Now()
+		require.NoError(t, s.ds.UpdateHost(ctx, h))
+		orbitKey := setOrbitEnrollment(t, h, s.ds)
+		h.OrbitNodeKey = &orbitKey
+		return h
+	}
+
+	// queuedInstallerID returns the software_installer_id queued for the host's pending install.
+	queuedInstallerID := func(hostID uint) uint {
+		var ids []uint
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &ids, `
+				SELECT siua.software_installer_id
+				FROM software_install_upcoming_activities siua
+				JOIN upcoming_activities ua ON ua.id = siua.upcoming_activity_id
+				WHERE ua.host_id = ?`, hostID)
+		})
+		require.Len(t, ids, 1)
+		return ids[0]
+	}
+
+	// Host in BOTH labels matches pkgA and pkgB → first-added (pkgA) installs.
+	hostBoth := newLinuxHost("both", []uint{labelA.ID, labelB.ID})
+	var resp installSoftwareResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", hostBoth.ID, titleID), nil, http.StatusAccepted, &resp)
+	require.Equal(t, installerA, queuedInstallerID(hostBoth.ID))
+
+	// Host in only labelB matches only pkgB → pkgB installs (never the first-added pkgA).
+	hostSecond := newLinuxHost("second", []uint{labelB.ID})
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", hostSecond.ID, titleID), nil, http.StatusAccepted, &resp)
+	require.Equal(t, installerB, queuedInstallerID(hostSecond.ID))
+
+	// Host in neither label is in scope for no package → install is rejected.
+	hostNeither := newLinuxHost("neither", nil)
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", hostNeither.ID, titleID), nil, http.StatusBadRequest, &resp)
+}
+
+// TestPolicyAutomationSoftwareInstallerSelection verifies a team policy defaults its install-software
+// automation to the title's first-added package and honors an explicitly chosen software_installer_id.
+func (s *integrationEnterpriseTestSuite) TestPolicyAutomationSoftwareInstallerSelection() {
+	t := s.T()
+	ctx := context.Background()
+
+	var createTeamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &fleet.Team{Name: t.Name()}, http.StatusOK, &createTeamResp)
+	teamID := createTeamResp.Team.ID
+	user := s.users["admin1@example.com"]
+
+	newPkg := func(storage, filename, version string) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello-"+storage), t.TempDir)
+		require.NoError(t, err)
+		id, _, err := s.ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			UninstallScript:  "uninstall",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         filename,
+			Title:            "PolicyMultiPkgApp",
+			Version:          version,
+			Source:           "deb_packages",
+			Extension:        "deb",
+			BundleIdentifier: "com.example.policymultipkg",
+			UserID:           user.ID,
+			TeamID:           &teamID,
+			Platform:         "linux",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+		return id
+	}
+	installerA := newPkg("pol-storage-a", "pkgA.deb", "1.0")
+	installerB := newPkg("pol-storage-b", "pkgB.deb", "2.0")
+	require.Less(t, installerA, installerB)
+	titleID := getSoftwareTitleID(t, s.ds, "PolicyMultiPkgApp", "deb_packages")
+
+	storedInstallerID := func(policyID uint) uint {
+		var ids []uint
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &ids, `SELECT software_installer_id FROM policies WHERE id = ?`, policyID)
+		})
+		require.Len(t, ids, 1)
+		return ids[0]
+	}
+
+	// No installer chosen → defaults to first-added.
+	var defResp fleet.TeamPolicyResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", teamID), fleet.TeamPolicyRequest{
+		Name:            "default first-added",
+		Query:           "SELECT 1;",
+		SoftwareTitleID: &titleID,
+	}, http.StatusOK, &defResp)
+	require.Equal(t, installerA, storedInstallerID(defResp.Policy.ID))
+
+	// Explicit installer chosen → honored.
+	var chosenResp fleet.TeamPolicyResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", teamID), fleet.TeamPolicyRequest{
+		Name:                "explicit choice",
+		Query:               "SELECT 2;",
+		SoftwareTitleID:     &titleID,
+		SoftwareInstallerID: &installerB,
+	}, http.StatusOK, &chosenResp)
+	require.Equal(t, installerB, storedInstallerID(chosenResp.Policy.ID))
+
+	// Modify the first policy to point at the chosen package.
+	var modResp fleet.ModifyTeamPolicyResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/policies/%d", teamID, defResp.Policy.ID), fleet.ModifyTeamPolicyRequest{
+		ModifyPolicyPayload: fleet.ModifyPolicyPayload{
+			SoftwareTitleID:     optjson.Any[uint]{Set: true, Valid: true, Value: titleID},
+			SoftwareInstallerID: optjson.Any[uint]{Set: true, Valid: true, Value: installerB},
+		},
+	}, http.StatusOK, &modResp)
+	require.Equal(t, installerB, storedInstallerID(defResp.Policy.ID))
+
+	// An installer_id that doesn't belong to the title is rejected.
+	var badResp fleet.TeamPolicyResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", teamID), fleet.TeamPolicyRequest{
+		Name:                "bad installer",
+		Query:               "SELECT 3;",
+		SoftwareTitleID:     &titleID,
+		SoftwareInstallerID: new(installerB + 100000),
+	}, http.StatusBadRequest, &badResp)
+}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -34,6 +34,7 @@ func teamPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 		Critical:                     req.Critical,
 		CalendarEventsEnabled:        req.CalendarEventsEnabled,
 		SoftwareTitleID:              req.SoftwareTitleID,
+		SoftwareInstallerID:          req.SoftwareInstallerID,
 		ScriptID:                     req.ScriptID,
 		LabelsIncludeAny:             req.LabelsIncludeAny,
 		LabelsIncludeAll:             req.LabelsIncludeAll,
@@ -293,7 +294,7 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 		policyType = fleet.PolicyTypePatch
 	}
 
-	softwareInstallerID, vppAppsTeamsID, err := svc.getInstallerOrVPPAppForTitle(ctx, &teamID, p.SoftwareTitleID)
+	softwareInstallerID, vppAppsTeamsID, err := svc.getInstallerOrVPPAppForTitle(ctx, &teamID, p.SoftwareTitleID, p.SoftwareInstallerID)
 	if err != nil {
 		return fleet.PolicyPayload{}, err
 	}
@@ -686,8 +687,19 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		policy.FailingHostCount = 0
 		policy.PassingHostCount = 0
 	}
+	// A chosen installer without a title has nothing to resolve against (the software block below
+	// only runs when the title is set), so reject it rather than silently ignore the choice.
+	if !p.SoftwareTitleID.Set && p.SoftwareInstallerID.Set && p.SoftwareInstallerID.Value != 0 {
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: "software_installer_id can only be set together with software_title_id",
+		})
+	}
 	if p.SoftwareTitleID.Set {
-		softwareInstallerID, vppAppsTeamsID, err := svc.getInstallerOrVPPAppForTitle(ctx, teamID, &p.SoftwareTitleID.Value)
+		var chosenInstallerID *uint
+		if p.SoftwareInstallerID.Set && p.SoftwareInstallerID.Value != 0 {
+			chosenInstallerID = &p.SoftwareInstallerID.Value
+		}
+		softwareInstallerID, vppAppsTeamsID, err := svc.getInstallerOrVPPAppForTitle(ctx, teamID, &p.SoftwareTitleID.Value, chosenInstallerID)
 		if err != nil {
 			return nil, err
 		}
@@ -816,19 +828,41 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	return policy, nil
 }
 
-func (svc *Service) getInstallerOrVPPAppForTitle(ctx context.Context, teamID *uint, softwareTitleID *uint) (installerID *uint, vppAppsTeamsID *uint, err error) {
-	if softwareTitleID == nil {
-		return nil, nil, nil
-	}
+func (svc *Service) getInstallerOrVPPAppForTitle(ctx context.Context, teamID *uint, softwareTitleID *uint, chosenInstallerID *uint) (installerID *uint, vppAppsTeamsID *uint, err error) {
+	installerChosen := chosenInstallerID != nil && *chosenInstallerID != 0
 
-	// If *p.SoftwareTitleID with value 0 is used to unset the current installer from the policy.
-	if *softwareTitleID == 0 {
+	// SoftwareTitleID value 0 (or nil) unsets the current installer from the policy. A chosen
+	// installer without a title has nothing to resolve against, so reject it rather than silently drop it.
+	if softwareTitleID == nil || *softwareTitleID == 0 {
+		if installerChosen {
+			return nil, nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: "software_installer_id can only be set together with software_title_id",
+			})
+		}
 		return nil, nil, nil
 	}
 
 	if teamID == nil {
 		return nil, nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: "Software title ID cannot be set on global policies",
+		})
+	}
+
+	// When the caller selects a specific package, honor it. A chosen installer is always a custom
+	// package (VPP apps have no per-package selection). Validate it against the title's active
+	// packages so it belongs to this title/team and isn't an inactive row.
+	if installerChosen {
+		pkgs, err := svc.ds.GetSoftwarePackagesByTeamAndTitleID(ctx, teamID, *softwareTitleID)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "list packages for chosen policy installer")
+		}
+		for _, p := range pkgs {
+			if p.InstallerID == *chosenInstallerID {
+				return new(*chosenInstallerID), nil, nil
+			}
+		}
+		return nil, nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: fmt.Sprintf("Software installer with ID %d does not belong to software title ID %d on team ID %d", *chosenInstallerID, *softwareTitleID, *teamID),
 		})
 	}
 


### PR DESCRIPTION
**Related issue:** Resolves #48398

  Applies first-added-wins install precedence everywhere a host can match more than one package of a software title: manual install, self-service, policy auto-install, setup experience, and the host-software read all resolve the first-added package the host is in label scope for. Policy automations can now target a specific package (defaulting to first-added), and deleting a package re-points its automations to the first-added surviving package.

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements).

  ## Testing

  - [x] Added/updated automated tests
  - [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
  - [x] QA'd all new/changed functionality manually