### PR TITLE
Allow multiple packages - GitOps

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -2020,6 +2020,18 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			return nil, err
 		}
 
+		// A title with more than one custom package is written to its own package YAML
+		// file, referenced by a single path entry in the fleet file.
+		if len(softwareTitle.Packages) > 1 {
+			_, inSetup := setupSoftwareBySoftwareTitle[softwareTitle.ID]
+			entry, err := cmd.generateMultiPackage(softwareTitle, sw.Name, teamID, teamFilename, downloadIcons, inSetup)
+			if err != nil {
+				return nil, err
+			}
+			packages = append(packages, entry)
+			continue
+		}
+
 		var slug string
 
 		if softwareTitle.SoftwarePackage != nil {
@@ -2308,6 +2320,87 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 	}
 
 	return result, nil
+}
+
+func (cmd *GenerateGitopsCommand) generateMultiPackage(title *fleet.SoftwareTitle, swName string, teamID uint, teamFilename string, downloadIcons bool, inSetup bool) (map[string]any, error) {
+	// Paths inside the package YAML file are resolved relative to that file, which
+	// lives in lib/<team>/software, so a sibling dir is reached with ../<dir>/<name>.
+	writeSideFile := func(dir string, name string, contents any) string {
+		cmd.FilesToWrite[fmt.Sprintf("lib/%s/%s/%s", teamFilename, dir, name)] = contents
+		return fmt.Sprintf("../%s/%s", dir, name)
+	}
+
+	items := make([]map[string]any, 0, len(title.Packages))
+	for i, pkg := range title.Packages {
+		prefix := fmt.Sprintf("%s-%s-%d", generateFilename(swName), pkg.Platform, i+1)
+		item := map[string]any{"hash_sha256": pkg.StorageID}
+		if pkg.URL != "" {
+			item["url"] = pkg.URL
+		}
+		if pkg.SelfService {
+			item["self_service"] = true
+		}
+		if len(pkg.Categories) > 0 {
+			item["categories"] = pkg.Categories
+		}
+		if pkg.InstallScript != "" {
+			item["install_script"] = map[string]any{"path": writeSideFile("scripts", prefix+"-install", pkg.InstallScript)}
+		}
+		if pkg.PostInstallScript != "" {
+			item["post_install_script"] = map[string]any{"path": writeSideFile("scripts", prefix+"-postinstall", pkg.PostInstallScript)}
+		}
+		if pkg.UninstallScript != "" {
+			item["uninstall_script"] = map[string]any{"path": writeSideFile("scripts", prefix+"-uninstall", pkg.UninstallScript)}
+		}
+		if pkg.PreInstallQuery != "" {
+			item["pre_install_query"] = map[string]any{"path": writeSideFile("queries", prefix+"-preinstallquery.yml", []map[string]any{{"query": pkg.PreInstallQuery}})}
+		}
+		if key, names := packageLabels(pkg); key != "" {
+			item[key] = names
+		}
+		items = append(items, item)
+	}
+
+	// The icon is per-title, so emit it once on the first package.
+	if downloadIcons && title.IconUrl != nil && strings.HasPrefix(*title.IconUrl, "/api") && len(items) > 0 {
+		icon, err := cmd.Client.GetSoftwareTitleIcon(title.ID, teamID)
+		if err != nil {
+			return nil, err
+		}
+		items[0]["icon"] = map[string]any{"path": writeSideFile("icons", generateFilename(swName)+"-icon.png", icon)}
+	}
+
+	// The fleet-level entry points at the package file relative to the fleet file.
+	packageFile := fmt.Sprintf("lib/%s/software/%s.package.yml", teamFilename, generateFilename(swName))
+	cmd.FilesToWrite[packageFile] = items
+	entry := map[string]any{"path": "../" + packageFile}
+	if inSetup {
+		entry["setup_experience"] = true
+	}
+	if title.DisplayName != "" {
+		entry["display_name"] = title.DisplayName
+	}
+	return entry, nil
+}
+
+func packageLabels(pkg fleet.SoftwareInstaller) (string, []string) {
+	var labels []fleet.SoftwareScopeLabel
+	var key string
+	switch {
+	case len(pkg.LabelsIncludeAny) > 0:
+		labels, key = pkg.LabelsIncludeAny, "labels_include_any"
+	case len(pkg.LabelsExcludeAny) > 0:
+		labels, key = pkg.LabelsExcludeAny, "labels_exclude_any"
+	case len(pkg.LabelsIncludeAll) > 0:
+		labels, key = pkg.LabelsIncludeAll, "labels_include_all"
+	default:
+		return "", nil
+	}
+	names := make([]string, len(labels))
+	for i, l := range labels {
+		names[i] = l.LabelName
+	}
+	return key, names
 }
 
 func (cmd *GenerateGitopsCommand) generateLabels(team *fleet.Team) ([]map[string]any, error) {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -2249,49 +2249,23 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			}
 		}
 
-		var labels []fleet.SoftwareScopeLabel
 		var labelKey string
+		var labelNames []string
 		if softwareTitle.SoftwarePackage != nil {
-			if len(softwareTitle.SoftwarePackage.LabelsIncludeAny) > 0 {
-				labels = softwareTitle.SoftwarePackage.LabelsIncludeAny
-				labelKey = "labels_include_any"
-			}
-			if len(softwareTitle.SoftwarePackage.LabelsExcludeAny) > 0 {
-				labels = softwareTitle.SoftwarePackage.LabelsExcludeAny
-				labelKey = "labels_exclude_any"
-			}
-			if len(softwareTitle.SoftwarePackage.LabelsIncludeAll) > 0 {
-				labels = softwareTitle.SoftwarePackage.LabelsIncludeAll
-				labelKey = "labels_include_all"
-			}
+			sp := softwareTitle.SoftwarePackage
+			labelKey, labelNames = scopeLabels(sp.LabelsIncludeAny, sp.LabelsExcludeAny, sp.LabelsIncludeAll)
 			if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
 				softwareSpec["setup_experience"] = true
 			}
 		} else {
-			platformAndAppID := softwareTitle.AppStoreApp.VPPAppID.String()
-
-			if len(softwareTitle.AppStoreApp.LabelsIncludeAny) > 0 {
-				labels = softwareTitle.AppStoreApp.LabelsIncludeAny
-				labelKey = "labels_include_any"
-			}
-			if len(softwareTitle.AppStoreApp.LabelsExcludeAny) > 0 {
-				labels = softwareTitle.AppStoreApp.LabelsExcludeAny
-				labelKey = "labels_exclude_any"
-			}
-			if len(softwareTitle.AppStoreApp.LabelsIncludeAll) > 0 {
-				labels = softwareTitle.AppStoreApp.LabelsIncludeAll
-				labelKey = "labels_include_all"
-			}
-			if _, exists := setupSoftwareByPlatformAndAppID[platformAndAppID]; exists {
+			app := softwareTitle.AppStoreApp
+			labelKey, labelNames = scopeLabels(app.LabelsIncludeAny, app.LabelsExcludeAny, app.LabelsIncludeAll)
+			if _, exists := setupSoftwareByPlatformAndAppID[app.VPPAppID.String()]; exists {
 				softwareSpec["setup_experience"] = true
 			}
 		}
-		if len(labels) > 0 {
-			labelsList := make([]string, len(labels))
-			for i, label := range labels {
-				labelsList[i] = label.LabelName
-			}
-			softwareSpec[labelKey] = labelsList
+		if labelKey != "" {
+			softwareSpec[labelKey] = labelNames
 		}
 
 		switch {
@@ -2355,7 +2329,7 @@ func (cmd *GenerateGitopsCommand) generateMultiPackage(title *fleet.SoftwareTitl
 		if pkg.PreInstallQuery != "" {
 			item["pre_install_query"] = map[string]any{"path": writeSideFile("queries", prefix+"-preinstallquery.yml", []map[string]any{{"query": pkg.PreInstallQuery}})}
 		}
-		if key, names := packageLabels(pkg); key != "" {
+		if key, names := scopeLabels(pkg.LabelsIncludeAny, pkg.LabelsExcludeAny, pkg.LabelsIncludeAll); key != "" {
 			item[key] = names
 		}
 		items = append(items, item)
@@ -2383,16 +2357,16 @@ func (cmd *GenerateGitopsCommand) generateMultiPackage(title *fleet.SoftwareTitl
 	return entry, nil
 }
 
-func packageLabels(pkg fleet.SoftwareInstaller) (string, []string) {
+func scopeLabels(includeAny []fleet.SoftwareScopeLabel, excludeAny []fleet.SoftwareScopeLabel, includeAll []fleet.SoftwareScopeLabel) (string, []string) {
 	var labels []fleet.SoftwareScopeLabel
 	var key string
 	switch {
-	case len(pkg.LabelsIncludeAny) > 0:
-		labels, key = pkg.LabelsIncludeAny, "labels_include_any"
-	case len(pkg.LabelsExcludeAny) > 0:
-		labels, key = pkg.LabelsExcludeAny, "labels_exclude_any"
-	case len(pkg.LabelsIncludeAll) > 0:
-		labels, key = pkg.LabelsIncludeAll, "labels_include_all"
+	case len(includeAny) > 0:
+		labels, key = includeAny, "labels_include_any"
+	case len(excludeAny) > 0:
+		labels, key = excludeAny, "labels_exclude_any"
+	case len(includeAll) > 0:
+		labels, key = includeAll, "labels_include_all"
 	default:
 		return "", nil
 	}

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/fleetdm/fleet/v4/client"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
-	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -2113,80 +2112,6 @@ func TestGenerateSoftwareMultiplePackages(t *testing.T) {
 	require.Equal(t, "install A", cmd.FilesToWrite[installA])
 	require.Equal(t, "install B", cmd.FilesToWrite[installB])
 	require.NotEqual(t, installA, installB)
-}
-
-// TestGenerateSoftwareMultiplePackagesRoundTrip generates a multi-package title,
-// writes the output to disk the way the command would, then re-parses it with the
-// gitops parser and checks the packages survive unchanged.
-func TestGenerateSoftwareMultiplePackagesRoundTrip(t *testing.T) {
-	fleetClient := &MockClientMultiPackage{}
-	appConfig, err := fleetClient.GetAppConfig()
-	require.NoError(t, err)
-	cmd := &GenerateGitopsCommand{
-		Client:       fleetClient,
-		CLI:          cli.NewContext(cli.NewApp(), nil, nil),
-		Messages:     Messages{},
-		FilesToWrite: make(map[string]any),
-		AppConfig:    appConfig,
-		SoftwareList: make(map[uint]Software),
-	}
-
-	software, err := cmd.generateSoftware("fleets/team-a.yml", 2, "team-a", false)
-	require.NoError(t, err)
-
-	// Write everything generate produced, mirroring the real writer: .yml files are
-	// marshaled, scripts are written verbatim. The fleet file lives under fleets/ so
-	// the generated ../lib/... paths resolve.
-	dir := t.TempDir()
-	write := func(relPath string, contents []byte) {
-		full := filepath.Join(dir, relPath)
-		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
-		require.NoError(t, os.WriteFile(full, contents, 0o644))
-	}
-	for path, contents := range cmd.FilesToWrite {
-		if strings.HasSuffix(path, ".yml") {
-			b, err := yaml.Marshal(contents)
-			require.NoError(t, err)
-			write(path, b)
-		} else {
-			write(path, []byte(contents.(string)))
-		}
-	}
-	teamFile, err := yaml.Marshal(map[string]any{
-		"name":          "team-a",
-		"team_settings": map[string]any{"secrets": []any{}},
-		"agent_options": nil,
-		"controls":      nil,
-		"policies":      nil,
-		"queries":       nil,
-		"software":      software,
-	})
-	require.NoError(t, err)
-	write("fleets/team-a.yml", teamFile)
-
-	appCfg := &fleet.EnrichedAppConfig{}
-	appCfg.License = &fleet.LicenseInfo{Tier: fleet.TierPremium}
-	parsed, err := spec.GitOpsFromFile(filepath.Join(dir, "fleets", "team-a.yml"), filepath.Join(dir, "fleets"), appCfg, func(string, ...any) {})
-	require.NoError(t, err)
-	require.Len(t, parsed.Software.Packages, 2)
-
-	first := parsed.Software.Packages[0]
-	assert.Equal(t, santaHashA, first.SHA256)
-	assert.Equal(t, "https://example.com/santa-2026.2.pkg", first.URL)
-	assert.True(t, first.SelfService)
-	assert.Equal(t, []string{"macOS"}, first.LabelsIncludeAll)
-	assert.Empty(t, first.Categories.Value)
-	installA, err := os.ReadFile(first.InstallScript.Path)
-	require.NoError(t, err)
-	assert.Equal(t, "install A", string(installA))
-
-	second := parsed.Software.Packages[1]
-	assert.Equal(t, santaHashB, second.SHA256)
-	assert.Equal(t, []string{"Productivity"}, second.Categories.Value)
-	assert.Equal(t, []string{"macOS", "IT test team"}, second.LabelsIncludeAll)
-	installB, err := os.ReadFile(second.InstallScript.Path)
-	require.NoError(t, err)
-	assert.Equal(t, "install B", string(installB))
 }
 
 func TestGeneratePolicies(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -2038,12 +2038,13 @@ func (c *MockClientMultiPackage) GetSoftwareTitleByID(id uint, teamID *uint) (*f
 			DisplayName: "Santa Security",
 			Packages: []fleet.SoftwareInstaller{
 				{
-					StorageID:        santaHashA,
-					URL:              "https://example.com/santa-2026.2.pkg",
-					Platform:         "darwin",
-					InstallScript:    "install A",
-					SelfService:      true,
-					LabelsIncludeAll: []fleet.SoftwareScopeLabel{{LabelName: "macOS"}},
+					StorageID:         santaHashA,
+					URL:               "https://example.com/santa-2026.2.pkg",
+					Platform:          "darwin",
+					InstallScript:     "install A",
+					PostInstallScript: "post A",
+					SelfService:       true,
+					LabelsIncludeAll:  []fleet.SoftwareScopeLabel{{LabelName: "macOS"}},
 				},
 				{
 					StorageID:        santaHashB,
@@ -2112,6 +2113,11 @@ func TestGenerateSoftwareMultiplePackages(t *testing.T) {
 	require.Equal(t, "install A", cmd.FilesToWrite[installA])
 	require.Equal(t, "install B", cmd.FilesToWrite[installB])
 	require.NotEqual(t, installA, installB)
+
+	// post_install_script is written per package as its own side file
+	postA := filepath.Join(pkgDir, list[0]["post_install_script"].(map[string]any)["path"].(string))
+	require.Equal(t, "post A", cmd.FilesToWrite[postA])
+	require.NotContains(t, list[1], "post_install_script")
 }
 
 func TestGeneratePolicies(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/client"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -2007,6 +2008,185 @@ func (c *MockClientWithScriptPackage) GetSetupExperienceSoftware(platform string
 		return []fleet.SoftwareTitleListResult{}, nil
 	}
 	return c.MockClient.GetSetupExperienceSoftware(platform, teamID)
+}
+
+const (
+	santaHashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	santaHashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+type MockClientMultiPackage struct {
+	MockClient
+}
+
+func (c *MockClientMultiPackage) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListResult, error) {
+	if query == "available_for_install=1&fleet_id=2" {
+		return []fleet.SoftwareTitleListResult{{
+			ID:              7,
+			Name:            "Santa",
+			HashSHA256:      new(santaHashA),
+			SoftwarePackage: &fleet.SoftwarePackageOrApp{Name: "santa-2026.2.pkg", Platform: "darwin", Version: "2026.2"},
+		}}, nil
+	}
+	return c.MockClient.ListSoftwareTitles(query)
+}
+
+func (c *MockClientMultiPackage) GetSoftwareTitleByID(id uint, teamID *uint) (*fleet.SoftwareTitle, error) {
+	if id == 7 {
+		return &fleet.SoftwareTitle{
+			ID:          7,
+			Name:        "Santa",
+			DisplayName: "Santa Security",
+			Packages: []fleet.SoftwareInstaller{
+				{
+					StorageID:        santaHashA,
+					URL:              "https://example.com/santa-2026.2.pkg",
+					Platform:         "darwin",
+					InstallScript:    "install A",
+					SelfService:      true,
+					LabelsIncludeAll: []fleet.SoftwareScopeLabel{{LabelName: "macOS"}},
+				},
+				{
+					StorageID:        santaHashB,
+					URL:              "https://example.com/santa-2026.4.pkg",
+					Platform:         "darwin",
+					InstallScript:    "install B",
+					SelfService:      true,
+					Categories:       []string{"Productivity"},
+					LabelsIncludeAll: []fleet.SoftwareScopeLabel{{LabelName: "macOS"}, {LabelName: "IT test team"}},
+				},
+			},
+		}, nil
+	}
+	return c.MockClient.GetSoftwareTitleByID(id, teamID)
+}
+
+func (c *MockClientMultiPackage) GetSetupExperienceSoftware(platform string, teamID uint) ([]fleet.SoftwareTitleListResult, error) {
+	if teamID == 2 {
+		return []fleet.SoftwareTitleListResult{}, nil
+	}
+	return c.MockClient.GetSetupExperienceSoftware(platform, teamID)
+}
+
+func TestGenerateSoftwareMultiplePackages(t *testing.T) {
+	fleetClient := &MockClientMultiPackage{}
+	appConfig, err := fleetClient.GetAppConfig()
+	require.NoError(t, err)
+	cmd := &GenerateGitopsCommand{
+		Client:       fleetClient,
+		CLI:          cli.NewContext(cli.NewApp(), nil, nil),
+		Messages:     Messages{},
+		FilesToWrite: make(map[string]any),
+		AppConfig:    appConfig,
+		SoftwareList: make(map[uint]Software),
+	}
+
+	res, err := cmd.generateSoftware("fleets/team-a.yml", 2, "team-a", false)
+	require.NoError(t, err)
+
+	// the fleet file references the title's packages by a single path entry
+	packages := res["packages"].([]map[string]any)
+	require.Len(t, packages, 1)
+	require.Equal(t, "Santa Security", packages[0]["display_name"])
+
+	// that path points at a package YAML file holding a two-item list, first-added
+	// first, with the per-package fields inline
+	listPath := strings.TrimPrefix(packages[0]["path"].(string), "../")
+	list := cmd.FilesToWrite[listPath].([]map[string]any)
+	require.Len(t, list, 2)
+
+	require.Equal(t, santaHashA, list[0]["hash_sha256"])
+	require.Equal(t, "https://example.com/santa-2026.2.pkg", list[0]["url"])
+	require.Equal(t, true, list[0]["self_service"])
+	require.Equal(t, []string{"macOS"}, list[0]["labels_include_all"])
+	require.NotContains(t, list[0], "categories")
+
+	require.Equal(t, santaHashB, list[1]["hash_sha256"])
+	require.Equal(t, []string{"Productivity"}, list[1]["categories"])
+	require.Equal(t, []string{"macOS", "IT test team"}, list[1]["labels_include_all"])
+
+	// each package's install script is written to its own file, referenced by a path
+	// relative to the package YAML file's directory
+	pkgDir := filepath.Dir(listPath)
+	installA := filepath.Join(pkgDir, list[0]["install_script"].(map[string]any)["path"].(string))
+	installB := filepath.Join(pkgDir, list[1]["install_script"].(map[string]any)["path"].(string))
+	require.Equal(t, "install A", cmd.FilesToWrite[installA])
+	require.Equal(t, "install B", cmd.FilesToWrite[installB])
+	require.NotEqual(t, installA, installB)
+}
+
+// TestGenerateSoftwareMultiplePackagesRoundTrip generates a multi-package title,
+// writes the output to disk the way the command would, then re-parses it with the
+// gitops parser and checks the packages survive unchanged.
+func TestGenerateSoftwareMultiplePackagesRoundTrip(t *testing.T) {
+	fleetClient := &MockClientMultiPackage{}
+	appConfig, err := fleetClient.GetAppConfig()
+	require.NoError(t, err)
+	cmd := &GenerateGitopsCommand{
+		Client:       fleetClient,
+		CLI:          cli.NewContext(cli.NewApp(), nil, nil),
+		Messages:     Messages{},
+		FilesToWrite: make(map[string]any),
+		AppConfig:    appConfig,
+		SoftwareList: make(map[uint]Software),
+	}
+
+	software, err := cmd.generateSoftware("fleets/team-a.yml", 2, "team-a", false)
+	require.NoError(t, err)
+
+	// Write everything generate produced, mirroring the real writer: .yml files are
+	// marshaled, scripts are written verbatim. The fleet file lives under fleets/ so
+	// the generated ../lib/... paths resolve.
+	dir := t.TempDir()
+	write := func(relPath string, contents []byte) {
+		full := filepath.Join(dir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, contents, 0o644))
+	}
+	for path, contents := range cmd.FilesToWrite {
+		if strings.HasSuffix(path, ".yml") {
+			b, err := yaml.Marshal(contents)
+			require.NoError(t, err)
+			write(path, b)
+		} else {
+			write(path, []byte(contents.(string)))
+		}
+	}
+	teamFile, err := yaml.Marshal(map[string]any{
+		"name":          "team-a",
+		"team_settings": map[string]any{"secrets": []any{}},
+		"agent_options": nil,
+		"controls":      nil,
+		"policies":      nil,
+		"queries":       nil,
+		"software":      software,
+	})
+	require.NoError(t, err)
+	write("fleets/team-a.yml", teamFile)
+
+	appCfg := &fleet.EnrichedAppConfig{}
+	appCfg.License = &fleet.LicenseInfo{Tier: fleet.TierPremium}
+	parsed, err := spec.GitOpsFromFile(filepath.Join(dir, "fleets", "team-a.yml"), filepath.Join(dir, "fleets"), appCfg, func(string, ...any) {})
+	require.NoError(t, err)
+	require.Len(t, parsed.Software.Packages, 2)
+
+	first := parsed.Software.Packages[0]
+	assert.Equal(t, santaHashA, first.SHA256)
+	assert.Equal(t, "https://example.com/santa-2026.2.pkg", first.URL)
+	assert.True(t, first.SelfService)
+	assert.Equal(t, []string{"macOS"}, first.LabelsIncludeAll)
+	assert.Empty(t, first.Categories.Value)
+	installA, err := os.ReadFile(first.InstallScript.Path)
+	require.NoError(t, err)
+	assert.Equal(t, "install A", string(installA))
+
+	second := parsed.Software.Packages[1]
+	assert.Equal(t, santaHashB, second.SHA256)
+	assert.Equal(t, []string{"Productivity"}, second.Categories.Value)
+	assert.Equal(t, []string{"macOS", "IT test team"}, second.LabelsIncludeAll)
+	installB, err := os.ReadFile(second.InstallScript.Path)
+	require.NoError(t, err)
+	assert.Equal(t, "install B", string(installB))
 }
 
 func TestGeneratePolicies(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -255,6 +255,13 @@ func StartSoftwareInstallerServer(t *testing.T) {
 					// serve same content as ruby.deb
 					w.Header().Set("Content-Type", "application/vnd.debian.binary-package")
 					_, _ = w.Write(b)
+				case strings.Contains(r.URL.Path, "ruby_variant.deb"):
+					// ruby.deb with extra trailing bytes: same package (the deb archive
+					// ignores trailing bytes) but a different hash, so it is a distinct
+					// package of the same title.
+					w.Header().Set("Content-Type", "application/vnd.debian.binary-package")
+					_, _ = w.Write(b)
+					_, _ = w.Write([]byte("\n# variant\n"))
 				case strings.HasSuffix(r.URL.Path, ".pkg"):
 					pkgDir := getPathRelative("../testdata/gitops/lib/")
 					http.ServeFile(w, r, filepath.Join(pkgDir, filepath.Base(r.URL.Path)))

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -396,6 +396,92 @@ settings:
 	}
 }
 
+func (s *enterpriseIntegrationGitopsTestSuite) TestMultiplePackagesRoundTrip() {
+	t := s.T()
+	ctx := context.Background()
+	testing_utils.StartSoftwareInstallerServer(t)
+
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+
+	const teamName = "roundtrip_multi"
+
+	// Apply a team holding two custom packages of the same title (ruby, with
+	// different content per architecture).
+	applyDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(applyDir, "fleets"), 0o755))
+	teamFile := filepath.Join(applyDir, "fleets", "team.yml")
+	require.NoError(t, os.WriteFile(teamFile, fmt.Appendf(nil, `
+name: %s
+team_settings:
+  secrets:
+    - secret: roundtrip_secret
+agent_options:
+controls:
+policies:
+queries:
+software:
+  packages:
+    - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+    - url: ${SOFTWARE_INSTALLER_URL}/ruby_variant.deb
+`, teamName), 0o644))
+
+	_, err := fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", teamFile})
+	require.NoError(t, err)
+
+	team, err := s.DS.TeamByName(ctx, teamName)
+	require.NoError(t, err)
+
+	// find the title that ended up with both packages
+	titleID := uint(0)
+	titles, _, _, err := s.DS.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: &team.ID}, fleet.TeamFilter{User: test.UserAdmin})
+	require.NoError(t, err)
+	for _, tl := range titles {
+		p, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, tl.ID)
+		require.NoError(t, err)
+		if len(p) == 2 {
+			titleID = tl.ID
+		}
+	}
+	require.NotZero(t, titleID, "the two packages should resolve to one title")
+
+	// first-added first
+	pkgs, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	firstID, secondID := pkgs[0].InstallerID, pkgs[1].InstallerID
+
+	// generate the team's config back out (needs an admin to read config), with real
+	// secrets so it re-applies cleanly
+	admin := fleet.User{
+		Name:       "Admin " + uuid.NewString(),
+		Email:      uuid.NewString() + "@example.com",
+		GlobalRole: new(fleet.RoleAdmin),
+	}
+	require.NoError(t, admin.SetPassword(test.GoodPassword, 10, 10))
+	_, err = s.DS.NewUser(ctx, &admin)
+	require.NoError(t, err)
+	adminConfig := s.createFleetctlConfig(t, admin)
+
+	genDir := t.TempDir()
+	_, err = fleetctltest.RunAppNoChecks([]string{"generate-gitops", "--config", adminConfig.Name(), "--fleet", teamName, "--dir", genDir, "--insecure"})
+	require.NoError(t, err)
+
+	genTeamFiles, err := filepath.Glob(filepath.Join(genDir, "fleets", "*.yml"))
+	require.NoError(t, err)
+	require.Len(t, genTeamFiles, 1)
+
+	// re-applying the generated output is a no-op: the same two packages, same ids
+	_, err = fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", genTeamFiles[0]})
+	require.NoError(t, err)
+
+	pkgs, err = s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	require.Equal(t, firstID, pkgs[0].InstallerID)
+	require.Equal(t, secondID, pkgs[1].InstallerID)
+}
+
 func (s *enterpriseIntegrationGitopsTestSuite) createFleetctlConfig(t *testing.T, user fleet.User) *os.File {
 	fleetctlConfig, err := os.CreateTemp(t.TempDir(), "*.yml")
 	require.NoError(t, err)

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -396,121 +396,6 @@ settings:
 	}
 }
 
-func (s *enterpriseIntegrationGitopsTestSuite) TestMultiplePackagesRoundTrip() {
-	t := s.T()
-	ctx := context.Background()
-	testing_utils.StartSoftwareInstallerServer(t)
-
-	user := s.createGitOpsUser(t)
-	fleetctlConfig := s.createFleetctlConfig(t, user)
-
-	const teamName = "roundtrip_multi"
-
-	// Apply a team holding two custom packages of the same title (ruby, with
-	// different content per architecture).
-	applyDir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(applyDir, "fleets"), 0o755))
-	teamFile := filepath.Join(applyDir, "fleets", "team.yml")
-	require.NoError(t, os.WriteFile(teamFile, fmt.Appendf(nil, `
-name: %s
-team_settings:
-  secrets:
-    - secret: roundtrip_secret
-agent_options:
-controls:
-policies:
-queries:
-software:
-  packages:
-    - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
-      self_service: true
-    - url: ${SOFTWARE_INSTALLER_URL}/ruby_variant.deb
-`, teamName), 0o644))
-
-	_, err := fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", teamFile})
-	require.NoError(t, err)
-
-	team, err := s.DS.TeamByName(ctx, teamName)
-	require.NoError(t, err)
-
-	// find the title that ended up with both packages
-	titleID := uint(0)
-	titles, _, _, err := s.DS.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: &team.ID}, fleet.TeamFilter{User: test.UserAdmin})
-	require.NoError(t, err)
-	for _, tl := range titles {
-		p, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, tl.ID)
-		require.NoError(t, err)
-		if len(p) == 2 {
-			titleID = tl.ID
-		}
-	}
-	require.NotZero(t, titleID, "the two packages should resolve to one title")
-
-	// first-added first, with the per-package self_service flag on ruby.deb only
-	pkgs, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
-	require.NoError(t, err)
-	require.Len(t, pkgs, 2)
-	firstID, secondID := pkgs[0].InstallerID, pkgs[1].InstallerID
-	require.True(t, pkgs[0].SelfService)
-	require.False(t, pkgs[1].SelfService)
-
-	// generate the team's config back out (needs an admin to read config), with real
-	// secrets so it re-applies cleanly
-	admin := fleet.User{
-		Name:       "Admin " + uuid.NewString(),
-		Email:      uuid.NewString() + "@example.com",
-		GlobalRole: new(fleet.RoleAdmin),
-	}
-	require.NoError(t, admin.SetPassword(test.GoodPassword, 10, 10))
-	_, err = s.DS.NewUser(ctx, &admin)
-	require.NoError(t, err)
-	adminConfig := s.createFleetctlConfig(t, admin)
-
-	genDir := t.TempDir()
-	_, err = fleetctltest.RunAppNoChecks([]string{"generate-gitops", "--config", adminConfig.Name(), "--fleet", teamName, "--dir", genDir, "--insecure"})
-	require.NoError(t, err)
-
-	genTeamFiles, err := filepath.Glob(filepath.Join(genDir, "fleets", "*.yml"))
-	require.NoError(t, err)
-	require.Len(t, genTeamFiles, 1)
-
-	// re-applying the generated output keeps the same two packages, ids, and per-package fields
-	_, err = fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", genTeamFiles[0]})
-	require.NoError(t, err)
-
-	pkgs, err = s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
-	require.NoError(t, err)
-	require.Len(t, pkgs, 2)
-	require.Equal(t, firstID, pkgs[0].InstallerID)
-	require.Equal(t, secondID, pkgs[1].InstallerID)
-	require.True(t, pkgs[0].SelfService)
-	require.False(t, pkgs[1].SelfService)
-
-	// generating again from the re-applied state yields byte-identical files: the
-	// round-trip is stable, so re-applying the generated config produced no diff
-	genDir2 := t.TempDir()
-	_, err = fleetctltest.RunAppNoChecks([]string{"generate-gitops", "--config", adminConfig.Name(), "--fleet", teamName, "--dir", genDir2, "--insecure"})
-	require.NoError(t, err)
-
-	readTree := func(dir string) map[string]string {
-		files := map[string]string{}
-		require.NoError(t, filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
-			require.NoError(t, err)
-			if info.IsDir() {
-				return nil
-			}
-			rel, err := filepath.Rel(dir, p)
-			require.NoError(t, err)
-			b, err := os.ReadFile(p) //nolint:gosec // reading generated files under t.TempDir()
-			require.NoError(t, err)
-			files[rel] = string(b)
-			return nil
-		}))
-		return files
-	}
-	require.Equal(t, readTree(genDir), readTree(genDir2))
-}
-
 func (s *enterpriseIntegrationGitopsTestSuite) createFleetctlConfig(t *testing.T, user fleet.User) *os.File {
 	fleetctlConfig, err := os.CreateTemp(t.TempDir(), "*.yml")
 	require.NoError(t, err)
@@ -5924,4 +5809,119 @@ labels:
 
 	realRunOutput := fleetctltest.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "-f", teamFile.Name()})
 	require.Contains(t, realRunOutput, "gitops succeeded")
+}
+
+func (s *enterpriseIntegrationGitopsTestSuite) TestMultiplePackagesRoundTrip() {
+	t := s.T()
+	ctx := context.Background()
+	testing_utils.StartSoftwareInstallerServer(t)
+
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+
+	const teamName = "roundtrip_multi"
+
+	// Apply a team holding two custom packages of the same title (ruby, with
+	// different content per architecture).
+	applyDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(applyDir, "fleets"), 0o755))
+	teamFile := filepath.Join(applyDir, "fleets", "team.yml")
+	require.NoError(t, os.WriteFile(teamFile, fmt.Appendf(nil, `
+name: %s
+team_settings:
+  secrets:
+    - secret: roundtrip_secret
+agent_options:
+controls:
+policies:
+queries:
+software:
+  packages:
+    - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+      self_service: true
+    - url: ${SOFTWARE_INSTALLER_URL}/ruby_variant.deb
+`, teamName), 0o644))
+
+	_, err := fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", teamFile})
+	require.NoError(t, err)
+
+	team, err := s.DS.TeamByName(ctx, teamName)
+	require.NoError(t, err)
+
+	// find the title that ended up with both packages
+	titleID := uint(0)
+	titles, _, _, err := s.DS.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: &team.ID}, fleet.TeamFilter{User: test.UserAdmin})
+	require.NoError(t, err)
+	for _, tl := range titles {
+		p, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, tl.ID)
+		require.NoError(t, err)
+		if len(p) == 2 {
+			titleID = tl.ID
+		}
+	}
+	require.NotZero(t, titleID, "the two packages should resolve to one title")
+
+	// first-added first, with the per-package self_service flag on ruby.deb only
+	pkgs, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	firstID, secondID := pkgs[0].InstallerID, pkgs[1].InstallerID
+	require.True(t, pkgs[0].SelfService)
+	require.False(t, pkgs[1].SelfService)
+
+	// generate the team's config back out (needs an admin to read config), with real
+	// secrets so it re-applies cleanly
+	admin := fleet.User{
+		Name:       "Admin " + uuid.NewString(),
+		Email:      uuid.NewString() + "@example.com",
+		GlobalRole: new(fleet.RoleAdmin),
+	}
+	require.NoError(t, admin.SetPassword(test.GoodPassword, 10, 10))
+	_, err = s.DS.NewUser(ctx, &admin)
+	require.NoError(t, err)
+	adminConfig := s.createFleetctlConfig(t, admin)
+
+	genDir := t.TempDir()
+	_, err = fleetctltest.RunAppNoChecks([]string{"generate-gitops", "--config", adminConfig.Name(), "--fleet", teamName, "--dir", genDir, "--insecure"})
+	require.NoError(t, err)
+
+	genTeamFiles, err := filepath.Glob(filepath.Join(genDir, "fleets", "*.yml"))
+	require.NoError(t, err)
+	require.Len(t, genTeamFiles, 1)
+
+	// re-applying the generated output keeps the same two packages, ids, and per-package fields
+	_, err = fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", genTeamFiles[0]})
+	require.NoError(t, err)
+
+	pkgs, err = s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	require.Equal(t, firstID, pkgs[0].InstallerID)
+	require.Equal(t, secondID, pkgs[1].InstallerID)
+	require.True(t, pkgs[0].SelfService)
+	require.False(t, pkgs[1].SelfService)
+
+	// generating again from the re-applied state yields byte-identical files: the
+	// round-trip is stable, so re-applying the generated config produced no diff
+	genDir2 := t.TempDir()
+	_, err = fleetctltest.RunAppNoChecks([]string{"generate-gitops", "--config", adminConfig.Name(), "--fleet", teamName, "--dir", genDir2, "--insecure"})
+	require.NoError(t, err)
+
+	readTree := func(dir string) map[string]string {
+		files := map[string]string{}
+		require.NoError(t, filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+			require.NoError(t, err)
+			if info.IsDir() {
+				return nil
+			}
+			rel, err := filepath.Rel(dir, p)
+			require.NoError(t, err)
+			b, err := os.ReadFile(p) //nolint:gosec // reading generated files under t.TempDir()
+			require.NoError(t, err)
+			files[rel] = string(b)
+			return nil
+		}))
+		return files
+	}
+	require.Equal(t, readTree(genDir), readTree(genDir2))
 }

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -423,6 +423,7 @@ queries:
 software:
   packages:
     - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+      self_service: true
     - url: ${SOFTWARE_INSTALLER_URL}/ruby_variant.deb
 `, teamName), 0o644))
 
@@ -445,11 +446,13 @@ software:
 	}
 	require.NotZero(t, titleID, "the two packages should resolve to one title")
 
-	// first-added first
+	// first-added first, with the per-package self_service flag on ruby.deb only
 	pkgs, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
 	require.NoError(t, err)
 	require.Len(t, pkgs, 2)
 	firstID, secondID := pkgs[0].InstallerID, pkgs[1].InstallerID
+	require.True(t, pkgs[0].SelfService)
+	require.False(t, pkgs[1].SelfService)
 
 	// generate the team's config back out (needs an admin to read config), with real
 	// secrets so it re-applies cleanly
@@ -471,7 +474,7 @@ software:
 	require.NoError(t, err)
 	require.Len(t, genTeamFiles, 1)
 
-	// re-applying the generated output is a no-op: the same two packages, same ids
+	// re-applying the generated output keeps the same two packages, ids, and per-package fields
 	_, err = fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", genTeamFiles[0]})
 	require.NoError(t, err)
 
@@ -480,6 +483,32 @@ software:
 	require.Len(t, pkgs, 2)
 	require.Equal(t, firstID, pkgs[0].InstallerID)
 	require.Equal(t, secondID, pkgs[1].InstallerID)
+	require.True(t, pkgs[0].SelfService)
+	require.False(t, pkgs[1].SelfService)
+
+	// generating again from the re-applied state yields byte-identical files: the
+	// round-trip is stable, so re-applying the generated config produced no diff
+	genDir2 := t.TempDir()
+	_, err = fleetctltest.RunAppNoChecks([]string{"generate-gitops", "--config", adminConfig.Name(), "--fleet", teamName, "--dir", genDir2, "--insecure"})
+	require.NoError(t, err)
+
+	readTree := func(dir string) map[string]string {
+		files := map[string]string{}
+		require.NoError(t, filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+			require.NoError(t, err)
+			if info.IsDir() {
+				return nil
+			}
+			rel, err := filepath.Rel(dir, p)
+			require.NoError(t, err)
+			b, err := os.ReadFile(p) //nolint:gosec // reading generated files under t.TempDir()
+			require.NoError(t, err)
+			files[rel] = string(b)
+			return nil
+		}))
+		return files
+	}
+	require.Equal(t, readTree(genDir), readTree(genDir2))
 }
 
 func (s *enterpriseIntegrationGitopsTestSuite) createFleetctlConfig(t *testing.T, user fleet.User) *os.File {

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -5823,8 +5823,22 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestMultiplePackagesRoundTrip() {
 
 	// Apply a team holding two custom packages of the same title (ruby, with
 	// different content per architecture).
+	// absolute path to a valid PNG fixture for the package icon
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	iconPath, err := filepath.Abs(filepath.Join(filepath.Dir(currentFile), "../../fleetctl/testdata/gitops/lib/icon.png"))
+	require.NoError(t, err)
+
+	// gitops validates that referenced labels exist, so create one to scope a package to
+	_, err = s.DS.NewLabel(ctx, &fleet.Label{Name: "roundtrip_multi_label", Query: "SELECT 1"})
+	require.NoError(t, err)
+
 	applyDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(applyDir, "fleets"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(applyDir, "queries"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(applyDir, "scripts"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(applyDir, "queries", "ruby-preinstall.yml"), []byte("- query: SELECT 1 FROM osquery_info\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(applyDir, "scripts", "ruby-postinstall.sh"), []byte("#!/bin/sh\necho postinstall\n"), 0o644))
 	teamFile := filepath.Join(applyDir, "fleets", "team.yml")
 	require.NoError(t, os.WriteFile(teamFile, fmt.Appendf(nil, `
 name: %s
@@ -5839,10 +5853,20 @@ software:
   packages:
     - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
       self_service: true
+      pre_install_query:
+        path: ../queries/ruby-preinstall.yml
+      labels_include_all:
+        - roundtrip_multi_label
+      icon:
+        path: %s
     - url: ${SOFTWARE_INSTALLER_URL}/ruby_variant.deb
-`, teamName), 0o644))
+      categories:
+        - "🔐 Security"
+      post_install_script:
+        path: ../scripts/ruby-postinstall.sh
+`, teamName, iconPath), 0o644))
 
-	_, err := fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", teamFile})
+	_, err = fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", teamFile})
 	require.NoError(t, err)
 
 	team, err := s.DS.TeamByName(ctx, teamName)
@@ -5861,13 +5885,32 @@ software:
 	}
 	require.NotZero(t, titleID, "the two packages should resolve to one title")
 
-	// first-added first, with the per-package self_service flag on ruby.deb only
+	// assertPackages checks the per-package fields that ride through apply and re-apply:
+	// ruby.deb keeps self_service, a pre-install query, and a scope label; ruby_variant.deb
+	// keeps a category and a post-install script.
+	assertPackages := func(pkgs []*fleet.SoftwareInstaller) {
+		require.True(t, pkgs[0].SelfService)
+		require.False(t, pkgs[1].SelfService)
+		require.Equal(t, "SELECT 1 FROM osquery_info", pkgs[0].PreInstallQuery)
+		require.Empty(t, pkgs[1].PreInstallQuery)
+		require.Len(t, pkgs[0].LabelsIncludeAll, 1)
+		require.Equal(t, "roundtrip_multi_label", pkgs[0].LabelsIncludeAll[0].LabelName)
+		require.Equal(t, "#!/bin/sh\necho postinstall\n", pkgs[1].PostInstallScript)
+		cats, err := s.DS.GetCategoriesForSoftwareInstallers(ctx, []uint{pkgs[1].InstallerID})
+		require.NoError(t, err)
+		require.Equal(t, []string{"🔐 Security"}, cats[pkgs[1].InstallerID])
+		// the icon is title-level, so it is fetched once from the title metadata
+		meta, err := s.DS.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &team.ID, titleID, false)
+		require.NoError(t, err)
+		require.NotNil(t, meta.IconUrl)
+	}
+
+	// first-added first
 	pkgs, err := s.DS.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
 	require.NoError(t, err)
 	require.Len(t, pkgs, 2)
 	firstID, secondID := pkgs[0].InstallerID, pkgs[1].InstallerID
-	require.True(t, pkgs[0].SelfService)
-	require.False(t, pkgs[1].SelfService)
+	assertPackages(pkgs)
 
 	// generate the team's config back out (needs an admin to read config), with real
 	// secrets so it re-applies cleanly
@@ -5898,8 +5941,7 @@ software:
 	require.Len(t, pkgs, 2)
 	require.Equal(t, firstID, pkgs[0].InstallerID)
 	require.Equal(t, secondID, pkgs[1].InstallerID)
-	require.True(t, pkgs[0].SelfService)
-	require.False(t, pkgs[1].SelfService)
+	assertPackages(pkgs)
 
 	// generating again from the re-applied state yields byte-identical files: the
 	// round-trip is stable, so re-applying the generated config produced no diff

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -304,13 +304,26 @@ func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePac
 		}
 	}
 
-	packageLevel.Categories = spec.Categories
-	packageLevel.LabelsIncludeAny = spec.LabelsIncludeAny
-	packageLevel.LabelsExcludeAny = spec.LabelsExcludeAny
-	packageLevel.LabelsIncludeAll = spec.LabelsIncludeAll
-	packageLevel.InstallDuringSetup = spec.InstallDuringSetup
-	packageLevel.SelfService = spec.SelfService
-	packageLevel.Configuration = spec.Configuration
+	// Inherit team-level fields the package didn't set. Labels, self_service, and
+	// categories are per-package for multiple packages, or inherited from the
+	// fleet-level file for a single package.
+	if !packageLevel.SelfService {
+		packageLevel.SelfService = spec.SelfService
+	}
+	if len(packageLevel.Categories.Value) == 0 {
+		packageLevel.Categories = spec.Categories
+	}
+	if len(packageLevel.LabelsIncludeAny) == 0 && len(packageLevel.LabelsExcludeAny) == 0 && len(packageLevel.LabelsIncludeAll) == 0 {
+		packageLevel.LabelsIncludeAny = spec.LabelsIncludeAny
+		packageLevel.LabelsExcludeAny = spec.LabelsExcludeAny
+		packageLevel.LabelsIncludeAll = spec.LabelsIncludeAll
+	}
+	if !packageLevel.InstallDuringSetup.Valid {
+		packageLevel.InstallDuringSetup = spec.InstallDuringSetup
+	}
+	if packageLevel.Configuration.Path == "" {
+		packageLevel.Configuration = spec.Configuration
+	}
 
 	// This will only override display name set at path: path/to/software.yml level
 	// if display_name is specified at the team level yml
@@ -319,6 +332,20 @@ func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePac
 	}
 
 	return packageLevel, nil
+}
+
+func validatePackageFieldPlacement(teamLevel SoftwarePackage, pkg *fleet.SoftwarePackageSpec, multiple bool) error {
+	if (teamLevel.SelfService && pkg.SelfService) ||
+		(len(teamLevel.Categories.Value) > 0 && len(pkg.Categories.Value) > 0) {
+		return fmt.Errorf(fleet.SoftwareSelfServiceCategoriesConflictMessage, pkg.URL)
+	}
+	if multiple && pkg.InstallDuringSetup.Valid {
+		return fmt.Errorf(fleet.SoftwareSetupExperienceFleetLevelOnlyMessage, pkg.URL)
+	}
+	if multiple && (len(teamLevel.LabelsIncludeAny) > 0 || len(teamLevel.LabelsExcludeAny) > 0 || len(teamLevel.LabelsIncludeAll) > 0) {
+		return fmt.Errorf(fleet.SoftwareLabelsPackageLevelOnlyMessage, pkg.URL)
+	}
+	return nil
 }
 
 type Software struct {
@@ -2225,41 +2252,38 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 					multiError = multierror.Append(multiError, fmt.Errorf("failed to expand environment in file %s: %w", *teamLevelPackage.Path, err))
 					continue
 				}
-				var singlePackageSpec SoftwarePackage
-				singlePackageSpec.ReferencedYamlPath = resolvedPath
-				if err := YamlUnmarshal(fileBytes, &singlePackageSpec); err == nil {
-					multiError = multierror.Append(multiError, validateYAMLKeys(fileBytes, reflect.TypeFor[SoftwarePackage](), *teamLevelPackage.Path, []string{"software", "packages"})...)
-					if singlePackageSpec.IncludesFieldsDisallowedInPackageFile() {
-						multiError = multierror.Append(multiError, fmt.Errorf("labels, categories, setup_experience, and self_service values must be specified at the team level; package-level specified in %s", *teamLevelPackage.Path))
-						continue
-					}
-					softwarePackageSpecs = append(softwarePackageSpecs, &singlePackageSpec.SoftwarePackageSpec)
-				} else if err = YamlUnmarshal(fileBytes, &softwarePackageSpecs); err == nil {
-					// Failing that, try to unmarshal as a list of SoftwarePackageSpecs
+				// A package YAML file is a list of packages. A file written as a single
+				// object is treated as a one-element list.
+				var singlePackageSpec fleet.SoftwarePackageSpec
+				listErr := YamlUnmarshal(fileBytes, &softwarePackageSpecs)
+				if listErr == nil {
 					multiError = multierror.Append(multiError, validateYAMLKeys(fileBytes, reflect.TypeFor[[]fleet.SoftwarePackageSpec](), *teamLevelPackage.Path, []string{"software", "packages"})...)
-					for i, spec := range softwarePackageSpecs {
-						if spec.IncludesFieldsDisallowedInPackageFile() {
-							multiError = multierror.Append(multiError, fmt.Errorf("labels, categories, setup_experience, and self_service values must be specified at the team level; package-level specified in %s", *teamLevelPackage.Path))
-							continue
-						}
-
-						softwarePackageSpecs[i].ReferencedYamlPath = resolvedPath
-					}
+				} else if err := YamlUnmarshal(fileBytes, &singlePackageSpec); err == nil {
+					multiError = multierror.Append(multiError, validateYAMLKeys(fileBytes, reflect.TypeFor[fleet.SoftwarePackageSpec](), *teamLevelPackage.Path, []string{"software", "packages"})...)
+					softwarePackageSpecs = append(softwarePackageSpecs, &singlePackageSpec)
 				} else {
-					// If we reached here, we couldn't unmarshal as either format.
-					multiError = multierror.Append(multiError, MaybeParseTypeError(*teamLevelPackage.Path, []string{"software", "packages"}, err))
+					// couldn't unmarshal as a list or a single object
+					multiError = multierror.Append(multiError, MaybeParseTypeError(*teamLevelPackage.Path, []string{"software", "packages"}, listErr))
 					continue
 				}
-
-				for i, spec := range softwarePackageSpecs {
-					softwarePackageSpec := spec.ResolveSoftwarePackagePaths(filepath.Dir(spec.ReferencedYamlPath))
+				// Collect the packages that validate and hydrate, dropping any that fail.
+				multiple := len(softwarePackageSpecs) > 1
+				var valid []*fleet.SoftwarePackageSpec
+				for _, spec := range softwarePackageSpecs {
+					spec.ReferencedYamlPath = resolvedPath
+					if err := validatePackageFieldPlacement(teamLevelPackage, spec, multiple); err != nil {
+						multiError = multierror.Append(multiError, err)
+						continue
+					}
+					softwarePackageSpec := spec.ResolveSoftwarePackagePaths(filepath.Dir(resolvedPath))
 					softwarePackageSpec, err = teamLevelPackage.HydrateToPackageLevel(softwarePackageSpec, ext)
 					if err != nil {
 						multiError = multierror.Append(multiError, err)
 						continue
 					}
-					softwarePackageSpecs[i] = &softwarePackageSpec
+					valid = append(valid, &softwarePackageSpec)
 				}
+				softwarePackageSpecs = valid
 
 			default:
 				multiError = multierror.Append(multiError, fmt.Errorf("software package path %s has unsupported extension %q; only .yml, .yaml, .sh, or .ps1 files are supported", *teamLevelPackage.Path, ext))

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2252,6 +2252,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 					multiError = multierror.Append(multiError, fmt.Errorf("failed to expand environment in file %s: %w", *teamLevelPackage.Path, err))
 					continue
 				}
+
 				// A package YAML file is a list of packages. A file written as a single
 				// object is treated as a one-element list.
 				var singlePackageSpec fleet.SoftwarePackageSpec
@@ -2266,6 +2267,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 					multiError = multierror.Append(multiError, MaybeParseTypeError(*teamLevelPackage.Path, []string{"software", "packages"}, listErr))
 					continue
 				}
+
 				// Collect the packages that validate and hydrate, dropping any that fail.
 				multiple := len(softwarePackageSpecs) > 1
 				var valid []*fleet.SoftwarePackageSpec

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -335,15 +335,16 @@ func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePac
 }
 
 func validatePackageFieldPlacement(teamLevel SoftwarePackage, pkg *fleet.SoftwarePackageSpec, multiple bool) error {
+	id := pkg.URL
+	if id == "" {
+		id = pkg.SHA256
+	}
 	if (teamLevel.SelfService && pkg.SelfService) ||
 		(len(teamLevel.Categories.Value) > 0 && len(pkg.Categories.Value) > 0) {
-		return fmt.Errorf(fleet.SoftwareSelfServiceCategoriesConflictMessage, pkg.URL)
+		return fmt.Errorf(fleet.SoftwareSelfServiceCategoriesConflictMessage, id)
 	}
 	if multiple && pkg.InstallDuringSetup.Valid {
-		return fmt.Errorf(fleet.SoftwareSetupExperienceFleetLevelOnlyMessage, pkg.URL)
-	}
-	if multiple && (len(teamLevel.LabelsIncludeAny) > 0 || len(teamLevel.LabelsExcludeAny) > 0 || len(teamLevel.LabelsIncludeAll) > 0) {
-		return fmt.Errorf(fleet.SoftwareLabelsPackageLevelOnlyMessage, pkg.URL)
+		return fmt.Errorf(fleet.SoftwareSetupExperienceFleetLevelOnlyMessage, id)
 	}
 	return nil
 }
@@ -2270,6 +2271,9 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 
 				// Collect the packages that validate and hydrate, dropping any that fail.
 				multiple := len(softwarePackageSpecs) > 1
+				if multiple && (len(teamLevelPackage.LabelsIncludeAny) > 0 || len(teamLevelPackage.LabelsExcludeAny) > 0 || len(teamLevelPackage.LabelsIncludeAll) > 0) {
+					multiError = multierror.Append(multiError, fmt.Errorf(fleet.SoftwareLabelsPackageLevelOnlyMessage, *teamLevelPackage.Path))
+				}
 				var valid []*fleet.SoftwarePackageSpec
 				for _, spec := range softwarePackageSpecs {
 					spec.ReferencedYamlPath = resolvedPath

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -304,9 +304,9 @@ func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePac
 		}
 	}
 
-	// Inherit team-level fields the package didn't set. Labels, self_service, and
-	// categories are per-package for multiple packages, or inherited from the
-	// fleet-level file for a single package.
+	// Inherit fleet-level fields onto any package that didn't set them, so a value
+	// set once at the fleet level applies to every package of the title. Which level
+	// a field may live at for a yaml file with multiple packages is validated separately.
 	if !packageLevel.SelfService {
 		packageLevel.SelfService = spec.SelfService
 	}
@@ -339,12 +339,23 @@ func validatePackageFieldPlacement(teamLevel SoftwarePackage, pkg *fleet.Softwar
 	if id == "" {
 		id = pkg.SHA256
 	}
+	if id == "" {
+		id = pkg.ReferencedYamlPath
+	}
+
 	if (teamLevel.SelfService && pkg.SelfService) ||
 		(len(teamLevel.Categories.Value) > 0 && len(pkg.Categories.Value) > 0) {
 		return fmt.Errorf(fleet.SoftwareSelfServiceCategoriesConflictMessage, id)
 	}
 	if multiple && pkg.InstallDuringSetup.Valid {
 		return fmt.Errorf(fleet.SoftwareSetupExperienceFleetLevelOnlyMessage, id)
+	}
+	// A single package may set labels at either level but not both. If multiple
+	// packages are defined, labels are not allowed at the fleet level.
+	teamLevelLabels := len(teamLevel.LabelsIncludeAny) > 0 || len(teamLevel.LabelsExcludeAny) > 0 || len(teamLevel.LabelsIncludeAll) > 0
+	pkgLabels := len(pkg.LabelsIncludeAny) > 0 || len(pkg.LabelsExcludeAny) > 0 || len(pkg.LabelsIncludeAll) > 0
+	if !multiple && teamLevelLabels && pkgLabels {
+		return fmt.Errorf(fleet.SoftwareLabelsConflictMessage, id)
 	}
 	return nil
 }
@@ -2271,6 +2282,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 
 				// Collect the packages that validate and hydrate, dropping any that fail.
 				multiple := len(softwarePackageSpecs) > 1
+				// This label rule is at the fleet level, so check it once here rather than per package.
 				if multiple && (len(teamLevelPackage.LabelsIncludeAny) > 0 || len(teamLevelPackage.LabelsExcludeAny) > 0 || len(teamLevelPackage.LabelsIncludeAll) > 0) {
 					multiError = multierror.Append(multiError, fmt.Errorf(fleet.SoftwareLabelsPackageLevelOnlyMessage, *teamLevelPackage.Path))
 				}

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2299,6 +2299,34 @@ labels_include_all: [macOS]
 		assert.True(t, gitops.Software.Packages[0].SelfService)
 		assert.Equal(t, []string{"macOS"}, gitops.Software.Packages[0].LabelsIncludeAll)
 	})
+
+	// A hash-only package (no URL) is identified by its hash, not an empty string.
+	t.Run("conflict error identifies a hash-only package by its hash", func(t *testing.T) {
+		_, err := setup(t,
+			"      self_service: true\n",
+			fmt.Sprintf(`- hash_sha256: %s
+  self_service: true
+- hash_sha256: %s
+`, hashA, hashB),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), hashA)
+		assert.NotContains(t, err.Error(), `("")`)
+	})
+
+	// The fleet-level labels rule is file-scope, so it reports once regardless of how
+	// many packages the file lists.
+	t.Run("labels error is reported once for multiple packages", func(t *testing.T) {
+		_, err := setup(t,
+			"      labels_include_all: [macOS]\n",
+			fmt.Sprintf(`- hash_sha256: %s
+- hash_sha256: %s
+- hash_sha256: %s
+`, hashA, hashB, hashA[:63]+"c"),
+		)
+		require.Error(t, err)
+		assert.Equal(t, 1, strings.Count(err.Error(), "Labels can be specified only"))
+	})
 }
 
 func TestSoftwarePackagesPathWithInline(t *testing.T) {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2188,6 +2188,105 @@ software:
 	require.NoError(t, err)
 }
 
+func TestMultiPackageFieldPlacement(t *testing.T) {
+	t.Parallel()
+
+	const hashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const hashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	// writeConfig writes the fleet-level file plus a package YAML file and returns
+	// the parsed result (or error).
+	setup := func(t *testing.T, fleetLevel string, packageFile string) (*GitOps, error) {
+		config := getTeamConfig([]string{"software"})
+		config += "software:\n  packages:\n    - path: software/pkgs.yml\n" + fleetLevel
+		path, basePath := createTempFile(t, "", config)
+		require.NoError(t, os.MkdirAll(filepath.Join(basePath, "software"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(basePath, "software", "pkgs.yml"), []byte(packageFile), 0o644))
+		return GitOpsFromFile(path, basePath, premiumAppConfig(), nopLogf)
+	}
+
+	t.Run("happy path keeps per-package fields and inherits fleet-level setup_experience", func(t *testing.T) {
+		gitops, err := setup(t,
+			"      setup_experience: true\n",
+			"- hash_sha256: "+hashA+"\n"+
+				"  self_service: true\n"+
+				"  labels_include_all: [macOS]\n"+
+				"- hash_sha256: "+hashB+"\n"+
+				"  categories: [\"Productivity\"]\n"+
+				"  labels_include_all: [macOS, IT team]\n",
+		)
+		require.NoError(t, err)
+		require.Len(t, gitops.Software.Packages, 2)
+
+		first := gitops.Software.Packages[0]
+		assert.True(t, first.SelfService)
+		assert.Equal(t, []string{"macOS"}, first.LabelsIncludeAll)
+		assert.True(t, first.InstallDuringSetup.Valid && first.InstallDuringSetup.Value)
+
+		second := gitops.Software.Packages[1]
+		assert.False(t, second.SelfService)
+		assert.Equal(t, []string{"Productivity"}, second.Categories.Value)
+		assert.Equal(t, []string{"macOS", "IT team"}, second.LabelsIncludeAll)
+		assert.True(t, second.InstallDuringSetup.Valid && second.InstallDuringSetup.Value)
+	})
+
+	for _, tc := range []struct {
+		name        string
+		fleetLevel  string
+		packageFile string
+		wantErr     string
+	}{
+		{
+			name:        "self_service in both fleet-level and package file",
+			fleetLevel:  "      self_service: true\n",
+			packageFile: "- hash_sha256: " + hashA + "\n  self_service: true\n- hash_sha256: " + hashB + "\n",
+			wantErr:     "self_service and categories can be specified either in the fleet-level file or in the package YAML file",
+		},
+		{
+			name:        "setup_experience in a package file",
+			fleetLevel:  "",
+			packageFile: "- hash_sha256: " + hashA + "\n  setup_experience: true\n- hash_sha256: " + hashB + "\n",
+			wantErr:     "setup_experience can be specified only in the fleet-level file",
+		},
+		{
+			name:        "labels in the fleet-level file",
+			fleetLevel:  "      labels_include_all: [macOS]\n",
+			packageFile: "- hash_sha256: " + hashA + "\n- hash_sha256: " + hashB + "\n",
+			wantErr:     "Labels can be specified only in the package-level file when adding multiple packages",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := setup(t, tc.fleetLevel, tc.packageFile)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+
+	// The setup_experience and fleet-level label rules only apply to a file with
+	// multiple packages. A single package can set setup_experience in the file and
+	// inherit labels from the fleet-level entry.
+	t.Run("single package may set setup_experience and inherit fleet-level labels", func(t *testing.T) {
+		gitops, err := setup(t,
+			"      labels_include_all: [macOS]\n",
+			"- hash_sha256: "+hashA+"\n  setup_experience: true\n",
+		)
+		require.NoError(t, err)
+		require.Len(t, gitops.Software.Packages, 1)
+		pkg := gitops.Software.Packages[0]
+		assert.True(t, pkg.InstallDuringSetup.Valid && pkg.InstallDuringSetup.Value)
+		assert.Equal(t, []string{"macOS"}, pkg.LabelsIncludeAll)
+	})
+
+	// A package file written as a single object is just a one-element list, so its
+	// per-package fields are preserved the same way.
+	t.Run("single object file keeps its per-package fields", func(t *testing.T) {
+		gitops, err := setup(t, "", "hash_sha256: "+hashA+"\nself_service: true\nlabels_include_all: [macOS]\n")
+		require.NoError(t, err)
+		require.Len(t, gitops.Software.Packages, 1)
+		assert.True(t, gitops.Software.Packages[0].SelfService)
+		assert.Equal(t, []string{"macOS"}, gitops.Software.Packages[0].LabelsIncludeAll)
+	})
+}
+
 func TestSoftwarePackagesPathWithInline(t *testing.T) {
 	t.Parallel()
 	config := getTeamConfig([]string{"software"})

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2231,6 +2231,23 @@ func TestMultiPackageFieldPlacement(t *testing.T) {
 		assert.True(t, second.InstallDuringSetup.Valid && second.InstallDuringSetup.Value)
 	})
 
+	// self_service and categories set once at the fleet level apply to every package
+	// that omits them.
+	t.Run("fleet-level self_service and categories inherit to all packages", func(t *testing.T) {
+		gitops, err := setup(t,
+			"      self_service: true\n      categories: [\"Productivity\"]\n",
+			fmt.Sprintf(`- hash_sha256: %s
+- hash_sha256: %s
+`, hashA, hashB),
+		)
+		require.NoError(t, err)
+		require.Len(t, gitops.Software.Packages, 2)
+		for _, pkg := range gitops.Software.Packages {
+			assert.True(t, pkg.SelfService)
+			assert.Equal(t, []string{"Productivity"}, pkg.Categories.Value)
+		}
+	})
+
 	for _, tc := range []struct {
 		name        string
 		fleetLevel  string
@@ -2262,6 +2279,31 @@ func TestMultiPackageFieldPlacement(t *testing.T) {
 - hash_sha256: %s
 `, hashA, hashB),
 			wantErr: "Labels can be specified only in the package-level file when adding multiple packages",
+		},
+		{
+			name:       "categories in both fleet-level and package file",
+			fleetLevel: "      categories: [\"Productivity\"]\n",
+			packageFile: fmt.Sprintf(`- hash_sha256: %s
+  categories: ["Dev tools"]
+- hash_sha256: %s
+`, hashA, hashB),
+			wantErr: "self_service and categories can be specified either in the fleet-level file or in the package YAML file",
+		},
+		{
+			name:       "self_service in both, single package",
+			fleetLevel: "      self_service: true\n",
+			packageFile: fmt.Sprintf(`- hash_sha256: %s
+  self_service: true
+`, hashA),
+			wantErr: "self_service and categories can be specified either in the fleet-level file or in the package YAML file",
+		},
+		{
+			name:       "labels in both fleet-level and package file, single package",
+			fleetLevel: "      labels_include_all: [macOS]\n",
+			packageFile: fmt.Sprintf(`- hash_sha256: %s
+  labels_include_all: [Windows]
+`, hashA),
+			wantErr: "Labels can be specified either in the fleet-level file or in the package YAML file",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2311,6 +2353,20 @@ labels_include_all: [macOS]
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), hashA)
+		assert.NotContains(t, err.Error(), `("")`)
+	})
+
+	// When a package has neither url nor hash, it is identified by the package file path
+	// rather than an empty string (url/hash are required but validated later).
+	t.Run("conflict error falls back to the file path when url and hash are absent", func(t *testing.T) {
+		_, err := setup(t,
+			"      self_service: true\n",
+			fmt.Sprintf(`- self_service: true
+- hash_sha256: %s
+`, hashA),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pkgs.yml")
 		assert.NotContains(t, err.Error(), `("")`)
 	})
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2208,12 +2208,13 @@ func TestMultiPackageFieldPlacement(t *testing.T) {
 	t.Run("happy path keeps per-package fields and inherits fleet-level setup_experience", func(t *testing.T) {
 		gitops, err := setup(t,
 			"      setup_experience: true\n",
-			"- hash_sha256: "+hashA+"\n"+
-				"  self_service: true\n"+
-				"  labels_include_all: [macOS]\n"+
-				"- hash_sha256: "+hashB+"\n"+
-				"  categories: [\"Productivity\"]\n"+
-				"  labels_include_all: [macOS, IT team]\n",
+			fmt.Sprintf(`- hash_sha256: %s
+  self_service: true
+  labels_include_all: [macOS]
+- hash_sha256: %s
+  categories: ["Productivity"]
+  labels_include_all: [macOS, IT team]
+`, hashA, hashB),
 		)
 		require.NoError(t, err)
 		require.Len(t, gitops.Software.Packages, 2)
@@ -2237,22 +2238,30 @@ func TestMultiPackageFieldPlacement(t *testing.T) {
 		wantErr     string
 	}{
 		{
-			name:        "self_service in both fleet-level and package file",
-			fleetLevel:  "      self_service: true\n",
-			packageFile: "- hash_sha256: " + hashA + "\n  self_service: true\n- hash_sha256: " + hashB + "\n",
-			wantErr:     "self_service and categories can be specified either in the fleet-level file or in the package YAML file",
+			name:       "self_service in both fleet-level and package file",
+			fleetLevel: "      self_service: true\n",
+			packageFile: fmt.Sprintf(`- hash_sha256: %s
+  self_service: true
+- hash_sha256: %s
+`, hashA, hashB),
+			wantErr: "self_service and categories can be specified either in the fleet-level file or in the package YAML file",
 		},
 		{
-			name:        "setup_experience in a package file",
-			fleetLevel:  "",
-			packageFile: "- hash_sha256: " + hashA + "\n  setup_experience: true\n- hash_sha256: " + hashB + "\n",
-			wantErr:     "setup_experience can be specified only in the fleet-level file",
+			name:       "setup_experience in a package file",
+			fleetLevel: "",
+			packageFile: fmt.Sprintf(`- hash_sha256: %s
+  setup_experience: true
+- hash_sha256: %s
+`, hashA, hashB),
+			wantErr: "setup_experience can be specified only in the fleet-level file",
 		},
 		{
-			name:        "labels in the fleet-level file",
-			fleetLevel:  "      labels_include_all: [macOS]\n",
-			packageFile: "- hash_sha256: " + hashA + "\n- hash_sha256: " + hashB + "\n",
-			wantErr:     "Labels can be specified only in the package-level file when adding multiple packages",
+			name:       "labels in the fleet-level file",
+			fleetLevel: "      labels_include_all: [macOS]\n",
+			packageFile: fmt.Sprintf(`- hash_sha256: %s
+- hash_sha256: %s
+`, hashA, hashB),
+			wantErr: "Labels can be specified only in the package-level file when adding multiple packages",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2267,7 +2276,9 @@ func TestMultiPackageFieldPlacement(t *testing.T) {
 	t.Run("single package may set setup_experience and inherit fleet-level labels", func(t *testing.T) {
 		gitops, err := setup(t,
 			"      labels_include_all: [macOS]\n",
-			"- hash_sha256: "+hashA+"\n  setup_experience: true\n",
+			fmt.Sprintf(`- hash_sha256: %s
+  setup_experience: true
+`, hashA),
 		)
 		require.NoError(t, err)
 		require.Len(t, gitops.Software.Packages, 1)
@@ -2279,7 +2290,10 @@ func TestMultiPackageFieldPlacement(t *testing.T) {
 	// A package file written as a single object is just a one-element list, so its
 	// per-package fields are preserved the same way.
 	t.Run("single object file keeps its per-package fields", func(t *testing.T) {
-		gitops, err := setup(t, "", "hash_sha256: "+hashA+"\nself_service: true\nlabels_include_all: [macOS]\n")
+		gitops, err := setup(t, "", fmt.Sprintf(`hash_sha256: %s
+self_service: true
+labels_include_all: [macOS]
+`, hashA))
 		require.NoError(t, err)
 		require.Len(t, gitops.Software.Packages, 1)
 		assert.True(t, gitops.Software.Packages[0].SelfService)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1429,32 +1429,24 @@ ORDER BY si.id ASC`
 		return nil, ctxerr.Wrap(ctx, err, "list software packages by team and title")
 	}
 
+	installerIDs := make([]uint, len(packages))
+	for i, pkg := range packages {
+		installerIDs[i] = pkg.InstallerID
+	}
+	categoriesByInstaller, err := ds.GetCategoriesForSoftwareInstallers(ctx, installerIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get categories for software packages")
+	}
+
 	for _, pkg := range packages {
 		pkg.LabelsExcludeAny, pkg.LabelsIncludeAny, pkg.LabelsIncludeAll, err = ds.scopedSoftwareInstallerLabels(ctx, pkg.InstallerID)
 		if err != nil {
 			return nil, err
 		}
-		pkg.Categories, err = ds.softwareInstallerCategories(ctx, pkg.InstallerID)
-		if err != nil {
-			return nil, err
-		}
+		pkg.Categories = categoriesByInstaller[pkg.InstallerID]
 	}
 
 	return packages, nil
-}
-
-func (ds *Datastore) softwareInstallerCategories(ctx context.Context, installerID uint) ([]string, error) {
-	const stmt = `
-SELECT sc.name
-FROM software_installer_software_categories sisc
-	JOIN software_categories sc ON sc.id = sisc.software_category_id
-WHERE sisc.software_installer_id = ?
-ORDER BY sc.name`
-	var categories []string
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &categories, stmt, installerID); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "get software installer categories")
-	}
-	return categories, nil
 }
 
 func (ds *Datastore) scopedSoftwareInstallerLabels(ctx context.Context, installerID uint) (excludeAny []fleet.SoftwareScopeLabel, includeAny []fleet.SoftwareScopeLabel, includeAll []fleet.SoftwareScopeLabel, err error) {
@@ -1874,14 +1866,7 @@ func (ds *Datastore) runInstallerUpdateSideEffectsInTransaction(ctx context.Cont
 	return affectedHostIDs, nil
 }
 
-func (ds *Datastore) deleteInstallerInBatch(ctx context.Context, tx sqlx.ExtContext, id uint, unsetPolicies bool) ([]uint, error) {
-	if unsetPolicies {
-		// TODO(JK): revisit re-pointing policies to a surviving sibling package
-		// instead of unsetting when a single package of several is removed.
-		if _, err := tx.ExecContext(ctx, `UPDATE policies SET software_installer_id = NULL WHERE software_installer_id = ?`, id); err != nil {
-			return nil, ctxerr.Wrapf(ctx, err, "unset policies for installer id %d", id)
-		}
-	}
+func (ds *Datastore) deleteInstallerInBatch(ctx context.Context, tx sqlx.ExtContext, id uint) ([]uint, error) {
 	affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true, false)
 	if err != nil {
 		return nil, ctxerr.Wrapf(ctx, err, "side effects for installer id %d", id)
@@ -2910,6 +2895,20 @@ SELECT id FROM software_installers
 WHERE global_or_team_id = ? AND title_id IN (?) AND id NOT IN (?)
 `
 
+	// re-point policies on dropped custom packages to the first-added surviving package
+	// (lowest id) of the same title, which always exists since the title is kept.
+	const repointDroppedPolicies = `
+UPDATE policies p
+JOIN software_installers d ON d.id = p.software_installer_id
+JOIN (
+	SELECT title_id, MIN(id) AS survivor_id FROM software_installers
+	WHERE global_or_team_id = ? AND id IN (?)
+	GROUP BY title_id
+) s ON s.title_id = d.title_id
+SET p.software_installer_id = s.survivor_id
+WHERE d.global_or_team_id = ? AND d.title_id IN (?) AND d.id NOT IN (?)
+`
+
 	// custom rows left on a title that is switching to a Fleet-maintained app.
 	const findStaleCustomInstallers = `
 SELECT id FROM software_installers
@@ -3029,15 +3028,15 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 		}
 
 		// Validate the per-title rules inside the tx so a title created here rolls back
-		// on failure. customTitleIDs feed the source-of-truth delete after the loop.
-		var customTitleIDs []uint
+		// on failure. customPackageTitleIDs feeds the source-of-truth delete after the loop.
+		var customPackageTitleIDs []uint
 		for titleID, group := range installersByTitle {
 			if err := fleet.ValidateTitlePackages(group, teamName); err != nil {
 				return ctxerr.Wrap(ctx, err, "validate title packages")
 			}
 			for _, installer := range group {
 				if installer.FleetMaintainedAppID == nil {
-					customTitleIDs = append(customTitleIDs, titleID)
+					customPackageTitleIDs = append(customPackageTitleIDs, titleID)
 					break
 				}
 			}
@@ -3573,7 +3572,7 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 			// These installers were replaced by a newer version and had their policies
 			// re-pointed above, so delete them without touching policies.
 			for _, id := range installerIDsToDelete {
-				affectedHostIDs, err := ds.deleteInstallerInBatch(ctx, tx, id, false)
+				affectedHostIDs, err := ds.deleteInstallerInBatch(ctx, tx, id)
 				if err != nil {
 					return err
 				}
@@ -3584,8 +3583,19 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 		// Source of truth for custom titles: remove any row this batch didn't write,
 		// which drops old custom versions and any leftover FMA row when a title
 		// switches to custom packages. FMA titles keep their cached versions.
-		if len(customTitleIDs) > 0 {
-			droppedStmt, droppedArgs, err := sqlx.In(findDroppedPackages, globalOrTeamID, customTitleIDs, keptInstallerIDs)
+		if len(customPackageTitleIDs) > 0 {
+			// Re-point policies off the dropped packages before deleting them, since the
+			// policies FK is RESTRICT. A title removed entirely is handled by the
+			// not-in-list cleanup above, so here the title always keeps a package.
+			repointStmt, repointArgs, err := sqlx.In(repointDroppedPolicies, globalOrTeamID, keptInstallerIDs, globalOrTeamID, customPackageTitleIDs, keptInstallerIDs)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "build statement to re-point dropped policies")
+			}
+			if _, err := tx.ExecContext(ctx, repointStmt, repointArgs...); err != nil {
+				return ctxerr.Wrap(ctx, err, "re-point dropped policies")
+			}
+
+			droppedStmt, droppedArgs, err := sqlx.In(findDroppedPackages, globalOrTeamID, customPackageTitleIDs, keptInstallerIDs)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "build statement to find dropped packages")
 			}
@@ -3594,7 +3604,7 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 				return ctxerr.Wrap(ctx, err, "find dropped packages")
 			}
 			for _, id := range droppedIDs {
-				affectedHostIDs, err := ds.deleteInstallerInBatch(ctx, tx, id, true)
+				affectedHostIDs, err := ds.deleteInstallerInBatch(ctx, tx, id)
 				if err != nil {
 					return err
 				}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1874,6 +1874,24 @@ func (ds *Datastore) runInstallerUpdateSideEffectsInTransaction(ctx context.Cont
 	return affectedHostIDs, nil
 }
 
+func (ds *Datastore) deleteInstallerInBatch(ctx context.Context, tx sqlx.ExtContext, id uint, unsetPolicies bool) ([]uint, error) {
+	if unsetPolicies {
+		// TODO(JK): revisit re-pointing policies to a surviving sibling package
+		// instead of unsetting when a single package of several is removed.
+		if _, err := tx.ExecContext(ctx, `UPDATE policies SET software_installer_id = NULL WHERE software_installer_id = ?`, id); err != nil {
+			return nil, ctxerr.Wrapf(ctx, err, "unset policies for installer id %d", id)
+		}
+	}
+	affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true, false)
+	if err != nil {
+		return nil, ctxerr.Wrapf(ctx, err, "side effects for installer id %d", id)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, id); err != nil {
+		return nil, ctxerr.Wrapf(ctx, err, "delete installer id %d", id)
+	}
+	return affectedHostIDs, nil
+}
+
 func (ds *Datastore) InsertSoftwareUninstallRequest(ctx context.Context, executionID string, hostID uint, softwareInstallerID uint, selfService bool) error {
 	const (
 		getInstallerStmt = `SELECT title_id, COALESCE(st.name, '[deleted title]') title_name, st.source
@@ -2885,6 +2903,19 @@ WHERE
 	stdn.team_id = ? AND stdn.software_title_id NOT IN (?)
 `
 
+	// custom packages on a kept title that this batch didn't write: dropped versions
+	// and any leftover FMA row when a title switches to custom packages.
+	const findDroppedPackages = `
+SELECT id FROM software_installers
+WHERE global_or_team_id = ? AND title_id IN (?) AND id NOT IN (?)
+`
+
+	// custom rows left on a title that is switching to a Fleet-maintained app.
+	const findStaleCustomInstallers = `
+SELECT id FROM software_installers
+WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+`
+
 	// use a team id of 0 if no-team
 	var globalOrTeamID uint
 	teamName := fleet.TeamNameNoTeam
@@ -3143,27 +3174,6 @@ WHERE
 		displayNameIDMap := make(map[uint]string, len(titlesWithDisplayNames))
 		for _, d := range titlesWithDisplayNames {
 			displayNameIDMap[d.TitleID] = d.Name
-		}
-
-		// Cancel a removed installer's pending activities and delete it. unsetPolicies
-		// clears policies pointing at it, for callers that haven't re-pointed them.
-		deleteInstaller := func(id uint, unsetPolicies bool) error {
-			if unsetPolicies {
-				// TODO(JK): revisit re-pointing policies to a surviving sibling package
-				// instead of unsetting when a single package of several is removed.
-				if _, err := tx.ExecContext(ctx, `UPDATE policies SET software_installer_id = NULL WHERE software_installer_id = ?`, id); err != nil {
-					return ctxerr.Wrapf(ctx, err, "unset policies for installer id %d", id)
-				}
-			}
-			affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true, false)
-			if err != nil {
-				return ctxerr.Wrapf(ctx, err, "side effects for installer id %d", id)
-			}
-			activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
-			if _, err := tx.ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, id); err != nil {
-				return ctxerr.Wrapf(ctx, err, "delete installer id %d", id)
-			}
-			return nil
 		}
 
 		// installer ids written by this batch, used after the loop to remove custom
@@ -3430,10 +3440,7 @@ WHERE
 				// A title switching to an FMA can't also hold custom rows, so remove
 				// them. Their policies were already re-pointed to the active FMA.
 				var staleCustomIDs []uint
-				if err := sqlx.SelectContext(ctx, tx, &staleCustomIDs, `
-					SELECT id FROM software_installers
-					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
-				`, globalOrTeamID, titleID); err != nil {
+				if err := sqlx.SelectContext(ctx, tx, &staleCustomIDs, findStaleCustomInstallers, globalOrTeamID, titleID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "find stale custom installers for FMA title %q", installer.Filename)
 				}
 				installerIDsToDelete = append(installerIDsToDelete, staleCustomIDs...)
@@ -3566,9 +3573,11 @@ WHERE
 			// These installers were replaced by a newer version and had their policies
 			// re-pointed above, so delete them without touching policies.
 			for _, id := range installerIDsToDelete {
-				if err := deleteInstaller(id, false); err != nil {
+				affectedHostIDs, err := ds.deleteInstallerInBatch(ctx, tx, id, false)
+				if err != nil {
 					return err
 				}
+				activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
 			}
 		}
 
@@ -3576,9 +3585,7 @@ WHERE
 		// which drops old custom versions and any leftover FMA row when a title
 		// switches to custom packages. FMA titles keep their cached versions.
 		if len(customTitleIDs) > 0 {
-			droppedStmt, droppedArgs, err := sqlx.In(
-				`SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id IN (?) AND id NOT IN (?)`,
-				globalOrTeamID, customTitleIDs, keptInstallerIDs)
+			droppedStmt, droppedArgs, err := sqlx.In(findDroppedPackages, globalOrTeamID, customTitleIDs, keptInstallerIDs)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "build statement to find dropped packages")
 			}
@@ -3587,9 +3594,11 @@ WHERE
 				return ctxerr.Wrap(ctx, err, "find dropped packages")
 			}
 			for _, id := range droppedIDs {
-				if err := deleteInstaller(id, true); err != nil {
+				affectedHostIDs, err := ds.deleteInstallerInBatch(ctx, tx, id, true)
+				if err != nil {
 					return err
 				}
+				activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
 			}
 		}
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1434,9 +1434,27 @@ ORDER BY si.id ASC`
 		if err != nil {
 			return nil, err
 		}
+		pkg.Categories, err = ds.softwareInstallerCategories(ctx, pkg.InstallerID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return packages, nil
+}
+
+func (ds *Datastore) softwareInstallerCategories(ctx context.Context, installerID uint) ([]string, error) {
+	const stmt = `
+SELECT sc.name
+FROM software_installer_software_categories sisc
+	JOIN software_categories sc ON sc.id = sisc.software_category_id
+WHERE sisc.software_installer_id = ?
+ORDER BY sc.name`
+	var categories []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &categories, stmt, installerID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get software installer categories")
+	}
+	return categories, nil
 }
 
 func (ds *Datastore) scopedSoftwareInstallerLabels(ctx context.Context, installerID uint) (excludeAny []fleet.SoftwareScopeLabel, includeAny []fleet.SoftwareScopeLabel, includeAll []fleet.SoftwareScopeLabel, err error) {
@@ -2681,11 +2699,11 @@ WHERE
 DELETE FROM software_title_team_pins WHERE team_id = ? AND title_id NOT IN (?)
 `
 
-	// ORDER BY is_active DESC, id DESC makes existing[0] the previously-active row.
+	// Match the package being upserted by its dedup_token, so this returns the row
+	// upsert will replace or no rows for a new package.
 	const checkExistingInstaller = `
 SELECT
 	id,
-	fleet_maintained_app_id,
 	storage_id != ? is_package_modified,
 	install_script_content_id != ? OR uninstall_script_content_id != ? OR pre_install_query != ? OR
 	COALESCE(post_install_script_content_id != ? OR
@@ -2696,8 +2714,8 @@ FROM
 	software_installers
 WHERE
 	global_or_team_id = ?	AND
-	title_id = ?
-ORDER BY is_active DESC, id DESC
+	title_id = ? AND
+	dedup_token = ?
 `
 
 	const insertNewOrEditedInstaller = `
@@ -2775,9 +2793,8 @@ FROM
 	software_installers
 WHERE
 	global_or_team_id = ?	AND
-	title_id = ?
-ORDER BY uploaded_at DESC, id DESC
-LIMIT 1
+	title_id = ? AND
+	dedup_token = ?
 `
 
 	const deleteInstallerLabelsNotInList = `
@@ -2951,6 +2968,7 @@ WHERE
 
 		titleIDs := make([]uint, 0, len(installers))
 		titleIDByInstaller := make(map[*fleet.UploadSoftwareInstallerPayload]uint, len(installers))
+		installersByTitle := make(map[uint][]*fleet.UploadSoftwareInstallerPayload, len(installers))
 		for _, installer := range installers {
 			// check for installers that target macOS if any package installer is
 			// associated with a software title that already has a VPP app for the same
@@ -2976,6 +2994,22 @@ WHERE
 			}
 			titleIDs = append(titleIDs, titleID)
 			titleIDByInstaller[installer] = titleID
+			installersByTitle[titleID] = append(installersByTitle[titleID], installer)
+		}
+
+		// Validate the per-title rules inside the tx so a title created here rolls back
+		// on failure. customTitleIDs feed the source-of-truth delete after the loop.
+		var customTitleIDs []uint
+		for titleID, group := range installersByTitle {
+			if err := fleet.ValidateTitlePackages(group, teamName); err != nil {
+				return ctxerr.Wrap(ctx, err, "validate title packages")
+			}
+			for _, installer := range group {
+				if installer.FleetMaintainedAppID == nil {
+					customTitleIDs = append(customTitleIDs, titleID)
+					break
+				}
+			}
 		}
 
 		stmt, args, err := sqlx.In(unsetInstallersNotInListFromPolicies, globalOrTeamID, titleIDs)
@@ -3111,6 +3145,30 @@ WHERE
 			displayNameIDMap[d.TitleID] = d.Name
 		}
 
+		// Cancel a removed installer's pending activities and delete it. unsetPolicies
+		// clears policies pointing at it, for callers that haven't re-pointed them.
+		deleteInstaller := func(id uint, unsetPolicies bool) error {
+			if unsetPolicies {
+				// TODO(JK): revisit re-pointing policies to a surviving sibling package
+				// instead of unsetting when a single package of several is removed.
+				if _, err := tx.ExecContext(ctx, `UPDATE policies SET software_installer_id = NULL WHERE software_installer_id = ?`, id); err != nil {
+					return ctxerr.Wrapf(ctx, err, "unset policies for installer id %d", id)
+				}
+			}
+			affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true, false)
+			if err != nil {
+				return ctxerr.Wrapf(ctx, err, "side effects for installer id %d", id)
+			}
+			activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
+			if _, err := tx.ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, id); err != nil {
+				return ctxerr.Wrapf(ctx, err, "delete installer id %d", id)
+			}
+			return nil
+		}
+
+		// installer ids written by this batch, used after the loop to remove custom
+		// package versions dropped from the YAML.
+		keptInstallerIDs := make([]uint, 0, len(installers))
 		for _, installer := range installers {
 			if installer.ValidatedLabels == nil {
 				return ctxerr.Errorf(ctx, "labels have not been validated for installer with name %s", installer.Filename)
@@ -3141,6 +3199,12 @@ WHERE
 
 			titleID := titleIDByInstaller[installer]
 
+			// dedup_token is storage_id for a custom package, version for an FMA.
+			dedupToken := installer.StorageID
+			if installer.FleetMaintainedAppID != nil {
+				dedupToken = installer.Version
+			}
+
 			wasUpdatedArgs := []interface{}{
 				// package update
 				installer.StorageID,
@@ -3154,14 +3218,14 @@ WHERE
 				// WHERE clause
 				globalOrTeamID,
 				titleID,
+				dedupToken,
 			}
 
 			// pull existing installer state if it exists so we can diff for side effects post-update
 			type existingInstallerUpdateCheckResult struct {
-				InstallerID          uint  `db:"id"`
-				FleetMaintainedAppID *uint `db:"fleet_maintained_app_id"`
-				IsPackageModified    bool  `db:"is_package_modified"`
-				IsMetadataModified   bool  `db:"is_metadata_modified"`
+				InstallerID        uint `db:"id"`
+				IsPackageModified  bool `db:"is_package_modified"`
+				IsMetadataModified bool `db:"is_metadata_modified"`
 			}
 			var existing []existingInstallerUpdateCheckResult
 			err = sqlx.SelectContext(ctx, tx, &existing, checkExistingInstaller, wasUpdatedArgs...)
@@ -3253,34 +3317,12 @@ WHERE
 			// ID (cannot use res.LastInsertID due to the upsert statement, won't
 			// give the id in case of update)
 			var installerID uint
-			if err := sqlx.GetContext(ctx, tx, &installerID, loadSoftwareInstallerID, globalOrTeamID, titleID); err != nil {
+			if err := sqlx.GetContext(ctx, tx, &installerID, loadSoftwareInstallerID, globalOrTeamID, titleID, dedupToken); err != nil {
 				return ctxerr.Wrapf(ctx, err, "load id of new/edited installer with name %q", installer.Filename)
 			}
+			keptInstallerIDs = append(keptInstallerIDs, installerID)
 
 			var installerIDsToDelete []uint
-
-			// For non-FMA (custom) packages, enforce one installer per title per team.
-			// With the unique constraint on (global_or_team_id, title_id, version),
-			// a version change inserts a new row instead of replacing — clean up the old one.
-			if installer.FleetMaintainedAppID == nil {
-				// Re-point any policies that reference the old installer to the new one
-				// before deleting, because policies.software_installer_id has a FK
-				// constraint without ON DELETE CASCADE.
-				if _, err := tx.ExecContext(ctx, `
-					UPDATE policies SET software_installer_id = ?
-					WHERE software_installer_id IN (
-						SELECT id FROM software_installers
-						WHERE global_or_team_id = ? AND title_id = ? AND id != ?
-					)
-				`, installerID, globalOrTeamID, titleID, installerID); err != nil {
-					return ctxerr.Wrapf(ctx, err, "re-point policies for old versions of custom installer %q", installer.Filename)
-				}
-				for _, e := range existing {
-					if e.InstallerID != installerID {
-						installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
-					}
-				}
-			}
 
 			// For FMA installers: determine the active version, then evict old versions
 			// (protecting the active one from eviction).
@@ -3350,9 +3392,9 @@ WHERE
 						return ctxerr.Wrapf(ctx, err, "re-point policies for evicted FMA versions of %q", installer.Filename)
 					}
 
-					for _, e := range existing {
-						if e.FleetMaintainedAppID != nil && !keepSet[e.InstallerID] {
-							installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
+					for _, v := range versions {
+						if !keepSet[v.ID] {
+							installerIDsToDelete = append(installerIDsToDelete, v.ID)
 						}
 					}
 				}
@@ -3385,12 +3427,16 @@ WHERE
 				`, activeInstallerID, globalOrTeamID, titleID, activeInstallerID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "re-point policies to active FMA installer %q", installer.Filename)
 				}
-				// Mark previous custom package installers for this title for deletion.
-				for _, e := range existing {
-					if e.FleetMaintainedAppID == nil && e.InstallerID != installerID {
-						installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
-					}
+				// A title switching to an FMA can't also hold custom rows, so remove
+				// them. Their policies were already re-pointed to the active FMA.
+				var staleCustomIDs []uint
+				if err := sqlx.SelectContext(ctx, tx, &staleCustomIDs, `
+					SELECT id FROM software_installers
+					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+				`, globalOrTeamID, titleID); err != nil {
+					return ctxerr.Wrapf(ctx, err, "find stale custom installers for FMA title %q", installer.Filename)
 				}
+				installerIDsToDelete = append(installerIDsToDelete, staleCustomIDs...)
 			}
 
 			// process the labels associated with that software installer
@@ -3517,16 +3563,32 @@ WHERE
 				activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
 			}
 
-			// Perform side effects and delete unnecessary installers.
+			// These installers were replaced by a newer version and had their policies
+			// re-pointed above, so delete them without touching policies.
 			for _, id := range installerIDsToDelete {
-				affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true, false)
-				if err != nil {
-					return ctxerr.Wrapf(ctx, err, "side effects for replaced installer id %d for %q", id, installer.Filename)
+				if err := deleteInstaller(id, false); err != nil {
+					return err
 				}
-				activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
+			}
+		}
 
-				if _, err := tx.ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, id); err != nil {
-					return ctxerr.Wrapf(ctx, err, "delete replaced installer id %d for %q", id, installer.Filename)
+		// Source of truth for custom titles: remove any row this batch didn't write,
+		// which drops old custom versions and any leftover FMA row when a title
+		// switches to custom packages. FMA titles keep their cached versions.
+		if len(customTitleIDs) > 0 {
+			droppedStmt, droppedArgs, err := sqlx.In(
+				`SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id IN (?) AND id NOT IN (?)`,
+				globalOrTeamID, customTitleIDs, keptInstallerIDs)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "build statement to find dropped packages")
+			}
+			var droppedIDs []uint
+			if err := sqlx.SelectContext(ctx, tx, &droppedIDs, droppedStmt, droppedArgs...); err != nil {
+				return ctxerr.Wrap(ctx, err, "find dropped packages")
+			}
+			for _, id := range droppedIDs {
+				if err := deleteInstaller(id, true); err != nil {
+					return err
 				}
 			}
 		}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1429,21 +1429,11 @@ ORDER BY si.id ASC`
 		return nil, ctxerr.Wrap(ctx, err, "list software packages by team and title")
 	}
 
-	installerIDs := make([]uint, len(packages))
-	for i, pkg := range packages {
-		installerIDs[i] = pkg.InstallerID
-	}
-	categoriesByInstaller, err := ds.GetCategoriesForSoftwareInstallers(ctx, installerIDs)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "get categories for software packages")
-	}
-
 	for _, pkg := range packages {
 		pkg.LabelsExcludeAny, pkg.LabelsIncludeAny, pkg.LabelsIncludeAll, err = ds.scopedSoftwareInstallerLabels(ctx, pkg.InstallerID)
 		if err != nil {
 			return nil, err
 		}
-		pkg.Categories = categoriesByInstaller[pkg.InstallerID]
 	}
 
 	return packages, nil
@@ -3028,7 +3018,8 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 		}
 
 		// Validate the per-title rules inside the tx so a title created here rolls back
-		// on failure. customPackageTitleIDs feeds the source-of-truth delete after the loop.
+		// on failure, and record which titles got a custom package for the
+		// source-of-truth delete after the loop.
 		var customPackageTitleIDs []uint
 		for titleID, group := range installersByTitle {
 			if err := fleet.ValidateTitlePackages(group, teamName); err != nil {
@@ -3580,9 +3571,9 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 			}
 		}
 
-		// Source of truth for custom titles: remove any row this batch didn't write,
-		// which drops old custom versions and any leftover FMA row when a title
-		// switches to custom packages. FMA titles keep their cached versions.
+		// Source of truth for titles with custom packages: remove any row this batch
+		// didn't write, which drops old custom versions and any leftover FMA row when a
+		// title switches to custom packages. FMA titles keep their cached versions.
 		if len(customPackageTitleIDs) > 0 {
 			// Re-point policies off the dropped packages before deleting them, since the
 			// policies FK is RESTRICT. A title removed entirely is handled by the

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2887,7 +2887,7 @@ WHERE global_or_team_id = ? AND title_id IN (?) AND id NOT IN (?)
 
 	// re-point policies on dropped custom packages to the first-added surviving package
 	// (lowest id) of the same title, which always exists since the title is kept.
-	const repointDroppedPolicies = `
+	const repointDeletedInstallerPolicies = `
 UPDATE policies p
 JOIN software_installers d ON d.id = p.software_installer_id
 JOIN (
@@ -3578,7 +3578,7 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 			// Re-point policies off the dropped packages before deleting them, since the
 			// policies FK is RESTRICT. A title removed entirely is handled by the
 			// not-in-list cleanup above, so here the title always keeps a package.
-			repointStmt, repointArgs, err := sqlx.In(repointDroppedPolicies, globalOrTeamID, keptInstallerIDs, globalOrTeamID, customPackageTitleIDs, keptInstallerIDs)
+			repointStmt, repointArgs, err := sqlx.In(repointDeletedInstallerPolicies, globalOrTeamID, keptInstallerIDs, globalOrTeamID, customPackageTitleIDs, keptInstallerIDs)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "build statement to re-point dropped policies")
 			}
@@ -3590,11 +3590,11 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "build statement to find dropped packages")
 			}
-			var droppedIDs []uint
-			if err := sqlx.SelectContext(ctx, tx, &droppedIDs, droppedStmt, droppedArgs...); err != nil {
+			var droppedInstallerIDs []uint
+			if err := sqlx.SelectContext(ctx, tx, &droppedInstallerIDs, droppedStmt, droppedArgs...); err != nil {
 				return ctxerr.Wrap(ctx, err, "find dropped packages")
 			}
-			for _, id := range droppedIDs {
+			for _, id := range droppedInstallerIDs {
 				affectedHostIDs, err := ds.deleteInstallerInBatch(ctx, tx, id)
 				if err != nil {
 					return err

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2692,8 +2692,6 @@ WHERE
 DELETE FROM software_title_team_pins WHERE team_id = ? AND title_id NOT IN (?)
 `
 
-	// Match the package being upserted by its dedup_token, so this returns the row
-	// upsert will replace or no rows for a new package.
 	const checkExistingInstaller = `
 SELECT
 	id,
@@ -2706,9 +2704,26 @@ SELECT
 FROM
 	software_installers
 WHERE
-	global_or_team_id = ?	AND
+	global_or_team_id = ? AND
 	title_id = ? AND
 	dedup_token = ?
+`
+
+	const checkExistingActiveInstaller = `
+SELECT
+	id,
+	storage_id != ? is_package_modified,
+	install_script_content_id != ? OR uninstall_script_content_id != ? OR pre_install_query != ? OR
+	COALESCE(post_install_script_content_id != ? OR
+		(post_install_script_content_id IS NULL AND ? IS NOT NULL) OR
+		(? IS NULL AND post_install_script_content_id IS NOT NULL)
+	, FALSE) is_metadata_modified
+FROM
+	software_installers
+WHERE
+	global_or_team_id = ? AND
+	title_id = ?
+ORDER BY is_active DESC, id DESC
 `
 
 	const insertNewOrEditedInstaller = `
@@ -3218,7 +3233,13 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 				// WHERE clause
 				globalOrTeamID,
 				titleID,
-				dedupToken,
+			}
+
+			// FMA matches the active version; a custom package matches its dedup_token.
+			wasUpdatedStmt := checkExistingActiveInstaller
+			if installer.FleetMaintainedAppID == nil {
+				wasUpdatedStmt = checkExistingInstaller
+				wasUpdatedArgs = append(wasUpdatedArgs, dedupToken)
 			}
 
 			// pull existing installer state if it exists so we can diff for side effects post-update
@@ -3228,7 +3249,7 @@ WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
 				IsMetadataModified bool `db:"is_metadata_modified"`
 			}
 			var existing []existingInstallerUpdateCheckResult
-			err = sqlx.SelectContext(ctx, tx, &existing, checkExistingInstaller, wasUpdatedArgs...)
+			err = sqlx.SelectContext(ctx, tx, &existing, wasUpdatedStmt, wasUpdatedArgs...)
 			if err != nil {
 				if !errors.Is(err, sql.ErrNoRows) {
 					return ctxerr.Wrapf(ctx, err, "checking for existing installer with name %q", installer.Filename)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -1700,6 +1700,16 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	})
 	require.Zero(t, fmaRows)
 
+	// removing the title's last package (title no longer in the batch) nulls out a
+	// policy that pointed at it, since there is no sibling to re-point to
+	orphanPolicy, err := ds.NewTeamPolicy(ctx, team.ID, &user1.ID, fleet.PolicyPayload{Name: "orphan", Query: "SELECT 1;", SoftwareInstallerID: &pkgs[0].InstallerID})
+	require.NoError(t, err)
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{pkg("Bravo", "com.example.bravo", "bravo-x", "1.0")})
+	require.NoError(t, err)
+	orphaned, err := ds.TeamPolicy(ctx, team.ID, orphanPolicy.ID)
+	require.NoError(t, err)
+	require.Nil(t, orphaned.SoftwareInstallerID)
+
 	// A single package file (one path entry) can hold packages for different titles on a
 	// separate team, including a mix of a single-package title and a multi-package title,
 	// with one title's packages interleaved with another's. Each still lands on its own

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -38,7 +38,6 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"CleanupUnusedSoftwareInstallers", testCleanupUnusedSoftwareInstallers},
 		{"BatchSetSoftwareInstallers", testBatchSetSoftwareInstallers},
 		{"BatchSetSoftwareInstallersMultipleCustomPackages", testBatchSetSoftwareInstallersMultipleCustomPackages},
-		{"BatchSetSoftwareInstallersMixedTitles", testBatchSetSoftwareInstallersMixedTitles},
 		{"BatchSetSoftwareInstallersWithUpgradeCodes", testBatchSetSoftwareInstallersWithUpgradeCodes},
 		{"GetSoftwareInstallersPendingDeletion", testGetSoftwareInstallersPendingDeletion},
 		{"GetSoftwareInstallerMetadataByTeamAndTitleID", testGetSoftwareInstallerMetadataByTeamAndTitleID},
@@ -1530,10 +1529,13 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
 	require.NoError(t, err)
 	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	host := test.NewHost(t, ds, "h1", "1", "h1key", "h1uuid", time.Now())
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
 
-	// pkg builds a custom package payload for the shared "Santa" title. Each package
-	// differs only by storage id (hash) and version.
-	pkg := func(storage string, version string) *fleet.UploadSoftwareInstallerPayload {
+	// pkg builds a custom package payload for the given title. santa wraps it for the
+	// shared "Santa" title used by the single-title lifecycle checks below; each santa
+	// package differs only by storage id (hash) and version.
+	pkg := func(title string, bundle string, storage string, version string) *fleet.UploadSoftwareInstallerPayload {
 		tfr, err := fleet.NewTempFileReader(bytes.NewReader([]byte(storage)), t.TempDir)
 		require.NoError(t, err)
 		return &fleet.UploadSoftwareInstallerPayload{
@@ -1541,21 +1543,24 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 			InstallerFile:    tfr,
 			StorageID:        storage,
 			Filename:         storage,
-			Title:            "Santa",
+			Title:            title,
 			Source:           "apps",
 			Version:          version,
 			UserID:           user1.ID,
 			Platform:         "darwin",
 			URL:              "https://example.com/" + storage,
-			BundleIdentifier: "com.northpolesec.santa",
+			BundleIdentifier: bundle,
 			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
 		}
+	}
+	santa := func(storage string, version string) *fleet.UploadSoftwareInstallerPayload {
+		return pkg("Santa", "com.northpolesec.santa", storage, version)
 	}
 
 	// apply two packages of the same title
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
-		pkg("santaA", "2026.2"),
-		pkg("santaB", "2026.4"),
+		santa("santaA", "2026.2"),
+		santa("santaB", "2026.4"),
 	})
 	require.NoError(t, err)
 
@@ -1576,8 +1581,8 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 
 	// re-apply with the list reordered: ids and order are unchanged
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
-		pkg("santaB", "2026.4"),
-		pkg("santaA", "2026.2"),
+		santa("santaB", "2026.4"),
+		santa("santaA", "2026.2"),
 	})
 	require.NoError(t, err)
 	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
@@ -1589,9 +1594,9 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 
 	// adding a package appends it after the existing ones
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
-		pkg("santaA", "2026.2"),
-		pkg("santaB", "2026.4"),
-		pkg("santaC", "2026.6"),
+		santa("santaA", "2026.2"),
+		santa("santaB", "2026.4"),
+		santa("santaC", "2026.6"),
 	})
 	require.NoError(t, err)
 	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
@@ -1602,10 +1607,20 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	require.Greater(t, pkgs[2].InstallerID, secondID)
 	require.Equal(t, "santaC", pkgs[2].StorageID)
 
+	// a policy and pending install point at santaA (kept) and santaB (about to be dropped)
+	keepPolicy, err := ds.NewTeamPolicy(ctx, team.ID, &user1.ID, fleet.PolicyPayload{Name: "keep", Query: "SELECT 1;", SoftwareInstallerID: &firstID})
+	require.NoError(t, err)
+	dropPolicy, err := ds.NewTeamPolicy(ctx, team.ID, &user1.ID, fleet.PolicyPayload{Name: "drop", Query: "SELECT 1;", SoftwareInstallerID: &secondID})
+	require.NoError(t, err)
+	_, err = ds.InsertSoftwareInstallRequest(ctx, host.ID, firstID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+	_, err = ds.InsertSoftwareInstallRequest(ctx, host.ID, secondID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+
 	// removing a package deletes it (source of truth), surviving siblings keep ids
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
-		pkg("santaA", "2026.2"),
-		pkg("santaC", "2026.6"),
+		santa("santaA", "2026.2"),
+		santa("santaC", "2026.6"),
 	})
 	require.NoError(t, err)
 	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
@@ -1615,10 +1630,22 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	require.Equal(t, "santaA", pkgs[0].StorageID)
 	require.Equal(t, "santaC", pkgs[1].StorageID)
 
+	// dropping santaB unset its policy and cancelled its pending install; santaA's are untouched
+	dropped, err := ds.TeamPolicy(ctx, team.ID, dropPolicy.ID)
+	require.NoError(t, err)
+	require.Nil(t, dropped.SoftwareInstallerID)
+	kept, err := ds.TeamPolicy(ctx, team.ID, keepPolicy.ID)
+	require.NoError(t, err)
+	require.NotNil(t, kept.SoftwareInstallerID)
+	require.Equal(t, firstID, *kept.SoftwareInstallerID)
+	pending, err := ds.ListPendingSoftwareInstalls(ctx, host.ID)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+
 	// a hash duplicate within the batch fails and leaves the title unchanged
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
-		pkg("santaA", "2026.2"),
-		pkg("santaA", "2026.2-dup"),
+		santa("santaA", "2026.2"),
+		santa("santaA", "2026.2-dup"),
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "already added")
@@ -1629,7 +1656,7 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	// exceeding the per-title package limit fails
 	tooMany := make([]*fleet.UploadSoftwareInstallerPayload, 0, fleet.MaxPackagesPerTitle+1)
 	for i := range fleet.MaxPackagesPerTitle + 1 {
-		tooMany = append(tooMany, pkg(fmt.Sprintf("santa-%d", i), fmt.Sprintf("v%d", i)))
+		tooMany = append(tooMany, santa(fmt.Sprintf("santa-%d", i), fmt.Sprintf("v%d", i)))
 	}
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, tooMany)
 	require.Error(t, err)
@@ -1643,21 +1670,21 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 		UniqueIdentifier: "com.northpolesec.santa",
 	})
 	require.NoError(t, err)
-	fma := pkg("santaFMA", "2026.8")
+	fma := santa("santaFMA", "2026.8")
 	fma.FleetMaintainedAppID = new(maintainedApp.ID)
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
-		pkg("santaA", "2026.2"),
+		santa("santaA", "2026.2"),
 		fma,
 	})
 	require.Error(t, err)
 
 	// switch the title to a Fleet-maintained app, then back to a custom package:
 	// the stale FMA row must be removed so the title holds only the custom package.
-	fmaOnly := pkg("santaFMA2", "2027.1")
+	fmaOnly := santa("santaFMA2", "2027.1")
 	fmaOnly.FleetMaintainedAppID = new(maintainedApp.ID)
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{fmaOnly})
 	require.NoError(t, err)
-	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{pkg("santaX", "2027.2")})
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{santa("santaX", "2027.2")})
 	require.NoError(t, err)
 	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
 	require.NoError(t, err)
@@ -1670,50 +1697,27 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 			team.ID, titleID)
 	})
 	require.Zero(t, fmaRows)
-}
 
-func testBatchSetSoftwareInstallersMixedTitles(t *testing.T, ds *Datastore) {
-	ctx := context.Background()
-	team, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	// A single package file (one path entry) can hold packages for different titles on a
+	// separate team, including a mix of a single-package title and a multi-package title,
+	// with one title's packages interleaved with another's. Each still lands on its own
+	// resolved title in file order.
+	mixedTeam, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-mixed"})
 	require.NoError(t, err)
-	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
-
-	pkg := func(title string, bundle string, storage string, version string) *fleet.UploadSoftwareInstallerPayload {
-		tfr, err := fleet.NewTempFileReader(bytes.NewReader([]byte(storage)), t.TempDir)
-		require.NoError(t, err)
-		return &fleet.UploadSoftwareInstallerPayload{
-			InstallScript:    "install",
-			InstallerFile:    tfr,
-			StorageID:        storage,
-			Filename:         storage,
-			Title:            title,
-			Source:           "apps",
-			Version:          version,
-			UserID:           user.ID,
-			Platform:         "darwin",
-			URL:              "https://example.com/" + storage,
-			BundleIdentifier: bundle,
-			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
-		}
-	}
-
-	// A single package file (one path entry) can hold packages for different titles,
-	// including a mix of a single-package title and a multi-package title, and the
-	// packages of one title can be interleaved with another's.
-	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+	err = ds.BatchSetSoftwareInstallers(ctx, &mixedTeam.ID, []*fleet.UploadSoftwareInstallerPayload{
 		pkg("Bravo", "com.example.bravo", "bravo-1", "1.0"),
 		pkg("Alpha", "com.example.alpha", "alpha-1", "1.0"),
 		pkg("Bravo", "com.example.bravo", "bravo-2", "2.0"),
 	})
 	require.NoError(t, err)
 
-	all, err := ds.GetSoftwareInstallers(ctx, team.ID)
+	mixedAll, err := ds.GetSoftwareInstallers(ctx, mixedTeam.ID)
 	require.NoError(t, err)
-	require.Len(t, all, 3)
+	require.Len(t, mixedAll, 3)
 
 	// each package landed on its own resolved title: Alpha has one, Bravo has two
 	countByTitle := map[uint]int{}
-	for _, si := range all {
+	for _, si := range mixedAll {
 		require.NotNil(t, si.TitleID)
 		countByTitle[*si.TitleID]++
 	}
@@ -1729,14 +1733,13 @@ func testBatchSetSoftwareInstallersMixedTitles(t *testing.T, ds *Datastore) {
 	}
 	require.Equal(t, 1, alphaCount)
 
-	// Bravo's packages keep file order (bravo-1 first-added) even though Alpha was
-	// listed between them.
-	pkgs, err := ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, bravoTitleID)
+	// Bravo's packages keep file order (bravo-1 first-added) even though Alpha was listed between them.
+	bravoPkgs, err := ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &mixedTeam.ID, bravoTitleID)
 	require.NoError(t, err)
-	require.Len(t, pkgs, 2)
-	require.Equal(t, "bravo-1", pkgs[0].StorageID)
-	require.Equal(t, "bravo-2", pkgs[1].StorageID)
-	require.Less(t, pkgs[0].InstallerID, pkgs[1].InstallerID)
+	require.Len(t, bravoPkgs, 2)
+	require.Equal(t, "bravo-1", bravoPkgs[0].StorageID)
+	require.Equal(t, "bravo-2", bravoPkgs[1].StorageID)
+	require.Less(t, bravoPkgs[0].InstallerID, bravoPkgs[1].InstallerID)
 }
 
 func testBatchSetSoftwareInstallersWithUpgradeCodes(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -1630,10 +1630,12 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	require.Equal(t, "santaA", pkgs[0].StorageID)
 	require.Equal(t, "santaC", pkgs[1].StorageID)
 
-	// dropping santaB unset its policy and cancelled its pending install; santaA's are untouched
+	// dropping santaB re-points its policy to the first-added surviving package (santaA)
+	// and cancels its pending install; santaA's own policy is untouched
 	dropped, err := ds.TeamPolicy(ctx, team.ID, dropPolicy.ID)
 	require.NoError(t, err)
-	require.Nil(t, dropped.SoftwareInstallerID)
+	require.NotNil(t, dropped.SoftwareInstallerID)
+	require.Equal(t, firstID, *dropped.SoftwareInstallerID)
 	kept, err := ds.TeamPolicy(ctx, team.ID, keepPolicy.ID)
 	require.NoError(t, err)
 	require.NotNil(t, kept.SoftwareInstallerID)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -37,6 +37,8 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"GetSoftwareInstallResults", testGetSoftwareInstallResult},
 		{"CleanupUnusedSoftwareInstallers", testCleanupUnusedSoftwareInstallers},
 		{"BatchSetSoftwareInstallers", testBatchSetSoftwareInstallers},
+		{"BatchSetSoftwareInstallersMultipleCustomPackages", testBatchSetSoftwareInstallersMultipleCustomPackages},
+		{"BatchSetSoftwareInstallersMixedTitles", testBatchSetSoftwareInstallersMixedTitles},
 		{"BatchSetSoftwareInstallersWithUpgradeCodes", testBatchSetSoftwareInstallersWithUpgradeCodes},
 		{"GetSoftwareInstallersPendingDeletion", testGetSoftwareInstallersPendingDeletion},
 		{"GetSoftwareInstallerMetadataByTeamAndTitleID", testGetSoftwareInstallerMetadataByTeamAndTitleID},
@@ -1520,6 +1522,221 @@ func testBatchSetSoftwareInstallers(t *testing.T, ds *Datastore) {
 	pendingHost1, err = ds.ListPendingSoftwareInstalls(ctx, host1.ID)
 	require.NoError(t, err)
 	require.Empty(t, pendingHost1)
+}
+
+func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	// pkg builds a custom package payload for the shared "Santa" title. Each package
+	// differs only by storage id (hash) and version.
+	pkg := func(storage string, version string) *fleet.UploadSoftwareInstallerPayload {
+		tfr, err := fleet.NewTempFileReader(bytes.NewReader([]byte(storage)), t.TempDir)
+		require.NoError(t, err)
+		return &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         storage,
+			Title:            "Santa",
+			Source:           "apps",
+			Version:          version,
+			UserID:           user1.ID,
+			Platform:         "darwin",
+			URL:              "https://example.com/" + storage,
+			BundleIdentifier: "com.northpolesec.santa",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		}
+	}
+
+	// apply two packages of the same title
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+		pkg("santaA", "2026.2"),
+		pkg("santaB", "2026.4"),
+	})
+	require.NoError(t, err)
+
+	all, err := ds.GetSoftwareInstallers(ctx, team.ID)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	require.NotNil(t, all[0].TitleID)
+	titleID := *all[0].TitleID
+
+	// both packages belong to one title, ordered first-added first (id ascending)
+	pkgs, err := ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	require.Less(t, pkgs[0].InstallerID, pkgs[1].InstallerID)
+	require.Equal(t, "santaA", pkgs[0].StorageID)
+	require.Equal(t, "santaB", pkgs[1].StorageID)
+	firstID, secondID := pkgs[0].InstallerID, pkgs[1].InstallerID
+
+	// re-apply with the list reordered: ids and order are unchanged
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+		pkg("santaB", "2026.4"),
+		pkg("santaA", "2026.2"),
+	})
+	require.NoError(t, err)
+	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	require.Equal(t, firstID, pkgs[0].InstallerID)
+	require.Equal(t, secondID, pkgs[1].InstallerID)
+	require.Equal(t, "santaA", pkgs[0].StorageID)
+
+	// adding a package appends it after the existing ones
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+		pkg("santaA", "2026.2"),
+		pkg("santaB", "2026.4"),
+		pkg("santaC", "2026.6"),
+	})
+	require.NoError(t, err)
+	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 3)
+	require.Equal(t, firstID, pkgs[0].InstallerID)
+	require.Equal(t, secondID, pkgs[1].InstallerID)
+	require.Greater(t, pkgs[2].InstallerID, secondID)
+	require.Equal(t, "santaC", pkgs[2].StorageID)
+
+	// removing a package deletes it (source of truth), surviving siblings keep ids
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+		pkg("santaA", "2026.2"),
+		pkg("santaC", "2026.6"),
+	})
+	require.NoError(t, err)
+	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	require.Equal(t, firstID, pkgs[0].InstallerID)
+	require.Equal(t, "santaA", pkgs[0].StorageID)
+	require.Equal(t, "santaC", pkgs[1].StorageID)
+
+	// a hash duplicate within the batch fails and leaves the title unchanged
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+		pkg("santaA", "2026.2"),
+		pkg("santaA", "2026.2-dup"),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "already added")
+	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+
+	// exceeding the per-title package limit fails
+	tooMany := make([]*fleet.UploadSoftwareInstallerPayload, 0, fleet.MaxPackagesPerTitle+1)
+	for i := range fleet.MaxPackagesPerTitle + 1 {
+		tooMany = append(tooMany, pkg(fmt.Sprintf("santa-%d", i), fmt.Sprintf("v%d", i)))
+	}
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, tooMany)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "packages")
+
+	// mixing a Fleet-maintained app with a custom package on one title fails
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Santa",
+		Slug:             "santa",
+		Platform:         "darwin",
+		UniqueIdentifier: "com.northpolesec.santa",
+	})
+	require.NoError(t, err)
+	fma := pkg("santaFMA", "2026.8")
+	fma.FleetMaintainedAppID = new(maintainedApp.ID)
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+		pkg("santaA", "2026.2"),
+		fma,
+	})
+	require.Error(t, err)
+
+	// switch the title to a Fleet-maintained app, then back to a custom package:
+	// the stale FMA row must be removed so the title holds only the custom package.
+	fmaOnly := pkg("santaFMA2", "2027.1")
+	fmaOnly.FleetMaintainedAppID = new(maintainedApp.ID)
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{fmaOnly})
+	require.NoError(t, err)
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{pkg("santaX", "2027.2")})
+	require.NoError(t, err)
+	pkgs, err = ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, titleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	require.Equal(t, "santaX", pkgs[0].StorageID)
+	var fmaRows int
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &fmaRows,
+			`SELECT COUNT(*) FROM software_installers WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL`,
+			team.ID, titleID)
+	})
+	require.Zero(t, fmaRows)
+}
+
+func testBatchSetSoftwareInstallersMixedTitles(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	pkg := func(title string, bundle string, storage string, version string) *fleet.UploadSoftwareInstallerPayload {
+		tfr, err := fleet.NewTempFileReader(bytes.NewReader([]byte(storage)), t.TempDir)
+		require.NoError(t, err)
+		return &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         storage,
+			Title:            title,
+			Source:           "apps",
+			Version:          version,
+			UserID:           user.ID,
+			Platform:         "darwin",
+			URL:              "https://example.com/" + storage,
+			BundleIdentifier: bundle,
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		}
+	}
+
+	// A single package file (one path entry) can hold packages for different titles,
+	// including a mix of a single-package title and a multi-package title, and the
+	// packages of one title can be interleaved with another's.
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+		pkg("Bravo", "com.example.bravo", "bravo-1", "1.0"),
+		pkg("Alpha", "com.example.alpha", "alpha-1", "1.0"),
+		pkg("Bravo", "com.example.bravo", "bravo-2", "2.0"),
+	})
+	require.NoError(t, err)
+
+	all, err := ds.GetSoftwareInstallers(ctx, team.ID)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+
+	// each package landed on its own resolved title: Alpha has one, Bravo has two
+	countByTitle := map[uint]int{}
+	for _, si := range all {
+		require.NotNil(t, si.TitleID)
+		countByTitle[*si.TitleID]++
+	}
+	require.Len(t, countByTitle, 2)
+	var bravoTitleID uint
+	var alphaCount int
+	for titleID, count := range countByTitle {
+		if count == 2 {
+			bravoTitleID = titleID
+		} else {
+			alphaCount = count
+		}
+	}
+	require.Equal(t, 1, alphaCount)
+
+	// Bravo's packages keep file order (bravo-1 first-added) even though Alpha was
+	// listed between them.
+	pkgs, err := ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &team.ID, bravoTitleID)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	require.Equal(t, "bravo-1", pkgs[0].StorageID)
+	require.Equal(t, "bravo-2", pkgs[1].StorageID)
+	require.Less(t, pkgs[0].InstallerID, pkgs[1].InstallerID)
 }
 
 func testBatchSetSoftwareInstallersWithUpgradeCodes(t *testing.T, ds *Datastore) {
@@ -4471,6 +4688,7 @@ func testGetSoftwarePackagesByTeamAndTitleID(t *testing.T, ds *Datastore) {
 			Source:           "apps",
 			Platform:         "darwin",
 			Version:          "1.0",
+			InstallScript:    "install " + storage,
 			UserID:           user.ID,
 			ValidatedLabels:  labels,
 			TeamID:           &team.ID,
@@ -4494,6 +4712,7 @@ func testGetSoftwarePackagesByTeamAndTitleID(t *testing.T, ds *Datastore) {
 	// returned first-added first, each with its own label scope
 	require.Equal(t, "multi-1.pkg", pkgs[0].Name)
 	require.Equal(t, "multi-1", pkgs[0].StorageID)
+	require.Equal(t, "install multi-1", pkgs[0].InstallScript)
 	require.Len(t, pkgs[0].LabelsIncludeAny, 1)
 	require.Equal(t, lbl.ID, pkgs[0].LabelsIncludeAny[0].LabelID)
 	require.Equal(t, "multi-2.pkg", pkgs[1].Name)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -1715,26 +1715,23 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	require.NoError(t, err)
 	require.Len(t, mixedAll, 3)
 
-	// each package landed on its own resolved title: Alpha has one, Bravo has two
-	countByTitle := map[uint]int{}
+	// each package resolved to a title by its storage id; Bravo's two packages share a
+	// title distinct from Alpha's
+	titleOf := map[string]uint{}
 	for _, si := range mixedAll {
 		require.NotNil(t, si.TitleID)
-		countByTitle[*si.TitleID]++
+		titleOf[si.HashSHA256] = *si.TitleID
 	}
-	require.Len(t, countByTitle, 2)
-	var bravoTitleID uint
-	var alphaCount int
-	for titleID, count := range countByTitle {
-		if count == 2 {
-			bravoTitleID = titleID
-		} else {
-			alphaCount = count
-		}
-	}
-	require.Equal(t, 1, alphaCount)
+	require.Equal(t, titleOf["bravo-1"], titleOf["bravo-2"])
+	require.NotEqual(t, titleOf["alpha-1"], titleOf["bravo-1"])
+
+	// Alpha holds one package
+	alphaPkgs, err := ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &mixedTeam.ID, titleOf["alpha-1"])
+	require.NoError(t, err)
+	require.Len(t, alphaPkgs, 1)
 
 	// Bravo's packages keep file order (bravo-1 first-added) even though Alpha was listed between them.
-	bravoPkgs, err := ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &mixedTeam.ID, bravoTitleID)
+	bravoPkgs, err := ds.GetSoftwarePackagesByTeamAndTitleID(ctx, &mixedTeam.ID, titleOf["bravo-1"])
 	require.NoError(t, err)
 	require.Len(t, bravoPkgs, 2)
 	require.Equal(t, "bravo-1", bravoPkgs[0].StorageID)

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -42,6 +42,9 @@ var (
 	SoftwareAlreadyHasFleetMaintainedAppMessage  = "%s already has a Fleet-maintained app on the %s fleet."
 	SoftwareAlreadyHasPackageMessage             = "%s already has a software package on the %s fleet."
 	SoftwarePackageLimitMessage                  = "%s already has %d packages. Before adding, delete one you no longer use."
+	SoftwareSelfServiceCategoriesConflictMessage = "Couldn't add software (%q). self_service and categories can be specified either in the fleet-level file or in the package YAML file."
+	SoftwareSetupExperienceFleetLevelOnlyMessage = "Couldn't add software (%q). setup_experience can be specified only in the fleet-level file."
+	SoftwareLabelsPackageLevelOnlyMessage        = "Couldn't add software (%q). Labels can be specified only in the package-level file when adding multiple packages of the same software."
 	ConfigProfileLabelScopingPremiumCauseMsg     = "Scoping configuration profiles with labels"
 )
 

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -45,6 +45,7 @@ var (
 	SoftwareSelfServiceCategoriesConflictMessage = "Couldn't add software (%q). self_service and categories can be specified either in the fleet-level file or in the package YAML file."
 	SoftwareSetupExperienceFleetLevelOnlyMessage = "Couldn't add software (%q). setup_experience can be specified only in the fleet-level file."
 	SoftwareLabelsPackageLevelOnlyMessage        = "Couldn't add software (%q). Labels can be specified only in the package-level file when adding multiple packages of the same software."
+	SoftwareLabelsConflictMessage                = "Couldn't add software (%q). Labels can be specified either in the fleet-level file or in the package YAML file."
 	ConfigProfileLabelScopingPremiumCauseMsg     = "Scoping configuration profiles with labels"
 )
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -925,11 +925,6 @@ func (spec SoftwarePackageSpec) ResolveSoftwarePackagePaths(baseDir string) Soft
 	return spec
 }
 
-func (spec SoftwarePackageSpec) IncludesFieldsDisallowedInPackageFile() bool {
-	return len(spec.LabelsExcludeAny) > 0 || len(spec.LabelsIncludeAny) > 0 || len(spec.LabelsIncludeAll) > 0 ||
-		len(spec.Categories.Value) > 0 || spec.SelfService || spec.InstallDuringSetup.Valid
-}
-
 func resolveApplyRelativePath(baseDir string, path string) string {
 	if path != "" && baseDir != "" && !filepath.IsAbs(path) {
 		return filepath.Join(baseDir, path)
@@ -1208,6 +1203,29 @@ const MaxSoftwareInstallAttempts = 3
 
 // MaxPackagesPerTitle caps how many custom packages a single software title can hold per team.
 const MaxPackagesPerTitle = 10
+
+func ValidateTitlePackages(payloads []*UploadSoftwareInstallerPayload, teamName string) error {
+	var customCount, fmaCount int
+	seenHash := make(map[string]struct{}, len(payloads))
+	for _, p := range payloads {
+		if p.FleetMaintainedAppID != nil {
+			fmaCount++
+			continue
+		}
+		customCount++
+		if _, dup := seenHash[p.StorageID]; dup {
+			return ConflictError{Message: fmt.Sprintf(SoftwarePackageHashConflictMessage, p.Filename)}
+		}
+		seenHash[p.StorageID] = struct{}{}
+	}
+	if fmaCount > 0 && customCount > 0 {
+		return ConflictError{Message: fmt.Sprintf(SoftwareAlreadyHasFleetMaintainedAppMessage, payloads[0].Title, teamName)}
+	}
+	if customCount > MaxPackagesPerTitle {
+		return ConflictError{Message: fmt.Sprintf(SoftwarePackageLimitMessage, payloads[0].Title, MaxPackagesPerTitle)}
+	}
+	return nil
+}
 
 // HostSoftwareInstallOptions contains options that apply to a software or VPP
 // app install request.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48399
Summary:
- Allows multiple installers for the same title to be defined in a yaml file
- `generate-gitops` generates a file like this if multiple installers are available per title
- Allows labels, self_service, categories keys to be defined per package
- Inherits fleet-level keys only if they are not set at the package-level
- Repoints policies.software_installer_id for a deleted installer to either the first added installer for that title, or NULL if none are available

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitOps output now supports software titles that contain multiple packages, generating a dedicated package file plus related assets.
  * Software imports and updates now preserve package order and handle multi-package titles more consistently.

* **Bug Fixes**
  * Improved inheritance and validation for software fields so package-level settings are respected and conflicting settings are flagged.
  * Fixed installer batch updates to better handle added, removed, and reordered packages without disrupting related policies or pending installs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->