### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cog-app/darwin.json
+++ b/ee/maintained-apps/outputs/cog-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3592",
+      "version": "3602",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.cogx.cog';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cogx.cog' AND version_compare(bundle_short_version, '3592') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cogx.cog' AND version_compare(bundle_short_version, '3602') < 0);"
       },
-      "installer_url": "https://cogcdn.cog.losno.co/Cog-ec25abc71.zip",
+      "installer_url": "https://cogcdn.cog.losno.co/Cog-730d4398f.zip",
       "install_script_ref": "b0e36626",
       "uninstall_script_ref": "e84a8314",
-      "sha256": "6f91002363d2d51c12af68ab708c3e680e82d18651e64233e5f5c49ae8fea219",
+      "sha256": "f616430ff6fe897adb04232ca2f2fe31136e96715cb3f60598ae87d17cebafb9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dayflow/darwin.json
+++ b/ee/maintained-apps/outputs/dayflow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.1",
+      "version": "2.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '1.14.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '2.0.0') < 0);"
       },
-      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v1.14.1/Dayflow.dmg",
+      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v2.0.0/Dayflow.dmg",
       "install_script_ref": "42e29e09",
       "uninstall_script_ref": "efe23f9c",
-      "sha256": "60a34d3a347c67bf461d870d24f603ccece6d6e35d7854de810386e338b64282",
+      "sha256": "e74a0aa651a6069b657ce88420c4bbb20c2fe80aa90cab741e4f594fa764c201",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.6.0.0",
+      "version": "3.6.1.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.6.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.6.1.0') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.0.85549.exe",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.1.85592.exe",
       "install_script_ref": "f635418b",
       "uninstall_script_ref": "a6821d8b",
-      "sha256": "5b83c3c3c83163c214552061a1e9a684a52088157536d05b39c9ff2a885b4b2a",
+      "sha256": "f20cc7fa620604182651bfaaae51841233287f7c9575e6c4c328ddf35d3952c6",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/powerphotos/darwin.json
+++ b/ee/maintained-apps/outputs/powerphotos/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.4",
+      "version": "3.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.fatcatsoftware.PowerPhotos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.fatcatsoftware.PowerPhotos' AND version_compare(bundle_short_version, '3.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.fatcatsoftware.PowerPhotos' AND version_compare(bundle_short_version, '3.4.1') < 0);"
       },
       "installer_url": "https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip",
       "install_script_ref": "1398e00e",

--- a/ee/maintained-apps/outputs/spotify/darwin.json
+++ b/ee/maintained-apps/outputs/spotify/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.2.92.148",
+      "version": "1.2.93.667",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client' AND version_compare(bundle_short_version, '1.2.92.148') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client' AND version_compare(bundle_short_version, '1.2.93.667') < 0);"
       },
       "installer_url": "https://download.scdn.co/SpotifyARM64.dmg",
       "install_script_ref": "0ddf928e",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated support for newer releases of several apps across macOS and Windows, including Cog, Dayflow, JetBrains Toolbox, PowerPhotos, and Spotify.
  * Improved version checks and installer metadata so the latest installers are recognized and handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->