### PR TITLE
Remove /api/mdm/microsoft/auth mentions from public endpoints guide

### DIFF
--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -55,9 +55,7 @@ If you would like to use Fleet's Windows MDM features, the following endpoints n
 - `/api/mdm/microsoft/enroll`: Delivers WS-Trust X.509v3 Token Enrollment (MS-WSTEP) functionality.
   - See the [section 3.4 on the MS-MDE2 specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wstep/4766a85d-0d18-4fa1-a51f-e5cb98b752ea) for more details.
 - `/api/mdm/microsoft/tos`: Presents end users with the Terms of Service agreement during out-of-the-box Windows setup. Required for automatic enrollment.
-- `/api/mdm/microsoft/auth`: If you use automatic enrollment, authenticates end users during out-of-the-box Windows setup. 
-  - See the [section 3.2 on the MS-MDE2 specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mde2/27ed8c2c-0140-41ce-b2fa-c3d1a793ab4a) for more details.
- 
+
 ### iOS and iPadOS
 
 If you would like to use Fleet's iOS/iPadOS MDM features, the following endpoints need to be exposed:
@@ -96,7 +94,6 @@ The `/mdm/apple/mdm` and `/api/mdm/apple/enroll` endpoints can use mTLS with the
 These endpoints don't use mTLS:
 - `/mdm/apple/scep`
 - `/api/mdm/microsoft/discovery`
-- `/api/mdm/microsoft/auth`
 - `/api/mdm/microsoft/policy`
 - `/api/mdm/microsoft/enroll`
 - `/api/mdm/microsoft/management`


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41056

Follow-up documentation change for #41056. The unused Windows MDM STS auth endpoint (`/api/mdm/microsoft/auth`) was removed in #48734, so this removes it from the "what API endpoints to expose to the public internet" guide:

- The "endpoints to expose" bullet in the Windows section, along with its now-orphaned MS-MDE2 section 3.2 reference.
- The entry in the "these endpoints don't use mTLS" list.

Supersedes #41058, which removes the same two references but leaves the section 3.2 sub-bullet dangling under `/api/mdm/microsoft/tos`.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (verified no remaining `/api/mdm/microsoft/auth` references in the article and that the surrounding lists render correctly).

Documentation-only change: no code, automated tests, database migrations, Fleet configuration settings, or fleetd/orbit/Fleet Desktop impact.
