### PR TITLE
Fix tables losing row selection on window focus

### DIFF
--- a/changes/48542-table-reload-on-window-focus
+++ b/changes/48542-table-reload-on-window-focus
@@ -1,0 +1,1 @@
+- Fixed tables (including policies and users) intermittently reloading and clearing the current selection or resetting to the first page when the browser window regained focus.

--- a/changes/48542-table-reload-on-window-focus
+++ b/changes/48542-table-reload-on-window-focus
@@ -1,1 +1,1 @@
-- Fixed tables (including policies and users) intermittently reloading and clearing the current selection or resetting to the first page when the browser window regained focus.
+- Fixed the policies and users tables intermittently reloading and clearing the current selection or resetting to the first page when the browser window regained focus.

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTable.tsx
@@ -73,6 +73,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
     () => usersAPI.loadAll({ globalFilter: querySearchText }),
     {
       select: (data: IUser[]) => data,
+      refetchOnWindowFocus: false,
     }
   );
 
@@ -88,6 +89,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
       select: (data: IInvite[]) => {
         return data;
       },
+      refetchOnWindowFocus: false,
     }
   );
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -278,6 +278,7 @@ const ManagePolicyPage = ({
       enabled: isRouteOk && isAllTeamsSelected,
       select: (data) => data.policies || [],
       staleTime: 5000,
+      refetchOnWindowFocus: false,
     }
   );
 
@@ -336,6 +337,7 @@ const ManagePolicyPage = ({
     {
       enabled: isRouteOk && isPremiumTier && !isAllTeamsSelected,
       select: (data: ILoadTeamPoliciesResponse) => data.policies || [],
+      refetchOnWindowFocus: false,
     }
   );
 
@@ -389,6 +391,7 @@ const ManagePolicyPage = ({
         setConfig(data);
       },
       staleTime: 5000,
+      refetchOnWindowFocus: false,
     }
   );
 
@@ -399,6 +402,7 @@ const ManagePolicyPage = ({
     // Enable for all teams including "No team" (teamIdForApi === 0)
     enabled: isRouteOk && teamIdForApi !== undefined,
     staleTime: 5000,
+    refetchOnWindowFocus: false,
   });
   const teamConfig = teamData?.team;
 

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -122,13 +122,7 @@ interface IAppWrapperProps {
   location?: any;
 }
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-    },
-  },
-});
+const queryClient = new QueryClient();
 
 // App.tsx needs the context for user and config. We also wrap the application
 // component in the required query client provider for react-query. This

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -122,7 +122,13 @@ interface IAppWrapperProps {
   location?: any;
 }
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 // App.tsx needs the context for user and config. We also wrap the application
 // component in the required query client provider for react-query. This


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48542

## Description

The `QueryClient` was created with `new QueryClient()` and no default options, so every query inherited React Query's default `refetchOnWindowFocus: true`. On pages like `/policies` and `/users`, queries are refetched every time the browser window regains focus. Those focus refetches re-rendered the table with fresh data, tripping react-table's `autoResetSelectedRows` and `autoResetPage` (both default `true`), so the table appeared to "reload," clearing the user's row selection and jumping back to the first page when they clicked away and back.


## Screen recording demonstrating the fix

https://github.com/user-attachments/assets/eabf30a5-65d3-420d-a8d3-5a529fa06089


# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users and policies tables from unexpectedly reloading when switching back to the browser window.
  * Preserved table state such as selected rows and current pagination instead of resetting to the first page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->