### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.8",
+      "version": "3.1.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.9') < 0);"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.8.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.9.zip",
       "install_script_ref": "c6782863",
       "uninstall_script_ref": "9e4b9fca",
-      "sha256": "b913064144feebccd394c64bd45a4ddf5a5f7296c402af22d7f9a83627b39865",
+      "sha256": "cdac12373f0389b1eaf73ad5303678de9ee4165862f1b19f1fe0e738e0356861",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/only-switch/darwin.json
+++ b/ee/maintained-apps/outputs/only-switch/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.6.8",
+      "version": "2.6.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch' AND version_compare(bundle_short_version, '2.6.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch' AND version_compare(bundle_short_version, '2.6.9') < 0);"
       },
-      "installer_url": "https://github.com/jacklandrin/OnlySwitch/releases/download/release_2.6.8/OnlySwitch.dmg",
+      "installer_url": "https://github.com/jacklandrin/OnlySwitch/releases/download/release_2.6.9/OnlySwitch.dmg",
       "install_script_ref": "42848bd5",
       "uninstall_script_ref": "c3c2aa39",
-      "sha256": "c4ded32119fa1c81f41c4ed325cadb5431cb49ba54a28e605f7f5824346da06e",
+      "sha256": "e2f5303608a3fe5dec39bb81fc490b04e412f10c915d7e7142404a613b30c24f",
       "default_categories": [
         "Utilities"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS app listings for Marked and OnlySwitch to the latest available versions.
  * Refreshed the download links and checksum values to match the newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->