### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/dbeaver-community/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-community/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.1",
+      "version": "26.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.1.2') < 0);"
       },
-      "installer_url": "https://dbeaver.io/files/26.1.1/dbeaver-ce-26.1.1-macos-aarch64.dmg",
+      "installer_url": "https://dbeaver.io/files/26.1.2/dbeaver-ce-26.1.2-macos-aarch64.dmg",
       "install_script_ref": "dc1883a0",
       "uninstall_script_ref": "f1704b2e",
-      "sha256": "3f0b85c0413e681106ff293036b101976d327eb69d7bc05d5141dd2c91819307",
+      "sha256": "7fc200acea315b133b1f85c4858e0320504fd81513079cd1e9c058fa193fe1be",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dockdoor/darwin.json
+++ b/ee/maintained-apps/outputs/dockdoor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.39.3",
+      "version": "1.39.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor' AND version_compare(bundle_short_version, '1.39.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor' AND version_compare(bundle_short_version, '1.39.4') < 0);"
       },
-      "installer_url": "https://github.com/ejbills/DockDoor/releases/download/1.39.3/DockDoor.dmg",
+      "installer_url": "https://github.com/ejbills/DockDoor/releases/download/1.39.4/DockDoor.dmg",
       "install_script_ref": "b1dfbe8c",
       "uninstall_script_ref": "0e456379",
-      "sha256": "fe28259b978df36af8c95099e5b875d40adcea3dd4179f3cc2b67cbd2ac86ab4",
+      "sha256": "3ec497dff5b77976f00a1f607e9e79bf2ec4c97d8d6fcb5358d8c0130e96ab16",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.8",
+      "version": "3.1.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.9') < 0);"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.8.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.9.zip",
       "install_script_ref": "c6782863",
       "uninstall_script_ref": "9e4b9fca",
-      "sha256": "b913064144feebccd394c64bd45a4ddf5a5f7296c402af22d7f9a83627b39865",
+      "sha256": "cdac12373f0389b1eaf73ad5303678de9ee4165862f1b19f1fe0e738e0356861",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/only-switch/darwin.json
+++ b/ee/maintained-apps/outputs/only-switch/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.6.8",
+      "version": "2.6.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch' AND version_compare(bundle_short_version, '2.6.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch' AND version_compare(bundle_short_version, '2.6.9') < 0);"
       },
-      "installer_url": "https://github.com/jacklandrin/OnlySwitch/releases/download/release_2.6.8/OnlySwitch.dmg",
+      "installer_url": "https://github.com/jacklandrin/OnlySwitch/releases/download/release_2.6.9/OnlySwitch.dmg",
       "install_script_ref": "42848bd5",
       "uninstall_script_ref": "c3c2aa39",
-      "sha256": "c4ded32119fa1c81f41c4ed325cadb5431cb49ba54a28e605f7f5824346da06e",
+      "sha256": "e2f5303608a3fe5dec39bb81fc490b04e412f10c915d7e7142404a613b30c24f",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/openrct2/darwin.json
+++ b/ee/maintained-apps/outputs/openrct2/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.5.2",
+      "version": "0.5.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.openrct2.OpenRCT2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.openrct2.OpenRCT2' AND version_compare(bundle_short_version, '0.5.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.openrct2.OpenRCT2' AND version_compare(bundle_short_version, '0.5.3') < 0);"
       },
-      "installer_url": "https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.5.2/OpenRCT2-v0.5.2-macos-universal.zip",
+      "installer_url": "https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.5.3/OpenRCT2-v0.5.3-macos-universal.zip",
       "install_script_ref": "a32ae41d",
       "uninstall_script_ref": "9fdb5f82",
-      "sha256": "b80fd9b439fb42d1c4d58245fb9215bbea89813326e3616b72e95181a8d06787",
+      "sha256": "dc597f5cc6115a7e5eff61c09a77a5edeb4686a69f72230dda4257c5c4f6f395",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.24.1",
+      "version": "2.24.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.24.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.24.3') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.24.1.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.24.3.dmg",
       "install_script_ref": "5f8295ce",
       "uninstall_script_ref": "a5d6883d",
-      "sha256": "ee93ac489152e9ae763c82357c456f6f14aa9aa826d5906f242321f6a3b9dafc",
+      "sha256": "aeebc56544d5adf81c95422811b838b74ecb55fd252c76460f57ec42a9a2793d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tunnelblick/darwin.json
+++ b/ee/maintained-apps/outputs/tunnelblick/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.tunnelblick.tunnelblick';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.tunnelblick.tunnelblick' AND version_compare(bundle_short_version, '8.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.tunnelblick.tunnelblick' AND version_compare(bundle_short_version, '8.0.3') < 0);"
       },
-      "installer_url": "https://tunnelblick.net/iprelease/Tunnelblick_8.0.2_build_6302.dmg",
+      "installer_url": "https://tunnelblick.net/iprelease/Tunnelblick_8.0.3_build_6303.dmg",
       "install_script_ref": "9739f1a1",
       "uninstall_script_ref": "ddae342f",
-      "sha256": "95901968ee899aa5b37622bf50eb567565e7f89b4c3132b5702e418060a6166f",
+      "sha256": "20c73f78697e4f4baf1c443dff7c494bd9746c9def92b0d5fdb0c1d689d241d7",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated macOS release metadata for several apps to their latest versions, including DBeaver Community, DockDoor, Marked, OnlySwitch, OpenRCT2, Spokenly, and Tunnelblick.
  * Refreshes download links and checksums so installers point to the newest available releases.

* **Bug Fixes**
  * Improved patch detection logic to match the updated app versions, helping keep upgrade checks accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->