### PR TITLE
Add VEX exclusions for fleetctl

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -316,6 +316,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:35:00
 
+### [CVE-2026-58016](https://nvd.nist.gov/vuln/detail/CVE-2026-58016)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use glib/GDBus introspection; libglib2.0-0t64 is a transitive OS dependency of libgtk-3-0/wine, installed only for installer-packaging tooling, and g_dbus_node_info_new_for_xml is never reached with untrusted input.
+- **Products:** `fleetctl`,`pkg:deb/debian/libglib2.0-0t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-06 08:51:11
+
 ### [CVE-2026-54513](https://nvd.nist.gov/vuln/detail/CVE-2026-54513)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2026-58016.vex.json
+++ b/security/vex/fleetctl/CVE-2026-58016.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-270999997a7f72e384a2e6ad98fcde6ff0807f564e765f02010b90a72a2f4495",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-06T08:51:11Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-58016"
+      },
+      "timestamp": "2026-07-06T08:51:11Z",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libglib2.0-0t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use glib/GDBus introspection; libglib2.0-0t64 is a transitive OS dependency of libgtk-3-0/wine, installed only for installer-packaging tooling, and g_dbus_node_info_new_for_xml is never reached with untrusted input.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/28775213423/job/85317520154.

New run: https://github.com/fleetdm/fleet/actions/runs/28779783653.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added vulnerability status information for a known issue affecting `fleetctl`, clarifying that it is not impacted by the reported problem.
  * Included a note explaining why the affected code path is not reached in typical use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->