### PR TITLE
Revert "Update apps when closed"

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -316,54 +316,40 @@ software:
   fleet_maintained_apps:
     # macOS apps
     - slug: 1password/darwin # 1Password for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-1password-running.yml
       self_service: true
       setup_experience: true
       categories:
         - Security
     - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-aws-vpn-client-running.yml
       self_service: true
       labels_include_any:
         - "IdP group: SAML-aws-vpn"
       categories:
         - Utilities
     - slug: google-chrome/darwin # Google Chrome for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-google-chrome-running.yml
       self_service: true
       setup_experience: true
       categories:
         - Browsers
     - slug: firefox/darwin # Mozilla Firefox for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-firefox-running.yml
       self_service: true
       labels_include_any:
         - Macs with Firefox installed
       categories:
         - Browsers
     - slug: brave-browser/darwin # Brave for macOS (ARM)
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-brave-browser-running.yml
       self_service: true
       labels_include_any:
         - Macs with Brave Browser installed
       categories:
         - Browsers
     - slug: docker-desktop/darwin # Docker for macOS (ARM)
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-docker-desktop-running.yml
       self_service: true
       labels_include_any:
         - Macs with Docker Desktop installed
       categories:
         - Developer tools
     - slug: visual-studio-code/darwin # Microsoft Visual Studio for macOS (ARM)
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-visual-studio-code-running.yml
       self_service: true
       labels_include_any:
         - Macs with Visual Studio Code installed
@@ -372,13 +358,9 @@ software:
     - slug: slack/darwin # Slack for macOS
       self_service: true
       setup_experience: true
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-slack-running.yml
       categories:
         - Communication
     - slug: zoom/darwin # Zoom for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-zoom-running.yml
       self_service: true
       setup_experience: true
       categories:
@@ -401,71 +383,53 @@ software:
       categories:
         - Utilities
     - slug: claude/darwin # Claude for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-claude-running.yml
       self_service: true
       setup_experience: true
       categories:
         - Productivity
     - slug: github/darwin # GitHub Desktop for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-github-desktop-running.yml
       self_service: true
       labels_include_any:
         - Macs with GitHub Desktop installed
       categories:
         - Developer tools
     - slug: utm/darwin # UTM for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-utm-running.yml
       self_service: true
       labels_include_any:
         - Macs with UTM installed
       categories:
         - Productivity
     - slug: postman/darwin # Postman for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-postman-running.yml
       self_service: true
       labels_include_any:
         - Macs with Postman installed
       categories:
         - Developer tools
     - slug: grammarly-desktop/darwin # Grammarly Desktop for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-grammarly-desktop-running.yml
       self_service: true
       labels_include_any:
         - Macs with Grammarly Desktop installed
       categories:
         - Productivity
     - slug: iterm2/darwin # iTerm2 for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-iterm2-running.yml
       self_service: true
       labels_include_any:
         - Macs with iTerm2 installed
       categories:
         - Developer tools
     - slug: sublime-text/darwin # Sublime Text for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-sublime-text-running.yml
       self_service: true
       labels_include_any:
         - Macs with Sublime Text installed
       categories:
         - Developer tools
     - slug: parallels/darwin # Parallels Desktop for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-parallels-running.yml
       self_service: true
       labels_include_any:
         - Macs with Parallels Desktop installed
       categories:
         - Productivity
     - slug: loom/darwin # Loom for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-loom-running.yml
       self_service: true
       labels_include_any:
         - Macs with Loom installed
@@ -477,80 +441,60 @@ software:
       categories:
         - Utilities
     - slug: spotify/darwin # Spotify for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-spotify-running.yml
       self_service: true
       labels_include_any:
         - Macs with Spotify installed
       categories:
         - Productivity
     - slug: rectangle/darwin # Rectangle for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-rectangle-running.yml
       self_service: true
       labels_include_any:
         - Macs with Rectangle installed
       categories:
         - Productivity
     - slug: logi-options+/darwin # Logi Options+ for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-logi-options-running.yml
       self_service: true
       labels_include_any:
         - Macs with Logi Options+ installed
       categories:
         - Productivity
     - slug: figma/darwin # Figma for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-figma-running.yml
       self_service: true
       labels_include_any:
         - Macs with Figma installed
       categories:
         - Productivity
     - slug: whatsapp/darwin # WhatsApp for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-whatsapp-running.yml
       self_service: true
       labels_include_any:
         - Macs with WhatsApp installed
       categories:
         - Communication
     - slug: android-studio/darwin # Android Studio for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-android-studio-running.yml
       self_service: true
       labels_include_any:
         - Macs with Android Studio installed
       categories:
         - Developer tools
     - slug: zed/darwin # Zed for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-zed-running.yml
       self_service: true
       labels_include_any:
         - Macs with Zed installed
       categories:
         - Developer tools
     - slug: obsidian/darwin # Obsidian for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-obsidian-running.yml
       self_service: true
       labels_include_any:
         - Macs with Obsidian installed
       categories:
         - Productivity
     - slug: google-drive/darwin # Google Drive for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-google-drive-running.yml
       self_service: true
       labels_include_any:
         - Macs with Google Drive installed
       categories:
         - Productivity
     - slug: cursor/darwin # Cursor for macOS
-      pre_install_query:
-        path: ../lib/macos/misc/pre-install-queries/is-cursor-running.yml
       self_service: true
       labels_include_any:
         - Macs with Cursor installed
@@ -570,15 +514,11 @@ software:
         - Productivity
     # Windows apps
     - slug: 1password/windows # 1Password for Windows
-      pre_install_query:
-        path: ../lib/windows/misc/pre-install-queries/is-1password-running.yml
       self_service: true
       setup_experience: true
       categories:
         - Security
     - slug: slack/windows # Slack for Windows
-      pre_install_query:
-        path: ../lib/windows/misc/pre-install-queries/is-slack-running.yml
       self_service: true
       setup_experience: true
       categories:
@@ -586,8 +526,6 @@ software:
       labels_include_any:
         - "x86-based Windows hosts"
     - slug: claude/windows # Claude for Windows
-      pre_install_query:
-        path: ../lib/windows/misc/pre-install-queries/is-claude-running.yml
       self_service: true
       setup_experience: true
       labels_include_any:
@@ -595,16 +533,12 @@ software:
       categories:
         - Productivity
     - slug: firefox/windows # Mozilla Firefox for Windows
-      pre_install_query:
-        path: ../lib/windows/misc/pre-install-queries/is-firefox-running.yml
       self_service: true
       categories:
         - Browsers
       labels_include_any:
         - "x86 Windows hosts with Firefox installed"
     - slug: google-chrome/windows # Google Chrome for Windows
-      pre_install_query:
-        path: ../lib/windows/misc/pre-install-queries/is-google-chrome-running.yml
       self_service: true
       setup_experience: true
       categories:
@@ -612,8 +546,6 @@ software:
       labels_include_any:
         - "x86-based Windows hosts"
     - slug: zoom/windows # Zoom for Windows (x86)
-      pre_install_query:
-        path: ../lib/windows/misc/pre-install-queries/is-zoom-running.yml
       self_service: true
       setup_experience: true
       categories:
@@ -621,8 +553,6 @@ software:
       labels_include_any:
         - "x86-based Windows hosts"
     - slug: visual-studio-code/windows # Microsoft Visual Studio for Windows
-      pre_install_query:
-        path: ../lib/windows/misc/pre-install-queries/is-visual-studio-code-running.yml
       self_service: true
       labels_include_any:
         - "x86 Windows hosts with Visual Studio Code installed"

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-1password-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-1password-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = '1Password');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-android-studio-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-android-studio-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE path LIKE '/Applications/Android Studio.app/%');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-aws-vpn-client-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-aws-vpn-client-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'AWS VPN Client');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-brave-browser-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-brave-browser-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Brave Browser');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-claude-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-claude-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Claude');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-cursor-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-cursor-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Cursor');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-docker-desktop-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-docker-desktop-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE path LIKE '/Applications/Docker.app/%');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-figma-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-figma-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Figma');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-firefox-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-firefox-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'firefox');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-github-desktop-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-github-desktop-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'GitHub Desktop');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-google-chrome-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-google-chrome-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Google Chrome');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-google-drive-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-google-drive-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Google Drive');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-grammarly-desktop-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-grammarly-desktop-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Grammarly Desktop');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-iterm2-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-iterm2-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'iTerm2');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-logi-options-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-logi-options-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'logioptionsplus');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-loom-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-loom-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Loom');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-obsidian-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-obsidian-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Obsidian');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-parallels-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-parallels-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'prl_client_app');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-postman-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-postman-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Postman');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-rectangle-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-rectangle-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Rectangle');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-slack-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-slack-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Slack');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-spotify-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-spotify-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'Spotify');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-sublime-text-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-sublime-text-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'sublime_text');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-utm-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-utm-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'UTM');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-visual-studio-code-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-visual-studio-code-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE path LIKE '/Applications/Visual Studio Code.app/%');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-whatsapp-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-whatsapp-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'WhatsApp');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-zed-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-zed-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE path LIKE '/Applications/Zed.app/%');

--- a/it-and-security/lib/macos/misc/pre-install-queries/is-zoom-running.yml
+++ b/it-and-security/lib/macos/misc/pre-install-queries/is-zoom-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'zoom.us');

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -1,10 +1,9 @@
 - name: macOS - Google Chrome up to date
   description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service."
+  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: google-chrome/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Google Chrome installed
 - name: macOS - 1Password up to date
@@ -12,27 +11,24 @@
   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
   type: patch
   fleet_maintained_app_slug: 1password/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   calendar_events_enabled: true
   labels_include_any:
     - Macs with 1Password installed
 - name: macOS - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Brave Browser if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: brave-browser/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Brave Browser installed
 - name: macOS - Docker Desktop up to date
   description: The host may have an outdated version of Docker Desktop, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Docker Desktop if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Docker Desktop's built-in update functionality. You can also delete Docker Desktop if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: docker-desktop/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Docker Desktop installed
 - name: macOS - Firefox up to date
@@ -40,36 +36,32 @@
   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
   type: patch
   fleet_maintained_app_slug: firefox/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   calendar_events_enabled: true
   labels_include_any:
     - Macs with Firefox installed
 - name: macOS - Visual Studio Code up to date
   description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Visual Studio Code if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also delete Visual Studio Code if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: visual-studio-code/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Visual Studio Code installed
 - name: macOS - Slack up to date
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service."
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: slack/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Slack installed
 - name: macOS - Zoom up to date
   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service."
+  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: zoom/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Zoom installed
 - name: macOS - Okta Verify up to date
@@ -98,182 +90,162 @@
     - Macs with Fleet Desktop.app installed
 - name: macOS - Claude up to date
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Claude if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also delete Claude if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: claude/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Claude installed
 - name: macOS - AWS VPN Client up to date
   description: The host may have an outdated version of AWS VPN Client, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete AWS VPN Client if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using AWS VPN Client's built-in update functionality. You can also delete AWS VPN Client if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: aws-vpn-client/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with AWS VPN Client installed
 - name: macOS - GitHub Desktop up to date
   description: The host may have an outdated version of GitHub Desktop, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete GitHub Desktop if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using GitHub Desktop's built-in update functionality. You can also delete GitHub Desktop if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: github/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with GitHub Desktop installed
 - name: macOS - UTM up to date
   description: The host may have an outdated version of UTM, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete UTM if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using UTM's built-in update functionality. You can also delete UTM if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: utm/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with UTM installed
 - name: macOS - Postman up to date
   description: The host may have an outdated version of Postman, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Postman if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Postman's built-in update functionality. You can also delete Postman if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: postman/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Postman installed
 - name: macOS - Grammarly Desktop up to date
   description: The host may have an outdated version of Grammarly Desktop, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Grammarly Desktop if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Grammarly Desktop's built-in update functionality. You can also delete Grammarly Desktop if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: grammarly-desktop/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Grammarly Desktop installed
 - name: macOS - iTerm2 up to date
   description: The host may have an outdated version of iTerm2, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete iTerm2 if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using iTerm2's built-in update functionality. You can also delete iTerm2 if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: iterm2/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with iTerm2 installed
 - name: macOS - Sublime Text up to date
   description: The host may have an outdated version of Sublime Text, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Sublime Text if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Sublime Text's built-in update functionality. You can also delete Sublime Text if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: sublime-text/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Sublime Text installed
 - name: macOS - Parallels Desktop up to date
   description: The host may have an outdated version of Parallels Desktop, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Parallels Desktop if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Parallels Desktop's built-in update functionality. You can also delete Parallels Desktop if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: parallels/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Parallels Desktop installed
 - name: macOS - Loom up to date
   description: The host may have an outdated version of Loom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Loom if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Loom's built-in update functionality. You can also delete Loom if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: loom/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Loom installed
 - name: macOS - Spotify up to date
   description: The host may have an outdated version of Spotify, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Spotify if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Spotify's built-in update functionality. You can also delete Spotify if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: spotify/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Spotify installed
 - name: macOS - Rectangle up to date
   description: The host may have an outdated version of Rectangle, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Rectangle if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Rectangle's built-in update functionality. You can also delete Rectangle if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: rectangle/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Rectangle installed
 - name: macOS - Logi Options+ up to date
   description: The host may have an outdated version of Logi Options+, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Logi Options+ if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Logi Options+'s built-in update functionality. You can also delete Logi Options+ if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: logi-options+/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Logi Options+ installed
 - name: macOS - Figma up to date
   description: The host may have an outdated version of Figma, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Figma if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Figma's built-in update functionality. You can also delete Figma if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: figma/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Figma installed
 - name: macOS - WhatsApp up to date
   description: The host may have an outdated version of WhatsApp, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete WhatsApp if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using WhatsApp's built-in update functionality. You can also delete WhatsApp if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: whatsapp/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with WhatsApp installed
 - name: macOS - Android Studio up to date
   description: The host may have an outdated version of Android Studio, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Android Studio if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Android Studio's built-in update functionality. You can also delete Android Studio if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: android-studio/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Android Studio installed
 - name: macOS - Zed up to date
   description: The host may have an outdated version of Zed, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Zed if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Zed's built-in update functionality. You can also delete Zed if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: zed/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Zed installed
 - name: macOS - Obsidian up to date
   description: The host may have an outdated version of Obsidian, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Obsidian if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Obsidian's built-in update functionality. You can also delete Obsidian if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: obsidian/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Obsidian installed
 - name: macOS - Google Drive up to date
   description: The host may have an outdated version of Google Drive, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Google Drive if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Google Drive's built-in update functionality. You can also delete Google Drive if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: google-drive/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Google Drive installed
 - name: macOS - Cursor up to date
   description: The host may have an outdated version of Cursor, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Cursor if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Cursor's built-in update functionality. You can also delete Cursor if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: cursor/darwin
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - Macs with Cursor installed
 - name: macOS - Nudge up to date

--- a/it-and-security/lib/macos/policies/update-claude.yml
+++ b/it-and-security/lib/macos/policies/update-claude.yml
@@ -2,5 +2,5 @@
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.1.9493') < 0);
   critical: false
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Claude if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also delete Claude if you are no longer using it."
   platform: darwin

--- a/it-and-security/lib/macos/policies/update-slack.yml
+++ b/it-and-security/lib/macos/policies/update-slack.yml
@@ -2,5 +2,5 @@
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.48.100') < 0);
   critical: false
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also delete Slack if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality. You can also delete Slack if you are no longer using it."
   platform: darwin

--- a/it-and-security/lib/windows/misc/pre-install-queries/is-1password-running.yml
+++ b/it-and-security/lib/windows/misc/pre-install-queries/is-1password-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = '1password.exe');

--- a/it-and-security/lib/windows/misc/pre-install-queries/is-claude-running.yml
+++ b/it-and-security/lib/windows/misc/pre-install-queries/is-claude-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'claude.exe');

--- a/it-and-security/lib/windows/misc/pre-install-queries/is-firefox-running.yml
+++ b/it-and-security/lib/windows/misc/pre-install-queries/is-firefox-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'firefox.exe');

--- a/it-and-security/lib/windows/misc/pre-install-queries/is-google-chrome-running.yml
+++ b/it-and-security/lib/windows/misc/pre-install-queries/is-google-chrome-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'chrome.exe');

--- a/it-and-security/lib/windows/misc/pre-install-queries/is-slack-running.yml
+++ b/it-and-security/lib/windows/misc/pre-install-queries/is-slack-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'slack.exe');

--- a/it-and-security/lib/windows/misc/pre-install-queries/is-visual-studio-code-running.yml
+++ b/it-and-security/lib/windows/misc/pre-install-queries/is-visual-studio-code-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'code.exe');

--- a/it-and-security/lib/windows/misc/pre-install-queries/is-zoom-running.yml
+++ b/it-and-security/lib/windows/misc/pre-install-queries/is-zoom-running.yml
@@ -1,1 +1,0 @@
-- query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'zoom.exe');

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -1,10 +1,9 @@
 - name: Windows - Slack up to date
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service."
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: slack/windows
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - x86 Windows hosts with Slack installed
 - name: Windows - 1Password up to date
@@ -12,54 +11,48 @@
   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
   type: patch
   fleet_maintained_app_slug: 1password/windows
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   calendar_events_enabled: true
   labels_include_any:
     - x86 Windows hosts with 1Password installed
 - name: Windows - Claude up to date
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also uninstall Claude if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: claude/windows
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - x86 Windows hosts with Claude installed
 - name: Windows - Firefox up to date
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also uninstall Firefox if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Firefox's built-in update functionality. You can also uninstall Firefox if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: firefox/windows
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - x86 Windows hosts with Firefox installed
 - name: Windows - Google Chrome up to date
   description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service."
+  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: google-chrome/windows
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - x86 Windows hosts with Google Chrome installed
 - name: Windows - Zoom up to date
   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service."
+  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: zoom/windows
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - x86 Windows hosts with Zoom installed
 - name: Windows - Visual Studio Code up to date
   description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also uninstall Visual Studio Code if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also uninstall Visual Studio Code if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: visual-studio-code/windows
-  install_software: true
-  continuous_automations_enabled: true
+  install_software: false
   labels_include_any:
     - x86 Windows hosts with Visual Studio Code installed
 - name: Windows - Adobe Acrobat Reader up to date

--- a/it-and-security/lib/windows/policies/update-claude.yml
+++ b/it-and-security/lib/windows/policies/update-claude.yml
@@ -2,5 +2,5 @@
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND version_compare(version, '1.1.9310') < 0);
   critical: false
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also uninstall Claude if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."
   platform: windows

--- a/it-and-security/lib/windows/policies/update-slack.yml
+++ b/it-and-security/lib/windows/policies/update-slack.yml
@@ -2,5 +2,5 @@
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND version_compare(version, '4.48.100') < 0);
   critical: false
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service. You can also uninstall Slack if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality. You can also uninstall Slack if you are no longer using it."
   platform: windows


### PR DESCRIPTION
Reverts fleetdm/fleet#48662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update guidance for several apps now points to each app’s built-in update option alongside Self Service.

* **Bug Fixes**
  * Removed app-running checks that could block installs or updates for many macOS and Windows apps.
  * Patch policies now use a lighter-touch approach, avoiding automatic software installation in favor of user-guided remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->