### PR TITLE
Refresh CIS compliance article copy

### DIFF
--- a/articles/cis-benchmarks-without-the-burden.md
+++ b/articles/cis-benchmarks-without-the-burden.md
@@ -1,8 +1,20 @@
-Most organizations have adopted CIS benchmarks. Far fewer can prove, at any given moment, that their entire fleet actually meets them.
+# Benchmarks without the burden: continuous CIS compliance
 
-That gap, between adopting a standard and continuously verifying it, is where most CIS compliance programs quietly break down. The benchmark documents are excellent. The Center for Internet Security publishes detailed, consensus-driven configuration guidance that represents the collective judgment of security experts worldwide. Adopting them is the right decision.
+*Adopting CIS benchmarks is a policy statement. Proving that every device in your fleet actually meets them, right now, is a different job — and it's the one most device tools were never built to do.*
 
-But adoption is a policy statement. Verification is an operational practice. And the tools most organizations use to manage devices were never built to close the distance between the two.
+Most organizations have adopted CIS benchmarks. Far fewer can prove, at any given moment, that their entire fleet actually meets them. The benchmark documents are excellent: the Center for Internet Security publishes detailed, consensus-driven configuration guidance that represents the collective judgment of security experts worldwide, and adopting it is the right decision.
+
+But adoption is a policy statement; verification is an operational practice. The gap between the two is where most CIS compliance programs quietly break down — and the tools most organizations use to manage devices were never built to close it.
+
+## Key takeaways
+
+- **A pushed profile isn't proof.** A traditional MDM can confirm it *sent* a setting; it can't tell you the setting is in effect right now. Fleet reads each device's live state, so a benchmark check reflects reality, not intent.
+- **Compliance becomes a live metric, not a quarterly snapshot.** Fleet evaluates CIS policies continuously against every enrolled device, so a machine that drifts out of compliance shows up the day it drifts instead of accumulating until the next assessment.
+- **Failures can self-heal, and audit evidence is always current.** A failed check can trigger a remediation script automatically, and the proof an auditor asks for already sits in the dashboard, current as of today, rather than being reconstructed under deadline pressure.
+- **One methodology spans every platform you manage.** macOS and Windows share Fleet's built-in benchmark library and report into one dashboard, so you stop reconciling separate per-OS tools into a single defensible number.
+- **Linux fits the same model, with honest limits.** Fleet doesn't ship a pre-built CIS Linux library today, but because every policy is just a query, teams can author CIS-aligned Linux checks and manage them in the same view with the same evidence trail.
+
+<a purpose="cta-button" href="https://fleetdm.com/security-and-control">See continuous compliance in Fleet</a>
 
 ## Adopting a benchmark is not the same as meeting it
 
@@ -12,9 +24,9 @@ A traditional MDM can push a configuration profile to a device and record that t
 
 This is the difference between knowing a configuration was pushed and knowing it is actually in place. For a compliance program, that difference is everything. An auditor does not want to see that you intended a device to be compliant. They want evidence that it is.
 
-Fleet closes this gap because it is built on osquery. Instead of trusting that a pushed configuration took effect, Fleet queries the device directly and reads its actual state. When a CIS benchmark says disk encryption must be enabled, Fleet does not check whether an encryption profile was sent. It checks whether encryption is on. Each benchmark becomes a policy, and each policy is a query that returns a clear pass or fail based on what the device actually reports.
+Fleet closes this gap by reading the device directly. Instead of trusting that a pushed configuration took effect, Fleet's agent queries the device and reads its actual state. When a CIS benchmark says disk encryption must be enabled, Fleet does not check whether an encryption profile was sent. It checks whether encryption is on. Each benchmark becomes a policy, and each policy is a query that returns a clear pass or fail based on what the device actually reports.
 
-Fleet provides out-of-the-box CIS benchmark policies for macOS and Windows, available in Fleet Premium and Ultimate, covering the full set of benchmarks that can be automated. Some CIS controls are not automatable by design and still require manual review, and Fleet is explicit about which ones those are rather than implying coverage it does not have. For everything that can be checked programmatically, Fleet checks the live state of the device, not a record of intent.
+Fleet provides out-of-the-box CIS benchmark policies for macOS and Windows, available in Fleet Premium, covering the full set of benchmarks that can be automated. Some CIS controls are not automatable by design and still require manual review, and Fleet is explicit about which ones those are rather than implying coverage it does not have. For everything that can be checked programmatically, Fleet checks the live state of the device, not a record of intent.
 
 ## Continuous evaluation turns compliance into a real-time metric
 
@@ -34,29 +46,21 @@ There is a compliance benefit beyond the operational one. A program that monitor
 
 CIS publishes benchmarks for macOS, Windows, and major Linux distributions. In most organizations, each platform is assessed by a different tool, on a different schedule, using a different methodology. The Mac team checks Macs one way. The Windows team checks Windows another way. Linux, if it is checked at all, is checked by a third process. When it is time to report fleet-wide compliance, someone has to reconcile three inconsistent data sets into a single number, and that reconciliation is slow, manual, and hard to defend.
 
-Fleet gives both IT and security a single compliance view across every platform it manages, evaluated through one consistent osquery-based methodology. Fleet's built-in CIS benchmark library covers macOS and Windows, and both run as policies through the same engine and report into the same dashboard. There is no separate Mac tool and Windows tool to reconcile. The macOS compliance number and the Windows compliance number are produced the same way, from live device state, in one place.
+Fleet gives both IT and security a single compliance view across every platform it manages, evaluated through one consistent, agent-based methodology. Fleet's built-in CIS benchmark library covers macOS and Windows, and both run as policies through the same engine and report into the same dashboard. There is no separate Mac tool and Windows tool to reconcile. The macOS compliance number and the Windows compliance number are produced the same way, from live device state, in one place.
 
-For Linux, the same continuous policy model applies, but the coverage is different and it is worth being precise about how. Fleet does not ship a pre-built CIS Linux benchmark library today. Because every policy is simply an osquery query, teams can author their own CIS-aligned Linux checks and manage them alongside macOS and Windows in the same view, using the same evaluation logic and the same evidence trail. So the unified compliance view spans Linux, but the ready-made CIS benchmark content does not yet, and closing that last gap is work the team takes on rather than something Fleet hands you out of the box.
+For Linux, the same continuous policy model applies, but the coverage is different and it is worth being precise about how. Fleet does not ship a pre-built CIS Linux benchmark library today. Because every policy is simply a query, teams can author their own CIS-aligned Linux checks and manage them alongside macOS and Windows in the same view, using the same evaluation logic and the same evidence trail. So the unified compliance view spans Linux, but the ready-made CIS benchmark content does not yet, and closing that last gap is work the team takes on rather than something Fleet hands you out of the box.
 
 That consistency is still valuable. Where the built-in benchmarks apply, every platform is measured the same way, from the same kind of live data, so the compliance story you tell an auditor is coherent rather than assembled from tools that each define and measure compliance differently.
 
 ## What changes when CIS compliance becomes continuous
 
-When benchmark compliance is verified from live device state and evaluated continuously, the practical changes are concrete:
-
-**You measure what is true, not what was intended.** Compliance reflects the actual configuration of each device right now, not a record that a profile was once delivered. The number you report is the number on the fleet.
-
-**Gaps get fixed when they happen.** Configuration drift surfaces immediately instead of accumulating until the next assessment. Failed checks can trigger automated remediation, so common issues resolve without a manual queue.
-
-**Audit preparation stops being a project.** Evidence is maintained continuously rather than reconstructed before a deadline. When an auditor asks for proof, the data already exists and is already current.
-
-**One methodology spans the fleet.** macOS and Windows are measured the same way through Fleet's built-in benchmarks, and Linux fits the same model through custom policies, so the compliance picture is consistent rather than reconciled from separate tools.
+When benchmark compliance is verified from live device state and evaluated continuously, four things change in practice. You measure what is actually true on each device, not a record that a profile was once delivered, so the number you report is the number on the fleet. Configuration drift surfaces the moment it happens instead of accumulating until the next assessment, and failed checks can trigger automated remediation so common issues resolve without a manual queue. Audit preparation stops being a project, because the evidence is maintained continuously rather than reconstructed before a deadline. And one methodology spans the fleet: macOS and Windows are measured the same way through Fleet's built-in benchmarks, with Linux fitting the same model through custom policies, so the compliance picture is consistent rather than reconciled from separate tools.
 
 ## The bottom line
 
 CIS benchmarks have always been worth adopting. The hard part was never the standard. It was proving, continuously and credibly, that a real fleet of real devices actually meets it.
 
-Fleet does that justice. By reading live device state through osquery rather than trusting that a configuration was pushed, by evaluating benchmark policies continuously rather than in periodic bursts, and by measuring every managed platform through one consistent methodology, Fleet turns CIS compliance from a recurring audit scramble into an ongoing operational practice.
+Fleet does that justice. By reading live device state through its agent rather than trusting that a configuration was pushed, by evaluating benchmark policies continuously rather than in periodic bursts, and by measuring every managed platform through one consistent methodology, Fleet turns CIS compliance from a recurring audit scramble into an ongoing operational practice.
 
 The benchmark tells you how devices should be configured. Fleet tells you, at any moment, whether they actually are.
 
@@ -65,6 +69,6 @@ The benchmark tells you how devices should be configured. Fleet tells you, at an
 <meta name="articleTitle" value="Benchmarks without the burden: continuous CIS compliance">
 <meta name="authorFullName" value="Dhruv Majumdar">
 <meta name="authorGitHubUsername" value="drvcodenta">
-<meta name="category" value="security">
+<meta name="category" value="articles">
 <meta name="publishedOn" value="2026-06-11">
 <meta name="description" value="Adopting CIS benchmarks isn't the same as meeting them. Fleet verifies CIS compliance continuously from live device state across macOS and Windows.">


### PR DESCRIPTION
Reworks the article opening with a stronger headline, intro framing, and a new key takeaways section plus CTA. It also tightens product language (agent/query-based verification, Premium benchmark availability), simplifies the “what changes” section into a clearer narrative, and updates metadata by moving the category from `security` to `articles`.