### PR TITLE
Include mobile hosts by default in "Hosts online" chart

### DIFF
--- a/changes/47661-hosts-online-chart-include-mobile-by-default
+++ b/changes/47661-hosts-online-chart-include-mobile-by-default
@@ -1,0 +1,1 @@
+- Removed the default platform filter on the "hosts online" chart, so iOS, iPadOS, and Android hosts are now included by default alongside desktop platforms.

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
@@ -200,7 +200,7 @@ describe("ChartCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("excludes mobile platforms by default and shows the Filtered badge", async () => {
+  it("includes mobile platforms by default and does not show the Filtered badge", async () => {
     let requestedPlatforms: string | null = null;
     mockServer.use(
       http.get(baseUrl("/charts/:metric"), ({ params, request }) => {
@@ -213,15 +213,14 @@ describe("ChartCard", () => {
     const render = createCustomRenderer({ withBackendMock: true });
     render(<ChartCard />);
 
-    // The default platform filter is the four non-mobile platforms, which both
-    // excludes iOS/iPadOS/Android and surfaces the "Filtered" badge on load.
+    // No platform filter is active by default, so all platforms (including
+    // iOS/iPadOS/Android) are included and the "Filtered" badge is absent.
     await waitFor(() => {
-      expect(screen.getByText("Filtered")).toBeInTheDocument();
+      const rects = document.querySelectorAll("rect");
+      expect(rects.length).toBeGreaterThan(0);
     });
-    await waitFor(() => {
-      expect(requestedPlatforms).toBe("darwin,windows,linux,chrome");
-    });
-    expect(requestedPlatforms).not.toMatch(/ios|ipados|android/);
+    expect(requestedPlatforms).toBeNull();
+    expect(screen.queryByText("Filtered")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -238,8 +238,8 @@ const ChartCard = ({
           given hour.
           <br />
           <br />
-          Locked iOS and iPadOS hosts count as online as long as they have power
-          and an internet connection.
+          iOS and iPadOS hosts count as online as long as they have power and an
+          internet connection.
         </>
       ),
       tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -238,8 +238,10 @@ const ChartCard = ({
           given hour.
           <br />
           <br />
-          iOS and iPadOS hosts count as online as long as they have power and an
-          internet connection.
+          iPhones/iPads check in and count as online anytime they have power and
+          an internet connection (including locked). Macs count as online
+          sometimes (infrequently) when the lid is closed. Android hosts never
+          show online when locked.
         </>
       ),
       tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -48,17 +48,9 @@ const baseClass = "chart-card";
 // configurable ranges we'll add UI and request-param plumbing for this.
 const CHART_DAYS = 30;
 
-// Mobile platforms (iOS, iPadOS, Android) are excluded from the chart by
-// default by seeding the platform filter with only the non-mobile platforms.
-// This is intentionally hard-coded to this chart for now rather than a general
-// per-chart "default filters" config. Because the platform filter is
-// inclusion-based, a non-empty default both excludes mobile and makes the
-// "Filtered" badge appear on load. Users can opt mobile back in via the filter.
-const DEFAULT_CHART_PLATFORMS = ["darwin", "windows", "linux", "chrome"];
-
 const DEFAULT_CHART_FILTERS: IChartFilterState = {
   labelIDs: [],
-  platforms: DEFAULT_CHART_PLATFORMS,
+  platforms: [],
   hostFilterMode: "none",
   selectedHosts: [],
   softwareFilters: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
@@ -246,9 +238,8 @@ const ChartCard = ({
           given hour.
           <br />
           <br />
-          iOS, iPadOS, and Android hosts are excluded by default; include them
-          in the filter settings. Locked iOS and iPadOS hosts count as online as
-          long as they have power and an internet connection.
+          Locked iOS and iPadOS hosts count as online as long as they have power
+          and an internet connection.
         </>
       ),
       tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
@@ -31,8 +31,7 @@ const baseClass = "chart-filter-modal";
 
 export type ChartFilterTab = "hosts" | "software";
 
-// Exported for testing. Mobile platforms (ios/ipados/android) are selectable
-// here; the chart excludes them by default via ChartCard's DEFAULT_CHART_PLATFORMS.
+// Exported for testing.
 export const PLATFORM_OPTIONS = [
   { label: "macOS", value: "darwin" },
   { label: "Windows", value: "windows" },


### PR DESCRIPTION
**Related issue:** Resolves #47661

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Improvements**
  * The “Hosts online” chart now includes mobile platforms (iOS/iPadOS/Android) by default, alongside desktop platforms.

* **Bug Fixes**
  * Initial load no longer shows a default “Filtered” badge; the chart reflects the full default platform selection.

* **Documentation**
  * Updated the “Hosts online” tooltip to clarify how locked iOS/iPadOS, lid-closed Mac, and locked Android states affect the online count.

* **Tests**
  * Updated chart card tests to match the new default platform behavior and initial chart request parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->