### PR TITLE
Add host name template endpoint

### DIFF
--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -94,6 +94,7 @@ func NewService(
 		HostFeatures:                      eeservice.HostFeatures,
 		TeamByIDOrName:                    eeservice.teamByIDOrName,
 		UpdateTeamMDMDiskEncryption:       eeservice.updateTeamMDMDiskEncryption,
+		UpdateTeamMDMHostNameTemplate:     eeservice.updateTeamMDMHostNameTemplate,
 		MDMAppleEnableFileVaultAndEscrow:  eeservice.MDMAppleEnableFileVaultAndEscrow,
 		MDMAppleDisableFileVaultAndEscrow: eeservice.MDMAppleDisableFileVaultAndEscrow,
 		DeleteMDMAppleSetupAssistant:      eeservice.DeleteMDMAppleSetupAssistant,

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -2274,6 +2274,46 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 	return nil
 }
 
+func (svc *Service) updateTeamMDMHostNameTemplate(ctx context.Context, tm *fleet.Team, nameTemplate string) error {
+	if tm.Config.MDM.HostNameTemplate == nameTemplate {
+		return nil
+	}
+
+	tm.Config.MDM.HostNameTemplate = nameTemplate
+	if _, err := svc.ds.SaveTeam(ctx, tm); err != nil {
+		return err
+	}
+
+	return svc.applyHostNameTemplateChange(ctx, tm.ID, tm.Name, nameTemplate)
+}
+
+func (svc *Service) applyHostNameTemplateChange(ctx context.Context, fleetID uint, fleetName, nameTemplate string) error {
+	if nameTemplate == "" {
+		if err := svc.ds.DeleteHostDeviceNameEnforcementForTeam(ctx, fleetID); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete host name enforcement for team")
+		}
+	} else if err := svc.ds.BulkUpsertHostDeviceNameEnforcement(ctx, fleetID); err != nil {
+		return ctxerr.Wrap(ctx, err, "queue host name enforcement for team")
+	}
+
+	var tmpl *string
+	if nameTemplate != "" {
+		tmpl = &nameTemplate
+	}
+	if err := svc.NewActivity(
+		ctx,
+		authz.UserFromContext(ctx),
+		fleet.ActivityTypeEditedHostNameTemplate{
+			FleetID:          &fleetID,
+			FleetName:        &fleetName,
+			HostNameTemplate: tmpl,
+		},
+	); err != nil {
+		return ctxerr.Wrap(ctx, err, "create activity for team host name template")
+	}
+	return nil
+}
+
 func (svc *Service) updateTeamMDMAppleSetup(ctx context.Context, tm *fleet.Team, payload fleet.MDMAppleSetupPayload) error {
 	appCfg, err := svc.ds.AppConfig(ctx)
 	if err != nil {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -655,9 +655,9 @@ func (a ActivityTypeDisabledRecoveryLockPasswords) ActivityName() string {
 }
 
 type ActivityTypeEditedHostNameTemplate struct {
-	FleetID      *uint   `json:"fleet_id"`
-	FleetName    *string `json:"fleet_name"`
-	NameTemplate *string `json:"name_template"` // nil when the template was cleared
+	FleetID          *uint   `json:"fleet_id"`
+	FleetName        *string `json:"fleet_name"`
+	HostNameTemplate *string `json:"name_template"` // nil when the template was cleared
 }
 
 func (a ActivityTypeEditedHostNameTemplate) ActivityName() string {

--- a/server/fleet/name_template.go
+++ b/server/fleet/name_template.go
@@ -13,9 +13,9 @@ import (
 
 const maxHostNameTemplateLength = 255
 
-// fleetVarsSupportedInNameTemplates is the allow-list of Fleet variables that
+// fleetVarsSupportedInHostNameTemplates is the allow-list of Fleet variables that
 // may be used in a host name template.
-var fleetVarsSupportedInNameTemplates = []FleetVarName{
+var fleetVarsSupportedInHostNameTemplates = []FleetVarName{
 	FleetVarHostHardwareSerial,
 	FleetVarHostUUID,
 	FleetVarHostPlatform,
@@ -23,12 +23,12 @@ var fleetVarsSupportedInNameTemplates = []FleetVarName{
 
 // nameTemplateVarRegexp matches every supported name-template variable in both
 // its $FLEET_VAR_NAME and ${FLEET_VAR_NAME} forms, in a single pattern. It is
-// derived from fleetVarsSupportedInNameTemplates so it stays in sync with the
+// derived from fleetVarsSupportedInHostNameTemplates so it stays in sync with the
 // allow-list. The unbraced form uses a trailing word boundary so that an
 // unsupported longer name (e.g. HOST_UUID_EXTRA) is not partially matched.
 var nameTemplateVarRegexp = func() *regexp.Regexp {
-	alts := make([]string, len(fleetVarsSupportedInNameTemplates))
-	for i, v := range fleetVarsSupportedInNameTemplates {
+	alts := make([]string, len(fleetVarsSupportedInHostNameTemplates))
+	for i, v := range fleetVarsSupportedInHostNameTemplates {
 		alts[i] = regexp.QuoteMeta(string(v))
 	}
 	alt := strings.Join(alts, "|")
@@ -64,7 +64,7 @@ func ValidateHostNameTemplate(tmpl string) (string, error) {
 
 	// Every Fleet variable used must be in the allow-list.
 	for _, v := range variables.Find(tmpl) {
-		if !slices.Contains(fleetVarsSupportedInNameTemplates, FleetVarName(v)) {
+		if !slices.Contains(fleetVarsSupportedInHostNameTemplates, FleetVarName(v)) {
 			return "", NewInvalidArgumentError("name_template",
 				"Fleet variable $FLEET_VAR_"+v+" is not supported in host name templates.")
 		}

--- a/server/fleet/name_template_test.go
+++ b/server/fleet/name_template_test.go
@@ -152,59 +152,59 @@ func TestResolveHostNameTemplate(t *testing.T) {
 	}
 }
 
-func TestTeamNameTemplateRoundTrip(t *testing.T) {
+func TestTeamHostNameTemplateRoundTrip(t *testing.T) {
 	t.Run("TeamMDM", func(t *testing.T) {
-		in := TeamMDM{NameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}
+		in := TeamMDM{HostNameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}
 		b, err := json.Marshal(in)
 		require.NoError(t, err)
 		require.Contains(t, string(b), `"name_template":"$FLEET_VAR_HOST_HARDWARE_SERIAL"`)
 
 		var out TeamMDM
 		require.NoError(t, json.Unmarshal(b, &out))
-		require.Equal(t, in.NameTemplate, out.NameTemplate)
+		require.Equal(t, in.HostNameTemplate, out.HostNameTemplate)
 	})
 
 	t.Run("TeamSpecMDM", func(t *testing.T) {
-		in := TeamSpecMDM{NameTemplate: optjson.SetString("$FLEET_VAR_HOST_UUID")}
+		in := TeamSpecMDM{HostNameTemplate: optjson.SetString("$FLEET_VAR_HOST_UUID")}
 		b, err := json.Marshal(in)
 		require.NoError(t, err)
 		require.Contains(t, string(b), `"name_template":"$FLEET_VAR_HOST_UUID"`)
 
 		var out TeamSpecMDM
 		require.NoError(t, json.Unmarshal(b, &out))
-		require.True(t, out.NameTemplate.Set)
-		require.True(t, out.NameTemplate.Valid)
-		require.Equal(t, "$FLEET_VAR_HOST_UUID", out.NameTemplate.Value)
+		require.True(t, out.HostNameTemplate.Set)
+		require.True(t, out.HostNameTemplate.Valid)
+		require.Equal(t, "$FLEET_VAR_HOST_UUID", out.HostNameTemplate.Value)
 	})
 
 	t.Run("TeamSpecMDM absent", func(t *testing.T) {
 		var out TeamSpecMDM
 		require.NoError(t, json.Unmarshal([]byte(`{}`), &out))
-		require.False(t, out.NameTemplate.Set)
+		require.False(t, out.HostNameTemplate.Set)
 	})
 
 	t.Run("TeamPayloadMDM", func(t *testing.T) {
-		in := TeamPayloadMDM{NameTemplate: optjson.SetString("$FLEET_VAR_HOST_PLATFORM")}
+		in := TeamPayloadMDM{HostNameTemplate: optjson.SetString("$FLEET_VAR_HOST_PLATFORM")}
 		b, err := json.Marshal(in)
 		require.NoError(t, err)
 		require.Contains(t, string(b), `"name_template":"$FLEET_VAR_HOST_PLATFORM"`)
 
 		var out TeamPayloadMDM
 		require.NoError(t, json.Unmarshal(b, &out))
-		require.True(t, out.NameTemplate.Set)
-		require.Equal(t, "$FLEET_VAR_HOST_PLATFORM", out.NameTemplate.Value)
+		require.True(t, out.HostNameTemplate.Set)
+		require.Equal(t, "$FLEET_VAR_HOST_PLATFORM", out.HostNameTemplate.Value)
 	})
 
 	t.Run("TeamConfig storage round-trip", func(t *testing.T) {
 		// name_template rides in the teams.config JSON blob (no dedicated
 		// column), so verify it survives the actual SQL Value()/Scan() boundary.
-		in := TeamConfig{MDM: TeamMDM{NameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}}
+		in := TeamConfig{MDM: TeamMDM{HostNameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}}
 		val, err := in.Value()
 		require.NoError(t, err)
 
 		var out TeamConfig
 		require.NoError(t, out.Scan(val))
-		require.Equal(t, "$FLEET_VAR_HOST_HARDWARE_SERIAL", out.MDM.NameTemplate)
+		require.Equal(t, "$FLEET_VAR_HOST_HARDWARE_SERIAL", out.MDM.HostNameTemplate)
 	})
 }
 
@@ -214,9 +214,9 @@ func TestActivityTypeEditedHostNameTemplate(t *testing.T) {
 	t.Run("marshal with template", func(t *testing.T) {
 		tmpl := "$FLEET_VAR_HOST_HARDWARE_SERIAL"
 		b, err := json.Marshal(ActivityTypeEditedHostNameTemplate{
-			FleetID:      new(uint(1)),
-			FleetName:    new("Workstations"),
-			NameTemplate: &tmpl,
+			FleetID:          new(uint(1)),
+			FleetName:        new("Workstations"),
+			HostNameTemplate: &tmpl,
 		})
 		require.NoError(t, err)
 		require.JSONEq(t, `{

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -23,7 +23,8 @@ type EnterpriseOverrides struct {
 	TeamByIDOrName func(ctx context.Context, id *uint, name *string) (*Team, error)
 	// UpdateTeamMDMDiskEncryption is the team-specific service method for when
 	// a team ID is provided to the UpdateMDMDiskEncryption method.
-	UpdateTeamMDMDiskEncryption func(ctx context.Context, tm *Team, enable *bool, requireBitLockerPIN *bool) error
+	UpdateTeamMDMDiskEncryption   func(ctx context.Context, tm *Team, enable *bool, requireBitLockerPIN *bool) error
+	UpdateTeamMDMHostNameTemplate func(ctx context.Context, tm *Team, nameTemplate string) error
 
 	// The next two functions are implemented by the ee/service, and called
 	// properly when called from an ee/service method (e.g. Modify Team), but
@@ -1083,6 +1084,10 @@ type Service interface {
 	// UpdateMDMDiskEncryption updates the disk encryption setting for a
 	// specified team or for hosts with no team.
 	UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, enableDiskEncryption *bool, requireBitLockerPIN *bool) error
+
+	// UpdateMDMHostNameTemplate updates the host name template for the specified
+	// fleet. An empty template clears the setting; clearing never renames hosts.
+	UpdateMDMHostNameTemplate(ctx context.Context, fleetID *uint, nameTemplate string) error
 
 	// VerifyMDMAppleConfigured verifies that the server is configured for
 	// Apple MDM. If an error is returned, authorization is skipped so the

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -96,8 +96,8 @@ type TeamPayloadMDM struct {
 	// WindowsUpdates defines the OS update settings for Windows devices.
 	WindowsUpdates *WindowsUpdates `json:"windows_updates"`
 
-	MacOSSetup   *MacOSSetup    `json:"macos_setup"`
-	NameTemplate optjson.String `json:"name_template"`
+	MacOSSetup       *MacOSSetup    `json:"macos_setup"`
+	HostNameTemplate optjson.String `json:"name_template"`
 }
 
 // Team is the data representation for the "Team" concept (group of hosts and
@@ -337,9 +337,9 @@ type TeamMDM struct {
 
 	AndroidSettings AndroidSettings `json:"android_settings"`
 
-	// NameTemplate is the template used to compute a host's display name from
+	// HostNameTemplate is the template used to compute a host's display name from
 	// host-identity Fleet variables (e.g. $FLEET_VAR_HOST_HARDWARE_SERIAL).
-	NameTemplate string `json:"name_template"`
+	HostNameTemplate string `json:"name_template"`
 	// NOTE: TeamSpecMDM must be kept in sync with TeamMDM.
 
 	/////////////////////////////////////////////////////////////////
@@ -425,8 +425,8 @@ type TeamSpecMDM struct {
 
 	WindowsSettings WindowsSettings `json:"windows_settings"`
 
-	AndroidSettings AndroidSettings `json:"android_settings"`
-	NameTemplate    optjson.String  `json:"name_template"`
+	AndroidSettings  AndroidSettings `json:"android_settings"`
+	HostNameTemplate optjson.String  `json:"name_template"`
 
 	// NOTE: TeamMDM must be kept in sync with TeamSpecMDM.
 }

--- a/server/fleet/teams_test.go
+++ b/server/fleet/teams_test.go
@@ -303,14 +303,14 @@ func TestTeamMDMCopy(t *testing.T) {
 		require.NotSame(t, tm.MacOSSettings.DeprecatedEnableDiskEncryption, clone.MacOSSettings.DeprecatedEnableDiskEncryption)
 	})
 
-	t.Run("copy NameTemplate", func(t *testing.T) {
-		tm := &TeamMDM{NameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}
+	t.Run("copy HostNameTemplate", func(t *testing.T) {
+		tm := &TeamMDM{HostNameTemplate: "$FLEET_VAR_HOST_HARDWARE_SERIAL"}
 		clone := tm.Copy()
-		require.Equal(t, tm.NameTemplate, clone.NameTemplate)
+		require.Equal(t, tm.HostNameTemplate, clone.HostNameTemplate)
 
 		// mutating the copy must not affect the original (plain-string value copy)
-		clone.NameTemplate = "changed"
-		require.Equal(t, "$FLEET_VAR_HOST_HARDWARE_SERIAL", tm.NameTemplate)
+		clone.HostNameTemplate = "changed"
+		require.Equal(t, "$FLEET_VAR_HOST_HARDWARE_SERIAL", tm.HostNameTemplate)
 	})
 }
 

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -666,6 +666,8 @@ type MDMAppleDisableFileVaultAndEscrowFunc func(ctx context.Context, teamID *uin
 
 type UpdateMDMDiskEncryptionFunc func(ctx context.Context, teamID *uint, enableDiskEncryption *bool, requireBitLockerPIN *bool) error
 
+type UpdateMDMHostNameTemplateFunc func(ctx context.Context, fleetID *uint, nameTemplate string) error
+
 type VerifyMDMAppleConfiguredFunc func(ctx context.Context) error
 
 type VerifyMDMWindowsConfiguredFunc func(ctx context.Context) error
@@ -1913,6 +1915,9 @@ type Service struct {
 
 	UpdateMDMDiskEncryptionFunc        UpdateMDMDiskEncryptionFunc
 	UpdateMDMDiskEncryptionFuncInvoked bool
+
+	UpdateMDMHostNameTemplateFunc        UpdateMDMHostNameTemplateFunc
+	UpdateMDMHostNameTemplateFuncInvoked bool
 
 	VerifyMDMAppleConfiguredFunc        VerifyMDMAppleConfiguredFunc
 	VerifyMDMAppleConfiguredFuncInvoked bool
@@ -4593,6 +4598,13 @@ func (s *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, ena
 	s.UpdateMDMDiskEncryptionFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateMDMDiskEncryptionFunc(ctx, teamID, enableDiskEncryption, requireBitLockerPIN)
+}
+
+func (s *Service) UpdateMDMHostNameTemplate(ctx context.Context, fleetID *uint, nameTemplate string) error {
+	s.mu.Lock()
+	s.UpdateMDMHostNameTemplateFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpdateMDMHostNameTemplateFunc(ctx, fleetID, nameTemplate)
 }
 
 func (s *Service) VerifyMDMAppleConfigured(ctx context.Context) error {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
@@ -3795,6 +3796,154 @@ func TestUpdateMDMAppleSettings(t *testing.T) {
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestUpdateMDMHostNameTemplate(t *testing.T) {
+	svc, baseCtx, ds, svcOpts := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+
+	currentTemplate := ""
+	ds.TeamWithExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+		return &fleet.Team{ID: id, Name: "team", Config: fleet.TeamConfig{
+			MDM: fleet.TeamMDM{HostNameTemplate: currentTemplate},
+		}}, nil
+	}
+	var savedTeam *fleet.Team
+	ds.SaveTeamFunc = func(ctx context.Context, tm *fleet.Team) (*fleet.Team, error) {
+		savedTeam = tm
+		return tm, nil
+	}
+	ds.BulkUpsertHostDeviceNameEnforcementFunc = func(ctx context.Context, teamID uint) error { return nil }
+	ds.DeleteHostDeviceNameEnforcementForTeamFunc = func(ctx context.Context, teamID uint) error { return nil }
+
+	var lastActivity activity_api.ActivityDetails
+	svcOpts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+		lastActivity = activity
+		return nil
+	}
+
+	resetInvoked := func() {
+		savedTeam = nil
+		lastActivity = nil
+		ds.SaveTeamFuncInvoked = false
+		ds.BulkUpsertHostDeviceNameEnforcementFuncInvoked = false
+		ds.DeleteHostDeviceNameEnforcementForTeamFuncInvoked = false
+		svcOpts.ActivityMock.NewActivityFuncInvoked = false
+	}
+
+	premiumAdminCtx := func() context.Context {
+		ctx := viewer.NewContext(baseCtx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+		return license.NewContext(ctx, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+	}
+
+	t.Run("license and authz matrix", func(t *testing.T) {
+		teamOne := new(uint(1))
+		testCases := []struct {
+			name    string
+			user    *fleet.User
+			premium bool
+			teamID  *uint
+			wantErr string
+		}{
+			{"free tier", &fleet.User{GlobalRole: new(fleet.RoleAdmin)}, false, teamOne, fleet.ErrMissingLicense.Error()},
+			{"missing fleet_id", &fleet.User{GlobalRole: new(fleet.RoleAdmin)}, true, nil, "this setting is only available for fleets"},
+			{"global admin", &fleet.User{GlobalRole: new(fleet.RoleAdmin)}, true, teamOne, ""},
+			{"global maintainer", &fleet.User{GlobalRole: new(fleet.RoleMaintainer)}, true, teamOne, ""},
+			{"global observer", &fleet.User{GlobalRole: new(fleet.RoleObserver)}, true, teamOne, authz.ForbiddenErrorMessage},
+			{"team admin, own team", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}}, true, teamOne, ""},
+			{"team admin, other team", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleAdmin}}}, true, teamOne, authz.ForbiddenErrorMessage},
+			{"team maintainer, own team", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer}}}, true, teamOne, ""},
+			{"team maintainer, other team", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleMaintainer}}}, true, teamOne, authz.ForbiddenErrorMessage},
+			{"team observer, own team", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}}, true, teamOne, authz.ForbiddenErrorMessage},
+			{"team gitops, own team", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}}, true, teamOne, ""},
+			{"user no roles", &fleet.User{ID: 1337}, true, teamOne, authz.ForbiddenErrorMessage},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.name, func(t *testing.T) {
+				resetInvoked()
+				ctx := viewer.NewContext(baseCtx, viewer.Viewer{User: tt.user})
+				tier := fleet.TierFree
+				if tt.premium {
+					tier = fleet.TierPremium
+				}
+				ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: tier})
+
+				// clearing an already-empty template is a valid no-op write, so
+				// allowed cases exercise authz without needing side effects.
+				err := svc.UpdateMDMHostNameTemplate(ctx, tt.teamID, "")
+				if tt.wantErr == "" {
+					require.NoError(t, err)
+					return
+				}
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			})
+		}
+	})
+
+	t.Run("invalid templates are rejected", func(t *testing.T) {
+		for _, tc := range []struct{ name, tmpl string }{
+			{"unsupported variable", "WS-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"},
+			{"secret variable", "WS-$FLEET_SECRET_FOO"},
+			{"control characters", "WS-\x07"},
+			{"too long", strings.Repeat("a", 256)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				resetInvoked()
+				err := svc.UpdateMDMHostNameTemplate(premiumAdminCtx(), new(uint(1)), tc.tmpl)
+				require.Error(t, err)
+				var invalid *fleet.InvalidArgumentError
+				require.ErrorAs(t, err, &invalid)
+				require.False(t, ds.SaveTeamFuncInvoked)
+				require.False(t, svcOpts.ActivityMock.NewActivityFuncInvoked)
+			})
+		}
+	})
+
+	t.Run("setting a template saves, emits activity and queues rows", func(t *testing.T) {
+		resetInvoked()
+		currentTemplate = ""
+		// surrounding whitespace is normalized away before persisting.
+		err := svc.UpdateMDMHostNameTemplate(premiumAdminCtx(), new(uint(1)), "  WS-$FLEET_VAR_HOST_HARDWARE_SERIAL ")
+		require.NoError(t, err)
+		require.NotNil(t, savedTeam)
+		require.Equal(t, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL", savedTeam.Config.MDM.HostNameTemplate)
+		require.True(t, ds.BulkUpsertHostDeviceNameEnforcementFuncInvoked)
+		require.False(t, ds.DeleteHostDeviceNameEnforcementForTeamFuncInvoked)
+
+		act, ok := lastActivity.(fleet.ActivityTypeEditedHostNameTemplate)
+		require.True(t, ok, "expected edited_host_name_template activity, got %T", lastActivity)
+		require.NotNil(t, act.FleetID)
+		require.Equal(t, uint(1), *act.FleetID)
+		require.NotNil(t, act.HostNameTemplate)
+		require.Equal(t, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL", *act.HostNameTemplate)
+	})
+
+	t.Run("saving the identical template is a no-op", func(t *testing.T) {
+		resetInvoked()
+		currentTemplate = "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL"
+		err := svc.UpdateMDMHostNameTemplate(premiumAdminCtx(), new(uint(1)), "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+		require.NoError(t, err)
+		require.False(t, ds.SaveTeamFuncInvoked)
+		require.False(t, svcOpts.ActivityMock.NewActivityFuncInvoked)
+		require.False(t, ds.BulkUpsertHostDeviceNameEnforcementFuncInvoked)
+		require.False(t, ds.DeleteHostDeviceNameEnforcementForTeamFuncInvoked)
+	})
+
+	t.Run("clearing deletes rows and logs a null template", func(t *testing.T) {
+		resetInvoked()
+		currentTemplate = "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL"
+		err := svc.UpdateMDMHostNameTemplate(premiumAdminCtx(), new(uint(1)), "")
+		require.NoError(t, err)
+		require.NotNil(t, savedTeam)
+		require.Empty(t, savedTeam.Config.MDM.HostNameTemplate)
+		require.True(t, ds.DeleteHostDeviceNameEnforcementForTeamFuncInvoked)
+		require.False(t, ds.BulkUpsertHostDeviceNameEnforcementFuncInvoked)
+
+		act, ok := lastActivity.(fleet.ActivityTypeEditedHostNameTemplate)
+		require.True(t, ok, "expected edited_host_name_template activity, got %T", lastActivity)
+		require.Nil(t, act.HostNameTemplate)
+	})
 }
 
 func TestUpdateMDMAppleSetup(t *testing.T) {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -844,6 +844,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// It was only used to set disk encryption.
 	mdmAnyMW.PATCH("/api/_version_/fleet/mdm/apple/settings", updateMDMAppleSettingsEndpoint, updateMDMAppleSettingsRequest{})
 	ue.POST("/api/_version_/fleet/disk_encryption", updateDiskEncryptionEndpoint, updateDiskEncryptionRequest{})
+	ue.POST("/api/_version_/fleet/host_name_template", updateHostNameTemplateEndpoint, updateHostNameTemplateRequest{})
 
 	// the following set of mdm endpoints must always be accessible (even
 	// if MDM is not configured) as it bootstraps the setup of MDM

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8248,6 +8248,9 @@ func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {
 	// update MDM disk encryption
 	_ = s.Do("POST", "/api/latest/fleet/disk_encryption", fleet.MDMAppleSettingsPayload{}, http.StatusPaymentRequired)
 
+	// update MDM host name template
+	_ = s.Do("POST", "/api/latest/fleet/host_name_template", updateHostNameTemplateRequest{}, http.StatusPaymentRequired)
+
 	// Turn on MDM.
 	ctx := t.Context()
 	appCfg, err := s.ds.AppConfig(ctx)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3034,6 +3034,62 @@ func (svc *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, e
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Update MDM host name template
+////////////////////////////////////////////////////////////////////////////////
+
+type updateHostNameTemplateRequest struct {
+	FleetID          *uint  `json:"fleet_id"`
+	HostNameTemplate string `json:"name_template"`
+}
+
+type updateHostNameTemplateResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r updateHostNameTemplateResponse) Error() error { return r.Err }
+
+func (r updateHostNameTemplateResponse) Status() int { return http.StatusNoContent }
+
+func updateHostNameTemplateEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*updateHostNameTemplateRequest)
+	if err := svc.UpdateMDMHostNameTemplate(ctx, req.FleetID, req.HostNameTemplate); err != nil {
+		return updateHostNameTemplateResponse{Err: err}, nil
+	}
+	return updateHostNameTemplateResponse{}, nil
+}
+
+func (svc *Service) UpdateMDMHostNameTemplate(ctx context.Context, fleetID *uint, nameTemplate string) error {
+	if !license.IsPremium(ctx) {
+		svc.authz.SkipAuthorization(ctx)
+		return fleet.ErrMissingLicense
+	}
+
+	if err := svc.authz.Authorize(ctx,
+		fleet.MDMAppleSettingsPayload{TeamID: fleetID}, fleet.ActionWrite); err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
+	if fleetID == nil {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("fleet_id",
+			"this setting is only available for fleets"))
+	}
+
+	if nameTemplate != "" {
+		validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err)
+		}
+		nameTemplate = validated
+	}
+
+	tm, err := svc.EnterpriseOverrides.TeamByIDOrName(ctx, fleetID, nil)
+	if err != nil {
+		return err
+	}
+	return svc.EnterpriseOverrides.UpdateTeamMDMHostNameTemplate(ctx, tm, nameTemplate)
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // POST /hosts/{id:[0-9]+}/configuration_profiles/{profile_uuid}
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tools/cloner-check/generated_files/teamconfig.txt
+++ b/tools/cloner-check/generated_files/teamconfig.txt
@@ -90,7 +90,7 @@ github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	Name	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	CertificateAuthorityName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectAlternativeName	string
-github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	NameTemplate	string
+github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	HostNameTemplate	string
 github.com/fleetdm/fleet/v4/server/fleet/TeamConfig	Features	fleet.Features
 github.com/fleetdm/fleet/v4/server/fleet/Features	EnableHostUsers	bool
 github.com/fleetdm/fleet/v4/server/fleet/Features	EnableSoftwareInventory	bool

--- a/tools/cloner-check/generated_files/teammdm.txt
+++ b/tools/cloner-check/generated_files/teammdm.txt
@@ -61,4 +61,4 @@ github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	Name	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	CertificateAuthorityName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectName	string
 github.com/fleetdm/fleet/v4/server/fleet/CertificateTemplateSpec	SubjectAlternativeName	string
-github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	NameTemplate	string
+github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	HostNameTemplate	string


### PR DESCRIPTION
Relates to #48623

Adds POST /api/v1/fleet/name_template endpoint.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating a team’s MDM host name template through the API.
  * When changed, the new setting is applied immediately and related host name enforcement is refreshed.

* **Bug Fixes**
  * Prevents unnecessary updates when the template hasn’t changed.
  * Clearing the template now removes existing enforcement entries and records the change correctly.

* **Tests**
  * Added coverage for access control, license checks, validation rules, and template update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->