### PR TITLE
Fix platform capitalization

### DIFF
--- a/frontend/interfaces/charts.ts
+++ b/frontend/interfaces/charts.ts
@@ -27,7 +27,7 @@ export const CVE_SOFTWARE_CATEGORIES = [
   {
     value: "browsers",
     label: "Browsers",
-    tooltipLabel: "browsers",
+    tooltipLabel: "Browsers",
     description: "Google Chrome, Safari, Mozilla Firefox, Brave, and Opera",
   },
   {

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
@@ -7,7 +7,10 @@ import { createCustomRenderer, baseUrl } from "test/test-utils";
 import mockServer from "test/mock-server";
 import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
 
-import ChartCard, { buildInitialChartFilters } from "./ChartCard";
+import ChartCard, {
+  buildInitialChartFilters,
+  hostFilterLines,
+} from "./ChartCard";
 
 // Mock ResizeObserver for CheckerboardViz
 const MOCK_WIDTH = 600;
@@ -265,5 +268,44 @@ describe("buildInitialChartFilters", () => {
       exclude_vulnerabilities: ["CVE-2025-50897"],
     });
     expect(filters.excludeCVEs).toEqual(["CVE-2025-50897"]);
+  });
+});
+
+describe("hostFilterLines", () => {
+  const filtersWithPlatforms = (platforms: string[]) => ({
+    ...buildInitialChartFilters(undefined),
+    platforms,
+  });
+
+  it("preserves branded platform casing (macOS, iOS, iPadOS)", () => {
+    const [line] = hostFilterLines(
+      filtersWithPlatforms(["darwin", "ios", "ipados"])
+    );
+    expect(line).toBe("macOS, iOS, and iPadOS");
+    // Guards the reported bug: no word-capitalized variants.
+    expect(line).not.toMatch(/MacOS|Ios|Ipados/);
+  });
+
+  it("renders a single platform without mangling its casing", () => {
+    expect(hostFilterLines(filtersWithPlatforms(["darwin"]))).toEqual([
+      "macOS",
+    ]);
+  });
+
+  it("maps every filterable platform to its correct display name", () => {
+    const [line] = hostFilterLines(
+      filtersWithPlatforms([
+        "darwin",
+        "windows",
+        "linux",
+        "chrome",
+        "ios",
+        "ipados",
+        "android",
+      ])
+    );
+    expect(line).toBe(
+      "macOS, Windows, Linux, ChromeOS, iOS, iPadOS, and Android"
+    );
   });
 });

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -126,17 +126,16 @@ const formatList = (items: string[]): string => {
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 };
 
+// A string-indexable view of the display-name map. Platform filter values are
+// arbitrary strings, so an unknown one indexes to undefined and we fall back to
+// the raw value below.
+const PLATFORM_LABELS: Record<string, string> = PLATFORM_DISPLAY_NAMES;
+
 export const hostFilterLines = (filters: IChartFilterState): string[] => {
   const lines: string[] = [];
   if (filters.platforms.length > 0) {
     lines.push(
-      formatList(
-        filters.platforms.map(
-          (p) =>
-            PLATFORM_DISPLAY_NAMES[p as keyof typeof PLATFORM_DISPLAY_NAMES] ??
-            p
-        )
-      )
+      formatList(filters.platforms.map((p) => PLATFORM_LABELS[p] ?? p))
     );
   }
   if (filters.labelIDs.length > 0) lines.push("Labels");

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -9,7 +9,7 @@ import chartsAPI, {
   IChartQueryKey,
 } from "services/entities/charts";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
-import stringUtils from "utilities/strings/stringUtils";
+import { PLATFORM_DISPLAY_NAMES } from "interfaces/platform";
 
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
@@ -118,27 +118,25 @@ const hasActiveSoftwareFilters = (filters: IChartFilterState): boolean =>
   isEpssActive(filters.epssMin, filters.epssMax) ||
   filters.excludeCVEs.length > 0;
 
-// Human-readable "a, b, and c".
+// Human-readable "a, b, and c". Items must already be correctly cased —
+// don't force-capitalize here or branded names like "macOS"/"iOS" break.
 const formatList = (items: string[]): string => {
-  items = items.map(stringUtils.capitalize);
   if (items.length <= 1) return items.join("");
   if (items.length === 2) return `${items[0]} and ${items[1]}`;
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 };
 
-// Maps platform filter values to their display names for the tooltip.
-const PLATFORM_LABELS: Record<string, string> = {
-  darwin: "macOS",
-  windows: "Windows",
-  linux: "Linux",
-  chrome: "ChromeOS",
-};
-
-const hostFilterLines = (filters: IChartFilterState): string[] => {
+export const hostFilterLines = (filters: IChartFilterState): string[] => {
   const lines: string[] = [];
   if (filters.platforms.length > 0) {
     lines.push(
-      formatList(filters.platforms.map((p) => PLATFORM_LABELS[p] ?? p))
+      formatList(
+        filters.platforms.map(
+          (p) =>
+            PLATFORM_DISPLAY_NAMES[p as keyof typeof PLATFORM_DISPLAY_NAMES] ??
+            p
+        )
+      )
     );
   }
   if (filters.labelIDs.length > 0) lines.push("Labels");


### PR DESCRIPTION
 **Related issue:** Resolves #48530

Fixes wrong platform-title capitalization in the "Filtered" tag tooltip on the Hosts and Vulnerabilities dashboard charts.

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart tooltip text for host/platform filters, ensuring branded platform names keep correct capitalization and combined lists use correct punctuation.
  * Refined chart tooltip/platform display mapping to avoid incorrect capitalization variants.
* **New Features**
  * Updated browser chart category labeling to show “Browsers” with consistent capitalization.
* **Tests**
  * Expanded ChartCard tests to validate platform tooltip line formatting for single and multiple selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->