### PR TITLE
Fix data race detected by Splunk tests in CI

### DIFF
--- a/server/logging/splunk.go
+++ b/server/logging/splunk.go
@@ -107,7 +107,10 @@ func (w *splunkLogWriter) Write(ctx context.Context, logs []json.RawMessage) err
 
 		// If adding this event would exceed the batch size, flush first.
 		if buf.Len() > 0 && buf.Len()+len(b) > splunkMaxBatchSize {
-			if err := w.send(ctx, buf.Bytes()); err != nil {
+			// Clone the batch: buf.Bytes() aliases buf's backing array, which we
+			// reuse below after Reset(). The HTTP transport may still be reading
+			// the request body when send() returns, so it needs its own copy.
+			if err := w.send(ctx, bytes.Clone(buf.Bytes())); err != nil {
 				return err
 			}
 			buf.Reset()


### PR DESCRIPTION
Fixes data race detected in https://github.com/fleetdm/fleet/actions/runs/28769705097/job/85300822820.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of log delivery by ensuring buffered log data is copied before being sent, preventing intermittent issues when batches are processed.
  * Reduced the risk of log entries being corrupted or lost during transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->