### PR TITLE
Reorder article intros and refresh CTAs

### DIFF
--- a/articles/ai-rewriting-the-job-description.md
+++ b/articles/ai-rewriting-the-job-description.md
@@ -2,18 +2,18 @@
 
 *AI isn't erasing IT work so much as redrawing who's positioned to do it. The dividing line runs straight through IT teams, and the data shows where.*
 
-When General Motors laid off more than 500 IT workers in May and immediately posted 80 open roles for AI-native developers and data engineers, TechCrunch called it a "skills swap." That framing is a little too neat, but it points at something real, and it's not just happening at GM. The question worth asking isn't whether AI is disrupting IT employment. It is. The question is how, and whether the answer is what you think it is.
-
 ## Key takeaways
 
 - **Experience, not job function, decides who benefits.** The workers AI displaces and the workers it amplifies often share the same title. What separates them is the accumulated judgment that turns AI into a collaborator instead of a substitute.
 - **The jobs didn't disappear, the required skills moved.** Roles demanding AI skills now carry a large wage premium, and it's climbing fast. The openings exist; the qualifications are changing faster than most people can keep pace with.
-- **AI rewards structured, code-first config.** AI tooling closes the loop in seconds against a legible GitOps repo and stalls against a GUI. It doesn't make ClickOps faster; it makes code-first workflows dramatically faster.
+- **AI rewards structured, code-first config.** AI tooling closes the loop in seconds against a legible GitOps repo and stalls against a GUI. ClickOps gets no speedup; code-first workflows get a multiplier.
 - **The productivity divide between teams is already measurable.** Client platform engineers on code-first workflows are pulling ahead of those still clicking through consoles, and the gap is widening now, not later.
 - **The disruption is real and lands unevenly.** Transition costs fall on individuals while the productivity gains accrue to organizations, and developers' own trust in AI accuracy is falling, not rising.
 - **Judgment is the skill that holds its value.** Knowing which policies matter, understanding your org's risk tolerance, and catching output that's technically correct but operationally wrong stay human problems.
 
 <a purpose="cta-button" href="https://fleetdm.com/articles/why-ai-powered-device-management-requires-gitops">See why code-first config wins</a>
+
+When General Motors laid off more than 500 IT workers in May and immediately posted 80 open roles for AI-native developers and data engineers, TechCrunch called it a "skills swap." That framing is a little too neat, but it points at something real, and it's not just happening at GM. The question worth asking isn't whether AI is disrupting IT employment. It is. The question is how, and whether the answer is what you think it is.
 
 ## The pattern in the data
 

--- a/articles/block-and-monitor-edr-freeze-on-macos-with-santa-and-fleet.md
+++ b/articles/block-and-monitor-edr-freeze-on-macos-with-santa-and-fleet.md
@@ -2,10 +2,6 @@
 
 *EDR Freeze suspends a security tool instead of killing it, so the process looks healthy while it quietly stops working. Santa 2026.3 can block it on macOS, and Fleet lets you ship the fix and watch for the attack across every host.*
 
-EDR Freeze started life on Windows — pause a security product so it stops alerting or responding, without crashing or uninstalling it. The same idea works on macOS: anything built on Apple's Endpoint Security framework can be frozen with the `pid_suspend` system call, and a suspended agent still looks healthy in every monitoring tool while an attacker slips actions past its checks or floods its event queue.
-
-The good news is that the fix is well understood, and you can ship and monitor it through Fleet today. Santa, the open-source binary authorization agent for macOS, added the `AntiSuspendSigningIDs` configuration key in version 2026.3, and Fleet gives you the delivery pipeline and the visibility to go with it. Here's how the attack works and how to close it.
-
 ## Key takeaways
 
 - **EDR Freeze is for staying hidden, not breaking in.** An attacker who already has root uses `pid_suspend` to freeze a security agent at the Mach task level. `ps` and Activity Monitor still show a healthy process, but it can't authorize, alert, or record anything.
@@ -16,6 +12,10 @@ The good news is that the fix is well understood, and you can ship and monitor i
 - **Independent signals cover what a frozen agent can't report.** Sequence-number gaps, server-side telemetry silence, deadline-kill log messages, and canary events all fire even when the agent is asleep.
 
 <a purpose="cta-button" href="https://fleetdm.com/articles/deploy-santa-with-fleet-gitops-and-skip-the-sync-server">Deploy Santa with Fleet</a>
+
+EDR Freeze started life on Windows — pause a security product so it stops alerting or responding, without crashing or uninstalling it. The same idea works on macOS: anything built on Apple's Endpoint Security framework can be frozen with the `pid_suspend` system call, and a suspended agent still looks healthy in every monitoring tool while an attacker slips actions past its checks or floods its event queue.
+
+The good news is that the fix is well understood, and you can ship and monitor it through Fleet today. Santa, the open-source binary authorization agent for macOS, added the `AntiSuspendSigningIDs` configuration key in version 2026.3, and Fleet gives you the delivery pipeline and the visibility to go with it. Here's how the attack works and how to close it.
 
 ## How EDR Freeze works on macOS
 

--- a/articles/cis-benchmarks-without-the-burden.md
+++ b/articles/cis-benchmarks-without-the-burden.md
@@ -2,10 +2,6 @@
 
 *Adopting CIS benchmarks is a policy statement. Proving that every device in your fleet actually meets them, right now, is a different job — and it's the one most device tools were never built to do.*
 
-Most organizations have adopted CIS benchmarks. Far fewer can prove, at any given moment, that their entire fleet actually meets them. The benchmark documents are excellent: the Center for Internet Security publishes detailed, consensus-driven configuration guidance that represents the collective judgment of security experts worldwide, and adopting it is the right decision.
-
-But adoption is a policy statement; verification is an operational practice. The gap between the two is where most CIS compliance programs quietly break down — and the tools most organizations use to manage devices were never built to close it.
-
 ## Key takeaways
 
 - **A pushed profile isn't proof.** A traditional MDM can confirm it *sent* a setting; it can't tell you the setting is in effect right now. Fleet reads each device's live state, so a benchmark check reflects reality, not intent.
@@ -15,6 +11,10 @@ But adoption is a policy statement; verification is an operational practice. The
 - **Linux fits the same model, with honest limits.** Fleet doesn't ship a pre-built CIS Linux library today, but because every policy is just a query, teams can author CIS-aligned Linux checks and manage them in the same view with the same evidence trail.
 
 <a purpose="cta-button" href="https://fleetdm.com/security-and-control">See continuous compliance in Fleet</a>
+
+Most organizations have adopted CIS benchmarks. Far fewer can prove, at any given moment, that their entire fleet actually meets them. The benchmark documents are excellent: the Center for Internet Security publishes detailed, consensus-driven configuration guidance that represents the collective judgment of security experts worldwide, and adopting it is the right decision.
+
+But adoption is a policy statement; verification is an operational practice. The gap between the two is where most CIS compliance programs quietly break down, and it's exactly where this piece picks up.
 
 ## Adopting a benchmark is not the same as meeting it
 

--- a/articles/managed-migration-assistant.md
+++ b/articles/managed-migration-assistant.md
@@ -2,10 +2,6 @@
 
 *For years, Mac-to-Mac migration was either blocked outright or left entirely to the person at the keyboard. macOS 26.4's Managed Migration Assistant makes it a declarative, auditable decision that IT controls, and that matters more than the feature name suggests.*
 
-Every hardware refresh ends with the one question IT never got to answer: what comes with you from the old Mac? The choices have always been bad. Block migration and frustrate users, or allow it and trust an end user to decide which folders, accounts, keys, and privacy settings land on a corporate machine, with no record of what actually moved.
-
-Apple's Managed Migration Assistant (macOS 26.4) closes that gap, turning migration from an unmanaged user choice into a declarative configuration your device management service delivers during Setup Assistant. Here's why that matters more than the feature name suggests.
-
 ## Key takeaways
 
 - **Migration stops being a user decision and becomes organizational policy.** You declare which folders and files are required, which are excluded, which accounts are off the table, and whether system-level privacy settings carry over.
@@ -14,7 +10,11 @@ Apple's Managed Migration Assistant (macOS 26.4) closes that gap, turning migrat
 - **The prerequisites are specific, so scope them deliberately.** Supervised devices enrolled through Apple Business Manager or Apple School Manager, the destination Mac on macOS 26.4 or later, and the declaration deployed with `await_device_configured`.
 - **The right way to operationalize it is config-as-code.** The whole policy is a small declaration. Managed as version-controlled YAML through a GitOps workflow, your migration policy gets peer review, rollback, and an audit trail, and you can verify in real time what actually landed on the new Mac.
 
-<a purpose="cta-button" href="https://fleetdm.com/contact">Get a demo</a>
+<a purpose="cta-button" href="https://fleetdm.com/guides/managed-migration-assistant-mac-to-mac-migration-with-fleet">Set up managed migration</a>
+
+Every hardware refresh ends with the one question IT never got to answer: what comes with you from the old Mac? The choices have always been bad. Block migration and frustrate users, or allow it and trust an end user to decide which folders, accounts, keys, and privacy settings land on a corporate machine, with no record of what actually moved.
+
+Apple's Managed Migration Assistant (macOS 26.4) closes that gap, turning migration from an unmanaged user choice into a declarative configuration your device management service delivers during Setup Assistant. Here's what that changes for security, compliance, and the pace of your refreshes.
 
 ## Migration has always been the ungoverned step
 

--- a/articles/the-cost-of-code-as-config.md
+++ b/articles/the-cost-of-code-as-config.md
@@ -2,20 +2,20 @@
 
 *Config-as-code has won the argument. The one still worth having is about cost — in time, in skill, and in how much of your operation walks out the door when one person does.*
 
-Config-as-code has quietly become the default expectation for device management. Jamf, Zentral, Workspace ONE, and Fleet all let you describe your endpoints in a repository, review changes through pull requests, and keep an audit trail of who changed what and why. That convergence is a good thing, and the argument about *whether* to manage devices as code is mostly over.
-
-The argument still worth having is about cost — not the license cost, but the cost in time, in skill, and in dependence on a single person. Two config-as-code setups can deliver the same governance benefits and still ask very different things of the team that has to live with them. This isn't a knock on any tool. It's the question every IT leader should ask before committing: when the person who set this up moves on, does the knowledge leave with them, or does it stay in Git?
-
 ## Key takeaways
 
 - **The debate that matters isn't code versus clicks.** Every serious platform now supports config-as-code, so the real decision is how much time, skill, and single-person dependence a given setup asks of you for the same governance benefits.
 - **Terraform brings its whole world along, every day.** Reaching config-as-code through a provider means owning providers, state files, plan/apply, and reference graphs — real infrastructure work that stays whether or not the task in front of you needed it.
 - **The simplest task reveals the gap.** Defining a group and scoping an app to it is a few readable lines of YAML in Fleet; the provider equivalent adds resources, IDs, and a reference graph you have to understand before the diff makes sense.
-- **Simplicity widens who can participate.** GitOps only delivers if many people can safely read, approve, and ship a change — a workflow only one specialist can operate has just moved the old bottleneck into a state file.
+- **Simplicity widens who can participate.** GitOps only delivers if many people can safely read, approve, and ship a change — a workflow only one specialist can operate has recreated the old bottleneck under a new name.
 - **You don't have to go all-in on day one.** Fleet's GitOps exceptions let you manage the parts you're confident about in Git while keeping others editable in the console, so the team can ramp instead of committing to a big-bang cutover.
 - **Turnover is the real test.** When your expert leaves, a documented schema and a readable repository keep your institutional memory in Git; a workflow that depends on deep tooling expertise keeps it only as long as the expert stays.
 
 <a purpose="cta-button" href="https://fleetdm.com/infrastructure-as-code">See config-as-code in Fleet</a>
+
+Config-as-code has quietly become the default expectation for device management. Jamf, Zentral, Workspace ONE, and Fleet all let you describe your endpoints in a repository, review changes through pull requests, and keep an audit trail of who changed what and why. That convergence is a good thing, and the argument about *whether* to manage devices as code is mostly over.
+
+The argument still worth having is about cost — not the license cost, but the cost in time, in skill, and in dependence on a single person. Two config-as-code setups can deliver the same governance benefits and still ask very different things of the team that has to live with them. This isn't a knock on any tool. It's the question every IT leader should ask before committing: when the person who set this up moves on, does the knowledge leave with them, or does it stay in Git?
 
 ## Two roads to the same place
 
@@ -121,7 +121,7 @@ The quickest way to see this in detail is to inspect our [it-and-security](https
 - [**Get a demo**](https://fleetdm.com/contact)**.**  We'll walk through how config-as-code and GitOps exceptions would work in your environment.
 - [**Join a GitOps training session**](https://fleetdm.com/gitops-workshop)**.** Learn to manage configuration as code: set up apps, configs, reports, and policies in Git, review changes with pull requests, and deploy through CI in our hands‑on workshop.
 
-*Fleet is the open-source endpoint management platform for macOS, Windows, Linux, and more. Want to try GitOps in your own fleet?* [*Get a demo*](https://fleetdm.com/contact) *or explore the* [*GitOps reference*](https://fleetdm.com/docs/configuration/yaml-files)*.*
+*Fleet is the open-source endpoint management platform for macOS, Windows, Linux, and more. Want to try GitOps in your own fleet? Explore the* [*GitOps reference*](https://fleetdm.com/docs/configuration/yaml-files)*.*
 
 <meta name="articleTitle" value="The hidden cost of config-as-code: simplicity, tribal knowledge, and what stays in Git">
 <meta name="authorFullName" value="Henry Stamerjohann">


### PR DESCRIPTION
Moves opening context paragraphs in several articles to follow the key takeaways section for a more consistent structure. Also refines a few takeaway phrases for clarity and updates calls to action, including linking the Managed Migration Assistant article to the setup guide and simplifying the closing CTA in the config-as-code article.
