### PR TITLE
Rename hosts name template gitops

### DIFF
--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -208,6 +208,7 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		macOSEnableEndUserAuthUpdated   bool
 		macOSManagedLocalAccountUpdated bool
 		conditionalAccessUpdated        bool
+		nameTemplateUpdated             bool
 	)
 	if payload.MDM != nil {
 		if payload.MDM.MacOSUpdates != nil {
@@ -321,6 +322,19 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 
 		if payload.MDM.RequireBitLockerPIN.Valid {
 			team.Config.MDM.RequireBitLockerPIN = payload.MDM.RequireBitLockerPIN.Value
+		}
+
+		if payload.MDM.HostNameTemplate.Set {
+			nameTemplate := payload.MDM.HostNameTemplate.Value
+			if nameTemplate != "" {
+				validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+				if err != nil {
+					return nil, ctxerr.Wrap(ctx, err)
+				}
+				nameTemplate = validated
+			}
+			nameTemplateUpdated = team.Config.MDM.HostNameTemplate != nameTemplate
+			team.Config.MDM.HostNameTemplate = nameTemplate
 		}
 
 		if payload.MDM.MacOSSetup != nil {
@@ -610,6 +624,11 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		}
 		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "create activity for team recovery lock password")
+		}
+	}
+	if nameTemplateUpdated {
+		if err := svc.applyHostNameTemplateChange(ctx, team.ID, team.Name, team.Config.MDM.HostNameTemplate); err != nil {
+			return nil, err
 		}
 	}
 	if macOSEnableEndUserAuthUpdated {
@@ -1504,6 +1523,15 @@ func (svc *Service) createTeamFromSpec(
 		}
 	}
 
+	nameTemplate := spec.MDM.HostNameTemplate.Value
+	if nameTemplate != "" {
+		validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err)
+		}
+		nameTemplate = validated
+	}
+
 	invalid := &fleet.InvalidArgumentError{}
 	if enableDiskEncryption && svc.config.Server.PrivateKey == "" {
 		return nil, ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
@@ -1585,6 +1613,7 @@ func (svc *Service) createTeamFromSpec(
 				MacOSSetup:                 macOSSetup,
 				WindowsSettings:            spec.MDM.WindowsSettings,
 				AndroidSettings:            spec.MDM.AndroidSettings,
+				HostNameTemplate:           nameTemplate,
 			},
 			HostExpirySettings: hostExpirySettings,
 			WebhookSettings: fleet.TeamWebhookSettings{
@@ -1643,6 +1672,12 @@ func (svc *Service) createTeamFromSpec(
 			fleet.ActivityTypeEnabledRecoveryLockPasswords{TeamID: &tm.ID, TeamName: &tm.Name},
 		); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "create activity for team recovery lock password")
+		}
+	}
+
+	if nameTemplate != "" {
+		if err := svc.applyHostNameTemplateChange(ctx, tm.ID, tm.Name, nameTemplate); err != nil {
+			return nil, err
 		}
 	}
 	return tm, nil
@@ -1770,6 +1805,20 @@ func (svc *Service) editTeamFromSpec(
 				`Couldn't update enable_recovery_lock_password because MDM features aren't turned on in Fleet.`))
 		}
 		team.Config.MDM.EnableRecoveryLockPassword = spec.MDM.EnableRecoveryLockPassword.Value
+	}
+
+	var didUpdateHostNameTemplate bool
+	if spec.MDM.HostNameTemplate.Set {
+		nameTemplate := spec.MDM.HostNameTemplate.Value
+		if nameTemplate != "" {
+			validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err)
+			}
+			nameTemplate = validated
+		}
+		didUpdateHostNameTemplate = team.Config.MDM.HostNameTemplate != nameTemplate
+		team.Config.MDM.HostNameTemplate = nameTemplate
 	}
 
 	if !team.Config.MDM.MacOSSetup.EnableReleaseDeviceManually.Valid {
@@ -2034,6 +2083,12 @@ func (svc *Service) editTeamFromSpec(
 		}
 		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 			return ctxerr.Wrap(ctx, err, "create activity for team recovery lock password")
+		}
+	}
+
+	if didUpdateHostNameTemplate {
+		if err := svc.applyHostNameTemplateChange(ctx, team.ID, team.Name, team.Config.MDM.HostNameTemplate); err != nil {
+			return err
 		}
 	}
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -3801,6 +3801,8 @@ func TestUpdateMDMAppleSettings(t *testing.T) {
 func TestUpdateMDMHostNameTemplate(t *testing.T) {
 	svc, baseCtx, ds, svcOpts := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
 
+	// currentTemplate is what the team already carries when loaded; individual
+	// subtests adjust it to exercise the idempotency and clear paths.
 	currentTemplate := ""
 	ds.TeamWithExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
 		return &fleet.Team{ID: id, Name: "team", Config: fleet.TeamConfig{

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -33864,3 +33864,98 @@ func (s *integrationEnterpriseTestSuite) TestResetPolicy() {
 	// 404 for a nonexistent policy.
 	s.Do("POST", "/api/latest/fleet/policies/999999/reset", nil, http.StatusNotFound)
 }
+
+func (s *integrationEnterpriseTestSuite) TestTeamHostNameTemplate() {
+	t := s.T()
+	ctx := t.Context()
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	const tmpl = "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL"
+	activityName := fleet.ActivityTypeEditedHostNameTemplate{}.ActivityName()
+	activityDetails := func(nameTemplate string) string {
+		jsonTemplate := "null"
+		if nameTemplate != "" {
+			jsonTemplate = fmt.Sprintf("%q", nameTemplate)
+		}
+		return fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "name_template": %s}`, team.ID, team.Name, jsonTemplate)
+	}
+	getTemplate := func() string {
+		var getResp getTeamResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &getResp)
+		return getResp.Team.Config.MDM.HostNameTemplate
+	}
+
+	// PATCH /teams/{id} with an invalid template is rejected
+	s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID),
+		json.RawMessage(`{"mdm": {"name_template": "X-$FLEET_SECRET_Y"}}`), http.StatusUnprocessableEntity)
+	require.Empty(t, getTemplate())
+
+	// PATCH sets the template and logs the activity
+	var tmResp teamResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID),
+		json.RawMessage(fmt.Sprintf(`{"mdm": {"name_template": %q}}`, tmpl)), http.StatusOK, &tmResp)
+	require.Equal(t, tmpl, tmResp.Team.Config.MDM.HostNameTemplate)
+	require.Equal(t, tmpl, getTemplate())
+	activityID := s.lastActivityMatches(activityName, activityDetails(tmpl), 0)
+
+	// re-PATCHing the identical template logs no duplicate activity
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID),
+		json.RawMessage(fmt.Sprintf(`{"mdm": {"name_template": %q}}`, tmpl)), http.StatusOK, &tmResp)
+	s.lastActivityMatches("", "", activityID)
+
+	// a PATCH without the key leaves the template untouched
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID),
+		json.RawMessage(`{"mdm": {"windows_require_bitlocker_pin": false}}`), http.StatusOK, &tmResp)
+	require.Equal(t, tmpl, getTemplate())
+
+	// team-spec apply: an invalid template is rejected, even in dry-run
+	specWith := func(mdm map[string]any) map[string]any {
+		return map[string]any{"specs": []any{map[string]any{"name": team.Name, "mdm": mdm}}}
+	}
+	s.Do("POST", "/api/latest/fleet/spec/fleets",
+		specWith(map[string]any{"name_template": "X-$FLEET_VAR_NOPE"}), http.StatusUnprocessableEntity)
+	s.Do("POST", "/api/latest/fleet/spec/fleets",
+		specWith(map[string]any{"name_template": "X-$FLEET_VAR_NOPE"}), http.StatusUnprocessableEntity, "dry_run", "true")
+
+	// a valid dry-run does not persist the change
+	s.Do("POST", "/api/latest/fleet/spec/fleets",
+		specWith(map[string]any{"name_template": "DR-$FLEET_VAR_HOST_UUID"}), http.StatusOK, "dry_run", "true")
+	require.Equal(t, tmpl, getTemplate())
+
+	// spec apply sets a new template and logs the activity
+	const specTmpl = "iPad $FLEET_VAR_HOST_UUID"
+	var applyResp applyTeamSpecsResponse
+	s.DoJSON("POST", "/api/latest/fleet/spec/fleets",
+		specWith(map[string]any{"name_template": specTmpl}), http.StatusOK, &applyResp)
+	require.Equal(t, specTmpl, getTemplate())
+	activityID = s.lastActivityOfTypeMatches(activityName, activityDetails(specTmpl), 0)
+
+	// re-applying the same spec logs no duplicate activity
+	s.DoJSON("POST", "/api/latest/fleet/spec/fleets",
+		specWith(map[string]any{"name_template": specTmpl}), http.StatusOK, &applyResp)
+	s.lastActivityOfTypeMatches(activityName, "", activityID)
+
+	// a spec without the key leaves the template untouched
+	s.DoJSON("POST", "/api/latest/fleet/spec/fleets",
+		specWith(map[string]any{}), http.StatusOK, &applyResp)
+	require.Equal(t, specTmpl, getTemplate())
+
+	// an empty string clears the template and logs a null-template activity
+	s.DoJSON("POST", "/api/latest/fleet/spec/fleets",
+		specWith(map[string]any{"name_template": ""}), http.StatusOK, &applyResp)
+	require.Empty(t, getTemplate())
+	s.lastActivityOfTypeMatches(activityName, activityDetails(""), 0)
+
+	// creating a new team from a spec with a template applies it and logs the activity
+	newTeamName := t.Name() + "-new"
+	s.DoJSON("POST", "/api/latest/fleet/spec/fleets",
+		map[string]any{"specs": []any{map[string]any{"name": newTeamName, "mdm": map[string]any{"name_template": tmpl}}}},
+		http.StatusOK, &applyResp)
+	newTeam, err := s.ds.TeamByName(ctx, newTeamName)
+	require.NoError(t, err)
+	require.Equal(t, tmpl, newTeam.Config.MDM.HostNameTemplate)
+	s.lastActivityOfTypeMatches(activityName,
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "name_template": %q}`, newTeam.ID, newTeam.Name, tmpl), 0)
+}


### PR DESCRIPTION
Relates to #48623

Plumbs mdm.name_template through PATCH /teams/{id} and team-spec apply (create and edit, which GitOps rides on).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team host name template settings can now be updated consistently through team settings and GitOps/spec-based workflows.
  * New teams created from specs can inherit a host name template automatically.

* **Bug Fixes**
  * Invalid host name templates are now rejected reliably.
  * Empty or omitted template values now behave correctly, including clearing an existing template.
  * Reapplying the same template no longer creates duplicate activity records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->