### PR TITLE
fleet-mcp: use /fleets endpoints instead of legacy /teams

### DIFF
--- a/tools/fleet-mcp/fleet_integration.go
+++ b/tools/fleet-mcp/fleet_integration.go
@@ -816,7 +816,7 @@ func (fc *FleetClient) GetPolicies(ctx context.Context) ([]Policy, error) {
 		go func(idx int, team Team) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			teamResp, err := fc.makeFleetRequest(ctx, "GET", fmt.Sprintf("/api/v1/fleet/teams/%d/policies", team.ID), nil)
+			teamResp, err := fc.makeFleetRequest(ctx, "GET", fmt.Sprintf("/api/v1/fleet/fleets/%d/policies", team.ID), nil)
 			if err != nil {
 				logrus.Warnf("team %d policies error: %v", team.ID, err)
 				return
@@ -934,7 +934,7 @@ func (fc *FleetClient) GetEndpointsWithAggregations(ctx context.Context) (*Aggre
 
 // GetTeams retrieves all teams from Fleet
 func (fc *FleetClient) GetTeams(ctx context.Context) ([]Team, error) {
-	endpoint := "/api/v1/fleet/teams"
+	endpoint := "/api/v1/fleet/fleets"
 	resp, err := fc.makeFleetRequest(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get teams: %w", err)
@@ -1466,13 +1466,13 @@ func (fc *FleetClient) GetPolicyCompliance(ctx context.Context, policyID string)
 }
 
 // GetTeamPolicyCompliance retrieves policy compliance scoped to a single fleet
-// (team). Wraps GET /api/v1/fleet/teams/:team_id/policies/:policy_id and
+// (team). Wraps GET /api/v1/fleet/fleets/:team_id/policies/:policy_id and
 // returns the same PolicyCompliance shape as the global variant so callers
 // can treat both uniformly. Use this — not GetPolicyCompliance — when the
 // caller knows the policy belongs to a specific fleet, or when global counts
 // would be misleading because the policy is fleet-scoped.
 func (fc *FleetClient) GetTeamPolicyCompliance(ctx context.Context, teamID, policyID string) (*PolicyCompliance, error) {
-	endpoint := fmt.Sprintf("/api/v1/fleet/teams/%s/policies/%s", url.PathEscape(teamID), url.PathEscape(policyID))
+	endpoint := fmt.Sprintf("/api/v1/fleet/fleets/%s/policies/%s", url.PathEscape(teamID), url.PathEscape(policyID))
 	resp, err := fc.makeFleetRequest(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get team policy compliance: %w", err)

--- a/tools/fleet-mcp/fleet_integration_test.go
+++ b/tools/fleet-mcp/fleet_integration_test.go
@@ -1080,7 +1080,7 @@ func TestGetPolicies_IncludesQueryField(t *testing.T) {
 				{"id":1,"name":"with sql","query":"` + wantSQL + `"},
 				{"id":2,"name":"empty sql","query":""}
 			]}`))
-		case "/api/v1/fleet/teams":
+		case "/api/v1/fleet/fleets":
 			_, _ = w.Write([]byte(`{"teams":[]}`))
 		default:
 			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #43544

The Fleet MCP calls the legacy `/api/v1/fleet/teams` routes for fleet and policy lookups. Fleet's current API endpoints catalog only lists the renamed `/fleets` routes, so an endpoint-restricted api-only user cannot be granted `/teams` and those calls return 403. This switches the MCP to the `/fleets` paths, which return the same response shape, so fleet resolution and per-fleet policy compliance work under a least-privilege token. Verified against a running Fleet.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team-related Fleet data now loads from the correct service endpoints, improving policy and compliance views.
  * Policy listings and policy detail checks for teams should now return the expected results.
  * Updated test coverage to match the revised Fleet route behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->