### PR TITLE
Add host name template enforcement pipeline and verification

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1902,6 +1902,9 @@ func newAppleMDMProfileManagerSchedule(
 		schedule.WithJob("manage_apple_declarations", func(ctx context.Context) error {
 			return service.ReconcileAppleDeclarationsBatched(ctx, ds, commander, logger)
 		}),
+		schedule.WithJob("manage_apple_device_names", func(ctx context.Context) error {
+			return service.ReconcileHostDeviceNames(ctx, ds, commander, logger)
+		}),
 	)
 
 	return s, nil

--- a/server/datastore/mysql/apple_device_names.go
+++ b/server/datastore/mysql/apple_device_names.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -76,27 +77,36 @@ func (ds *Datastore) ListHostsPendingDeviceNameCommand(ctx context.Context, limi
 	return pending, nil
 }
 
-func (ds *Datastore) SetHostDeviceNameCommandSent(ctx context.Context, hostUUID, commandUUID, expectedName string) error {
+func (ds *Datastore) SetHostDeviceNameStatus(ctx context.Context, hostUUID string, status fleet.MDMDeliveryStatus, commandUUID *string, expectedName, detail string) error {
+	// commandUUID is bound directly: a non-nil value records the enqueued
+	// command; nil clears it so a result from a previously sent command can't
+	// match this row and overwrite the outcome recorded here.
 	const stmt = `
 		UPDATE host_mdm_apple_device_names
-		SET status = ?, command_uuid = ?, expected_device_name = ?, detail = ''
+		SET status = ?, command_uuid = ?, expected_device_name = ?, detail = ?
 		WHERE host_uuid = ?`
 
-	res, err := ds.writer(ctx).ExecContext(ctx, stmt, fleet.MDMDeliveryPending, commandUUID, expectedName, hostUUID)
+	res, err := ds.writer(ctx).ExecContext(ctx, stmt, status, commandUUID, expectedName, detail, hostUUID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "set host device name command sent")
+		return ctxerr.Wrap(ctx, err, "set host device name status")
 	}
 	if rows, _ := res.RowsAffected(); rows == 0 {
-		// The row went away between the cron listing it and sending the command
-		// (e.g. the template was cleared). The command's later result will simply
-		// not match any row and be dropped.
-		ds.logger.DebugContext(ctx, "device name command sent but no enforcement row updated", "host_uuid", hostUUID, "command_uuid", commandUUID)
+		// The row went away between the cron listing it and this write (e.g. the
+		// template was cleared); nothing to record. Any command already sent will
+		// simply not match a row when its result arrives and be dropped.
+		ds.logger.DebugContext(ctx, "host device name status set but no enforcement row updated", "host_uuid", hostUUID)
 	}
 	return nil
 }
 
-func (ds *Datastore) UpdateHostDeviceNameStatusFromCommand(ctx context.Context, commandUUID string, status fleet.MDMDeliveryStatus, detail string) (hostUUID string, expectedName string, err error) {
-	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+func (ds *Datastore) UpdateHostDeviceNameStatusFromCommand(ctx context.Context, commandUUID string, acknowledged bool, detail string) error {
+	// The command result is one of exactly two outcomes: acknowledged (the
+	// device applied the rename → verifying) or an error (→ failed).
+	status := fleet.MDMDeliveryFailed
+	if acknowledged {
+		status = fleet.MDMDeliveryVerifying
+	}
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		// The UPDATE is authoritative. A 0-row result means no current row holds
 		// this command UUID: it was superseded by a newer command for the same
 		// host (the row keeps only the latest) or the row was deleted. Either way
@@ -113,51 +123,93 @@ func (ds *Datastore) UpdateHostDeviceNameStatusFromCommand(ctx context.Context, 
 			return ctxerr.Wrap(ctx, notFound("HostDeviceNameEnforcement").WithName(commandUUID))
 		}
 
-		// Read back the host and the name we told the device to apply so the
-		// caller can rename the host in Fleet; a plain UPDATE can't return these.
-		// The row is locked by the UPDATE above, so this can't miss.
-		var row struct {
-			HostUUID           string  `db:"host_uuid"`
+		if !acknowledged {
+			// Only an acknowledgment renames the host; error results just record
+			// the failure on the row.
+			return nil
+		}
+
+		// Acknowledged: rename the host in Fleet in this same transaction so the
+		// row transition and the Fleet-side rename are atomic. Join the row to
+		// its host to read the expected name and the fields needed to derive the
+		// display name. The row is locked by the UPDATE above, so this can't miss.
+		var host struct {
+			ID                 uint    `db:"id"`
+			HardwareModel      string  `db:"hardware_model"`
+			HardwareSerial     string  `db:"hardware_serial"`
 			ExpectedDeviceName *string `db:"expected_device_name"`
 		}
 		const selectStmt = `
-			SELECT host_uuid, expected_device_name
-			FROM host_mdm_apple_device_names
-			WHERE command_uuid = ?`
-		if err := sqlx.GetContext(ctx, tx, &row, selectStmt, commandUUID); err != nil {
-			return ctxerr.Wrapf(ctx, err, "get host device name enforcement for command %s", commandUUID)
+			SELECT h.id, h.hardware_model, h.hardware_serial, n.expected_device_name
+			FROM host_mdm_apple_device_names n
+			JOIN hosts h ON h.uuid = n.host_uuid
+			WHERE n.command_uuid = ?`
+		if err := sqlx.GetContext(ctx, tx, &host, selectStmt, commandUUID); err != nil {
+			return ctxerr.Wrapf(ctx, err, "get host to rename for command %s", commandUUID)
 		}
+		// A row only carries a command_uuid when SetHostDeviceNameStatus set it
+		// together with the resolved expected_device_name, so a row matched here by
+		// command_uuid always has a name.
+		name := *host.ExpectedDeviceName
 
-		hostUUID = row.HostUUID
-		if row.ExpectedDeviceName != nil {
-			expectedName = *row.ExpectedDeviceName
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE hosts SET computer_name = ?, hostname = ? WHERE id = ?`, name, name, host.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "rename host from device name")
+		}
+		displayName := fleet.HostDisplayName(name, name, host.HardwareModel, host.HardwareSerial)
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO host_display_names (host_id, display_name) VALUES (?, ?)
+			ON DUPLICATE KEY UPDATE display_name = VALUES(display_name)`, host.ID, displayName); err != nil {
+			return ctxerr.Wrap(ctx, err, "update host display name from device name")
 		}
 		return nil
 	})
-	return hostUUID, expectedName, err
 }
 
-func (ds *Datastore) VerifyHostDeviceName(ctx context.Context, hostUUID, reportedName string) error {
+// deviceNameVerifyGracePeriod is how long after an acknowledgment (the row
+// entered verifying) a mismatching reported name is ignored rather than
+// recorded as drift. A report the agent collected before the device applied the
+// rename can arrive after the acknowledgment carrying the old name; the only
+// staleness is the agent's collect-to-submit latency (seconds), so a small
+// fixed window comfortably covers it. The comparison is entirely against the DB
+// clock (updated_at vs NOW()), so there's no cross-machine skew to pad for.
+const deviceNameVerifyGracePeriod = 60 * time.Second
+
+func (ds *Datastore) UpdateHostDeviceNameStatusFromReport(ctx context.Context, hostUUID, reportedName string) error {
 	// Only rows already awaiting or past verification are reconciled against the
 	// device-reported name: a match confirms the rename (verified), a mismatch
 	// records drift (failed). Rows in any other state and hosts with no row are
 	// left untouched.
+	//
+	// A mismatch on a row acknowledged within the last deviceNameVerifyGracePeriod
+	// is left untouched (false drift; failed rows only recover via an explicit
+	// resend). Rows already verified reached that state through a fresh
+	// post-rename report, so a mismatch there is genuine drift regardless of age.
+	// When the CASEs resolve to the current values, MySQL skips the row write,
+	// preserving updated_at (the grace anchor).
 	const stmt = `
 		UPDATE host_mdm_apple_device_names
 		SET
-			status = CASE WHEN expected_device_name = ? THEN ? ELSE ? END,
-			detail = CASE WHEN expected_device_name = ? THEN '' ELSE ? END
+			status = CASE
+				WHEN expected_device_name = ? THEN ?
+				WHEN status = ? AND updated_at > DATE_SUB(NOW(6), INTERVAL ? SECOND) THEN status
+				ELSE ? END,
+			detail = CASE
+				WHEN expected_device_name = ? THEN ''
+				WHEN status = ? AND updated_at > DATE_SUB(NOW(6), INTERVAL ? SECOND) THEN detail
+				ELSE ? END
 		WHERE host_uuid = ?
 			AND status IN (?, ?)`
 
 	const driftDetail = "Host was renamed on the device and no longer matches the fleet's naming template."
+	graceSeconds := int(deviceNameVerifyGracePeriod.Seconds())
 	if _, err := ds.writer(ctx).ExecContext(ctx, stmt,
-		reportedName, fleet.MDMDeliveryVerified, fleet.MDMDeliveryFailed,
-		reportedName, driftDetail,
+		reportedName, fleet.MDMDeliveryVerified, fleet.MDMDeliveryVerifying, graceSeconds, fleet.MDMDeliveryFailed,
+		reportedName, fleet.MDMDeliveryVerifying, graceSeconds, driftDetail,
 		hostUUID,
 		fleet.MDMDeliveryVerifying, fleet.MDMDeliveryVerified,
 	); err != nil {
-		return ctxerr.Wrap(ctx, err, "verify host device name")
+		return ctxerr.Wrap(ctx, err, "update host device name status from report")
 	}
 	return nil
 }

--- a/server/datastore/mysql/apple_device_names_test.go
+++ b/server/datastore/mysql/apple_device_names_test.go
@@ -30,6 +30,8 @@ func TestHostDeviceNames(t *testing.T) {
 		{"TeamDeletionCleanup", testHostDeviceNamesTeamDeletionCleanup},
 		{"HostDeletionCleanup", testHostDeviceNamesHostDeletionCleanup},
 		{"FullLifecycle", testHostDeviceNamesFullLifecycle},
+		{"ResolveResult", testHostDeviceNamesResolveResult},
+		{"VerifyGracePeriod", testHostDeviceNamesVerifyGracePeriod},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -144,7 +146,7 @@ func testHostDeviceNamesCommandLifecycle(t *testing.T, ds *Datastore) {
 	require.Equal(t, team.ID, *pending[0].TeamID)
 
 	// Marking the command as sent moves the row to pending and records details.
-	require.NoError(t, ds.SetHostDeviceNameCommandSent(ctx, host.UUID, "DEVNAME-cmd-1", "WS-SERIAL123"))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-cmd-1"), "WS-SERIAL123", ""))
 	row := getDeviceNameRow(t, ds, host.UUID)
 	require.NotNil(t, row.Status)
 	require.Equal(t, fleet.MDMDeliveryPending, *row.Status)
@@ -158,25 +160,25 @@ func testHostDeviceNamesCommandLifecycle(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Empty(t, pending)
 
-	// An acknowledgment updates the row by command UUID and returns the host and
-	// expected name so the caller can rename the host in Fleet.
-	gotUUID, gotName, err := ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd-1", fleet.MDMDeliveryVerifying, "")
-	require.NoError(t, err)
-	require.Equal(t, host.UUID, gotUUID)
-	require.Equal(t, "WS-SERIAL123", gotName)
+	// An acknowledgment moves the row to verifying and renames the host in Fleet
+	// (computer_name, hostname, display name) to the expected name, atomically.
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd-1", true, ""))
 	require.Equal(t, fleet.MDMDeliveryVerifying, *getDeviceNameRow(t, ds, host.UUID).Status)
-
-	// An error result records the Apple detail.
-	require.NoError(t, ds.SetHostDeviceNameCommandSent(ctx, host.UUID, "DEVNAME-cmd-2", "WS-SERIAL123"))
-	gotUUID, _, err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd-2", fleet.MDMDeliveryFailed, "Apple error chain")
+	renamed, err := ds.Host(ctx, host.ID)
 	require.NoError(t, err)
-	require.Equal(t, host.UUID, gotUUID)
+	require.Equal(t, "WS-SERIAL123", renamed.ComputerName)
+	require.Equal(t, "WS-SERIAL123", renamed.Hostname)
+	require.Equal(t, "WS-SERIAL123", renamed.DisplayName())
+
+	// An error result records the Apple detail and does not rename the host.
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-cmd-2"), "WS-SERIAL123", ""))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd-2", false, "Apple error chain"))
 	row = getDeviceNameRow(t, ds, host.UUID)
 	require.Equal(t, fleet.MDMDeliveryFailed, *row.Status)
 	require.Equal(t, "Apple error chain", row.Detail)
 
 	// An unknown command UUID is a not-found error.
-	_, _, err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-nope", fleet.MDMDeliveryVerifying, "")
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-nope", true, "")
 	require.True(t, fleet.IsNotFound(err))
 
 	// Getting an enforcement row for a host with none is a not-found error.
@@ -192,28 +194,28 @@ func testHostDeviceNamesVerify(t *testing.T, ds *Datastore) {
 	host := enrollAppleHostForDeviceName(t, ds, "mac", "darwin", team.ID, false)
 
 	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
-	require.NoError(t, ds.SetHostDeviceNameCommandSent(ctx, host.UUID, "DEVNAME-cmd", "WS-1"))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-cmd"), "WS-1", ""))
 
 	// A NULL/pending row is left untouched by verification.
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "WS-1"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "WS-1"))
 	require.Equal(t, fleet.MDMDeliveryPending, *getDeviceNameRow(t, ds, host.UUID).Status)
 
 	// Move to verifying, then a matching report verifies it.
-	_, _, err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd", fleet.MDMDeliveryVerifying, "")
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd", true, "")
 	require.NoError(t, err)
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "WS-1"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "WS-1"))
 	require.Equal(t, fleet.MDMDeliveryVerified, *getDeviceNameRow(t, ds, host.UUID).Status)
 
 	// Re-verifying an already-verified, still-matching row is a no-op: status
 	// stays verified and the row is not rewritten (updated_at unchanged).
 	verifiedAt := getDeviceNameRow(t, ds, host.UUID).UpdatedAt
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "WS-1"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "WS-1"))
 	afterReverify := getDeviceNameRow(t, ds, host.UUID)
 	require.Equal(t, fleet.MDMDeliveryVerified, *afterReverify.Status)
 	require.True(t, afterReverify.UpdatedAt.Equal(verifiedAt), "re-verifying a matching row must not rewrite it")
 
 	// A later mismatching report is drift: verified -> failed with a detail.
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "renamed-by-user"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "renamed-by-user"))
 	row := getDeviceNameRow(t, ds, host.UUID)
 	require.Equal(t, fleet.MDMDeliveryFailed, *row.Status)
 	require.NotEmpty(t, row.Detail)
@@ -221,11 +223,11 @@ func testHostDeviceNamesVerify(t *testing.T, ds *Datastore) {
 	// A failed row is left untouched even by a later matching report: only
 	// verifying/verified rows are reconciled, so recovery requires an explicit
 	// resend rather than silent self-healing.
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "WS-1"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "WS-1"))
 	require.Equal(t, fleet.MDMDeliveryFailed, *getDeviceNameRow(t, ds, host.UUID).Status)
 
 	// A host with no row is a no-op (no error).
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, "missing-uuid", "anything"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, "missing-uuid", "anything"))
 }
 
 func testHostDeviceNamesResend(t *testing.T, ds *Datastore) {
@@ -236,8 +238,8 @@ func testHostDeviceNamesResend(t *testing.T, ds *Datastore) {
 	host := enrollAppleHostForDeviceName(t, ds, "mac", "darwin", team.ID, false)
 
 	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
-	require.NoError(t, ds.SetHostDeviceNameCommandSent(ctx, host.UUID, "DEVNAME-cmd", "WS-1"))
-	_, _, err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd", fleet.MDMDeliveryFailed, "boom")
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-cmd"), "WS-1", ""))
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd", false, "boom")
 	require.NoError(t, err)
 	require.Equal(t, fleet.MDMDeliveryFailed, *getDeviceNameRow(t, ds, host.UUID).Status)
 
@@ -249,7 +251,7 @@ func testHostDeviceNamesResend(t *testing.T, ds *Datastore) {
 	require.Nil(t, row.CommandUUID)
 
 	// The previous command's late acknowledgment no longer matches any row.
-	_, _, err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd", fleet.MDMDeliveryVerifying, "")
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd", true, "")
 	require.True(t, fleet.IsNotFound(err))
 	require.Nil(t, getDeviceNameRow(t, ds, host.UUID).Status, "late ack must not resurrect the row")
 
@@ -567,6 +569,94 @@ func testHostDeviceNamesHostDeletionCleanup(t *testing.T, ds *Datastore) {
 	require.True(t, fleet.IsNotFound(err), "enforcement row must be deleted with the host")
 }
 
+func testHostDeviceNamesResolveResult(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "resolve-team"})
+	require.NoError(t, err)
+	host := enrollAppleHostForDeviceName(t, ds, "mac", "darwin", team.ID, false)
+
+	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
+
+	// A too-long resolution fails the row without sending a command; the row
+	// leaves the pending list so the cron does not retry it.
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryFailed, nil, "", "Resolved name exceeds 63 bytes."))
+	row := getDeviceNameRow(t, ds, host.UUID)
+	require.NotNil(t, row.Status)
+	require.Equal(t, fleet.MDMDeliveryFailed, *row.Status)
+	require.Equal(t, "Resolved name exceeds 63 bytes.", row.Detail)
+	require.Nil(t, row.CommandUUID)
+	pending, err := ds.ListHostsPendingDeviceNameCommand(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, pending)
+
+	// An already-matching host goes straight to verified with the resolved name
+	// recorded, so later reports can still detect drift from that name.
+	require.NoError(t, ds.ResendHostDeviceName(ctx, host.UUID))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryVerified, nil, "WS-1", ""))
+	row = getDeviceNameRow(t, ds, host.UUID)
+	require.Equal(t, fleet.MDMDeliveryVerified, *row.Status)
+	require.NotNil(t, row.ExpectedDeviceName)
+	require.Equal(t, "WS-1", *row.ExpectedDeviceName)
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "renamed-on-device"))
+	require.Equal(t, fleet.MDMDeliveryFailed, *getDeviceNameRow(t, ds, host.UUID).Status)
+
+	// Recording a resolve result clears any previously sent command UUID, so a
+	// stale result for that command can't overwrite the outcome.
+	require.NoError(t, ds.ResendHostDeviceName(ctx, host.UUID))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-stale"), "WS-1", ""))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryVerified, nil, "WS-1", ""))
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-stale", false, "boom")
+	require.True(t, fleet.IsNotFound(err))
+	require.Equal(t, fleet.MDMDeliveryVerified, *getDeviceNameRow(t, ds, host.UUID).Status)
+
+	// A host with no row is a no-op (no error).
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, "missing-uuid", fleet.MDMDeliveryVerified, nil, "WS-1", ""))
+}
+
+func testHostDeviceNamesVerifyGracePeriod(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "grace-team"})
+	require.NoError(t, err)
+	host := enrollAppleHostForDeviceName(t, ds, "mac", "darwin", team.ID, false)
+
+	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-cmd"), "WS-1", ""))
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd", true, "")
+	require.NoError(t, err)
+
+	// A mismatching report arriving shortly after the acknowledgment is a report
+	// that was generated before the device applied the rename, not drift: the row
+	// stays verifying and waits for a fresh report.
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "stale-pre-rename-name"))
+	require.Equal(t, fleet.MDMDeliveryVerifying, *getDeviceNameRow(t, ds, host.UUID).Status)
+
+	// A matching report is trusted at any time.
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "WS-1"))
+	require.Equal(t, fleet.MDMDeliveryVerified, *getDeviceNameRow(t, ds, host.UUID).Status)
+
+	// A mismatch on a verified row is genuine drift, grace period or not: the
+	// verified state was reached by a fresh post-rename report, so a later
+	// mismatch means the device was renamed off-template.
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "renamed-by-user"))
+	require.Equal(t, fleet.MDMDeliveryFailed, *getDeviceNameRow(t, ds, host.UUID).Status)
+
+	// Once the grace period has elapsed, a mismatch on a still-verifying row is
+	// no longer explainable as an in-flight stale report and fails the row.
+	require.NoError(t, ds.ResendHostDeviceName(ctx, host.UUID))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-cmd-2"), "WS-1", ""))
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-cmd-2", true, "")
+	require.NoError(t, err)
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`UPDATE host_mdm_apple_device_names SET updated_at = DATE_SUB(NOW(6), INTERVAL 1 HOUR) WHERE host_uuid = ?`, host.UUID)
+	require.NoError(t, err)
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "still-the-old-name"))
+	row := getDeviceNameRow(t, ds, host.UUID)
+	require.Equal(t, fleet.MDMDeliveryFailed, *row.Status)
+	require.NotEmpty(t, row.Detail)
+}
+
 // testHostDeviceNamesFullLifecycle walks a single host through the entire
 // enforcement state machine in the order the real actors drive it: admin saves a
 // template (bulk upsert), the cron picks up the queued row and sends a command,
@@ -582,13 +672,6 @@ func testHostDeviceNamesFullLifecycle(t *testing.T, ds *Datastore) {
 	_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET hardware_serial = ?, computer_name = ? WHERE id = ?`, "SERIAL1", "old-name", host.ID)
 	require.NoError(t, err)
 
-	// renameHost simulates the ack handler renaming the host in Fleet, so name
-	// ingestion (VerifyHostDeviceName) has a real name to report back.
-	renameHost := func(name string) {
-		_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET computer_name = ? WHERE id = ?`, name, host.ID)
-		require.NoError(t, err)
-	}
-
 	// 1. Admin saves a template -> the host is queued (status NULL).
 	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
 	require.Nil(t, getDeviceNameRow(t, ds, host.UUID).Status)
@@ -598,23 +681,19 @@ func testHostDeviceNamesFullLifecycle(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, pending, 1)
 	require.Equal(t, host.UUID, pending[0].HostUUID)
-	require.NoError(t, ds.SetHostDeviceNameCommandSent(ctx, host.UUID, "DEVNAME-1", "WS-SERIAL1"))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-1"), "WS-SERIAL1", ""))
 	require.Equal(t, fleet.MDMDeliveryPending, *getDeviceNameRow(t, ds, host.UUID).Status)
 
-	// 3. MDM acks the command -> rename the host in Fleet, row goes verifying.
-	gotUUID, gotName, err := ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-1", fleet.MDMDeliveryVerifying, "")
-	require.NoError(t, err)
-	require.Equal(t, host.UUID, gotUUID)
-	require.Equal(t, "WS-SERIAL1", gotName)
-	renameHost(gotName)
+	// 3. MDM acks the command -> row goes verifying and the host is renamed in Fleet.
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-1", true, ""))
 	require.Equal(t, fleet.MDMDeliveryVerifying, *getDeviceNameRow(t, ds, host.UUID).Status)
 
 	// 4. Name ingestion reports the matching name -> verified.
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "WS-SERIAL1"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "WS-SERIAL1"))
 	require.Equal(t, fleet.MDMDeliveryVerified, *getDeviceNameRow(t, ds, host.UUID).Status)
 
 	// 5. The device drifts (renamed on-device) -> failed with a detail.
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "renamed-on-device"))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "renamed-on-device"))
 	failed := getDeviceNameRow(t, ds, host.UUID)
 	require.Equal(t, fleet.MDMDeliveryFailed, *failed.Status)
 	require.NotEmpty(t, failed.Detail)
@@ -628,20 +707,17 @@ func testHostDeviceNamesFullLifecycle(t *testing.T, ds *Datastore) {
 
 	// 7. A second command supersedes an in-flight one: the cron sends command 2
 	// while command 1 is still outstanding, then command 1's stale ack arrives.
-	require.NoError(t, ds.SetHostDeviceNameCommandSent(ctx, host.UUID, "DEVNAME-2a", "WS-SERIAL1"))
-	require.NoError(t, ds.SetHostDeviceNameCommandSent(ctx, host.UUID, "DEVNAME-2b", "WS-SERIAL1"))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-2a"), "WS-SERIAL1", ""))
+	require.NoError(t, ds.SetHostDeviceNameStatus(ctx, host.UUID, fleet.MDMDeliveryPending, new("DEVNAME-2b"), "WS-SERIAL1", ""))
 
 	// The superseded command's ack no longer matches the row -> not found, and
 	// the row is untouched (still pending on the newest command).
-	_, _, err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-2a", fleet.MDMDeliveryVerifying, "")
+	err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-2a", true, "")
 	require.True(t, fleet.IsNotFound(err))
 	require.Equal(t, fleet.MDMDeliveryPending, *getDeviceNameRow(t, ds, host.UUID).Status)
 
-	// The newest command's ack is applied.
-	gotUUID, _, err = ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-2b", fleet.MDMDeliveryVerifying, "")
-	require.NoError(t, err)
-	require.Equal(t, host.UUID, gotUUID)
-	renameHost("WS-SERIAL1")
-	require.NoError(t, ds.VerifyHostDeviceName(ctx, host.UUID, "WS-SERIAL1"))
+	// The newest command's ack is applied and renames the host.
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromCommand(ctx, "DEVNAME-2b", true, ""))
+	require.NoError(t, ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, "WS-SERIAL1"))
 	require.Equal(t, fleet.MDMDeliveryVerified, *getDeviceNameRow(t, ds, host.UUID).Status)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1804,14 +1804,25 @@ type Datastore interface {
 	// cron needs to resolve the template and enqueue a Settings/DeviceName command.
 	ListHostsPendingDeviceNameCommand(ctx context.Context, limit int) ([]HostDeviceNamePending, error)
 
-	// SetHostDeviceNameCommandSent marks a host's enforcement row as pending,
-	// recording the enqueued command UUID and the resolved name that was sent.
-	SetHostDeviceNameCommandSent(ctx context.Context, hostUUID, commandUUID, expectedName string) error
+	// SetHostDeviceNameStatus records the outcome of processing a host's queued
+	// enforcement row, keyed by host UUID. It sets the row's status, expected
+	// device name, and detail, and sets command_uuid to commandUUID (nil clears
+	// it). The cron uses it two ways:
+	//   - a command was sent: status=pending, commandUUID=<the enqueued command>,
+	//     expectedName=<resolved name>, detail="";
+	//   - no command was sent (resolve outcome): status=verified when the host
+	//     already matches the resolved name, or failed when it can't be applied
+	//     (e.g. exceeds Apple's 63-byte limit), commandUUID=nil so a stale prior
+	//     command result can't overwrite the outcome.
+	SetHostDeviceNameStatus(ctx context.Context, hostUUID string, status MDMDeliveryStatus, commandUUID *string, expectedName, detail string) error
 
 	// UpdateHostDeviceNameStatusFromCommand updates the enforcement row matching
-	// the given command UUID to the given status and detail, returning the host
-	// UUID and expected name so the caller can rename the host in Fleet on
-	// acknowledgment.
+	// the given command UUID based on the command result: acknowledged=true (the
+	// device applied the rename) moves the row to verifying and also renames the
+	// host in Fleet in the same transaction — setting the host's computer name and
+	// hostname to the row's expected name and updating its display name — so the
+	// row transition and the Fleet-side rename are atomic; acknowledged=false (the
+	// device returned an error) moves the row to failed and records detail.
 	//
 	// A host holds only its most recently sent command UUID (one row per host),
 	// so a result for a superseded command (e.g. the template was re-saved or the
@@ -1820,16 +1831,23 @@ type Datastore interface {
 	// command, ignore" (check fleet.IsNotFound) rather than a failure: the device
 	// processes commands FIFO and ends on the latest name, which the matching
 	// (newest) command's result records.
-	UpdateHostDeviceNameStatusFromCommand(ctx context.Context, commandUUID string, status MDMDeliveryStatus, detail string) (hostUUID string, expectedName string, err error)
+	UpdateHostDeviceNameStatusFromCommand(ctx context.Context, commandUUID string, acknowledged bool, detail string) error
 
-	// VerifyHostDeviceName reconciles the enforcement row for a host against the
-	// name reported by the device. reportedName is the host's current name as
-	// observed at a name-ingestion site: the DeviceName in the iOS/iPadOS refetch
-	// result, or computer_name from macOS osquery system_info. It only acts on
-	// rows in the verifying or verified state: a match moves the row to verified;
-	// a mismatch moves it to failed (drift). Rows in any other state, or hosts
-	// with no row, are left untouched.
-	VerifyHostDeviceName(ctx context.Context, hostUUID, reportedName string) error
+	// UpdateHostDeviceNameStatusFromReport reconciles the enforcement row for a
+	// host against the name reported by the device (mutating). reportedName is the
+	// host's current name as observed at a name-ingestion site: the DeviceName in
+	// the iOS/iPadOS refetch result, or computer_name from macOS osquery
+	// system_info. It only acts on rows in the verifying or verified state: a
+	// match moves the row to verified; a mismatch moves it to failed (drift). Rows
+	// in any other state, or hosts with no row, are left untouched.
+	//
+	// A mismatch on a row that entered verifying only recently is ignored (the
+	// row stays verifying): a report generated before the device applied the
+	// rename can arrive after the acknowledgment and still carry the old name,
+	// and treating it as drift would strand the host at failed until an explicit
+	// resend. The stale window is the agent's collect-to-submit latency, so a
+	// small fixed grace covers it.
+	UpdateHostDeviceNameStatusFromReport(ctx context.Context, hostUUID, reportedName string) error
 
 	// GetHostDeviceNameEnforcement returns the host-name enforcement row for the
 	// given host, or a not-found error if the host has no row.

--- a/server/fleet/name_template.go
+++ b/server/fleet/name_template.go
@@ -13,6 +13,12 @@ import (
 
 const maxHostNameTemplateLength = 255
 
+// MaxResolvedHostNameBytes is Apple's byte limit for a device name (the resolved
+// host name). A resolved name longer than this can't be applied, so the cron
+// fails those rows; ValidateHostNameTemplate also rejects a template whose fixed
+// text alone already exceeds it.
+const MaxResolvedHostNameBytes = 63
+
 // fleetVarsSupportedInHostNameTemplates is the allow-list of Fleet variables that
 // may be used in a host name template.
 var fleetVarsSupportedInHostNameTemplates = []FleetVarName{
@@ -68,6 +74,17 @@ func ValidateHostNameTemplate(tmpl string) (string, error) {
 			return "", NewInvalidArgumentError("name_template",
 				"Fleet variable $FLEET_VAR_"+v+" is not supported in host name templates.")
 		}
+	}
+
+	// The resolved name must fit Apple's device name limit. Stripping the
+	// variables yields the shortest a resolved name can be (a variable may
+	// resolve to an empty value), so if the fixed text alone exceeds the limit no
+	// host can ever get a valid name — reject it now rather than silently failing
+	// every host at resolve time. Per-host overflow from variable expansion is
+	// still caught by the cron when it resolves against a host's actual values.
+	if literal := nameTemplateVarRegexp.ReplaceAllString(tmpl, ""); len(literal) > MaxResolvedHostNameBytes {
+		return "", NewInvalidArgumentError("name_template",
+			fmt.Sprintf("Host name template's fixed text can't be longer than %d bytes (the device name limit).", MaxResolvedHostNameBytes))
 	}
 
 	return tmpl, nil

--- a/server/fleet/name_template_test.go
+++ b/server/fleet/name_template_test.go
@@ -57,11 +57,19 @@ func TestValidateHostNameTemplate(t *testing.T) {
 		{name: "rtl override format char", tmpl: "bad\u202ename", wantErr: "control characters"},
 		{name: "zero-width joiner format char", tmpl: "bad\u200dname", wantErr: "control characters"},
 		{name: "invalid utf-8", tmpl: "bad\xff\xfename", wantErr: "valid UTF-8"},
-		{name: "too long", tmpl: strings.Repeat("a", 256), wantErr: "255 characters"},
-		{name: "max length ok", tmpl: strings.Repeat("a", 255), wantNorm: strings.Repeat("a", 255)},
-		// The limit is 255 characters, not bytes: 255 multi-byte runes must pass.
-		{name: "255 multi-byte runes ok", tmpl: strings.Repeat("é", 255), wantNorm: strings.Repeat("é", 255)},
+		// The 255-char cap is on the whole template string and counts runes, not
+		// bytes; it fires before the byte-floor check below.
+		{name: "template over 255 chars", tmpl: strings.Repeat("a", 256), wantErr: "255 characters"},
 		{name: "256 multi-byte runes too long", tmpl: strings.Repeat("é", 256), wantErr: "255 characters"},
+		// A resolved name can't exceed the device-name byte limit, so a template
+		// whose fixed text alone already exceeds it is rejected at save time.
+		{name: "literal at 63-byte limit ok", tmpl: strings.Repeat("a", 63), wantNorm: strings.Repeat("a", 63)},
+		{name: "literal over 63 bytes", tmpl: strings.Repeat("a", 64), wantErr: "63 bytes"},
+		// The floor is bytes, not runes: 32 two-byte runes is 64 bytes.
+		{name: "multi-byte literal over 63 bytes", tmpl: strings.Repeat("é", 32), wantErr: "63 bytes"},
+		// Only the fixed text counts toward the floor — a short literal plus a
+		// (longer) variable token is fine.
+		{name: "short literal with variable ok", tmpl: "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL", wantNorm: "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL"},
 	}
 
 	for _, c := range cases {

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -490,14 +490,14 @@ func (svc *MDMAppleCommander) DeviceInformation(ctx context.Context, hostUUIDs [
 	return svc.EnqueueCommand(ctx, hostUUIDs, raw)
 }
 
-// DeviceNameSetting sends the Settings command with a DeviceName item to rename the device.
-// Requires supervision on iOS/iPadOS.
-func (svc *MDMAppleCommander) DeviceNameSetting(ctx context.Context, hostUUID, cmdUUID, deviceName string) error {
+// deviceNameSettingCommand builds the raw Settings/DeviceName command used to
+// rename a device.
+func deviceNameSettingCommand(deviceName, cmdUUID string) (string, error) {
 	escaped, err := mobileconfig.XMLEscapeString(deviceName)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "escaping device name for XML")
+		return "", err
 	}
-	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -518,9 +518,38 @@ func (svc *MDMAppleCommander) DeviceNameSetting(ctx context.Context, hostUUID, c
 	<key>CommandUUID</key>
 	<string>%s</string>
 </dict>
-</plist>`, escaped, cmdUUID)
+</plist>`, escaped, cmdUUID), nil
+}
 
+// DeviceNameSetting sends the Settings command with a DeviceName item to rename the device.
+// Requires supervision on iOS/iPadOS.
+func (svc *MDMAppleCommander) DeviceNameSetting(ctx context.Context, hostUUID, cmdUUID, deviceName string) error {
+	raw, err := deviceNameSettingCommand(deviceName, cmdUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "escaping device name for XML")
+	}
 	return svc.EnqueueCommand(ctx, []string{hostUUID}, raw)
+}
+
+// DeviceNameSettingWithoutNotifications is like DeviceNameSetting but only
+// enqueues the command; it does not send an APNs push. The caller must invoke
+// SendNotifications afterwards. This lets a bulk sender enqueue one command per
+// host and then wake every device with a single batched push instead of one
+// APNs request per host.
+func (svc *MDMAppleCommander) DeviceNameSettingWithoutNotifications(ctx context.Context, hostUUID, cmdUUID, deviceName string) error {
+	raw, err := deviceNameSettingCommand(deviceName, cmdUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "escaping device name for XML")
+	}
+	cmd, err := mdm.DecodeCommand([]byte(raw))
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "decoding command")
+	}
+	if _, err := svc.storage.EnqueueCommand(ctx, []string{hostUUID},
+		&mdm.CommandWithSubtype{Command: *cmd, Subtype: mdm.CommandSubtypeNone}); err != nil {
+		return ctxerr.Wrap(ctx, err, "enqueuing for DeviceName")
+	}
+	return nil
 }
 
 func (svc *MDMAppleCommander) InstalledApplicationList(ctx context.Context, hostUUIDs []string, cmdUUID string, managedOnly bool) error {

--- a/server/mdm/apple/commander_test.go
+++ b/server/mdm/apple/commander_test.go
@@ -812,6 +812,55 @@ func TestMDMAppleCommanderDeviceNameSetting(t *testing.T) {
 	require.NotContains(t, string(gotRaw), "<iPad>")
 }
 
+func TestMDMAppleCommanderDeviceNameSettingWithoutNotifications(t *testing.T) {
+	ctx := context.Background()
+	mdmStorage := &mdmmock.MDMAppleStore{}
+	pushFactory, _ := newMockAPNSPushProviderFactory()
+	pusher := nanomdm_pushsvc.New(
+		mdmStorage,
+		mdmStorage,
+		pushFactory,
+		stdlogfmt.New(),
+	)
+	cmdr := NewMDMAppleCommander(mdmStorage, pusher)
+
+	hostUUID := "host-uuid-1"
+	cmdUUID := uuid.New().String()
+	deviceName := "Bob & Alice's <iPad>"
+
+	var gotRaw []byte
+	mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+		require.Equal(t, []string{hostUUID}, id)
+		require.Equal(t, "Settings", cmd.Command.Command.RequestType)
+		require.Contains(t, string(cmd.Raw), cmdUUID)
+		gotRaw = cmd.Raw
+		return nil, nil
+	}
+
+	err := cmdr.DeviceNameSettingWithoutNotifications(ctx, hostUUID, cmdUUID, deviceName)
+	require.NoError(t, err)
+	// The command is enqueued but no push is sent: the caller batches the push.
+	require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
+	require.False(t, mdmStorage.RetrievePushInfoFuncInvoked)
+
+	// The emitted plist is identical to the notifying variant's.
+	var parsed struct {
+		CommandUUID string
+		Command     struct {
+			RequestType string
+			Settings    []struct {
+				Item       string
+				DeviceName string
+			}
+		}
+	}
+	require.NoError(t, plist.Unmarshal(gotRaw, &parsed))
+	require.Equal(t, cmdUUID, parsed.CommandUUID)
+	require.Len(t, parsed.Command.Settings, 1)
+	require.Equal(t, "DeviceName", parsed.Command.Settings[0].Item)
+	require.Equal(t, deviceName, parsed.Command.Settings[0].DeviceName)
+}
+
 func TestAccountConfigurationWithAdminAccount(t *testing.T) {
 	ctx := context.Background()
 	mdmStorage := &mdmmock.MDMAppleStore{}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1158,11 +1158,11 @@ type DeleteHostDeviceNameEnforcementForTeamFunc func(ctx context.Context, teamID
 
 type ListHostsPendingDeviceNameCommandFunc func(ctx context.Context, limit int) ([]fleet.HostDeviceNamePending, error)
 
-type SetHostDeviceNameCommandSentFunc func(ctx context.Context, hostUUID string, commandUUID string, expectedName string) error
+type SetHostDeviceNameStatusFunc func(ctx context.Context, hostUUID string, status fleet.MDMDeliveryStatus, commandUUID *string, expectedName string, detail string) error
 
-type UpdateHostDeviceNameStatusFromCommandFunc func(ctx context.Context, commandUUID string, status fleet.MDMDeliveryStatus, detail string) (hostUUID string, expectedName string, err error)
+type UpdateHostDeviceNameStatusFromCommandFunc func(ctx context.Context, commandUUID string, acknowledged bool, detail string) error
 
-type VerifyHostDeviceNameFunc func(ctx context.Context, hostUUID string, reportedName string) error
+type UpdateHostDeviceNameStatusFromReportFunc func(ctx context.Context, hostUUID string, reportedName string) error
 
 type GetHostDeviceNameEnforcementFunc func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error)
 
@@ -3860,14 +3860,14 @@ type DataStore struct {
 	ListHostsPendingDeviceNameCommandFunc        ListHostsPendingDeviceNameCommandFunc
 	ListHostsPendingDeviceNameCommandFuncInvoked bool
 
-	SetHostDeviceNameCommandSentFunc        SetHostDeviceNameCommandSentFunc
-	SetHostDeviceNameCommandSentFuncInvoked bool
+	SetHostDeviceNameStatusFunc        SetHostDeviceNameStatusFunc
+	SetHostDeviceNameStatusFuncInvoked bool
 
 	UpdateHostDeviceNameStatusFromCommandFunc        UpdateHostDeviceNameStatusFromCommandFunc
 	UpdateHostDeviceNameStatusFromCommandFuncInvoked bool
 
-	VerifyHostDeviceNameFunc        VerifyHostDeviceNameFunc
-	VerifyHostDeviceNameFuncInvoked bool
+	UpdateHostDeviceNameStatusFromReportFunc        UpdateHostDeviceNameStatusFromReportFunc
+	UpdateHostDeviceNameStatusFromReportFuncInvoked bool
 
 	GetHostDeviceNameEnforcementFunc        GetHostDeviceNameEnforcementFunc
 	GetHostDeviceNameEnforcementFuncInvoked bool
@@ -9332,25 +9332,25 @@ func (s *DataStore) ListHostsPendingDeviceNameCommand(ctx context.Context, limit
 	return s.ListHostsPendingDeviceNameCommandFunc(ctx, limit)
 }
 
-func (s *DataStore) SetHostDeviceNameCommandSent(ctx context.Context, hostUUID string, commandUUID string, expectedName string) error {
+func (s *DataStore) SetHostDeviceNameStatus(ctx context.Context, hostUUID string, status fleet.MDMDeliveryStatus, commandUUID *string, expectedName string, detail string) error {
 	s.mu.Lock()
-	s.SetHostDeviceNameCommandSentFuncInvoked = true
+	s.SetHostDeviceNameStatusFuncInvoked = true
 	s.mu.Unlock()
-	return s.SetHostDeviceNameCommandSentFunc(ctx, hostUUID, commandUUID, expectedName)
+	return s.SetHostDeviceNameStatusFunc(ctx, hostUUID, status, commandUUID, expectedName, detail)
 }
 
-func (s *DataStore) UpdateHostDeviceNameStatusFromCommand(ctx context.Context, commandUUID string, status fleet.MDMDeliveryStatus, detail string) (hostUUID string, expectedName string, err error) {
+func (s *DataStore) UpdateHostDeviceNameStatusFromCommand(ctx context.Context, commandUUID string, acknowledged bool, detail string) error {
 	s.mu.Lock()
 	s.UpdateHostDeviceNameStatusFromCommandFuncInvoked = true
 	s.mu.Unlock()
-	return s.UpdateHostDeviceNameStatusFromCommandFunc(ctx, commandUUID, status, detail)
+	return s.UpdateHostDeviceNameStatusFromCommandFunc(ctx, commandUUID, acknowledged, detail)
 }
 
-func (s *DataStore) VerifyHostDeviceName(ctx context.Context, hostUUID string, reportedName string) error {
+func (s *DataStore) UpdateHostDeviceNameStatusFromReport(ctx context.Context, hostUUID string, reportedName string) error {
 	s.mu.Lock()
-	s.VerifyHostDeviceNameFuncInvoked = true
+	s.UpdateHostDeviceNameStatusFromReportFuncInvoked = true
 	s.mu.Unlock()
-	return s.VerifyHostDeviceNameFunc(ctx, hostUUID, reportedName)
+	return s.UpdateHostDeviceNameStatusFromReportFunc(ctx, hostUUID, reportedName)
 }
 
 func (s *DataStore) GetHostDeviceNameEnforcement(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {

--- a/server/service/apple_device_names.go
+++ b/server/service/apple_device_names.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/google/uuid"
+)
+
+// reconcileHostDeviceNamesBatchSize bounds how many queued rename rows a
+// single cron tick processes; remaining rows are picked up on subsequent
+// ticks, amortizing command delivery for large teams.
+//
+// var (not const) so tests can override it.
+var reconcileHostDeviceNamesBatchSize = 500
+
+// ReconcileHostDeviceNames runs one pass of host-name template enforcement:
+// for each host whose enforcement row is queued (status NULL), it resolves
+// the host's team name template and either enqueues a Settings/DeviceName
+// command or records the outcome directly (name already matching → verified;
+// resolved name unusable → failed).
+func ReconcileHostDeviceNames(
+	ctx context.Context,
+	ds fleet.Datastore,
+	commander *apple_mdm.MDMAppleCommander,
+	logger *slog.Logger,
+) error {
+	appConfig, err := ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "reading app config")
+	}
+	if !appConfig.MDM.EnabledAndConfigured {
+		return nil
+	}
+
+	pending, err := ds.ListHostsPendingDeviceNameCommand(ctx, reconcileHostDeviceNamesBatchSize)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list hosts pending device name command")
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	templates := make(map[uint]string) // team ID → name template
+	var notify []string                // hosts with a freshly-enqueued command to push
+	for _, host := range pending {
+		if host.TeamID == nil {
+			// Enforcement rows are only created for hosts on a team with a
+			// template; the host moved to "no team" between cron runs and its
+			// row is reconciled by the transfer path. Leave it queued.
+			continue
+		}
+		tmpl, ok := templates[*host.TeamID]
+		if !ok {
+			mdmConfig, err := ds.TeamMDMConfig(ctx, *host.TeamID)
+			if err != nil {
+				if fleet.IsNotFound(err) {
+					// team deleted between cron runs
+					templates[*host.TeamID] = ""
+					continue
+				}
+				return ctxerr.Wrap(ctx, err, "get team mdm config for device name")
+			}
+			tmpl = mdmConfig.HostNameTemplate
+			templates[*host.TeamID] = tmpl
+		}
+		if tmpl == "" {
+			// Template cleared between cron runs, or the team was deleted (cached
+			// as "" above). Either way the clear/delete path removes the rows, so
+			// there's nothing to enforce here.
+			continue
+		}
+
+		resolved := fleet.ResolveHostNameTemplate(tmpl, &fleet.Host{
+			UUID:           host.HostUUID,
+			HardwareSerial: host.HardwareSerial,
+			Platform:       host.Platform,
+		})
+		switch {
+		case len(resolved) > fleet.MaxResolvedHostNameBytes:
+			// The resolved name is not stored: it can exceed the column width,
+			// and failed rows are never compared against reported names.
+			if err := ds.SetHostDeviceNameStatus(ctx, host.HostUUID, fleet.MDMDeliveryFailed, nil, "",
+				"Resolved name exceeds 63 bytes."); err != nil {
+				return ctxerr.Wrap(ctx, err, "mark device name row failed for too-long name")
+			}
+			logger.InfoContext(ctx, "host name template resolves past the device name limit, not sending command",
+				"host_uuid", host.HostUUID, "resolved_bytes", len(resolved))
+		case resolved == host.ComputerName:
+			// The device already carries the resolved name; no command needed.
+			if err := ds.SetHostDeviceNameStatus(ctx, host.HostUUID, fleet.MDMDeliveryVerified, nil, resolved, ""); err != nil {
+				return ctxerr.Wrap(ctx, err, "mark device name row verified for matching name")
+			}
+		default:
+			cmdUUID := fleet.DeviceNameCommandUUIDPrefix + uuid.NewString()
+			if err := commander.DeviceNameSettingWithoutNotifications(ctx, host.HostUUID, cmdUUID, resolved); err != nil {
+				// The command was not persisted; leave the row queued so the
+				// next cron run retries this host, and move on so one bad
+				// host doesn't starve the rest of the batch.
+				logger.ErrorContext(ctx, "enqueue device name command", "host_uuid", host.HostUUID, "err", err)
+				continue
+			}
+			// The command is persisted; the device will apply it on its next
+			// check-in even if the batched push below never reaches it. Collect
+			// the UUID so every device in this batch is woken with a single APNs
+			// push instead of one request per host.
+			notify = append(notify, host.HostUUID)
+			if err := ds.SetHostDeviceNameStatus(ctx, host.HostUUID, fleet.MDMDeliveryPending, &cmdUUID, resolved, ""); err != nil {
+				// The command was sent but recording it failed; log and move on
+				// rather than aborting the batch, consistent with the
+				// enqueue-failure handling above. The row stays queued and a
+				// later cron run re-sends; the device resolves to the latest
+				// command, and the superseded one's result is dropped as stale.
+				logger.ErrorContext(ctx, "mark device name command sent", "host_uuid", host.HostUUID, "command_uuid", cmdUUID, "err", err)
+				continue
+			}
+		}
+	}
+
+	if len(notify) > 0 {
+		// One batched push wakes every device whose command was just enqueued.
+		// Same handling as the iOS/iPadOS revive cron: a per-device APNs failure
+		// is tolerable (the command is already persisted, so the device applies
+		// it on its next check-in) so it's logged and the run succeeds — retrying
+		// would enqueue duplicates. Any other error means the push subsystem
+		// itself failed, so surface it.
+		if err := commander.SendNotifications(ctx, notify); err != nil {
+			var apnsErr *apple_mdm.APNSDeliveryError
+			if !errors.As(err, &apnsErr) {
+				return ctxerr.Wrap(ctx, err, "push device name commands")
+			}
+			logger.InfoContext(ctx, "failed to push device name command to some hosts", "err", apnsErr.Error())
+		}
+	}
+	return nil
+}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4170,6 +4170,14 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 		return svc.handleRefetch(r, cmdResult)
 	}
 
+	// Results of the Settings/DeviceName command that enforces a team's host
+	// name template are routed by their UUID prefix rather than a "Settings"
+	// request-type case: other features may send Settings commands carrying
+	// different items, so the prefix scopes handling to renames.
+	if strings.HasPrefix(cmdResult.CommandUUID, fleet.DeviceNameCommandUUIDPrefix) {
+		return nil, svc.handleDeviceNameCommandResult(r.Context, cmdResult)
+	}
+
 	// We explicitly get the request type because it comes empty. There's a
 	// RequestType field in the struct, but it's used when a mdm.Command is
 	// issued.
@@ -5272,6 +5280,78 @@ func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEPro
 	return nil
 }
 
+// handleDeviceNameCommandResult processes the result of a Settings/DeviceName
+// command sent to enforce a team's host name template. On acknowledgment the
+// host is renamed in Fleet right away — the device just applied the name, so
+// the next osquery/DeviceInformation ingest confirms the rename (verifying →
+// verified) instead of reverting an optimistic early write. On error the
+// enforcement row lands failed with Apple's error chain; the cron only picks
+// up queued rows, so a failed command is not retried until an admin resends.
+func (svc *MDMAppleCheckinAndCommandService) handleDeviceNameCommandResult(ctx context.Context, cmdResult *mdm.CommandResults) error {
+	status := cmdResult.Status
+	detail := ""
+	switch status {
+	case fleet.MDMAppleStatusAcknowledged:
+		// A Settings command can report per-item failures inside an
+		// acknowledged result; this command carries a single DeviceName item,
+		// so any item-level error means the rename failed.
+		if itemDetail, itemFailed := deviceNameSettingsItemError(ctx, svc.logger, cmdResult.Raw); itemFailed {
+			status = fleet.MDMAppleStatusError
+			detail = itemDetail
+		}
+	case fleet.MDMAppleStatusError, fleet.MDMAppleStatusCommandFormatError:
+		detail = apple_mdm.FmtErrorChain(cmdResult.ErrorChain)
+	default:
+		// Idle/NotNow — the command hasn't completed yet; nothing to record.
+		return nil
+	}
+
+	if status == fleet.MDMAppleStatusAcknowledged {
+		// On acknowledgment the datastore moves the row to verifying and renames
+		// the host in Fleet in the same transaction. A not-found means the row
+		// tracks a newer command (template re-saved or resend clicked before this
+		// result arrived); this result is stale and the newer command's result
+		// carries the final name, so it's ignored.
+		if err := svc.ds.UpdateHostDeviceNameStatusFromCommand(ctx, cmdResult.CommandUUID, true, ""); err != nil && !fleet.IsNotFound(err) {
+			return ctxerr.Wrap(ctx, err, "update device name row from acknowledged command")
+		}
+		return nil
+	}
+
+	if err := svc.ds.UpdateHostDeviceNameStatusFromCommand(ctx, cmdResult.CommandUUID, false, detail); err != nil && !fleet.IsNotFound(err) {
+		return ctxerr.Wrap(ctx, err, "update device name row from failed command")
+	}
+	return nil
+}
+
+// deviceNameSettingsItemError inspects a Settings command acknowledgment for
+// per-item statuses: each item in the Settings array of the response can
+// individually report an Error even when the overall command is Acknowledged.
+// It returns a human-readable detail and true when any item failed.
+func deviceNameSettingsItemError(ctx context.Context, logger *slog.Logger, raw []byte) (string, bool) {
+	var ack struct {
+		Settings []struct {
+			Status     string           `plist:"Status"`
+			ErrorChain []mdm.ErrorChain `plist:"ErrorChain"`
+		} `plist:"Settings"`
+	}
+	if err := plist.Unmarshal(raw, &ack); err != nil {
+		// A malformed per-item array shouldn't fail the acknowledged command.
+		logger.WarnContext(ctx, "unmarshal Settings command acknowledgment for per-item statuses", "err", err)
+		return "", false
+	}
+	for _, item := range ack.Settings {
+		if item.Status != "" && item.Status != fleet.MDMAppleStatusAcknowledged {
+			detail := apple_mdm.FmtErrorChain(item.ErrorChain)
+			if detail == "" {
+				detail = "Settings item returned status " + item.Status + "."
+			}
+			return detail, true
+		}
+	}
+	return "", false
+}
+
 func (svc *MDMAppleCheckinAndCommandService) handleRefetchDeviceResults(ctx context.Context, host *fleet.Host, cmdResult *mdm.CommandResults) (*mdm.Command, error) {
 	if !strings.HasPrefix(cmdResult.CommandUUID, fleet.RefetchDeviceCommandUUIDPrefix) {
 		// Caller should have checked this, but just in case we'll return an error.
@@ -5395,6 +5475,16 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchDeviceResults(ctx cont
 	if err := svc.ds.UpdateHost(ctx, host); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "failed to update host")
 	}
+
+	if deviceNameOK && fleet.IsAppleMobilePlatform(host.Platform) {
+		// Reconcile the host-name enforcement row (if any) against the name the
+		// device reported: confirms a rename (verifying → verified) or records
+		// drift (verified → failed). No-op for hosts without a row.
+		if err := svc.ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, deviceName); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "update host device name status from refetch")
+		}
+	}
+
 	// Skip the disk space update when either capacity field is missing/invalid,
 	// since the percent-available calculation divides by deviceCapacity.
 	if deviceCapacityOK && availableDeviceCapacityOK && deviceCapacity > 0 {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -5452,6 +5452,11 @@ func TestMDMCommandAndReportResultsIOSIPadOSRefetch(t *testing.T) {
 		require.Equal(t, commandUUID, currentCommandUUID)
 		return nil
 	}
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
+		require.Equal(t, hostUUID, incomingHostUUID)
+		require.Equal(t, "Work iPad", reportedName)
+		return nil
+	}
 
 	_, err := svc.CommandAndReportResults(
 		&mdm.Request{Context: ctx},
@@ -5572,6 +5577,9 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersion(t *testing.T)
 		return nil
 	}
 	ds.CleanupStaleNanoRefetchCommandsFunc = func(ctx context.Context, enrollmentID string, commandUUIDPrefix string, currentCommandUUID string) error {
+		return nil
+	}
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
 		return nil
 	}
 
@@ -5834,6 +5842,9 @@ func TestMDMCommandAndReportResultsIOSIPadOSRefetchDefensive(t *testing.T) {
 			ds.CleanupStaleNanoRefetchCommandsFunc = func(ctx context.Context, enrollmentID string, commandUUIDPrefix string, currentCommandUUID string) error {
 				return nil
 			}
+			ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
+				return nil
+			}
 
 			ds.UpdateHostFunc = func(ctx context.Context, host *fleet.Host) error {
 				assert.Equal(t, tc.expect.expectComputerName, host.ComputerName, "ComputerName")
@@ -5918,6 +5929,9 @@ func TestMDMCommandAndReportResultsIOSRefetchMissingProductNameIPhone(t *testing
 	ds.CleanupStaleNanoRefetchCommandsFunc = func(ctx context.Context, enrollmentID, commandUUIDPrefix, currentCommandUUID string) error {
 		return nil
 	}
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
+		return nil
+	}
 
 	var updatedHost *fleet.Host
 	ds.UpdateHostFunc = func(ctx context.Context, host *fleet.Host) error {
@@ -5985,6 +5999,123 @@ func TestMDMCommandAndReportResultsIOSRefetchMissingProductNameIPhone(t *testing
 	assert.Equal(t, "ios", updatedOS.Platform)
 }
 
+func TestHandleDeviceNameCommandResult(t *testing.T) {
+	cmdUUID := fleet.DeviceNameCommandUUIDPrefix + "cmd-1"
+
+	// settingsAck builds a Settings command acknowledgment whose single item
+	// carries the given per-item status and (optional) error chain.
+	settingsAck := func(itemStatus string, chain []mdm.ErrorChain) []byte {
+		var errChainXML string
+		for _, e := range chain {
+			errChainXML += fmt.Sprintf(`<dict>
+				<key>ErrorCode</key><integer>%d</integer>
+				<key>ErrorDomain</key><string>%s</string>
+				<key>USEnglishDescription</key><string>%s</string>
+			</dict>`, e.ErrorCode, e.ErrorDomain, e.USEnglishDescription)
+		}
+		itemErrChain := ""
+		if errChainXML != "" {
+			itemErrChain = "<key>ErrorChain</key><array>" + errChainXML + "</array>"
+		}
+		return []byte(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+	<key>CommandUUID</key><string>%s</string>
+	<key>Status</key><string>Acknowledged</string>
+	<key>Settings</key>
+	<array><dict><key>Item</key><string>DeviceName</string><key>Status</key><string>%s</string>%s</dict></array>
+</dict></plist>`, cmdUUID, itemStatus, itemErrChain))
+	}
+
+	cases := []struct {
+		name         string
+		status       string
+		raw          []byte
+		errorChain   []mdm.ErrorChain
+		notFound     bool // UpdateHostDeviceNameStatusFromCommand returns not-found (stale)
+		wantStatus   fleet.MDMDeliveryStatus
+		wantDetail   string
+		wantNoUpdate bool
+	}{
+		{
+			name:       "acknowledged clean renames and verifies",
+			status:     fleet.MDMAppleStatusAcknowledged,
+			raw:        settingsAck(fleet.MDMAppleStatusAcknowledged, nil),
+			wantStatus: fleet.MDMDeliveryVerifying,
+		},
+		{
+			name:   "acknowledged with per-item Settings error fails",
+			status: fleet.MDMAppleStatusAcknowledged,
+			raw: settingsAck("Error", []mdm.ErrorChain{
+				{ErrorCode: 12026, ErrorDomain: "MCMDMErrorDomain", USEnglishDescription: "The device is not supervised."},
+			}),
+			wantStatus: fleet.MDMDeliveryFailed,
+			wantDetail: "The device is not supervised.",
+		},
+		{
+			name:       "command error fails with the apple error chain",
+			status:     fleet.MDMAppleStatusError,
+			errorChain: []mdm.ErrorChain{{ErrorCode: 99, ErrorDomain: "MCMDMErrorDomain", USEnglishDescription: "boom"}},
+			wantStatus: fleet.MDMDeliveryFailed,
+			wantDetail: "boom",
+		},
+		{
+			name:         "stale result for a superseded command is ignored",
+			status:       fleet.MDMAppleStatusAcknowledged,
+			raw:          settingsAck(fleet.MDMAppleStatusAcknowledged, nil),
+			notFound:     true,
+			wantNoUpdate: true,
+		},
+		{
+			name:         "not-now is a no-op",
+			status:       fleet.MDMAppleStatusNotNow,
+			wantNoUpdate: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			svc := MDMAppleCheckinAndCommandService{ds: ds, logger: slog.New(slog.DiscardHandler)}
+
+			var gotAcknowledged bool
+			var gotDetail string
+			ds.UpdateHostDeviceNameStatusFromCommandFunc = func(ctx context.Context, commandUUID string, acknowledged bool, detail string) error {
+				require.Equal(t, cmdUUID, commandUUID)
+				gotAcknowledged, gotDetail = acknowledged, detail
+				if tc.notFound {
+					return &notFoundError{}
+				}
+				return nil
+			}
+
+			err := svc.handleDeviceNameCommandResult(t.Context(), &mdm.CommandResults{
+				CommandUUID: cmdUUID,
+				Status:      tc.status,
+				ErrorChain:  tc.errorChain,
+				Raw:         tc.raw,
+			})
+			require.NoError(t, err)
+
+			if tc.wantNoUpdate {
+				if tc.notFound {
+					// the update was attempted but returned not-found; no rename
+					require.True(t, ds.UpdateHostDeviceNameStatusFromCommandFuncInvoked)
+				} else {
+					require.False(t, ds.UpdateHostDeviceNameStatusFromCommandFuncInvoked)
+				}
+				return
+			}
+
+			require.True(t, ds.UpdateHostDeviceNameStatusFromCommandFuncInvoked)
+			// The datastore now receives a bool: verifying == acknowledged.
+			require.Equal(t, tc.wantStatus == fleet.MDMDeliveryVerifying, gotAcknowledged)
+			if tc.wantDetail != "" {
+				require.Contains(t, gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
 func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersionNonString(t *testing.T) {
 	ctx := context.Background()
 	hostID := uint(99)
@@ -6016,6 +6147,9 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersionNonString(t *t
 		return nil
 	}
 	ds.CleanupStaleNanoRefetchCommandsFunc = func(ctx context.Context, enrollmentID string, commandUUIDPrefix string, currentCommandUUID string) error {
+		return nil
+	}
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
 		return nil
 	}
 
@@ -6093,6 +6227,9 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersionFallbackTrunca
 		return nil
 	}
 	ds.CleanupStaleNanoRefetchCommandsFunc = func(ctx context.Context, enrollmentID string, commandUUIDPrefix string, currentCommandUUID string) error {
+		return nil
+	}
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
 		return nil
 	}
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -25307,3 +25307,300 @@ func (s *integrationMDMTestSuite) TestErrorOnEnrollmentInstallProfileProducesAct
 	require.NoError(t, apple_mdm.HandleHostMDMProfileInstallResult(ctx, s.ds, host.UUID, case4RenewCmd, &verifying, "", s.fleetSvc.NewActivity))
 	require.Zero(t, countRenewalActivitiesForCmd(case4RenewCmd))
 }
+
+func (s *integrationMDMTestSuite) TestHostNameTemplateEndToEnd() {
+	t := s.T()
+	ctx := t.Context()
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	setFleetMDMData := func(hostID uint, personal bool) {
+		require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, hostID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, "", personal))
+	}
+
+	// A macOS host that walks the whole pipeline: command, ack, osquery verify, drift.
+	macHost, macDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(macHost.ID, false)
+
+	// A macOS host whose name already matches the resolved template: verified
+	// directly, no command.
+	matchingHost, matchingDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(matchingHost.ID, false)
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE hosts SET computer_name = ? WHERE id = ?`, "WS-"+matchingHost.HardwareSerial, matchingHost.ID)
+		return err
+	})
+
+	// An iOS host that acks the rename and later verifies through the
+	// DeviceInformation refetch path.
+	iosHost, iosDevice := s.createAppleMobileHostThenEnrollMDM("ios")
+	setFleetMDMData(iosHost.ID, false)
+
+	// An iOS host whose device rejects the command (e.g. unsupervised).
+	iosFailHost, iosFailDevice := s.createAppleMobileHostThenEnrollMDM("ios")
+	setFleetMDMData(iosFailHost.ID, false)
+
+	// A BYOD (personal enrollment) host: never enforced.
+	byodHost, _ := s.createAppleMobileHostThenEnrollMDM("ios")
+	setFleetMDMData(byodHost.ID, true)
+
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID,
+		[]uint{macHost.ID, matchingHost.ID, iosHost.ID, iosFailHost.ID, byodHost.ID})))
+
+	requireRowStatus := func(hostUUID string, want *fleet.MDMDeliveryStatus) *fleet.HostDeviceNameEnforcement {
+		row, err := s.ds.GetHostDeviceNameEnforcement(ctx, hostUUID)
+		require.NoError(t, err)
+		if want == nil {
+			require.Nil(t, row.Status)
+		} else {
+			require.NotNil(t, row.Status)
+			require.Equal(t, *want, *row.Status)
+		}
+		return row
+	}
+	requireNoRow := func(hostUUID string) {
+		_, err := s.ds.GetHostDeviceNameEnforcement(ctx, hostUUID)
+		require.True(t, fleet.IsNotFound(err))
+	}
+	runDeviceNameCron := func() {
+		require.NoError(t, ReconcileHostDeviceNames(ctx, s.ds, s.mdmCommander, s.logger))
+	}
+
+	// --- endpoint validation ---
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{HostNameTemplate: "WS-1"}, http.StatusUnprocessableEntity)
+	res := s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"}, http.StatusUnprocessableEntity)
+	require.Contains(t, extractServerErrorText(res.Body), "not supported in host name templates")
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-$FLEET_SECRET_TOKEN"}, http.StatusUnprocessableEntity)
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-\x07"}, http.StatusUnprocessableEntity)
+	// fixed text alone longer than the 63-byte device-name limit is rejected up front
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: strings.Repeat("N", 64)}, http.StatusUnprocessableEntity)
+	// nothing was created or logged by the failed attempts
+	requireNoRow(macHost.UUID)
+
+	// --- set the template ---
+	const tmpl = "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL"
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: tmpl}, http.StatusNoContent)
+	activityID := s.lastActivityMatches("edited_host_name_template",
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "name_template": %q}`, team.ID, team.Name, tmpl), 0)
+
+	// eligible hosts are queued; the BYOD host has no row
+	requireRowStatus(macHost.UUID, nil)
+	requireRowStatus(matchingHost.UUID, nil)
+	requireRowStatus(iosHost.UUID, nil)
+	requireRowStatus(iosFailHost.UUID, nil)
+	requireNoRow(byodHost.UUID)
+
+	// re-saving the identical template emits no duplicate activity
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: tmpl}, http.StatusNoContent)
+	s.lastActivityMatches("edited_host_name_template", "", activityID)
+
+	// --- cron: resolve + enqueue ---
+	runDeviceNameCron()
+
+	// the already-matching host goes straight to verified, and its device got no command
+	matchingRow := requireRowStatus(matchingHost.UUID, &fleet.MDMDeliveryVerified)
+	require.NotNil(t, matchingRow.ExpectedDeviceName)
+	require.Equal(t, "WS-"+matchingHost.HardwareSerial, *matchingRow.ExpectedDeviceName)
+	cmd, err := matchingDevice.Idle()
+	require.NoError(t, err)
+	require.Nil(t, cmd)
+
+	// the other eligible hosts are pending on a DEVNAME- command with the resolved name
+	macRow := requireRowStatus(macHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, macRow.CommandUUID)
+	require.True(t, strings.HasPrefix(*macRow.CommandUUID, fleet.DeviceNameCommandUUIDPrefix))
+	require.NotNil(t, macRow.ExpectedDeviceName)
+	require.Equal(t, "WS-"+macHost.HardwareSerial, *macRow.ExpectedDeviceName)
+
+	// --- mac: device receives the Settings command and acknowledges ---
+	cmd, err = macDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "Settings", cmd.Command.RequestType)
+	require.Equal(t, *macRow.CommandUUID, cmd.CommandUUID)
+	var settingsCmd struct {
+		Command struct {
+			Settings []struct {
+				Item       string
+				DeviceName string
+			}
+		}
+	}
+	require.NoError(t, plist.Unmarshal(cmd.Raw, &settingsCmd))
+	require.Len(t, settingsCmd.Command.Settings, 1)
+	require.Equal(t, "DeviceName", settingsCmd.Command.Settings[0].Item)
+	require.Equal(t, "WS-"+macHost.HardwareSerial, settingsCmd.Command.Settings[0].DeviceName)
+
+	_, err = macDevice.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+
+	// the ack renamed the host in Fleet and moved the row to verifying
+	requireRowStatus(macHost.UUID, &fleet.MDMDeliveryVerifying)
+	renamedMac, err := s.ds.Host(ctx, macHost.ID)
+	require.NoError(t, err)
+	require.Equal(t, "WS-"+macHost.HardwareSerial, renamedMac.ComputerName)
+	require.Equal(t, "WS-"+macHost.HardwareSerial, renamedMac.Hostname)
+	require.Equal(t, "WS-"+macHost.HardwareSerial, renamedMac.DisplayName())
+
+	// --- mac: osquery reports the matching name -> verified ---
+	submitSystemInfo := func(computerName string) {
+		distributedReq := SubmitDistributedQueryResultsRequest{
+			NodeKey: *macHost.NodeKey,
+			Results: map[string][]map[string]string{
+				"fleet_detail_query_system_info": {
+					{
+						"computer_name":      computerName,
+						"hostname":           computerName,
+						"uuid":               macHost.UUID,
+						"hardware_serial":    macHost.HardwareSerial,
+						"hardware_model":     "MacBookPro16,1",
+						"physical_memory":    "16000000000",
+						"cpu_physical_cores": "8",
+						"cpu_logical_cores":  "8",
+					},
+				},
+			},
+			Statuses: map[string]fleet.OsqueryStatus{
+				"fleet_detail_query_system_info": 0,
+			},
+		}
+		distributedResp := submitDistributedQueryResultsResponse{}
+		s.DoJSON("POST", "/api/osquery/distributed/write", distributedReq, http.StatusOK, &distributedResp)
+	}
+
+	// a report that was generated before the device applied the rename (still
+	// carrying the old name) arriving right after the ack is not drift: the row
+	// stays verifying until a fresh report decides it
+	submitSystemInfo("stale-pre-rename-name")
+	requireRowStatus(macHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	submitSystemInfo("WS-" + macHost.HardwareSerial)
+	requireRowStatus(macHost.UUID, &fleet.MDMDeliveryVerified)
+
+	// --- mac: the end user renames the device -> drift -> failed ---
+	submitSystemInfo("Renamed by user")
+	driftedRow := requireRowStatus(macHost.UUID, &fleet.MDMDeliveryFailed)
+	require.Contains(t, driftedRow.Detail, "renamed on the device")
+
+	// --- iOS: ack then verify through the DeviceInformation refetch path ---
+	cmd, err = iosDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "Settings", cmd.Command.RequestType)
+	_, err = iosDevice.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+	requireRowStatus(iosHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/refetch", iosHost.ID), nil, http.StatusOK)
+	cmd, err = iosDevice.Idle()
+	require.NoError(t, err)
+	for cmd != nil {
+		switch cmd.Command.RequestType {
+		case "InstalledApplicationList":
+			cmd, err = iosDevice.AcknowledgeInstalledApplicationList(iosDevice.UUID, cmd.CommandUUID, nil)
+		case "CertificateList":
+			cmd, err = iosDevice.AcknowledgeCertificateList(iosDevice.UUID, cmd.CommandUUID, nil)
+		case "DeviceInformation":
+			cmd, err = iosDevice.AcknowledgeDeviceInformation(iosDevice.UUID, cmd.CommandUUID,
+				"WS-"+iosHost.HardwareSerial, "iPhone14,6", "America/Los_Angeles")
+		default:
+			cmd, err = iosDevice.Acknowledge(cmd.CommandUUID)
+		}
+		require.NoError(t, err)
+	}
+	requireRowStatus(iosHost.UUID, &fleet.MDMDeliveryVerified)
+
+	// --- iOS failure: the device errors the command (e.g. unsupervised) ---
+	cmd, err = iosFailDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "Settings", cmd.Command.RequestType)
+	_, err = iosFailDevice.Err(cmd.CommandUUID, []mdm.ErrorChain{
+		{ErrorCode: 12026, ErrorDomain: "MCMDMErrorDomain", USEnglishDescription: "The device is not supervised."},
+	})
+	require.NoError(t, err)
+	failedRow := requireRowStatus(iosFailHost.UUID, &fleet.MDMDeliveryFailed)
+	require.Contains(t, failedRow.Detail, "The device is not supervised.")
+
+	// a failed command is not re-sent by subsequent cron runs
+	runDeviceNameCron()
+	requireRowStatus(iosFailHost.UUID, &fleet.MDMDeliveryFailed)
+	cmd, err = iosFailDevice.Idle()
+	require.NoError(t, err)
+	require.Nil(t, cmd)
+
+	// --- a template resolving past 63 bytes fails without sending a command ---
+	// The fixed text (50 bytes) passes save-time validation, but expanding the
+	// UUID (36 chars) pushes the resolved name over the 63-byte limit — that
+	// per-host overflow is only detectable at resolve time, by the cron.
+	longTemplate := strings.Repeat("N", 50) + "$FLEET_VAR_HOST_UUID"
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: longTemplate}, http.StatusNoContent)
+	requireRowStatus(macHost.UUID, nil) // rows re-queued by the new template
+	runDeviceNameCron()
+	longRow := requireRowStatus(macHost.UUID, &fleet.MDMDeliveryFailed)
+	require.Equal(t, "Resolved name exceeds 63 bytes.", longRow.Detail)
+	cmd, err = macDevice.Idle()
+	require.NoError(t, err)
+	require.Nil(t, cmd)
+
+	// --- an APNs push failure doesn't lose or duplicate the command ---
+	// re-save the resolvable template to queue rows again
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: tmpl}, http.StatusNoContent)
+	originalPushMock := s.pushProvider.PushFunc
+	// Restore via defer so a failed assertion below can't leak the failing push
+	// mock into later tests. Nothing after this in the test pushes (the second
+	// cron run has no pending rows; Idle/Acknowledge are device-driven), so
+	// keeping the mock active until the test ends is harmless.
+	defer func() { s.pushProvider.PushFunc = originalPushMock }()
+	s.pushProvider.PushFunc = func(_ context.Context, pushes []*mdm.Push) (map[string]*push.Response, error) {
+		res := make(map[string]*push.Response, len(pushes))
+		for _, p := range pushes {
+			res[p.Token.String()] = &push.Response{Id: uuid.New().String(), Err: errors.New("APNs is down")}
+		}
+		return res, nil
+	}
+	runDeviceNameCron()
+
+	// the command was persisted despite the failed push, so the row is pending
+	// on it and a later cron run does not enqueue a duplicate
+	apnsRow := requireRowStatus(macHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, apnsRow.CommandUUID)
+	runDeviceNameCron()
+	afterRetry := requireRowStatus(macHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, afterRetry.CommandUUID)
+	require.Equal(t, *apnsRow.CommandUUID, *afterRetry.CommandUUID)
+
+	// the device still receives that single command on its next check-in
+	cmd, err = macDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "Settings", cmd.Command.RequestType)
+	require.Equal(t, *apnsRow.CommandUUID, cmd.CommandUUID)
+	cmd, err = macDevice.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+	require.Nil(t, cmd)
+	requireRowStatus(macHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	// --- clearing deletes all rows and never renames ---
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: ""}, http.StatusNoContent)
+	s.lastActivityMatches("edited_host_name_template",
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "name_template": null}`, team.ID, team.Name), 0)
+	for _, h := range []*fleet.Host{macHost, matchingHost, iosHost, iosFailHost} {
+		requireNoRow(h.UUID)
+	}
+	// the host keeps the last name it was given; clearing renames nothing
+	unchangedMac, err := s.ds.Host(ctx, macHost.ID)
+	require.NoError(t, err)
+	require.Equal(t, "WS-"+macHost.HardwareSerial, unchangedMac.ComputerName)
+}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1405,6 +1405,12 @@ func (svc *Service) SubmitDistributedQueryResults(
 		}
 	}
 
+	if detailUpdated && ac.MDM.EnabledAndConfigured && host.Platform == "darwin" && host.ComputerName != "" {
+		if err := svc.ds.UpdateHostDeviceNameStatusFromReport(ctx, host.UUID, host.ComputerName); err != nil {
+			logging.WithErr(ctx, err)
+		}
+	}
+
 	if host.DiskEncryptionKeyEscrowed {
 		if err := svc.NewActivity(
 			ctx,

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1729,6 +1729,9 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	}
 	ctx = hostctx.NewContext(ctx, host)
 
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, hostUUID, reportedName string) error {
+		return nil
+	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{Features: fleet.Features{
 			EnableHostUsers:         true,
@@ -1931,6 +1934,9 @@ func TestDetailQueries(t *testing.T) {
 
 	lq.On("QueriesForHost", host.ID).Return(map[string]string{}, nil)
 
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, hostUUID, reportedName string) error {
+		return nil
+	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{Features: fleet.Features{
 			EnableHostUsers:         true,


### PR DESCRIPTION
Relates to #48623

Adds the mdm_apple_profile_manager cron step that resolves each queued host's name template and enqueues the Settings/DeviceName command, the DEVNAME- command-result handler, and independent verification with drift detection at both name-ingestion sites (iOS/iPadOS DeviceInformation refetch and macOS osquery detail ingest). Mismatching reports arriving shortly after an acknowledgment are treated as stale pre-rename reports rather than drift.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated host device-name reconciliation for Apple-enrolled devices, including scheduled checks and end-to-end handling of name updates.
  * Improved support for device-name templates across Mac and iPhone/iPad enrollments, with clearer status tracking during updates.

* **Bug Fixes**
  * Reduced false drift reports during recent renames.
  * Improved handling for long or invalid device names and stale command results.
  * Made retries more reliable when device commands fail or are delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->