### PR TITLE
Fix custom packages download button

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.stories.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta<typeof LibraryItemAccordion> = {
     failedPath: statusPath("failed"),
     hashSha256:
       "af001543fcc5fbf484203b207d8af4fce44fc6975ca3db0eac49a49581af29b7",
-    downloadUrl: "https://example.com/installer.pkg",
+    canDownload: true,
   },
   decorators: [
     (Story) => (
@@ -118,7 +118,7 @@ export const Inactive: Story = {
 /** Active row, user lacks edit permission. The label-count badge demotes to a
  * static span (no button + no click handler), the expanded-panel labels list
  * renders as plain text rather than a CustomLink, and the trash button is
- * hidden entirely. The download button stays (gated only by `downloadUrl`). */
+ * hidden entirely. The download button stays (gated only by `canDownload`). */
 export const ActiveCannotEditSoftware: Story = {
   args: {
     canEditSoftware: false,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
@@ -40,7 +40,7 @@ const baseProps: ILibraryItemAccordionProps = {
   failedPath: statusPath("failed"),
   hashSha256:
     "af001543fcc5fbf484203b207d8af4fce44fc6975ca3db0eac49a49581af29b7",
-  downloadUrl: "https://example.com/installer.pkg",
+  canDownload: true,
 };
 
 const makeLabels = (count: number): ILabelSoftwareTitle[] =>
@@ -362,8 +362,8 @@ describe("LibraryItemAccordion", () => {
       expect(onDownloadClick).toHaveBeenCalledTimes(1);
     });
 
-    it("is omitted when downloadUrl is not provided", async () => {
-      const { user } = renderAccordion({ downloadUrl: undefined });
+    it("is omitted when canDownload is false", async () => {
+      const { user } = renderAccordion({ canDownload: false });
 
       await user.click(screen.getByRole("button", { expanded: false }));
       expect(
@@ -381,7 +381,7 @@ describe("LibraryItemAccordion", () => {
       expect(
         screen.queryByRole("button", { name: "Delete this version" })
       ).not.toBeInTheDocument();
-      // Download stays — gated only by `downloadUrl`, not edit permission.
+      // Download stays — gated only by `canDownload`, not edit permission.
       expect(
         screen.getByRole("button", { name: "Download installer" })
       ).toBeVisible();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -86,11 +86,10 @@ export interface ILibraryItemAccordionProps {
   failedPath: string;
 
   hashSha256?: string | null;
-  /** Show the download button. True for any package backed by a stored
-   * installer file (custom packages, tarballs, FMAs); false for script-only
-   * packages (no file to download) and App Store / Play Store apps. The
-   * download itself is driven by `onDownloadClick`, which mints a one-shot
-   * token server-side — this flag only gates the button's visibility. */
+  /** Show the download button for this row. This should be true only when
+   * `onDownloadClick` is wired to download the installer represented by this
+   * row (typically the active installer). False for script-only packages (no
+   * file to download) and App Store / Play Store apps. */
   canDownload?: boolean;
 
   /** Click handler for whichever badge is rendered per `badgeState`. The

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -86,7 +86,12 @@ export interface ILibraryItemAccordionProps {
   failedPath: string;
 
   hashSha256?: string | null;
-  downloadUrl?: string;
+  /** Show the download button. True for any package backed by a stored
+   * installer file (custom packages, tarballs, FMAs); false for script-only
+   * packages (no file to download) and App Store / Play Store apps. The
+   * download itself is driven by `onDownloadClick`, which mints a one-shot
+   * token server-side — this flag only gates the button's visibility. */
+  canDownload?: boolean;
 
   /** Click handler for whichever badge is rendered per `badgeState`. The
    * consumer can branch on `badgeState` inside the callback if it needs to
@@ -126,7 +131,7 @@ const LibraryItemAccordion = ({
   pendingPath,
   failedPath,
   hashSha256,
-  downloadUrl,
+  canDownload,
   onBadgeClick,
   onLabelCountClick,
   onLabelsClick,
@@ -596,7 +601,7 @@ const LibraryItemAccordion = ({
           </div>
 
           <div className={`${baseClass}__actions-column`}>
-            {downloadUrl && (
+            {canDownload && (
               <Button
                 variant="icon"
                 onClick={onDownloadClick}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordionList.stories.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordionList.stories.tsx
@@ -247,7 +247,7 @@ export const PinnedToMajorVersion: Story = {
           pending={5}
           failed={3}
           hashSha256="af001543fcc5fbf484203b207d8af4fce44fc6975ca3db0eac49a49581af29b7"
-          downloadUrl="https://example.com/chrome-149.0.7827.54.pkg"
+          canDownload
         />
         <StoryRow
           filename="Google Chrome"
@@ -324,7 +324,7 @@ export const MacCustomPackageMultipleVersions: Story = {
           pending={3}
           failed={1}
           hashSha256="b9d3a9d6c1e9442f9c0bb56af4f37b87f0bcb6df7f8db5a30e1bdce20c40a8d3"
-          downloadUrl="https://example.com/acme-helper-2.4.0.pkg"
+          canDownload
         />
         <StoryRow
           filename="AcmeHelper.pkg"
@@ -369,7 +369,7 @@ export const WindowsCustomPackageMultipleVersions: Story = {
           pending={4}
           failed={2}
           hashSha256="2e8a4f3b9c1d5e7a8b6c2f0d1e3a5b7c9d2e4f6a8b0c1d3e5f7a9b1c3d5e7f9a"
-          downloadUrl="https://example.com/npp-8.6.9.msi"
+          canDownload
         />
         <StoryRow
           filename="NotepadPlusPlus.msi"
@@ -419,7 +419,7 @@ export const WindowsMixedCustomAndFma: Story = {
           pending={6}
           failed={2}
           hashSha256="9f2c4e6a8b0d1f3e5a7c9b1d3f5e7a9c1b3d5f7e9a1c3b5d7f9e1a3c5b7d9f1e"
-          downloadUrl="https://example.com/firefox-131.0.3.msi"
+          canDownload
         />
         <StoryRow
           filename="Mozilla Firefox"
@@ -478,7 +478,7 @@ export const MacOSMixedCustomAndFma: Story = {
           pending={4}
           failed={2}
           hashSha256="d4e7a1c3b5f9e1a3c5b7d9f1e3a5c7b9d1f3e5a7c9b1d3f5e7a9c1b3d5f7e9a1"
-          downloadUrl="https://example.com/slack-4.39.95.pkg"
+          canDownload
         />
         <StoryRow
           filename="Slack"
@@ -560,7 +560,7 @@ export const IOSInHouseIpaMultipleVersions: Story = {
           pending={2}
           failed={1}
           hashSha256="6b1d3a5c7e9f0b2d4a6c8e1f3b5d7a9c0e2f4b6d8a0c1e3f5b7d9a1c3e5f7b9d"
-          downloadUrl="https://example.com/acme-warehouse-5.2.1.ipa"
+          canDownload
         />
         <StoryRow
           filename="AcmeWarehouse.ipa"

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -320,7 +320,7 @@ const SoftwareTitleDetailsPage = ({
               pendingPath={statusPath("pending")}
               failedPath={statusPath("failed")}
               hashSha256={row.isActive ? pkg.hash_sha256 ?? null : null}
-              downloadUrl={row.isActive ? pkg.url : undefined}
+              canDownload={row.isActive && !isScriptPackage}
               onBadgeClick={
                 isFma && canEditSoftware
                   ? () => setShowVersionsModal(true)


### PR DESCRIPTION
**Related issue:** Resolves #48418

  Fixes the missing download button for custom software packages on the software details page by gating the button on whether the package has a downloadable installer file, rather than on the package's source URL (which is empty for directly-uploaded custom packages).

  # Checklist for submitter

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually

<img width="1400" height="1000" alt="FIXED-custom-package-receipts" src="https://github.com/user-attachments/assets/7be76a27-3f2f-463e-8cdd-481e6058be53" />
<img width="1400" height="1000" alt="FIXED-fma-010editor" src="https://github.com/user-attachments/assets/5ba0aaa9-c15c-4e4a-bd5a-342e100d164e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated library item download visibility to rely on an explicit download permission, so the download button now appears only when downloading is allowed.
  * Aligned software page rows and stories with the new download behavior across active library items.
  * Refined related test coverage and examples to match the updated download-button logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->