### PR TITLE
Fix heatmap current slot color

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
@@ -740,6 +740,43 @@ describe("CheckerboardViz", () => {
       });
     });
 
+    it("renders the current timeframe cell at level-0 even when it carries a value", async () => {
+      // The current slot has a non-zero value in the generated data, but it's
+      // still being collected ("No data"), so its fill must match — level-0,
+      // not a graded color. Regression test for #47977.
+      const data = generateData(3); // every slot has percentage 50
+      const { container } = renderWithSetup(
+        <CheckerboardViz data={data} selectedDays={14} />
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+      });
+
+      const currentCell = container.querySelector(
+        "rect.checkerboard-viz__cell--current"
+      );
+      expect(currentCell?.getAttribute("class")).toContain("--level-0");
+    });
+
+    it("renders future timeframe cells at level-0", async () => {
+      const data = generateData(3); // every slot has percentage 50
+      const { container } = renderWithSetup(
+        <CheckerboardViz data={data} selectedDays={14} />
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+      });
+
+      // The last rendered cell is the final slot of the latest day (Mar 3),
+      // entirely in the future — its fill should match its "No data" tooltip.
+      const rects = container.querySelectorAll("rect");
+      const futureCell = rects[rects.length - 1];
+      expect(futureCell.getAttribute("aria-label")).toContain("No data");
+      expect(futureCell.getAttribute("class")).toContain("--level-0");
+    });
+
     it("still reports the value for past timeframes", async () => {
       const data = generateData(3); // every slot has percentage 50
       const { container } = renderWithSetup(

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
@@ -756,7 +756,8 @@ describe("CheckerboardViz", () => {
       const currentCell = container.querySelector(
         "rect.checkerboard-viz__cell--current"
       );
-      expect(currentCell?.getAttribute("class")).toContain("--level-0");
+      expect(currentCell).not.toBeNull();
+      expect(currentCell).toHaveClass("checkerboard-viz__cell--level-0");
     });
 
     it("renders future timeframe cells at level-0", async () => {

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -356,12 +356,12 @@ const CheckerboardViz = ({
               // a partial value. Without this the fill contradicts the tooltip.
               const level = cell.isFuture ? 0 : getColorLevel(cell);
               // Filled cells have a bg-colored 1px stroke that visually blends
-              // away. Outlined cells (level-0 and the current-timeframe cell)
-              // use a visible colored stroke instead, so without insetting they
-              // would look 1px larger than filled cells. Inset by half the
-              // stroke so the outline's outer edge sits where the filled cell's
-              // invisible stroke does.
-              const inset = level === 0 || cell.isCurrent ? 0.5 : 0;
+              // away. Level-0 cells (no data, which now includes the current
+              // and future slots) use a visible colored stroke instead, so
+              // without insetting they would look 1px larger than filled cells.
+              // Inset by half the stroke so the outline's outer edge sits where
+              // the filled cell's invisible stroke does.
+              const inset = level === 0 ? 0.5 : 0;
               return (
                 <rect
                   key={`${cell.dayIndex}-${cell.hourRow}`}

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -350,7 +350,11 @@ const CheckerboardViz = ({
             {grid.map((cell) => {
               const col = is24h ? cell.hourRow : cell.dayIndex;
               const row = is24h ? 0 : cell.hourRow;
-              const level = getColorLevel(cell);
+              // The current slot and future slots have no collected data yet —
+              // their tooltip and aria-label read "No data" — so render them at
+              // the level-0 "no data" swatch even when the current slot carries
+              // a partial value. Without this the fill contradicts the tooltip.
+              const level = cell.isFuture ? 0 : getColorLevel(cell);
               // Filled cells have a bg-colored 1px stroke that visually blends
               // away. Outlined cells (level-0 and the current-timeframe cell)
               // use a visible colored stroke instead, so without insetting they


### PR DESCRIPTION
**Related issue:** Resolves #47977

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the checkerboard chart so all future-timeframe cells render with the “No data” styling, and their outlines align with the intended visual treatment (including partially populated future slots).
  * Ensured accessibility labels and tooltip/context for non-graded future slots no longer suggest they are graded data.
* **Tests**
  * Added regression coverage to verify “No data” styling and labeling for the current “now” slot and the final future slot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->