### PR TITLE
Link directly to the uninstall guide, rather than the FAQ (which links to the guide)

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1272,7 +1272,7 @@ module.exports.routes = {
   'GET /learn-more-about/agent-options': '/docs/configuration/agent-configuration',
   'GET /learn-more-about/enable-user-collection': '/docs/using-fleet/gitops#features',
   'GET /learn-more-about/host-identifiers': '/docs/rest-api/rest-api#get-host-by-identifier',
-  'GET /learn-more-about/uninstall-fleetd': '/docs/using-fleet/faq#how-can-i-uninstall-fleetd',
+  'GET /learn-more-about/uninstall-fleetd': '/guides/how-to-uninstall-fleetd',
   'GET /learn-more-about/vulnerability-processing': '/docs/using-fleet/vulnerability-processing',
   'GET /learn-more-about/dep-profile': 'https://developer.apple.com/documentation/devicemanagement/define_a_profile',
   'GET /learn-more-about/apple-business-manager-tokens-api': '/docs/rest-api/rest-api#list-apple-business-ab-tokens',


### PR DESCRIPTION
[Slack thread](https://fleetdm.slack.com/archives/C072L58U878/p1783362669331309?thread_ts=1783362528.927249&cid=C072L58U878) for context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `Get /learn-more-about/uninstall-fleetd` redirect to send visitors to the new uninstall guide location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->