### PR TITLE
Persist byod=true enroll param through IdP redirects

### DIFF
--- a/changes/48805-byod-idp-enroll
+++ b/changes/48805-byod-idp-enroll
@@ -1,0 +1,1 @@
+* Fixed a bug where a user's BYOD selection was not persisted through IdP authentication

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -265,6 +265,7 @@ func initiateOTAEnrollSSO(svc fleet.Service, w http.ResponseWriter, r *http.Requ
 	if r.URL.Query().Get("fully_managed") == "true" {
 		requestURL += "&fully_managed=true"
 	}
+	// Same with the byod modifier parameter for Apple enrollments
 	if r.URL.Query().Get("byod") == "true" {
 		requestURL += "&byod=true"
 	}

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -265,6 +265,9 @@ func initiateOTAEnrollSSO(svc fleet.Service, w http.ResponseWriter, r *http.Requ
 	if r.URL.Query().Get("fully_managed") == "true" {
 		requestURL += "&fully_managed=true"
 	}
+	if r.URL.Query().Get("byod") == "true" {
+		requestURL += "&byod=true"
+	}
 	ssnID, ssnDurationSecs, idpURL, err := svc.InitiateMDMSSO(r.Context(), fleet.SSOInitiatorOTAEnroll, requestURL, "")
 	if err != nil {
 		return err

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -150,6 +150,76 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 	}
 }
 
+// ssoURLCaptureService captures the customOriginalURL passed to InitiateMDMSSO so
+// tests can assert which query parameters survive into the SAML round-trip.
+type ssoURLCaptureService struct {
+	fleet.Service
+	capturedOriginalURL string
+}
+
+func (s *ssoURLCaptureService) InitiateMDMSSO(_ context.Context, _, customOriginalURL, _ string) (string, int, string, error) {
+	s.capturedOriginalURL = customOriginalURL
+	return "session-id", 300, "https://idp.example.com/sso", nil
+}
+
+// The original URL is where the user lands after completing SAML auth, so any
+// enrollment query parameter (fully_managed, byod) must be threaded through it or
+// it is lost across the round-trip.
+func TestInitiateOTAEnrollSSOPersistsQueryParams(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		query        string
+		wantContains []string
+		wantExcludes []string
+	}{
+		{
+			name:         "byod true is persisted",
+			query:        "byod=true",
+			wantContains: []string{"&byod=true"},
+		},
+		{
+			name:         "byod absent is not added",
+			query:        "",
+			wantExcludes: []string{"byod"},
+		},
+		{
+			name:         "byod false is not persisted",
+			query:        "byod=false",
+			wantExcludes: []string{"byod"},
+		},
+		{
+			name:         "byod and fully_managed both persisted",
+			query:        "byod=true&fully_managed=true",
+			wantContains: []string{"&byod=true", "&fully_managed=true"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &ssoURLCaptureService{}
+			target := "/enroll?enroll_secret=foo"
+			if tc.query != "" {
+				target += "&" + tc.query
+			}
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			err := initiateOTAEnrollSSO(svc, rec, req, "foo")
+			require.NoError(t, err)
+
+			require.Contains(t, svc.capturedOriginalURL, "enroll_secret=foo")
+			for _, want := range tc.wantContains {
+				require.Contains(t, svc.capturedOriginalURL, want)
+			}
+			for _, exclude := range tc.wantExcludes {
+				require.NotContains(t, svc.capturedOriginalURL, exclude)
+			}
+
+			// The handler should redirect the browser to the IdP.
+			require.Equal(t, http.StatusSeeOther, rec.Code)
+			require.Equal(t, "https://idp.example.com/sso", rec.Header().Get("Location"))
+		})
+	}
+}
+
 func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 	if !hasBuildTag("full") {
 		t.Skip("This test requires running with -tags full")


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48805

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve a user’s BYOD selection through IdP authentication so it no longer gets lost mid-flow.
  * Enrollment redirects to IdP SSO now retain the correct enrollment query settings (including BYOD and fully managed) for consistent enrollment behavior.
* **Tests**
  * Added coverage to ensure the SSO initiation redirect preserves the expected query parameters and returns the correct redirect response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->