### PR TITLE
Rename Gemini app to Google Gemini

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/google-gemini.json
+++ b/ee/maintained-apps/inputs/homebrew/google-gemini.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gemini",
+  "name": "Google Gemini",
   "unique_identifier": "com.google.GeminiMacOS",
   "token": "google-gemini",
   "installer_format": "dmg",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -3292,11 +3292,11 @@
       "description": "Google Earth Pro is a virtual globe."
     },
     {
-      "name": "Gemini",
+      "name": "Google Gemini",
       "slug": "google-gemini/darwin",
       "platform": "darwin",
       "unique_identifier": "com.google.GeminiMacOS",
-      "description": "Gemini is a native desktop AI assistant from Google."
+      "description": "Google Gemini is a native desktop AI assistant from Google."
     },
     {
       "name": "GoToMeeting",


### PR DESCRIPTION
Updates the maintained app name from "Gemini" to "Google Gemini" in both the input config and generated apps.json output, including the app description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app listing to show **Google Gemini** instead of **Gemini**.
  * Refreshed the app description to match the new name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->