### PR TITLE
Custom host vitals: variable resolution + delete-protection (backend)

### DIFF
--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -138,6 +138,9 @@ func RunServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 	ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, documents []string) error {
 		return nil
 	}
+	ds.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error {
+		return nil
+	}
 	ds.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
 		return nil, nil
 	}

--- a/ee/server/service/maintained_apps.go
+++ b/ee/server/service/maintained_apps.go
@@ -57,6 +57,9 @@ func (svc *Service) AddFleetMaintainedApp(
 		// We should not get to this point. If we did, it means we have another issue, such as large read replica latency.
 		return 0, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")
 	}
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{installScript, postInstallScript, uninstallScript}); err != nil {
+		return 0, fleet.NewInvalidArgumentError("script", err.Error())
+	}
 
 	app, err := svc.ds.GetMaintainedAppByID(ctx, appID, teamID)
 	if err != nil {

--- a/ee/server/service/maintained_apps.go
+++ b/ee/server/service/maintained_apps.go
@@ -58,7 +58,14 @@ func (svc *Service) AddFleetMaintainedApp(
 		return 0, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")
 	}
 	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{installScript, postInstallScript, uninstallScript}); err != nil {
-		return 0, fleet.NewInvalidArgumentError("script", err.Error())
+		var argErr *fleet.InvalidArgumentError
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "install script", &installScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "post-install script", &postInstallScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "uninstall script", &uninstallScript, argErr)
+		if argErr != nil {
+			return 0, argErr
+		}
+		return 0, ctxerr.Wrap(ctx, err, "transient server issue validating custom host vitals")
 	}
 
 	app, err := svc.ds.GetMaintainedAppByID(ctx, appID, teamID)

--- a/ee/server/service/setup_experience.go
+++ b/ee/server/service/setup_experience.go
@@ -140,6 +140,9 @@ func (svc *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, 
 	if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{script.ScriptContents}); err != nil {
 		return fleet.NewInvalidArgumentError("script", err.Error())
 	}
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{script.ScriptContents}); err != nil {
+		return fleet.NewInvalidArgumentError("script", err.Error())
+	}
 
 	// setup experience is only supported for macOS currently so we need to override the file
 	// extension check in the general script validation

--- a/ee/server/service/setup_experience_test.go
+++ b/ee/server/service/setup_experience_test.go
@@ -312,6 +312,27 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 	})
 }
 
+func TestSetupExperienceScriptRejectsUnknownCustomHostVital(t *testing.T) {
+	ctx := test.UserContext(context.Background(), test.UserAdmin)
+	ds := new(mock.Store)
+	svc, baseSvc := newTestServiceWithMock(t, ds)
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, documents []string) error { return nil }
+	ds.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error {
+		return &fleet.MissingCustomHostVitalsError{MissingIDs: []uint{99}}
+	}
+	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) error { return nil }
+	baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error { return nil }
+
+	err := svc.SetSetupExperienceScript(ctx, nil, "potato.sh", bytes.NewReader([]byte("echo $FLEET_HOST_VITAL_99")))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Custom host vital")
+	require.False(t, ds.SetSetupExperienceScriptFuncInvoked)
+}
+
 // TestSetupExperienceNextStepPolicyGated covers the policy-gated (Windows/Linux) branch of SetupExperienceNextStep: the policy is
 // used only as a gate (pass -> skip, fail -> install via the normal ForSetupExperience path), the item is held running while
 // awaiting a fresh result, an out-of-scope gating policy falls back to installing, and the host policy clock is reset once when a

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -159,6 +159,9 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 		// We should not get to this point. If we did, it means we have another issue, such as large read replica latency.
 		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")
 	}
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{payload.InstallScript, payload.PostInstallScript, payload.UninstallScript}); err != nil {
+		return nil, fleet.NewInvalidArgumentError("script", err.Error())
+	}
 
 	installerID, titleID, err := svc.ds.MatchOrCreateSoftwareInstaller(ctx, payload)
 	if err != nil {
@@ -383,6 +386,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 		// We should not get to this point. If we did, it means we have another issue, such as large read replica latency.
 		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")
+	}
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, scripts); err != nil {
+		return nil, fleet.NewInvalidArgumentError("script", err.Error())
 	}
 
 	// get software by ID, fail if it does not exist or does not have an existing installer
@@ -2453,6 +2459,9 @@ func (svc *Service) BatchSetSoftwareInstallers(
 		// we only want to ensure that secrets are in the database on the
 		// non-dry run case.
 		if err := svc.ds.ValidateEmbeddedSecrets(ctx, allScripts); err != nil {
+			return "", ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("script", err.Error()))
+		}
+		if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, allScripts); err != nil {
 			return "", ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("script", err.Error()))
 		}
 	}

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -116,6 +116,18 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{payload.InstallScript, payload.PostInstallScript, payload.UninstallScript}); err != nil {
+		// Redo per-script to report which script references the undefined custom host vital.
+		var argErr *fleet.InvalidArgumentError
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "install script", &payload.InstallScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "post-install script", &payload.PostInstallScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "uninstall script", &payload.UninstallScript, argErr)
+		if argErr != nil {
+			return nil, argErr
+		}
+		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating custom host vitals")
+	}
+
 	if payload.AutomaticInstall && payload.AutomaticInstallQuery == "" {
 		switch {
 		//
@@ -158,16 +170,6 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 		// We should not get to this point. If we did, it means we have another issue, such as large read replica latency.
 		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")
-	}
-	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{payload.InstallScript, payload.PostInstallScript, payload.UninstallScript}); err != nil {
-		var argErr *fleet.InvalidArgumentError
-		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "install script", &payload.InstallScript, argErr)
-		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "post-install script", &payload.PostInstallScript, argErr)
-		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "uninstall script", &payload.UninstallScript, argErr)
-		if argErr != nil {
-			return nil, argErr
-		}
-		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating custom host vitals")
 	}
 
 	installerID, titleID, err := svc.ds.MatchOrCreateSoftwareInstaller(ctx, payload)

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -160,7 +160,14 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")
 	}
 	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{payload.InstallScript, payload.PostInstallScript, payload.UninstallScript}); err != nil {
-		return nil, fleet.NewInvalidArgumentError("script", err.Error())
+		var argErr *fleet.InvalidArgumentError
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "install script", &payload.InstallScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "post-install script", &payload.PostInstallScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "uninstall script", &payload.UninstallScript, argErr)
+		if argErr != nil {
+			return nil, argErr
+		}
+		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating custom host vitals")
 	}
 
 	installerID, titleID, err := svc.ds.MatchOrCreateSoftwareInstaller(ctx, payload)
@@ -388,7 +395,14 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")
 	}
 	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, scripts); err != nil {
-		return nil, fleet.NewInvalidArgumentError("script", err.Error())
+		var argErr *fleet.InvalidArgumentError
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "install script", payload.InstallScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "post-install script", payload.PostInstallScript, argErr)
+		argErr = svc.validateReferencedCustomHostVitalsOnScript(ctx, "uninstall script", payload.UninstallScript, argErr)
+		if argErr != nil {
+			return nil, argErr
+		}
+		return nil, ctxerr.Wrap(ctx, err, "transient server issue validating custom host vitals")
 	}
 
 	// get software by ID, fail if it does not exist or does not have an existing installer
@@ -850,6 +864,23 @@ func (svc *Service) validateEmbeddedSecretsOnScript(ctx context.Context, scriptN
 ) *fleet.InvalidArgumentError {
 	if script != nil {
 		if errScript := svc.ds.ValidateEmbeddedSecrets(ctx, []string{*script}); errScript != nil {
+			if argErr != nil {
+				argErr.Append(scriptName, errScript.Error())
+			} else {
+				argErr = fleet.NewInvalidArgumentError(scriptName, errScript.Error())
+			}
+		}
+	}
+	return argErr
+}
+
+// validateReferencedCustomHostVitalsOnScript mirrors validateEmbeddedSecretsOnScript
+// so callers can report which specific script references an undefined custom host vital.
+func (svc *Service) validateReferencedCustomHostVitalsOnScript(ctx context.Context, scriptName string, script *string,
+	argErr *fleet.InvalidArgumentError,
+) *fleet.InvalidArgumentError {
+	if script != nil {
+		if errScript := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{*script}); errScript != nil {
 			if argErr != nil {
 				argErr.Append(scriptName, errScript.Error())
 			} else {

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -718,6 +718,7 @@ func newTestService(t *testing.T, ds fleet.Datastore) *Service {
 	t.Helper()
 	authorizer, err := authz.NewAuthorizer()
 	require.NoError(t, err)
+	defaultMockCustomHostVitalsValidation(ds)
 	svc := &Service{
 		authz:  authorizer,
 		ds:     ds,
@@ -730,6 +731,7 @@ func newTestServiceWithMock(t *testing.T, ds fleet.Datastore) (*Service, *svcmoc
 	t.Helper()
 	authorizer, err := authz.NewAuthorizer()
 	require.NoError(t, err)
+	defaultMockCustomHostVitalsValidation(ds)
 	baseSvc := new(svcmock.Service)
 	svc := &Service{
 		Service: baseSvc,
@@ -737,6 +739,14 @@ func newTestServiceWithMock(t *testing.T, ds fleet.Datastore) (*Service, *svcmoc
 		ds:      ds,
 	}
 	return svc, baseSvc
+}
+
+// Software installer and setup-experience uploads validate referenced custom
+// host vitals, so mock-backed tests that don't care about it needn't stub it.
+func defaultMockCustomHostVitalsValidation(ds fleet.Datastore) {
+	if mockDS, ok := ds.(*mock.Store); ok && mockDS.ValidateReferencedCustomHostVitalsFunc == nil {
+		mockDS.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error { return nil }
+	}
 }
 
 func TestAddScriptPackageMetadata(t *testing.T) {

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -625,6 +625,29 @@ func (ds *Datastore) listAppleDeclarationsForReconcileTransaction(ctx context.Co
 				d.HasFleetVariables = true
 			}
 		}
+
+		// Custom host vitals ($FLEET_HOST_VITAL_<id>) are a separate variable
+		// namespace that isn't recorded in mdm_configuration_profile_variables, so
+		// detect them by scanning the declaration body. Marking them
+		// HasFleetVariables makes the reconciler stamp variables_updated_at, which
+		// (a) lets handleDeclarationItems load raw_json and drop declarations it
+		// can't resolve for a host from the manifest, and (b) cache-busts the DDM
+		// token so a per-host value change is re-delivered. INSTR matches the
+		// prefix without the leading '$' so it catches both $FOO and ${FOO} forms.
+		const vitalsStmt = `SELECT declaration_uuid FROM mdm_apple_declarations WHERE declaration_uuid IN (?) AND INSTR(raw_json, ?) > 0`
+		q, args, err = sqlx.In(vitalsStmt, declUUIDs, fleet.CustomHostVitalPrefix)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "build apple declaration custom host vitals query")
+		}
+		var withVitals []string
+		if err := sqlx.SelectContext(ctx, tx, &withVitals, q, args...); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "select apple declarations with custom host vitals")
+		}
+		for _, u := range withVitals {
+			if d, ok := byUUID[u]; ok {
+				d.HasFleetVariables = true
+			}
+		}
 	}
 
 	return out, nil

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -240,15 +240,133 @@ func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, nam
 }
 
 func (ds *Datastore) SetHostCustomHostVitalValue(ctx context.Context, hostID uint, vitalID uint, value string) error {
-	_, err := ds.writer(ctx).ExecContext(ctx, `
-		INSERT INTO host_custom_host_vitals (host_id, custom_host_vital_id, value)
-		VALUES (?, ?, ?)
-		ON DUPLICATE KEY UPDATE value = VALUES(value)`,
-		hostID, vitalID, value,
-	)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "set host custom host vital value")
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO host_custom_host_vitals (host_id, custom_host_vital_id, value)
+			VALUES (?, ?, ?)
+			ON DUPLICATE KEY UPDATE value = VALUES(value)`,
+			hostID, vitalID, value,
+		); err != nil {
+			return ctxerr.Wrap(ctx, err, "set host custom host vital value")
+		}
+
+		// Re-queue any MDM profiles/declarations already delivered to this host
+		// that reference the vital, so the reconcilers re-expand
+		// $FLEET_HOST_VITAL_<id> with the new value. Runs in the same transaction
+		// as the value write so the reconciler never reads a stale value.
+		if err := resendMDMProfilesForCustomHostVital(ctx, tx, hostID, vitalID); err != nil {
+			return ctxerr.Wrap(ctx, err, "resend mdm profiles for custom host vital value change")
+		}
+		return nil
+	})
+}
+
+// The resend SELECTs below filter on host_uuid first, which is the leftmost
+// column of each host-profile table's PRIMARY KEY (host_uuid, {profile,declaration}_uuid).
+// The INSTR content match therefore only evaluates the rows for a single host
+// (the profiles/declarations assigned to it), not the whole table — so cost is
+// independent of fleet size.
+const (
+	customHostVitalResendAppleProfilesSelectStmt = `SELECT hmap.profile_uuid AS uuid, macp.mobileconfig AS contents
+		FROM host_mdm_apple_profiles hmap
+		JOIN mdm_apple_configuration_profiles macp ON macp.profile_uuid = hmap.profile_uuid
+		WHERE hmap.host_uuid = ? AND hmap.operation_type = ? AND hmap.status IS NOT NULL AND INSTR(macp.mobileconfig, ?) > 0`
+
+	customHostVitalResendWindowsProfilesSelectStmt = `SELECT hmwp.profile_uuid AS uuid, mwcp.syncml AS contents
+		FROM host_mdm_windows_profiles hmwp
+		JOIN mdm_windows_configuration_profiles mwcp ON mwcp.profile_uuid = hmwp.profile_uuid
+		WHERE hmwp.host_uuid = ? AND hmwp.operation_type = ? AND hmwp.status IS NOT NULL AND INSTR(mwcp.syncml, ?) > 0`
+
+	customHostVitalResendAppleDeclarationsSelectStmt = `SELECT hmad.declaration_uuid AS uuid, mad.raw_json AS contents
+		FROM host_mdm_apple_declarations hmad
+		JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
+		WHERE hmad.host_uuid = ? AND hmad.operation_type = ? AND hmad.status IS NOT NULL AND INSTR(mad.raw_json, ?) > 0`
+)
+
+// resendMDMProfilesForCustomHostVital resets the status of the Apple/Windows
+// configuration profiles and Apple DDM declarations already delivered to the
+// host that reference $FLEET_HOST_VITAL_<vitalID>, so the reconcilers resend
+// them with the host's newly-set value. Mirrors triggerResendProfilesUsingVariables,
+// but matches by profile/declaration content because custom host vitals aren't
+// tracked in mdm_configuration_profile_variables. Declarations only reset status
+// (the DDM reconciler re-stamps variables_updated_at, cache-busting the token).
+//
+// Unlike the IdP resend, this deliberately omits certificate templates and
+// Android managed configs: a vital can't reach either (cert templates only take
+// fleet_variables, and Android rejects $FLEET_HOST_VITAL_ at upload), so there's
+// nothing on those surfaces to resend.
+func resendMDMProfilesForCustomHostVital(ctx context.Context, tx sqlx.ExtContext, hostID, vitalID uint) error {
+	var hostUUID string
+	if err := sqlx.GetContext(ctx, tx, &hostUUID, `SELECT uuid FROM hosts WHERE id = ?`, hostID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return ctxerr.Wrap(ctx, err, "get host uuid for custom host vital resend")
 	}
+
+	// varName is the exact token (id included) matched precisely, id-boundary and
+	// ${...}-aware, by ContainsVar in Go. The INSTR prefix filter in SQL only
+	// narrows candidates; it deliberately over-matches (ignores the id) so the
+	// Go pass does the authoritative match.
+	varName := fmt.Sprintf("%s%d", fleet.CustomHostVitalPrefix, vitalID)
+
+	targets := []struct {
+		desc       string
+		selectStmt string
+		updateStmt string
+	}{
+		{
+			desc:       "apple profiles",
+			selectStmt: customHostVitalResendAppleProfilesSelectStmt,
+			updateStmt: `UPDATE host_mdm_apple_profiles
+				SET status = NULL, detail = NULL, command_uuid = ''
+				WHERE host_uuid = ? AND operation_type = ? AND profile_uuid IN (?)`,
+		},
+		{
+			desc:       "windows profiles",
+			selectStmt: customHostVitalResendWindowsProfilesSelectStmt,
+			updateStmt: `UPDATE host_mdm_windows_profiles
+				SET status = NULL, detail = NULL, command_uuid = ''
+				WHERE host_uuid = ? AND operation_type = ? AND profile_uuid IN (?)`,
+		},
+		{
+			desc:       "apple declarations",
+			selectStmt: customHostVitalResendAppleDeclarationsSelectStmt,
+			updateStmt: `UPDATE host_mdm_apple_declarations
+				SET status = NULL, detail = NULL
+				WHERE host_uuid = ? AND operation_type = ? AND declaration_uuid IN (?)`,
+		},
+	}
+
+	for _, tgt := range targets {
+		var rows []struct {
+			UUID     string `db:"uuid"`
+			Contents string `db:"contents"`
+		}
+		if err := sqlx.SelectContext(ctx, tx, &rows, tgt.selectStmt,
+			hostUUID, fleet.MDMOperationTypeInstall, fleet.CustomHostVitalPrefix); err != nil {
+			return ctxerr.Wrap(ctx, err, "select "+tgt.desc+" referencing custom host vital")
+		}
+
+		var uuids []string
+		for _, r := range rows {
+			if fleet.ContainsVar(r.Contents, varName) {
+				uuids = append(uuids, r.UUID)
+			}
+		}
+		if len(uuids) == 0 {
+			continue
+		}
+
+		stmt, args, err := sqlx.In(tgt.updateStmt, hostUUID, fleet.MDMOperationTypeInstall, uuids)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "build resend update for "+tgt.desc)
+		}
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "reset "+tgt.desc+" for custom host vital resend")
+		}
+	}
+
 	return nil
 }
 

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -115,6 +117,13 @@ func (ds *Datastore) DeleteCustomHostVital(ctx context.Context, id uint) (name s
 			return ctxerr.Wrap(ctx, err, "getting name of custom host vital to delete")
 		}
 
+		// Refuse to delete a definition still referenced by a script/profile.
+		if useErr, err := customHostVitalUsedBy(ctx, tx, id, name); err != nil {
+			return ctxerr.Wrap(ctx, err, "checking custom host vital references")
+		} else if useErr != nil {
+			return ctxerr.Wrap(ctx, useErr, "found custom host vital in use")
+		}
+
 		if _, err := tx.ExecContext(ctx, `DELETE FROM custom_host_vitals WHERE id = ?`, id); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete custom host vital")
 		}
@@ -124,6 +133,110 @@ func (ds *Datastore) DeleteCustomHostVital(ctx context.Context, id uint) (name s
 	}
 
 	return name, nil
+}
+
+// customHostVitalRefEntity is a script or profile scanned for $FLEET_HOST_VITAL_<id>
+// references during delete-protection.
+type customHostVitalRefEntity struct {
+	// Type is the entity type, "script", "apple_profile", "apple_declaration", or "windows_profile".
+	Type string `db:"entity"`
+	// Name is the name of the entity.
+	Name string `db:"name"`
+	// FleetName is the name of the fleet (team) the entity belongs to.
+	FleetName string `db:"team_name"`
+	// Contents is the content of the entity (script's/profile's body).
+	Contents string `db:"contents"`
+}
+
+// customHostVitalUsedBy scans script_contents, Apple configuration profiles,
+// Apple declarations, and Windows configuration profiles for a
+// $FLEET_HOST_VITAL_<id> (or ${FLEET_HOST_VITAL_<id>}) reference to the given
+// vital id. It returns a *fleet.CustomHostVitalUsedError describing the first
+// referencing entity found, or nil if unreferenced. Mirrors the scan structure
+// of DeleteSecretVariable. The second return is a real DB error.
+func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, name string) (*fleet.CustomHostVitalUsedError, error) {
+	// The token embeds the numeric id (survives renames), so match by id, not name.
+	token := fmt.Sprintf("%s%d", fleet.CustomHostVitalPrefix, id)
+
+	// Each scan mirrors DeleteSecretVariable: pull the content column of every
+	// script/profile/declaration and check for the token in Go (os.Expand-based,
+	// so it matches both $VAR and ${VAR} forms).
+	scans := []struct {
+		desc string
+		stmt string
+	}{
+		{
+			desc: "get script contents",
+			stmt: `SELECT 'script' AS entity, s.name,
+				COALESCE(t.name, 'No team') AS team_name, sc.contents
+				FROM script_contents sc
+				JOIN scripts s ON s.script_content_id = sc.id
+				LEFT JOIN teams t ON t.id = s.team_id;`,
+		},
+		{
+			desc: "get apple profile contents",
+			stmt: `SELECT 'apple_profile' AS entity, p.name,
+				COALESCE(t.name, 'No team') AS team_name, p.mobileconfig AS contents
+				FROM mdm_apple_configuration_profiles p
+				LEFT JOIN teams t ON t.id = p.team_id;`,
+		},
+		{
+			desc: "get apple declaration contents",
+			stmt: `SELECT 'apple_declaration' AS entity, d.name,
+				COALESCE(t.name, 'No team') AS team_name, d.raw_json AS contents
+				FROM mdm_apple_declarations d
+				LEFT JOIN teams t ON t.id = d.team_id;`,
+		},
+		{
+			desc: "get windows profile contents",
+			stmt: `SELECT 'windows_profile' AS entity, p.name,
+				COALESCE(t.name, 'No team') AS team_name, p.syncml AS contents
+				FROM mdm_windows_configuration_profiles p
+				LEFT JOIN teams t ON t.id = p.team_id;`,
+		},
+		// Software installer and setup-experience scripts exceed secret-variable
+		// delete-protection (which doesn't scan them), so a vital can't be deleted
+		// while a script that runs it would silently start failing on hosts.
+		{
+			desc: "get software installer script contents",
+			stmt: `SELECT 'software_installer' AS entity, COALESCE(st.name, si.filename) AS name,
+				COALESCE(t.name, 'No team') AS team_name, sc.contents
+				FROM software_installers si
+				JOIN script_contents sc ON sc.id IN (si.install_script_content_id, si.post_install_script_content_id, si.uninstall_script_content_id)
+				LEFT JOIN software_titles st ON st.id = si.title_id
+				LEFT JOIN teams t ON t.id = si.team_id;`,
+		},
+		{
+			desc: "get setup experience script contents",
+			stmt: `SELECT 'setup_experience_script' AS entity, ses.name,
+				COALESCE(t.name, 'No team') AS team_name, sc.contents
+				FROM setup_experience_scripts ses
+				JOIN script_contents sc ON sc.id = ses.script_content_id
+				LEFT JOIN teams t ON t.id = ses.team_id;`,
+		},
+	}
+
+	for _, scan := range scans {
+		var entities []customHostVitalRefEntity
+		if err := sqlx.SelectContext(ctx, tx, &entities, scan.stmt); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, scan.desc)
+		}
+		for _, e := range entities {
+			if fleet.ContainsVar(e.Contents, token) {
+				return &fleet.CustomHostVitalUsedError{
+					CustomHostVitalID:   id,
+					CustomHostVitalName: name,
+					Entity: fleet.EntityUsingCustomHostVital{
+						Type:      e.Type,
+						Name:      e.Name,
+						FleetName: e.FleetName,
+					},
+				}, nil
+			}
+		}
+	}
+
+	return nil, nil
 }
 
 func (ds *Datastore) SetHostCustomHostVitalValue(ctx context.Context, hostID uint, vitalID uint, value string) error {
@@ -152,6 +265,100 @@ func (ds *Datastore) GetHostCustomHostVitals(ctx context.Context, hostID uint) (
 		return nil, ctxerr.Wrap(ctx, err, "get host custom host vitals")
 	}
 	return vitals, nil
+}
+
+// ExpandCustomHostVitals substitutes $FLEET_HOST_VITAL_<id> tokens in the
+// document with the given host's stored values, applying format-aware escaping
+// (JSON/XML) like expandEmbeddedSecrets. If a referenced vital has no value for
+// the host (no row, or an empty value), it returns a MissingCustomHostVitalValueError
+// so delivery fails rather than substituting an empty value (product decision).
+func (ds *Datastore) ExpandCustomHostVitals(ctx context.Context, hostID uint, document string) (string, error) {
+	refIDs := fleet.ContainsCustomHostVitalIDs(document)
+	if len(refIDs) == 0 {
+		return document, nil
+	}
+
+	vitals, err := ds.GetHostCustomHostVitals(ctx, hostID)
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "expanding custom host vitals")
+	}
+
+	// A vital with an empty value counts as missing: we refuse to ship an empty
+	// substitution.
+	valueByID := make(map[uint]string, len(vitals))
+	for _, v := range vitals {
+		if v.Value == "" {
+			continue
+		}
+		valueByID[v.CustomHostVitalID] = v.Value
+	}
+
+	var missingIDs []uint
+	for _, id := range refIDs {
+		if _, ok := valueByID[id]; !ok {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+	if len(missingIDs) > 0 {
+		// The vital exists (validated on upload); the host just has no value for it.
+		return "", &fleet.MissingCustomHostVitalValueError{MissingIDs: missingIDs}
+	}
+
+	expanded := expandDocumentVars(document, func(s string) (string, bool) {
+		if !strings.HasPrefix(s, fleet.CustomHostVitalPrefix) {
+			return "", false
+		}
+		id, parseErr := strconv.ParseUint(strings.TrimPrefix(s, fleet.CustomHostVitalPrefix), 10, 64)
+		if parseErr != nil {
+			return "", false
+		}
+		val, ok := valueByID[uint(id)]
+		return val, ok
+	})
+
+	return expanded, nil
+}
+
+// ValidateReferencedCustomHostVitals parses $FLEET_HOST_VITAL_<id> tokens from
+// the given documents and verifies every referenced id resolves to a definition.
+// Mirrors ValidateEmbeddedSecrets. Returns a MissingCustomHostVitalsError listing
+// any unknown ids.
+func (ds *Datastore) ValidateReferencedCustomHostVitals(ctx context.Context, documents []string) error {
+	wantIDs := make(map[uint]struct{})
+	for _, document := range documents {
+		for _, id := range fleet.ContainsCustomHostVitalIDs(document) {
+			wantIDs[id] = struct{}{}
+		}
+	}
+	if len(wantIDs) == 0 {
+		return nil
+	}
+
+	wantIDsList := make([]uint, 0, len(wantIDs))
+	for id := range wantIDs {
+		wantIDsList = append(wantIDsList, id)
+	}
+
+	dbVitals, err := ds.GetCustomHostVitals(ctx, wantIDsList)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "validating document referenced custom host vitals")
+	}
+
+	haveIDs := make(map[uint]struct{}, len(dbVitals))
+	for _, v := range dbVitals {
+		haveIDs[v.ID] = struct{}{}
+	}
+
+	var missingIDs []uint
+	for id := range wantIDs {
+		if _, ok := haveIDs[id]; !ok {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+	if len(missingIDs) > 0 {
+		return &fleet.MissingCustomHostVitalsError{MissingIDs: missingIDs}
+	}
+	return nil
 }
 
 func (ds *Datastore) GetCustomHostVitals(ctx context.Context, ids []uint) ([]fleet.CustomHostVital, error) {

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -118,10 +118,10 @@ func (ds *Datastore) DeleteCustomHostVital(ctx context.Context, id uint) (name s
 		}
 
 		// Refuse to delete a definition still referenced by a script/profile.
-		if useErr, err := customHostVitalUsedBy(ctx, tx, id, name); err != nil {
+		if usedByInfo, err := customHostVitalUsedBy(ctx, tx, id, name); err != nil {
 			return ctxerr.Wrap(ctx, err, "checking custom host vital references")
-		} else if useErr != nil {
-			return ctxerr.Wrap(ctx, useErr, "found custom host vital in use")
+		} else if usedByInfo != nil {
+			return ctxerr.Wrap(ctx, &fleet.CustomHostVitalUsedError{CustomHostVitalUsedInfo: *usedByInfo}, "found custom host vital in use")
 		}
 
 		if _, err := tx.ExecContext(ctx, `DELETE FROM custom_host_vitals WHERE id = ?`, id); err != nil {
@@ -151,10 +151,10 @@ type customHostVitalRefEntity struct {
 // customHostVitalUsedBy scans script_contents, Apple configuration profiles,
 // Apple declarations, and Windows configuration profiles for a
 // $FLEET_HOST_VITAL_<id> (or ${FLEET_HOST_VITAL_<id>}) reference to the given
-// vital id. It returns a *fleet.CustomHostVitalUsedError describing the first
+// vital id. It returns a *fleet.CustomHostVitalUsedInfo describing the first
 // referencing entity found, or nil if unreferenced. Mirrors the scan structure
 // of DeleteSecretVariable. The second return is a real DB error.
-func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, name string) (*fleet.CustomHostVitalUsedError, error) {
+func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, name string) (*fleet.CustomHostVitalUsedInfo, error) {
 	// The token embeds the numeric id (survives renames), so match by id, not name.
 	token := fmt.Sprintf("%s%d", fleet.CustomHostVitalPrefix, id)
 
@@ -168,7 +168,7 @@ func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, nam
 		{
 			desc: "get script contents",
 			stmt: `SELECT 'script' AS entity, s.name,
-				COALESCE(t.name, 'No team') AS team_name, sc.contents
+				COALESCE(t.name, 'Unassigned') AS team_name, sc.contents
 				FROM script_contents sc
 				JOIN scripts s ON s.script_content_id = sc.id
 				LEFT JOIN teams t ON t.id = s.team_id;`,
@@ -176,21 +176,21 @@ func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, nam
 		{
 			desc: "get apple profile contents",
 			stmt: `SELECT 'apple_profile' AS entity, p.name,
-				COALESCE(t.name, 'No team') AS team_name, p.mobileconfig AS contents
+				COALESCE(t.name, 'Unassigned') AS team_name, p.mobileconfig AS contents
 				FROM mdm_apple_configuration_profiles p
 				LEFT JOIN teams t ON t.id = p.team_id;`,
 		},
 		{
 			desc: "get apple declaration contents",
 			stmt: `SELECT 'apple_declaration' AS entity, d.name,
-				COALESCE(t.name, 'No team') AS team_name, d.raw_json AS contents
+				COALESCE(t.name, 'Unassigned') AS team_name, d.raw_json AS contents
 				FROM mdm_apple_declarations d
 				LEFT JOIN teams t ON t.id = d.team_id;`,
 		},
 		{
 			desc: "get windows profile contents",
 			stmt: `SELECT 'windows_profile' AS entity, p.name,
-				COALESCE(t.name, 'No team') AS team_name, p.syncml AS contents
+				COALESCE(t.name, 'Unassigned') AS team_name, p.syncml AS contents
 				FROM mdm_windows_configuration_profiles p
 				LEFT JOIN teams t ON t.id = p.team_id;`,
 		},
@@ -200,7 +200,7 @@ func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, nam
 		{
 			desc: "get software installer script contents",
 			stmt: `SELECT 'software_installer' AS entity, COALESCE(st.name, si.filename) AS name,
-				COALESCE(t.name, 'No team') AS team_name, sc.contents
+				COALESCE(t.name, 'Unassigned') AS team_name, sc.contents
 				FROM software_installers si
 				JOIN script_contents sc ON sc.id IN (si.install_script_content_id, si.post_install_script_content_id, si.uninstall_script_content_id)
 				LEFT JOIN software_titles st ON st.id = si.title_id
@@ -209,7 +209,7 @@ func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, nam
 		{
 			desc: "get setup experience script contents",
 			stmt: `SELECT 'setup_experience_script' AS entity, ses.name,
-				COALESCE(t.name, 'No team') AS team_name, sc.contents
+				COALESCE(t.name, 'Unassigned') AS team_name, sc.contents
 				FROM setup_experience_scripts ses
 				JOIN script_contents sc ON sc.id = ses.script_content_id
 				LEFT JOIN teams t ON t.id = ses.team_id;`,
@@ -223,7 +223,7 @@ func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, nam
 		}
 		for _, e := range entities {
 			if fleet.ContainsVar(e.Contents, token) {
-				return &fleet.CustomHostVitalUsedError{
+				return &fleet.CustomHostVitalUsedInfo{
 					CustomHostVitalID:   id,
 					CustomHostVitalName: name,
 					Entity: fleet.EntityUsingCustomHostVital{
@@ -261,28 +261,6 @@ func (ds *Datastore) SetHostCustomHostVitalValue(ctx context.Context, hostID uin
 	})
 }
 
-// The resend SELECTs below filter on host_uuid first, which is the leftmost
-// column of each host-profile table's PRIMARY KEY (host_uuid, {profile,declaration}_uuid).
-// The INSTR content match therefore only evaluates the rows for a single host
-// (the profiles/declarations assigned to it), not the whole table — so cost is
-// independent of fleet size.
-const (
-	customHostVitalResendAppleProfilesSelectStmt = `SELECT hmap.profile_uuid AS uuid, macp.mobileconfig AS contents
-		FROM host_mdm_apple_profiles hmap
-		JOIN mdm_apple_configuration_profiles macp ON macp.profile_uuid = hmap.profile_uuid
-		WHERE hmap.host_uuid = ? AND hmap.operation_type = ? AND hmap.status IS NOT NULL AND INSTR(macp.mobileconfig, ?) > 0`
-
-	customHostVitalResendWindowsProfilesSelectStmt = `SELECT hmwp.profile_uuid AS uuid, mwcp.syncml AS contents
-		FROM host_mdm_windows_profiles hmwp
-		JOIN mdm_windows_configuration_profiles mwcp ON mwcp.profile_uuid = hmwp.profile_uuid
-		WHERE hmwp.host_uuid = ? AND hmwp.operation_type = ? AND hmwp.status IS NOT NULL AND INSTR(mwcp.syncml, ?) > 0`
-
-	customHostVitalResendAppleDeclarationsSelectStmt = `SELECT hmad.declaration_uuid AS uuid, mad.raw_json AS contents
-		FROM host_mdm_apple_declarations hmad
-		JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
-		WHERE hmad.host_uuid = ? AND hmad.operation_type = ? AND hmad.status IS NOT NULL AND INSTR(mad.raw_json, ?) > 0`
-)
-
 // resendMDMProfilesForCustomHostVital resets the status of the Apple/Windows
 // configuration profiles and Apple DDM declarations already delivered to the
 // host that reference $FLEET_HOST_VITAL_<vitalID>, so the reconcilers resend
@@ -309,6 +287,27 @@ func resendMDMProfilesForCustomHostVital(ctx context.Context, tx sqlx.ExtContext
 	// narrows candidates; it deliberately over-matches (ignores the id) so the
 	// Go pass does the authoritative match.
 	varName := fmt.Sprintf("%s%d", fleet.CustomHostVitalPrefix, vitalID)
+
+	// These SELECTs filter on host_uuid first — the leftmost column of each
+	// host-profile table's PRIMARY KEY (host_uuid, {profile,declaration}_uuid) —
+	// so the INSTR content match only evaluates this one host's rows, not the
+	// whole table; cost is independent of fleet size.
+	const (
+		customHostVitalResendAppleProfilesSelectStmt = `SELECT hmap.profile_uuid AS uuid, macp.mobileconfig AS contents
+			FROM host_mdm_apple_profiles hmap
+			JOIN mdm_apple_configuration_profiles macp ON macp.profile_uuid = hmap.profile_uuid
+			WHERE hmap.host_uuid = ? AND hmap.operation_type = ? AND hmap.status IS NOT NULL AND INSTR(macp.mobileconfig, ?) > 0`
+
+		customHostVitalResendWindowsProfilesSelectStmt = `SELECT hmwp.profile_uuid AS uuid, mwcp.syncml AS contents
+			FROM host_mdm_windows_profiles hmwp
+			JOIN mdm_windows_configuration_profiles mwcp ON mwcp.profile_uuid = hmwp.profile_uuid
+			WHERE hmwp.host_uuid = ? AND hmwp.operation_type = ? AND hmwp.status IS NOT NULL AND INSTR(mwcp.syncml, ?) > 0`
+
+		customHostVitalResendAppleDeclarationsSelectStmt = `SELECT hmad.declaration_uuid AS uuid, mad.raw_json AS contents
+			FROM host_mdm_apple_declarations hmad
+			JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
+			WHERE hmad.host_uuid = ? AND hmad.operation_type = ? AND hmad.status IS NOT NULL AND INSTR(mad.raw_json, ?) > 0`
+	)
 
 	targets := []struct {
 		desc       string
@@ -443,10 +442,25 @@ func (ds *Datastore) ExpandCustomHostVitals(ctx context.Context, hostID uint, do
 // any unknown ids.
 func (ds *Datastore) ValidateReferencedCustomHostVitals(ctx context.Context, documents []string) error {
 	wantIDs := make(map[uint]struct{})
+	var malformed []string
+	seenMalformed := make(map[string]struct{})
 	for _, document := range documents {
+		// A $FLEET_HOST_VITAL_<x> token whose <x> isn't a valid ID (e.g. a typo like
+		// $FLEET_HOST_VITAL_asset_tag) is rejected rather than silently delivered as
+		// a literal token, matching how $FLEET_VAR_*/$FLEET_SECRET_* reject unknowns.
+		for _, ref := range fleet.ContainsMalformedCustomHostVitalRefs(document) {
+			if _, ok := seenMalformed[ref]; ok {
+				continue
+			}
+			seenMalformed[ref] = struct{}{}
+			malformed = append(malformed, ref)
+		}
 		for _, id := range fleet.ContainsCustomHostVitalIDs(document) {
 			wantIDs[id] = struct{}{}
 		}
+	}
+	if len(malformed) > 0 {
+		return &fleet.InvalidCustomHostVitalRefError{Refs: malformed}
 	}
 	if len(wantIDs) == 0 {
 		return nil

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -1,11 +1,14 @@
 package mysql
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +25,7 @@ func TestCustomHostVitals(t *testing.T) {
 		{"SetAndGetHostCustomHostVitals", testSetAndGetHostCustomHostVitals},
 		{"GetCustomHostVitals", testGetCustomHostVitals},
 		{"DeleteCustomHostVital", testDeleteCustomHostVital},
+		{"DeleteUsedCustomHostVital", testDeleteUsedCustomHostVital},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -228,4 +232,166 @@ func testDeleteCustomHostVital(t *testing.T, ds *Datastore) {
 	require.Error(t, err)
 	var nfe fleet.NotFoundError
 	require.ErrorAs(t, err, &nfe)
+}
+
+func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	foobarTeam, err := ds.NewTeam(ctx, &fleet.Team{Name: "Foobar"})
+	require.NoError(t, err)
+
+	id := createCustomHostVital(t, ds, "FUNCTION")
+	id2 := createCustomHostVital(t, ds, "OTHER")
+
+	// $FLEET_HOST_VITAL_<id> token that references FUNCTION.
+	token := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, id)
+	// ${FLEET_HOST_VITAL_<id>} braced form.
+	bracedToken := fmt.Sprintf("${%s%d}", fleet.CustomHostVitalPrefix, id)
+
+	t.Run("apple configuration profiles", func(t *testing.T) {
+		appleProfile, err := ds.NewMDMAppleConfigProfile(ctx, fleet.MDMAppleConfigProfile{
+			Name:         "Name0",
+			Identifier:   "Identifier0",
+			Mobileconfig: []byte(token),
+		}, nil)
+		require.NoError(t, err)
+
+		_, err = ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, "apple_profile", useErr.Entity.Type)
+		require.Equal(t, "Name0", useErr.Entity.Name)
+		require.Equal(t, "No team", useErr.Entity.FleetName)
+
+		// Deleting an unreferenced vital is allowed.
+		_, err = ds.DeleteCustomHostVital(ctx, id2)
+		require.NoError(t, err)
+		// Recreate for later subtests.
+		id2 = createCustomHostVital(t, ds, "OTHER")
+
+		require.NoError(t, ds.DeleteMDMAppleConfigProfile(ctx, appleProfile.ProfileUUID))
+	})
+
+	t.Run("apple declarations", func(t *testing.T) {
+		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Identifier: "decl-1",
+			Name:       "decl-1",
+			RawJSON:    json.RawMessage(fmt.Sprintf(`{"Identifier": "%s"}`, bracedToken)),
+			TeamID:     &foobarTeam.ID,
+		}, nil)
+		require.NoError(t, err)
+
+		_, err = ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, "apple_declaration", useErr.Entity.Type)
+		require.Equal(t, "decl-1", useErr.Entity.Name)
+		require.Equal(t, "Foobar", useErr.Entity.FleetName)
+
+		require.NoError(t, ds.DeleteMDMAppleDeclaration(ctx, decl.DeclarationUUID))
+	})
+
+	t.Run("windows profiles", func(t *testing.T) {
+		winProfile, err := ds.NewMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+			Name:   "zoo",
+			SyncML: []byte(fmt.Sprintf("<Replace>%s</Replace>", token)),
+		}, nil)
+		require.NoError(t, err)
+
+		_, err = ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, "windows_profile", useErr.Entity.Type)
+		require.Equal(t, "zoo", useErr.Entity.Name)
+		require.Equal(t, "No team", useErr.Entity.FleetName)
+
+		require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, winProfile.ProfileUUID))
+	})
+
+	t.Run("scripts", func(t *testing.T) {
+		script, err := ds.NewScript(ctx, &fleet.Script{
+			Name:           "collect.sh",
+			ScriptContents: fmt.Sprintf("echo %s", token),
+			TeamID:         &foobarTeam.ID,
+		})
+		require.NoError(t, err)
+
+		_, err = ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, "script", useErr.Entity.Type)
+		require.Equal(t, "collect.sh", useErr.Entity.Name)
+		require.Equal(t, "Foobar", useErr.Entity.FleetName)
+
+		require.NoError(t, ds.DeleteScript(ctx, script.ID))
+	})
+
+	t.Run("software installers", func(t *testing.T) {
+		user := test.NewUser(t, ds, "Installer Author", "chv-del-installer@example.com", true)
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
+		require.NoError(t, err)
+		installerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:   fmt.Sprintf("install %s", token),
+			UninstallScript: "uninstall",
+			InstallerFile:   tfr,
+			StorageID:       "chv-del-storage",
+			Filename:        "chv-del.pkg",
+			Title:           "chv-del-title",
+			Version:         "1.0",
+			Source:          "apps",
+			TeamID:          &foobarTeam.ID,
+			UserID:          user.ID,
+			ValidatedLabels: &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+
+		_, err = ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, "software_installer", useErr.Entity.Type)
+		require.Equal(t, "chv-del-title", useErr.Entity.Name)
+		require.Equal(t, "Foobar", useErr.Entity.FleetName)
+
+		require.NoError(t, ds.DeleteSoftwareInstaller(ctx, installerID))
+	})
+
+	t.Run("setup experience scripts", func(t *testing.T) {
+		require.NoError(t, ds.SetSetupExperienceScript(ctx, &fleet.Script{
+			Name:           "setup.sh",
+			ScriptContents: fmt.Sprintf("echo %s", token),
+			TeamID:         &foobarTeam.ID,
+		}))
+
+		_, err := ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, "setup_experience_script", useErr.Entity.Type)
+		require.Equal(t, "setup.sh", useErr.Entity.Name)
+		require.Equal(t, "Foobar", useErr.Entity.FleetName)
+
+		require.NoError(t, ds.DeleteSetupExperienceScript(ctx, &foobarTeam.ID))
+	})
+
+	// With all references removed, delete now succeeds.
+	name, err := ds.DeleteCustomHostVital(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "FUNCTION", name)
 }

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,6 +28,8 @@ func TestCustomHostVitals(t *testing.T) {
 		{"GetCustomHostVitals", testGetCustomHostVitals},
 		{"DeleteCustomHostVital", testDeleteCustomHostVital},
 		{"DeleteUsedCustomHostVital", testDeleteUsedCustomHostVital},
+		{"SetHostValueResendsReferencingProfiles", testSetHostCustomHostVitalValueResendsProfiles},
+		{"ReconcileSnapshotMarksVitalDeclarations", testReconcileSnapshotMarksVitalDeclarations},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -394,4 +398,117 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 	name, err := ds.DeleteCustomHostVital(ctx, id)
 	require.NoError(t, err)
 	require.Equal(t, "FUNCTION", name)
+}
+
+// Setting a host's value for a vital must re-queue the MDM profiles and DDM
+// declarations already delivered to that host that reference the vital, so the
+// reconcilers re-expand $FLEET_HOST_VITAL_<id> with the new value. Profiles
+// referencing a different vital (or none), and other hosts, must be untouched.
+func testSetHostCustomHostVitalValueResendsProfiles(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	host := test.NewHost(t, ds, "mac", "1", "mackey", "macuuid", time.Now())
+	winHost := test.NewHost(t, ds, "win", "2", "winkey", "winuuid", time.Now(), test.WithPlatform("windows"))
+
+	vitalID := createCustomHostVital(t, ds, "FUNCTION")
+	otherID := createCustomHostVital(t, ds, "OTHER")
+	token := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, vitalID)
+	otherToken := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, otherID)
+
+	// generateAppleCP/generateWindowsCP embed name+identifier in the profile
+	// body, so passing the token there puts the reference in the content the
+	// resend scan matches on.
+	profVital, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("pv", token, 0), nil)
+	require.NoError(t, err)
+	profOther, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("po", otherToken, 0), nil)
+	require.NoError(t, err)
+	profNone, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("pn", "plain", 0), nil)
+	require.NoError(t, err)
+
+	profWVital, err := ds.NewMDMWindowsConfigProfile(ctx, *generateWindowsCP("wv", token, 0), nil)
+	require.NoError(t, err)
+	profWNone, err := ds.NewMDMWindowsConfigProfile(ctx, *generateWindowsCP("wn", "plain", 0), nil)
+	require.NoError(t, err)
+
+	forceSetAppleHostProfileStatus(t, ds, host.UUID, profVital, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+	forceSetAppleHostProfileStatus(t, ds, host.UUID, profOther, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+	forceSetAppleHostProfileStatus(t, ds, host.UUID, profNone, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+	forceSetWindowsHostProfileStatus(t, ds, winHost.UUID, profWVital, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+	forceSetWindowsHostProfileStatus(t, ds, winHost.UUID, profWNone, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+
+	// DDM declaration referencing the vital, delivered (verifying) to the mac host.
+	bracedToken := fmt.Sprintf("${%s%d}", fleet.CustomHostVitalPrefix, vitalID)
+	declVital, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		Identifier: "decl-vital", Name: "decl-vital",
+		RawJSON: json.RawMessage(fmt.Sprintf(`{"note":"%s"}`, bracedToken)),
+	}, nil)
+	require.NoError(t, err)
+	forceSetAppleHostDeclarationStatus(t, ds, host.UUID, declVital, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+
+	// Set the value on both hosts; only referencing entities on the same host reset.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, host.ID, vitalID, "Engineering"))
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, winHost.ID, vitalID, "Engineering"))
+
+	// A reset row has NULL status, which assertHostProfileStatus reports as
+	// pending. The declaration surfaces through GetHostMDMAppleProfiles too, so
+	// it's included here; it should also be reset.
+	assertHostProfileStatus(t, ds, host.UUID,
+		hostProfileStatus{profVital.ProfileUUID, fleet.MDMDeliveryPending},
+		hostProfileStatus{profOther.ProfileUUID, fleet.MDMDeliveryVerifying},
+		hostProfileStatus{profNone.ProfileUUID, fleet.MDMDeliveryVerifying},
+		hostProfileStatus{declVital.DeclarationUUID, fleet.MDMDeliveryPending})
+	assertHostProfileStatus(t, ds, winHost.UUID,
+		hostProfileStatus{profWVital.ProfileUUID, fleet.MDMDeliveryPending},
+		hostProfileStatus{profWNone.ProfileUUID, fleet.MDMDeliveryVerifying})
+
+	var declStatus *fleet.MDMDeliveryStatus
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &declStatus,
+			`SELECT status FROM host_mdm_apple_declarations WHERE host_uuid = ? AND declaration_uuid = ?`,
+			host.UUID, declVital.DeclarationUUID)
+	})
+	require.Nil(t, declStatus, "declaration should be reset (NULL status) so the DDM reconciler re-delivers it")
+}
+
+// The DDM reconcile snapshot must flag declarations that reference a custom host
+// vital as HasFleetVariables, so the reconciler stamps variables_updated_at on
+// the host declaration row — the signal handleDeclarationItems relies on to load
+// raw_json, drop unresolvable declarations from the manifest, and cache-bust the
+// DDM token. Custom host vitals aren't in mdm_configuration_profile_variables, so
+// this depends on the body scan rather than the variables join.
+func testReconcileSnapshotMarksVitalDeclarations(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// A macOS host must be MDM-enrolled to enter the reconcile window; otherwise
+	// the snapshot skips loading declarations entirely.
+	host := test.NewHost(t, ds, "macos-1", "1", "macos-1-key", "macos-1-uuid", time.Now())
+	nanoEnroll(t, ds, host, false)
+
+	vitalID := createCustomHostVital(t, ds, "FUNCTION")
+	bracedToken := fmt.Sprintf("${%s%d}", fleet.CustomHostVitalPrefix, vitalID)
+
+	declVital, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		Identifier: "decl-vital", Name: "decl-vital",
+		RawJSON: json.RawMessage(fmt.Sprintf(`{"note":"%s"}`, bracedToken)),
+	}, nil)
+	require.NoError(t, err)
+	declPlain, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		Identifier: "decl-plain", Name: "decl-plain",
+		RawJSON: json.RawMessage(`{"note":"static"}`),
+	}, nil)
+	require.NoError(t, err)
+
+	_, allDecls, _, _, err := ds.GetAppleDeclarationReconcileSnapshot(ctx, "", 100)
+	require.NoError(t, err)
+
+	byUUID := make(map[string]*fleet.AppleDeclarationForReconcile, len(allDecls))
+	for _, d := range allDecls {
+		byUUID[d.DeclarationUUID] = d
+	}
+	require.Contains(t, byUUID, declVital.DeclarationUUID)
+	require.Contains(t, byUUID, declPlain.DeclarationUUID)
+	assert.True(t, byUUID[declVital.DeclarationUUID].HasFleetVariables,
+		"declaration referencing a custom host vital should be marked HasFleetVariables")
+	assert.False(t, byUUID[declPlain.DeclarationUUID].HasFleetVariables,
+		"declaration without any variables should not be marked")
 }

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -505,10 +505,12 @@ func testReconcileSnapshotMarksVitalDeclarations(t *testing.T, ds *Datastore) {
 	for _, d := range allDecls {
 		byUUID[d.DeclarationUUID] = d
 	}
-	require.Contains(t, byUUID, declVital.DeclarationUUID)
-	require.Contains(t, byUUID, declPlain.DeclarationUUID)
-	assert.True(t, byUUID[declVital.DeclarationUUID].HasFleetVariables,
+	vitalDecl := byUUID[declVital.DeclarationUUID]
+	plainDecl := byUUID[declPlain.DeclarationUUID]
+	require.NotNil(t, vitalDecl, "vital declaration missing from reconcile snapshot")
+	require.NotNil(t, plainDecl, "plain declaration missing from reconcile snapshot")
+	assert.True(t, vitalDecl.HasFleetVariables, //nolint:nilaway // cannot be nil due to require.NotNil above
 		"declaration referencing a custom host vital should be marked HasFleetVariables")
-	assert.False(t, byUUID[declPlain.DeclarationUUID].HasFleetVariables,
+	assert.False(t, plainDecl.HasFleetVariables, //nolint:nilaway // cannot be nil due to require.NotNil above
 		"declaration without any variables should not be marked")
 }

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -30,6 +30,7 @@ func TestCustomHostVitals(t *testing.T) {
 		{"DeleteUsedCustomHostVital", testDeleteUsedCustomHostVital},
 		{"SetHostValueResendsReferencingProfiles", testSetHostCustomHostVitalValueResendsProfiles},
 		{"ReconcileSnapshotMarksVitalDeclarations", testReconcileSnapshotMarksVitalDeclarations},
+		{"ValidateReferencedCustomHostVitalsRejectsMalformed", testValidateReferencedCustomHostVitalsRejectsMalformed},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -268,7 +269,7 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
 		require.Equal(t, "apple_profile", useErr.Entity.Type)
 		require.Equal(t, "Name0", useErr.Entity.Name)
-		require.Equal(t, "No team", useErr.Entity.FleetName)
+		require.Equal(t, "Unassigned", useErr.Entity.FleetName)
 
 		// Deleting an unreferenced vital is allowed.
 		_, err = ds.DeleteCustomHostVital(ctx, id2)
@@ -316,7 +317,7 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
 		require.Equal(t, "windows_profile", useErr.Entity.Type)
 		require.Equal(t, "zoo", useErr.Entity.Name)
-		require.Equal(t, "No team", useErr.Entity.FleetName)
+		require.Equal(t, "Unassigned", useErr.Entity.FleetName)
 
 		require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, winProfile.ProfileUUID))
 	})
@@ -513,4 +514,35 @@ func testReconcileSnapshotMarksVitalDeclarations(t *testing.T, ds *Datastore) {
 		"declaration referencing a custom host vital should be marked HasFleetVariables")
 	assert.False(t, plainDecl.HasFleetVariables, //nolint:nilaway // cannot be nil due to require.NotNil above
 		"declaration without any variables should not be marked")
+}
+
+// A $FLEET_HOST_VITAL_ token whose suffix isn't a valid vital ID must be rejected on upload
+func testValidateReferencedCustomHostVitalsRejectsMalformed(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	vitalID := createCustomHostVital(t, ds, "Function")
+
+	// Valid numeric reference to an existing vital passes.
+	require.NoError(t, ds.ValidateReferencedCustomHostVitals(ctx,
+		[]string{fmt.Sprintf("echo $%s%d", fleet.CustomHostVitalPrefix, vitalID)}))
+
+	// Non-numeric suffix is a malformed reference -> InvalidCustomHostVitalRefError.
+	var invalidErr *fleet.InvalidCustomHostVitalRefError
+	err := ds.ValidateReferencedCustomHostVitals(ctx,
+		[]string{fmt.Sprintf("echo $%sasset_tag", fleet.CustomHostVitalPrefix)})
+	require.ErrorAs(t, err, &invalidErr)
+
+	// Braced malformed form -> also InvalidCustomHostVitalRefError.
+	invalidErr = nil
+	err = ds.ValidateReferencedCustomHostVitals(ctx,
+		[]string{fmt.Sprintf("echo ${%sFOOBAR}", fleet.CustomHostVitalPrefix)})
+	require.ErrorAs(t, err, &invalidErr)
+
+	// Numeric-but-nonexistent id -> MissingCustomHostVitalsError (distinct from malformed).
+	var missingErr *fleet.MissingCustomHostVitalsError
+	err = ds.ValidateReferencedCustomHostVitals(ctx,
+		[]string{fmt.Sprintf("echo $%s999999", fleet.CustomHostVitalPrefix)})
+	require.ErrorAs(t, err, &missingErr)
+
+	// No token at all -> no error.
+	require.NoError(t, ds.ValidateReferencedCustomHostVitals(ctx, []string{"echo hello"}))
 }

--- a/server/datastore/mysql/secret_variables.go
+++ b/server/datastore/mysql/secret_variables.go
@@ -356,34 +356,47 @@ func (ds *Datastore) expandEmbeddedSecrets(ctx context.Context, document string)
 		return "", nil, fleet.MissingSecretsError{MissingSecrets: missingSecrets}
 	}
 
-	// Detect document format so we can escape the secret value appropriately.
+	expanded := expandDocumentVars(document, func(s string) (string, bool) {
+		if !strings.HasPrefix(s, fleet.ServerSecretPrefix) {
+			return "", false
+		}
+		val, ok := secretMap[strings.TrimPrefix(s, fleet.ServerSecretPrefix)]
+		return val, ok
+	})
+
+	return expanded, secrets, nil
+}
+
+// expandDocumentVars runs fleet.MaybeExpand over document, resolving each
+// variable name via resolve and escaping the substituted value for the
+// document's format (JSON or XML) so an injected value can't break the
+// surrounding profile. resolve returns the raw (unescaped) value and whether the
+// variable was handled; unhandled variables are left in place. Shared by
+// ExpandEmbeddedSecrets ($FLEET_SECRET_) and ExpandCustomHostVitals
+// ($FLEET_HOST_VITAL_) so the format escaping has a single implementation.
+func expandDocumentVars(document string, resolve func(name string) (string, bool)) string {
 	// XML detection is aggressive because Windows profiles do not begin with <?xml.
 	trimmed := strings.TrimSpace(document)
 	documentIsXML := strings.HasPrefix(trimmed, "<")
 	documentIsJSON := strings.HasPrefix(trimmed, "{")
 
-	expanded := fleet.MaybeExpand(document, func(s string, startPos, endPos int) (string, bool) {
-		if !strings.HasPrefix(s, fleet.ServerSecretPrefix) {
+	return fleet.MaybeExpand(document, func(s string, _, _ int) (string, bool) {
+		val, ok := resolve(s)
+		if !ok {
 			return "", false
 		}
-		val, ok := secretMap[strings.TrimPrefix(s, fleet.ServerSecretPrefix)]
-
 		switch {
 		case documentIsJSON:
 			val = jsonEscapeString(val)
 		case documentIsXML:
 			var b strings.Builder
-			err = xml.EscapeText(&b, []byte(val))
-			if err != nil {
+			if err := xml.EscapeText(&b, []byte(val)); err != nil {
 				return "", false
 			}
 			val = b.String()
 		}
-
-		return val, ok
+		return val, true
 	})
-
-	return expanded, secrets, nil
 }
 
 // jsonEscapeString returns the JSON-escaped interior of a string value

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -129,22 +129,29 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
 		return nil, ctxerr.Wrap(ctx, err, "get software install details")
 	}
 
-	expandedInstallScript, err := ds.ExpandEmbeddedSecrets(ctx, result.InstallScript)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "expanding secrets in install script")
-	}
-	expandedPostInstallScript, err := ds.ExpandEmbeddedSecrets(ctx, result.PostInstallScript)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "expanding secrets in post-install script")
-	}
-	expandedUninstallScript, err := ds.ExpandEmbeddedSecrets(ctx, result.UninstallScript)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "expanding secrets in uninstall script")
+	// Install scripts run per-host, so custom host vitals resolve against the target host.
+	expand := func(script, kind string) (string, error) {
+		expanded, err := ds.ExpandEmbeddedSecrets(ctx, script)
+		if err != nil {
+			return "", ctxerr.Wrapf(ctx, err, "expanding secrets in %s script", kind)
+		}
+		expanded, err = ds.ExpandCustomHostVitals(ctx, result.HostID, expanded)
+		if err != nil {
+			return "", ctxerr.Wrapf(ctx, err, "expanding custom host vitals in %s script", kind)
+		}
+		return expanded, nil
 	}
 
-	result.InstallScript = expandedInstallScript
-	result.PostInstallScript = expandedPostInstallScript
-	result.UninstallScript = expandedUninstallScript
+	var err error
+	if result.InstallScript, err = expand(result.InstallScript, "install"); err != nil {
+		return nil, err
+	}
+	if result.PostInstallScript, err = expand(result.PostInstallScript, "post-install"); err != nil {
+		return nil, err
+	}
+	if result.UninstallScript, err = expand(result.UninstallScript, "uninstall"); err != nil {
+		return nil, err
+	}
 
 	// Check if this install is part of setup experience and set retry count accordingly
 	var setupExperienceCount int

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -140,7 +140,7 @@ func testGetSoftwareInstallDetailsCustomHostVitals(t *testing.T, ds *Datastore) 
 	_, err = ds.GetSoftwareInstallDetails(ctx, execID2)
 	var missing *fleet.MissingCustomHostVitalValueError
 	require.ErrorAs(t, err, &missing)
-	require.Equal(t, []uint{dept.ID}, missing.MissingIDs)
+	require.Equal(t, []uint{dept.ID}, missing.MissingIDs) //nolint:nilaway // cannot be nil due to require.ErrorAs above
 }
 
 func testListPendingSoftwareInstalls(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -73,6 +73,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"SetHostSoftwareInstallResultResolvesOrphanedActivity", testSetHostSoftwareInstallResultResolvesOrphanedActivity},
 		{"GetSoftwareTitlesForInstallAll", testGetSoftwareTitlesForInstallAll},
 		{"SummaryUpcomingPerHostNoDropout", testSummaryUpcomingPerHostNoDropout},
+		{"GetSoftwareInstallDetailsCustomHostVitals", testGetSoftwareInstallDetailsCustomHostVitals},
 	}
 
 	for _, c := range cases {
@@ -81,6 +82,65 @@ func TestSoftwareInstallers(t *testing.T) {
 			c.fn(t, ds)
 		})
 	}
+}
+
+func testGetSoftwareInstallDetailsCustomHostVitals(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host := test.NewHost(t, ds, "chv-host", "chv-1", "chv-key", "chv-uuid", time.Now())
+	user := test.NewUser(t, ds, "Alice", "alice-chv@example.com", true)
+
+	assetTag, err := ds.CreateCustomHostVital(ctx, "Asset tag")
+	require.NoError(t, err)
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, host.ID, assetTag.ID, "A-123"))
+
+	newInstaller := func(t *testing.T, storageID string, scripts map[string]string) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
+		require.NoError(t, err)
+		id, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:     scripts["install"],
+			PostInstallScript: scripts["post"],
+			UninstallScript:   scripts["uninstall"],
+			PreInstallQuery:   "SELECT 1",
+			InstallerFile:     tfr,
+			StorageID:         storageID,
+			Filename:          storageID,
+			Title:             storageID,
+			Version:           "1.0",
+			Source:            "apps",
+			UserID:            user.ID,
+			ValidatedLabels:   &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+		return id
+	}
+
+	token := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, assetTag.ID)
+	installerID := newInstaller(t, "chv-storage-1", map[string]string{
+		"install": "install " + token, "post": "post " + token, "uninstall": "uninstall " + token,
+	})
+	execID, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, installerID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+
+	details, err := ds.GetSoftwareInstallDetails(ctx, execID)
+	require.NoError(t, err)
+	require.Equal(t, "install A-123", details.InstallScript)
+	require.Equal(t, "post A-123", details.PostInstallScript)
+	require.Equal(t, "uninstall A-123", details.UninstallScript)
+
+	// A referenced vital with no value for the host fails delivery.
+	dept, err := ds.CreateCustomHostVital(ctx, "Department")
+	require.NoError(t, err)
+	installerID2 := newInstaller(t, "chv-storage-2", map[string]string{
+		"install": fmt.Sprintf("install $%s%d", fleet.CustomHostVitalPrefix, dept.ID),
+	})
+	execID2, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, installerID2, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+
+	_, err = ds.GetSoftwareInstallDetails(ctx, execID2)
+	var missing *fleet.MissingCustomHostVitalValueError
+	require.ErrorAs(t, err, &missing)
+	require.Equal(t, []uint{dept.ID}, missing.MissingIDs)
 }
 
 func testListPendingSoftwareInstalls(t *testing.T, ds *Datastore) {

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -122,10 +122,16 @@ func parseAndroidProfileValidationError(err error) error {
 }
 
 func validateAndroidProfileFleetVariables(rawJSON []byte, decoded map[string]any) error {
-	// $FLEET_HOST_VITAL_<id> is expanded per-host only for Apple and Windows at
-	// delivery; Android has no expansion path, so reject it here rather than
-	// silently shipping the literal token. Checked before the variables.Find
-	// early-return below because vitals use a different prefix that Find ignores.
+	// Custom host vitals are a secret-style, per-host variable (modeled on
+	// $FLEET_SECRET_*), not a $FLEET_VAR_*. Android expands only the $FLEET_VAR_*
+	// allowlist in app config (SubstituteFleetVarsInAndroidAppConfig) and has no
+	// embedded-secret or custom-host-vital substitution, so a $FLEET_HOST_VITAL_
+	// token here would reach the device literally — reject at upload instead.
+	// Checked before the variables.Find early-return below because vitals use a
+	// different prefix that Find ignores.
+	// TODO(product): confirm Android should stay unsupported for custom host
+	// vitals (parity with $FLEET_SECRET_*, also unsupported on Android) rather
+	// than gaining its own expansion path.
 	if ids := ContainsCustomHostVitalIDs(string(rawJSON)); len(ids) > 0 {
 		return errors.New("Couldn't edit profile. Custom host vitals aren't supported in Android configuration profiles.")
 	}

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -122,6 +122,14 @@ func parseAndroidProfileValidationError(err error) error {
 }
 
 func validateAndroidProfileFleetVariables(rawJSON []byte, decoded map[string]any) error {
+	// $FLEET_HOST_VITAL_<id> is expanded per-host only for Apple and Windows at
+	// delivery; Android has no expansion path, so reject it here rather than
+	// silently shipping the literal token. Checked before the variables.Find
+	// early-return below because vitals use a different prefix that Find ignores.
+	if ids := ContainsCustomHostVitalIDs(string(rawJSON)); len(ids) > 0 {
+		return errors.New("Couldn't edit profile. Custom host vitals aren't supported in Android configuration profiles.")
+	}
+
 	found := variables.Find(string(rawJSON))
 	if len(found) == 0 {
 		return nil

--- a/server/fleet/android_test.go
+++ b/server/fleet/android_test.go
@@ -220,6 +220,18 @@ func TestValidateUserProvided_FleetVariables(t *testing.T) {
 			wantErr:   true,
 			errSubstr: "Invalid JSON payload",
 		},
+		{
+			name:      "custom host vital is not supported on Android",
+			rawJSON:   `{"name": "$FLEET_HOST_VITAL_7"}`,
+			wantErr:   true,
+			errSubstr: "Custom host vitals aren't supported in Android configuration profiles",
+		},
+		{
+			name:      "custom host vital rejected even alongside a supported variable",
+			rawJSON:   `{"name": "$FLEET_VAR_HOST_UUID $FLEET_HOST_VITAL_7"}`,
+			wantErr:   true,
+			errSubstr: "Custom host vitals aren't supported in Android configuration profiles",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -537,9 +537,12 @@ type AppleDeclarationForReconcile struct {
 	IncludeMode           AppleProfileIncludeMode
 	IncludeLabels         []AppleProfileLabelRef
 	ExcludeLabels         []AppleProfileLabelRef
-	// HasFleetVariables is true if the declaration references any $FLEET_VAR_*.
-	// The reconciler sets VariablesUpdatedAt on the host declaration row so the
-	// host knows to re-deliver when variable values change.
+	// HasFleetVariables is true if the declaration references any per-host Fleet
+	// variable that is expanded at delivery time: a $FLEET_VAR_* or a custom host
+	// vital ($FLEET_HOST_VITAL_*). Both behave identically here — the reconciler
+	// sets VariablesUpdatedAt on the host declaration row so the host knows to
+	// re-deliver when a variable value changes — so they share this flag even
+	// though custom host vitals are a separate variable namespace.
 	//
 	// This does not cover $FLEET_SECRET_* variables and SecretsUpdatedAt as that is handled at upload time
 	// where we extract the secrets and their last update time.

--- a/server/fleet/custom_host_vitals.go
+++ b/server/fleet/custom_host_vitals.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -37,6 +38,76 @@ func (HostCustomHostVitalValue) AuthzType() string {
 	return "host_custom_vital"
 }
 
+type MissingCustomHostVitalsError struct {
+	MissingIDs []uint
+}
+
+func (e MissingCustomHostVitalsError) Error() string {
+	tokens := make([]string, 0, len(e.MissingIDs))
+	for _, id := range e.MissingIDs {
+		tokens = append(tokens, fmt.Sprintf("\"$%s%d\"", CustomHostVitalPrefix, id))
+	}
+	plural := ""
+	if len(tokens) > 1 {
+		plural = "s"
+	}
+	return fmt.Sprintf("Couldn't add. Custom host vital%s %s missing from database", plural, strings.Join(tokens, ", "))
+}
+
+// MissingCustomHostVitalValueError is returned when expanding $FLEET_HOST_VITAL_<id>
+// at delivery time for a host that has no value set for that (existing) vital.
+// Distinct from MissingCustomHostVitalsError (upload-time: the id doesn't exist)
+// so the delivery failure detail shown to admins names the real cause.
+type MissingCustomHostVitalValueError struct {
+	MissingIDs []uint
+}
+
+func (e MissingCustomHostVitalValueError) Error() string {
+	tokens := make([]string, 0, len(e.MissingIDs))
+	for _, id := range e.MissingIDs {
+		tokens = append(tokens, fmt.Sprintf("\"$%s%d\"", CustomHostVitalPrefix, id))
+	}
+	plural := ""
+	if len(tokens) > 1 {
+		plural = "s"
+	}
+	return fmt.Sprintf("Couldn't populate custom host vital%s %s: no value set for this host", plural, strings.Join(tokens, ", "))
+}
+
+// Describes an entity that references a custom host vital.
+type EntityUsingCustomHostVital struct {
+	// "script", "apple_profile", "apple_declaration", "windows_profile",
+	// "software_installer", or "setup_experience_script".
+	Type string
+	// Name is the name of the entity.
+	Name string
+	// FleetName is the name of the fleet (team) the entity belongs to.
+	FleetName string
+}
+
+type CustomHostVitalUsedError struct {
+	CustomHostVitalID   uint
+	CustomHostVitalName string
+	Entity              EntityUsingCustomHostVital
+}
+
+// Error implements the error interface.
+func (e *CustomHostVitalUsedError) Error() string {
+	noun, action := "configuration profile", "Please delete the configuration profile and try again."
+	switch e.Entity.Type {
+	case "script":
+		noun, action = "script", "Please edit or delete the script and try again."
+	case "software_installer":
+		noun, action = "software", "Please edit or delete the software and try again."
+	case "setup_experience_script":
+		noun, action = "setup experience script", "Please edit or delete the setup experience script and try again."
+	}
+	return fmt.Sprintf(
+		"Custom host vital %q (used as $%s%d) is used by the %q %s in the %q team. %s",
+		e.CustomHostVitalName, CustomHostVitalPrefix, e.CustomHostVitalID, e.Entity.Name, noun, e.Entity.FleetName, action,
+	)
+}
+
 func ValidateCustomHostVitalName(name string) error {
 	if len(name) == 0 {
 		return NewInvalidArgumentError("name", "custom host vital name cannot be empty")
@@ -48,4 +119,25 @@ func ValidateCustomHostVitalName(name string) error {
 		return NewInvalidArgumentError("name", fmt.Sprintf("custom host vital name is too long: %s", name))
 	}
 	return nil
+}
+
+func ContainsCustomHostVitalIDs(text string) []uint {
+	suffixes := ContainsPrefixVars(text, CustomHostVitalPrefix)
+	if len(suffixes) == 0 {
+		return nil
+	}
+	seen := make(map[uint]struct{}, len(suffixes))
+	ids := make([]uint, 0, len(suffixes))
+	for _, s := range suffixes {
+		id, err := strconv.ParseUint(s, 10, 64)
+		if err != nil || id == 0 {
+			continue
+		}
+		if _, ok := seen[uint(id)]; ok {
+			continue
+		}
+		seen[uint(id)] = struct{}{}
+		ids = append(ids, uint(id))
+	}
+	return ids
 }

--- a/server/fleet/custom_host_vitals.go
+++ b/server/fleet/custom_host_vitals.go
@@ -51,7 +51,30 @@ func (e MissingCustomHostVitalsError) Error() string {
 	if len(tokens) > 1 {
 		plural = "s"
 	}
-	return fmt.Sprintf("Couldn't add. Custom host vital%s %s missing from database", plural, strings.Join(tokens, ", "))
+	return fmt.Sprintf("Couldn't add. Custom host vital%s %s is not defined", plural, strings.Join(tokens, ", "))
+}
+
+// InvalidCustomHostVitalRefError is returned on upload when a document contains a
+// $FLEET_HOST_VITAL_<x> token whose <x> is not a valid custom host vital ID
+// (a positive integer) — e.g. a typo like $FLEET_HOST_VITAL_asset_tag.
+type InvalidCustomHostVitalRefError struct {
+	// Refs are the offending tokens without the leading '$', e.g. "FLEET_HOST_VITAL_asset_tag".
+	Refs []string
+}
+
+func (e InvalidCustomHostVitalRefError) Error() string {
+	tokens := make([]string, 0, len(e.Refs))
+	for _, r := range e.Refs {
+		tokens = append(tokens, fmt.Sprintf("\"$%s\"", r))
+	}
+	plural := ""
+	if len(tokens) > 1 {
+		plural = "s"
+	}
+	return fmt.Sprintf(
+		"Couldn't add. Invalid custom host vital reference%s %s; the value after $%s must be a custom host vital ID",
+		plural, strings.Join(tokens, ", "), CustomHostVitalPrefix,
+	)
 }
 
 // MissingCustomHostVitalValueError is returned when expanding $FLEET_HOST_VITAL_<id>
@@ -85,16 +108,17 @@ type EntityUsingCustomHostVital struct {
 	FleetName string
 }
 
-type CustomHostVitalUsedError struct {
+// CustomHostVitalUsedInfo describes a script/profile/declaration that references a custom host vital.
+type CustomHostVitalUsedInfo struct {
 	CustomHostVitalID   uint
 	CustomHostVitalName string
 	Entity              EntityUsingCustomHostVital
 }
 
-// Error implements the error interface.
-func (e *CustomHostVitalUsedError) Error() string {
+// Message returns the human-readable "X is used by Y" explanation.
+func (i CustomHostVitalUsedInfo) Message() string {
 	noun, action := "configuration profile", "Please delete the configuration profile and try again."
-	switch e.Entity.Type {
+	switch i.Entity.Type {
 	case "script":
 		noun, action = "script", "Please edit or delete the script and try again."
 	case "software_installer":
@@ -103,9 +127,19 @@ func (e *CustomHostVitalUsedError) Error() string {
 		noun, action = "setup experience script", "Please edit or delete the setup experience script and try again."
 	}
 	return fmt.Sprintf(
-		"Custom host vital %q (used as $%s%d) is used by the %q %s in the %q team. %s",
-		e.CustomHostVitalName, CustomHostVitalPrefix, e.CustomHostVitalID, e.Entity.Name, noun, e.Entity.FleetName, action,
+		"Custom host vital %q (used as $%s%d) is used by the %q %s in the %q fleet. %s",
+		i.CustomHostVitalName, CustomHostVitalPrefix, i.CustomHostVitalID, i.Entity.Name, noun, i.Entity.FleetName, action,
 	)
+}
+
+// CustomHostVitalUsedError wraps CustomHostVitalUsedInfo as an error, returned when
+// a custom host vital can't be deleted because it is still referenced.
+type CustomHostVitalUsedError struct {
+	CustomHostVitalUsedInfo
+}
+
+func (e *CustomHostVitalUsedError) Error() string {
+	return e.Message()
 }
 
 func ValidateCustomHostVitalName(name string) error {
@@ -140,4 +174,18 @@ func ContainsCustomHostVitalIDs(text string) []uint {
 		ids = append(ids, uint(id))
 	}
 	return ids
+}
+
+// ContainsMalformedCustomHostVitalRefs returns the $FLEET_HOST_VITAL_<x> tokens in
+// text whose <x> is not a valid custom host vital ID (a positive integer), e.g. a
+// typo like $FLEET_HOST_VITAL_asset_tag.
+// Returned tokens omit the leading '$' (e.g. "FLEET_HOST_VITAL_asset_tag").
+func ContainsMalformedCustomHostVitalRefs(text string) []string {
+	var malformed []string
+	for _, s := range ContainsPrefixVars(text, CustomHostVitalPrefix) {
+		if id, err := strconv.ParseUint(s, 10, 64); err != nil || id == 0 {
+			malformed = append(malformed, CustomHostVitalPrefix+s)
+		}
+	}
+	return malformed
 }

--- a/server/fleet/custom_host_vitals_test.go
+++ b/server/fleet/custom_host_vitals_test.go
@@ -49,8 +49,8 @@ func TestMissingCustomHostVitalValueError(t *testing.T) {
 	single := MissingCustomHostVitalValueError{MissingIDs: []uint{5}}
 	require.Contains(t, single.Error(), `"$FLEET_HOST_VITAL_5"`)
 	require.Contains(t, single.Error(), "no value set for this host")
-	// Distinct from the upload-time "missing from database" wording.
-	require.NotContains(t, single.Error(), "missing from database")
+	// Distinct from the upload-time "is not defined" wording.
+	require.NotContains(t, single.Error(), "is not defined")
 
 	multi := MissingCustomHostVitalValueError{MissingIDs: []uint{5, 9}}
 	require.Contains(t, multi.Error(), "custom host vitals")

--- a/server/fleet/custom_host_vitals_test.go
+++ b/server/fleet/custom_host_vitals_test.go
@@ -1,0 +1,59 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainsCustomHostVitalIDs(t *testing.T) {
+	t.Run("both token forms and dedupe", func(t *testing.T) {
+		doc := `
+#!/bin/sh
+echo $FLEET_HOST_VITAL_1
+echo words${FLEET_HOST_VITAL_2}words
+echo $FLEET_HOST_VITAL_1 again
+`
+		ids := ContainsCustomHostVitalIDs(doc)
+		require.ElementsMatch(t, []uint{1, 2}, ids)
+	})
+
+	t.Run("ignores non-numeric and zero suffixes", func(t *testing.T) {
+		doc := `$FLEET_HOST_VITAL_ABC ${FLEET_HOST_VITAL_} $FLEET_HOST_VITAL_0 $FLEET_HOST_VITAL_12X $FLEET_HOST_VITAL_7`
+		ids := ContainsCustomHostVitalIDs(doc)
+		require.Equal(t, []uint{7}, ids)
+	})
+
+	t.Run("no tokens", func(t *testing.T) {
+		require.Empty(t, ContainsCustomHostVitalIDs("no vitals here $FLEET_SECRET_FOO $FLEET_VAR_HOST_UUID"))
+	})
+
+	t.Run("does not match a longer variable that starts with the prefix name", func(t *testing.T) {
+		// FLEET_VAR_ prefix should not be caught.
+		require.Empty(t, ContainsCustomHostVitalIDs("$FLEET_VAR_HOST_VITAL_1"))
+	})
+}
+
+func TestMissingCustomHostVitalsError(t *testing.T) {
+	single := MissingCustomHostVitalsError{MissingIDs: []uint{5}}
+	require.Contains(t, single.Error(), `"$FLEET_HOST_VITAL_5"`)
+	require.Contains(t, single.Error(), "Custom host vital ")
+
+	multi := MissingCustomHostVitalsError{MissingIDs: []uint{5, 9}}
+	require.Contains(t, multi.Error(), "Custom host vitals")
+	require.Contains(t, multi.Error(), `"$FLEET_HOST_VITAL_5"`)
+	require.Contains(t, multi.Error(), `"$FLEET_HOST_VITAL_9"`)
+}
+
+func TestMissingCustomHostVitalValueError(t *testing.T) {
+	single := MissingCustomHostVitalValueError{MissingIDs: []uint{5}}
+	require.Contains(t, single.Error(), `"$FLEET_HOST_VITAL_5"`)
+	require.Contains(t, single.Error(), "no value set for this host")
+	// Distinct from the upload-time "missing from database" wording.
+	require.NotContains(t, single.Error(), "missing from database")
+
+	multi := MissingCustomHostVitalValueError{MissingIDs: []uint{5, 9}}
+	require.Contains(t, multi.Error(), "custom host vitals")
+	require.Contains(t, multi.Error(), `"$FLEET_HOST_VITAL_5"`)
+	require.Contains(t, multi.Error(), `"$FLEET_HOST_VITAL_9"`)
+}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3136,6 +3136,16 @@ type Datastore interface {
 	SetHostCustomHostVitalValue(ctx context.Context, hostID uint, vitalID uint, value string) error
 	GetHostCustomHostVitals(ctx context.Context, hostID uint) ([]HostCustomHostVital, error)
 	GetCustomHostVitals(ctx context.Context, ids []uint) ([]CustomHostVital, error)
+	// ValidateReferencedCustomHostVitals parses $FLEET_HOST_VITAL_<id> tokens from
+	// the given documents and checks that every referenced id exists. Returns a
+	// MissingCustomHostVitalsError if any referenced id is unknown.
+	ValidateReferencedCustomHostVitals(ctx context.Context, documents []string) error
+
+	// ExpandCustomHostVitals substitutes $FLEET_HOST_VITAL_<id> tokens in the
+	// document with the given host's stored values (format-aware escaping).
+	// Returns a MissingCustomHostVitalValueError if a referenced vital has no value
+	// for the host.
+	ExpandCustomHostVitals(ctx context.Context, hostID uint, document string) (string, error)
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// Android

--- a/server/fleet/embedded_variables.go
+++ b/server/fleet/embedded_variables.go
@@ -1,0 +1,16 @@
+package fleet
+
+import "context"
+
+// ValidateEmbeddedSecretsAndCustomHostVitals validates the database-backed
+// variables a script or profile can embed: $FLEET_SECRET_* secrets and
+// $FLEET_HOST_VITAL_<id> custom host vitals. Callers run it on upload so a
+// document referencing a non-existent secret or vital is rejected up front. It
+// lives in the fleet package (rather than a secrets- or vitals-specific file)
+// because it spans both domains.
+func ValidateEmbeddedSecretsAndCustomHostVitals(ctx context.Context, ds Datastore, documents []string) error {
+	if err := ds.ValidateEmbeddedSecrets(ctx, documents); err != nil {
+		return err
+	}
+	return ds.ValidateReferencedCustomHostVitals(ctx, documents)
+}

--- a/server/mdm/apple/profile_processor.go
+++ b/server/mdm/apple/profile_processor.go
@@ -187,10 +187,11 @@ func preprocessProfileContents(
 			continue
 		}
 
-		// Check if Fleet variables are present.
+		// Check if Fleet variables or custom host vitals are present.
 		contentsStr := string(contents)
 		fleetVars := variables.Find(contentsStr)
-		if len(fleetVars) == 0 {
+		hasHostVitals := len(fleet.ContainsCustomHostVitalIDs(contentsStr)) > 0
+		if len(fleetVars) == 0 && !hasHostVitals {
 			continue
 		}
 
@@ -631,6 +632,44 @@ func preprocessProfileContents(
 					// This was handled in the above switch statement, so we should never reach this case
 				}
 			}
+
+			// Expand per-host custom host vitals ($FLEET_HOST_VITAL_<id>). This is a
+			// top-level prefix not handled by the FLEET_VAR_ loop above. On a
+			// missing/empty value for this host, mark the profile failed with a
+			// detail rather than shipping a blank substitution.
+			if !failed && hasHostVitals {
+				hostForVitals, ok, err := profiles.HydrateHost(ctx, ds, hostLite, onMismatchedHostCount)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "hydrating host for custom host vitals")
+				}
+				if !ok {
+					// onMismatchedHostCount already marked the profile failed.
+					failed = true
+				} else {
+					hostLite = hostForVitals
+					expanded, err := ds.ExpandCustomHostVitals(ctx, hostLite.ID, hostContents)
+					if err != nil {
+						var missing *fleet.MissingCustomHostVitalValueError
+						if !errors.As(err, &missing) {
+							return ctxerr.Wrap(ctx, err, "expanding custom host vitals")
+						}
+						if updErr := ds.UpdateOrDeleteHostMDMAppleProfile(ctx, &fleet.HostMDMAppleProfile{
+							CommandUUID:        target.CmdUUID,
+							HostUUID:           hostUUID,
+							Status:             &fleet.MDMDeliveryFailed,
+							Detail:             missing.Error(),
+							OperationType:      fleet.MDMOperationTypeInstall,
+							VariablesUpdatedAt: variablesUpdatedAt,
+						}); updErr != nil {
+							return ctxerr.Wrap(ctx, updErr, "marking profile failed for missing custom host vital")
+						}
+						failed = true
+					} else {
+						hostContents = expanded
+					}
+				}
+			}
+
 			if !failed {
 				addedTargets[tempProfUUID] = &fleet.CmdTarget{
 					CmdUUID:           tempCmdUUID,

--- a/server/mdm/microsoft/custom_host_vitals_test.go
+++ b/server/mdm/microsoft/custom_host_vitals_test.go
@@ -1,0 +1,65 @@
+package microsoft_mdm
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreprocessWindowsProfileContentsCustomHostVitals(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+		return []*fleet.Host{{ID: 55, UUID: "host-uuid-55"}}, nil
+	}
+
+	ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+	appConfig, err := ds.AppConfig(ctx)
+	require.NoError(t, err)
+
+	newDeps := func() ProfilePreprocessDependencies {
+		return ProfilePreprocessDependencies{
+			Context:                    ctx,
+			Logger:                     slog.New(slog.DiscardHandler),
+			DataStore:                  ds,
+			HostIDForUUIDCache:         map[string]uint{},
+			AppConfig:                  appConfig,
+			ManagedCertificatePayloads: &[]*fleet.MDMManagedCertificate{},
+		}
+	}
+
+	profile := `<Replace><Item><Data>$FLEET_HOST_VITAL_3</Data></Item></Replace>`
+
+	t.Run("substitutes the host's value with XML escaping", func(t *testing.T) {
+		ds.ExpandCustomHostVitalsFunc = func(ctx context.Context, hostID uint, doc string) (string, error) {
+			require.Equal(t, uint(55), hostID)
+			// simulate escaping of a value containing an XML-special char
+			return `<Replace><Item><Data>a &amp; b</Data></Item></Replace>`, nil
+		}
+		result, err := PreprocessWindowsProfileContentsForDeployment(newDeps(), ProfilePreprocessParams{
+			HostUUID: "host-uuid-55", ProfileUUID: "prof-1",
+		}, profile)
+		require.NoError(t, err)
+		require.Equal(t, `<Replace><Item><Data>a &amp; b</Data></Item></Replace>`, result)
+	})
+
+	t.Run("missing/empty value marks the profile failed with detail", func(t *testing.T) {
+		ds.ExpandCustomHostVitalsFunc = func(ctx context.Context, hostID uint, doc string) (string, error) {
+			return "", &fleet.MissingCustomHostVitalValueError{MissingIDs: []uint{3}}
+		}
+		_, err := PreprocessWindowsProfileContentsForDeployment(newDeps(), ProfilePreprocessParams{
+			HostUUID: "host-uuid-55", ProfileUUID: "prof-1",
+		}, profile)
+		require.Error(t, err)
+		var procErr *MicrosoftProfileProcessingError
+		require.ErrorAs(t, err, &procErr)
+		require.Contains(t, procErr.Error(), "FLEET_HOST_VITAL_3")
+	})
+}

--- a/server/mdm/microsoft/profile_variables.go
+++ b/server/mdm/microsoft/profile_variables.go
@@ -2,6 +2,7 @@ package microsoft_mdm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -78,9 +79,10 @@ type ProfilePreprocessParams struct {
 // implementation and to the interface if it's required for both verification and deployment. For new dependencies that
 // vary profile-to-profile, add them to ProfilePreprocessParams.
 func preprocessWindowsProfileContents(deps ProfilePreprocessDependencies, params ProfilePreprocessParams, profileContents string) (string, error) {
-	// Check if Fleet variables are present
+	// Check if Fleet variables or custom host vitals are present.
 	fleetVars := variables.Find(profileContents)
-	if len(fleetVars) == 0 {
+	hasHostVitals := len(fleet.ContainsCustomHostVitalIDs(profileContents)) > 0
+	if len(fleetVars) == 0 && !hasHostVitals {
 		// No variables to replace, return original content
 		return profileContents, nil
 	}
@@ -184,6 +186,27 @@ func preprocessWindowsProfileContents(deps ProfilePreprocessDependencies, params
 		case fleetVar == string(fleet.FleetVarNDESSCEPProxyURL):
 			result = profiles.ReplaceNDESSCEPProxyURLVariable(deps.AppConfig.MDMUrl(), params.HostUUID, params.ProfileUUID, result)
 		}
+	}
+
+	// Expand per-host custom host vitals. On a missing/empty value the datastore
+	// returns a MissingCustomHostVitalValueError, which we surface as a
+	// MicrosoftProfileProcessingError so the caller marks the profile failed with
+	// this detail rather than shipping a blank substitution.
+	if hasHostVitals {
+		hostLite, _, err := profiles.HydrateHost(deps.Context, deps.DataStore, fleet.Host{UUID: params.HostUUID}, func(hostCount int) error {
+			return &MicrosoftProfileProcessingError{message: fmt.Sprintf("Found %d hosts with UUID %s. Custom host vital substitution requires exactly one host.", hostCount, params.HostUUID)}
+		})
+		if err != nil {
+			return profileContents, err
+		}
+		expanded, err := deps.DataStore.ExpandCustomHostVitals(deps.Context, hostLite.ID, result)
+		if err != nil {
+			if missing, ok := errors.AsType[*fleet.MissingCustomHostVitalValueError](err); ok {
+				return profileContents, &MicrosoftProfileProcessingError{message: missing.Error()}
+			}
+			return profileContents, err
+		}
+		result = expanded
 	}
 
 	return result, nil

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1828,6 +1828,10 @@ type GetHostCustomHostVitalsFunc func(ctx context.Context, hostID uint) ([]fleet
 
 type GetCustomHostVitalsFunc func(ctx context.Context, ids []uint) ([]fleet.CustomHostVital, error)
 
+type ValidateReferencedCustomHostVitalsFunc func(ctx context.Context, documents []string) error
+
+type ExpandCustomHostVitalsFunc func(ctx context.Context, hostID uint, document string) (string, error)
+
 type CreateEnterpriseFunc func(ctx context.Context, userID uint) (uint, error)
 
 type GetEnterpriseByIDFunc func(ctx context.Context, id uint) (*android.EnterpriseDetails, error)
@@ -4858,6 +4862,12 @@ type DataStore struct {
 
 	GetCustomHostVitalsFunc        GetCustomHostVitalsFunc
 	GetCustomHostVitalsFuncInvoked bool
+
+	ValidateReferencedCustomHostVitalsFunc        ValidateReferencedCustomHostVitalsFunc
+	ValidateReferencedCustomHostVitalsFuncInvoked bool
+
+	ExpandCustomHostVitalsFunc        ExpandCustomHostVitalsFunc
+	ExpandCustomHostVitalsFuncInvoked bool
 
 	CreateEnterpriseFunc        CreateEnterpriseFunc
 	CreateEnterpriseFuncInvoked bool
@@ -11660,6 +11670,20 @@ func (s *DataStore) GetCustomHostVitals(ctx context.Context, ids []uint) ([]flee
 	s.GetCustomHostVitalsFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetCustomHostVitalsFunc(ctx, ids)
+}
+
+func (s *DataStore) ValidateReferencedCustomHostVitals(ctx context.Context, documents []string) error {
+	s.mu.Lock()
+	s.ValidateReferencedCustomHostVitalsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ValidateReferencedCustomHostVitalsFunc(ctx, documents)
+}
+
+func (s *DataStore) ExpandCustomHostVitals(ctx context.Context, hostID uint, document string) (string, error) {
+	s.mu.Lock()
+	s.ExpandCustomHostVitalsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ExpandCustomHostVitalsFunc(ctx, hostID, document)
 }
 
 func (s *DataStore) CreateEnterprise(ctx context.Context, userID uint) (uint, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -423,6 +423,10 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, d
 		return nil, ctxerr.Wrap(ctx, err, "validating fleet variables")
 	}
 
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{string(data)}); err != nil {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", err.Error()))
+	}
+
 	cp, err := fleet.NewMDMAppleConfigProfile([]byte(expanded), &teamID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
@@ -919,6 +923,11 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 		return nil, ctxerr.Wrap(ctx, err, "validating declaration Fleet variables")
 	}
 
+	// Validate custom host vital references (top-level $FLEET_HOST_VITAL_<id>).
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{string(data)}); err != nil {
+		return nil, fleet.NewInvalidArgumentError("profile", err.Error())
+	}
+
 	varNames := make([]fleet.FleetVarName, 0, len(declVars))
 	for _, v := range declVars {
 		varNames = append(varNames, fleet.FleetVarName(v))
@@ -1089,8 +1098,12 @@ func jsonEscapeString(s string) string {
 func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 	ctx context.Context, contents string, hostUUID string,
 ) (string, error) {
+	// variables.Find only detects $FLEET_VAR_; custom host vitals are a separate
+	// top-level prefix, so gate on both so a declaration referencing only custom
+	// host vitals is still expanded.
 	fleetVars := variables.Find(contents)
-	if len(fleetVars) == 0 {
+	hasHostVitals := len(fleet.ContainsCustomHostVitalIDs(contents)) > 0
+	if len(fleetVars) == 0 && !hasHostVitals {
 		return contents, nil
 	}
 
@@ -1114,6 +1127,19 @@ func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 		hostLite = h
 		hostHydrated = true
 		return nil
+	}
+
+	// Expand custom host vitals first. On a missing/empty value the caller marks
+	// the declaration failed with this error's Detail.
+	if hasHostVitals {
+		if err := hydrateHost(); err != nil {
+			return "", err
+		}
+		expanded, err := svc.ds.ExpandCustomHostVitals(ctx, hostLite.ID, contents)
+		if err != nil {
+			return "", err
+		}
+		contents = expanded
 	}
 
 	var idpUser *fleet.HostEndUser
@@ -2857,6 +2883,9 @@ func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tm
 			return ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), err.Error()),
 				"missing fleet secrets")
+		}
+		if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{string(prof)}); err != nil {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), err.Error()))
 		}
 		mdmProf, err := fleet.NewMDMAppleConfigProfile([]byte(expanded), tmID)
 		if err != nil {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1129,19 +1129,6 @@ func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 		return nil
 	}
 
-	// Expand custom host vitals first. On a missing/empty value the caller marks
-	// the declaration failed with this error's Detail.
-	if hasHostVitals {
-		if err := hydrateHost(); err != nil {
-			return "", err
-		}
-		expanded, err := svc.ds.ExpandCustomHostVitals(ctx, hostLite.ID, contents)
-		if err != nil {
-			return "", err
-		}
-		contents = expanded
-	}
-
 	var idpUser *fleet.HostEndUser
 	resolveIDPUser := func(varName string) (*fleet.HostEndUser, error) {
 		if idpUser != nil {
@@ -1235,6 +1222,23 @@ func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 		}
 
 		contents = variables.Replace(contents, fleetVar, jsonEscapeString(value))
+	}
+
+	// Expand custom host vitals last, after the Fleet-var pass. variables.Replace
+	// is a blind global string replace, so expanding vitals earlier would let a
+	// vital value that happens to contain a literal $FLEET_VAR_<name> be rewritten
+	// by that pass. Doing it last makes the vital value the terminal substitution.
+	// On a missing/empty value the caller marks the declaration failed with this
+	// error's Detail.
+	if hasHostVitals {
+		if err := hydrateHost(); err != nil {
+			return "", err
+		}
+		expanded, err := svc.ds.ExpandCustomHostVitals(ctx, hostLite.ID, contents)
+		if err != nil {
+			return "", err
+		}
+		contents = expanded
 	}
 
 	return contents, nil

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -51,7 +51,7 @@ func TestReplaceDeclarationFleetVariablesExpandsVitalsLast(t *testing.T) {
 	// The genuine $FLEET_VAR_HOST_HARDWARE_SERIAL reference expands to the serial,
 	// but the identical token inside the vital's value survives intact because
 	// vitals are expanded last (variables.Replace never sees it).
-	require.Equal(t, `{"vital":"tag-$FLEET_VAR_HOST_HARDWARE_SERIAL","serial":"SERIAL123"}`, out)
+	require.JSONEq(t, `{"vital":"tag-$FLEET_VAR_HOST_HARDWARE_SERIAL","serial":"SERIAL123"}`, out)
 }
 
 func TestDeclarativeManagement_DeclarationItems(t *testing.T) {

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -17,6 +17,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Custom host vital values are arbitrary admin/external strings, so one may
+// contain a literal $FLEET_VAR_<name>. variables.Replace is a blind global
+// string replace, so vitals must be expanded after the Fleet-var pass — else a
+// $FLEET_VAR_ token embedded in a vital value would be rewritten by that pass.
+func TestReplaceDeclarationFleetVariablesExpandsVitalsLast(t *testing.T) {
+	ctx := t.Context()
+	ds := mysqltest.CreateMySQLDS(t)
+	svc := MDMAppleDDMService{
+		ds:     ds,
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		UUID:            "vital-order-uuid",
+		Hostname:        "vital-order-host",
+		HardwareSerial:  "SERIAL123",
+		OsqueryHostID:   new("vital-order"),
+		NodeKey:         new("vital-order"),
+		DetailUpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	vital, err := ds.CreateCustomHostVital(ctx, "asset_tag")
+	require.NoError(t, err)
+	// The vital's value deliberately embeds a literal $FLEET_VAR_ token.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, host.ID, vital.ID, "tag-$FLEET_VAR_HOST_HARDWARE_SERIAL"))
+
+	contents := fmt.Sprintf(`{"vital":"$FLEET_HOST_VITAL_%d","serial":"$FLEET_VAR_HOST_HARDWARE_SERIAL"}`, vital.ID)
+	out, err := svc.replaceDeclarationFleetVariables(ctx, contents, host.UUID)
+	require.NoError(t, err)
+
+	// The genuine $FLEET_VAR_HOST_HARDWARE_SERIAL reference expands to the serial,
+	// but the identical token inside the vital's value survives intact because
+	// vitals are expanded last (variables.Replace never sees it).
+	require.Equal(t, `{"vital":"tag-$FLEET_VAR_HOST_HARDWARE_SERIAL","serial":"SERIAL123"}`, out)
+}
+
 func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 	ctx := t.Context()
 	ds := mysqltest.CreateMySQLDS(t)

--- a/server/service/custom_host_vitals.go
+++ b/server/service/custom_host_vitals.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -145,6 +147,11 @@ func (svc *Service) DeleteCustomHostVital(ctx context.Context, id uint) error {
 
 	name, err := svc.ds.DeleteCustomHostVital(ctx, id)
 	if err != nil {
+		if usedErr, ok := errors.AsType[*fleet.CustomHostVitalUsedError](err); ok {
+			return ctxerr.Wrap(ctx, &fleet.ConflictError{
+				Message: fmt.Sprintf("Couldn't delete. %s", usedErr.Error()),
+			}, "delete custom host vital")
+		}
 		return ctxerr.Wrap(ctx, err, "delete custom host vital")
 	}
 

--- a/server/service/custom_host_vitals_resolution_test.go
+++ b/server/service/custom_host_vitals_resolution_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeExpandCustomHostVitals mimics the datastore's ExpandCustomHostVitals
+// behavior (missing/empty value -> MissingCustomHostVitalValueError) for the given
+// per-host value map, so service-layer tests don't need a real DB.
+func fakeExpandCustomHostVitals(valueByID map[uint]string) func(context.Context, uint, string) (string, error) {
+	return func(_ context.Context, _ uint, document string) (string, error) {
+		refIDs := fleet.ContainsCustomHostVitalIDs(document)
+		if len(refIDs) == 0 {
+			return document, nil
+		}
+		var missing []uint
+		for _, id := range refIDs {
+			if v, ok := valueByID[id]; !ok || v == "" {
+				missing = append(missing, id)
+			}
+		}
+		if len(missing) > 0 {
+			return "", &fleet.MissingCustomHostVitalValueError{MissingIDs: missing}
+		}
+		expanded := fleet.MaybeExpand(document, func(s string, _, _ int) (string, bool) {
+			if !strings.HasPrefix(s, fleet.CustomHostVitalPrefix) {
+				return "", false
+			}
+			id, err := strconv.ParseUint(strings.TrimPrefix(s, fleet.CustomHostVitalPrefix), 10, 64)
+			if err != nil {
+				return "", false
+			}
+			v, ok := valueByID[uint(id)]
+			return v, ok
+		})
+		return expanded, nil
+	}
+}
+
+func TestGetHostScriptExpandsCustomHostVitals(t *testing.T) {
+	ds := new(mock.Store)
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+
+	host := &fleet.Host{ID: 42, UUID: "host-uuid-42", OrbitNodeKey: new("nk")}
+
+	ds.ExpandEmbeddedSecretsFunc = func(ctx context.Context, doc string) (string, error) {
+		return doc, nil
+	}
+
+	t.Run("substitutes the host's value", func(t *testing.T) {
+		ds.GetHostScriptExecutionResultFunc = func(ctx context.Context, execID string) (*fleet.HostScriptResult, error) {
+			return &fleet.HostScriptResult{HostID: host.ID, ExecutionID: execID, ScriptContents: "echo $FLEET_HOST_VITAL_7"}, nil
+		}
+		ds.ExpandCustomHostVitalsFunc = fakeExpandCustomHostVitals(map[uint]string{7: "engineering"})
+
+		hctx := hostctx.NewContext(ctx, host)
+		res, err := svc.GetHostScript(hctx, "exec-1")
+		require.NoError(t, err)
+		require.Equal(t, "echo engineering", res.ScriptContents)
+	})
+
+	t.Run("empty/missing value fails the script fetch", func(t *testing.T) {
+		ds.GetHostScriptExecutionResultFunc = func(ctx context.Context, execID string) (*fleet.HostScriptResult, error) {
+			return &fleet.HostScriptResult{HostID: host.ID, ExecutionID: execID, ScriptContents: "echo $FLEET_HOST_VITAL_9"}, nil
+		}
+		// host 42 has no value for vital 9
+		ds.ExpandCustomHostVitalsFunc = fakeExpandCustomHostVitals(map[uint]string{7: "engineering"})
+
+		hctx := hostctx.NewContext(ctx, host)
+		_, err := svc.GetHostScript(hctx, "exec-2")
+		require.Error(t, err)
+		var missing *fleet.MissingCustomHostVitalValueError
+		require.ErrorAs(t, err, &missing)
+		require.Equal(t, []uint{9}, missing.MissingIDs)
+	})
+}
+
+func TestCreateScriptValidatesCustomHostVitals(t *testing.T) {
+	ds := new(mock.Store)
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+	ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, documents []string) error { return nil }
+
+	// Simulate the real datastore: unknown ids -> MissingCustomHostVitalsError.
+	ds.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error {
+		want := map[uint]struct{}{}
+		for _, d := range documents {
+			for _, id := range fleet.ContainsCustomHostVitalIDs(d) {
+				want[id] = struct{}{}
+			}
+		}
+		// only id 1 exists
+		var missing []uint
+		for id := range want {
+			if id != 1 {
+				missing = append(missing, id)
+			}
+		}
+		if len(missing) > 0 {
+			return &fleet.MissingCustomHostVitalsError{MissingIDs: missing}
+		}
+		return nil
+	}
+
+	// Unknown id (999) should be rejected.
+	_, err := svc.NewScript(ctx, nil, "myscript.sh", strings.NewReader("#!/bin/sh\necho $FLEET_HOST_VITAL_999\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "FLEET_HOST_VITAL_999")
+
+	// ValidateReferencedCustomHostVitals must actually have been called.
+	require.True(t, ds.ValidateReferencedCustomHostVitalsFuncInvoked)
+}

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -100,12 +100,6 @@ func TestHostDetails(t *testing.T) {
 	ds.IsHostDiskEncryptionKeyArchivedFunc = func(ctx context.Context, hostID uint) (bool, error) {
 		return false, nil
 	}
-	ds.ConditionalAccessBypassedAtFunc = func(ctx context.Context, hostID uint) (*time.Time, error) {
-		return nil, nil
-	}
-	ds.GetHostCustomHostVitalsFunc = func(ctx context.Context, hostID uint) ([]fleet.HostCustomHostVital, error) {
-		return nil, nil
-	}
 
 	opts := fleet.HostDetailOptions{
 		IncludeCVEScores: false,

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2242,6 +2242,22 @@ func (svc *Service) BatchSetMDMProfiles(
 		return ctxerr.Wrap(ctx, err, "validating profiles")
 	}
 
+	// Only Apple and Windows profiles expand $FLEET_HOST_VITAL_ tokens at delivery.
+	// Android has no expansion path and is rejected outright in getAndroidProfiles
+	// (MDMAndroidConfigProfile.ValidateUserProvided) below; skip it here so an Android
+	// profile referencing a vital gets that clear "not supported" error rather than a
+	// misleading "missing from database" one from this existence check.
+	customHostVitalDocs := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		if mdm.GetRawProfilePlatform(p.Contents) == "android" {
+			continue
+		}
+		customHostVitalDocs = append(customHostVitalDocs, string(p.Contents))
+	}
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, customHostVitalDocs); err != nil {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profiles", err.Error()))
+	}
+
 	appleProfiles, appleDecls, err := getAppleProfiles(ctx, tmID, appCfg, profilesWithSecrets, labelMap, svc.config.MDM)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "validating macOS profiles")

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -3654,6 +3654,13 @@ func ReconcileWindowsProfilesForEnrollingHost(ctx context.Context, ds fleet.Data
 	return executeWindowsProfileReconcileBatch(ctx, ds, logger, appConfig, toInstall, toRemove, desiredByHost)
 }
 
+// windowsProfileNeedsPerHostProcessing reports whether a Windows profile must be
+// processed per-host at delivery time — i.e. it references any FLEET_VAR_ variable
+// or any $FLEET_HOST_VITAL_<id> custom host vital.
+func windowsProfileNeedsPerHostProcessing(syncML []byte) bool {
+	return variables.ContainsBytes(syncML) || len(fleet.ContainsCustomHostVitalIDs(string(syncML))) > 0
+}
+
 // ReconcileWindowsProfiles applies configuration profiles to Windows MDM hosts.
 //
 // It walks every enrolled Windows host via a host_uuid cursor (persisted in Redis through the mysqlredis wrapper), loading a
@@ -3971,7 +3978,7 @@ func executeWindowsProfileReconcileBatch(
 			continue
 		}
 		p, ok := profileContents[profUUID]
-		if !ok || variables.ContainsBytes(p.SyncML) {
+		if !ok || windowsProfileNeedsPerHostProcessing(p.SyncML) {
 			continue // variable profiles get per-host commands, can't pre-build
 		}
 		command, err := buildCommandFromProfileBytes(p.SyncML, target.cmdUUID)
@@ -4016,7 +4023,7 @@ func executeWindowsProfileReconcileBatch(
 			continue
 		}
 
-		if !variables.ContainsBytes(p.SyncML) {
+		if !windowsProfileNeedsPerHostProcessing(p.SyncML) {
 			// No Fleet variables, send the same command to all hosts
 			payloads, ok := batchProfileCmdsMap[target.cmdUUID]
 			if !ok {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -1095,6 +1095,11 @@ func (svc *Service) GetHostScript(ctx context.Context, execID string) (*fleet.Ho
 		return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("expand embedded secrets for host %d and script %s", host.ID, execID))
 	}
 
+	script.ScriptContents, err = svc.ds.ExpandCustomHostVitals(ctx, host.ID, script.ScriptContents)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("expand custom host vitals for host %d and script %s", host.ID, execID))
+	}
+
 	return script, nil
 }
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -128,7 +128,7 @@ func (svc *Service) RunHostScript(ctx context.Context, request *fleet.HostScript
 	}
 
 	if request.ScriptContents != "" {
-		if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{request.ScriptContents}); err != nil {
+		if err := fleet.ValidateEmbeddedSecretsAndCustomHostVitals(ctx, svc.ds, []string{request.ScriptContents}); err != nil {
 			svc.authz.SkipAuthorization(ctx)
 			return nil, fleet.NewInvalidArgumentError("script", err.Error())
 		}
@@ -410,7 +410,7 @@ func (svc *Service) NewScript(ctx context.Context, teamID *uint, name string, r 
 		ScriptContents: file.Dos2UnixNewlines(string(b)),
 	}
 
-	if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{script.ScriptContents}); err != nil {
+	if err := fleet.ValidateEmbeddedSecretsAndCustomHostVitals(ctx, svc.ds, []string{script.ScriptContents}); err != nil {
 		return nil, fleet.NewInvalidArgumentError("script", err.Error())
 	}
 
@@ -613,7 +613,7 @@ func (svc *Service) UpdateScript(ctx context.Context, scriptID uint, r io.Reader
 
 	scriptContents := file.Dos2UnixNewlines(string(b))
 
-	if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{scriptContents}); err != nil {
+	if err := fleet.ValidateEmbeddedSecretsAndCustomHostVitals(ctx, svc.ds, []string{scriptContents}); err != nil {
 		return nil, fleet.NewInvalidArgumentError("script", err.Error())
 	}
 
@@ -766,7 +766,7 @@ func (svc *Service) BatchSetScripts(ctx context.Context, maybeTmID *uint, maybeT
 		return nil, nil
 	}
 
-	if err := svc.ds.ValidateEmbeddedSecrets(ctx, scriptContents); err != nil {
+	if err := fleet.ValidateEmbeddedSecretsAndCustomHostVitals(ctx, svc.ds, scriptContents); err != nil {
 		return nil, fleet.NewInvalidArgumentError("script", err.Error())
 	}
 

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -88,6 +88,16 @@ func newTestService(t *testing.T, ds fleet.Datastore, rs fleet.QueryResultStore,
 }
 
 func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig config.FleetConfig, rs fleet.QueryResultStore, lq fleet.LiveQueryStore, opts ...*TestServerOpts) (fleet.Service, context.Context) {
+	// Custom host vital reference validation is wired into all script/profile
+	// upload paths. Provide a permissive default so tests that don't reference
+	// $FLEET_HOST_VITAL_<id> don't need to stub it (the real datastore no-ops
+	// when the document has no such tokens). Tests that assert on it can override.
+	if mockDS, ok := ds.(*fleet_mock.Store); ok {
+		if mockDS.ValidateReferencedCustomHostVitalsFunc == nil {
+			mockDS.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error { return nil }
+		}
+	}
+
 	lic := &fleet.LicenseInfo{Tier: fleet.TierFree}
 	logger := slog.New(slog.DiscardHandler)
 	writer, err := logging.NewFilesystemLogWriter(t.Context(), fleetConfig.Filesystem.StatusLogFile, logger, fleetConfig.Filesystem.EnableLogRotation,

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -92,7 +92,7 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 	}
 	cp.LabelsExcludeAny = excludeLabels
 
-	if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{string(cp.SyncML)}); err != nil {
+	if err := fleet.ValidateEmbeddedSecretsAndCustomHostVitals(ctx, svc.ds, []string{string(cp.SyncML)}); err != nil {
 		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", err.Error()))
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48761

This PR adds the backend for custom host vitals: validating `$FLEET_HOST_VITAL_<id>` on upload and expanding it per-host at delivery (scripts, Apple/Windows/DDM configuration profiles, software-installer + setup-experience scripts), plus delete-protection.
Stacked on the CRUD PR which has already been merged to the feature branch.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in feature branch.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


Env:
- dev server
- one enrolled macOS 26.5.1 VM (`host_id=1`)
- fleet "💻 Workstations".
- The Controls → Variables management UI is still on mocks, so vital definitions/values were created via the REST API; everything else via the UI.

### 1. Scripts: expansion at fetch time
- Created vital `asset_tag` (`$FLEET_HOST_VITAL_1`), **no value** on the host. Ran `echo "asset tag: $FLEET_HOST_VITAL_1"` → run **failed to fetch**; server log:
  `err="…Couldn't populate custom host vital \"$FLEET_HOST_VITAL_1\": no value set for this host"`. Run stayed **Upcoming** (never executed; re-attempts each poll).
- Set the value to `LAPTOP-042` → the pending run fetched successfully on the next poll and completed (exit 0) with `asset tag: LAPTOP-042`.

<img width="825" height="328" alt="laptop042_script" src="https://github.com/user-attachments/assets/28eb057c-94b7-4072-996b-9db40db330b2" />

### 2. Apple configuration profile: re-delivery

Profile writes `AssetTag = $FLEET_HOST_VITAL_1` into a managed preference domain.

- **Delivered with value:** VM shows `AssetTag = LAPTOP-042`.

<img width="488" height="452" alt="laptop042_mobileconfig_value_already_set" src="https://github.com/user-attachments/assets/48ace314-75d8-4981-a999-23d1c0f55e74" />


- **Re-push on change:** changed the value to `LAPTOP-999` via API (no re-upload/re-scope) → profile re-delivered → VM shows `AssetTag = LAPTOP-999`.

<img width="505" height="476" alt="laptop042_change_to_laptop999_repush" src="https://github.com/user-attachments/assets/22e61208-1600-48c2-85f8-84ca330734c3" />


- **No-value → Failed:** a second profile references `$FLEET_HOST_VITAL_2` (`department`, no value) → profile lands **Failed** and is not applied on the VM. Reason is stored as the profile's per-host `detail`: `Couldn't populate custom host vital "$FLEET_HOST_VITAL_2": no value set for this host`.

<img width="672" height="445" alt="step3_novalue_fails" src="https://github.com/user-attachments/assets/d7eb7da6-ddf4-4ceb-84d1-c6096d27ae2e" />


- **Failed → set value → recovered:** set `department = Engineering` → the Failed profile reset (`failed → pending`, detail cleared) and re-delivered → VM shows `Department = Engineering`.

<img width="499" height="457" alt="step3_no_value_set_value" src="https://github.com/user-attachments/assets/bd52bf43-01f8-4524-8f81-827f45cad2be" />


### 3. DDM declaration
Declaration `com.apple.configuration.softwareupdate.enforcement.specific` with `TargetOSVersion = $FLEET_HOST_VITAL_3` (`min_os`).

- **No-value → Failed:** with no value, the declaration lands **Failed** on the host; detail `Couldn't populate custom host vital "$FLEET_HOST_VITAL_3": no value set for this host`, the reconciler flagged it and the manifest builder dropped it (not a device-side rejection).

<img width="679" height="442" alt="ddm_failed_no_value" src="https://github.com/user-attachments/assets/cd866c28-c180-4453-8e81-8740808888c4" />


- **Set value → Verified:** set `min_os = 26.5.1` (VM's current OS → enforcement is a no-op) → declaration reset `failed → pending`, re-synced → **Verified**. Verified ⇒ the token expanded to a valid version (a literal token would be an invalid OS version and get rejected).

<img width="663" height="433" alt="ddm_set_value_verified" src="https://github.com/user-attachments/assets/01cee1c7-fb65-48b3-9597-cbc068f1ef4b" />


- DB confirmation of the fix: `host_mdm_apple_declarations.variables_updated_at` for this declaration is **non-NULL** (`2026-07-10 00:11:34`), i.e. the vital-referencing declaration was flagged `HasFleetVariables` and stamped.

### 4. Delete-protection
- **Referenced → 409:** `DELETE` on each of the three vitals returned **409 Conflict** naming the referencing entity: across a **script** (`helloworld.sh`), an **Apple profile**, and a **DDM declaration**, proving the reference scan covers all types.
- **Unreferenced → deletes + cascade:** after removing the references, `DELETE` returned **200**; DB confirmed `custom_host_vitals` and `host_custom_host_vitals` both empty (per-host values cascaded via FK `ON DELETE CASCADE`); `deleted_custom_host_vital` activity fired for each.

### Not covered here (would need QA assistance)
- **Windows** configuration profile (needs an enrolled Windows host) re-delivery path.
- **Software-installer** + **setup-experience** scripts (validation-on-save + expansion-at-run mirror).
- **Android** negative (rejection on upload): needs an Android enrollment.

## Note about scope & parity with `$FLEET_SECRET_*`

Custom host vitals are **user-defined** (like `$FLEET_SECRET_*`), not built-in (like `$FLEET_VAR_*`), so they were scoped to the **same entities as embedded secrets**. Confirmed with product at standup after re-asking ([Slack thread](https://fleetdm.slack.com/archives/C084F4MKYSJ/p1783349366719079); screenshot below).
The table double-checks parity holds across every surface (line numbers = the validate/expand wiring, non-test).

<img width="925" height="308" alt="Screenshot 2026-07-09 at 10 14 03 PM" src="https://github.com/user-attachments/assets/307ea1de-0b3b-4f3e-8ab0-704d387deda6" />


| Delivery surface | `$FLEET_SECRET_*` | `$FLEET_HOST_VITAL_*` | Parity |
|---|---|---|---|
| **Scripts** (ad-hoc + saved) | validate `scripts.go:131/413/616/769`; expand `orbit.go:1092` | same validate (combined helper); expand `orbit.go:1098` | ✅ |
| **Apple config profiles** | upload `apple_mdm.go:411`; nano re-expand `nanomdm_storage.go:360` | validate `apple_mdm.go:426`; expand `profile_processor.go:650` | ✅ |
| **Apple DDM declarations** | upload `apple_mdm.go:911`; delivery `apple_mdm.go:6344` | validate `apple_mdm.go:927` / `mdm.go:2257`; expand `apple_mdm.go:1237` | ✅ |
| **Windows config profiles** | validate `windows_mdm_profiles.go:95`; expand `microsoft_mdm.go:2036/1051` | same validate (combined helper); expand `profile_variables.go:202` | ✅ |
| **Software-installer scripts** | validate `software_installers.go:149/377/2461`; expand `:134` | validate `:162/390/2464`; expand `:138` | ✅ |
| **Setup-experience scripts** | validate `setup_experience.go:140`; expand via script path | validate `setup_experience.go:143`; expand via script path | ✅ |
| **Fleet-maintained-app scripts** | validate `maintained_apps.go:47` | validate `maintained_apps.go:60` | ✅ |
| **Android app config** | ✗ no secret expansion in Android path | ✗ rejected at upload | ✅ (both unsupported) |

In several files the vital validate/expand call sits 1–13 lines after the secret one (e.g. `setup_experience.go:140→143`, `software_installers.go:149→162`, `apple_mdm.go:411→426`). One deliberate architectural difference (not a gap): secrets are **global** (expanded at upload), vitals are **per-host** (validated at upload, expanded at delivery) — which is why the re-delivery fixes were needed for vitals but not secrets. **Android** is the single surface where neither is supported, so rejecting vitals there matches secret behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Script, software installer, and setup-experience content can now reference custom host vitals and will be expanded with per-host values during delivery.
  * MDM Apple and Windows profile processing now expands custom host vitals; Android configuration profiles still reject custom host vitals.
  * Batch MDM profile submission now rejects payloads that reference unknown custom host vitals.

* **Bug Fixes**
  * Prevent saving content that references unknown custom host vitals.
  * Prevent deleting a custom host vital while it’s still referenced (with a clearer conflict message).
  * Improved delivery-time errors when a custom host vital has no value for the target host.

* **Refactor**
  * Unified embedded secret validation with referenced custom-host-vital validation across script and profile upload flows.

* **Tests**
  * Added coverage for unknown vitals rejection, delivery expansion failures, and installer/profile expansion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->