### PR TITLE
Update tools/migration-cleanup to support main commit comparisons

### DIFF
--- a/tools/migration-cleanup/README.md
+++ b/tools/migration-cleanup/README.md
@@ -65,6 +65,23 @@ go run ./tools/migration-cleanup \
 If the branch only exists on the remote, pass the plain branch name. The tool
 tries the local branch first, then `origin/<branch>`.
 
+### Comparing two revisions of main
+
+`--base` defaults to `main` (the RC-branch case). To compare two revisions of
+`main` — for example to see renumbers that landed between two merged PRs —
+pass the older revision as `--base` and the newer one as `-b`:
+
+```sh
+go run ./tools/migration-cleanup \
+  -b <newer-main-sha> \
+  --base <older-main-sha>
+```
+
+The tool walks `<older>..<newer>` and reports any migration renames it finds.
+The generated SQL still assumes a contiguous grouped renumber (as an RC would
+produce), so inspect it before running `--apply` against a real database when
+the renames span unrelated commits.
+
 ## Dry run
 
 Dry run connects to MySQL, loads the real rows from `migration_status_tables`

--- a/tools/migration-cleanup/main.go
+++ b/tools/migration-cleanup/main.go
@@ -66,6 +66,7 @@ type sqlStatements struct {
 type options struct {
 	checkout string
 	branch   string
+	base     string
 	output   string
 	dryRun   bool
 	apply    bool
@@ -130,6 +131,7 @@ func newRootCmd(opts *options) *cobra.Command {
 	cmd.PersistentFlags().String("config", "", "Path to a Fleet configuration file")
 	cmd.Flags().StringVarP(&opts.checkout, "checkout", "c", ".", "Path to fleetdm/fleet git checkout")
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch name")
+	cmd.Flags().StringVar(&opts.base, "base", "main", "Base ref to compare against (branch name or SHA)")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "Write SQL to file instead of stdout")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Connect to MySQL, simulate the SQL, and verify the final state")
 	cmd.Flags().BoolVar(&opts.apply, "apply", false, "Execute SQL against the database in a transaction")
@@ -213,7 +215,15 @@ func run(ctx context.Context, configManager configpkg.Manager, opts options) err
 		fmt.Fprintf(os.Stderr, "Resolved branch: %s\n", branch)
 	}
 
-	mergeBase, err := getMergeBase(checkout, branch)
+	base, err := resolveBranch(checkout, opts.base)
+	if err != nil {
+		return exitError{code: exitGeneral, message: err.Error()}
+	}
+	if opts.verbose {
+		fmt.Fprintf(os.Stderr, "Resolved base: %s\n", base)
+	}
+
+	mergeBase, err := getMergeBase(checkout, base, branch)
 	if err != nil {
 		return exitError{code: exitGeneral, message: err.Error()}
 	}
@@ -367,8 +377,8 @@ func resolveBranch(checkout, branch string) (string, error) {
 	return "", fmt.Errorf("ERROR: cannot resolve branch %q", branch)
 }
 
-func getMergeBase(checkout, branch string) (string, error) {
-	out, err := git(checkout, "merge-base", "main", branch)
+func getMergeBase(checkout, base, branch string) (string, error) {
+	out, err := git(checkout, "merge-base", base, branch)
 	return strings.TrimSpace(out), err
 }
 


### PR DESCRIPTION
- Adds `--base` with default `main` to support targeting sha's.