### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/beekeeper-studio/darwin.json
+++ b/ee/maintained-apps/outputs/beekeeper-studio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.9.0",
+      "version": "5.9.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.beekeeperstudio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.beekeeperstudio.desktop' AND version_compare(bundle_short_version, '5.9.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.beekeeperstudio.desktop' AND version_compare(bundle_short_version, '5.9.1') < 0);"
       },
-      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.9.0/Beekeeper-Studio-5.9.0-arm64.dmg",
+      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.9.1/Beekeeper-Studio-5.9.1-arm64.dmg",
       "install_script_ref": "8f0b1e9d",
       "uninstall_script_ref": "eaf45799",
-      "sha256": "4e8412e8e82b19c078e7bc0cdb6baac17add1da973d789b439e778fff4b17aa0",
+      "sha256": "51fc3e09aeef0bcee4ea0e8ba4aa7aa09c6be1d10cac59f37af12e5cee2f8c16",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/beekeeper-studio/windows.json
+++ b/ee/maintained-apps/outputs/beekeeper-studio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.9.0",
+      "version": "5.9.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team' AND version_compare(version, '5.9.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team' AND version_compare(version, '5.9.1') < 0);"
       },
-      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.9.0/Beekeeper-Studio-Setup-5.9.0.exe",
+      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.9.1/Beekeeper-Studio-Setup-5.9.1.exe",
       "install_script_ref": "13334753",
       "uninstall_script_ref": "44e6f772",
-      "sha256": "f7b55be50225f55dc8d33c7ba75b644acf3633065f3a2ca1153916fab66cacae",
+      "sha256": "3c8eeb0480bb0a5790fb6c37301c1506f87e24ccac7761b5fb9b3cc79ce49709",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.18286.0",
+      "version": "1.18286.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.18286.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.18286.2') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.18286.0/Claude-259c3fc2a647e4222ca15e99bba9b2649f31f051.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.18286.2/Claude-b682d9f76a56cebb3327f0de7eda65a8399d4835.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "80a74053d52f478d447f10b48af6ac840c1b6dd172b3354b43107ff6d3bcc3b4",
+      "sha256": "75bb948b73e8a951280ded915e20871871f497640af59e374f4edad540b30953",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/codex-app/darwin.json
+++ b/ee/maintained-apps/outputs/codex-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.623.101652",
+      "version": "26.623.141536",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.623.101652') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.codex' AND version_compare(bundle_short_version, '26.623.141536') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.623.101652.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.623.141536.zip",
       "install_script_ref": "5e3efa57",
       "uninstall_script_ref": "a2b5ee81",
-      "sha256": "3283ebded45412c46810c5cbca2e3ab4fc36a735b79e531c182b7c35ca069bba",
+      "sha256": "d948dc36b8358f5a2924b033fbf08398eea7860dc9e97cb5ab9b354490283a0a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.40.0",
+      "version": "0.41.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.40.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.41.0') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.40.0/CodexBar-macos-universal-0.40.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.41.0/CodexBar-macos-universal-0.41.0.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "f1c908d932c8a60e229474b54833ed6e71bfeccba371b365ee9b04331a6f9075",
+      "sha256": "3378b4e58bb5e6e4cb77f6cee44e5b61e9f7758a35893108ff3efe571785858d",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/devin-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/devin-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.22",
+      "version": "3.4.27",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '3.4.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '3.4.27') < 0);"
       },
-      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/0c84d3332806347c90e571331f48dd13a957d880/Devin-darwin-arm64-3.4.22.dmg",
+      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/0d4bf12ed4a7597cb8ae9016fe8474468aad98a2/Devin-darwin-arm64-3.4.27.dmg",
       "install_script_ref": "917a2397",
       "uninstall_script_ref": "4fdaa2d1",
-      "sha256": "725d14dadd820a326c38e19a7d4da1dd0e51631df5a9cfdfaa7995cd1871efc2",
+      "sha256": "0d15df47d926a46d4afb3851433384ac8e4bbab3b47757ed0ed0881607b45303",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/discord/darwin.json
+++ b/ee/maintained-apps/outputs/discord/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.0.397",
+      "version": "0.0.398",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.397') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.398') < 0);"
       },
-      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.397/Discord.dmg",
+      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.398/Discord.dmg",
       "install_script_ref": "de3e67db",
       "uninstall_script_ref": "46a242eb",
-      "sha256": "6f453b7078ebfa7aeb7d5b241e7e1ae009f14943f549c1b70e9329b89ba0f057",
+      "sha256": "2f52b403801ed8c663406afa0ead8a07bb3588a9655ba9022bb24c574c5f610e",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/google-drive/darwin.json
+++ b/ee/maintained-apps/outputs/google-drive/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "127.0",
+      "version": "128.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs' AND version_compare(bundle_short_version, '127.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs' AND version_compare(bundle_short_version, '128.0') < 0);"
       },
       "installer_url": "https://dl.google.com/drive-file-stream/5-percent/GoogleDrive.dmg",
       "install_script_ref": "91aa50c7",

--- a/ee/maintained-apps/outputs/kiro-cli/darwin.json
+++ b/ee/maintained-apps/outputs/kiro-cli/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.11.0",
+      "version": "2.11.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.11.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.11.1') < 0);"
       },
-      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.11.0/Kiro%20CLI.dmg",
+      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.11.1/Kiro%20CLI.dmg",
       "install_script_ref": "7bf3d706",
       "uninstall_script_ref": "31b59062",
-      "sha256": "3dd3a3e4e6616b742c70ee836d31419cdf74130130139f6139742f330308cd3e",
+      "sha256": "8878bb271f0d2484ef2c8a854618d45b8ed614d1f4863f4b8a5cec3d6643ad71",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/milanote/darwin.json
+++ b/ee/maintained-apps/outputs/milanote/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.18.113",
+      "version": "3.18.114",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.milanote.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.milanote.app' AND version_compare(bundle_short_version, '3.18.113') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.milanote.app' AND version_compare(bundle_short_version, '3.18.114') < 0);"
       },
-      "installer_url": "https://milanote-app-releases.s3.amazonaws.com/Milanote-3.18.113.dmg",
+      "installer_url": "https://milanote-app-releases.s3.amazonaws.com/Milanote-3.18.114.dmg",
       "install_script_ref": "ed82e649",
       "uninstall_script_ref": "19269206",
-      "sha256": "e539716804abacd5fb72be8ba34515b69e1c2420d5b927b8ae18466943a56088",
+      "sha256": "50248ac62b448238590b0d3e5da30c1af938c2b432dc096b571e50a38381c1d1",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.18.0",
+      "version": "12.18.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.18.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.18.1') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.18.0/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.18.1/osx_arm64",
       "install_script_ref": "96d73870",
       "uninstall_script_ref": "966b2fa5",
-      "sha256": "80428dc2b1cdc7e83b9b0b15f8f010726d3bbe6b5901386aeca9deb370077670",
+      "sha256": "e165f132feb9aeb53ca5359d66df46f85554fd129295cf8ca027fa9520970f33",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/wealthfolio/darwin.json
+++ b/ee/maintained-apps/outputs/wealthfolio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.6.0",
+      "version": "3.6.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.teymz.wealthfolio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.teymz.wealthfolio' AND version_compare(bundle_short_version, '3.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.teymz.wealthfolio' AND version_compare(bundle_short_version, '3.6.1') < 0);"
       },
-      "installer_url": "https://github.com/afadil/wealthfolio/releases/download/v3.6.0/Wealthfolio_3.6.0_aarch64.dmg",
+      "installer_url": "https://github.com/afadil/wealthfolio/releases/download/v3.6.1/Wealthfolio_3.6.1_aarch64.dmg",
       "install_script_ref": "161e063d",
       "uninstall_script_ref": "cd049db6",
-      "sha256": "73ee6c3523dec43d47b93cbcf962e4898e8b5fdd7474a81867fb77f403cfdac1",
+      "sha256": "214ea7b9060a114324ab5d1e214ab8d69c89ff6bd68aea638e1b16fe18aec602",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release metadata for several maintained apps on macOS and Windows, including Beekeeper Studio, Claude, Codex, CodexBar, Devin Desktop, Discord, Google Drive, Kiro CLI, Milanote, Postman, and Wealthfolio.
  * Refreshed version checks, download links, and checksum values so app availability and update detection stay accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->