### PR TITLE
Add host name detail API, resend, and transfer/enrollment reconciliation

### DIFF
--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -165,6 +165,9 @@ func RunServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
 		return nil, nil
 	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+		return nil, nil
+	}
 	ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
 		return &fleet.TeamMDM{}, nil
 	}

--- a/server/datastore/mysql/apple_device_names.go
+++ b/server/datastore/mysql/apple_device_names.go
@@ -199,44 +199,48 @@ func (ds *Datastore) ReconcileHostDeviceNamesForHosts(ctx context.Context, hostI
 	if len(hostIDs) == 0 {
 		return nil
 	}
-
-	// A host should have a queued enforcement row when it is eligible and its team
-	// carries a non-empty name template; otherwise any existing row is removed.
-	// The template lives in teams.config JSON at $.mdm.name_template (empty string
-	// when unset, NULL for teams whose config predates the feature).
-	//
-	// Rather than conditionally upsert-or-delete per host, we delete every row for
-	// the given hosts and re-create queued rows only for the ones that should
-	// still be enforced. Both statements run in a single transaction, so no
-	// window ever exposes a missing row; the only observable difference from an
-	// upsert is that created_at resets, which is correct after a team change.
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		deleteStmt, deleteArgs, err := sqlx.In(`
-			DELETE hmadn
-			FROM host_mdm_apple_device_names hmadn
-			JOIN hosts h ON h.uuid = hmadn.host_uuid
-			WHERE h.id IN (?)`, hostIDs)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "build reconcile device name delete")
-		}
-		if _, err := tx.ExecContext(ctx, deleteStmt, deleteArgs...); err != nil {
-			return ctxerr.Wrap(ctx, err, "reconcile device name delete")
-		}
-
-		insertStmt, insertArgs, err := sqlx.In(`
-			INSERT INTO host_mdm_apple_device_names (host_uuid, status)
-			SELECT h.uuid, NULL`+deviceNameEligibleHostsJoins+`
-			JOIN teams t ON t.id = h.team_id
-			WHERE h.id IN (?)
-				AND `+deviceNameEligibleHostsWhere+`
-				AND t.config->>'$.mdm.name_template' IS NOT NULL
-				AND t.config->>'$.mdm.name_template' != ''`, hostIDs)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "build reconcile device name insert")
-		}
-		if _, err := tx.ExecContext(ctx, insertStmt, insertArgs...); err != nil {
-			return ctxerr.Wrap(ctx, err, "reconcile device name insert")
-		}
-		return nil
+		return reconcileHostDeviceNamesForHostsDB(ctx, tx, hostIDs)
 	})
+}
+
+// reconcileHostDeviceNamesForHostsDB upserts or deletes host-name enforcement
+// rows for the given hosts based on each host's current team template.
+//
+// A host should have a queued enforcement row when it is eligible and its team
+// carries a non-empty name template; otherwise any existing row is removed. The
+// template lives in teams.config JSON at $.mdm.name_template (empty string when
+// unset, NULL for teams whose config predates the feature).
+func reconcileHostDeviceNamesForHostsDB(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint) error {
+	if len(hostIDs) == 0 {
+		return nil
+	}
+
+	deleteStmt, deleteArgs, err := sqlx.In(`
+		DELETE hmadn
+		FROM host_mdm_apple_device_names hmadn
+		JOIN hosts h ON h.uuid = hmadn.host_uuid
+		WHERE h.id IN (?)`, hostIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build reconcile device name delete")
+	}
+	if _, err := tx.ExecContext(ctx, deleteStmt, deleteArgs...); err != nil {
+		return ctxerr.Wrap(ctx, err, "reconcile device name delete")
+	}
+
+	insertStmt, insertArgs, err := sqlx.In(`
+		INSERT INTO host_mdm_apple_device_names (host_uuid, status)
+		SELECT h.uuid, NULL`+deviceNameEligibleHostsJoins+`
+		JOIN teams t ON t.id = h.team_id
+		WHERE h.id IN (?)
+			AND `+deviceNameEligibleHostsWhere+`
+			AND t.config->>'$.mdm.name_template' IS NOT NULL
+			AND t.config->>'$.mdm.name_template' != ''`, hostIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build reconcile device name insert")
+	}
+	if _, err := tx.ExecContext(ctx, insertStmt, insertArgs...); err != nil {
+		return ctxerr.Wrap(ctx, err, "reconcile device name insert")
+	}
+	return nil
 }

--- a/server/datastore/mysql/apple_device_names_test.go
+++ b/server/datastore/mysql/apple_device_names_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +23,11 @@ func TestHostDeviceNames(t *testing.T) {
 		{"Verify", testHostDeviceNamesVerify},
 		{"Resend", testHostDeviceNamesResend},
 		{"Reconcile", testHostDeviceNamesReconcile},
+		{"TransferViaAddHostsToTeam", testHostDeviceNamesTransferViaAddHostsToTeam},
+		{"TransferBatched", testHostDeviceNamesTransferBatched},
+		{"SummaryAndFilter", testHostDeviceNamesSummaryAndFilter},
+		{"SummaryFilterLabel", testHostDeviceNamesSummaryFilterLabel},
+		{"TeamDeletionCleanup", testHostDeviceNamesTeamDeletionCleanup},
 		{"HostDeletionCleanup", testHostDeviceNamesHostDeletionCleanup},
 		{"FullLifecycle", testHostDeviceNamesFullLifecycle},
 	}
@@ -300,6 +306,249 @@ func testHostDeviceNamesReconcile(t *testing.T, ds *Datastore) {
 
 	// An empty host list is a no-op.
 	require.NoError(t, ds.ReconcileHostDeviceNamesForHosts(ctx, nil))
+}
+
+// setDeviceNameTemplate writes name_template into a team's config JSON directly,
+// so the eligibility/reconcile SQL sees a non-empty template without depending on
+// the TeamMDM struct field.
+func setDeviceNameTemplate(t *testing.T, ds *Datastore, teamID uint, tmpl string) {
+	_, err := ds.writer(t.Context()).ExecContext(t.Context(),
+		`UPDATE teams SET config = JSON_SET(config, '$.mdm.name_template', ?) WHERE id = ?`, tmpl, teamID)
+	require.NoError(t, err)
+}
+
+// testHostDeviceNamesTransferViaAddHostsToTeam exercises the transfer
+// reconciliation wired into the AddHostsToTeam datastore transaction, which
+// covers every service entry point that moves hosts between teams.
+func testHostDeviceNamesTransferViaAddHostsToTeam(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	withTemplate, err := ds.NewTeam(ctx, &fleet.Team{Name: "transfer-with-template"})
+	require.NoError(t, err)
+	setDeviceNameTemplate(t, ds, withTemplate.ID, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+
+	noTemplate, err := ds.NewTeam(ctx, &fleet.Team{Name: "transfer-no-template"})
+	require.NoError(t, err)
+
+	// A host starts in the template team with a queued row.
+	host := enrollAppleHostForDeviceName(t, ds, "mac", "darwin", withTemplate.ID, false)
+	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, withTemplate.ID))
+	require.Nil(t, getDeviceNameRow(t, ds, host.UUID).Status)
+
+	// Give the host a name so we can assert the transfer never renames it.
+	_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET computer_name = ? WHERE id = ?`, "keep-this-name", host.ID)
+	require.NoError(t, err)
+
+	// template -> template-less: the row is deleted (enforcement stops) and the
+	// host's name is left untouched.
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&noTemplate.ID, []uint{host.ID})))
+	_, err = ds.GetHostDeviceNameEnforcement(ctx, host.UUID)
+	require.True(t, fleet.IsNotFound(err), "transfer to a template-less team should delete the enforcement row")
+	var name string
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &name, `SELECT computer_name FROM hosts WHERE id = ?`, host.ID))
+	require.Equal(t, "keep-this-name", name, "transfer must not rename the host")
+
+	// template-less -> template: reconcile re-creates the queued row (UI reverts
+	// to Enforcing/Pending).
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&withTemplate.ID, []uint{host.ID})))
+	require.Nil(t, getDeviceNameRow(t, ds, host.UUID).Status, "transfer into a template team should create a queued row")
+
+	// template -> template (a different team that also has a template): the row is
+	// reset to NULL so the destination team's template is enforced afresh. Mark it
+	// verified first to prove the transfer resets an already-settled row.
+	_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE host_mdm_apple_device_names SET status = ? WHERE host_uuid = ?`, fleet.MDMDeliveryVerified, host.UUID)
+	require.NoError(t, err)
+	otherTemplate, err := ds.NewTeam(ctx, &fleet.Team{Name: "transfer-other-template"})
+	require.NoError(t, err)
+	setDeviceNameTemplate(t, ds, otherTemplate.ID, "Lab-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&otherTemplate.ID, []uint{host.ID})))
+	require.Nil(t, getDeviceNameRow(t, ds, host.UUID).Status, "transfer between template teams should reset the row to queued")
+
+	// template -> No team: the row is deleted (No team never enforces).
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(nil, []uint{host.ID})))
+	_, err = ds.GetHostDeviceNameEnforcement(ctx, host.UUID)
+	require.True(t, fleet.IsNotFound(err), "transfer to No team should delete the enforcement row")
+}
+
+// testHostDeviceNamesTransferBatched moves several hosts at once with a batch
+// size smaller than the host count, so the reconcile runs across multiple batches
+// within AddHostsToTeam.
+func testHostDeviceNamesTransferBatched(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	noTemplate, err := ds.NewTeam(ctx, &fleet.Team{Name: "batch-no-template"})
+	require.NoError(t, err)
+	withTemplate, err := ds.NewTeam(ctx, &fleet.Team{Name: "batch-with-template"})
+	require.NoError(t, err)
+	setDeviceNameTemplate(t, ds, withTemplate.ID, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+
+	// Three eligible hosts start in the template-less team (no rows) plus one BYOD
+	// host that must never get a row.
+	var hostIDs []uint
+	eligible := make([]*fleet.Host, 0, 3)
+	for i := range 3 {
+		h := enrollAppleHostForDeviceName(t, ds, "batch"+string(rune('a'+i)), "darwin", noTemplate.ID, false)
+		eligible = append(eligible, h)
+		hostIDs = append(hostIDs, h.ID)
+	}
+	byod := enrollAppleHostForDeviceName(t, ds, "batch-byod", "ios", noTemplate.ID, true)
+	hostIDs = append(hostIDs, byod.ID)
+
+	// Move all four into the template team with a batch size of 1 so the reconcile
+	// runs once per batch.
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&withTemplate.ID, hostIDs).WithBatchSize(1)))
+	for _, h := range eligible {
+		require.Nil(t, getDeviceNameRow(t, ds, h.UUID).Status, "eligible host %s should be queued after batched transfer", h.Hostname)
+	}
+	_, err = ds.GetHostDeviceNameEnforcement(ctx, byod.UUID)
+	require.True(t, fleet.IsNotFound(err), "BYOD host must not get a row")
+
+	// Move them all back to the template-less team, again batched: all rows deleted.
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&noTemplate.ID, hostIDs).WithBatchSize(2)))
+	for _, h := range eligible {
+		_, err = ds.GetHostDeviceNameEnforcement(ctx, h.UUID)
+		require.True(t, fleet.IsNotFound(err), "row for %s should be deleted after batched transfer out", h.Hostname)
+	}
+}
+
+// testHostDeviceNamesSummaryAndFilter asserts that host-name enforcement rows are
+// folded into the OS-settings aggregate counts and the os_settings host-list
+// filter, and that ineligible hosts (no row) count in no bucket.
+func testHostDeviceNamesSummaryAndFilter(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "summary-team"})
+	require.NoError(t, err)
+	setDeviceNameTemplate(t, ds, team.ID, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+
+	failedHost := enrollAppleHostForDeviceName(t, ds, "failed", "darwin", team.ID, false)
+	verifiedHost := enrollAppleHostForDeviceName(t, ds, "verified", "ios", team.ID, false)
+	verifyingHost := enrollAppleHostForDeviceName(t, ds, "verifying", "ios", team.ID, false)
+	queuedHost := enrollAppleHostForDeviceName(t, ds, "queued", "ipados", team.ID, false)
+	comboHost := enrollAppleHostForDeviceName(t, ds, "combo", "darwin", team.ID, false)
+	byodHost := enrollAppleHostForDeviceName(t, ds, "byod", "ios", team.ID, true)
+
+	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
+	// The BYOD host is ineligible, so it never got a row.
+	_, err = ds.GetHostDeviceNameEnforcement(ctx, byodHost.UUID)
+	require.True(t, fleet.IsNotFound(err))
+
+	setStatus := func(hostUUID string, status fleet.MDMDeliveryStatus) {
+		_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE host_mdm_apple_device_names SET status = ? WHERE host_uuid = ?`, status, hostUUID)
+		require.NoError(t, err)
+	}
+	setStatus(failedHost.UUID, fleet.MDMDeliveryFailed)
+	setStatus(verifiedHost.UUID, fleet.MDMDeliveryVerified)
+	setStatus(verifyingHost.UUID, fleet.MDMDeliveryVerifying)
+	setStatus(comboHost.UUID, fleet.MDMDeliveryFailed)
+	// queuedHost keeps its NULL status from the bulk upsert, which renders as pending.
+
+	// comboHost has a failed rename (set above) AND a verified (install) config
+	// profile: the shared status CASE must combine the profile and device-name
+	// buckets and let the failed rename win (failed > verified precedence).
+	_, err = ds.writer(ctx).ExecContext(ctx, `
+		INSERT INTO host_mdm_apple_profiles
+			(host_uuid, profile_uuid, command_uuid, status, operation_type, detail, profile_name, profile_identifier, checksum)
+		VALUES (?, ?, '', ?, ?, '', 'p1', 'com.example.p1', ?)`,
+		comboHost.UUID, "a"+comboHost.UUID, fleet.MDMDeliveryVerified, fleet.MDMOperationTypeInstall, []byte("csum"))
+	require.NoError(t, err)
+
+	// Aggregate summary folds the rename statuses in (a NULL/queued row counts as
+	// pending); the BYOD host is in no bucket, and comboHost lands in failed.
+	summary, err := ds.GetMDMAppleProfilesSummary(ctx, &team.ID)
+	require.NoError(t, err)
+	require.Equal(t, uint(2), summary.Failed, "failedHost + comboHost (failed rename wins over its verified profile)")
+	require.Equal(t, uint(1), summary.Verified)
+	require.Equal(t, uint(1), summary.Verifying)
+	require.Equal(t, uint(1), summary.Pending)
+
+	// Each aggregate card's host-list filter returns the matching hosts, including
+	// the queued (NULL-status) host under pending and comboHost under failed.
+	userFilter := fleet.TeamFilter{User: test.UserAdmin}
+	assertFilter := func(status fleet.OSSettingsStatus, want ...*fleet.Host) {
+		hosts, err := ds.ListHosts(ctx, userFilter, fleet.HostListOptions{TeamFilter: &team.ID, OSSettingsFilter: status})
+		require.NoError(t, err)
+		gotIDs := make([]uint, 0, len(hosts))
+		for _, h := range hosts {
+			gotIDs = append(gotIDs, h.ID)
+		}
+		wantIDs := make([]uint, 0, len(want))
+		for _, h := range want {
+			wantIDs = append(wantIDs, h.ID)
+		}
+		require.ElementsMatch(t, wantIDs, gotIDs)
+	}
+	assertFilter(fleet.OSSettingsFailed, failedHost, comboHost)
+	assertFilter(fleet.OSSettingsVerified, verifiedHost)
+	assertFilter(fleet.OSSettingsVerifying, verifyingHost)
+	assertFilter(fleet.OSSettingsPending, queuedHost)
+}
+
+// testHostDeviceNamesSummaryFilterLabel covers the os_settings host-list filter
+// on the label-hosts path (ListHostsInLabel), which folds in the same
+// device-name status join as the main list path.
+func testHostDeviceNamesSummaryFilterLabel(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "label-team"})
+	require.NoError(t, err)
+	setDeviceNameTemplate(t, ds, team.ID, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+
+	failedHost := enrollAppleHostForDeviceName(t, ds, "label-failed", "darwin", team.ID, false)
+	verifiedHost := enrollAppleHostForDeviceName(t, ds, "label-verified", "ios", team.ID, false)
+	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
+	_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE host_mdm_apple_device_names SET status = ? WHERE host_uuid = ?`, fleet.MDMDeliveryFailed, failedHost.UUID)
+	require.NoError(t, err)
+	_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE host_mdm_apple_device_names SET status = ? WHERE host_uuid = ?`, fleet.MDMDeliveryVerified, verifiedHost.UUID)
+	require.NoError(t, err)
+
+	label, err := ds.NewLabel(ctx, &fleet.Label{Name: "label-dn", Query: "select 1"})
+	require.NoError(t, err)
+	for _, h := range []*fleet.Host{failedHost, verifiedHost} {
+		require.NoError(t, ds.RecordLabelQueryExecutions(ctx, h, map[uint]*bool{label.ID: new(true)}, time.Now(), false))
+	}
+
+	userFilter := fleet.TeamFilter{User: test.UserAdmin}
+	hosts, err := ds.ListHostsInLabel(ctx, userFilter, label.ID, fleet.HostListOptions{TeamFilter: &team.ID, OSSettingsFilter: fleet.OSSettingsFailed})
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	require.Equal(t, failedHost.ID, hosts[0].ID)
+}
+
+// testHostDeviceNamesTeamDeletionCleanup asserts that deleting a team removes the
+// host-name enforcement rows for its hosts. Team deletion moves the hosts to "No
+// team" via ON DELETE SET NULL (not AddHostsToTeam), so the enforcement rows must
+// be cleaned up explicitly in DeleteTeam.
+func testHostDeviceNamesTeamDeletionCleanup(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "delete-me"})
+	require.NoError(t, err)
+	setDeviceNameTemplate(t, ds, team.ID, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+	host := enrollAppleHostForDeviceName(t, ds, "del", "darwin", team.ID, false)
+
+	otherTeam, err := ds.NewTeam(ctx, &fleet.Team{Name: "keep-me"})
+	require.NoError(t, err)
+	setDeviceNameTemplate(t, ds, otherTeam.ID, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL")
+	otherHost := enrollAppleHostForDeviceName(t, ds, "keep", "darwin", otherTeam.ID, false)
+
+	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, team.ID))
+	require.NoError(t, ds.BulkUpsertHostDeviceNameEnforcement(ctx, otherTeam.ID))
+	require.Nil(t, getDeviceNameRow(t, ds, host.UUID).Status)
+	require.Nil(t, getDeviceNameRow(t, ds, otherHost.UUID).Status)
+
+	require.NoError(t, ds.DeleteTeam(ctx, team.ID))
+
+	// The deleted team's host keeps its record but moves to No team; its
+	// enforcement row is gone.
+	_, err = ds.GetHostDeviceNameEnforcement(ctx, host.UUID)
+	require.True(t, fleet.IsNotFound(err), "enforcement row must be deleted with the team")
+	movedHost, err := ds.Host(ctx, host.ID)
+	require.NoError(t, err)
+	require.Nil(t, movedHost.TeamID, "host should have moved to No team, not been deleted")
+
+	// The other team's row is untouched.
+	require.Nil(t, getDeviceNameRow(t, ds, otherHost.UUID).Status, "other team's row must survive")
 }
 
 func testHostDeviceNamesHostDeletionCleanup(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2960,8 +2960,10 @@ func (ds *Datastore) UpdateOrDeleteHostMDMAppleProfile(ctx context.Context, prof
 }
 
 // sqlCaseMDMAppleStatus returns a SQL snippet that can be used to determine the status of a host
-// based on the status of its profiles, declarations, filevault status, and recovery lock status. It should be used in
-// conjunction with sqlJoinMDMAppleProfilesStatus, sqlJoinMDMAppleDeclarationsStatus, and sqlJoinRecoveryLockStatus. It assumes the
+// based on the status of its profiles, declarations, filevault status, recovery lock status, and host-name
+// template status. It should be used in conjunction with sqlJoinMDMAppleProfilesStatus,
+// sqlJoinMDMAppleDeclarationsStatus, sqlJoinRecoveryLockStatus, and sqlJoinDeviceNameStatus (all four joins are
+// required — omitting any one leaves a referenced column, e.g. dn_failed, undefined). It assumes the
 // hosts table to be aliased as 'h' and the host_disk_encryption_keys table to be aliased as 'hdek'.
 func sqlCaseMDMAppleStatus() string {
 	// NOTE: To make this snippet reusable, we're not using sqlx.Named here because it would
@@ -2976,11 +2978,13 @@ func sqlCaseMDMAppleStatus() string {
 	CASE WHEN (prof_failed
 		OR decl_failed
 		OR fv_failed
-		OR rl_failed) THEN
+		OR rl_failed
+		OR dn_failed) THEN
 		` + failed + `
 	WHEN (prof_pending
 		OR decl_pending
 		OR rl_pending
+		OR dn_pending
 		-- special case for filevault, it's pending if the profile is
 		-- pending OR the profile is verified or verifying but we still
 		-- don't have an encryption key.
@@ -2992,6 +2996,7 @@ func sqlCaseMDMAppleStatus() string {
 	WHEN (prof_verifying
 		OR decl_verifying
 		OR rl_verifying
+		OR dn_verifying
 		-- special case when fv profile is verifying, and we already have an encryption key, in any state, we treat as verifying
 		OR(fv_verifying
 			AND hdek.base64_encrypted IS NOT NULL AND (hdek.decryptable IS NULL OR hdek.decryptable = 1))
@@ -3002,6 +3007,7 @@ func sqlCaseMDMAppleStatus() string {
 	WHEN (prof_verified
 		OR decl_verified
 		OR rl_verified
+		OR dn_verified
 		OR(fv_verified
 			AND hdek.base64_encrypted IS NOT NULL AND hdek.decryptable = 1)) THEN
 		` + verified + `
@@ -3076,6 +3082,35 @@ func sqlJoinRecoveryLockStatus() string {
 `
 }
 
+// sqlJoinDeviceNameStatus returns a SQL snippet that can be used to join the
+// host_mdm_apple_device_names table (host-name template enforcement) to the
+// hosts table. For each host it derives a boolean value for each status
+// category; the value will be 1 if the host has a device-name row in the given
+// status. Ineligible hosts have no row, so they contribute to no bucket. A NULL
+// status is treated as pending (queued for the cron), same as recovery lock. The
+// snippet assumes the hosts table to be aliased as 'h'.
+func sqlJoinDeviceNameStatus() string {
+	var (
+		failed    = fmt.Sprintf("'%s'", string(fleet.MDMDeliveryFailed))
+		pending   = fmt.Sprintf("'%s'", string(fleet.MDMDeliveryPending))
+		verifying = fmt.Sprintf("'%s'", string(fleet.MDMDeliveryVerifying))
+		verified  = fmt.Sprintf("'%s'", string(fleet.MDMDeliveryVerified))
+	)
+	return `
+	LEFT JOIN (
+		-- host-name template status per host (host_uuid is the primary key)
+		-- NULL status is treated as pending (queued for the cron)
+		SELECT
+			host_uuid,
+			IF(status IS NULL OR status = ` + pending + `, 1, 0) AS dn_pending,
+			IF(status = ` + failed + `, 1, 0) AS dn_failed,
+			IF(status = ` + verifying + `, 1, 0) AS dn_verifying,
+			IF(status = ` + verified + `, 1, 0) AS dn_verified
+		FROM
+			host_mdm_apple_device_names) hmadn ON h.uuid = hmadn.host_uuid
+`
+}
+
 // sqlJoinMDMAppleDeclarationsStatus returns a SQL snippet that can be used to join a table derived from
 // host_mdm_apple_declarations (grouped by host_uuid and status) and the hosts table. For each host_uuid,
 // it derives a boolean value for each status category. The value will be 1 if the host has any
@@ -3119,6 +3154,7 @@ FROM
 	%s
 	%s
 	%s
+	%s
 	LEFT JOIN host_disk_encryption_keys hdek ON h.id = hdek.host_id
 WHERE
 	platform IN('darwin', 'ios', 'ipados') AND %s
@@ -3130,7 +3166,7 @@ GROUP BY
 		teamFilter = fmt.Sprintf("team_id = %d", *teamID)
 	}
 
-	stmt = fmt.Sprintf(stmt, sqlCaseMDMAppleStatus(), sqlJoinMDMAppleProfilesStatus(), sqlJoinMDMAppleDeclarationsStatus(), sqlJoinRecoveryLockStatus(), teamFilter)
+	stmt = fmt.Sprintf(stmt, sqlCaseMDMAppleStatus(), sqlJoinMDMAppleProfilesStatus(), sqlJoinMDMAppleDeclarationsStatus(), sqlJoinRecoveryLockStatus(), sqlJoinDeviceNameStatus(), teamFilter)
 
 	var dest []struct {
 		Count  uint   `db:"count"`

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1429,12 +1429,14 @@ func (ds *Datastore) applyHostFilters(
 	mdmAppleProfilesStatusJoin := ""
 	mdmAppleDeclarationsStatusJoin := ""
 	mdmRecoveryLockStatusJoin := ""
+	mdmDeviceNameStatusJoin := ""
 	mdmAndroidProfilesStatusJoin := ""
 	if opt.OSSettingsFilter.IsValid() ||
 		opt.MacOSSettingsFilter.IsValid() {
 		mdmAppleProfilesStatusJoin = sqlJoinMDMAppleProfilesStatus()
 		mdmAppleDeclarationsStatusJoin = sqlJoinMDMAppleDeclarationsStatus()
 		mdmRecoveryLockStatusJoin = sqlJoinRecoveryLockStatus()
+		mdmDeviceNameStatusJoin = sqlJoinDeviceNameStatus()
 	}
 
 	if opt.OSSettingsFilter.IsValid() {
@@ -1487,6 +1489,7 @@ func (ds *Datastore) applyHostFilters(
     %s
 	%s
 	%s
+	%s
 		WHERE TRUE AND %s AND %s AND %s AND %s AND %s %s
     `,
 
@@ -1502,6 +1505,7 @@ func (ds *Datastore) applyHostFilters(
 		mdmAppleProfilesStatusJoin,
 		mdmAppleDeclarationsStatusJoin,
 		mdmRecoveryLockStatusJoin,
+		mdmDeviceNameStatusJoin,
 		mdmAndroidProfilesStatusJoin,
 		batchScriptExecutionJoin,
 		hostMDMSeenJoin,
@@ -3638,6 +3642,14 @@ func (ds *Datastore) AddHostsToTeam(ctx context.Context, params *fleet.AddHostsT
 
 				if err := cleanupDiskEncryptionKeysOnTeamChangeDB(ctx, tx, hostIDsBatch, teamID); err != nil {
 					return ctxerr.Wrap(ctx, err, "AddHostsToTeam cleanup disk encryption keys")
+				}
+
+				// Reconcile host-name template enforcement against the destination
+				// team: eligible hosts moving into a template team get queued rows,
+				// and hosts moving to a template-less team or "No team" have their rows deleted .
+				// This runs after the team_id update above so the eligibility query sees the new team.
+				if err := reconcileHostDeviceNamesForHostsDB(ctx, tx, hostIDsBatch); err != nil {
+					return ctxerr.Wrap(ctx, err, "AddHostsToTeam reconcile host device names")
 				}
 
 				return nil

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1346,6 +1346,7 @@ func (ds *Datastore) applyHostLabelFilters(ctx context.Context, filter fleet.Tea
 		query += sqlJoinMDMAppleProfilesStatus()
 		query += sqlJoinMDMAppleDeclarationsStatus()
 		query += sqlJoinRecoveryLockStatus()
+		query += sqlJoinDeviceNameStatus()
 	}
 
 	if opt.OSSettingsFilter.IsValid() {

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -216,6 +216,20 @@ func (ds *Datastore) DeleteTeam(ctx context.Context, tid uint) error {
 			}
 		}
 
+		// Delete host-name template enforcement rows for this team's hosts before
+		// the team is removed, while the hosts still carry this team_id. Deleting
+		// the team reassigns them to "No team" via ON DELETE SET NULL (hosts are not
+		// deleted), which never routes through AddHostsToTeam, so the transfer
+		// reconcile can't clean these up. "No team" is never enforced, so the rows
+		// must go — matching how a transfer to a template-less team deletes them.
+		if _, err = tx.ExecContext(ctx, `
+			DELETE hmadn
+			FROM host_mdm_apple_device_names hmadn
+			JOIN hosts h ON h.uuid = hmadn.host_uuid
+			WHERE h.team_id = ?`, tid); err != nil {
+			return ctxerr.Wrapf(ctx, err, "deleting host device name enforcement for team %d", tid)
+		}
+
 		_, err = tx.ExecContext(ctx, `DELETE FROM teams WHERE id = ?`, tid)
 		if err != nil {
 			return ctxerr.Wrapf(ctx, err, "delete team %d", tid)

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -679,6 +679,23 @@ type HostMDMOSSettings struct {
 	DiskEncryption       HostMDMDiskEncryption       `json:"disk_encryption" db:"-" csv:"-"`
 	RecoveryLockPassword HostMDMRecoveryLockPassword `json:"recovery_lock_password" db:"-" csv:"-"`
 	ManagedLocalAccount  HostMDMManagedLocalAccount  `json:"managed_local_account" db:"-" csv:"-"`
+	HostName             *HostMDMHostNameSetting     `json:"host_name,omitempty" db:"-" csv:"-"`
+}
+
+// HostNameSettingStatus is the per-host status of the host-name template
+// enforcement surfaced in the host detail response.
+type HostNameSettingStatus string
+
+const (
+	HostNameSettingPending   HostNameSettingStatus = "pending"
+	HostNameSettingVerifying HostNameSettingStatus = "verifying"
+	HostNameSettingVerified  HostNameSettingStatus = "verified"
+	HostNameSettingFailed    HostNameSettingStatus = "failed"
+)
+
+type HostMDMHostNameSetting struct {
+	Status HostNameSettingStatus `json:"status" db:"-" csv:"-"`
+	Detail string                `json:"detail" db:"-" csv:"-"`
 }
 
 type HostMDMDiskEncryption struct {

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -507,4 +508,19 @@ func TestIsPlaceholderHardwareSerial(t *testing.T) {
 			assert.Equal(t, tc.want, IsPlaceholderHardwareSerial(tc.serial))
 		})
 	}
+}
+
+func TestHostMDMHostNameSettingJSON(t *testing.T) {
+	// Omitted entirely when there is no enforcement (host_name is a nil pointer
+	// with omitempty), matching the recovery-lock treatment for ineligible hosts.
+	b, err := json.Marshal(HostMDMOSSettings{})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "host_name")
+
+	// Present with the fleets-forward status/detail contract the frontend consumes.
+	b, err = json.Marshal(HostMDMOSSettings{
+		HostName: &HostMDMHostNameSetting{Status: HostNameSettingFailed, Detail: "boom"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"host_name":{"status":"failed","detail":"boom"}`)
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1292,6 +1292,11 @@ type Service interface {
 	// ResendHostMDMProfile resends the MDM profile to the host.
 	ResendHostMDMProfile(ctx context.Context, hostID uint, profileUUID string) error
 
+	// ResendHostNameTemplate resets a host's host-name template enforcement so
+	// the cron re-sends the Settings/DeviceName command on its next run. Only
+	// hosts in a "failed" or "verified" state can be resent.
+	ResendHostNameTemplate(ctx context.Context, hostID uint) error
+
 	// ResendDeviceHostMDMProfile resends the MDM profile to the device host that requested it.
 	ResendDeviceHostMDMProfile(ctx context.Context, host *Host, profileUUID string) error
 

--- a/server/mdm/lifecycle/lifecycle.go
+++ b/server/mdm/lifecycle/lifecycle.go
@@ -179,8 +179,33 @@ func (t *HostLifecycle) resetApple(ctx context.Context, opts HostOptions) error 
 		}
 	}
 
-	err := t.ds.MDMResetEnrollment(ctx, opts.UUID, opts.SCEPRenewalInProgress)
-	return ctxerr.Wrap(ctx, err, "reset mdm enrollment")
+	if err := t.ds.MDMResetEnrollment(ctx, opts.UUID, opts.SCEPRenewalInProgress); err != nil {
+		return ctxerr.Wrap(ctx, err, "reset mdm enrollment")
+	}
+
+	// Reconcile host-name template enforcement on (re-)enrollment. Skipped during
+	// SCEP renewal, which isn't a real enrollment change and where host.ID isn't
+	// populated (the upsert above is skipped too).
+	if !opts.SCEPRenewalInProgress {
+		if err := t.reconcileHostNameEnforcement(ctx, host.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// reconcileHostNameEnforcement upserts or deletes the host's host-name template
+// enforcement row based on its current team template, so a host enrolling into a
+// team with a template gets a queued row.
+func (t *HostLifecycle) reconcileHostNameEnforcement(ctx context.Context, hostID uint) error {
+	if hostID == 0 {
+		return nil
+	}
+	if err := t.ds.ReconcileHostDeviceNamesForHosts(ctx, []uint{hostID}); err != nil {
+		return ctxerr.Wrap(ctx, err, "reconcile host name enforcement")
+	}
+	return nil
 }
 
 func (t *HostLifecycle) turnOnApple(ctx context.Context, opts HostOptions) error {
@@ -243,6 +268,18 @@ func (t *HostLifecycle) turnOnApple(ctx context.Context, opts HostOptions) error
 	var tmID *uint
 	if info.TeamID != 0 {
 		tmID = &info.TeamID
+	}
+
+	// Reconcile host-name template enforcement now that the host is enrolled: if
+	// its team has a template and it's eligible.
+	// Done before the branches below since they return early.
+	//
+	// resetApple also reconciles, so a normal Authenticate->TokenUpdate enrollment
+	// reconciles twice; that's intentional and idempotent. Both hooks are needed
+	// because a re-enrollment can arrive as Authenticate (resetApple) without a
+	// fresh TokenUpdate reaching this branch (guarded on TokenUpdateTally == 1).
+	if err := t.reconcileHostNameEnforcement(ctx, info.HostID); err != nil {
+		return err
 	}
 
 	// TODO: improve this to not enqueue the job if a host that is

--- a/server/mdm/lifecycle/lifecycle_test.go
+++ b/server/mdm/lifecycle/lifecycle_test.go
@@ -66,6 +66,109 @@ func TestDoParamValidation(t *testing.T) {
 	}
 }
 
+// TestReconcileHostNameEnforcementOnEnrollment verifies that both Apple
+// enrollment lifecycle branches — turn-on (TokenUpdate) and reset (Authenticate,
+// covering re-enrollment) — reconcile the host's host-name template enforcement,
+// so a host enrolling into a team with a template gets a queued row.
+func TestReconcileHostNameEnforcementOnEnrollment(t *testing.T) {
+	ctx := license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+	const hostID = uint(99)
+
+	t.Run("turn-on reconciles with the enrolled host id", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, uuid string) (*fleet.NanoEnrollment, error) {
+			return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
+		}
+		ds.GetHostMDMCheckinInfoFunc = func(ctx context.Context, uuid string) (*fleet.HostMDMCheckinInfo, error) {
+			return &fleet.HostMDMCheckinInfo{HostID: hostID, Platform: "darwin"}, nil
+		}
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) { return job, nil }
+		var gotIDs []uint
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(ctx context.Context, hostIDs []uint) error {
+			gotIDs = hostIDs
+			return nil
+		}
+
+		lc := New(ds, slog.New(slog.DiscardHandler), nopNewActivity)
+		require.NoError(t, lc.Do(ctx, HostOptions{Action: HostActionTurnOn, Platform: "darwin", UUID: "host-uuid"}))
+		require.True(t, ds.ReconcileHostDeviceNamesForHostsFuncInvoked)
+		require.Equal(t, []uint{hostID}, gotIDs)
+	})
+
+	t.Run("turn-on reconciles on the DEP branch before its early return", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, uuid string) (*fleet.NanoEnrollment, error) {
+			return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
+		}
+		// DEPAssignedToFleet takes the DEP branch, which queues a job and returns
+		// early — the reconcile must run before that branch.
+		ds.GetHostMDMCheckinInfoFunc = func(ctx context.Context, uuid string) (*fleet.HostMDMCheckinInfo, error) {
+			return &fleet.HostMDMCheckinInfo{HostID: hostID, Platform: "darwin", DEPAssignedToFleet: true}, nil
+		}
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) { return job, nil }
+		var gotIDs []uint
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(ctx context.Context, hostIDs []uint) error {
+			gotIDs = hostIDs
+			return nil
+		}
+
+		lc := New(ds, slog.New(slog.DiscardHandler), nopNewActivity)
+		require.NoError(t, lc.Do(ctx, HostOptions{Action: HostActionTurnOn, Platform: "darwin", UUID: "host-uuid"}))
+		require.True(t, ds.ReconcileHostDeviceNamesForHostsFuncInvoked)
+		require.Equal(t, []uint{hostID}, gotIDs)
+		require.True(t, ds.NewJobFuncInvoked, "DEP branch should have been taken")
+	})
+
+	t.Run("turn-on skips reconcile when the enrollment is not ready", func(t *testing.T) {
+		ds := new(mock.Store)
+		// TokenUpdateTally != 1 makes turnOnApple short-circuit before reconciling.
+		ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, uuid string) (*fleet.NanoEnrollment, error) {
+			return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 2}, nil
+		}
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(ctx context.Context, hostIDs []uint) error { return nil }
+
+		lc := New(ds, slog.New(slog.DiscardHandler), nopNewActivity)
+		require.NoError(t, lc.Do(ctx, HostOptions{Action: HostActionTurnOn, Platform: "darwin", UUID: "host-uuid"}))
+		require.False(t, ds.ReconcileHostDeviceNamesForHostsFuncInvoked)
+	})
+
+	t.Run("reset reconciles with the upserted host id", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.MDMAppleUpsertHostFunc = func(ctx context.Context, mdmHost *fleet.Host, fromPersonalEnrollment bool) error {
+			mdmHost.ID = hostID
+			return nil
+		}
+		ds.MDMResetEnrollmentFunc = func(ctx context.Context, uuid string, scepRenewalInProgress bool) error { return nil }
+		var gotIDs []uint
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(ctx context.Context, hostIDs []uint) error {
+			gotIDs = hostIDs
+			return nil
+		}
+
+		lc := New(ds, slog.New(slog.DiscardHandler), nopNewActivity)
+		require.NoError(t, lc.Do(ctx, HostOptions{
+			Action: HostActionReset, Platform: "darwin",
+			UUID: "host-uuid", HardwareSerial: "serial", HardwareModel: "MacBookPro",
+		}))
+		require.True(t, ds.ReconcileHostDeviceNamesForHostsFuncInvoked)
+		require.Equal(t, []uint{hostID}, gotIDs)
+	})
+
+	t.Run("reset skips reconcile during SCEP renewal", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.MDMResetEnrollmentFunc = func(ctx context.Context, uuid string, scepRenewalInProgress bool) error { return nil }
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(ctx context.Context, hostIDs []uint) error { return nil }
+
+		lc := New(ds, slog.New(slog.DiscardHandler), nopNewActivity)
+		require.NoError(t, lc.Do(ctx, HostOptions{
+			Action: HostActionReset, Platform: "darwin",
+			UUID: "host-uuid", HardwareSerial: "serial", HardwareModel: "MacBookPro",
+			SCEPRenewalInProgress: true,
+		}))
+		require.False(t, ds.ReconcileHostDeviceNamesForHostsFuncInvoked)
+	})
+}
+
 // TestDeleteAppleDuplicateDEPHost verifies that deleting one of a set of
 // duplicate DEP hosts (same serial) does not recreate a pending "ghost" host
 // when another DEP-assigned host with that serial still exists, while a host

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -778,6 +778,8 @@ type GetMDMDiskEncryptionSummaryFunc func(ctx context.Context, teamID *uint) (*f
 
 type ResendHostMDMProfileFunc func(ctx context.Context, hostID uint, profileUUID string) error
 
+type ResendHostNameTemplateFunc func(ctx context.Context, hostID uint) error
+
 type ResendDeviceHostMDMProfileFunc func(ctx context.Context, host *fleet.Host, profileUUID string) error
 
 type BatchResendMDMProfileToHostsFunc func(ctx context.Context, profileUUID string, filters fleet.BatchResendMDMProfileFilters) error
@@ -2083,6 +2085,9 @@ type Service struct {
 
 	ResendHostMDMProfileFunc        ResendHostMDMProfileFunc
 	ResendHostMDMProfileFuncInvoked bool
+
+	ResendHostNameTemplateFunc        ResendHostNameTemplateFunc
+	ResendHostNameTemplateFuncInvoked bool
 
 	ResendDeviceHostMDMProfileFunc        ResendDeviceHostMDMProfileFunc
 	ResendDeviceHostMDMProfileFuncInvoked bool
@@ -4990,6 +4995,13 @@ func (s *Service) ResendHostMDMProfile(ctx context.Context, hostID uint, profile
 	s.ResendHostMDMProfileFuncInvoked = true
 	s.mu.Unlock()
 	return s.ResendHostMDMProfileFunc(ctx, hostID, profileUUID)
+}
+
+func (s *Service) ResendHostNameTemplate(ctx context.Context, hostID uint) error {
+	s.mu.Lock()
+	s.ResendHostNameTemplateFuncInvoked = true
+	s.mu.Unlock()
+	return s.ResendHostNameTemplateFunc(ctx, hostID)
 }
 
 func (s *Service) ResendDeviceHostMDMProfile(ctx context.Context, host *fleet.Host, profileUUID string) error {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -197,6 +197,7 @@ func setupAppleMDMService(t *testing.T, license *fleet.LicenseInfo) (fleet.Servi
 	ds.MDMAppleListDevicesFunc = func(ctx context.Context) ([]fleet.MDMAppleDevice, error) {
 		return nil, nil
 	}
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 	ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 		return &fleet.NanoEnrollment{Enabled: false}, nil
 	}
@@ -1313,6 +1314,9 @@ func TestHostDetailsMDMProfiles(t *testing.T) {
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
 		return nil, nil
 	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+		return nil, nil
+	}
 
 	expectedNilSlice := []fleet.HostMDMAppleProfile(nil)
 	expectedEmptySlice := []fleet.HostMDMAppleProfile{}
@@ -1443,6 +1447,7 @@ func TestMDMCommandAuthz(t *testing.T) {
 	}
 
 	var mdmEnabled atomic.Bool
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 	ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 		// This function is called twice during EnqueueMDMAppleCommandRemoveEnrollmentProfile.
 		// It first is called to check that the device is enrolled as a pre-condition to enqueueing the
@@ -1751,6 +1756,8 @@ func TestAppleMDMUnenrollment(t *testing.T) {
 		return nil, nil, nil
 	}
 
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
+
 	ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 		enrollmentType := mdm.EnrollType(mdm.Device).String()
 		if hostUUID == "test-host-no-team-2" {
@@ -1812,6 +1819,8 @@ func TestMDMTokenUpdate(t *testing.T) {
 	ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{}, nil
 	}
+
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 
 	ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 		return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
@@ -2011,6 +2020,7 @@ func TestMDMTokenUpdateResetOnReenrollment(t *testing.T) {
 		ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
 			return &fleet.AppConfig{}, nil
 		}
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 		ds.GetNanoMDMEnrollmentFunc = func(context.Context, string) (*fleet.NanoEnrollment, error) {
 			return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
 		}
@@ -2142,6 +2152,7 @@ func TestMDMTokenUpdateResetOnReenrollment(t *testing.T) {
 					SCEPRenewalInProgress: c.scepRenewalInProgress,
 				}, nil
 			}
+			ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 			ds.GetNanoMDMEnrollmentFunc = func(context.Context, string) (*fleet.NanoEnrollment, error) {
 				if c.nanoEnrollNil {
 					return nil, nil
@@ -2244,6 +2255,8 @@ func TestMDMTokenUpdateIOS(t *testing.T) {
 		}, nil
 	}
 
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
+
 	ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 		return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
 	}
@@ -2301,6 +2314,8 @@ func TestMDMTokenUpdateIOS(t *testing.T) {
 		}, nil
 	}
 
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
+
 	ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 		return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 2}, nil
 	}
@@ -2333,6 +2348,8 @@ func TestMDMTokenUpdateIOS(t *testing.T) {
 			Platform:           "ios",
 		}, nil
 	}
+
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 
 	ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 		return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
@@ -2394,6 +2411,7 @@ func TestMDMTokenUpdateUserEnrollmentManagedAppleID(t *testing.T) {
 			Platform: "ios",
 		}, nil
 	}
+	ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 	ds.GetNanoMDMEnrollmentFunc = func(context.Context, string) (*fleet.NanoEnrollment, error) {
 		return &fleet.NanoEnrollment{
 			Enabled:          true,
@@ -2520,6 +2538,7 @@ func TestMDMTokenUpdateUserEnrollmentManagedAppleID(t *testing.T) {
 		ds.SetHostManagedAppleIDFunc = func(context.Context, uint, string) error {
 			return nil
 		}
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 		ds.GetNanoMDMEnrollmentFunc = func(context.Context, string) (*fleet.NanoEnrollment, error) {
 			return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
 		}
@@ -2597,6 +2616,7 @@ func TestMDMTokenUpdateUserEnrollmentSetupExperience(t *testing.T) {
 
 	doTokenUpdate := func(t *testing.T, enrollType string, tokenUpdateTally int) {
 		t.Helper()
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 		ds.GetNanoMDMEnrollmentFunc = func(context.Context, string) (*fleet.NanoEnrollment, error) {
 			return &fleet.NanoEnrollment{
 				Enabled:          true,
@@ -7719,6 +7739,7 @@ func TestMDMTokenUpdateSCEPRenewal(t *testing.T) {
 			require.Equal(t, wantTeamID, teamID)
 			return true, nil
 		}
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(context.Context, []uint) error { return nil }
 		ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
 			return &fleet.NanoEnrollment{Enabled: true, Type: "Device", TokenUpdateTally: 1}, nil
 		}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -837,6 +837,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// POST /hosts/{host_id:[0-9]+}/configuration_profiles/{profile_uuid}/resend endpoint.
 	mdmAnyMW.POST("/api/_version_/fleet/hosts/{host_id:[0-9]+}/configuration_profiles/resend/{profile_uuid}", resendHostMDMProfileEndpoint, resendHostMDMProfileRequest{})
 	mdmAnyMW.POST("/api/_version_/fleet/hosts/{host_id:[0-9]+}/configuration_profiles/{profile_uuid}/resend", resendHostMDMProfileEndpoint, resendHostMDMProfileRequest{})
+	mdmAnyMW.POST("/api/_version_/fleet/hosts/{host_id:[0-9]+}/name_template/resend", resendHostNameTemplateEndpoint, resendHostNameTemplateRequest{})
 	mdmAnyMW.POST("/api/_version_/fleet/configuration_profiles/resend/batch", batchResendMDMProfileToHostsEndpoint, batchResendMDMProfileToHostsRequest{})
 	mdmAnyMW.GET("/api/_version_/fleet/configuration_profiles/{profile_uuid}/status", getMDMConfigProfileStatusEndpoint, getMDMConfigProfileStatusRequest{})
 

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1828,6 +1828,24 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				// raw decryptable key status.
 				host.MDM.PopulateOSSettingsAndMacOSSettings(profs, mobileconfig.FleetFileVaultPayloadIdentifier)
 
+				// populate host-name template enforcement status (macOS, iOS, iPadOS).
+				// Omitted entirely when the host has no enforcement row.
+				dnEnforcement, err := svc.ds.GetHostDeviceNameEnforcement(ctx, host.UUID)
+				if err != nil && !fleet.IsNotFound(err) {
+					return nil, ctxerr.Wrap(ctx, err, "get host device name enforcement")
+				}
+				if dnEnforcement != nil {
+					// A NULL DB status is a queued row waiting; it renders as pending
+					status := fleet.HostNameSettingPending
+					if dnEnforcement.Status != nil {
+						status = fleet.HostNameSettingStatus(*dnEnforcement.Status)
+					}
+					host.MDM.OSSettings.HostName = &fleet.HostMDMHostNameSetting{
+						Status: status,
+						Detail: dnEnforcement.Detail,
+					}
+				}
+
 				// populate recovery lock password status for macOS hosts
 				if host.Platform == "darwin" {
 					rlpStatus, err := svc.ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -164,6 +164,9 @@ func TestHostDetailsMDMAppleDiskEncryption(t *testing.T) {
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
 		return nil, nil
 	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+		return nil, nil
+	}
 
 	cases := []struct {
 		name       string
@@ -468,6 +471,9 @@ func TestHostDetailsMDMTimestamps(t *testing.T) {
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
 		return nil, nil
 	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+		return nil, nil
+	}
 
 	ts1 := time.Now().Add(-1 * time.Hour).UTC()
 	ts2 := time.Now().Add(-2 * time.Hour).UTC()
@@ -576,6 +582,9 @@ func TestHostDetailsOSSettings(t *testing.T) {
 		return nil, nil
 	}
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
+		return nil, nil
+	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
 		return nil, nil
 	}
 
@@ -824,6 +833,9 @@ func TestHostDetailsRecoveryLockPasswordStatus(t *testing.T) {
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
 		return nil, nil
 	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+		return nil, nil
+	}
 
 	t.Run("recovery lock password status populates for macOS", func(t *testing.T) {
 		failedStatus := fleet.MDMDeliveryFailed
@@ -868,6 +880,135 @@ func TestHostDetailsRecoveryLockPasswordStatus(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, hostDetail)
 		require.False(t, ds.GetHostRecoveryLockPasswordStatusFuncInvoked)
+	})
+}
+
+func TestHostDetailsHostNameStatus(t *testing.T) {
+	ds := new(mock.Store)
+	svc := &Service{ds: ds}
+
+	ds.ListLabelsForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Label, error) { return nil, nil }
+	ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Pack, error) { return nil, nil }
+	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeCVEScores bool) error { return nil }
+	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) { return nil, nil }
+	ds.ListHostBatteriesFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostBattery, error) { return nil, nil }
+	ds.ListUpcomingHostMaintenanceWindowsFunc = func(ctx context.Context, hid uint) ([]*fleet.HostMaintenanceWindow, error) {
+		return nil, nil
+	}
+	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hid uint) (*fleet.HostMDMMacOSSetup, error) { return nil, nil }
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
+	}
+	ds.GetHostMDMAppleProfilesFunc = func(ctx context.Context, uuid string) ([]fleet.HostMDMAppleProfile, error) { return nil, nil }
+	ds.GetHostMDMWindowsProfilesFunc = func(ctx context.Context, uuid string) ([]fleet.HostMDMWindowsProfile, error) { return nil, nil }
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
+		return &fleet.HostLockWipeStatus{}, nil
+	}
+	ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+		return &fleet.HostMDM{Enrolled: true, IsServer: false}, nil
+	}
+	ds.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) { return nil, nil }
+	ds.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) { return nil, nil }
+	ds.ConditionalAccessBypassedAtFunc = func(ctx context.Context, hostID uint) (*time.Time, error) { return nil, nil }
+	ds.IsHostDiskEncryptionKeyArchivedFunc = func(ctx context.Context, hostID uint) (bool, error) { return false, nil }
+	ds.GetNanoMDMEnrollmentDetailsFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoMDMEnrollmentDetails, error) {
+		return &fleet.NanoMDMEnrollmentDetails{}, nil
+	}
+	ds.GetHostRecoveryLockPasswordStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMRecoveryLockPassword, error) {
+		return nil, nil
+	}
+	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
+		return nil, nil
+	}
+
+	getDetails := func(t *testing.T, platform string) *fleet.HostDetail {
+		ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		hostDetail, err := svc.getHostDetails(test.UserContext(ctx, test.UserAdmin),
+			&fleet.Host{ID: 42, Platform: platform, UUID: "test-uuid"},
+			fleet.HostDetailOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, hostDetail)
+		return hostDetail
+	}
+
+	// Each of the four statuses surfaces, and a NULL (queued) row renders pending.
+	statusCases := []struct {
+		name   string
+		dbRow  *fleet.HostDeviceNameEnforcement
+		expect fleet.HostNameSettingStatus
+		detail string
+	}{
+		{"queued NULL renders pending", &fleet.HostDeviceNameEnforcement{HostUUID: "test-uuid", Status: nil}, fleet.HostNameSettingPending, ""},
+		{"pending", &fleet.HostDeviceNameEnforcement{HostUUID: "test-uuid", Status: new(fleet.MDMDeliveryPending)}, fleet.HostNameSettingPending, ""},
+		{"verifying", &fleet.HostDeviceNameEnforcement{HostUUID: "test-uuid", Status: new(fleet.MDMDeliveryVerifying)}, fleet.HostNameSettingVerifying, ""},
+		{"verified", &fleet.HostDeviceNameEnforcement{HostUUID: "test-uuid", Status: new(fleet.MDMDeliveryVerified)}, fleet.HostNameSettingVerified, ""},
+		{"failed with detail", &fleet.HostDeviceNameEnforcement{HostUUID: "test-uuid", Status: new(fleet.MDMDeliveryFailed), Detail: "boom"}, fleet.HostNameSettingFailed, "boom"},
+	}
+	for _, tc := range statusCases {
+		for _, platform := range []string{"darwin", "ios", "ipados"} {
+			t.Run(tc.name+"/"+platform, func(t *testing.T) {
+				ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+					return tc.dbRow, nil
+				}
+				hd := getDetails(t, platform)
+				require.NotNil(t, hd.MDM.OSSettings.HostName, "host_name must be present for eligible host")
+				require.Equal(t, tc.expect, hd.MDM.OSSettings.HostName.Status)
+				require.Equal(t, tc.detail, hd.MDM.OSSettings.HostName.Detail)
+			})
+		}
+	}
+
+	t.Run("omitted when the host has no enforcement row", func(t *testing.T) {
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return nil, newNotFoundError()
+		}
+		hd := getDetails(t, "darwin")
+		require.Nil(t, hd.MDM.OSSettings.HostName, "host_name must be omitted for an ineligible host")
+	})
+
+	t.Run("not queried for non-Apple platforms", func(t *testing.T) {
+		ds.GetHostDeviceNameEnforcementFuncInvoked = false
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return nil, nil
+		}
+		ds.GetMDMWindowsBitLockerStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostMDMDiskEncryption, error) {
+			return nil, nil
+		}
+		hd := getDetails(t, "windows")
+		require.False(t, ds.GetHostDeviceNameEnforcementFuncInvoked)
+		require.Nil(t, hd.MDM.OSSettings.HostName)
+	})
+
+	t.Run("not queried when MDM is not configured", func(t *testing.T) {
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: false}}, nil
+		}
+		ds.GetHostDeviceNameEnforcementFuncInvoked = false
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return &fleet.HostDeviceNameEnforcement{HostUUID: hostUUID}, nil
+		}
+
+		ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		hd, err := svc.getHostDetails(test.UserContext(ctx, test.UserAdmin),
+			&fleet.Host{ID: 42, Platform: "darwin", UUID: "test-uuid"}, fleet.HostDetailOptions{})
+		require.NoError(t, err)
+		require.False(t, ds.GetHostDeviceNameEnforcementFuncInvoked, "must not query enforcement when MDM is off")
+		require.Nil(t, hd.MDM.OSSettings) // OS settings are only assembled when MDM is configured
+	})
+
+	t.Run("non-not-found datastore error propagates", func(t *testing.T) {
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
+		}
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return nil, errors.New("db exploded")
+		}
+
+		ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		_, err := svc.getHostDetails(test.UserContext(ctx, test.UserAdmin),
+			&fleet.Host{ID: 42, Platform: "darwin", UUID: "test-uuid"}, fleet.HostDetailOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "db exploded")
 	})
 }
 
@@ -3261,6 +3402,9 @@ func TestHostMDMProfileDetail(t *testing.T) {
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
 		return nil, nil
 	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+		return nil, nil
+	}
 
 	cases := []struct {
 		name           string
@@ -3403,6 +3547,9 @@ func TestHostMDMProfileScopes(t *testing.T) {
 		return nil, nil
 	}
 	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
+		return nil, nil
+	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
 		return nil, nil
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3090,6 +3090,81 @@ func (svc *Service) UpdateMDMHostNameTemplate(ctx context.Context, fleetID *uint
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// POST /hosts/{host_id:[0-9]+}/name_template/resend
+////////////////////////////////////////////////////////////////////////////////
+
+type resendHostNameTemplateRequest struct {
+	HostID uint `url:"host_id"`
+}
+
+type resendHostNameTemplateResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r resendHostNameTemplateResponse) Error() error { return r.Err }
+
+func (r resendHostNameTemplateResponse) Status() int { return http.StatusAccepted }
+
+func resendHostNameTemplateEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*resendHostNameTemplateRequest)
+
+	if err := svc.ResendHostNameTemplate(ctx, req.HostID); err != nil {
+		return resendHostNameTemplateResponse{Err: err}, nil
+	}
+
+	return resendHostNameTemplateResponse{}, nil
+}
+
+func (svc *Service) ResendHostNameTemplate(ctx context.Context, hostID uint) error {
+	if !license.IsPremium(ctx) {
+		svc.authz.SkipAuthorization(ctx)
+		return fleet.ErrMissingLicense
+	}
+
+	// Coarse gate before loading the host. We use selective_list (like the profile
+	// resend) so GitOps tokens are admitted here — GitOps manages host name
+	// templates (controls.name_template), so it must also be able to resend.
+	// Team-scoped enforcement is the ActionResend check below, once the host's team
+	// is known (that policy admits GitOps for the host's team too).
+	if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionSelectiveList); err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
+	host, err := svc.ds.HostLite(ctx, hostID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
+	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: host.TeamID}, fleet.ActionResend); err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
+	if host.TeamID == nil {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id",
+			"Host names are only enforced for hosts that belong to a fleet.").WithStatus(http.StatusUnprocessableEntity))
+	}
+
+	enforcement, err := svc.ds.GetHostDeviceNameEnforcement(ctx, host.UUID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("HostName", "Unable to match host name to host.").WithStatus(http.StatusNotFound), "getting host device name enforcement")
+		}
+		return ctxerr.Wrap(ctx, err, "getting host device name enforcement")
+	}
+
+	// A NULL status is a queued row. Pending and verifying rows can't be resent.
+	if enforcement.Status == nil || *enforcement.Status == fleet.MDMDeliveryPending || *enforcement.Status == fleet.MDMDeliveryVerifying {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("HostName", `Couldn't resend. Host names with "pending" or "verifying" status can't be resent.`).WithStatus(http.StatusConflict), "check host name status")
+	}
+
+	if err := svc.ds.ResendHostDeviceName(ctx, host.UUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "resending host device name")
+	}
+
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // POST /hosts/{id:[0-9]+}/configuration_profiles/{profile_uuid}
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -2737,6 +2737,153 @@ func TestMDMResendConfigProfileAuthz(t *testing.T) {
 	}
 }
 
+func TestResendHostNameTemplate(t *testing.T) {
+	ds := new(mock.Store)
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
+	}
+	ds.HostLiteFunc = func(ctx context.Context, hid uint) (*fleet.Host, error) {
+		return &fleet.Host{ID: hid, UUID: "host-uuid-1", Platform: "darwin", TeamID: new(uint(1))}, nil
+	}
+
+	adminCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+	t.Run("resets a failed row and returns no error", func(t *testing.T) {
+		failed := fleet.MDMDeliveryFailed
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return &fleet.HostDeviceNameEnforcement{HostUUID: hostUUID, Status: &failed}, nil
+		}
+		ds.ResendHostDeviceNameFuncInvoked = false
+		ds.ResendHostDeviceNameFunc = func(ctx context.Context, hostUUID string) error { return nil }
+
+		require.NoError(t, svc.ResendHostNameTemplate(adminCtx, 1))
+		require.True(t, ds.ResendHostDeviceNameFuncInvoked)
+	})
+
+	t.Run("resets a verified row", func(t *testing.T) {
+		verified := fleet.MDMDeliveryVerified
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return &fleet.HostDeviceNameEnforcement{HostUUID: hostUUID, Status: &verified}, nil
+		}
+		ds.ResendHostDeviceNameFuncInvoked = false
+		ds.ResendHostDeviceNameFunc = func(ctx context.Context, hostUUID string) error { return nil }
+
+		require.NoError(t, svc.ResendHostNameTemplate(adminCtx, 1))
+		require.True(t, ds.ResendHostDeviceNameFuncInvoked)
+	})
+
+	t.Run("409 for pending, verifying, and queued (NULL) rows", func(t *testing.T) {
+		pending := fleet.MDMDeliveryPending
+		verifying := fleet.MDMDeliveryVerifying
+		for _, status := range []*fleet.MDMDeliveryStatus{&pending, &verifying, nil} {
+			ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+				return &fleet.HostDeviceNameEnforcement{HostUUID: hostUUID, Status: status}, nil
+			}
+			ds.ResendHostDeviceNameFuncInvoked = false
+
+			err := svc.ResendHostNameTemplate(adminCtx, 1)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "can't be resent")
+			require.False(t, ds.ResendHostDeviceNameFuncInvoked)
+		}
+	})
+
+	t.Run("404 when the host is not enforced", func(t *testing.T) {
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return nil, newNotFoundError()
+		}
+		ds.ResendHostDeviceNameFuncInvoked = false
+
+		err := svc.ResendHostNameTemplate(adminCtx, 1)
+		require.Error(t, err)
+		// The error carries a 404 status.
+		var statusErr interface{ Status() int }
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, http.StatusNotFound, statusErr.Status())
+		require.False(t, ds.ResendHostDeviceNameFuncInvoked)
+	})
+
+	t.Run("authz matches profile resend", func(t *testing.T) {
+		failed := fleet.MDMDeliveryFailed
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return &fleet.HostDeviceNameEnforcement{HostUUID: hostUUID, Status: &failed}, nil
+		}
+		ds.ResendHostDeviceNameFunc = func(ctx context.Context, hostUUID string) error { return nil }
+
+		// team observer on the host's team is denied
+		observerCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}},
+		}})
+		require.Error(t, svc.ResendHostNameTemplate(observerCtx, 1))
+
+		// maintainer of a different team is denied
+		otherTeamCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleMaintainer}},
+		}})
+		require.Error(t, svc.ResendHostNameTemplate(otherTeamCtx, 1))
+
+		// maintainer of the host's team is allowed
+		teamMaintainerCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer}},
+		}})
+		require.NoError(t, svc.ResendHostNameTemplate(teamMaintainerCtx, 1))
+
+		// GitOps is allowed (parity with profile resend): GitOps manages host name
+		// templates, so it can also resend.
+		gitopsCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleGitOps)}})
+		require.NoError(t, svc.ResendHostNameTemplate(gitopsCtx, 1))
+	})
+
+	t.Run("no-team host is explicitly rejected as fleets-only", func(t *testing.T) {
+		ds.HostLiteFunc = func(ctx context.Context, hid uint) (*fleet.Host, error) {
+			return &fleet.Host{ID: hid, UUID: "no-team-uuid", Platform: "darwin", TeamID: nil}, nil
+		}
+		ds.ResendHostDeviceNameFuncInvoked = false
+		ds.GetHostDeviceNameEnforcementFuncInvoked = false
+		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return nil, errors.New("should not be reached for a No-team host")
+		}
+
+		// A No-team host is rejected with a fleets-only 422 before the enforcement
+		// row is ever looked up. Only callers who pass the team-scoped authz (a
+		// global role, since the host has no team) reach the guard.
+		err := svc.ResendHostNameTemplate(adminCtx, 1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "only enforced for hosts that belong to a fleet")
+		require.False(t, ds.GetHostDeviceNameEnforcementFuncInvoked)
+		require.False(t, ds.ResendHostDeviceNameFuncInvoked)
+
+		// A team-scoped user gets a uniform forbidden error instead of the
+		// fleets-only message, so the response can't be used as an oracle to
+		// distinguish No-team hosts from hosts in other teams.
+		teamMaintainerCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer}},
+		}})
+		err = svc.ResendHostNameTemplate(teamMaintainerCtx, 1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
+		require.NotContains(t, err.Error(), "only enforced for hosts that belong to a fleet")
+		require.False(t, ds.GetHostDeviceNameEnforcementFuncInvoked)
+	})
+
+	t.Run("free tier returns ErrMissingLicense before any authz or DB access", func(t *testing.T) {
+		freeDS := new(mock.Store)
+		freeSvc, freeCtx := newTestService(t, freeDS, nil, nil, &TestServerOpts{
+			License: &fleet.LicenseInfo{Tier: fleet.TierFree}, SkipCreateTestUsers: true,
+		})
+		adminFreeCtx := viewer.NewContext(freeCtx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+		err := freeSvc.ResendHostNameTemplate(adminFreeCtx, 1)
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
+		// The license check short-circuits before loading the host or touching the row.
+		require.False(t, freeDS.HostLiteFuncInvoked)
+		require.False(t, freeDS.ResendHostDeviceNameFuncInvoked)
+	})
+}
+
 func TestBatchSetMDMProfilesLabels(t *testing.T) {
 	ds := new(mock.Store)
 	// while the config profiles are not premium-only, teams are and we want to test with teams.


### PR DESCRIPTION
Relates to #48624

Surface per-host host-name template state and wire the enforcement lifecycle:

- host.mdm.os_settings.host_name in the host detail response, omitted for ineligible hosts (recovery-lock style)
- fold device-name rows into the OS-settings aggregate counts (GetMDMAppleProfilesSummary) and the os_settings host-list filter via the shared apple-status CASE + a new device-name join
- POST /hosts/{id}/name_template/resend endpoint (202/409/404, profile resend authz)
- transfer reconciliation inside the AddHostsToTeam transaction (covers all entry points)
- enrollment reconciliation on both Apple lifecycle branches (turn-on and reset)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host name template enforcement visibility in host details and MDM OS settings responses.
  * Added an endpoint to resend host name template enforcement for eligible hosts.

* **Bug Fixes**
  * Host transfers now keep host name enforcement in sync with team changes.
  * Enrollment and reset flows now refresh host name enforcement automatically.

* **Changes**
  * MDM status summaries and host filters now include host name enforcement state.
  * Added support for showing pending, verifying, verified, and failed host name statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->