### PR TITLE
Add onURLBlur handler for InputField

### DIFF
--- a/changes/40410-webhook-url-validation-onblur.md
+++ b/changes/40410-webhook-url-validation-onblur.md
@@ -1,0 +1,1 @@
+- Fixed the vulnerability automations webhook "Destination URL" field to validate on blur (when the user clicks out of the field), consistent with other URL fields in Fleet, instead of only showing an error on save.

--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tests.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import mockServer from "test/mock-server";
+import { createGetConfigHandler } from "test/handlers/config-handlers";
+
+import createMockConfig from "__mocks__/configMock";
+
+import ManageSoftwareAutomationsModal from "./ManageSoftwareAutomationsModal";
+
+const INVALID_URL_ERROR = "Destination URL is not a valid URL";
+const REQUIRED_URL_ERROR = "Please add a destination URL";
+const URL_PLACEHOLDER = "https://server.com/example";
+
+// Start with the webhook workflow already enabled so the Destination URL field
+// is rendered and editable, letting us exercise the on-blur validation directly.
+const softwareConfig = createMockConfig({
+  webhook_settings: {
+    vulnerabilities_webhook: {
+      enable_vulnerabilities_webhook: true,
+      destination_url: "",
+    },
+  },
+  integrations: { jira: [], zendesk: [] },
+});
+
+const defaultProps = {
+  router: createMockRouter(),
+  onCancel: jest.fn(),
+  onCreateWebhookSubmit: jest.fn(),
+  togglePreviewPayloadModal: jest.fn(),
+  togglePreviewTicketModal: jest.fn(),
+  showPreviewPayloadModal: false,
+  showPreviewTicketModal: false,
+  softwareConfig,
+};
+
+const renderModal = () => {
+  mockServer.use(createGetConfigHandler());
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: { app: { config: createMockConfig(), isFreeTier: false } },
+  });
+  return render(<ManageSoftwareAutomationsModal {...defaultProps} />);
+};
+
+describe("ManageSoftwareAutomationsModal - Destination URL validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not show a validation error while typing an invalid URL", async () => {
+    const { user } = renderModal();
+
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    await user.type(urlInput, "not-a-valid-url");
+
+    expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("shows an error when the field is blurred with an invalid URL", async () => {
+    const { user } = renderModal();
+
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    await user.type(urlInput, "not-a-valid-url");
+    await user.tab();
+
+    expect(await screen.findByText(INVALID_URL_ERROR)).toBeInTheDocument();
+  });
+
+  it("clears the error once the user edits the field again", async () => {
+    const { user } = renderModal();
+
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    await user.type(urlInput, "not-a-valid-url");
+    await user.tab();
+    expect(await screen.findByText(INVALID_URL_ERROR)).toBeInTheDocument();
+
+    await user.type(urlInput, "a");
+
+    await waitFor(() => {
+      expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows no error when the field is blurred with a valid URL", async () => {
+    const { user } = renderModal();
+
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    await user.type(urlInput, "https://example.com/webhook");
+    await user.tab();
+
+    expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
+    expect(screen.queryByText(REQUIRED_URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("shows a required error when the field is blurred while empty", async () => {
+    const { user } = renderModal();
+
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    await user.click(urlInput);
+    await user.tab();
+
+    expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import mockServer from "test/mock-server";
 import { createGetConfigHandler } from "test/handlers/config-handlers";
@@ -35,11 +35,18 @@ const defaultProps = {
   softwareConfig,
 };
 
-const renderModal = () => {
+const renderModal = ({ gitOpsModeEnabled = false } = {}) => {
   mockServer.use(createGetConfigHandler());
   const render = createCustomRenderer({
     withBackendMock: true,
-    context: { app: { config: createMockConfig(), isFreeTier: false } },
+    context: {
+      app: {
+        config: createMockConfig({
+          gitops: { gitops_mode_enabled: gitOpsModeEnabled },
+        }),
+        isFreeTier: false,
+      },
+    },
   });
   return render(<ManageSoftwareAutomationsModal {...defaultProps} />);
 };
@@ -102,5 +109,18 @@ describe("ManageSoftwareAutomationsModal - Destination URL validation", () => {
     await user.tab();
 
     expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+  });
+
+  it("does not validate on blur when GitOps mode disables the field", () => {
+    renderModal({ gitOpsModeEnabled: true });
+
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    expect(urlInput).toBeDisabled();
+
+    // The field is read-only in GitOps mode, so a blur must not surface an error.
+    fireEvent.blur(urlInput);
+
+    expect(screen.queryByText(REQUIRED_URL_ERROR)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
@@ -227,6 +227,16 @@ const ManageAutomationsModal = ({
     setDestinationUrl(value);
   };
 
+  const onURLBlur = () => {
+    // Only validate while the webhook workflow is active; the field is disabled
+    // otherwise, so avoid surfacing an error on a control the user can't edit.
+    if (!softwareAutomationsEnabled) {
+      return;
+    }
+    const { errors: webhookErrors } = validateWebhookURL(destinationUrl);
+    setErrors((prevErrs) => ({ ...omit(prevErrs, "url"), ...webhookErrors }));
+  };
+
   const handleSaveAutomation = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
 
@@ -459,6 +469,7 @@ const ManageAutomationsModal = ({
           type="text"
           value={destinationUrl}
           onChange={onURLChange}
+          onBlur={onURLBlur}
           error={errors.url}
           helpText={
             "For each new vulnerability detected, Fleet will send a JSON payload to this URL with a list of the affected hosts."

--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
@@ -228,9 +228,10 @@ const ManageAutomationsModal = ({
   };
 
   const onURLBlur = () => {
-    // Only validate while the webhook workflow is active; the field is disabled
-    // otherwise, so avoid surfacing an error on a control the user can't edit.
-    if (!softwareAutomationsEnabled) {
+    // Skip validation whenever the field is disabled (automations off or GitOps
+    // mode) so we don't surface an error on a control the user can't edit. This
+    // must mirror the InputField's `disabled` condition below.
+    if (!softwareAutomationsEnabled || gitOpsModeEnabled) {
       return;
     }
     const { errors: webhookErrors } = validateWebhookURL(destinationUrl);


### PR DESCRIPTION
 **Related issue:** Resolves #40410

  # Checklist for submitter

  - [x] Changes file added for user-visible changes in `changes/`. See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
  - [x] Input data is properly validated (webhook Destination URL is now validated on blur, matching the other URL fields in the app).

  ## Testing

  - [x] QA'd all new/changed functionality manually

[qa-40410.webm](https://github.com/user-attachments/assets/eefdddf0-a6dd-47d0-b819-89e9ac99c6f1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Destination URL” validation by checking the URL when the field loses focus and surfacing invalid webhook URLs immediately.
  * Validation and error display are now suppressed when vulnerability automations are disabled or when GitOps mode is enabled, preventing confusing blur-time errors.
* **Tests**
  * Added automated coverage for blur-time URL validation, including typing/clearing behavior, valid vs empty states, and GitOps mode scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->