### PR TITLE
Fix App Store picker 403 for non-admin roles

### DIFF
--- a/changes/46057-vpp-tokens-maintainer-authz
+++ b/changes/46057-vpp-tokens-maintainer-authz
@@ -1,0 +1,1 @@
+- Fixed a bug where the Add software > App Store picker failed with an error for maintainer and technician roles because listing VPP tokens required admin access.

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -1539,23 +1539,60 @@ func (svc *Service) UpdateVPPTokenTeams(ctx context.Context, tokenID uint, teamI
 }
 
 func (svc *Service) GetVPPTokens(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
-	// Authorize like reading App Store apps (fleet.VPPApp struct) so
-	// maintainers and technicians can use the Add software > App Store picker,
-	// which reads the token list. This endpoint has no team parameter, so for
-	// team-scoped users we authorize against their first team (same approach as
-	// CreateAndroidWebApp).
-	var teamID *uint
-	if user := authz.UserFromContext(ctx); user != nil {
-		if len(user.Teams) > 0 {
-			teamID = &user.Teams[0].ID
+	// The Add software > App Store picker reads the token list, so this must be
+	// readable by the same roles that can read App Store apps
+	// (fleet.VPPApp/installable_entity), not just admins. Global roles can read
+	// every token; team-scoped users can only read tokens assigned to a team
+	// where they have read access (plus "All teams" tokens).
+	globalRead := svc.authz.Authorize(ctx, &fleet.VPPApp{}, fleet.ActionRead)
+
+	// Collect the teams where a team-scoped user has read access. Left empty for
+	// global readers since they can see everything.
+	readableTeams := make(map[uint]struct{})
+	if globalRead != nil {
+		if user := authz.UserFromContext(ctx); user != nil {
+			for _, t := range user.Teams {
+				teamID := t.ID
+				if err := svc.authz.Authorize(ctx, &fleet.VPPApp{TeamID: &teamID}, fleet.ActionRead); err == nil {
+					readableTeams[teamID] = struct{}{}
+				}
+			}
+		}
+
+		// No read access globally or on any team: return the forbidden error.
+		if len(readableTeams) == 0 {
+			return nil, globalRead
 		}
 	}
 
-	if err := svc.authz.Authorize(ctx, &fleet.VPPApp{TeamID: teamID}, fleet.ActionRead); err != nil {
+	tokens, err := svc.ds.ListVPPTokens(ctx)
+	if err != nil {
 		return nil, err
 	}
 
-	return svc.ds.ListVPPTokens(ctx)
+	// Global readers get every token unchanged.
+	if globalRead == nil {
+		return tokens, nil
+	}
+
+	filtered := make([]*fleet.VPPTokenDB, 0, len(tokens))
+	for _, tok := range tokens {
+		// A non-nil, empty Teams slice means the token is assigned to "All
+		// teams" and is visible to any user with read access. A nil slice means
+		// the token is unassigned and only global readers should see it.
+		if tok.Teams != nil && len(tok.Teams) == 0 {
+			filtered = append(filtered, tok)
+			continue
+		}
+		for _, tt := range tok.Teams {
+			if _, ok := readableTeams[tt.ID]; ok {
+				filtered = append(filtered, tok)
+				break
+			}
+		}
+	}
+
+	return filtered, nil
 }
 
 func (svc *Service) DeleteVPPToken(ctx context.Context, tokenID uint) error {

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -1539,7 +1539,19 @@ func (svc *Service) UpdateVPPTokenTeams(ctx context.Context, tokenID uint, teamI
 }
 
 func (svc *Service) GetVPPTokens(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.AppleCSR{}, fleet.ActionRead); err != nil {
+	// Authorize like reading App Store apps (fleet.VPPApp struct) so
+	// maintainers and technicians can use the Add software > App Store picker,
+	// which reads the token list. This endpoint has no team parameter, so for
+	// team-scoped users we authorize against their first team (same approach as
+	// CreateAndroidWebApp).
+	var teamID *uint
+	if user := authz.UserFromContext(ctx); user != nil {
+		if len(user.Teams) > 0 {
+			teamID = &user.Teams[0].ID
+		}
+	}
+
+	if err := svc.authz.Authorize(ctx, &fleet.VPPApp{TeamID: teamID}, fleet.ActionRead); err != nil {
 		return nil, err
 	}
 

--- a/ee/server/service/vpp_test.go
+++ b/ee/server/service/vpp_test.go
@@ -345,3 +345,74 @@ func TestBatchAssociateVPPAppsDedupsMissingAssetsError(t *testing.T) {
 	require.Equal(t, 1, strings.Count(err.Error(), adamID),
 		"missing-asset error must dedup by AdamID, got: %s", err.Error())
 }
+
+// TestGetVPPTokensScoping verifies that GetVPPTokens returns every token to
+// global readers but scopes the list to a team-scoped user's readable teams
+// (plus "All teams" tokens), without leaking tokens from teams the user can't
+// read. See #46057.
+func TestGetVPPTokensScoping(t *testing.T) {
+	ds := new(mock.Store)
+	// Tokens: team 1, team 2, "All teams" (non-nil empty Teams), and an
+	// unassigned token (nil Teams).
+	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
+		return []*fleet.VPPTokenDB{
+			{ID: 1, OrgName: "team1", Teams: []fleet.TeamTuple{{ID: 1, Name: "Workstations"}}},
+			{ID: 2, OrgName: "team2", Teams: []fleet.TeamTuple{{ID: 2, Name: "Servers"}}},
+			{ID: 3, OrgName: "allteams", Teams: []fleet.TeamTuple{}},
+			{ID: 4, OrgName: "unassigned", Teams: nil},
+		}, nil
+	}
+
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+	svc := &Service{
+		authz:  authorizer,
+		ds:     ds,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	globalMaintainer := &fleet.User{GlobalRole: new(fleet.RoleMaintainer)}
+	teamMaintainer1 := &fleet.User{Teams: []fleet.UserTeam{
+		{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer},
+	}}
+	// Observer on the first team, maintainer on the second: must still be
+	// authorized (via team 2) and scoped to team 2, never team 1.
+	observerThenMaintainer := &fleet.User{Teams: []fleet.UserTeam{
+		{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver},
+		{Team: fleet.Team{ID: 2}, Role: fleet.RoleMaintainer},
+	}}
+	teamObserver1 := &fleet.User{Teams: []fleet.UserTeam{
+		{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver},
+	}}
+
+	tests := []struct {
+		name    string
+		user    *fleet.User
+		wantErr bool
+		wantIDs []uint
+	}{
+		{"global admin sees all", &fleet.User{GlobalRole: new(fleet.RoleAdmin)}, false, []uint{1, 2, 3, 4}},
+		{"global maintainer sees all", globalMaintainer, false, []uint{1, 2, 3, 4}},
+		{"team maintainer scoped to team + all-teams", teamMaintainer1, false, []uint{1, 3}},
+		{"observer-then-maintainer scoped to second team", observerThenMaintainer, false, []uint{2, 3}},
+		{"team observer forbidden", teamObserver1, true, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := viewer.NewContext(t.Context(), viewer.Viewer{User: tt.user})
+			got, err := svc.GetVPPTokens(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, (&authz.Forbidden{}).Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+			gotIDs := make([]uint, 0, len(got))
+			for _, tok := range got {
+				gotIDs = append(gotIDs, tok.ID)
+			}
+			require.ElementsMatch(t, tt.wantIDs, gotIDs)
+		})
+	}
+}

--- a/ee/server/service/vpp_test.go
+++ b/ee/server/service/vpp_test.go
@@ -372,8 +372,14 @@ func TestGetVPPTokensScoping(t *testing.T) {
 	}
 
 	globalMaintainer := &fleet.User{GlobalRole: new(fleet.RoleMaintainer)}
+	// Technician can read installable entities but not write them, so it must be
+	// able to read the token list to use the picker (#46057 names this role).
+	globalTechnician := &fleet.User{GlobalRole: new(fleet.RoleTechnician)}
 	teamMaintainer1 := &fleet.User{Teams: []fleet.UserTeam{
 		{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer},
+	}}
+	teamTechnician1 := &fleet.User{Teams: []fleet.UserTeam{
+		{Team: fleet.Team{ID: 1}, Role: fleet.RoleTechnician},
 	}}
 	// Observer on the first team, maintainer on the second: must still be
 	// authorized (via team 2) and scoped to team 2, never team 1.
@@ -393,7 +399,9 @@ func TestGetVPPTokensScoping(t *testing.T) {
 	}{
 		{"global admin sees all", &fleet.User{GlobalRole: new(fleet.RoleAdmin)}, false, []uint{1, 2, 3, 4}},
 		{"global maintainer sees all", globalMaintainer, false, []uint{1, 2, 3, 4}},
+		{"global technician sees all", globalTechnician, false, []uint{1, 2, 3, 4}},
 		{"team maintainer scoped to team + all-teams", teamMaintainer1, false, []uint{1, 3}},
+		{"team technician scoped to team + all-teams", teamTechnician1, false, []uint{1, 3}},
 		{"observer-then-maintainer scoped to second team", observerThenMaintainer, false, []uint{2, 3}},
 		{"team observer forbidden", teamObserver1, true, nil},
 	}

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -192,8 +192,8 @@ func TestMDMAppleAuthorization(t *testing.T) {
 		_, err = svc.UploadVPPToken(ctx, nil)
 		checkAuthErr(t, shouldFailWithAuth, err)
 
-		_, err = svc.GetVPPTokens(ctx)
-		checkAuthErr(t, shouldFailWithAuth, err)
+		// GetVPPTokens is not admin-only (maintainers/technicians can read it to
+		// use the App Store picker); its authorization is covered by TestVPPAuth.
 
 		err = svc.DeleteVPPToken(ctx, 0)
 		checkAuthErr(t, shouldFailWithAuth, err)

--- a/server/service/vpp_test.go
+++ b/server/service/vpp_test.go
@@ -15,7 +15,6 @@ import (
 	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
 	android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	"github.com/fleetdm/fleet/v4/server/mock"
-	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
@@ -66,34 +65,38 @@ func TestVPPAuth(t *testing.T) {
 		shouldFailRead         bool
 		shouldFailWrite        bool
 		shouldFailCreateWebApp bool
+		// GetVPPTokens has no team parameter; like CreateAndroidWebApp it
+		// authorizes against the user's first team, so the expected result
+		// depends only on the user, not on teamID.
+		shouldFailGetTokens bool
 	}{
-		{"no role no team", test.UserNoRoles, nil, true, true, true},
-		{"no role team", test.UserNoRoles, ptr.Uint(1), true, true, true},
-		{"global admin no team", test.UserAdmin, nil, false, false, false},
-		{"global admin team", test.UserAdmin, ptr.Uint(1), false, false, false},
-		{"global maintainer no team", test.UserMaintainer, nil, false, false, false},
-		{"global maintainer team", test.UserMaintainer, ptr.Uint(1), false, false, false},
-		{"global observer no team", test.UserObserver, nil, true, true, true},
-		{"global observer team", test.UserObserver, ptr.Uint(1), true, true, true},
-		{"global observer+ no team", test.UserObserverPlus, nil, true, true, true},
-		{"global observer+ team", test.UserObserverPlus, ptr.Uint(1), true, true, true},
-		{"global gitops no team", test.UserGitOps, nil, false, false, false},
-		{"global gitops team", test.UserGitOps, ptr.Uint(1), false, false, false},
-		{"team admin no team", test.UserTeamAdminTeam1, nil, true, true, false},
-		{"team admin team", test.UserTeamAdminTeam1, ptr.Uint(1), false, false, false},
-		{"team admin other team", test.UserTeamAdminTeam2, ptr.Uint(1), true, true, false},
-		{"team maintainer no team", test.UserTeamMaintainerTeam1, nil, true, true, false},
-		{"team maintainer team", test.UserTeamMaintainerTeam1, ptr.Uint(1), false, false, false},
-		{"team maintainer other team", test.UserTeamMaintainerTeam2, ptr.Uint(1), true, true, false},
-		{"team observer no team", test.UserTeamObserverTeam1, nil, true, true, true},
-		{"team observer team", test.UserTeamObserverTeam1, ptr.Uint(1), true, true, true},
-		{"team observer other team", test.UserTeamObserverTeam2, ptr.Uint(1), true, true, true},
-		{"team observer+ no team", test.UserTeamObserverPlusTeam1, nil, true, true, true},
-		{"team observer+ team", test.UserTeamObserverPlusTeam1, ptr.Uint(1), true, true, true},
-		{"team observer+ other team", test.UserTeamObserverPlusTeam2, ptr.Uint(1), true, true, true},
-		{"team gitops no team", test.UserTeamGitOpsTeam1, nil, true, true, false},
-		{"team gitops team", test.UserTeamGitOpsTeam1, ptr.Uint(1), false, false, false},
-		{"team gitops other team", test.UserTeamGitOpsTeam2, ptr.Uint(1), true, true, false},
+		{"no role no team", test.UserNoRoles, nil, true, true, true, true},
+		{"no role team", test.UserNoRoles, new(uint(1)), true, true, true, true},
+		{"global admin no team", test.UserAdmin, nil, false, false, false, false},
+		{"global admin team", test.UserAdmin, new(uint(1)), false, false, false, false},
+		{"global maintainer no team", test.UserMaintainer, nil, false, false, false, false},
+		{"global maintainer team", test.UserMaintainer, new(uint(1)), false, false, false, false},
+		{"global observer no team", test.UserObserver, nil, true, true, true, true},
+		{"global observer team", test.UserObserver, new(uint(1)), true, true, true, true},
+		{"global observer+ no team", test.UserObserverPlus, nil, true, true, true, true},
+		{"global observer+ team", test.UserObserverPlus, new(uint(1)), true, true, true, true},
+		{"global gitops no team", test.UserGitOps, nil, false, false, false, false},
+		{"global gitops team", test.UserGitOps, new(uint(1)), false, false, false, false},
+		{"team admin no team", test.UserTeamAdminTeam1, nil, true, true, false, false},
+		{"team admin team", test.UserTeamAdminTeam1, new(uint(1)), false, false, false, false},
+		{"team admin other team", test.UserTeamAdminTeam2, new(uint(1)), true, true, false, false},
+		{"team maintainer no team", test.UserTeamMaintainerTeam1, nil, true, true, false, false},
+		{"team maintainer team", test.UserTeamMaintainerTeam1, new(uint(1)), false, false, false, false},
+		{"team maintainer other team", test.UserTeamMaintainerTeam2, new(uint(1)), true, true, false, false},
+		{"team observer no team", test.UserTeamObserverTeam1, nil, true, true, true, true},
+		{"team observer team", test.UserTeamObserverTeam1, new(uint(1)), true, true, true, true},
+		{"team observer other team", test.UserTeamObserverTeam2, new(uint(1)), true, true, true, true},
+		{"team observer+ no team", test.UserTeamObserverPlusTeam1, nil, true, true, true, true},
+		{"team observer+ team", test.UserTeamObserverPlusTeam1, new(uint(1)), true, true, true, true},
+		{"team observer+ other team", test.UserTeamObserverPlusTeam2, new(uint(1)), true, true, true, true},
+		{"team gitops no team", test.UserTeamGitOpsTeam1, nil, true, true, false, false},
+		{"team gitops team", test.UserTeamGitOpsTeam1, new(uint(1)), false, false, false, false},
+		{"team gitops other team", test.UserTeamGitOpsTeam2, new(uint(1)), true, true, false, false},
 	}
 
 	for _, tt := range testCases {
@@ -117,6 +120,9 @@ func TestVPPAuth(t *testing.T) {
 			ds.GetEnterpriseFunc = func(ctx context.Context) (*android.Enterprise, error) {
 				return &android.Enterprise{}, nil
 			}
+			ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
+				return []*fleet.VPPTokenDB{}, nil
+			}
 			// Note: these calls always return an error because they're attempting to unmarshal a
 			// non-existent VPP token.
 			_, err := svc.GetAppStoreApps(ctx, tt.teamID)
@@ -135,6 +141,11 @@ func TestVPPAuth(t *testing.T) {
 
 			_, err = svc.CreateAndroidWebApp(ctx, "test", "http://example.com", nil)
 			checkAuthErr(t, tt.shouldFailCreateWebApp, err)
+
+			// GetVPPTokens backs the Add software > App Store picker, so it must
+			// be readable by the same roles that can add App Store apps.
+			_, err = svc.GetVPPTokens(ctx)
+			checkAuthErr(t, tt.shouldFailGetTokens, err)
 		})
 	}
 }


### PR DESCRIPTION
**Related issue:** Resolves #46057

Authorize `GetVPPTokens` against `VPPApp` instead of admin-only `AppleCSR`, so maintainer/technician roles no longer get a 403 that broke the App Store picker.

  # Checklist for submitter

  - [x] Changes file added for user-visible changes in `changes/`.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “Add software > App Store” picker so maintainer and technician roles no longer encounter access errors when browsing VPP tokens.
  * Improved VPP token visibility for team-scoped users by restricting listings to teams they can read, while including “all teams” tokens and excluding unassigned/unauthorized ones.
  * Ensured users without appropriate access receive the correct authorization response instead of broader token listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->