### PR TITLE
[Update] Simplify profile upload requirements in documentation

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6854,7 +6854,7 @@ Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` 
 You can upload a new profile file to replace the contents of the existing profile. The new profile must match the identity of the existing profile:
 
 - **DDM (declarative management) profiles** (`.json`): The new profile must have the same **Identifier** as the existing profile.
-- **v1 .mobileconfig profiles**: The new profile must have the same **PayloadIdentifier** as the existing profile.
+- **.mobileconfig profiles**: The new profile must have the same **PayloadIdentifier** as the existing profile.
 
 If the new profile does not match the required identifiers, the request will be rejected.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6853,8 +6853,8 @@ Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` 
 
 You can upload a new profile file to replace the contents of the existing profile. The new profile must match the identity of the existing profile:
 
-- **DDM (declarative management) profiles** (`.json`): The new profile must have the same **Identifier** and **file name** as the existing profile.
-- **v1 .mobileconfig profiles**: The new profile must have the same **PayloadIdentifier** and **PayloadDisplayName** as the existing profile.
+- **DDM (declarative management) profiles** (`.json`): The new profile must have the same **Identifier** as the existing profile.
+- **v1 .mobileconfig profiles**: The new profile must have the same **PayloadIdentifier** as the existing profile.
 
 If the new profile does not match the required identifiers, the request will be rejected.
 


### PR DESCRIPTION
Removed file name requirement for DDM profiles and PayloadDisplayName for v1 mobileconfig profiles.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38869