### PR TITLE
Restrict SCIM endpoints to global admin only

### DIFF
--- a/changes/scim-admin-only-access
+++ b/changes/scim-admin-only-access
@@ -1,0 +1,1 @@
+Restricted SCIM endpoint access to global admin users only.

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -66,12 +66,12 @@ func testAuth(t *testing.T, s *Suite) {
 	scimDetails := contract.ScimDetailsResponse{}
 	s.DoJSON(t, "GET", scimPath("/details"), nil, http.StatusUnauthorized, &scimDetails)
 	// Make sure unauthenticated response wasn't saved as the last SCIM request
-	s.Token = s.GetTestToken(t, service.TestMaintainerUserEmail, test.GoodPassword)
+	s.Token = s.GetTestAdminToken(t)
 	scimDetails = contract.ScimDetailsResponse{}
 	s.DoJSON(t, "GET", scimPath("/details"), nil, http.StatusOK, &scimDetails)
 	assert.Nil(t, scimDetails.LastRequest, "last_request should NOT be present for unauthenticated requests")
 
-	// Unauthorized
+	// Unauthorized (observer)
 	resp = nil
 	s.Token = s.GetTestToken(t, service.TestObserverUserEmail, test.GoodPassword)
 	s.DoJSON(t, "GET", scimPath("/Schemas"), nil, http.StatusForbidden, &resp)
@@ -79,7 +79,7 @@ func testAuth(t *testing.T, s *Suite) {
 	assert.EqualValues(t, resp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
 	s.DoJSON(t, "GET", scimPath("/details"), nil, http.StatusForbidden, &scimDetails)
 	// Make sure unauthorized response WAS saved as the last SCIM request
-	s.Token = s.GetTestToken(t, service.TestMaintainerUserEmail, test.GoodPassword)
+	s.Token = s.GetTestAdminToken(t)
 	scimDetails = contract.ScimDetailsResponse{}
 	s.DoJSON(t, "GET", scimPath("/details"), nil, http.StatusOK, &scimDetails)
 	require.NotNil(t, scimDetails.LastRequest)
@@ -87,9 +87,16 @@ func testAuth(t *testing.T, s *Suite) {
 	assert.NotZero(t, scimDetails.LastRequest.RequestedAt)
 	assert.Equal(t, authz.ForbiddenErrorMessage, scimDetails.LastRequest.Details)
 
-	// Authorized
+	// Unauthorized (maintainer - no longer allowed)
 	resp = nil
 	s.Token = s.GetTestToken(t, service.TestMaintainerUserEmail, test.GoodPassword)
+	s.DoJSON(t, "GET", scimPath("/Schemas"), nil, http.StatusForbidden, &resp)
+	assert.Contains(t, resp["detail"], "forbidden")
+	assert.EqualValues(t, resp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+
+	// Authorized (admin only)
+	resp = nil
+	s.Token = s.GetTestAdminToken(t)
 	s.DoJSON(t, "GET", scimPath("/Schemas"), nil, http.StatusOK, &resp)
 	assert.EqualValues(t, resp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:ListResponse"})
 }

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -90,9 +90,20 @@ func testAuth(t *testing.T, s *Suite) {
 	// Unauthorized (maintainer - no longer allowed)
 	resp = nil
 	s.Token = s.GetTestToken(t, service.TestMaintainerUserEmail, test.GoodPassword)
+	// Maintainer denied on read (Schemas endpoint)
 	s.DoJSON(t, "GET", scimPath("/Schemas"), nil, http.StatusForbidden, &resp)
 	assert.Contains(t, resp["detail"], "forbidden")
 	assert.EqualValues(t, resp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+	// Maintainer denied on write (create user)
+	resp = nil
+	s.DoJSON(t, "POST", scimPath("/Users"), map[string]interface{}{
+		"schemas":  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName": "maintainer-attempt@example.com",
+	}, http.StatusForbidden, &resp)
+	assert.Contains(t, resp["detail"], "forbidden")
+	// Maintainer denied on details endpoint
+	resp = nil
+	s.DoJSON(t, "GET", scimPath("/details"), nil, http.StatusForbidden, &resp)
 
 	// Authorized (admin only)
 	resp = nil

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -93,10 +93,10 @@ func testAuth(t *testing.T, s *Suite) {
 	// Maintainer denied on read (Schemas endpoint)
 	s.DoJSON(t, "GET", scimPath("/Schemas"), nil, http.StatusForbidden, &resp)
 	assert.Contains(t, resp["detail"], "forbidden")
-	assert.EqualValues(t, resp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+	assert.EqualValues(t, []any{"urn:ietf:params:scim:api:messages:2.0:Error"}, resp["schemas"])
 	// Maintainer denied on write (create user)
 	resp = nil
-	s.DoJSON(t, "POST", scimPath("/Users"), map[string]interface{}{
+	s.DoJSON(t, "POST", scimPath("/Users"), map[string]any{
 		"schemas":  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
 		"userName": "maintainer-attempt@example.com",
 	}, http.StatusForbidden, &resp)

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -1288,10 +1288,10 @@ allow {
 ##
 # SCIM (System for Cross-domain Identity Management)
 ##
-# Global admins and maintainers can access SCIM.
+# Only global admins can access SCIM.
 allow {
   object.type == "scim_user"
-  subject.global_role == [admin, maintainer][_]
+  subject.global_role == admin
   action == [read, write][_]
 }
 


### PR DESCRIPTION
**Related issue:** N/A

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

## Summary

Restricts SCIM endpoint access to global admin users only. Previously, global maintainers also had access, which is broader than necessary.

### Changes
- **`server/authz/policy.rego`**: Removed `maintainer` from the SCIM authorization rule, leaving only `admin`.
- **`ee/server/integrationtest/scim/scim_test.go`**: Updated auth tests to verify maintainers now get 403, and that only admins can access SCIM endpoints.

> **Breaking change for 4.89**: Customers using a global maintainer API token for SCIM will need to update to a global admin token before upgrading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restricted SCIM endpoint access to global administrators only.

* **Bug Fixes**
  * Prevented unauthorized observer and maintainer users from accessing SCIM reads, writes, and details.
  * Improved authorization error tracking for denied SCIM requests (including recorded request status and details).

* **Tests**
  * Updated SCIM authorization integration tests to reflect the tightened admin-only access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->