### PR TITLE
Fleet UI: 'Latest' pin only shows on Fleet-maintained apps

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.stories.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.stories.tsx
@@ -80,21 +80,34 @@ export const Expanded: Story = {
   },
 };
 
+/** FMA row: the pin is a clickable button that opens the versions modal. */
 export const LatestActive: Story = {
   args: {
     badgeState: "latest",
+    onBadgeClick: () => undefined,
   },
 };
 
 export const PinnedActive: Story = {
   args: {
     badgeState: "pinned",
+    onBadgeClick: () => undefined,
   },
 };
 
 export const MajorVersionPinnedActive: Story = {
   args: {
     badgeState: "majorVersion",
+    onBadgeClick: () => undefined,
+  },
+};
+
+/** Custom (non-FMA) package: no versions modal, so the "Latest" pin renders as
+ * a static span rather than a button — no pointer/hover affordance. */
+export const LatestActiveDecorative: Story = {
+  args: {
+    badgeState: "latest",
+    onBadgeClick: undefined,
   },
 };
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.stories.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.stories.tsx
@@ -102,15 +102,6 @@ export const MajorVersionPinnedActive: Story = {
   },
 };
 
-/** Custom (non-FMA) package: no versions modal, so the "Latest" pin renders as
- * a static span rather than a button — no pointer/hover affordance. */
-export const LatestActiveDecorative: Story = {
-  args: {
-    badgeState: "latest",
-    onBadgeClick: undefined,
-  },
-};
-
 export const AllHostsNoLabels: Story = {
   args: {
     badgeState: "latest",

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
@@ -85,34 +85,49 @@ describe("LibraryItemAccordion", () => {
   });
 
   describe("badges", () => {
-    it("renders the Latest badge when badgeState is 'latest'", () => {
-      renderAccordion({ badgeState: "latest" });
+    it("renders the Latest badge as a button when onBadgeClick is wired", () => {
+      renderAccordion({ badgeState: "latest", onBadgeClick: jest.fn() });
       expect(screen.getByRole("button", { name: "Latest" })).toBeVisible();
     });
 
-    it("renders the Pinned badge when badgeState is 'pinned'", () => {
-      renderAccordion({ badgeState: "pinned" });
+    it("renders the Pinned badge as a button when onBadgeClick is wired", () => {
+      renderAccordion({ badgeState: "pinned", onBadgeClick: jest.fn() });
       expect(screen.getByRole("button", { name: "Pinned" })).toBeVisible();
     });
 
-    it("renders the Major version badge when badgeState is 'majorVersion'", () => {
-      renderAccordion({ badgeState: "majorVersion" });
+    it("renders the Major version badge as a button when onBadgeClick is wired", () => {
+      renderAccordion({ badgeState: "majorVersion", onBadgeClick: jest.fn() });
       expect(
         screen.getByRole("button", { name: "Major version" })
       ).toBeVisible();
     });
+
+    it.each([
+      ["latest", "Latest"],
+      ["pinned", "Pinned"],
+      ["majorVersion", "Major version"],
+    ] as const)(
+      "renders the %s badge as a static span (no bogus click affordance) when onBadgeClick is undefined",
+      (state, label) => {
+        renderAccordion({ badgeState: state, onBadgeClick: undefined });
+        // No button — clicking the pin on custom / App Store rows would go
+        // nowhere, so it should not look interactive.
+        expect(
+          screen.queryByRole("button", { name: label })
+        ).not.toBeInTheDocument();
+        // Text still displays.
+        expect(screen.getByText(label)).toBeVisible();
+      }
+    );
 
     it("renders no badge when badgeState is undefined", () => {
       renderAccordion({ badgeState: undefined });
       expect(
         screen.queryByRole("button", { name: "Latest" })
       ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: "Pinned" })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: "Major version" })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Latest")).not.toBeInTheDocument();
+      expect(screen.queryByText("Pinned")).not.toBeInTheDocument();
+      expect(screen.queryByText("Major version")).not.toBeInTheDocument();
     });
 
     it("renders the label-count badge when labels are scoped", () => {
@@ -133,9 +148,9 @@ describe("LibraryItemAccordion", () => {
       expect(screen.getByText("All hosts")).toBeVisible();
     });
 
-    it("does not render 'All hosts' when badgeState is undefined (no badge means no fallback)", () => {
+    it("renders 'All hosts' on rows with no badgeState (custom/App Store rows still show the label fallback)", () => {
       renderAccordion({ badgeState: undefined, labels: [] });
-      expect(screen.queryByText("All hosts")).not.toBeInTheDocument();
+      expect(screen.getByText("All hosts")).toBeVisible();
     });
 
     it("renders a tooltip with the label list when hovering the count badge", async () => {
@@ -402,16 +417,17 @@ describe("LibraryItemAccordion", () => {
 
   // Cross-cutting: every callback prop is optional, so a row with none wired
   // up must still click through every interactive element without throwing.
+  // (The status-badge — "Latest"/"Pinned"/"Major version" — is intentionally
+  // non-interactive without a handler; covered in the "badges" block above.)
   describe("no-handler safety", () => {
     it("does not throw when interactive elements are clicked without handlers", async () => {
       const { user } = renderAccordion({
         badgeState: "latest",
         labels: makeLabels(2),
-        // intentionally no onBadgeClick / onLabelCountClick / onDownloadClick /
-        // onTrashClick — exercising the optional-callback no-op paths
+        // intentionally no onLabelCountClick / onDownloadClick / onTrashClick —
+        // exercising the optional-callback no-op paths
       });
 
-      await user.click(screen.getByRole("button", { name: "Latest" }));
       await user.click(screen.getByRole("button", { name: "2" }));
       await user.click(screen.getByRole("button", { expanded: false }));
       await user.click(

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
@@ -110,8 +110,8 @@ describe("LibraryItemAccordion", () => {
       "renders the %s badge as a static span (no bogus click affordance) when onBadgeClick is undefined",
       (state, label) => {
         renderAccordion({ badgeState: state, onBadgeClick: undefined });
-        // No button — clicking the pin on custom / App Store rows would go
-        // nowhere, so it should not look interactive.
+        // Observer viewing an FMA: the pin state stays visible but is not a
+        // click target, since observers can't open the versions modal.
         expect(
           screen.queryByRole("button", { name: label })
         ).not.toBeInTheDocument();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -96,8 +96,9 @@ export interface ILibraryItemAccordionProps {
   /** Click handler for whichever badge is rendered per `badgeState`. The
    * consumer can branch on `badgeState` inside the callback if it needs to
    * differentiate (e.g. exact vs major-version pin); the row itself fires the
-   * same callback for all three. When undefined, the badge renders as a
-   * non-interactive span (decorative label with no pointer/hover affordance). */
+   * same callback for all three. When undefined, the badge still renders but
+   * as a non-interactive span — used for FMA rows viewed by users without
+   * edit permission, so the pin state is visible without a bogus affordance. */
   onBadgeClick?: () => void;
   onLabelCountClick?: () => void;
   /** Click on the labels list in the expanded panel — opens the edit software
@@ -184,9 +185,10 @@ const LibraryItemAccordion = ({
     handler?.();
   };
 
-  // FMA versions modal is the only consumer that wires a click handler; for
-  // custom packages and App Store apps the badge is decorative, so render as a
-  // static span to avoid a bogus pointer/hover affordance.
+  // Only FMA rows receive a `badgeState`; the click handler is further gated
+  // on canEditSoftware. When the handler is present, render as a Button that
+  // opens the versions modal; when absent (observer viewing an FMA), render
+  // as a static span so the pin state stays visible without a bogus affordance.
   const renderStatusBadge = (iconName: IconNames, label: string) => {
     if (onBadgeClick) {
       return (

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -9,6 +9,7 @@ import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
 import TruncatedTextList from "components/TruncatedTextList";
+import { IconNames } from "components/icons";
 import { ILabelSoftwareTitle } from "interfaces/label";
 import { InstallerType } from "interfaces/software";
 import InstallerDetailsWidget from "pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget";
@@ -95,7 +96,8 @@ export interface ILibraryItemAccordionProps {
   /** Click handler for whichever badge is rendered per `badgeState`. The
    * consumer can branch on `badgeState` inside the callback if it needs to
    * differentiate (e.g. exact vs major-version pin); the row itself fires the
-   * same callback for all three. */
+   * same callback for all three. When undefined, the badge renders as a
+   * non-interactive span (decorative label with no pointer/hover affordance). */
   onBadgeClick?: () => void;
   onLabelCountClick?: () => void;
   /** Click on the labels list in the expanded panel — opens the edit software
@@ -141,8 +143,7 @@ const LibraryItemAccordion = ({
 
   const labelCount = labels?.length ?? 0;
   const hasLabelScope = labelCount > 0;
-  const showAllHostsBadge =
-    isActive && !hasLabelScope && badgeState !== undefined;
+  const showAllHostsBadge = isActive && !hasLabelScope;
 
   const canExpand = isActive;
   const isExpanded = canExpand && expanded;
@@ -183,44 +184,42 @@ const LibraryItemAccordion = ({
     handler?.();
   };
 
+  // FMA versions modal is the only consumer that wires a click handler; for
+  // custom packages and App Store apps the badge is decorative, so render as a
+  // static span to avoid a bogus pointer/hover affordance.
+  const renderStatusBadge = (iconName: IconNames, label: string) => {
+    if (onBadgeClick) {
+      return (
+        <Button
+          variant="inverse"
+          size="small"
+          onClick={handleBadgeClick(onBadgeClick)}
+          className={`${baseClass}__badge-button`}
+        >
+          <Icon name={iconName} color="ui-fleet-black-75" />
+          <span>{label}</span>
+        </Button>
+      );
+    }
+    return (
+      <span
+        className={`${baseClass}__badge-button ${baseClass}__badge-button--static`}
+      >
+        <Icon name={iconName} color="ui-fleet-black-75" />
+        <span>{label}</span>
+      </span>
+    );
+  };
+
   const renderHeaderBadges = () => {
     if (!isActive) return null;
 
     return (
       <div className={`${baseClass}__badges`}>
-        {badgeState === "latest" && (
-          <Button
-            variant="inverse"
-            size="small"
-            onClick={handleBadgeClick(onBadgeClick)}
-            className={`${baseClass}__badge-button`}
-          >
-            <Icon name="refresh" color="ui-fleet-black-75" />
-            <span>Latest</span>
-          </Button>
-        )}
-        {badgeState === "pinned" && (
-          <Button
-            variant="inverse"
-            size="small"
-            onClick={handleBadgeClick(onBadgeClick)}
-            className={`${baseClass}__badge-button`}
-          >
-            <Icon name="pin" color="ui-fleet-black-75" />
-            <span>Pinned</span>
-          </Button>
-        )}
-        {badgeState === "majorVersion" && (
-          <Button
-            variant="inverse"
-            size="small"
-            onClick={handleBadgeClick(onBadgeClick)}
-            className={`${baseClass}__badge-button`}
-          >
-            <Icon name="pin" color="ui-fleet-black-75" />
-            <span>Major version</span>
-          </Button>
-        )}
+        {badgeState === "latest" && renderStatusBadge("refresh", "Latest")}
+        {badgeState === "pinned" && renderStatusBadge("pin", "Pinned")}
+        {badgeState === "majorVersion" &&
+          renderStatusBadge("pin", "Major version")}
         {hasLabelScope && (
           <TooltipWrapper
             tipContent={renderLabelCountTooltip()}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -258,7 +258,6 @@ const SoftwareTitleDetailsPage = ({
               }
               isIosOrIpadosApp={isIosOrIpadosApp}
               isActive
-              badgeState="latest"
               labels={labels}
               labelKind={kind}
               canEditSoftware={canEditSoftware}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
@@ -10,7 +10,9 @@ const v = (id: number, version: string) => ({
 
 describe("SoftwareTitleDetailsPage helpers", () => {
   describe("buildLibraryVersionRows", () => {
-    it("renders a single active 'Latest' row when there is no cached-version list", () => {
+    it("renders a single active un-badged row when there is no cached-version list", () => {
+      // Custom packages have no FMA-style version history to pin against, so
+      // no badge is emitted for the fallback row.
       expect(
         buildLibraryVersionRows({
           fleetMaintainedVersions: null,
@@ -24,7 +26,6 @@ describe("SoftwareTitleDetailsPage helpers", () => {
           version: "1.2.3",
           uploaded_at: "2026-02-02T00:00:00Z",
           isActive: true,
-          badgeState: "latest",
         },
       ]);
     });

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
@@ -44,8 +44,10 @@ export interface ILibraryVersionRow {
 
 /** Builds the Library accordion rows for a title: one row per cached
  * Fleet-maintained version (the active row badged from the pin, the rest dimmed
- * rollback candidates), or a single active "Latest" row for installer types
- * that have no cached-version list. */
+ * rollback candidates), or a single active un-badged row for installer types
+ * that have no cached-version list. The `latest`/`pinned`/`majorVersion` badges
+ * are FMA-semantics — custom packages have no version history to pin against,
+ * so no badge is rendered. */
 export const buildLibraryVersionRows = ({
   fleetMaintainedVersions,
   activeVersion,
@@ -73,7 +75,6 @@ export const buildLibraryVersionRows = ({
       version: activeVersion ?? "",
       uploaded_at: addedTimestamp,
       isActive: true,
-      badgeState: "latest",
     },
   ];
 };


### PR DESCRIPTION
## Issue
Closes #48480

## Description
- Bug fix (root cause): the "Latest" pin was rendered on every active library-accordion row regardless of installer type. `buildLibraryVersionRows` stamped `badgeState: "latest"` on the non-FMA fallback row and `SoftwareTitleDetailsPage` hard-coded it on the App Store branch. But the pin is FMA-only semantics (introduced with the FMA versioning feature in #47944) — for custom packages and App Store apps it had no meaning and no click handler, so it looked interactive (pointer cursor, hover state) without doing anything.
- Fix: drop `badgeState` on custom and App Store rows so no pin renders. FMA rows still show it — clickable for admins/maintainers via the versions modal, static for observers.
- `LibraryItemAccordion`: extracted the three duplicated badge blocks (`latest` / `pinned` / `majorVersion`) into one `renderStatusBadge` helper that emits a `<Button>` when `onBadgeClick` is wired and a static `<span>` (reusing the existing `--static` modifier) when it isn't. Covers the observer-viewing-FMA case, where the pin is info-only.
- Kept the label-count and "All hosts" fallback badges on non-FMA rows — labels can be scoped on any installer type.

## Screenrecording

https://github.com/user-attachments/assets/a964b60e-1a29-4847-9aa2-2109ee79febc


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status badges in the software library accordion now reliably switch between clickable controls (when enabled) and non-clickable decorative text (when disabled).

* **Bug Fixes**
  * “All hosts” visibility now behaves correctly across more active-row scenarios when no label scope is set.
  * Fallback software version rows no longer show an unnecessary “Latest” badge when version history isn’t available.

* **Tests**
  * Expanded coverage for badge interactivity and “All hosts”/fallback rendering behavior.

* **Documentation**
  * Updated software library version badge semantics to match the new clickable vs non-clickable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->