### PR TITLE
Fleet UI: Fix ManageSoftwareAutomationsModal test type errors

### DIFF
--- a/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tests.tsx
@@ -20,6 +20,17 @@ const softwareConfig = createMockConfig({
       enable_vulnerabilities_webhook: true,
       destination_url: "",
     },
+    failing_policies_webhook: {
+      enable_failing_policies_webhook: false,
+      destination_url: "",
+      policy_ids: [],
+      host_batch_size: 0,
+    },
+    host_status_webhook: null,
+    activities_webhook: {
+      enable_activities_webhook: false,
+      destination_url: "",
+    },
   },
   integrations: { jira: [], zendesk: [] },
 });
@@ -42,7 +53,11 @@ const renderModal = ({ gitOpsModeEnabled = false } = {}) => {
     context: {
       app: {
         config: createMockConfig({
-          gitops: { gitops_mode_enabled: gitOpsModeEnabled },
+          gitops: {
+            gitops_mode_enabled: gitOpsModeEnabled,
+            repository_url: "",
+            exceptions: { labels: false, software: false, secrets: true },
+          },
         }),
         isFreeTier: false,
       },


### PR DESCRIPTION
## Issue
Broken test file introduced in #48854 — failing on the `build-binaries > Generate static files` job (first surfaced on #48871's CI run).

## Description
- Root cause: `babel-jest` strips TS types by erasure without type-checking, so Jest CI passed on #48854. Strict TS check runs inside webpack's `ForkTsCheckerWebpackPlugin` (`webpack.config.js:15`), which only fires during `make generate-js` in the build-binaries job — that job apparently didn't gate #48854 and first surfaced the failure on a downstream PR.
- Bug: the test passed partial nested objects to `createMockConfig`, which accepts `Partial<IConfig>` — top-level keys may be omitted, but each included value must be complete. `webhook_settings` needed `failing_policies_webhook`, `host_status_webhook`, and `activities_webhook` alongside the provided `vulnerabilities_webhook`; `gitops` needed `repository_url` and `exceptions` alongside `gitops_mode_enabled`.
- Fix: fill in the missing required fields in the two `createMockConfig(...)` call sites in `ManageSoftwareAutomationsModal.tests.tsx`.

## Screenrecording
- N/A (test-only change)


<!-- recording -->


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test data to cover additional software webhook settings and destination URL validation scenarios.
  * Refined mocked GitOps configuration used in modal tests to better reflect current settings structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->