### PR TITLE
Website: cache workshop details in platform record

### DIFF
--- a/website/api/controllers/view-workshops.js
+++ b/website/api/controllers/view-workshops.js
@@ -18,114 +18,139 @@ module.exports = {
 
   fn: async function () {
 
-    let futureGitopsWorkshops = [];
+    // Retrieve the single platform record from the database.
+    let platformRecords = await Platform.find();
+    let platformRecord = platformRecords[0];
+    if(!platformRecord) {
+      throw new Error(`Consistency violation: when a user visited the workshops page, no platform record was found.`);
+    }
+
+    // Check the workshopDetailsLastUpdatedAt timestamp on the platform record
+    let nowAt = Date.now();
+    let twoHoursAgoAt = nowAt - (1000 * 60 * 60 * 2);
+    let eventDetailsWereUpdatedLessThanTwoHoursAgo = (twoHoursAgoAt > platformRecord.workshopDetailsLastUpdatedAt);
+
+    // Get the event details from the platform record.
+    let eventDetails = platformRecord.workshopDetails;
+
+    let futureWorkshops = [];
+
+    // If the platform record was updated in the past two hours, use the event details stored in the website's database.
+    if(eventDetails.length > 1 && !eventDetailsWereUpdatedLessThanTwoHoursAgo) {
+      futureWorkshops = eventDetails;
+    } else {// Otherwise, fetch fresh data from the EventBrite API
+      let futureGitopsEvents = await sails.helpers.http.get.with({
+        url: `https://www.eventbriteapi.com/v3/organizations/${sails.config.custom.eventbriteOrgId}/events/?show_series_parent=true&page_size=200&time_filter=current_future&status=live`,
+        headers: {
+          authorization: `Bearer ${sails.config.custom.eventbriteApiToken}`
+        },
+      }).tolerate((err)=>{
+        sails.log.warn(`When a user visited the gitops workshop page, a list of future gitiops workshops could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
+        return {
+          events: [],
+        };
+      });
+
+      let eventsToGetDetailsFor = futureGitopsEvents.events;
+
+      await sails.helpers.flow.simultaneouslyForEach(eventsToGetDetailsFor, async (event)=>{
+        // Determine if this event is a GitOps workshop or an Apple administrator workshop.
+        let eventType = _.contains(event.name.text.toLowerCase(), 'gitops') ? 'GitOps workshop' : _.contains(event.name.text.toLowerCase(), 'apple administrator') ? 'Apple administrator workshop' : undefined;
+        // If it is not one of those types of events, skip it.
+        if(!eventType) {
+          return;
+        }
+
+        // Convert the ISO timestamps that represent the start and end time of the event into a formatted string.
+        // Create new Date objects from the start and end times.
+        let eventStartsOn = new Date(event.start.utc);
+        let eventEndsOn = new Date(event.end.utc);
+        // Get a JS timestamp of when this event starts (used to sort the final list of events.)
+        let eventStartsAt = eventStartsOn.getTime();
+        let eventTimeZone = event.start.timezone;
+        let formattedDateString = new Intl.DateTimeFormat('en-US', {
+          timeZone: eventTimeZone,
+          month: 'short',
+          day: 'numeric',
+        }).format(eventStartsOn);
+        // ex: 2026-02-03T13:00:00 »»» Feb 3
+
+        // Create a new Intl.DateTimeFormat object using the start Date object, and use the formatToParts() method to get an abbreviated timezone string.
+        let partsOfTimezone = new Intl.DateTimeFormat('en-US', {
+          timeZone: event.start.timezone,
+          timeZoneName: 'short'
+        }).formatToParts(eventStartsOn);// [?]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts
+
+        // Get the value of the timeZoneName object in the partsOfTimezone array/
+        let shortenedTimeZone = _.find(partsOfTimezone, {type: 'timeZoneName'});
+        let abbreviatedTimeZoneString = shortenedTimeZone.value;
+
+        let startTime =  new Intl.DateTimeFormat('en-US', {
+          timeZone: eventTimeZone,
+          hour: 'numeric',
+          minute: 'numeric',
+          hour12: true
+        })
+        .format(eventStartsOn)
+        .replace(':00 ', '')
+        .toLowerCase();
+
+        let endTime =  new Intl.DateTimeFormat('en-US', {
+          timeZone: eventTimeZone,
+          hour: 'numeric',
+          minute: 'numeric',
+          hour12: true
+        })
+        .format(eventEndsOn)
+        .replace(':00 ', '')
+        .toLowerCase();
+        let eventTimeDetailsString = `${formattedDateString} from ${startTime} to ${endTime} ${abbreviatedTimeZoneString}`;
+        let eventDetails = {
+          eventbriteLink: event.url,
+          eventTime: eventTimeDetailsString,
+          startsAt: eventStartsAt,
+          type: eventType,
+        };
+
+        // If an event has a venue_id, we'll send a request to the Eventbrite API to get details about the venue.
+        if(event.venue_id) {
+          let eventVenueResponse = await sails.helpers.http.get.with({
+            url: `https://www.eventbriteapi.com/v3/venues/${event.venue_id}/`,
+            headers: {
+              authorization: `Bearer ${sails.config.custom.eventbriteApiToken}`
+            },
+          }).tolerate((err)=>{
+            sails.log.warn(`When a user visited the gitops workshop page, details about a venue for an event (${event.name.text}) could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
+            // If there was an error getting details about the venue for this event, set the address to 'TBA' and use the event name instead of the city name.
+            return {
+              address: { city: event.name.text },
+              name: 'TBA'
+            };
+          });
+          eventDetails.workshopCity = eventVenueResponse.address.city;
+          eventDetails.workshopAddress = eventVenueResponse.name;
+        } else {
+          // IF the event is missing a venue_id, set the address to 'TBA' and use the event name instead of the city name.
+          eventDetails.workshopCity = event.name.text;
+          eventDetails.workshopAddress = 'TBA';
+        }
 
 
-    let futureGitopsEvents = await sails.helpers.http.get.with({
-      url: `https://www.eventbriteapi.com/v3/organizations/${sails.config.custom.eventbriteOrgId}/events/?show_series_parent=true&page_size=200&time_filter=current_future&status=live`,
-      headers: {
-        authorization: `Bearer ${sails.config.custom.eventbriteApiToken}`
-      },
-    }).tolerate((err)=>{
-      sails.log.warn(`When a user visited the gitops workshop page, a list of future gitiops workshops could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
-      return {
-        events: [],
-      };
-    });
-
-    let eventsToGetDetailsFor = futureGitopsEvents.events;
-
-    await sails.helpers.flow.simultaneouslyForEach(eventsToGetDetailsFor, async (event)=>{
-      // Determine if this event is a GitOps workshop or an Apple administrator workshop.
-      let eventType = _.contains(event.name.text.toLowerCase(), 'gitops') ? 'GitOps workshop' : _.contains(event.name.text.toLowerCase(), 'apple administrator') ? 'Apple administrator workshop' : undefined;
-      // If it is not one of those types of events, skip it.
-      if(!eventType) {
-        return;
-      }
-
-      // Convert the ISO timestamps that represent the start and end time of the event into a formatted string.
-      // Create new Date objects from the start and end times.
-      let eventStartsOn = new Date(event.start.utc);
-      let eventEndsOn = new Date(event.end.utc);
-      // Get a JS timestamp of when this event starts (used to sort the final list of events.)
-      let eventStartsAt = eventStartsOn.getTime();
-      let eventTimeZone = event.start.timezone;
-      let formattedDateString = new Intl.DateTimeFormat('en-US', {
-        timeZone: eventTimeZone,
-        month: 'short',
-        day: 'numeric',
-      }).format(eventStartsOn);
-      // ex: 2026-02-03T13:00:00 »»» Feb 3
-
-      // Create a new Intl.DateTimeFormat object using the start Date object, and use the formatToParts() method to get an abbreviated timezone string.
-      let partsOfTimezone = new Intl.DateTimeFormat('en-US', {
-        timeZone: event.start.timezone,
-        timeZoneName: 'short'
-      }).formatToParts(eventStartsOn);// [?]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts
-
-      // Get the value of the timeZoneName object in the partsOfTimezone array/
-      let shortenedTimeZone = _.find(partsOfTimezone, {type: 'timeZoneName'});
-      let abbreviatedTimeZoneString = shortenedTimeZone.value;
-
-      let startTime =  new Intl.DateTimeFormat('en-US', {
-        timeZone: eventTimeZone,
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: true
-      })
-      .format(eventStartsOn)
-      .replace(':00 ', '')
-      .toLowerCase();
-
-      let endTime =  new Intl.DateTimeFormat('en-US', {
-        timeZone: eventTimeZone,
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: true
-      })
-      .format(eventEndsOn)
-      .replace(':00 ', '')
-      .toLowerCase();
-      let eventTimeDetailsString = `${formattedDateString} from ${startTime} to ${endTime} ${abbreviatedTimeZoneString}`;
-      let eventDetails = {
-        eventbriteLink: event.url,
-        eventTime: eventTimeDetailsString,
-        startsAt: eventStartsAt,
-        type: eventType,
-      };
-
-      // If an event has a venue_id, we'll send a request to the Eventbrite API to get details about the venue.
-      if(event.venue_id) {
-        let eventVenueResponse = await sails.helpers.http.get.with({
-          url: `https://www.eventbriteapi.com/v3/venues/${event.venue_id}/`,
-          headers: {
-            authorization: `Bearer ${sails.config.custom.eventbriteApiToken}`
-          },
-        }).tolerate((err)=>{
-          sails.log.warn(`When a user visited the gitops workshop page, details about a venue for an event (${event.name.text}) could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
-          // If there was an error getting details about the venue for this event, set the address to 'TBA' and use the event name instead of the city name.
-          return {
-            address: { city: event.name.text },
-            name: 'TBA'
-          };
-        });
-        eventDetails.workshopCity = eventVenueResponse.address.city;
-        eventDetails.workshopAddress = eventVenueResponse.name;
-      } else {
-        // IF the event is missing a venue_id, set the address to 'TBA' and use the event name instead of the city name.
-        eventDetails.workshopCity = event.name.text;
-        eventDetails.workshopAddress = 'TBA';
-
-      }
+        futureWorkshops.push(eventDetails);
+      });
 
 
-      futureGitopsWorkshops.push(eventDetails);
-    });
+      // Update the plaform record with the latest workshop event details
+      await Platform.updateOne({id: platformRecord.id}).set({workshopDetails: futureWorkshops, workshopDetailsLastUpdatedAt: Date.now()});
+    }
+
+
+
     // Sort the events that will be displayed on the page.
-    futureGitopsWorkshops = _.sortBy(futureGitopsWorkshops, 'startsAt');
+    futureWorkshops = _.sortBy(futureWorkshops, 'startsAt');
     // Respond with view.
     return {
-      futureGitopsWorkshops
+      futureWorkshops
     };
 
   }

--- a/website/api/controllers/view-workshops.js
+++ b/website/api/controllers/view-workshops.js
@@ -45,7 +45,7 @@ module.exports = {
           authorization: `Bearer ${sails.config.custom.eventbriteApiToken}`
         },
       }).tolerate((err)=>{
-        sails.log.warn(`When a user visited the gitops workshop page, a list of future gitiops workshops could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
+        sails.log.warn(`When a user visited the gitops workshop page, a list of future workshops could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
         return {
           events: [],
         };
@@ -120,7 +120,7 @@ module.exports = {
               authorization: `Bearer ${sails.config.custom.eventbriteApiToken}`
             },
           }).tolerate((err)=>{
-            sails.log.warn(`When a user visited the gitops workshop page, details about a venue for an event (${event.name.text}) could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
+            sails.log.warn(`When a user visited the workshop page, details about a venue for an event (${event.name.text}) could not be obtained from the Eventbrite API. Full error: ${require('util').inspect(err)}`);
             // If there was an error getting details about the venue for this event, set the address to 'TBA' and use the event name instead of the city name.
             return {
               address: { city: event.name.text },

--- a/website/api/controllers/view-workshops.js
+++ b/website/api/controllers/view-workshops.js
@@ -36,7 +36,7 @@ module.exports = {
     let futureWorkshops = [];
 
     // If the platform record was updated in the past two hours, use the event details stored in the website's database.
-    if(eventDetails.length > 1 && !eventDetailsWereUpdatedLessThanTwoHoursAgo) {
+    if(eventDetails.length > 0 && !eventDetailsWereUpdatedLessThanTwoHoursAgo) {
       futureWorkshops = eventDetails;
     } else {// Otherwise, fetch fresh data from the EventBrite API
       let futureGitopsEvents = await sails.helpers.http.get.with({

--- a/website/api/models/Platform.js
+++ b/website/api/models/Platform.js
@@ -23,6 +23,7 @@ module.exports = {
       type: 'json',
       description: 'An array containing the most recent event details formatted to be used on the workshops page',
       required: true,
+      defaultsTo: [],
       example: [
         {
           eventTime: 'Jul 13 from 1pm to 5pm PDT',
@@ -39,6 +40,7 @@ module.exports = {
     workshopDetailsLastUpdatedAt: {
       type: 'number',
       required: true,
+      defaultsTo: 1,
       description: 'A JS timestamp representing when the event details were last updated.',
     },
 

--- a/website/api/models/Platform.js
+++ b/website/api/models/Platform.js
@@ -23,7 +23,6 @@ module.exports = {
       type: 'json',
       description: 'An array containing the most recent event details formatted to be used on the workshops page',
       required: true,
-      defaultsTo: [],
       example: [
         {
           eventTime: 'Jul 13 from 1pm to 5pm PDT',
@@ -40,7 +39,6 @@ module.exports = {
     workshopDetailsLastUpdatedAt: {
       type: 'number',
       required: true,
-      defaultsTo: 1,
       description: 'A JS timestamp representing when the event details were last updated.',
     },
 

--- a/website/api/models/Platform.js
+++ b/website/api/models/Platform.js
@@ -17,7 +17,30 @@ module.exports = {
       description: 'An array containing the numbers of PRs to the fleetdm/fleet repo that can currently bypass MergeFreeze.',
       example: [13638, 13447, 13673],
       required: true,
-    }
+    },
+
+    workshopDetails: {
+      type: 'json',
+      description: 'An array containing the most recent event details formatted to be used on the workshops page',
+      required: true,
+      example: [
+        {
+          eventTime: 'Jul 13 from 1pm to 5pm PDT',
+          eventbriteLink: 'https://www.eventbrite.com/e/gitops-workshop-example-00000000000',
+          startsAt: 1783972800000,
+          type: 'string',
+          workshopAddress: 'string',
+          workshopCity: 'string',
+        }
+      ],
+    },
+
+
+    workshopDetailsLastUpdatedAt: {
+      type: 'number',
+      required: true,
+      description: 'A JS timestamp representing when the event details were last updated.',
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/website/config/bootstrap.js
+++ b/website/config/bootstrap.js
@@ -15,7 +15,7 @@ module.exports.bootstrap = async function() {
   var path = require('path');
 
   // This bootstrap version indicates what version of fake data we're dealing with here.
-  var HARD_CODED_DATA_VERSION = 1;
+  var HARD_CODED_DATA_VERSION = 2;
 
   // This path indicates where to store/look for the JSON file that tracks the "last run bootstrap info"
   // locally on this development computer (if we happen to be on a development computer).
@@ -79,7 +79,6 @@ module.exports.bootstrap = async function() {
     fleetPremiumTrialLicenseKeyExpiresAt: Date.now() + (60 * 60 * 24 * 30 * 1000),
   }).fetch();
 
-  // Note: We do not create a platform record to avoid potential consistency violations.
 
   if (sails.config.custom.enableBillingFeatures) {
     let stripeCustomerId = await sails.helpers.stripe.saveBillingInfo.with({
@@ -92,6 +91,12 @@ module.exports.bootstrap = async function() {
     });
   }
 
+  // Create a platform record.
+  await Platform.create({
+    currentUnfrozenGitHubPrNumbers: [],
+    workshopDetails: [],
+    workshopDetailsLastUpdatedAt: Date.now()
+  });
 
   // Save new bootstrap version
   await sails.helpers.fs.writeJson.with({

--- a/website/views/pages/workshops.ejs
+++ b/website/views/pages/workshops.ejs
@@ -102,8 +102,8 @@
           <p>Join our free, hands-on workshop and earn your Fleet Level 1 Certificate.</p>
         </div>
         <div purpose="event-cards">
-          <%if(futureGitopsWorkshops.length > 0){%>
-            <% for(let event of futureGitopsWorkshops) { %>
+          <%if(futureWorkshops.length > 0){%>
+            <% for(let event of futureWorkshops) { %>
               <div purpose="event-card">
                   <p purpose="event-city">
                     <%= event.type %>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/48142

Changes:
- Added two new attributes to the website's platform record: `workshopDetails`, an array containing formatted event details to be used on the /workshops page, and `workshopDetailsLastUpdatedAt`, a JS timestamp representing when workshop event details were last retrieved from the EventBrite API
- Update the website's bootstrap configuration to create a platform record
- Updated the view action for the workshops page to load workshop event details from the database if they were updated less than two hours ago.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workshop listings now reuse cached upcoming event details for up to 2 hours to improve load speed.
  * Upcoming workshops are rendered from a single unified, start-time-sorted list.

* **Bug Fixes**
  * When cached event details are stale, the page fetches fresh future workshops automatically.
  * Venue details are more resilient: if lookup fails or venue data is missing, workshop cards use fallback location text and a “TBA” address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->