### PR TITLE
Filter cross-team memberships from user list responses

### DIFF
--- a/changes/16691-cross-team-user-list-teams-authz
+++ b/changes/16691-cross-team-user-list-teams-authz
@@ -1,0 +1,1 @@
+- Fixed team-scoped admins seeing team memberships (IDs, names, and roles) for teams they do not administer when listing users shared across multiple teams via `GET /api/latest/fleet/users`.

--- a/changes/16691-cross-team-user-list-teams-authz
+++ b/changes/16691-cross-team-user-list-teams-authz
@@ -1,1 +1,1 @@
-- Fixed team-scoped admins seeing team memberships (IDs, names, and roles) for teams they do not administer when listing users shared across multiple teams via `GET /api/latest/fleet/users`.
+- Fixed fleet-scoped context when retrieving a list of users in a fleet. 

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -469,11 +469,43 @@ func listUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 		return listUsersResponse{Err: err}, nil
 	}
 
+	// The datastore loads each user's full team membership. A team-scoped
+	// requester is only authorized to list users of a team they administer, so
+	// strip any team memberships (IDs/names/roles) for teams the requester has
+	// no role in before returning them. Global roles are authorized to see all
+	// teams and are left untouched.
+	var requester *fleet.User
+	if vc, ok := viewer.FromContext(ctx); ok {
+		requester = vc.User
+	}
+
 	resp := listUsersResponse{Users: []fleet.User{}}
 	for _, user := range users {
-		resp.Users = append(resp.Users, *user)
+		u := *user
+		u.Teams = filterUserTeamsToRequesterScope(u.Teams, requester)
+		resp.Users = append(resp.Users, u)
 	}
 	return resp, nil
+}
+
+// filterUserTeamsToRequesterScope returns the subset of teams that the
+// requester is permitted to see. A requester with any global role sees all
+// teams unchanged; a team-scoped requester sees only teams they have a role in.
+// A nil requester (should not happen on authenticated endpoints) is treated as
+// having no scope, so nothing is disclosed.
+func filterUserTeamsToRequesterScope(teams []fleet.UserTeam, requester *fleet.User) []fleet.UserTeam {
+	if requester != nil && requester.HasAnyGlobalRole() {
+		return teams
+	}
+	filtered := make([]fleet.UserTeam, 0, len(teams))
+	if requester != nil {
+		for _, t := range teams {
+			if requester.HasAnyRoleInTeam(t.ID) {
+				filtered = append(filtered, t)
+			}
+		}
+	}
+	return filtered
 }
 
 func (svc *Service) ListUsers(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -469,21 +469,9 @@ func listUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 		return listUsersResponse{Err: err}, nil
 	}
 
-	// The datastore loads each user's full team membership. A team-scoped
-	// requester is only authorized to list users of a team they administer, so
-	// strip any team memberships (IDs/names/roles) for teams the requester has
-	// no role in before returning them. Global roles are authorized to see all
-	// teams and are left untouched.
-	var requester *fleet.User
-	if vc, ok := viewer.FromContext(ctx); ok {
-		requester = vc.User
-	}
-
 	resp := listUsersResponse{Users: []fleet.User{}}
 	for _, user := range users {
-		u := *user
-		u.Teams = filterUserTeamsToRequesterScope(u.Teams, requester)
-		resp.Users = append(resp.Users, u)
+		resp.Users = append(resp.Users, *user)
 	}
 	return resp, nil
 }
@@ -491,18 +479,14 @@ func listUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 // filterUserTeamsToRequesterScope returns the subset of teams that the
 // requester is permitted to see. A requester with any global role sees all
 // teams unchanged; a team-scoped requester sees only teams they have a role in.
-// A nil requester (should not happen on authenticated endpoints) is treated as
-// having no scope, so nothing is disclosed.
 func filterUserTeamsToRequesterScope(teams []fleet.UserTeam, requester *fleet.User) []fleet.UserTeam {
-	if requester != nil && requester.HasAnyGlobalRole() {
+	if requester.HasAnyGlobalRole() {
 		return teams
 	}
 	filtered := make([]fleet.UserTeam, 0, len(teams))
-	if requester != nil {
-		for _, t := range teams {
-			if requester.HasAnyRoleInTeam(t.ID) {
-				filtered = append(filtered, t)
-			}
+	for _, t := range teams {
+		if requester.HasAnyRoleInTeam(t.ID) {
+			filtered = append(filtered, t)
 		}
 	}
 	return filtered
@@ -517,7 +501,26 @@ func (svc *Service) ListUsers(ctx context.Context, opt fleet.UserListOptions) ([
 		return nil, err
 	}
 
-	return svc.ds.ListUsers(ctx, opt)
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return nil, fleet.ErrNoContext
+	}
+
+	users, err := svc.ds.ListUsers(ctx, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	// The datastore loads each user's full team membership. A team-scoped
+	// requester is only authorized to list users of a team they administer, so
+	// strip any team memberships (IDs/names/roles) for teams the requester has
+	// no role in before returning them. Global roles are authorized to see all
+	// teams and are left untouched.
+	for _, user := range users {
+		user.Teams = filterUserTeamsToRequesterScope(user.Teams, vc.User)
+	}
+
+	return users, nil
 }
 
 func (svc *Service) UsersByIDs(ctx context.Context, ids []uint) ([]*fleet.UserSummary, error) {

--- a/server/service/users_test.go
+++ b/server/service/users_test.go
@@ -1907,3 +1907,74 @@ func TestPasswordChangeClearsTokensAndSessions(t *testing.T) {
 		assert.Equal(t, []uint{otherSession.ID}, destroyedSessionIDs, "should only destroy the other session, not the current one")
 	})
 }
+
+// TestListUsersFiltersTeamsToRequesterScope verifies that a team-scoped admin
+// listing users does not receive team memberships (IDs/names/roles) for teams
+// the requester has no role in. Regression test for the cross-team data
+// exposure on GET /api/latest/fleet/users for shared multi-team users.
+func TestListUsersFiltersTeamsToRequesterScope(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	// A user shared across team 1 and team 2, as returned by the datastore
+	// (ds.ListUsers always loads the user's full team list).
+	sharedUserTeams := []fleet.UserTeam{
+		{Team: fleet.Team{ID: 1, Name: "Team 1"}, Role: fleet.RoleObserver},
+		{Team: fleet.Team{ID: 2, Name: "Team 2"}, Role: fleet.RoleObserver},
+	}
+	ds.ListUsersFunc = func(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {
+		return []*fleet.User{{
+			ID:    10,
+			Teams: append([]fleet.UserTeam{}, sharedUserTeams...),
+		}}, nil
+	}
+
+	// Requester is an admin of team 1 only, listing users of team 1.
+	teamOneAdmin := &fleet.User{
+		ID:    1,
+		Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}},
+	}
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: teamOneAdmin})
+
+	resp, err := listUsersEndpoint(ctx, &listUsersRequest{
+		ListOptions: fleet.UserListOptions{TeamID: 1},
+	}, svc)
+	require.NoError(t, err)
+
+	lr, ok := resp.(listUsersResponse)
+	require.True(t, ok)
+	require.NoError(t, lr.Err)
+	require.Len(t, lr.Users, 1)
+
+	// The requester must only see team 1 (in scope), never team 2.
+	require.Len(t, lr.Users[0].Teams, 1)
+	require.Equal(t, uint(1), lr.Users[0].Teams[0].ID)
+}
+
+// TestListUsersGlobalRequesterSeesAllTeams verifies the filter does not strip
+// teams for a global-role requester, who is authorized to see all teams.
+func TestListUsersGlobalRequesterSeesAllTeams(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	ds.ListUsersFunc = func(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {
+		return []*fleet.User{{
+			ID: 10,
+			Teams: []fleet.UserTeam{
+				{Team: fleet.Team{ID: 1, Name: "Team 1"}, Role: fleet.RoleObserver},
+				{Team: fleet.Team{ID: 2, Name: "Team 2"}, Role: fleet.RoleObserver},
+			},
+		}}, nil
+	}
+
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: test.UserAdmin})
+
+	resp, err := listUsersEndpoint(ctx, &listUsersRequest{}, svc)
+	require.NoError(t, err)
+
+	lr, ok := resp.(listUsersResponse)
+	require.True(t, ok)
+	require.NoError(t, lr.Err)
+	require.Len(t, lr.Users, 1)
+	require.Len(t, lr.Users[0].Teams, 2)
+}


### PR DESCRIPTION
From Lucas:
- [X] QA'd all new/changed functionality manually

## Summary

A team-scoped admin listing users of a team they administer (`GET /api/latest/fleet/users?team_id=A`) received the full team membership — team IDs, names, and roles — of any user also shared with other teams, disclosing teams the requester has no role in.

The single-user `GET /users/{id}` endpoint already blocks this: its authorization requires the requester to administer *every* team the target belongs to. The list endpoint authorizes against a synthetic single-team object (correct, so team admins can manage their members), but then returned each user's complete team list as loaded by the datastore.

This filters each returned user's teams down to the requester's scope at the response layer. Requesters with any global role are unchanged (they're authorized to see all teams).

## Why the response layer, not `Service.User`

`ModifyUser` and the password-reset flow reuse `Service.User` and read `user.Teams` to compute write diffs. Filtering there would silently drop team memberships on edits, so the filter is applied in `listUsersEndpoint` only.

`GET /users/{id}` is intentionally not changed — it is not exploitable (authz already requires admin-of-all-the-target's-teams), and its legitimate readers should keep seeing the full team list.

## Testing

- `TestListUsersFiltersTeamsToRequesterScope` — team-1 admin listing team 1 sees only team 1 for a user shared with {1,2}.
- `TestListUsersGlobalRequesterSeesAllTeams` — global admin sees all teams.
- Existing `TestUserAuth` / `TestAuthorizeUser` pass unchanged (no authz regression).

Fixes fleetdm/confidential#16691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user listing so returned team membership details are scoped to the requesting user’s permissions, including fleet-scoped context.
  * Team-scoped requesters now only see memberships for teams they’re allowed to view; global-role requesters still see all memberships.
  * When scoped viewer context is missing, team membership details are no longer included in the response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->