### PR TITLE
Host details: render custom host vitals + set per-host value (#48556)

### DIFF
--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -160,6 +160,7 @@ export enum ActivityType {
   EscrowedDiskEncryptionKey = "escrowed_disk_encryption_key",
   CreatedCustomVariable = "created_custom_variable",
   DeletedCustomVariable = "deleted_custom_variable",
+  EditedCustomHostVitalValue = "edited_custom_host_vital_value",
   EditedSetupExperienceSoftware = "edited_setup_experience_software",
   EditedHostIdpData = "edited_host_idp_data",
   AddedGoogleWorkspaceIntegration = "added_google_workspace_integration",
@@ -228,7 +229,8 @@ export type IHostPastActivityType =
   | ActivityType.RotatedManagedLocalAccountPassword
   | ActivityType.FailedToRotateManagedLocalAccountPassword
   | ActivityType.FailedEnrollmentProfileRenewal
-  | ActivityType.RanCustomMdmCommand;
+  | ActivityType.RanCustomMdmCommand
+  | ActivityType.EditedCustomHostVitalValue;
 
 /** This is a subset of ActivityType that are shown only for the host upcoming activities */
 export type IHostUpcomingActivityType =
@@ -353,6 +355,7 @@ export interface IActivityDetails {
   ticket_key?: string;
   ticket_id?: number;
   custom_variable_name?: string;
+  custom_host_vital_name?: string;
   domain?: string;
   host_idp_username?: string;
   idp_full_name?: string;
@@ -522,6 +525,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
   escrowed_disk_encryption_key: "Escrowed disk encryption key",
   created_custom_variable: "Created custom variable",
   deleted_custom_variable: "Deleted custom variable",
+  [ActivityType.EditedCustomHostVitalValue]: "Edited custom host vital value",
   [ActivityType.HostDeleted]: "Host deleted",
   [ActivityType.AddedHydrant]: "Added certificate authority (CA): Hydrant",
   [ActivityType.DeletedHydrant]: "Deleted certificate authority (CA): Hydrant",

--- a/frontend/interfaces/custom_host_vitals.ts
+++ b/frontend/interfaces/custom_host_vitals.ts
@@ -8,3 +8,10 @@ export interface ICustomHostVital {
 export interface ICustomHostVitalFormData {
   name: string;
 }
+
+// The per-host projection of a custom host vital
+export interface IHostCustomVital {
+  custom_host_vital_id: number;
+  name: string;
+  value: string;
+}

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -14,6 +14,7 @@ import {
   DiskEncryptionStatus,
 } from "./mdm";
 import { HostPlatform } from "./platform";
+import { IHostCustomVital } from "./custom_host_vitals";
 
 export default PropTypes.shape({
   created_at: PropTypes.string,
@@ -386,6 +387,7 @@ export interface IHost {
   device_mapping: IDeviceUser[] | null;
   /** There will be at most 1 end user */
   end_users?: IHostEndUser[];
+  custom_host_vitals?: IHostCustomVital[];
   conditional_access_bypassed: boolean;
   mdm_enrollment_hardware_attested?: boolean;
 }

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -22,6 +22,7 @@ import teamAPI, { ILoadTeamsResponse } from "services/entities/teams";
 import commandAPI from "services/entities/command";
 
 import { IHost, IMacadminsResponse, IHostResponse } from "interfaces/host";
+import { IHostCustomVital } from "interfaces/custom_host_vitals";
 import { ILabel } from "interfaces/label";
 import { IListSort } from "interfaces/list_options";
 import { IHostPolicy } from "interfaces/policy";
@@ -148,6 +149,7 @@ import HostHeader from "../cards/HostHeader";
 import InventoryVersionsModal from "../modals/InventoryVersionsModal";
 import UpdateEndUserModal from "../cards/User/components/UpdateEndUserModal";
 import LocationModal from "../modals/LocationModal";
+import EditHostVitalModal from "../modals/EditHostVitalModal";
 import MDMStatusModal from "../modals/MDMStatusModal";
 import ClearPasscodeModal from "./modals/ClearPasscodeModal";
 
@@ -256,6 +258,11 @@ const HostDetailsPage = ({
   }, [location.query.show_mdm_status]);
 
   const [showClearPasscodeModal, setShowClearPasscodeModal] = useState(false);
+
+  const [
+    editingCustomHostVital,
+    setEditingCustomHostVital,
+  ] = useState<IHostCustomVital | null>(null);
 
   // General-use updating state
   const [isUpdating, setIsUpdating] = useState(false);
@@ -1310,6 +1317,12 @@ const HostDetailsPage = ({
   // had one — so we don't gate visibility on orbit/MDM state.
   const canViewMyDeviceLink = isGlobalAdmin;
 
+  const canEditCustomHostVitals =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isHostTeamAdmin ||
+    isHostTeamMaintainer;
+
   const showSoftwareLibraryTab = isPremiumTier;
   const showReportsEmptyState = host.mdm?.enrollment_status === "Pending";
   const showAgentOptionsCard = !isIosOrIpadosHost && !isAndroidHost;
@@ -1507,6 +1520,12 @@ const HostDetailsPage = ({
                   )}
                   toggleLocationModal={toggleLocationModal}
                   toggleMDMStatusModal={toggleMDMStatusModal}
+                  customHostVitals={host.custom_host_vitals}
+                  onEditCustomHostVital={
+                    canEditCustomHostVitals
+                      ? setEditingCustomHostVital
+                      : undefined
+                  }
                 />
                 <ActivityCard
                   className={
@@ -2007,6 +2026,18 @@ const HostDetailsPage = ({
               setShowLocationModal(undefined);
             }}
             detailsUpdatedAt={host.detail_updated_at}
+          />
+        )}
+        {editingCustomHostVital && (
+          <EditHostVitalModal
+            hostId={host.id}
+            vital={editingCustomHostVital}
+            onCancel={() => setEditingCustomHostVital(null)}
+            onSave={() => {
+              refetchHostDetails();
+              refetchPastActivities();
+              setEditingCustomHostVital(null);
+            }}
           />
         )}
         {showMDMStatusModal && host.mdm.enrollment_status && (

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -36,6 +36,7 @@ import FailedToRotateManagedLocalAccountPasswordActivityItem from "./ActivityIte
 import FailedEnrollmentProfileRenewalActivityItem from "./ActivityItems/FailedEnrollmentProfileRenewalActivityItem";
 import MdmUnenrolledActivityItem from "./ActivityItems/MdmUnenrolledActivityItem";
 import RanCustomMdmCommandActivityItem from "./ActivityItems/RanCustomMdmCommandActivityItem";
+import EditedCustomHostVitalValueActivityItem from "./ActivityItems/EditedCustomHostVitalValueActivityItem";
 
 /** The component props that all host activity items must adhere to */
 export interface IHostActivityItemComponentProps {
@@ -92,6 +93,7 @@ export const pastActivityComponentMap: Record<
   [ActivityType.FailedEnrollmentProfileRenewal]: FailedEnrollmentProfileRenewalActivityItem,
   [ActivityType.MdmUnenrolled]: MdmUnenrolledActivityItem,
   [ActivityType.RanCustomMdmCommand]: RanCustomMdmCommandActivityItem,
+  [ActivityType.EditedCustomHostVitalValue]: EditedCustomHostVitalValueActivityItem,
 };
 
 export const upcomingActivityComponentMap: Record<

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/EditedCustomHostVitalValueActivityItem/EditedCustomHostVitalValueActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/EditedCustomHostVitalValueActivityItem/EditedCustomHostVitalValueActivityItem.tests.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+import { ActivityType } from "interfaces/activity";
+
+import EditedCustomHostVitalValueActivityItem from "./EditedCustomHostVitalValueActivityItem";
+
+describe("EditedCustomHostVitalValueActivityItem", () => {
+  const activity = createMockHostPastActivity({
+    actor_full_name: "Test User",
+    type: ActivityType.EditedCustomHostVitalValue,
+    details: { custom_host_vital_name: "Asset tag" },
+  });
+
+  it("renders the activity content", () => {
+    render(
+      <EditedCustomHostVitalValueActivityItem activity={activity} tab="past" />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText("Asset tag")).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <EditedCustomHostVitalValueActivityItem activity={activity} tab="past" />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <EditedCustomHostVitalValueActivityItem activity={activity} tab="past" />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/EditedCustomHostVitalValueActivityItem/EditedCustomHostVitalValueActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/EditedCustomHostVitalValueActivityItem/EditedCustomHostVitalValueActivityItem.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import ActivityItem from "components/ActivityItem";
+
+import { IHostActivityItemComponentProps } from "../../ActivityConfig";
+
+const baseClass = "edited-custom-host-vital-value-activity-item";
+
+const EditedCustomHostVitalValueActivityItem = ({
+  activity,
+}: IHostActivityItemComponentProps) => {
+  return (
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel
+      hideShowDetails
+    >
+      <b>{activity.actor_full_name}</b> edited the value for custom host vital{" "}
+      <b>{activity.details?.custom_host_vital_name}</b>.
+    </ActivityItem>
+  );
+};
+
+export default EditedCustomHostVitalValueActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/EditedCustomHostVitalValueActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/EditedCustomHostVitalValueActivityItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditedCustomHostVitalValueActivityItem";

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -615,3 +615,60 @@ describe("Disk space field visibility", () => {
     expect(screen.queryByText("Disk space available")).not.toBeInTheDocument();
   });
 });
+
+describe("Custom host vitals", () => {
+  const customHostVitals = [
+    { custom_host_vital_id: 1, name: "Asset tag", value: "FLEET-001234" },
+    { custom_host_vital_id: 2, name: "Purchase date", value: "" },
+  ];
+
+  it("renders each custom host vital as a name/value row, falling back to the empty cell value when unset", () => {
+    const mockHost = createMockHost({ platform: "darwin" });
+
+    render(
+      <Vitals vitalsData={mockHost} customHostVitals={customHostVitals} />
+    );
+
+    expect(screen.getByText("Asset tag")).toBeInTheDocument();
+    expect(screen.getByText("FLEET-001234")).toBeInTheDocument();
+    expect(screen.getByText("Purchase date")).toBeInTheDocument();
+    // The vital with no value falls back to the default empty cell value.
+    expect(screen.getByText(DEFAULT_EMPTY_CELL_VALUE)).toBeInTheDocument();
+  });
+
+  it("renders values as plain text (no edit affordance) when no edit handler is provided", () => {
+    const mockHost = createMockHost({ platform: "darwin" });
+
+    render(
+      <Vitals vitalsData={mockHost} customHostVitals={customHostVitals} />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Edit Asset tag" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("FLEET-001234")).toBeInTheDocument();
+  });
+
+  it("renders an edit pencil next to the label and calls the edit handler on click", async () => {
+    const mockHost = createMockHost({ platform: "darwin" });
+    const onEditCustomHostVital = jest.fn();
+    const customRender = createCustomRenderer({});
+
+    const { user } = customRender(
+      <Vitals
+        vitalsData={mockHost}
+        customHostVitals={customHostVitals}
+        onEditCustomHostVital={onEditCustomHostVital}
+      />
+    );
+
+    expect(screen.getByText("FLEET-001234")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "FLEET-001234" })
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit Asset tag" }));
+
+    expect(onEditCustomHostVital).toHaveBeenCalledWith(customHostVitals[0]);
+  });
+});

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import classnames from "classnames";
 
 import { IAppleDeviceUpdates } from "interfaces/config";
+import { IHostCustomVital } from "interfaces/custom_host_vitals";
 import { IHostMdmData, IMunkiData } from "interfaces/host";
 import {
   isAndroid,
@@ -54,6 +55,8 @@ interface IVitalsProps {
    * the My device page) so the row renders as plain text instead of a link.
    */
   toggleMDMStatusModal?: () => void;
+  customHostVitals?: IHostCustomVital[];
+  onEditCustomHostVital?: (vital: IHostCustomVital) => void;
 }
 
 type VitalForSort = { sortKey: string; element: React.ReactNode };
@@ -125,6 +128,8 @@ const Vitals = ({
   className,
   toggleLocationModal,
   toggleMDMStatusModal,
+  customHostVitals,
+  onEditCustomHostVital,
 }: IVitalsProps) => {
   const isIosOrIpadosHost = isIPadOrIPhone(vitalsData.platform);
   const isAndroidHost = isAndroid(vitalsData.platform);
@@ -628,6 +633,38 @@ const Vitals = ({
         ),
       });
     }
+
+    customHostVitals?.forEach((vital) => {
+      const displayValue =
+        vital.value === "" ? DEFAULT_EMPTY_CELL_VALUE : vital.value;
+      const title = onEditCustomHostVital ? (
+        <span className={`${baseClass}__custom-vital-title`}>
+          {vital.name}
+          <Button
+            variant="icon"
+            size="small"
+            onClick={() => onEditCustomHostVital(vital)}
+            ariaLabel={`Edit ${vital.name}`}
+          >
+            <Icon name="pencil" size="small" />
+          </Button>
+        </span>
+      ) : (
+        vital.name
+      );
+
+      vitals.push({
+        sortKey: vital.name,
+        element: (
+          <DataSet
+            className={`${baseClass}__custom-vital`}
+            key={`custom-host-vital-${vital.custom_host_vital_id}`}
+            title={title}
+            value={displayValue}
+          />
+        ),
+      });
+    });
 
     // Sort alphabetically by title and render
     return (

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -105,6 +105,12 @@
     }
   }
 
+  &__custom-vital-title {
+    display: inline-flex;
+    align-items: center;
+    gap: $pad-xsmall;
+  }
+
   .text-muted {
     color: $ui-fleet-black-50;
   }

--- a/frontend/pages/hosts/details/modals/EditHostVitalModal/EditHostVitalModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/EditHostVitalModal/EditHostVitalModal.tests.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+
+import { screen, waitFor } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+
+import customHostVitalsAPI from "services/entities/custom_host_vitals";
+
+import EditHostVitalModal from "./EditHostVitalModal";
+
+jest.mock("services/entities/custom_host_vitals");
+
+const vital = {
+  custom_host_vital_id: 5,
+  name: "Asset tag",
+  value: "FLEET-001234",
+};
+
+describe("EditHostVitalModal", () => {
+  const render = createCustomRenderer({ withBackendMock: true });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders the static title with the vital name as the field label, prefilled with its value", () => {
+    render(
+      <EditHostVitalModal
+        hostId={7}
+        vital={vital}
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Edit host vital")).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Asset tag" })).toHaveValue(
+      "FLEET-001234"
+    );
+  });
+
+  it("saves the edited value and calls onSave on success", async () => {
+    (customHostVitalsAPI.updateHostCustomHostVitalValue as jest.Mock).mockResolvedValue(
+      undefined
+    );
+    const onSave = jest.fn();
+
+    const { user } = render(
+      <EditHostVitalModal
+        hostId={7}
+        vital={vital}
+        onCancel={jest.fn()}
+        onSave={onSave}
+      />
+    );
+
+    const input = screen.getByRole("textbox", { name: "Asset tag" });
+    await user.clear(input);
+    await user.type(input, "FLEET-999");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(
+        customHostVitalsAPI.updateHostCustomHostVitalValue
+      ).toHaveBeenCalledWith(7, 5, "FLEET-999");
+    });
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+  });
+
+  it("does not call onSave when the update errors", async () => {
+    (customHostVitalsAPI.updateHostCustomHostVitalValue as jest.Mock).mockRejectedValue(
+      new Error("boom")
+    );
+    const onSave = jest.fn();
+
+    const { user } = render(
+      <EditHostVitalModal
+        hostId={7}
+        vital={vital}
+        onCancel={jest.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(
+        customHostVitalsAPI.updateHostCustomHostVitalValue
+      ).toHaveBeenCalledWith(7, 5, "FLEET-001234");
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel when the Cancel button is clicked", async () => {
+    const onCancel = jest.fn();
+
+    const { user } = render(
+      <EditHostVitalModal
+        hostId={7}
+        vital={vital}
+        onCancel={onCancel}
+        onSave={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/hosts/details/modals/EditHostVitalModal/EditHostVitalModal.tsx
+++ b/frontend/pages/hosts/details/modals/EditHostVitalModal/EditHostVitalModal.tsx
@@ -64,10 +64,10 @@ const EditHostVitalModal = ({
           onChange={setValue}
         />
         <div className="modal-cta-wrap">
-          <Button type="submit" isLoading={isSaving}>
+          <Button type="submit" isLoading={isSaving} disabled={isSaving}>
             Save
           </Button>
-          <Button variant="inverse" onClick={onCancel}>
+          <Button variant="inverse" onClick={onCancel} disabled={isSaving}>
             Cancel
           </Button>
         </div>

--- a/frontend/pages/hosts/details/modals/EditHostVitalModal/EditHostVitalModal.tsx
+++ b/frontend/pages/hosts/details/modals/EditHostVitalModal/EditHostVitalModal.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { useMutation } from "react-query";
+
+import { IHostCustomVital } from "interfaces/custom_host_vitals";
+import { getErrorReason } from "interfaces/errors";
+import customHostVitalsAPI from "services/entities/custom_host_vitals";
+
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+import InputField from "components/forms/fields/InputField";
+import { notify } from "components/ToastNotification";
+
+const baseClass = "edit-host-vital-modal";
+
+interface IEditHostVitalModalProps {
+  hostId: number;
+  vital: IHostCustomVital;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+const EditHostVitalModal = ({
+  hostId,
+  vital,
+  onCancel,
+  onSave,
+}: IEditHostVitalModalProps) => {
+  const [value, setValue] = useState(vital.value);
+
+  const { mutate: saveValue, isLoading: isSaving } = useMutation(
+    () =>
+      customHostVitalsAPI.updateHostCustomHostVitalValue(
+        hostId,
+        vital.custom_host_vital_id,
+        value
+      ),
+    {
+      onSuccess: () => {
+        notify.success("Successfully updated custom host vital.");
+        onSave();
+      },
+      onError: (error) => {
+        notify.error(
+          getErrorReason(error) ||
+            "Couldn't update custom host vital. Please try again.",
+          { response: error }
+        );
+      },
+    }
+  );
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    saveValue();
+  };
+
+  return (
+    <Modal title="Edit host vital" onExit={onCancel} className={baseClass}>
+      <form className={`${baseClass}__form`} onSubmit={onSubmit}>
+        <InputField
+          value={value}
+          label={vital.name}
+          name="value"
+          onChange={setValue}
+        />
+        <div className="modal-cta-wrap">
+          <Button type="submit" isLoading={isSaving}>
+            Save
+          </Button>
+          <Button variant="inverse" onClick={onCancel}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default EditHostVitalModal;

--- a/frontend/pages/hosts/details/modals/EditHostVitalModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/EditHostVitalModal/_styles.scss
@@ -1,0 +1,5 @@
+.edit-host-vital-modal {
+  &__form {
+    @include vertical-modal-layout;
+  }
+}

--- a/frontend/pages/hosts/details/modals/EditHostVitalModal/index.ts
+++ b/frontend/pages/hosts/details/modals/EditHostVitalModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditHostVitalModal";

--- a/frontend/services/entities/custom_host_vitals.ts
+++ b/frontend/services/entities/custom_host_vitals.ts
@@ -53,4 +53,9 @@ export default {
     const { CUSTOM_HOST_VITALS } = endpoints;
     return sendRequest("DELETE", `${CUSTOM_HOST_VITALS}/${id}`);
   },
+
+  updateHostCustomHostVitalValue(hostId: number, id: number, value: string) {
+    const { HOST_CUSTOM_HOST_VITAL } = endpoints;
+    return sendRequest("PUT", HOST_CUSTOM_HOST_VITAL(hostId, id), { value });
+  },
 };

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -94,6 +94,8 @@ export default {
   HOSTS_REPORT: `/${API_VERSION}/fleet/hosts/report`,
   HOSTS_TRANSFER: `/${API_VERSION}/fleet/hosts/transfer`,
   HOSTS_TRANSFER_BY_FILTER: `/${API_VERSION}/fleet/hosts/transfer/filter`,
+  HOST_CUSTOM_HOST_VITAL: (hostId: number, vitalId: number) =>
+    `/${API_VERSION}/fleet/hosts/${hostId}/custom_host_vitals/${vitalId}`,
   HOST_LOCK: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/lock`,
   HOST_UNLOCK: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/unlock`,
   HOST_WIPE: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/wipe`,

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -142,10 +142,11 @@ func (ds *Datastore) SetHostCustomHostVitalValue(ctx context.Context, hostID uin
 func (ds *Datastore) GetHostCustomHostVitals(ctx context.Context, hostID uint) ([]fleet.HostCustomHostVital, error) {
 	var vitals []fleet.HostCustomHostVital
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &vitals, `
-		SELECT chv.id AS custom_host_vital_id, chv.name, hchv.value
-		FROM host_custom_host_vitals hchv
-		JOIN custom_host_vitals chv ON chv.id = hchv.custom_host_vital_id
-		WHERE hchv.host_id = ?`,
+		SELECT chv.id AS custom_host_vital_id, chv.name, COALESCE(hchv.value, '') AS value
+		FROM custom_host_vitals chv
+		LEFT JOIN host_custom_host_vitals hchv
+			ON hchv.custom_host_vital_id = chv.id AND hchv.host_id = ?
+		ORDER BY chv.name`,
 		hostID,
 	)
 	if err != nil {

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -150,10 +150,14 @@ func testSetAndGetHostCustomHostVitals(t *testing.T, ds *Datastore) {
 	funcID := createCustomHostVital(t, ds, "Function")
 	deptID := createCustomHostVital(t, ds, "Department")
 
-	// No values yet.
+	// With no per-host values set yet, every definition is still returned for
+	// the host with an empty value.
 	got, err := ds.GetHostCustomHostVitals(ctx, host.ID)
 	require.NoError(t, err)
-	require.Empty(t, got)
+	require.Len(t, got, 2)
+	for _, v := range got {
+		require.Empty(t, v.Value)
+	}
 
 	// Insert two values.
 	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, host.ID, funcID, "engineering"))

--- a/server/service/integration_custom_host_vitals_test.go
+++ b/server/service/integration_custom_host_vitals_test.go
@@ -65,8 +65,17 @@ func (s *integrationTestSuite) TestCustomHostVitalsCRUD() {
 	s.DoJSON("GET", "/api/latest/fleet/custom_host_vitals", nil, http.StatusOK, &listResp, "query", "nomatch")
 	require.Empty(t, listResp.CustomHostVitals)
 
-	// Set a value for the vital on a host.
+	// Before any value is set, the host detail still surfaces every definition
+	// with an empty value.
 	host := s.createHosts(t)[0]
+	var preSetResp getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &preSetResp)
+	require.Len(t, preSetResp.Host.CustomHostVitals, 1)
+	assert.Equal(t, vitalID, preSetResp.Host.CustomHostVitals[0].CustomHostVitalID)
+	assert.Equal(t, "Asset ID", preSetResp.Host.CustomHostVitals[0].Name)
+	assert.Empty(t, preSetResp.Host.CustomHostVitals[0].Value)
+
+	// Set a value for the vital on a host.
 	s.Do("PUT", fmt.Sprintf("/api/latest/fleet/hosts/%d/custom_host_vitals/%d", host.ID, vitalID), fleet.SetHostCustomHostVitalValueRequest{Value: "engineering"}, http.StatusOK)
 	s.lastActivityMatches(
 		fleet.ActivityTypeEditedCustomHostVitalValue{}.ActivityName(),


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48556

Introduces rendering of the custom vitals on the Vitals card, adds an inline edit modal (with permission gating), and adds the `edited_custom_host_vital_value` host activity item.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/6bd13846-1d05-4ca2-a0ff-987110283088



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosts can now display custom vital metrics on the host details page.
  * Users with sufficient permissions can edit custom vital values from the host details view.
  * Activity history now includes entries for edited custom vital values, including the custom vital name.
* **Bug Fixes**
  * Custom vitals are now shown even before any host-specific value is set, with empty values handled consistently.
* **Tests**
  * Added coverage for custom vital rendering, editing, and the new activity item behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->