### PR TITLE
Manage Hosts: Custom host vitals entry point

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tests.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tests.tsx
@@ -148,7 +148,7 @@ describe("ManageHostsPage", () => {
 
     // Add hosts button still visible in the page header
     const headerWrap = screen
-      .getByText("Manage enroll secret")
+      .getByText("Enroll secrets")
       .closest(".manage-hosts__button-wrap");
     expect(
       within(headerWrap as HTMLElement).getByText("Add hosts")

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -80,6 +80,7 @@ import {
   PolicyResponse,
 } from "utilities/constants";
 import { getNextLocationPath } from "utilities/helpers";
+import { getPathWithQueryParams } from "utilities/url";
 import getDeleteLabelErrorMessages from "pages/labels/helpers";
 import { strToBool } from "utilities/strings/stringUtils";
 
@@ -446,6 +447,9 @@ const ManageHostsPage = ({
   // ========= derived permissions
   // canEnrollHosts is hoisted above the deep-link effects (see earlier)
   const canEnrollGlobalHosts = isGlobalAdmin || isGlobalMaintainer;
+  // Mirrors the Controls > Variables > Custom host vitals tab, which only lets
+  // global admins/maintainers manage vital definitions.
+  const canManageCustomHostVitals = isGlobalAdmin || isGlobalMaintainer;
   const canAddNewLabels =
     (isGlobalAdmin ||
       isGlobalMaintainer ||
@@ -2064,13 +2068,31 @@ const ManageHostsPage = ({
         <div className={`${baseClass}__header-wrap`}>
           {renderHeader()}
           <div className={`${baseClass}__button-wrap`}>
+            {canManageCustomHostVitals && !hasErrors && (
+              <Button
+                onClick={() =>
+                  router.push(
+                    getPathWithQueryParams(
+                      PATHS.CONTROLS_VARIABLES_CUSTOM_HOST_VITALS,
+                      { fleet_id: teamIdForApi }
+                    )
+                  )
+                }
+                className={`${baseClass}__custom-host-vitals`}
+                variant="inverse"
+              >
+                <Icon name="pencil" />
+                <span>Custom host vitals</span>
+              </Button>
+            )}
             {canEnrollHosts && !hasErrors && (
               <Button
                 onClick={() => setShowEnrollSecretModal(true)}
                 className={`${baseClass}__enroll-hosts button`}
                 variant="inverse"
               >
-                Manage enroll secret
+                <Icon name="settings" />
+                <span>Enroll secrets</span>
               </Button>
             )}
             {showAddHostsButton && (


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48557

Adds a "Custom host vitals" header button that navigates there to the new Custom host vitals tab, and restyles the adjacent enroll-secret button per design (gear icon + "Enroll secrets" label).

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/13db084c-cc35-4609-a262-d20ed2607a6f

