### PR TITLE
Fleet UI: Restore download button for script-only packages

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -88,8 +88,8 @@ export interface ILibraryItemAccordionProps {
   hashSha256?: string | null;
   /** Show the download button for this row. This should be true only when
    * `onDownloadClick` is wired to download the installer represented by this
-   * row (typically the active installer). False for script-only packages (no
-   * file to download) and App Store / Play Store apps. */
+   * row (typically the active installer). False for App Store / Play Store
+   * apps, which have no installer file to download. */
   canDownload?: boolean;
 
   /** Click handler for whichever badge is rendered per `badgeState`. The

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -320,7 +320,7 @@ const SoftwareTitleDetailsPage = ({
               pendingPath={statusPath("pending")}
               failedPath={statusPath("failed")}
               hashSha256={row.isActive ? pkg.hash_sha256 ?? null : null}
-              canDownload={row.isActive && !isScriptPackage}
+              canDownload={row.isActive}
               onBadgeClick={
                 isFma && canEditSoftware
                   ? () => setShowVersionsModal(true)


### PR DESCRIPTION
## Issue
Closes #48907

## Description
- Bug fix (root cause): #48794 changed the accordion download gate to `row.isActive && !isScriptPackage`, silently dropping the download button for script-only custom packages. 4.87.1 and the 4.88 RC still show Download + Delete for any custom package (including script-only) via the older `SoftwareInstallerCard`, and nothing in #48418 or the handbook asks to exclude script packages.
- Fix: drop the `!isScriptPackage` clause on `SoftwareTitleDetailsPage.tsx` so `canDownload` tracks `row.isActive` only. Backend (`DownloadSoftwareInstaller`) already serves the script file from the same object store as `.pkg`/`.msi`, so no server change needed.
- Doc: correct the stale `canDownload` prop comment that claimed script-only packages have no downloadable file.

## Screenshot
- Download button appears on the software details page for a script-only custom package and downloads the script file
- Please ignore the "Latest" badge visible in the screenshot — that's addressed in a separate PR currently in review

<img width="1613" height="766" alt="Screenshot 2026-07-07 at 1 13 11 PM" src="https://github.com/user-attachments/assets/22d91ddf-edc0-4369-a437-66bbac6d9b48" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Download buttons now appear for active package rows more consistently.
  * App Store and Play Store rows continue to hide download options when no installer is available.
* **Documentation**
  * Clarified the download-button guidance for supported row types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->