### PR TITLE
Add global activity items for custom host vitals

### DIFF
--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -196,6 +196,9 @@ export enum ActivityType {
   RanAutomationTicket = "ran_automation_ticket",
   RanAutomationCalendarEvent = "ran_automation_calendar_event",
   RanAutomationConditionalAccess = "ran_automation_conditional_access",
+  CreatedCustomHostVital = "created_custom_host_vital",
+  EditedCustomHostVital = "edited_custom_host_vital",
+  DeletedCustomHostVital = "deleted_custom_host_vital",
 }
 
 /** This is a subset of ActivityType that are shown only for the host past activities */
@@ -353,6 +356,8 @@ export interface IActivityDetails {
   ticket_key?: string;
   ticket_id?: number;
   custom_variable_name?: string;
+  custom_host_vital_id?: number;
+  custom_host_vital_name?: string;
   domain?: string;
   host_idp_username?: string;
   idp_full_name?: string;
@@ -594,4 +599,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
     "Policy automation: calendar event created",
   [ActivityType.RanAutomationConditionalAccess]:
     "Policy automation: single sign-on blocked",
+  [ActivityType.CreatedCustomHostVital]: "Created custom host vital",
+  [ActivityType.EditedCustomHostVital]: "Edited custom host vital",
+  [ActivityType.DeletedCustomHostVital]: "Deleted custom host vital",
 };

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -2206,4 +2206,43 @@ describe("Activity Feed", () => {
     expect(screen.getByText(/a custom MDM command/i)).toBeInTheDocument();
     expect(screen.getByText("Huck's MacBook Pro")).toBeInTheDocument();
   });
+
+  it("renders a created_custom_host_vital activity", () => {
+    const activity = createMockActivity({
+      type: ActivityType.CreatedCustomHostVital,
+      details: { custom_host_vital_id: 1, custom_host_vital_name: "Function" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText("created a custom host vital", { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Function")).toBeInTheDocument();
+  });
+
+  it("renders an edited_custom_host_vital activity", () => {
+    const activity = createMockActivity({
+      type: ActivityType.EditedCustomHostVital,
+      details: { custom_host_vital_id: 1, custom_host_vital_name: "Asset tag" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText("edited custom host vital", { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Asset tag")).toBeInTheDocument();
+  });
+
+  it("renders a deleted_custom_host_vital activity", () => {
+    const activity = createMockActivity({
+      type: ActivityType.DeletedCustomHostVital,
+      details: { custom_host_vital_id: 1, custom_host_vital_name: "Asset tag" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText("deleted custom host vital", { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Asset tag")).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -2040,6 +2040,30 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  createdCustomHostVital: (activity: IActivity) => {
+    const { custom_host_vital_name } = activity.details || {};
+    return (
+      <>
+        created a custom host vital <b>{custom_host_vital_name}</b>.
+      </>
+    );
+  },
+  editedCustomHostVital: (activity: IActivity) => {
+    const { custom_host_vital_name } = activity.details || {};
+    return (
+      <>
+        edited custom host vital <b>{custom_host_vital_name}</b>.
+      </>
+    );
+  },
+  deletedCustomHostVital: (activity: IActivity) => {
+    const { custom_host_vital_name } = activity.details || {};
+    return (
+      <>
+        deleted custom host vital <b>{custom_host_vital_name}</b>.
+      </>
+    );
+  },
   editedSetupExperienceSoftware: (activity: IActivity) => {
     const { platform, team_name, team_id } = activity.details || {};
 
@@ -2622,6 +2646,15 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     }
     case ActivityType.DeletedCustomVariable: {
       return TAGGED_TEMPLATES.deletedCustomVariable(activity);
+    }
+    case ActivityType.CreatedCustomHostVital: {
+      return TAGGED_TEMPLATES.createdCustomHostVital(activity);
+    }
+    case ActivityType.EditedCustomHostVital: {
+      return TAGGED_TEMPLATES.editedCustomHostVital(activity);
+    }
+    case ActivityType.DeletedCustomHostVital: {
+      return TAGGED_TEMPLATES.deletedCustomHostVital(activity);
     }
     case ActivityType.EditedSetupExperienceSoftware: {
       return TAGGED_TEMPLATES.editedSetupExperienceSoftware(activity);


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48644

Renders global activities for custom host vitals (create, edit, delete).

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

<img width="711" height="406" alt="Screenshot 2026-07-07 at 5 19 19 PM" src="https://github.com/user-attachments/assets/e0b16ff5-0ce8-4514-a171-d3139bcfcda9" />


