### PR TITLE
Add Global variables and Custom host vitals to command palette

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -138,6 +138,16 @@ const CommandPalette = (): JSX.Element | null => {
     isAnyTeamMaintainer ||
     isTechnician;
 
+  // The Variables section (and its Global variables / Custom host vitals
+  // sub-tabs) is hidden from technicians in the Controls sub-nav — they only
+  // get OS settings and Scripts (see ManageControlsPage). canAccessControls
+  // includes technicians, so use this narrower flag for Variables.
+  const canAccessVariables =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isAnyTeamAdmin ||
+    isAnyTeamMaintainer;
+
   // Custom variables are admin-tier global config (mirrors Variables.tsx
   // `canEdit`). Team admins/maintainers/technicians lack the role even
   // though they have `canWrite`, so the destination page would render
@@ -403,6 +413,7 @@ const CommandPalette = (): JSX.Element | null => {
         availableTeams,
         config,
         canAccessControls,
+        canAccessVariables,
         canWrite,
         canRunLiveReport,
         canAccessSettings,
@@ -438,6 +449,7 @@ const CommandPalette = (): JSX.Element | null => {
       availableTeams,
       config,
       canAccessControls,
+      canAccessVariables,
       canWrite,
       canRunLiveReport,
       canAccessSettings,

--- a/frontend/components/CommandPalette/groups/controls.ts
+++ b/frontend/components/CommandPalette/groups/controls.ts
@@ -7,7 +7,13 @@ const buildControlsItems = (
   ctx: ICommandPaletteContext,
   derived: IDerivedContext
 ): ICommandItem[] => {
-  const { canAccessControls, isPremiumTier, isTechnician, withTeamId } = ctx;
+  const {
+    canAccessControls,
+    canAccessVariables,
+    isPremiumTier,
+    isTechnician,
+    withTeamId,
+  } = ctx;
   const { hasTeamOrUnassigned } = derived;
 
   // Controls pages don't support "All fleets" (includeAllTeams: false),
@@ -187,14 +193,34 @@ const buildControlsItems = (
         },
       ],
     },
-    // Variables
-    {
-      id: "controls-variables",
-      label: "Variables",
-      group: "Controls" as const,
-      path: withTeamId(paths.CONTROLS_VARIABLES),
-      keywords: ["custom", "scripts", "profiles"],
-    },
+    // Variables — including its Global variables and Custom host vitals
+    // sub-tabs. Gated on canAccessVariables (admins + maintainers) since the
+    // Controls sub-nav hides this section from technicians.
+    ...(canAccessVariables
+      ? [
+          {
+            id: "controls-variables",
+            label: "Variables",
+            group: "Controls" as const,
+            path: withTeamId(paths.CONTROLS_VARIABLES),
+            keywords: ["custom", "scripts", "profiles"],
+            subItems: [
+              {
+                id: "controls-global-variables",
+                label: "Global variables",
+                path: withTeamId(paths.CONTROLS_VARIABLES_GLOBAL_VARIABLES),
+                keywords: ["custom", "secret"],
+              },
+              {
+                id: "controls-custom-host-vitals",
+                label: "Custom host vitals",
+                path: withTeamId(paths.CONTROLS_VARIABLES_CUSTOM_HOST_VITALS),
+                keywords: ["host", "vital", "custom", "host vital"],
+              },
+            ],
+          },
+        ]
+      : []),
   ];
 };
 

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -26,6 +26,7 @@ const BASE_CONTEXT: ICommandPaletteContext = {
   currentTeam: undefined,
   config: createMockConfig(),
   canAccessControls: true,
+  canAccessVariables: true,
   canWrite: true,
   canRunLiveReport: true,
   canAccessSettings: true,
@@ -389,6 +390,32 @@ describe("CommandPalette helpers", () => {
       expect(subIds).toContain("controls-passwords");
     });
 
+    it("includes Variables with its Global variables and Custom host vitals sub-tabs when canAccessVariables", () => {
+      const items = buildPaletteItems({
+        ...BASE_CONTEXT,
+        hasTeamSelected: true,
+        currentTeam: { id: 1, name: "Engineering" },
+      });
+
+      const variables = items.find((i) => i.id === "controls-variables");
+      const subIds = variables?.subItems?.map((s) => s.id) ?? [];
+      expect(subIds).toContain("controls-global-variables");
+      expect(subIds).toContain("controls-custom-host-vitals");
+    });
+
+    it("hides Variables entirely when !canAccessVariables (technicians)", () => {
+      const items = buildPaletteItems({
+        ...BASE_CONTEXT,
+        canAccessVariables: false,
+        isTechnician: true,
+        hasTeamSelected: true,
+        currentTeam: { id: 1, name: "Engineering" },
+      });
+
+      const ids = items.map((i) => i.id);
+      expect(ids).not.toContain("controls-variables");
+    });
+
     it("appends fleet_id via withTeamId for team-scoped paths", () => {
       const mockWithTeamId = (path: string) => `${path}?fleet_id=5`;
 
@@ -708,6 +735,12 @@ describe("CommandPalette helpers", () => {
           ?.subItems?.map((s) => s.id) ?? [];
       expect(scriptsSubIds).toContain("controls-scripts-library");
       expect(scriptsSubIds).toContain("controls-scripts-batch-progress");
+      const variablesSubIds =
+        items
+          .find((i) => i.id === "controls-variables")
+          ?.subItems?.map((s) => s.id) ?? [];
+      expect(variablesSubIds).toContain("controls-global-variables");
+      expect(variablesSubIds).toContain("controls-custom-host-vitals");
     });
 
     it("surfaces Add script on Free (script library is Free-available)", () => {

--- a/frontend/components/CommandPalette/helpers.ts
+++ b/frontend/components/CommandPalette/helpers.ts
@@ -40,6 +40,7 @@ export interface ICommandPaletteContext {
   availableTeams?: ITeamSummary[];
   config: IConfig | null;
   canAccessControls?: boolean;
+  canAccessVariables?: boolean;
   canWrite?: boolean;
   canRunLiveReport?: boolean;
   canAccessSettings?: boolean;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48686

The Controls > Variables sub-nav (shipped in #48555) added two tabs: Global variables and Custom host vitals.This adds both as navigable palette entries under the existing Variables entry.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually