### PR TITLE
Website: use git to get lastModifiedAt timestamps for markdown and yaml files, show last updated date on article pages

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -47,6 +47,7 @@ jobs:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         persist-credentials: false
+        fetch-depth: 0
 
     # Configure our access credentials for the Heroku CLI
     - uses: akhileshns/heroku-deploy@e3eb99d45a8e2ec5dca08735e089607befa4bf28 # v3.14.15

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       # Set the Node.js version
       - name: Use Node.js ${{ matrix.node-version }}

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -50,6 +50,14 @@ module.exports = {
     }
     // Sort articles in descending order by publish date.
     articles = _.sortByOrder(articles, 'meta.publishedOn', 'DESC');
+    // If an article was updated three days after it's publishedOn timestamp, we'll show a timestamp of when the markdown file was last changed.
+    for(let article of articles) {
+      article.showUpdatedTimestamp = false;
+      let publishedAt = new Date(article.meta.publishedOn).getTime();
+      if(publishedAt + (1000 * 60 * 60 * 24 * 3) <= article.lastModifiedAt) {
+        article.showUpdatedTimestamp = true;
+      }
+    }
 
     let pageTitleForMeta = 'Fleet blog';
     let pageDescriptionForMeta = 'Read the latest articles written by Fleet.';

--- a/website/api/controllers/articles/view-basic-article.js
+++ b/website/api/controllers/articles/view-basic-article.js
@@ -58,6 +58,14 @@ module.exports = {
       pageDescriptionForMeta = _.trimRight(thisPage.meta.articleTitle, '.') + ' by ' + thisPage.meta.authorFullName;
     }//ﬁ
 
+
+    // If an article was updated three days after it was published, we'll show the user the date when it was last updated.
+    let showUpdatedTimestamp = false;
+    let publishedAt = new Date(thisPage.meta.publishedOn).getTime();
+    if(publishedAt + (1000 * 60 * 60 * 24 * 3) <= thisPage.lastModifiedAt) {
+      showUpdatedTimestamp = true;
+    }
+
     let articleCategorySlug = this.req.path.split('/')[1];
     // console.log(articleCategorySlug);
     let categoryFriendlyNamesByCategorySlug = {
@@ -78,6 +86,7 @@ module.exports = {
     return {
       path: require('path'),
       thisPage: thisPage,
+      showUpdatedTimestamp,
       markdownPages: sails.config.builtStaticContent.markdownPages,
       compiledPagePartialsAppPath: sails.config.builtStaticContent.compiledPagePartialsAppPath,
       pageTitleForMeta,

--- a/website/assets/styles/pages/articles/articles.less
+++ b/website/assets/styles/pages/articles/articles.less
@@ -347,6 +347,14 @@
       [parasails-component='js-timestamp'] {
         font-size: 12px;
       }
+      [purpose='updated-timestamp'] {
+        margin-left: 8px;
+        font-size: 10px;
+        font-style: italic;
+        [parasails-component='js-timestamp'] {
+          font-size: 10px;
+        }
+      }
     }
   }
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -571,29 +571,12 @@ module.exports = {
               }//ﬁ
 
               // Get last modified timestamp using git, and represent it as a JS timestamp.
-              let lastModifiedAt;
-              if(!githubAccessToken) {
-                lastModifiedAt = Date.now();
-              } else if(process.env.GITHUB_REF_NAME && process.env.GITHUB_REF_NAME === 'main') {// Only add lastModifiedAt timestamps if this test is running on the main branch
-                let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
-                  url: 'https://api.github.com/repos/fleetdm/fleet/commits',
-                  data: {
-                    path: path.join(sectionRepoPath, pageRelSourcePath),
-                    page: 1,
-                    per_page: 1,//eslint-disable-line camelcase
-                  },
-                  headers: baseHeadersForGithubRequests,
-                }).intercept((err)=>{
-                  return new Error(`When getting the commit history for ${path.join(sectionRepoPath, pageRelSourcePath)} to get a lastModifiedAt timestamp, an error occured. ${util.inspect(err)}`);
-                });
-                // The value we'll use for the lastModifiedAt timestamp will be date value of the `commiter` property of the `commit` we got in the API response from github.
-                let mostRecentCommitToThisFile = responseData[0];
-                if(!mostRecentCommitToThisFile.commit || !mostRecentCommitToThisFile.commit.committer) {
-                  // Throw an error if the the response from GitHub is missing a commit or commiter.
-                  throw new Error(`When getting the commit history for ${path.join(sectionRepoPath, pageRelSourcePath)} to get a lastModifiedAt timestamp, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
-                }
-                lastModifiedAt = (new Date(mostRecentCommitToThisFile.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
-              }
+              // > Inspired by https://github.com/uncletammy/doc-templater/blob/2969726b598b39aa78648c5379e4d9503b65685e/lib/compile-markdown-tree-from-remote-git-repo.js#L265-L273
+              let lastModifiedAt = (new Date((await sails.helpers.process.executeCommand.with({
+                command: `git log -1 --format="%ai" '${path.relative(topLvlRepoPath, pageSourcePath)}'`,
+                dir: topLvlRepoPath,
+              })).stdout)).getTime();
+
 
               // Determine display title (human-readable title) to use for this page.
               let pageTitle;
@@ -855,30 +838,14 @@ module.exports = {
         let RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO = 'handbook/company/open-positions.yml';
 
         // Get last modified timestamp using git, and represent it as a JS timestamp.
-        let lastModifiedAt;
-        if(!githubAccessToken) {
-          lastModifiedAt = Date.now();
-        } else {
-          // If we're including a lastModifiedAt value for schema tables, we'll send a request to the GitHub API to get a timestamp of when the last commit
-          let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
-            url: 'https://api.github.com/repos/fleetdm/fleet/commits',
-            data: {
-              path: RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO,
-              page: 1,
-              per_page: 1,//eslint-disable-line camelcase
-            },
-            headers: baseHeadersForGithubRequests,
-          }).intercept((err)=>{
-            return new Error(`When getting the commit history for the open positions YAML to get a lastModifiedAt timestamp, an error occured. ${util.inspect(err)}`);
-          });
-          // The value we'll use for the lastModifiedAt timestamp will be date value of the `commiter` property of the `commit` we got in the API response from github.
-          let mostRecentCommitToThisFile = responseData[0];
-          if(!mostRecentCommitToThisFile.commit || !mostRecentCommitToThisFile.commit.committer) {
-            // Throw an error if the the response from GitHub is missing a commit or commiter.
-            throw new Error(`When trying to get a lastModifiedAt timestamp for the open positions YAML, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
-          }
-          lastModifiedAt = (new Date(mostRecentCommitToThisFile.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
-        }
+        // > Inspired by https://github.com/uncletammy/doc-templater/blob/2969726b598b39aa78648c5379e4d9503b65685e/lib/compile-markdown-tree-from-remote-git-repo.js#L265-L273
+        let lastModifiedAt = (new Date((await sails.helpers.process.executeCommand.with({
+          command: `git log -1 --format="%ai" '${path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)}'`,
+          dir: topLvlRepoPath,
+        })).stdout)).getTime();
+        // Sanity check log to make sure we're checking out the full git history.
+        // TODO: remove before this pull request is ready to merge
+        console.log('open positions yaml:'+lastModifiedAt);
 
         let openPositionsYaml = await sails.helpers.fs.read(path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)).intercept('doesNotExist', (err)=>new Error(`Could not find open positions YAML file at "${RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO}".  Was it accidentally moved?  Raw error: `+err.message));
         let openPositionsToCreatePartialsFor = YAML.parse(openPositionsYaml, {prettyErrors: true});

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -843,9 +843,7 @@ module.exports = {
           command: `git log -1 --format="%ai" '${path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)}'`,
           dir: topLvlRepoPath,
         })).stdout)).getTime();
-        // Sanity check log to make sure we're checking out the full git history.
-        // TODO: remove before this pull request is ready to merge
-        console.log('open positions yaml:'+lastModifiedAt);
+
 
         let openPositionsYaml = await sails.helpers.fs.read(path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)).intercept('doesNotExist', (err)=>new Error(`Could not find open positions YAML file at "${RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO}".  Was it accidentally moved?  Raw error: `+err.message));
         let openPositionsToCreatePartialsFor = YAML.parse(openPositionsYaml, {prettyErrors: true});

--- a/website/views/pages/articles/articles.ejs
+++ b/website/views/pages/articles/articles.ejs
@@ -49,7 +49,8 @@
               <p purpose="article-name">{{article.meta.articleTitle}}</p>
             </div>
             <div purpose="article-description" v-if="article.meta.description"><p>{{article.meta.description}}</p></div>
-            <div purpose="publish-date"><js-timestamp format="billing" :at="article.meta.publishedOn"></js-timestamp></div>
+            <div purpose="publish-date"><js-timestamp format="billing" :at="article.meta.publishedOn"></js-timestamp><span purpose="updated-timestamp" v-if="article.showUpdatedTimestamp">Updated <js-timestamp format="billing" :at="article.lastModifiedAt"></js-timestamp></span></div>
+
           </div>
           <div class="d-flex flex-column justify-content-center">
             <svg purpose="animated-arrow" style="stroke: #192147;" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">

--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -35,7 +35,7 @@
         <div class="d-flex flex-sm-row flex-column justify-content-between align-items-sm-center">
           <div purpose="article-details" class="d-flex align-items-sm-center">
             <span v-if="!showUpdatedTimestamp"><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
-            <span v-else>Updated <js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
+            <span v-else>Updated <js-timestamp format="billing" :at="thisPage.lastModifiedAt"></js-timestamp></span>
             <span  purpose="divider" class="px-2">|</span>
             <% if(articleCategorySlug !== 'customers') { %>
               <div purpose="article-author" class="d-flex flex-row align-items-center">

--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -34,7 +34,8 @@
         </div>
         <div class="d-flex flex-sm-row flex-column justify-content-between align-items-sm-center">
           <div purpose="article-details" class="d-flex align-items-sm-center">
-            <span><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
+            <span v-if="!showUpdatedTimestamp"><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
+            <span v-else>Updated <js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
             <span  purpose="divider" class="px-2">|</span>
             <% if(articleCategorySlug !== 'customers') { %>
               <div purpose="article-author" class="d-flex flex-row align-items-center">
@@ -84,7 +85,8 @@
           </div>
           <div class="d-flex flex-sm-row flex-column justify-content-between align-items-sm-center">
             <div purpose="article-details" class="d-flex flex-row align-items-center">
-              <span><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
+              <span v-if="!showUpdatedTimestamp"><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
+              <span v-else>Updated <js-timestamp format="billing" :at="thisPage.lastModifiedAt"></js-timestamp></span>
               <% if(articleCategorySlug !== 'customers') { %>
                 <span class="px-2">|</span>
                 <img style="height: 28px; width: 28px; border-radius: 100%;" alt="The author's GitHub profile picture" :src="'https://github.com/'+thisPage.meta.authorGitHubUsername+'.png?size=200'">


### PR DESCRIPTION
Changes:
- Updated the "Test Fleet website" and "Deploy Fleet website" workflows to include the full git history when checking out the repo.
- Updated the website's build-static-content script to use git to build lastModifiedAt timestamps for Markdown and YAML files on the website.
- Updated the article template page and article category pages to show a timestamp of when an article's Markdown file was last changed, if it was updated >3 days after it was published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Articles now conditionally display an **Updated** timestamp when they were substantially modified after publication.
  * The **Updated** indicator is shown on both article listing pages and individual article pages (including mobile/desktop headers).

* **Bug Fixes**
  * Timestamp rendering is now more consistent, helping readers distinguish original publish dates from later edits.

* **Styling**
  * Added styling to support the new “updated timestamp” label and timestamp formatting within article cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->