### PR TITLE
Generate CPE for Firefox Developer Edition on macOS

### DIFF
--- a/changes/48689-firefox-developer-edition-cpe.md
+++ b/changes/48689-firefox-developer-edition-cpe.md
@@ -1,0 +1,1 @@
+- Fixed a false-negative vulnerability report where Firefox Developer Edition on macOS was not matched to any CVEs because Fleet generated no CPE for it.

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -675,6 +675,16 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				BundleIdentifier: "org.mozilla.firefox",
 			}, cpe: "cpe:2.3:a:mozilla:firefox:105.0.1:*:*:*:*:macos:*:*",
 		},
+		{ // Firefox Developer Edition tracks standard Firefox; its bundle's product
+			// token isn't a real NVD product, so a translation maps it to mozilla:firefox (#48689).
+			software: fleet.Software{
+				Name:             "Firefox Developer Edition.app",
+				Source:           "apps",
+				Version:          "105.0.1",
+				Vendor:           "",
+				BundleIdentifier: "org.mozilla.firefoxdeveloperedition",
+			}, cpe: "cpe:2.3:a:mozilla:firefox:105.0.1:*:*:*:*:macos:*:*",
+		},
 		{
 			software: fleet.Software{
 				Name:             "Google Chrome.app",

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -711,6 +711,16 @@
   },
   {
     "software": {
+      "bundle_identifier": ["org.mozilla.firefoxdeveloperedition"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["firefox"],
+      "vendor": ["mozilla"]
+    }
+  },
+  {
+    "software": {
       "bundle_identifier": ["com.logi.bolt.app"],
       "source": ["apps"]
     },

--- a/server/vulnerabilities/nvd/cpe_translations_test.go
+++ b/server/vulnerabilities/nvd/cpe_translations_test.go
@@ -1,11 +1,40 @@
 package nvd
 
 import (
+	"path/filepath"
 	"slices"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
 )
+
+// TestFirefoxDeveloperEditionTranslation loads the real, shipped cpe_translations.json
+// and verifies Firefox Developer Edition (bundle org.mozilla.firefoxdeveloperedition)
+// translates to the standard mozilla:firefox product. Without this rule the
+// generated CPE is empty (the bundle's product token "firefoxdeveloperedition"
+// has no NVD entry), so Firefox CVEs are never matched (#48689). This test needs
+// no CPE dictionary or network — it exercises only the translation rule.
+func TestFirefoxDeveloperEditionTranslation(t *testing.T) {
+	translations, err := loadCPETranslations(filepath.Join(".", cpeTranslationsFilename))
+	require.NoError(t, err)
+
+	software := &fleet.Software{
+		Name:             "Firefox Developer Edition.app",
+		BundleIdentifier: "org.mozilla.firefoxdeveloperedition",
+		Source:           "apps",
+		Version:          "153.0",
+	}
+
+	filter, matched, err := translations.Translate(newRegexpCache(), software)
+	require.NoError(t, err)
+	require.True(t, matched, "Firefox Developer Edition should match a translation rule")
+	require.Equal(t, []string{"firefox"}, filter.Product)
+	require.Equal(t, []string{"mozilla"}, filter.Vendor)
+	// It tracks standard Firefox advisories, so it must not be pinned to an
+	// sw_edition (that is reserved for ESR).
+	require.Empty(t, filter.SWEdition)
+}
 
 func TestTranslate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**Related issue:** Resolves #48689

Adds a CPE translation so Firefox Developer Edition on macOS resolves to the standard `mozilla:firefox` product. Without it, `CPEFromSoftware` generates no CPE for the app, so it matches no Firefox CVEs and shows as vulnerability-free — a silent false negative.

The root cause is that none of the standard matching paths fit Developer Edition: its bundle identifier `org.mozilla.firefoxdeveloperedition` splits to a product token (`firefoxdeveloperedition`) that has no NVD entry, and the sanitized-name and full-text fallbacks don't resolve to `firefox` either. Regular Firefox works only because its bundle (`org.mozilla.firefox`) splits cleanly to `mozilla`/`firefox`. The fix uses the same translation mechanism the existing Firefox ESR rule uses, mapping the Developer Edition bundle to `product: firefox`, `vendor: mozilla` — with no `sw_edition`, since Developer Edition tracks standard Firefox advisories (ESR is the special case that needs the `esr` edition).

Match is on the bundle identifier rather than the display name so it's stable regardless of how the app name is ingested.

**Out of scope:** Firefox Nightly (`org.mozilla.nightly`) has the same failure mode but uses pre-release version strings (e.g. `155.0a1`) that don't line up with NVD's per-version Firefox CPEs, so mapping it to `firefox` risks bad matches — it warrants separate handling. Firefox Beta already works today (its bundle is `org.mozilla.firefox`), so it needs no change.

**Testing.** Two layers, matching how the codebase already tests CPE rules:
- An offline unit test (`TestFirefoxDeveloperEditionTranslation`) loads the real shipped `cpe_translations.json` and asserts Developer Edition translates to `mozilla:firefox` with no `sw_edition`. It needs no CPE dictionary or network, so it runs in the fast suite.
- A case in the network-gated `TestCPEFromSoftwareIntegration`, alongside the existing regular-Firefox case, asserts the full CPE string against the live NVD dictionary in CI. It reuses the known-good `105.0.1` Firefox entry. The downstream CPE→CVE step is unchanged and already covered for `mozilla:firefox` by `TestTranslateCPEToCVE`, so no new CVE-matching test is needed.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually — ran `TestFirefoxDeveloperEditionTranslation` locally against the shipped rule (passes); the full software→CPE resolution against live NVD data is exercised by the network-gated integration case in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Firefox Developer Edition on macOS so it maps to the expected Firefox vulnerability data.
  * Better handling of version matching for this app, helping scan results stay accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->