### PR TITLE
Add instructions for iOS sysdiagnose

### DIFF
--- a/articles/fleet-troubleshooting-for-it-admins.md
+++ b/articles/fleet-troubleshooting-for-it-admins.md
@@ -68,3 +68,15 @@ fleetctl debug errors
 <meta name="publishedOn" value="2026-02-13">
 <meta name="articleTitle" value="Fleet troubleshooting for IT admins">
 <meta name="description" value="Basic troubleshooting steps for when things go wrong.">
+
+## iOS & iPadOS MDMClient logs
+
+You can obtain MDMClient related logs on iOS and iPadOS using sysdiagnose. This will assist with troubleshooting MDM command and profile delivery issues to those devices.
+
+- Hold down **Power** and **Volume Up + Down** buttons together for ~ 1 second
+- An iPhone will vibrate once, and trigger a screenshot (iPad will trigger a screenshot)
+- Wait a few minutes for the log archive to be generated
+- Go to **Settings > Privacy & Security > Analytics & Improvements > Analytics Data**
+- Search for `sysdiag` and share the `.tar.gz` file
+- Search the archive for `system_logs.logarchive` and open with **Console**
+- Filter for `mdmclient`


### PR DESCRIPTION
This adds a section with instructions on collecting and exporting the sysdiagnose logs from an iOS or iPadOS device without having to use Feedback Assistant, or Apple Configurator.

Closes #48929 
