### PR TITLE
Remove Zorin from platform for labels

### DIFF
--- a/frontend/pages/labels/components/PlatformField/PlatformField.tsx
+++ b/frontend/pages/labels/components/PlatformField/PlatformField.tsx
@@ -19,7 +19,6 @@ const platformOptions: CustomOptionType[] = [
   { label: "macOS", value: "darwin" },
   { label: "Windows", value: "windows" },
   { label: "Ubuntu", value: "ubuntu" },
-  { label: "Zorin OS", value: "zorin" },
   { label: "Centos", value: "centos" },
 ];
 


### PR DESCRIPTION
Fixing `Zorin OS` incorrectly showing up as platform option for labels.

Coming soon we'll have a "Linux" platform for labels (https://github.com/fleetdm/fleet/issues/44088).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed **Zorin OS** from the platform dropdown, so it is no longer available as a selectable option.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->