### PR TITLE
Python script only packages BE support

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1812,10 +1812,10 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 
 	packages, ok := software["packages"].([]interface{})
 	require.True(t, ok, "packages should be an array")
-	require.Len(t, packages, 3, "should have 3 packages: 1 regular + 2 scripts (.sh and .ps1)")
+	require.Len(t, packages, 4, "should have 4 packages: 1 regular + 3 scripts (.sh, .ps1, and .py)")
 
 	// Identify by URL since hash_sha256 includes comment tokens
-	var shScriptPkg, ps1ScriptPkg, regularPkg map[string]interface{}
+	var shScriptPkg, ps1ScriptPkg, pyScriptPkg, regularPkg map[string]any
 	for _, pkg := range packages {
 		p := pkg.(map[string]interface{})
 		url, ok := p["url"].(string)
@@ -1827,6 +1827,8 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 			shScriptPkg = p
 		case "https://example.com/download/setup.ps1":
 			ps1ScriptPkg = p
+		case "https://example.com/download/install.py":
+			pyScriptPkg = p
 		case "https://example.com/download/regular-package.deb":
 			regularPkg = p
 		}
@@ -1834,6 +1836,7 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 
 	require.NotNil(t, shScriptPkg, ".sh script package should exist")
 	require.NotNil(t, ps1ScriptPkg, ".ps1 script package should exist")
+	require.NotNil(t, pyScriptPkg, ".py script package should exist")
 	require.NotNil(t, regularPkg, "regular package should exist")
 
 	_, hasInstallScript := shScriptPkg["install_script"]
@@ -1860,10 +1863,24 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 	_, hasPreInstallQuery = ps1ScriptPkg["pre_install_query"]
 	require.False(t, hasPreInstallQuery, ".ps1 script package should NOT have pre_install_query in YAML output")
 
+	_, hasInstallScript = pyScriptPkg["install_script"]
+	require.False(t, hasInstallScript, ".py script package should NOT have install_script in YAML output")
+
+	_, hasPostInstallScript = pyScriptPkg["post_install_script"]
+	require.False(t, hasPostInstallScript, ".py script package should NOT have post_install_script in YAML output")
+
+	_, hasUninstallScript = pyScriptPkg["uninstall_script"]
+	require.False(t, hasUninstallScript, ".py script package should NOT have uninstall_script in YAML output")
+
+	_, hasPreInstallQuery = pyScriptPkg["pre_install_query"]
+	require.False(t, hasPreInstallQuery, ".py script package should NOT have pre_install_query in YAML output")
+
 	require.Contains(t, shScriptPkg, "url", ".sh script package should have url")
 	require.Contains(t, shScriptPkg, "hash_sha256", ".sh script package should have hash_sha256")
 	require.Contains(t, ps1ScriptPkg, "url", ".ps1 script package should have url")
 	require.Contains(t, ps1ScriptPkg, "hash_sha256", ".ps1 script package should have hash_sha256")
+	require.Contains(t, pyScriptPkg, "url", ".py script package should have url")
+	require.Contains(t, pyScriptPkg, "hash_sha256", ".py script package should have hash_sha256")
 
 	require.Contains(t, regularPkg, "install_script", "regular package should have install_script")
 	require.Contains(t, regularPkg, "post_install_script", "regular package should have post_install_script")
@@ -1881,6 +1898,7 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 	}
 	require.NotContains(t, commentFor("my-script.sh"), "version", ".sh script package comment should not mention version")
 	require.NotContains(t, commentFor("setup.ps1"), "version", ".ps1 script package comment should not mention version")
+	require.NotContains(t, commentFor("install.py"), "version", ".py script package comment should not mention version")
 	require.Contains(t, commentFor("regular-package.deb"), "version", "regular package comment should still mention version")
 
 	for filename := range cmd.FilesToWrite {
@@ -1893,6 +1911,11 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 		require.NotContains(t, filename, "powershell-script-windows-postinstall", "should not write post-install script file for .ps1 script package")
 		require.NotContains(t, filename, "powershell-script-windows-uninstall", "should not write uninstall script file for .ps1 script package")
 		require.NotContains(t, filename, "powershell-script-windows-preinstallquery", "should not write pre-install query file for .ps1 script package")
+
+		require.NotContains(t, filename, "python-script-linux-install", "should not write install script file for .py script package")
+		require.NotContains(t, filename, "python-script-linux-postinstall", "should not write post-install script file for .py script package")
+		require.NotContains(t, filename, "python-script-linux-uninstall", "should not write uninstall script file for .py script package")
+		require.NotContains(t, filename, "python-script-linux-preinstallquery", "should not write pre-install query file for .py script package")
 	}
 }
 
@@ -1932,6 +1955,16 @@ func (c *MockClientWithScriptPackage) ListSoftwareTitles(query string) ([]fleet.
 					Name:     "setup.ps1",
 					Platform: "windows",
 					Version:  "1.5",
+				},
+			},
+			{
+				ID:         6,
+				Name:       "Python Script",
+				HashSHA256: new("py-script-hash"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					Name:     "install.py",
+					Platform: "linux",
+					Version:  "1.2",
 				},
 			},
 		}, nil
@@ -1995,6 +2028,25 @@ func (c *MockClientWithScriptPackage) GetSoftwareTitleByID(id uint, teamID *uint
 				Platform:          "windows",
 				URL:               "https://example.com/download/setup.ps1",
 				Name:              "setup.ps1",
+			},
+		}, nil
+	case 6:
+		if *teamID != 2 {
+			return nil, errors.New("team ID mismatch")
+		}
+		// InstallScript is populated internally from file contents, but these fields
+		// should NOT be output in GitOps YAML
+		return &fleet.SoftwareTitle{
+			ID: 6,
+			SoftwarePackage: &fleet.SoftwareInstaller{
+				InstallScript:     "#!/usr/bin/env python3\nprint('This is the Python script content')",
+				PostInstallScript: "",
+				UninstallScript:   "",
+				PreInstallQuery:   "",
+				SelfService:       true,
+				Platform:          "linux",
+				URL:               "https://example.com/download/install.py",
+				Name:              "install.py",
 			},
 		}, nil
 	default:

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -35,7 +35,7 @@ func TestGitOpsTeamSoftwareInstallers(t *testing.T) {
 	}{
 		{"testdata/gitops/team_software_installer_not_found.yml", "Please make sure that URLs are reachable from your Fleet server."},
 		{"testdata/gitops/team_software_installer_install_script_secret.yml", "environment variable \"FLEET_SECRET_NAME\" not set"},
-		{"testdata/gitops/team_software_installer_unsupported.yml", "The file should be .pkg, .msi, .exe, .zip, .deb, .rpm, .tar.gz, .sh, .ipa or .ps1."},
+		{"testdata/gitops/team_software_installer_unsupported.yml", "The file should be .pkg, .msi, .exe, .zip, .deb, .rpm, .tar.gz, .sh, .py, .ipa or .ps1."},
 		{"testdata/gitops/team_software_installer_too_large.yml", "The maximum file size is 513MiB"},
 		{"testdata/gitops/team_software_installer_valid.yml", ""},
 		{"testdata/gitops/team_software_installer_subdir.yml", ""},
@@ -427,7 +427,7 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 		wantErr    string
 	}{
 		{"testdata/gitops/no_team_software_installer_not_found.yml", "Please make sure that URLs are reachable from your Fleet server."},
-		{"testdata/gitops/no_team_software_installer_unsupported.yml", "The file should be .pkg, .msi, .exe, .zip, .deb, .rpm, .tar.gz, .sh, .ipa or .ps1."},
+		{"testdata/gitops/no_team_software_installer_unsupported.yml", "The file should be .pkg, .msi, .exe, .zip, .deb, .rpm, .tar.gz, .sh, .py, .ipa or .ps1."},
 		{"testdata/gitops/no_team_software_installer_too_large.yml", "The maximum file size is 513MiB"},
 		{"testdata/gitops/no_team_software_installer_valid.yml", ""},
 		{"testdata/gitops/no_team_software_installer_subdir.yml", ""},

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1799,8 +1799,8 @@ func (svc *Service) installSoftwareTitleUsingInstaller(ctx context.Context, host
 	}
 
 	if host.FleetPlatform() != requiredPlatform {
-		// Allow .sh scripts for any unix-like platform (linux and darwin)
-		if !(ext == ".sh" && fleet.IsUnixLike(host.Platform)) {
+		// Allow .sh and .py scripts for any unix-like platform (linux and darwin)
+		if !((ext == ".sh" || ext == ".py") && fleet.IsUnixLike(host.Platform)) {
 			return &fleet.BadRequestError{
 				Message: fmt.Sprintf("Package (%s) can be installed only on %s hosts.", ext, requiredPlatform),
 				InternalErr: ctxerr.NewWithData(
@@ -2097,7 +2097,7 @@ func (svc *Service) addMetadataToSoftwarePayload(ctx context.Context, payload *f
 	if err != nil {
 		if errors.Is(err, file.ErrUnsupportedType) {
 			return "", &fleet.BadRequestError{
-				Message:     "Couldn't edit software. File type not supported. The file should be .pkg, .msi, .exe, .zip, .deb, .rpm, .tar.gz, .sh, .ipa or .ps1.",
+				Message:     "Couldn't edit software. File type not supported. The file should be .pkg, .msi, .exe, .zip, .deb, .rpm, .tar.gz, .sh, .py, .ipa or .ps1.",
 				InternalErr: ctxerr.Wrap(ctx, err, "extracting metadata from installer"),
 			}
 		}
@@ -2271,6 +2271,8 @@ func (svc *Service) addScriptPackageMetadata(ctx context.Context, payload *fleet
 		payload.Source = "sh_packages"
 	case "ps1":
 		payload.Source = "ps1_packages"
+	case "py":
+		payload.Source = "py_packages"
 	}
 
 	platform, err := fleet.SoftwareInstallerPlatformFromExtension(extension)
@@ -2956,7 +2958,7 @@ func (svc *Service) softwareBatchUpload(
 					ext = strings.TrimPrefix(ext, ".")
 
 					if !fleet.IsScriptPackage(ext) {
-						return fmt.Errorf("script:// URL must reference a .sh or .ps1 file, got: %s", filename)
+						return fmt.Errorf("script:// URL must reference a .sh, .py, or .ps1 file, got: %s", filename)
 					}
 
 					if p.InstallScript == "" {
@@ -3728,7 +3730,7 @@ func packageExtensionToPlatform(ext string) string {
 		requiredPlatform = "windows"
 	case ".pkg", ".dmg":
 		requiredPlatform = "darwin"
-	case ".deb", ".rpm", ".gz", ".tgz", ".sh":
+	case ".deb", ".rpm", ".gz", ".tgz", ".sh", ".py":
 		requiredPlatform = "linux"
 	default:
 		return ""

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -803,6 +803,82 @@ func TestAddScriptPackageMetadata(t *testing.T) {
 		require.NotEmpty(t, payload.StorageID)
 	})
 
+	t.Run("valid python script", func(t *testing.T) {
+		scriptContents := "#!/usr/bin/env python3\nprint('Installing software')\n"
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.py")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+		_, err = tmpFile.WriteString(scriptContents)
+		require.NoError(t, err)
+
+		tfr, err := fleet.NewKeepFileReader(tmpFile.Name())
+		require.NoError(t, err)
+		defer tfr.Close()
+
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallerFile: tfr,
+			Filename:      "install-app.py",
+		}
+
+		err = svc.addScriptPackageMetadata(ctx, payload, "py")
+		require.NoError(t, err)
+		require.Equal(t, "install-app", payload.Title)
+		require.Empty(t, payload.Version)
+		require.Equal(t, scriptContents, payload.InstallScript)
+		require.Equal(t, "linux", payload.Platform)
+		require.Equal(t, "py_packages", payload.Source)
+		require.Empty(t, payload.BundleIdentifier)
+		require.Empty(t, payload.PackageIDs)
+		require.NotEmpty(t, payload.StorageID)
+		require.Equal(t, "py", payload.Extension)
+	})
+
+	t.Run("python script without shebang", func(t *testing.T) {
+		scriptContents := "print('hello')\n"
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.py")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+		_, err = tmpFile.WriteString(scriptContents)
+		require.NoError(t, err)
+
+		tfr, err := fleet.NewKeepFileReader(tmpFile.Name())
+		require.NoError(t, err)
+		defer tfr.Close()
+
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallerFile: tfr,
+			Filename:      "test.py",
+		}
+
+		err = svc.addScriptPackageMetadata(ctx, payload, "py")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Script validation failed")
+		require.Contains(t, err.Error(), "python shebang")
+	})
+
+	t.Run("python script with shell shebang", func(t *testing.T) {
+		scriptContents := "#!/bin/bash\necho 'hello'\n"
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.py")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+		_, err = tmpFile.WriteString(scriptContents)
+		require.NoError(t, err)
+
+		tfr, err := fleet.NewKeepFileReader(tmpFile.Name())
+		require.NoError(t, err)
+		defer tfr.Close()
+
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallerFile: tfr,
+			Filename:      "test.py",
+		}
+
+		err = svc.addScriptPackageMetadata(ctx, payload, "py")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Script validation failed")
+		require.Contains(t, err.Error(), "python shebang")
+	})
+
 	t.Run("invalid shebang", func(t *testing.T) {
 		scriptContents := "#!/usr/bin/python\nprint('hello')\n"
 		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.sh")
@@ -947,6 +1023,32 @@ func TestAddScriptPackageMetadataLargeScript(t *testing.T) {
 		}
 
 		err = svc.addScriptPackageMetadata(ctx, payload, "ps1")
+		require.NoError(t, err)
+		require.Equal(t, scriptContents, payload.InstallScript)
+	})
+
+	t.Run("large python script within saved limit", func(t *testing.T) {
+		t.Parallel()
+		scriptContents := "#!/usr/bin/env python3\n" + strings.Repeat("print('line')\n", 1000)
+		require.Greater(t, len(scriptContents), fleet.UnsavedScriptMaxRuneLen)
+		require.Less(t, len(scriptContents), fleet.SavedScriptMaxRuneLen)
+
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.py")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+		_, err = tmpFile.WriteString(scriptContents)
+		require.NoError(t, err)
+
+		tfr, err := fleet.NewKeepFileReader(tmpFile.Name())
+		require.NoError(t, err)
+		defer tfr.Close()
+
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallerFile: tfr,
+			Filename:      "large-install.py",
+		}
+
+		err = svc.addScriptPackageMetadata(ctx, payload, "py")
 		require.NoError(t, err)
 		require.Equal(t, scriptContents, payload.InstallScript)
 	})
@@ -1222,6 +1324,120 @@ func TestInstallShScriptOnWindowsFails(t *testing.T) {
 	// Install .sh on windows should fail with BadRequestError
 	err := svc.InstallSoftwareTitle(ctx, 1, 100)
 	require.Error(t, err, ".sh install on windows should fail")
+
+	var bre *fleet.BadRequestError
+	require.ErrorAs(t, err, &bre, "error should be BadRequestError")
+	require.NotNil(t, bre)
+	require.Contains(t, bre.Message, "can be installed only on linux hosts")
+}
+
+// .py packages are stored with platform='linux', but the unix-like exception
+// must still let them install on darwin hosts.
+func TestInstallPyScriptOnUnixLike(t *testing.T) {
+	t.Parallel()
+
+	for _, platform := range []string{"linux", "darwin"} {
+		t.Run(platform, func(t *testing.T) {
+			t.Parallel()
+			ds := new(mock.Store)
+			svc := newTestService(t, ds)
+
+			ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+				return &fleet.Host{
+					ID:           1,
+					OrbitNodeKey: new("orbit_key"),
+					Platform:     platform,
+					TeamID:       new(uint(1)),
+				}, nil
+			}
+
+			ds.GetInHouseAppMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) (*fleet.SoftwareInstaller, error) {
+				return nil, nil
+			}
+
+			ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+				return &fleet.SoftwareInstaller{
+					InstallerID: 10,
+					Name:        "script.py",
+					Extension:   "py",
+					Platform:    "linux",
+					TeamID:      new(uint(1)),
+					TitleID:     new(uint(100)),
+					SelfService: false,
+				}, nil
+			}
+
+			ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
+				return true, nil
+			}
+
+			ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
+				return nil, nil
+			}
+
+			ds.ResetNonPolicyInstallAttemptsFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint) error {
+				return nil
+			}
+
+			ds.InsertSoftwareInstallRequestFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
+				return "install-uuid", nil
+			}
+
+			ctx := viewer.NewContext(context.Background(), viewer.Viewer{
+				User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)},
+			})
+
+			err := svc.InstallSoftwareTitle(ctx, 1, 100)
+			require.NoError(t, err, ".py install on %s should succeed", platform)
+			require.True(t, ds.InsertSoftwareInstallRequestFuncInvoked, "install request should be created")
+		})
+	}
+}
+
+func TestInstallPyScriptOnWindowsFails(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc := newTestService(t, ds)
+
+	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return &fleet.Host{
+			ID:           1,
+			OrbitNodeKey: new("orbit_key"),
+			Platform:     "windows",
+			TeamID:       new(uint(1)),
+		}, nil
+	}
+
+	ds.GetInHouseAppMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) (*fleet.SoftwareInstaller, error) {
+		return nil, nil
+	}
+
+	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{
+			InstallerID: 10,
+			Name:        "script.py",
+			Extension:   "py",
+			Platform:    "linux",
+			TeamID:      new(uint(1)),
+			TitleID:     new(uint(100)),
+			SelfService: false,
+		}, nil
+	}
+
+	ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
+		return true, nil
+	}
+
+	ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
+		return nil, nil
+	}
+
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{
+		User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)},
+	})
+
+	err := svc.InstallSoftwareTitle(ctx, 1, 100)
+	require.Error(t, err, ".py install on windows should fail")
 
 	var bre *fleet.BadRequestError
 	require.ErrorAs(t, err, &bre, "error should be BadRequestError")

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -736,6 +736,8 @@ func SofwareInstallerSourceFromExtensionAndName(ext, name string) (string, error
 		return "sh_packages", nil
 	case "ps1":
 		return "ps1_packages", nil
+	case "py":
+		return "py_packages", nil
 	default:
 		return "", fmt.Errorf("unsupported file type: %s", ext)
 	}
@@ -744,7 +746,7 @@ func SofwareInstallerSourceFromExtensionAndName(ext, name string) (string, error
 func SoftwareInstallerPlatformFromExtension(ext string) (string, error) {
 	ext = strings.TrimPrefix(ext, ".")
 	switch ext {
-	case "deb", "rpm", "tar.gz", "sh":
+	case "deb", "rpm", "tar.gz", "sh", "py":
 		return "linux", nil
 	case "exe", "msi", "ps1", "zip":
 		return "windows", nil
@@ -758,10 +760,10 @@ func SoftwareInstallerPlatformFromExtension(ext string) (string, error) {
 }
 
 // IsScriptPackage returns true if the extension represents a script package
-// (.sh or .ps1 files where the file contents become the install script).
+// (.sh, .ps1, or .py files where the file contents become the install script).
 func IsScriptPackage(ext string) bool {
 	ext = strings.TrimPrefix(ext, ".")
-	return ext == "sh" || ext == "ps1"
+	return ext == "sh" || ext == "ps1" || ext == "py"
 }
 
 // HostSoftwareWithInstaller represents the list of software installed on a

--- a/server/fleet/software_installer_test.go
+++ b/server/fleet/software_installer_test.go
@@ -160,6 +160,8 @@ func TestSoftwareInstallerPlatformFromExtension(t *testing.T) {
 		{"sh", "linux", false},
 		{".ps1", "windows", false},
 		{"ps1", "windows", false},
+		{".py", "linux", false},
+		{"py", "linux", false},
 
 		// Unsupported extensions (msix is fleet-maintained only, not custom upload)
 		{".msix", "", true},
@@ -212,6 +214,8 @@ func TestSofwareInstallerSourceFromExtensionAndName(t *testing.T) {
 		{"sh", "setup.sh", "sh_packages", false},
 		{".ps1", "script.ps1", "ps1_packages", false},
 		{"ps1", "setup.ps1", "ps1_packages", false},
+		{".py", "script.py", "py_packages", false},
+		{"py", "setup.py", "py_packages", false},
 
 		// Unsupported extensions (msix is fleet-maintained only, not custom upload)
 		{".msix", "app.msix", "", true},
@@ -244,6 +248,8 @@ func TestIsScriptPackage(t *testing.T) {
 		{"sh", true},
 		{".ps1", true},
 		{"ps1", true},
+		{".py", true},
+		{"py", true},
 
 		// Non-script extensions - should return false
 		{".pkg", false},
@@ -263,6 +269,7 @@ func TestIsScriptPackage(t *testing.T) {
 		{"", false},
 		{".SH", false},   // Case sensitive
 		{".PS1", false},  // Case sensitive
+		{".PY", false},   // Case sensitive
 		{".bash", false}, // Not recognized
 	}
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -17118,6 +17118,77 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploads() {
 		return sqlx.GetContext(ctx, q, &storedURL, `SELECT url FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, &team.ID, "hello world.sh")
 	})
 	require.Empty(t, storedURL, "cache-hit re-apply must drop the placeholder url too")
+
+	pyContent := "#!/usr/bin/env python3\nprint('Installing...')\n"
+	pyFile, err := fleet.NewTempFileReader(strings.NewReader(pyContent), func() string { return t.TempDir() })
+	require.NoError(t, err)
+	defer pyFile.Close()
+
+	payload = &fleet.UploadSoftwareInstallerPayload{
+		Filename:         "install-app.py",
+		TeamID:           &team.ID,
+		AutomaticInstall: true,
+		InstallerFile:    pyFile,
+	}
+	s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, "Couldn't add. Fleet can't create a policy to detect existing installations for .py packages.")
+
+	err = pyFile.Rewind()
+	require.NoError(t, err)
+
+	badPyContent := "print('no shebang')\n"
+	badPyFile, err := fleet.NewTempFileReader(strings.NewReader(badPyContent), func() string { return t.TempDir() })
+	require.NoError(t, err)
+	defer badPyFile.Close()
+	payload = &fleet.UploadSoftwareInstallerPayload{
+		Filename:      "no-shebang.py",
+		TeamID:        &team.ID,
+		InstallerFile: badPyFile,
+	}
+	s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, "Script validation failed")
+
+	// install_script is derived from the file, so any install_script param is ignored.
+	payload = &fleet.UploadSoftwareInstallerPayload{
+		Filename:          "install-app.py",
+		Title:             "install-app.py",
+		TeamID:            &team.ID,
+		InstallScript:     "this should be ignored",
+		UninstallScript:   "echo 'uninstall py'",
+		PostInstallScript: "echo 'post py'",
+		PreInstallQuery:   "SELECT 1;",
+		InstallerFile:     pyFile,
+	}
+	s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
+
+	var pyStored struct {
+		Source            string `db:"source"`
+		InstallScript     string `db:"install_script"`
+		UninstallScript   string `db:"uninstall_script"`
+		PostInstallScript string `db:"post_install_script"`
+		PreInstallQuery   string `db:"pre_install_query"`
+		Platform          string `db:"platform"`
+	}
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &pyStored, `
+			SELECT
+				st.source,
+				COALESCE(inst.contents, '') AS install_script,
+				COALESCE(uninst.contents, '') AS uninstall_script,
+				COALESCE(postinst.contents, '') AS post_install_script,
+				si.pre_install_query,
+				si.platform
+			FROM software_installers si
+			JOIN software_titles st ON st.id = si.title_id
+			LEFT JOIN script_contents inst ON inst.id = si.install_script_content_id
+			LEFT JOIN script_contents uninst ON uninst.id = si.uninstall_script_content_id
+			LEFT JOIN script_contents postinst ON postinst.id = si.post_install_script_content_id
+			WHERE si.global_or_team_id = ? AND si.filename = ?`, team.ID, payload.Filename)
+	})
+	require.Equal(t, "py_packages", pyStored.Source, "py package should be stored with py_packages source")
+	require.Equal(t, pyContent, pyStored.InstallScript, "install_script should be the .py file contents, not the ignored param")
+	require.Equal(t, "echo 'uninstall py'", pyStored.UninstallScript)
+	require.Equal(t, "echo 'post py'", pyStored.PostInstallScript)
+	require.Equal(t, "SELECT 1;", pyStored.PreInstallQuery)
+	require.Equal(t, "linux", pyStored.Platform, ".py packages are stored with the linux platform")
 }
 
 // 1. host reports software
@@ -22159,6 +22230,11 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 	err = os.WriteFile(ps1ScriptPath, ps1ScriptContent, 0o644)
 	require.NoError(t, err)
 
+	pyScriptPath := filepath.Join(tmpDir, "test-script.py")
+	pyScriptContent := []byte("#!/usr/bin/env python3\nprint('Installing...')\n")
+	err = os.WriteFile(pyScriptPath, pyScriptContent, 0o644)
+	require.NoError(t, err)
+
 	t.Run("sh script package preserves advanced options", func(t *testing.T) {
 		installerFile, err := fleet.NewKeepFileReader(shScriptPath)
 		require.NoError(t, err)
@@ -22247,6 +22323,53 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 		require.Equal(t, "Write-Host 'post-install'", installer.PostInstallScript, ".ps1 script package should persist post_install_script")
 		require.Equal(t, "Write-Host 'uninstall'", installer.UninstallScript, ".ps1 script package should persist uninstall_script")
 		require.Equal(t, "SELECT 1", installer.PreInstallQuery, ".ps1 script package should persist pre_install_query")
+
+		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, 204, "team_id", "0")
+	})
+
+	t.Run("py script package preserves advanced options", func(t *testing.T) {
+		installerFile, err := fleet.NewKeepFileReader(pyScriptPath)
+		require.NoError(t, err)
+		defer installerFile.Close()
+
+		// install_script is ignored (the file is the install script); the rest persist.
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:     "print('install_script is ignored')",
+			PostInstallScript: "echo 'post-install'",
+			UninstallScript:   "echo 'uninstall'",
+			PreInstallQuery:   "SELECT 1",
+			Filename:          "test-script.py",
+			InstallerFile:     installerFile,
+		}
+
+		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
+
+		var listResp listSoftwareTitlesResponse
+		s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, http.StatusOK, &listResp, "team_id", "0", "available_for_install", "true")
+
+		var found bool
+		var titleID uint
+		for _, sw := range listResp.SoftwareTitles {
+			if sw.SoftwarePackage != nil && sw.SoftwarePackage.Name == "test-script.py" {
+				found = true
+				titleID = sw.ID
+				break
+			}
+		}
+		require.True(t, found, "Script package should be created")
+
+		var titleResp getSoftwareTitleResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, http.StatusOK, &titleResp, "team_id", "0")
+
+		require.NotNil(t, titleResp.SoftwareTitle.SoftwarePackage)
+		installer := titleResp.SoftwareTitle.SoftwarePackage
+
+		require.Equal(t, "py_packages", titleResp.SoftwareTitle.Source, ".py script package should have py_packages source")
+		require.Equal(t, string(pyScriptContent), installer.InstallScript, ".py script package should have install_script from file contents")
+		require.NotEqual(t, "print('install_script is ignored')", installer.InstallScript, "user-provided install_script should be overwritten")
+		require.Equal(t, "echo 'post-install'", installer.PostInstallScript, ".py script package should persist post_install_script")
+		require.Equal(t, "echo 'uninstall'", installer.UninstallScript, ".py script package should persist uninstall_script")
+		require.Equal(t, "SELECT 1", installer.PreInstallQuery, ".py script package should persist pre_install_query")
 
 		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, 204, "team_id", "0")
 	})

--- a/server/service/testdata/software-installers/script.py
+++ b/server/service/testdata/software-installers/script.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print("script")


### PR DESCRIPTION
**Related issue:** Resolves #48393

Adds `.py` as an accepted script-only software package on the server — mirroring `.sh`, assigned the new `py_packages` source and installable on macOS and Linux hosts.

  # Checklist for submitter

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  ## Testing

  - [x] Added/updated automated tests
  - [x] QA'd all new/changed functionality manually