### PR TITLE
Add Host names card to Controls > OS settings

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -155,6 +155,16 @@ const CommandPalette = (): JSX.Element | null => {
     !!isTeamAdmin ||
     !!isTeamMaintainer;
 
+  // Admin/maintainer-only Controls sub-items (Certificates, Passwords, Host
+  // names). Technicians can reach Controls (canAccessControls) but not these,
+  // so gate them on the positive admin/maintainer role rather than
+  // `!isTechnician`.
+  const isAdminOrMaintainer =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isAnyTeamAdmin ||
+    isAnyTeamMaintainer;
+
   // Observer+ users can run live queries even though they can't write.
   const canRunLiveReport =
     canWrite || !!isObserverPlus || !!isAnyTeamObserverPlus;
@@ -411,6 +421,7 @@ const CommandPalette = (): JSX.Element | null => {
         canManageReportAutomations,
         canEditCustomVariable,
         canAddSoftware,
+        isAdminOrMaintainer,
         isTechnician,
         isPremiumTier,
         isPrimoMode,
@@ -446,6 +457,7 @@ const CommandPalette = (): JSX.Element | null => {
       canManageReportAutomations,
       canEditCustomVariable,
       canAddSoftware,
+      isAdminOrMaintainer,
       isTechnician,
       isPremiumTier,
       isPrimoMode,

--- a/frontend/components/CommandPalette/groups/controls.ts
+++ b/frontend/components/CommandPalette/groups/controls.ts
@@ -7,7 +7,12 @@ const buildControlsItems = (
   ctx: ICommandPaletteContext,
   derived: IDerivedContext
 ): ICommandItem[] => {
-  const { canAccessControls, isPremiumTier, isTechnician, withTeamId } = ctx;
+  const {
+    canAccessControls,
+    isPremiumTier,
+    isAdminOrMaintainer,
+    withTeamId,
+  } = ctx;
   const { hasTeamOrUnassigned } = derived;
 
   // Controls pages don't support "All fleets" (includeAllTeams: false),
@@ -79,9 +84,8 @@ const buildControlsItems = (
             "windows csp",
           ],
         },
-        // Certificates and Passwords — Premium-only, and not
-        // available to technicians.
-        ...(isPremiumTier && !isTechnician
+        // Certificates and Passwords — Premium-only, admin/maintainer only.
+        ...(isPremiumTier && isAdminOrMaintainer
           ? [
               {
                 id: "controls-certificates",
@@ -105,9 +109,9 @@ const buildControlsItems = (
               },
             ]
           : []),
-        // Host names — Premium-only, not available to technicians. Supported
-        // for both fleets and "No team" / Unassigned.
-        ...(isPremiumTier && !isTechnician
+        // Host names — Premium-only, admin/maintainer only. Supported for
+        // both fleets and "No team" / Unassigned.
+        ...(isPremiumTier && isAdminOrMaintainer
           ? [
               {
                 id: "controls-host-name-template",

--- a/frontend/components/CommandPalette/groups/controls.ts
+++ b/frontend/components/CommandPalette/groups/controls.ts
@@ -8,7 +8,7 @@ const buildControlsItems = (
   derived: IDerivedContext
 ): ICommandItem[] => {
   const { canAccessControls, isPremiumTier, isTechnician, withTeamId } = ctx;
-  const { hasTeamOrUnassigned, isUnassigned } = derived;
+  const { hasTeamOrUnassigned } = derived;
 
   // Controls pages don't support "All fleets" (includeAllTeams: false),
   // so only show when a team or unassigned is selected. Also gated by
@@ -105,9 +105,9 @@ const buildControlsItems = (
               },
             ]
           : []),
-        // Host names — Premium-only, not available to technicians, and
-        // fleets-only (hidden for "No team" / Unassigned).
-        ...(isPremiumTier && !isTechnician && !isUnassigned
+        // Host names — Premium-only, not available to technicians. Supported
+        // for both fleets and "No team" / Unassigned.
+        ...(isPremiumTier && !isTechnician
           ? [
               {
                 id: "controls-host-name-template",

--- a/frontend/components/CommandPalette/groups/controls.ts
+++ b/frontend/components/CommandPalette/groups/controls.ts
@@ -8,7 +8,7 @@ const buildControlsItems = (
   derived: IDerivedContext
 ): ICommandItem[] => {
   const { canAccessControls, isPremiumTier, isTechnician, withTeamId } = ctx;
-  const { hasTeamOrUnassigned } = derived;
+  const { hasTeamOrUnassigned, isUnassigned } = derived;
 
   // Controls pages don't support "All fleets" (includeAllTeams: false),
   // so only show when a team or unassigned is selected. Also gated by
@@ -102,6 +102,24 @@ const buildControlsItems = (
                 label: "Passwords",
                 path: withTeamId(paths.CONTROLS_PASSWORDS),
                 keywords: ["rotation", "recovery", "macos", "laps"],
+              },
+            ]
+          : []),
+        // Host names — Premium-only, not available to technicians, and
+        // fleets-only (hidden for "No team" / Unassigned).
+        ...(isPremiumTier && !isTechnician && !isUnassigned
+          ? [
+              {
+                id: "controls-host-name-template",
+                label: "Host names",
+                path: withTeamId(paths.CONTROLS_HOST_NAME_TEMPLATE),
+                keywords: [
+                  "rename",
+                  "naming",
+                  "template",
+                  "convention",
+                  "device name",
+                ],
               },
             ]
           : []),

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -34,6 +34,7 @@ const BASE_CONTEXT: ICommandPaletteContext = {
   canManageReportAutomations: true,
   canEditCustomVariable: true,
   canAddSoftware: true,
+  isAdminOrMaintainer: true,
   isTechnician: false,
   isPremiumTier: true,
   isMacMdmEnabledAndConfigured: true,
@@ -365,6 +366,7 @@ describe("CommandPalette helpers", () => {
       const items = buildPaletteItems({
         ...BASE_CONTEXT,
         isTechnician: true,
+        isAdminOrMaintainer: false,
         hasTeamSelected: true,
         currentTeam: { id: 1, name: "Engineering" },
       });
@@ -387,6 +389,47 @@ describe("CommandPalette helpers", () => {
       const subIds = osSettings?.subItems?.map((s) => s.id) ?? [];
       expect(subIds).toContain("controls-certificates");
       expect(subIds).toContain("controls-passwords");
+    });
+
+    it("includes Host names for admin/maintainer on a fleet", () => {
+      const items = buildPaletteItems({
+        ...BASE_CONTEXT,
+        hasTeamSelected: true,
+        currentTeam: { id: 1, name: "Engineering" },
+      });
+
+      const osSettings = items.find((i) => i.id === "controls-os-settings");
+      const subIds = osSettings?.subItems?.map((s) => s.id) ?? [];
+      expect(subIds).toContain("controls-host-name-template");
+    });
+
+    it("includes Host names for admin/maintainer on 'No team'", () => {
+      // The template is supported for "No team" too. Unassigned satisfies
+      // hasTeamOrUnassigned, so the Controls group and the Host names entry
+      // both render.
+      const items = buildPaletteItems({
+        ...BASE_CONTEXT,
+        hasTeamSelected: false,
+        currentTeam: { id: 0, name: "No team" },
+      });
+
+      const osSettings = items.find((i) => i.id === "controls-os-settings");
+      const subIds = osSettings?.subItems?.map((s) => s.id) ?? [];
+      expect(subIds).toContain("controls-host-name-template");
+    });
+
+    it("excludes Host names for technicians", () => {
+      const items = buildPaletteItems({
+        ...BASE_CONTEXT,
+        isTechnician: true,
+        isAdminOrMaintainer: false,
+        hasTeamSelected: true,
+        currentTeam: { id: 1, name: "Engineering" },
+      });
+
+      const osSettings = items.find((i) => i.id === "controls-os-settings");
+      const subIds = osSettings?.subItems?.map((s) => s.id) ?? [];
+      expect(subIds).not.toContain("controls-host-name-template");
     });
 
     it("appends fleet_id via withTeamId for team-scoped paths", () => {
@@ -630,7 +673,7 @@ describe("CommandPalette helpers", () => {
       // of the parent is sufficient.
     });
 
-    it("hides Disk encryption, Certificates, and Passwords OS-settings sub-items", () => {
+    it("hides Disk encryption, Certificates, Passwords, and Host names OS-settings sub-items", () => {
       const osSettings = buildPaletteItems(FREE_CONTEXT).find(
         (i) => i.id === "controls-os-settings"
       );
@@ -638,6 +681,7 @@ describe("CommandPalette helpers", () => {
       expect(subIds).not.toContain("controls-disk-encryption");
       expect(subIds).not.toContain("controls-certificates");
       expect(subIds).not.toContain("controls-passwords");
+      expect(subIds).not.toContain("controls-host-name-template");
       // Configuration profiles is not premium-gated; keep it.
       expect(subIds).toContain("controls-custom-settings");
     });

--- a/frontend/components/CommandPalette/helpers.ts
+++ b/frontend/components/CommandPalette/helpers.ts
@@ -62,6 +62,10 @@ export interface ICommandPaletteContext {
    *  page despite passing `canWrite`. Gates every software-add palette
    *  item (FMA, VPP, Android, custom package). */
   canAddSoftware?: boolean;
+  /** Global or any-team admin/maintainer. Gates the admin/maintainer-only
+   *  Controls > OS settings sub-items (Certificates, Passwords, Host names),
+   *  which technicians can't manage despite passing `canAccessControls`. */
+  isAdminOrMaintainer?: boolean;
   isTechnician?: boolean;
   isPremiumTier?: boolean;
   isPrimoMode?: boolean;

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -50,6 +50,9 @@ export interface IMdmConfig {
   /** Update this URL if you're self-hosting Fleet and you want your hosts to talk to a different URL for MDM features. (If not configured, hosts will use the base URL of the Fleet instance.) */
   apple_server_url: string;
   enable_disk_encryption: boolean;
+  /** Host name template applied to "No team" Apple hosts. Mirrors
+  `enable_disk_encryption` as a global-scope Controls > OS setting. */
+  name_template?: string;
   enable_recovery_lock_password: boolean;
   windows_require_bitlocker_pin: boolean;
   /** `enabled_and_configured` only tells us if Apples MDM has been enabled and

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -49,6 +49,7 @@ export interface ITeam extends ITeamSummary {
   mdm?: {
     enable_disk_encryption: boolean;
     enable_recovery_lock_password: boolean;
+    name_template?: string;
     windows_require_bitlocker_pin: boolean;
     macos_updates: IAppleDeviceUpdates;
     ios_updates: IAppleDeviceUpdates;

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
@@ -56,8 +56,8 @@ const OSSettings = ({
   const isTechnician = !!isTeamTechnician || !!isGlobalTechnician;
 
   const filteredNavItems = useMemo(() => {
-    return getOSSettingsNavItems(isTechnician);
-  }, [isTechnician]);
+    return getOSSettingsNavItems(isTechnician, teamId === API_NO_TEAM_ID);
+  }, [isTechnician, teamId]);
 
   const DEFAULT_SETTINGS_SECTION = filteredNavItems[0];
 

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
@@ -56,8 +56,8 @@ const OSSettings = ({
   const isTechnician = !!isTeamTechnician || !!isGlobalTechnician;
 
   const filteredNavItems = useMemo(() => {
-    return getOSSettingsNavItems(isTechnician, teamId === API_NO_TEAM_ID);
-  }, [isTechnician, teamId]);
+    return getOSSettingsNavItems(isTechnician);
+  }, [isTechnician]);
 
   const DEFAULT_SETTINGS_SECTION = filteredNavItems[0];
 

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tests.tsx
@@ -2,18 +2,20 @@ import getOSSettingsNavItems from "./OSSettingsNavItems";
 
 describe("getOSSettingsNavItems", () => {
   it("includes the Host names card for a fleet (non-technician)", () => {
-    const titles = getOSSettingsNavItems(false, false).map((i) => i.title);
+    const titles = getOSSettingsNavItems(false).map((i) => i.title);
     expect(titles).toContain("Host names");
     expect(titles[titles.length - 1]).toBe("Host names");
   });
 
-  it("excludes the Host names card for 'No team' (fleets-only)", () => {
-    const titles = getOSSettingsNavItems(false, true).map((i) => i.title);
-    expect(titles).not.toContain("Host names");
+  it("includes the Host names card for 'No team'", () => {
+    // The template is supported for fleets and for "No team" (global config),
+    // so the card renders in both scopes.
+    const titles = getOSSettingsNavItems(false).map((i) => i.title);
+    expect(titles).toContain("Host names");
   });
 
   it("excludes the Host names card for technicians", () => {
-    const titles = getOSSettingsNavItems(true, false).map((i) => i.title);
+    const titles = getOSSettingsNavItems(true).map((i) => i.title);
     expect(titles).not.toContain("Host names");
   });
 });

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tests.tsx
@@ -1,0 +1,19 @@
+import getOSSettingsNavItems from "./OSSettingsNavItems";
+
+describe("getOSSettingsNavItems", () => {
+  it("includes the Host names card for a fleet (non-technician)", () => {
+    const titles = getOSSettingsNavItems(false, false).map((i) => i.title);
+    expect(titles).toContain("Host names");
+    expect(titles[titles.length - 1]).toBe("Host names");
+  });
+
+  it("excludes the Host names card for 'No team' (fleets-only)", () => {
+    const titles = getOSSettingsNavItems(false, true).map((i) => i.title);
+    expect(titles).not.toContain("Host names");
+  });
+
+  it("excludes the Host names card for technicians", () => {
+    const titles = getOSSettingsNavItems(true, false).map((i) => i.title);
+    expect(titles).not.toContain("Host names");
+  });
+});

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tests.tsx
@@ -1,17 +1,12 @@
 import getOSSettingsNavItems from "./OSSettingsNavItems";
 
 describe("getOSSettingsNavItems", () => {
-  it("includes the Host names card for a fleet (non-technician)", () => {
+  it("includes the Host names card, last, for non-technicians", () => {
+    // The card is team-agnostic in the nav — it renders for both fleets and
+    // "No team"; scope is resolved inside the card, not by the nav filter.
     const titles = getOSSettingsNavItems(false).map((i) => i.title);
     expect(titles).toContain("Host names");
     expect(titles[titles.length - 1]).toBe("Host names");
-  });
-
-  it("includes the Host names card for 'No team'", () => {
-    // The template is supported for fleets and for "No team" (global config),
-    // so the card renders in both scopes.
-    const titles = getOSSettingsNavItems(false).map((i) => i.title);
-    expect(titles).toContain("Host names");
   });
 
   it("excludes the Host names card for technicians", () => {

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tsx
@@ -24,8 +24,7 @@ type IOSSettingsCardProps = IDiskEncryptionProps | IConfigurationProfilesProps;
 // Observers and observers+ will not have access to the Controls page at all, so the only role to
 // exclude at this point is technician
 const getOSSettingsNavItems = (
-  isTechnician: boolean,
-  isNoTeam: boolean
+  isTechnician: boolean
 ): ISideNavItem<IOSSettingsCardProps>[] => {
   const items = [
     {
@@ -59,7 +58,7 @@ const getOSSettingsNavItems = (
       Card: HostNameTemplate,
       urlSection: "host-name-template",
       path: PATHS.CONTROLS_HOST_NAME_TEMPLATE,
-      exclude: isTechnician || isNoTeam,
+      exclude: isTechnician,
     },
   ];
   return items.filter((item) => !item.exclude);

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettingsNavItems.tsx
@@ -7,6 +7,7 @@ import DiskEncryption from "./cards/DiskEncryption";
 import ConfigurationProfiles from "./cards/ConfigurationProfiles";
 import Certificates from "./cards/Certificates";
 import Passwords from "./cards/Passwords";
+import HostNameTemplate from "./cards/HostNameTemplate";
 import { IConfigurationProfilesProps } from "./cards/ConfigurationProfiles/ConfigurationProfiles";
 import { IDiskEncryptionProps } from "./cards/DiskEncryption/DiskEncryption";
 
@@ -23,7 +24,8 @@ type IOSSettingsCardProps = IDiskEncryptionProps | IConfigurationProfilesProps;
 // Observers and observers+ will not have access to the Controls page at all, so the only role to
 // exclude at this point is technician
 const getOSSettingsNavItems = (
-  isTechnician: boolean
+  isTechnician: boolean,
+  isNoTeam: boolean
 ): ISideNavItem<IOSSettingsCardProps>[] => {
   const items = [
     {
@@ -51,6 +53,13 @@ const getOSSettingsNavItems = (
       urlSection: "passwords",
       path: PATHS.CONTROLS_PASSWORDS,
       exclude: isTechnician,
+    },
+    {
+      title: "Host names",
+      Card: HostNameTemplate,
+      urlSection: "host-name-template",
+      path: PATHS.CONTROLS_HOST_NAME_TEMPLATE,
+      exclude: isTechnician || isNoTeam,
     },
   ];
   return items.filter((item) => !item.exclude);

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tests.tsx
@@ -124,6 +124,106 @@ describe("HostNameTemplate card", () => {
     });
   });
 
+  it("saves the No-team template with fleet_id 0 and refreshes app config", async () => {
+    let savedBody: unknown;
+    let configRefetched = false;
+    mockServer.use(
+      http.post(baseUrl("/host_name_template"), async ({ request }) => {
+        savedBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+      // onSuccess refreshes the global app config for the No-team scope.
+      http.get(baseUrl("/config"), () => {
+        configRefetched = true;
+        return HttpResponse.json({
+          mdm: {
+            enabled_and_configured: true,
+            name_template: "No team $FLEET_VAR_HOST_HARDWARE_SERIAL",
+          },
+        });
+      })
+    );
+    const successSpy = jest.spyOn(notify, "success");
+    const errorSpy = jest.spyOn(notify, "error");
+
+    const onMutation = jest.fn();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          setConfig: jest.fn(),
+          config: {
+            mdm: { enabled_and_configured: true, name_template: "" },
+            gitops: { gitops_mode_enabled: false },
+          },
+        },
+      },
+    });
+
+    const { user } = render(
+      <HostNameTemplate
+        {...baseProps}
+        currentTeamId={0}
+        onMutation={onMutation}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByRole("textbox"),
+      "No team $FLEET_VAR_HOST_HARDWARE_SERIAL"
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(onMutation).toHaveBeenCalled();
+    });
+    expect(savedBody).toEqual({
+      fleet_id: 0,
+      name_template: "No team $FLEET_VAR_HOST_HARDWARE_SERIAL",
+    });
+    expect(successSpy).toHaveBeenCalledWith(
+      "Successfully updated host name template."
+    );
+    await waitFor(() => {
+      expect(configRefetched).toBe(true);
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("disables the input in GitOps mode for 'No team'", async () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: {
+              enabled_and_configured: true,
+              name_template: "No team iPad $FLEET_VAR_HOST_HARDWARE_SERIAL",
+            },
+            gitops: {
+              gitops_mode_enabled: true,
+              repository_url: "https://github.com/example/repo",
+            },
+          },
+        },
+      },
+    });
+
+    render(<HostNameTemplate {...baseProps} currentTeamId={0} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("No team iPad $FLEET_VAR_HOST_HARDWARE_SERIAL")
+      ).toBeDisabled();
+    });
+  });
+
   it("saves the template and fires onMutation", async () => {
     mockServer.use(teamHandler(""));
     let savedBody: unknown;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tests.tsx
@@ -1,0 +1,287 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import {
+  baseUrl,
+  createCustomRenderer,
+  createMockRouter,
+} from "test/test-utils";
+import mockServer from "test/mock-server";
+import { notify } from "components/ToastNotification";
+
+import HostNameTemplate from "./HostNameTemplate";
+
+const mockRouter = createMockRouter();
+
+const teamHandler = (nameTemplate = "") =>
+  http.get(baseUrl("/fleets/1"), () =>
+    HttpResponse.json({
+      team: { id: 1, name: "Team 1", mdm: { name_template: nameTemplate } },
+      fleet: { id: 1, name: "Team 1", mdm: { name_template: nameTemplate } },
+    })
+  );
+
+const baseProps = {
+  currentTeamId: 1,
+  router: mockRouter,
+  onMutation: jest.fn(),
+};
+
+describe("HostNameTemplate card", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders the PremiumFeatureMessage on Free tier", () => {
+    mockServer.use(teamHandler());
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: false,
+          config: { mdm: { enabled_and_configured: true } },
+        },
+      },
+    });
+
+    render(<HostNameTemplate {...baseProps} />);
+
+    expect(
+      screen.getByText("This feature is included in Fleet Premium.")
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(/./)).not.toBeInTheDocument();
+  });
+
+  it("renders the MDM-not-configured empty state", () => {
+    mockServer.use(teamHandler());
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: { mdm: { enabled_and_configured: false } },
+        },
+      },
+    });
+
+    render(<HostNameTemplate {...baseProps} />);
+
+    expect(
+      screen.getByText("MDM must be turned on to apply host name settings.")
+    ).toBeInTheDocument();
+  });
+
+  it("loads and displays the current name template", async () => {
+    mockServer.use(teamHandler("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL"));
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: { enabled_and_configured: true },
+            gitops: { gitops_mode_enabled: false },
+          },
+        },
+      },
+    });
+
+    render(<HostNameTemplate {...baseProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("saves the template and fires onMutation", async () => {
+    mockServer.use(teamHandler(""));
+    let savedBody: unknown;
+    mockServer.use(
+      http.post(baseUrl("/host_name_template"), async ({ request }) => {
+        savedBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+    const successSpy = jest.spyOn(notify, "success");
+
+    const onMutation = jest.fn();
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: { enabled_and_configured: true },
+            gitops: { gitops_mode_enabled: false },
+          },
+        },
+      },
+    });
+
+    const { user } = render(
+      <HostNameTemplate {...baseProps} onMutation={onMutation} />
+    );
+
+    // Save is disabled until the pristine form is edited.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+
+    await user.type(
+      screen.getByRole("textbox"),
+      "iPad $FLEET_VAR_HOST_HARDWARE_SERIAL"
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(onMutation).toHaveBeenCalled();
+    });
+    expect(savedBody).toEqual({
+      fleet_id: 1,
+      name_template: "iPad $FLEET_VAR_HOST_HARDWARE_SERIAL",
+    });
+    expect(successSpy).toHaveBeenCalledWith(
+      "Successfully updated host name template."
+    );
+  });
+
+  it("surfaces the server's 422 message verbatim on save error", async () => {
+    mockServer.use(teamHandler(""));
+    const serverMessage =
+      "Fleet variable $FLEET_VAR_HOST_END_USER_IDP_GROUPS is not supported in host name templates.";
+    mockServer.use(
+      http.post(baseUrl("/host_name_template"), () =>
+        HttpResponse.json(
+          {
+            message: "Validation Failed",
+            errors: [{ name: "name_template", reason: serverMessage }],
+          },
+          { status: 422 }
+        )
+      )
+    );
+    const errorSpy = jest.spyOn(notify, "error");
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: { enabled_and_configured: true },
+            gitops: { gitops_mode_enabled: false },
+          },
+        },
+      },
+    });
+
+    const { user } = render(<HostNameTemplate {...baseProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByRole("textbox"),
+      "$FLEET_VAR_HOST_END_USER_IDP_GROUPS"
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(serverMessage, expect.anything());
+    });
+  });
+
+  it("keeps Save disabled while the form is pristine", async () => {
+    mockServer.use(teamHandler("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL"));
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: { enabled_and_configured: true },
+            gitops: { gitops_mode_enabled: false },
+          },
+        },
+      },
+    });
+
+    const { user } = render(<HostNameTemplate {...baseProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL")
+      ).toBeInTheDocument();
+    });
+
+    // Pristine: no changes yet.
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+    // Editing enables Save...
+    await user.type(screen.getByRole("textbox"), " 2");
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("enables Save when a previously-set template is cleared", async () => {
+    mockServer.use(teamHandler("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL"));
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: { enabled_and_configured: true },
+            gitops: { gitops_mode_enabled: false },
+          },
+        },
+      },
+    });
+
+    const { user } = render(<HostNameTemplate {...baseProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL")
+      ).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByRole("textbox"));
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("disables the input in GitOps mode", async () => {
+    mockServer.use(teamHandler("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL"));
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: { enabled_and_configured: true },
+            gitops: {
+              gitops_mode_enabled: true,
+              repository_url: "https://github.com/example/repo",
+            },
+          },
+        },
+      },
+    });
+
+    render(<HostNameTemplate {...baseProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("iPad $FLEET_VAR_HOST_HARDWARE_SERIAL")
+      ).toBeDisabled();
+    });
+  });
+});

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tests.tsx
@@ -97,6 +97,33 @@ describe("HostNameTemplate card", () => {
     });
   });
 
+  it("renders for 'No team' with the value sourced from app config", async () => {
+    // No team reads its template from the global app config, not a team query.
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          config: {
+            mdm: {
+              enabled_and_configured: true,
+              name_template: "No team iPad $FLEET_VAR_HOST_HARDWARE_SERIAL",
+            },
+            gitops: { gitops_mode_enabled: false },
+          },
+        },
+      },
+    });
+
+    render(<HostNameTemplate {...baseProps} currentTeamId={0} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("No team iPad $FLEET_VAR_HOST_HARDWARE_SERIAL")
+      ).toBeInTheDocument();
+    });
+  });
+
   it("saves the template and fires onMutation", async () => {
     mockServer.use(teamHandler(""));
     let savedBody: unknown;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
@@ -1,0 +1,183 @@
+import React, { useContext, useState } from "react";
+import { useMutation, useQuery } from "react-query";
+
+import { AppContext } from "context/app";
+import { notify } from "components/ToastNotification";
+import { API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
+import { getErrorReason } from "interfaces/errors";
+
+import {
+  DEFAULT_USE_QUERY_OPTIONS,
+  LEARN_MORE_ABOUT_BASE_LINK,
+} from "utilities/constants";
+import { getPathWithQueryParams } from "utilities/url";
+
+import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
+import hostNameTemplateAPI from "services/entities/host_name_template";
+
+import PATHS from "router/paths";
+
+import Button from "components/buttons/Button";
+import CustomLink from "components/CustomLink";
+import EmptyState from "components/EmptyState";
+import InputField from "components/forms/fields/InputField";
+import PremiumFeatureMessage from "components/PremiumFeatureMessage";
+import Spinner from "components/Spinner";
+import SectionHeader from "components/SectionHeader";
+import PageDescription from "components/PageDescription";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+
+import { IOSSettingsCommonProps } from "../../OSSettingsNavItems";
+
+const baseClass = "host-name-template";
+const NAME_TEMPLATE_MAX_LENGTH = 255;
+
+const HostNameTemplate = ({
+  currentTeamId,
+  router,
+  onMutation,
+}: IOSSettingsCommonProps) => {
+  const { isPremiumTier, config } = useContext(AppContext);
+
+  const mdmEnabled = config?.mdm.enabled_and_configured;
+
+  const [nameTemplate, setNameTemplate] = useState<string>();
+  const [savedNameTemplate, setSavedNameTemplate] = useState<string>();
+
+  const { isLoading: isLoadingTeam, isError: isTeamError } = useQuery<
+    ILoadTeamResponse,
+    Error,
+    ITeamConfig
+  >(["team", currentTeamId], () => teamsAPI.load(currentTeamId), {
+    ...DEFAULT_USE_QUERY_OPTIONS,
+    enabled: isPremiumTier && !!mdmEnabled && currentTeamId !== API_NO_TEAM_ID,
+    select: (res) => res.fleet,
+    onSuccess: (res) => {
+      const loaded = res.mdm?.name_template ?? "";
+      setNameTemplate(loaded);
+      setSavedNameTemplate(loaded);
+    },
+    onError: (err) => {
+      notify.error("Couldn't load fleet settings. Please try again.", {
+        response: err,
+      });
+    },
+  });
+
+  const { mutate: saveNameTemplate, isLoading: updating } = useMutation(
+    (tmpl: string) =>
+      hostNameTemplateAPI.updateHostNameTemplate(tmpl, currentTeamId),
+    {
+      onSuccess: (_data, tmpl) => {
+        // Optimistically adopt the saved value as the new baseline.
+        setSavedNameTemplate(tmpl);
+        notify.success("Successfully updated host name template.");
+        onMutation();
+      },
+      onError: (e) => {
+        // The server's 422 carries the specific invalid-variable message;
+        // surface it verbatim.
+        notify.error(
+          getErrorReason(e) ||
+            "Couldn't update host name template. Please try again.",
+          { response: e }
+        );
+      },
+    }
+  );
+
+  const isFormDisabled =
+    isLoadingTeam || isTeamError || nameTemplate === undefined;
+  const isPristine = nameTemplate === savedNameTemplate;
+
+  const renderCardBody = () => {
+    if (!isPremiumTier) {
+      return <PremiumFeatureMessage />;
+    }
+    // Waiting on app config to know whether MDM is configured.
+    if (mdmEnabled === undefined) {
+      return <Spinner />;
+    }
+    if (!mdmEnabled) {
+      return (
+        <EmptyState
+          variant="form"
+          header="Manage your hosts"
+          info="MDM must be turned on to apply host name settings."
+          primaryButton={
+            <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
+              Turn on
+            </Button>
+          }
+        />
+      );
+    }
+    if (isLoadingTeam) {
+      return <Spinner />;
+    }
+    return (
+      <div className={`form ${baseClass}__content`}>
+        <InputField
+          label="Name template"
+          name="name-template"
+          value={nameTemplate ?? ""}
+          onChange={(value: string) => setNameTemplate(value)}
+          placeholder="iPad $FLEET_VAR_HOST_HARDWARE_SERIAL"
+          helpText="This will be the host's name in Fleet and on the device itself."
+          disabled={isFormDisabled || config?.gitops?.gitops_mode_enabled}
+          inputOptions={{ maxLength: NAME_TEMPLATE_MAX_LENGTH }}
+        />
+        <div className="button-wrap">
+          <GitOpsModeTooltipWrapper
+            tipOffset={8}
+            renderChildren={(gitopsDisabled) => (
+              <Button
+                disabled={
+                  isFormDisabled || isPristine || updating || gitopsDisabled
+                }
+                isLoading={updating}
+                className={`${baseClass}__save-button`}
+                onClick={() =>
+                  nameTemplate !== undefined && saveNameTemplate(nameTemplate)
+                }
+              >
+                Save
+              </Button>
+            )}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className={baseClass}>
+      <SectionHeader title="Host names" alignLeftHeaderVertically />
+      <PageDescription
+        variant="right-panel"
+        content={
+          <>
+            Set a naming convention for all macOS, iOS, or iPadOS hosts in this
+            fleet. Use{" "}
+            <CustomLink
+              text="built-in"
+              url={`${LEARN_MORE_ABOUT_BASE_LINK}/built-in-variables`}
+              newTab
+            />{" "}
+            or{" "}
+            <CustomLink
+              text="custom"
+              url={getPathWithQueryParams(PATHS.CONTROLS_VARIABLES, {
+                fleet_id: currentTeamId,
+              })}
+            />{" "}
+            variables to differentiate between hosts.
+          </>
+        }
+      />
+      {renderCardBody()}
+    </div>
+  );
+};
+
+export default HostNameTemplate;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useMutation, useQuery } from "react-query";
 
 import { AppContext } from "context/app";
@@ -13,6 +13,7 @@ import {
 import { getPathWithQueryParams } from "utilities/url";
 
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
+import configAPI from "services/entities/config";
 import hostNameTemplateAPI from "services/entities/host_name_template";
 
 import PATHS from "router/paths";
@@ -37,12 +38,26 @@ const HostNameTemplate = ({
   router,
   onMutation,
 }: IOSSettingsCommonProps) => {
-  const { isPremiumTier, config } = useContext(AppContext);
+  const { isPremiumTier, config, setConfig } = useContext(AppContext);
 
   const mdmEnabled = config?.mdm.enabled_and_configured;
 
+  // "No team" stores its template on the global app config (there is no team
+  // row for No team), mirroring how DiskEncryption sources its value by scope.
+  const isNoTeam = currentTeamId === API_NO_TEAM_ID;
+
   const [nameTemplate, setNameTemplate] = useState<string>();
   const [savedNameTemplate, setSavedNameTemplate] = useState<string>();
+
+  // Seed the No-team value from app config once it's available, and re-seed
+  // after a save refreshes the config. Fleets seed from the team query below.
+  useEffect(() => {
+    if (isNoTeam) {
+      const loaded = config?.mdm.name_template ?? "";
+      setNameTemplate(loaded);
+      setSavedNameTemplate(loaded);
+    }
+  }, [isNoTeam, config?.mdm.name_template]);
 
   const { isLoading: isLoadingTeam, isError: isTeamError } = useQuery<
     ILoadTeamResponse,
@@ -50,7 +65,7 @@ const HostNameTemplate = ({
     ITeamConfig
   >(["team", currentTeamId], () => teamsAPI.load(currentTeamId), {
     ...DEFAULT_USE_QUERY_OPTIONS,
-    enabled: isPremiumTier && !!mdmEnabled && currentTeamId !== API_NO_TEAM_ID,
+    enabled: isPremiumTier && !!mdmEnabled && !isNoTeam,
     select: (res) => res.fleet,
     onSuccess: (res) => {
       const loaded = res.mdm?.name_template ?? "";
@@ -68,11 +83,23 @@ const HostNameTemplate = ({
     (tmpl: string) =>
       hostNameTemplateAPI.updateHostNameTemplate(tmpl, currentTeamId),
     {
-      onSuccess: (_data, tmpl) => {
+      onSuccess: async (_data, tmpl) => {
         // Optimistically adopt the saved value as the new baseline.
         setSavedNameTemplate(tmpl);
         notify.success("Successfully updated host name template.");
         onMutation();
+        // The No-team template lives on the global app config, so refresh the
+        // cached config to keep it in sync (mirrors DiskEncryption).
+        if (isNoTeam) {
+          try {
+            setConfig(await configAPI.loadAll());
+          } catch (err) {
+            notify.error(
+              "Could not retrieve updated app config. Please try again.",
+              { response: err }
+            );
+          }
+        }
       },
       onError: (e) => {
         // The server's 422 carries the specific invalid-variable message;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
@@ -1,16 +1,15 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { useMutation, useQuery } from "react-query";
 
 import { AppContext } from "context/app";
 import { notify } from "components/ToastNotification";
-import { API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
+import { API_NO_TEAM_ID } from "interfaces/team";
 import { getErrorReason } from "interfaces/errors";
 
 import {
   DEFAULT_USE_QUERY_OPTIONS,
   LEARN_MORE_ABOUT_BASE_LINK,
 } from "utilities/constants";
-import { getPathWithQueryParams } from "utilities/url";
 
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import configAPI from "services/entities/config";
@@ -49,35 +48,50 @@ const HostNameTemplate = ({
   const [nameTemplate, setNameTemplate] = useState<string>();
   const [savedNameTemplate, setSavedNameTemplate] = useState<string>();
 
-  // Seed the No-team value from app config once it's available, and re-seed
-  // after a save refreshes the config. Fleets seed from the team query below.
-  useEffect(() => {
-    if (isNoTeam) {
-      const loaded = config?.mdm.name_template ?? "";
-      setNameTemplate(loaded);
-      setSavedNameTemplate(loaded);
+  const {
+    data: teamData,
+    isLoading: isLoadingTeam,
+    isError: isTeamError,
+  } = useQuery<ILoadTeamResponse, Error>(
+    ["team", currentTeamId],
+    () => teamsAPI.load(currentTeamId),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: isPremiumTier && !!mdmEnabled && !isNoTeam,
+      onError: (err) => {
+        notify.error("Couldn't load fleet settings. Please try again.", {
+          response: err,
+        });
+      },
     }
-  }, [isNoTeam, config?.mdm.name_template]);
+  );
 
-  const { isLoading: isLoadingTeam, isError: isTeamError } = useQuery<
-    ILoadTeamResponse,
-    Error,
-    ITeamConfig
-  >(["team", currentTeamId], () => teamsAPI.load(currentTeamId), {
-    ...DEFAULT_USE_QUERY_OPTIONS,
-    enabled: isPremiumTier && !!mdmEnabled && !isNoTeam,
-    select: (res) => res.fleet,
-    onSuccess: (res) => {
-      const loaded = res.mdm?.name_template ?? "";
+  // Seed the form once per scope (team) from whichever source owns the
+  // template — the global app config for "No team", or the team query for a
+  // fleet. An effect keeps state seeding in one place (react-query deprecates
+  // useQuery's onSuccess in newer versions). Guarding on the scope prevents a
+  // post-save config refresh (No team) or a background team refetch from
+  // clobbering in-progress edits; switching teams re-seeds for the new scope.
+  const seededTeamRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (seededTeamRef.current === currentTeamId) {
+      return;
+    }
+    if (isNoTeam) {
+      if (!config) {
+        return; // wait until app config is available
+      }
+      const loaded = config.mdm.name_template ?? "";
       setNameTemplate(loaded);
       setSavedNameTemplate(loaded);
-    },
-    onError: (err) => {
-      notify.error("Couldn't load fleet settings. Please try again.", {
-        response: err,
-      });
-    },
-  });
+      seededTeamRef.current = currentTeamId;
+    } else if (teamData) {
+      const loaded = teamData.fleet?.mdm?.name_template ?? "";
+      setNameTemplate(loaded);
+      setSavedNameTemplate(loaded);
+      seededTeamRef.current = currentTeamId;
+    }
+  }, [currentTeamId, isNoTeam, config, teamData]);
 
   const { mutate: saveNameTemplate, isLoading: updating } = useMutation(
     (tmpl: string) =>
@@ -184,19 +198,12 @@ const HostNameTemplate = ({
         variant="right-panel"
         content={
           <>
-            Set a naming convention for all macOS, iOS, or iPadOS hosts in this
-            fleet. Use{" "}
+            Set a naming convention for all macOS, iOS, or iPadOS hosts{" "}
+            {isNoTeam ? "with no fleet" : "in this fleet"}. Use{" "}
             <CustomLink
               text="built-in"
               url={`${LEARN_MORE_ABOUT_BASE_LINK}/built-in-variables`}
               newTab
-            />{" "}
-            or{" "}
-            <CustomLink
-              text="custom"
-              url={getPathWithQueryParams(PATHS.CONTROLS_VARIABLES, {
-                fleet_id: currentTeamId,
-              })}
             />{" "}
             variables to differentiate between hosts.
           </>

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/_styles.scss
@@ -1,0 +1,9 @@
+.host-name-template {
+  @include vertical-card-layout;
+
+
+  &__content {
+    gap: $pad-large;
+    animation: fade-in 250ms ease-out;
+  }
+}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/index.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HostNameTemplate";

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -15,6 +15,7 @@ export default {
   CONTROLS_CERTIFICATES: `${URL_PREFIX}/controls/os-settings/certificates`,
   CONTROLS_DISK_ENCRYPTION: `${URL_PREFIX}/controls/os-settings/disk-encryption`,
   CONTROLS_PASSWORDS: `${URL_PREFIX}/controls/os-settings/passwords`,
+  CONTROLS_HOST_NAME_TEMPLATE: `${URL_PREFIX}/controls/os-settings/host-name-template`,
   CONTROLS_SETUP_EXPERIENCE: `${URL_PREFIX}/controls/setup-experience`,
   CONTROLS_USERS: `${URL_PREFIX}/controls/setup-experience/users`,
   CONTROLS_BOOTSTRAP_PACKAGE: `${URL_PREFIX}/controls/setup-experience/bootstrap-package`,

--- a/frontend/services/entities/host_name_template.ts
+++ b/frontend/services/entities/host_name_template.ts
@@ -1,0 +1,15 @@
+import sendRequest from "services";
+
+import endpoints from "utilities/endpoints";
+
+const hostNameTemplateService = {
+  updateHostNameTemplate: (nameTemplate: string, teamId: number) => {
+    const { HOST_NAME_TEMPLATE } = endpoints;
+    return sendRequest("POST", HOST_NAME_TEMPLATE, {
+      fleet_id: teamId,
+      name_template: nameTemplate,
+    });
+  },
+};
+
+export default hostNameTemplateService;

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -187,6 +187,7 @@ export default {
   MDM_UPDATE_APPLE_SETTINGS: `/${API_VERSION}/fleet/mdm/apple/settings`,
   PROFILES_STATUS_SUMMARY: `/${API_VERSION}/fleet/configuration_profiles/summary`,
   DISK_ENCRYPTION: `/${API_VERSION}/fleet/disk_encryption`,
+  HOST_NAME_TEMPLATE: `/${API_VERSION}/fleet/host_name_template`,
   MDM_APPLE_SSO: `/${API_VERSION}/fleet/mdm/sso`,
   MDM_APPLE_ENROLLMENT_PROFILE: (
     token: string,


### PR DESCRIPTION
Relates to #48626

<img width="1556" height="722" alt="Screenshot 2026-07-08 at 12 17 47 PM" src="https://github.com/user-attachments/assets/55b6e8ed-933d-4bc1-b50d-ea73e9a43be1" />


Add the "Host names" card under Controls > OS settings for saving a host name template per fleet. Includes the name-template input with Figma copy, premium gating, MDM-not-configured empty state, and GitOps-mode disabled treatment, saving against POST /api/v1/fleet/host_name_template.

- Register CONTROLS_HOST_NAMES route and host_name_template endpoint/service
- Add the card last in the OS-settings nav, hidden for No team (fleets-only) and technicians via the exclude mechanism
- Add name_template to the team MDM config interface
- Add a command palette entry for the card
- Surface the server's 422 message verbatim on save error

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Host names” option in OS settings for eligible premium users.
  * Introduced a screen to view and update the host name template for a team.

* **Bug Fixes**
  * Improved OS settings navigation so the new option only appears in the right contexts.
  * Fixed the settings menu to refresh correctly when switching teams.

* **Tests**
  * Added coverage for the new menu item and host name template behavior, including save states and validation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->