### PR TITLE
Fix lint for linux only code

### DIFF
--- a/orbit/pkg/luks/snapd_client.go
+++ b/orbit/pkg/luks/snapd_client.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package luks
 
 import (

--- a/orbit/pkg/luks/snapd_client_test.go
+++ b/orbit/pkg/luks/snapd_client_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package luks
 
 import (

--- a/orbit/pkg/luks/snapd_fde.go
+++ b/orbit/pkg/luks/snapd_fde.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package luks
 
 import (

--- a/orbit/pkg/luks/snapd_fde_test.go
+++ b/orbit/pkg/luks/snapd_fde_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package luks
 
 import (


### PR DESCRIPTION
- [X] QA'd all new/changed functionality manually

Fixes:
```
make lint-go
[...]
orbit/pkg/luks/snapd_client.go:21:7: const snapdSocketPath is unused (unused)
const snapdSocketPath = "/run/snapd.socket"
      ^
orbit/pkg/luks/snapd_client.go:46:6: func newSnapdClient is unused (unused)
func newSnapdClient() *snapdClient {
     ^
orbit/pkg/luks/snapd_fde.go:62:6: func newSnapdSocketFDE is unused (unused)
func newSnapdSocketFDE() *snapdSocketFDE {
     ^
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux-specific handling for recovery-key and snapd interactions.
  * Added fallback behavior when an existing keyslot causes a conflict, so recovery-key setup can still complete successfully.
  * Better surfaces error messages from failed snapd requests.

* **Tests**
  * Added Linux-only tests covering synchronous and asynchronous snapd request flows.
  * Added coverage for recovery-key creation, polling, fallback replacement, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->