### PR TITLE
Time ago timestamps: use days instead of months when under 90 days

### DIFF
--- a/changes/46965-time-ago-timestamps-use-days
+++ b/changes/46965-time-ago-timestamps-use-days
@@ -1,0 +1,1 @@
+* Updated relative "time ago" timestamps to show days instead of months when the timestamp is less than 90 days ago.

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -8,7 +8,7 @@
 
 import React, { useState } from "react";
 import { useQuery } from "react-query";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import { AxiosError } from "axios";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -134,7 +134,7 @@ export const StatusMessage = ({
   const displayTimeStamp = ["failed_install", "installed"].includes(
     status || ""
   )
-    ? ` (${formatDistanceToNow(new Date(updated_at || created_at), {
+    ? ` (${timeAgo(new Date(updated_at || created_at), {
         includeSeconds: true,
         addSuffix: true,
       })})`

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from "react";
 import { useQuery } from "react-query";
 import { AxiosError } from "axios";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import commandAPI, {
   IGetCommandResultsResponse,
@@ -84,7 +84,7 @@ export const getStatusMessage = ({
   const displayTimestamp =
     ["failed_install", "installed"].includes(displayStatus || "") &&
     commandUpdatedAt
-      ? ` (${formatDistanceToNow(new Date(commandUpdatedAt), {
+      ? ` (${timeAgo(new Date(commandUpdatedAt), {
           includeSeconds: true,
           addSuffix: true,
         })})`

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tsx
@@ -11,7 +11,7 @@
 
 import React, { useState } from "react";
 import { useQuery } from "react-query";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import { AxiosError } from "axios";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -88,7 +88,7 @@ export const StatusMessage = ({
   const displayTimeStamp = ["failed_install", "installed"].includes(
     status || ""
   )
-    ? ` (${formatDistanceToNow(new Date(updated_at || created_at), {
+    ? ` (${timeAgo(new Date(updated_at || created_at), {
         includeSeconds: true,
         addSuffix: true,
       })})`

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AxiosError } from "axios";
 import { useQuery } from "react-query";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import deviceUserAPI from "services/entities/device_user";
 import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
@@ -54,7 +54,7 @@ export const StatusMessage = ({
   const isPending = isPendingStatus(status);
   const displayTimeStamp =
     !isPending && timestamp
-      ? ` (${formatDistanceToNow(new Date(timestamp), {
+      ? ` (${timeAgo(new Date(timestamp), {
           includeSeconds: true,
           addSuffix: true,
         })})`

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from "react";
 import { useQuery } from "react-query";
 import { AxiosError } from "axios";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import commandAPI, {
   IGetCommandResultsResponse,
@@ -96,7 +96,7 @@ export const getStatusMessage = ({
   const displayTimestamp =
     ["failed_install", "installed"].includes(displayStatus || "") &&
     commandUpdatedAt
-      ? ` (${formatDistanceToNow(new Date(commandUpdatedAt), {
+      ? ` (${timeAgo(new Date(commandUpdatedAt), {
           includeSeconds: true,
           addSuffix: true,
         })})`

--- a/frontend/components/LastUpdatedText/LastUpdatedText.tsx
+++ b/frontend/components/LastUpdatedText/LastUpdatedText.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatDistanceToNowStrict } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import { abbreviateTimeUnits } from "utilities/helpers";
 
 import TooltipWrapper from "components/TooltipWrapper";
@@ -31,8 +31,9 @@ const LastUpdatedText = ({
     lastUpdatedAt = "never";
   } else {
     lastUpdatedAt = abbreviateTimeUnits(
-      formatDistanceToNowStrict(new Date(lastUpdatedAt), {
+      timeAgo(new Date(lastUpdatedAt), {
         addSuffix: true,
+        strict: true,
       })
     );
   }

--- a/frontend/components/modals/FailedEnrollmentProfileModal/FailedEnrollmentProfileModal.tsx
+++ b/frontend/components/modals/FailedEnrollmentProfileModal/FailedEnrollmentProfileModal.tsx
@@ -3,7 +3,7 @@ import { ICommandResult } from "interfaces/command";
 import CommandResultsModal, {
   getIconName,
 } from "pages/hosts/components/CommandDetailsModal";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import IconStatusMessage from "components/IconStatusMessage";
 import CustomLink from "components/CustomLink";
 
@@ -17,7 +17,7 @@ const failedEnrollmentProfileContentBody = (
   result: ICommandResult
 ) => {
   const displayTime = result.updated_at
-    ? ` (${formatDistanceToNow(new Date(result.updated_at), {
+    ? ` (${timeAgo(new Date(result.updated_at), {
         includeSeconds: true,
         addSuffix: true,
       })})`

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useState } from "react";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import { useQuery } from "react-query";
 import { isEmpty } from "lodash";
 import { InjectedRouter } from "react-router";
@@ -517,8 +517,8 @@ const ActivityFeed = ({
             const cmdDisplayName = getMdmCommandDisplayName(
               result.request_type
             );
-            const timeAgo = result.updated_at
-              ? ` (${formatDistanceToNow(new Date(result.updated_at), {
+            const timeAgoText = result.updated_at
+              ? ` (${timeAgo(new Date(result.updated_at), {
                   addSuffix: true,
                 })})`
               : "";
@@ -540,7 +540,7 @@ const ActivityFeed = ({
                       )}
                       {" is pending on "}
                       <b>{result.hostname}</b>
-                      {`${timeAgo}.`}
+                      {`${timeAgoText}.`}
                     </span>
                   ) : (
                     <span>

--- a/frontend/pages/DashboardPage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/DashboardPage/cards/WelcomeHost/WelcomeHost.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import PATHS from "router/paths";
 import { useQuery } from "react-query";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import { notify } from "components/ToastNotification";
 import { IHost, IHostResponse } from "interfaces/host";
@@ -274,7 +274,7 @@ const WelcomeHost = ({
           </Button>
           <span>
             Last updated{" "}
-            {formatDistanceToNow(new Date(host.detail_updated_at), {
+            {timeAgo(new Date(host.detail_updated_at), {
               addSuffix: true,
             })}
           </span>

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -203,7 +203,8 @@ const Certificates = ({
 
             const details = (
               <>
-                {caName} &bull; Updated {timeAgo(new Date(created_at))} ago
+                {caName} &bull; Updated{" "}
+                {timeAgo(new Date(created_at), { addSuffix: true })}
               </>
             );
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useContext } from "react";
 import { AxiosError } from "axios";
 import { useQuery } from "react-query";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import { AppContext } from "context/app";
 import PATHS from "router/paths";
@@ -203,8 +203,7 @@ const Certificates = ({
 
             const details = (
               <>
-                {caName} &bull; Updated{" "}
-                {formatDistanceToNow(new Date(created_at))} ago
+                {caName} &bull; Updated {timeAgo(new Date(created_at))} ago
               </>
             );
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/ViewCertificateModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/ViewCertificateModal/ViewCertificateModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import { ICertificate } from "services/entities/certificates";
 
@@ -32,7 +32,7 @@ const ViewCertificateModal = ({ cert, onExit }: IViewCertificateModalProps) => {
             <DataSet title="Certificate authority" value={caName} />
             <DataSet
               title="Added"
-              value={`${formatDistanceToNow(new Date(created_at))} ago`}
+              value={timeAgo(new Date(created_at), { addSuffix: true })}
             />
           </div>
           <InputField

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { format, formatDistanceToNow } from "date-fns";
+import { format } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import FileSaver from "file-saver";
 import classnames from "classnames";
 
@@ -62,7 +63,7 @@ const ProfileDetails = ({
       <span className={`${baseClass}__platform`}>{getPlatformName()}</span>
       <span>&bull;</span>
       <span className={`${baseClass}__list-item-uploaded`}>
-        {`Uploaded ${formatDistanceToNow(new Date(uploadedAt))} ago`}
+        {`Uploaded ${timeAgo(new Date(uploadedAt))} ago`}
       </span>
     </div>
   );

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
@@ -63,7 +63,7 @@ const ProfileDetails = ({
       <span className={`${baseClass}__platform`}>{getPlatformName()}</span>
       <span>&bull;</span>
       <span className={`${baseClass}__list-item-uploaded`}>
-        {`Uploaded ${timeAgo(new Date(uploadedAt))} ago`}
+        {`Uploaded ${timeAgo(new Date(uploadedAt), { addSuffix: true })}`}
       </span>
     </div>
   );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import URL_PREFIX from "router/url_prefix";
 
 import { IBootstrapPackageMetadata } from "interfaces/mdm";
@@ -68,9 +68,7 @@ const BootstrapPackageListItem = ({
             {bootstrapPackage.name}
           </span>
           <span className={`${baseClass}__list-item-uploaded`}>
-            {`Uploaded ${formatDistanceToNow(
-              new Date(bootstrapPackage.created_at)
-            )} ago`}
+            {`Uploaded ${timeAgo(new Date(bootstrapPackage.created_at))} ago`}
           </span>
         </div>
       </div>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
@@ -68,7 +68,9 @@ const BootstrapPackageListItem = ({
             {bootstrapPackage.name}
           </span>
           <span className={`${baseClass}__list-item-uploaded`}>
-            {`Uploaded ${timeAgo(new Date(bootstrapPackage.created_at))} ago`}
+            {`Uploaded ${timeAgo(new Date(bootstrapPackage.created_at), {
+              addSuffix: true,
+            })}`}
           </span>
         </div>
       </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaListItem/EulaListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaListItem/EulaListItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import endpoints from "utilities/endpoints";
 import { IEulaMetadataResponse } from "services/entities/mdm";
@@ -30,9 +30,7 @@ const EulaListItem = ({ eulaData, onDelete }: IEulaListItemProps) => {
             {eulaData.name}
           </span>
           <span className={`${baseClass}__list-item-uploaded`}>
-            {`Uploaded ${formatDistanceToNow(
-              new Date(eulaData.created_at)
-            )} ago`}
+            {`Uploaded ${timeAgo(new Date(eulaData.created_at))} ago`}
           </span>
         </div>
       </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaListItem/EulaListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaListItem/EulaListItem.tsx
@@ -30,7 +30,9 @@ const EulaListItem = ({ eulaData, onDelete }: IEulaListItemProps) => {
             {eulaData.name}
           </span>
           <span className={`${baseClass}__list-item-uploaded`}>
-            {`Uploaded ${timeAgo(new Date(eulaData.created_at))} ago`}
+            {`Uploaded ${timeAgo(new Date(eulaData.created_at), {
+              addSuffix: true,
+            })}`}
           </span>
         </div>
       </div>

--- a/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tsx
+++ b/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useQuery } from "react-query";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
@@ -63,7 +63,7 @@ export const getVerbForCommandStatus = (status: string): string => {
 
 const getStatusMessage = (result: ICommandResult): React.ReactNode => {
   const displayTime = result.updated_at
-    ? ` (${formatDistanceToNow(new Date(result.updated_at), {
+    ? ` (${timeAgo(new Date(result.updated_at), {
         includeSeconds: true,
         addSuffix: true,
       })})`

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useCallback, useEffect } from "react";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 import { Params, InjectedRouter } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
@@ -1875,8 +1875,8 @@ const HostDetailsPage = ({
                 const cmdDisplayName = getMdmCommandDisplayName(
                   result.request_type
                 );
-                const timeAgo = result.updated_at
-                  ? ` (${formatDistanceToNow(new Date(result.updated_at), {
+                const timeAgoText = result.updated_at
+                  ? ` (${timeAgo(new Date(result.updated_at), {
                       addSuffix: true,
                     })})`
                   : "";
@@ -1898,7 +1898,7 @@ const HostDetailsPage = ({
                           )}
                           {" is pending on "}
                           <b>{result.hostname}</b>
-                          {`${timeAgo}.`}
+                          {`${timeAgoText}.`}
                         </span>
                       ) : (
                         <span>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/components/ScriptStatusCell/ScriptStatusCell.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/components/ScriptStatusCell/ScriptStatusCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "utilities/date_format";
 
 import { ILastExecution, IScriptExecutionStatus } from "interfaces/script";
 
@@ -50,10 +50,9 @@ const ScriptStatusCell = ({ lastExecution }: IScriptStatusCellProps) => {
     lastExecution.status
   ];
 
-  const humanizedExecutedAt = formatDistanceToNow(
-    new Date(lastExecution.executed_at),
-    { includeSeconds: true }
-  );
+  const humanizedExecutedAt = timeAgo(new Date(lastExecution.executed_at), {
+    includeSeconds: true,
+  });
 
   return (
     <StatusIndicatorWithIcon

--- a/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssuesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssuesTableConfig.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { capitalize } from "lodash";
 
-import { formatDistanceToNowStrict } from "date-fns";
 import { abbreviateTimeUnits } from "utilities/helpers";
+import { timeAgo } from "utilities/date_format";
 
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
@@ -107,8 +107,9 @@ export const munkiIssuesTableHeaders: IDataColumn[] = [
     accessor: "created_at",
     Cell: (cellProps: IStringCellProps) => {
       const time = abbreviateTimeUnits(
-        formatDistanceToNowStrict(new Date(cellProps.cell.value), {
+        timeAgo(new Date(cellProps.cell.value), {
           addSuffix: true,
+          strict: true,
         })
       );
       return <TextCell value={time} />;

--- a/frontend/utilities/date_format/date_format.tests.ts
+++ b/frontend/utilities/date_format/date_format.tests.ts
@@ -8,6 +8,14 @@ import {
 } from ".";
 
 describe("date_format utilities", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-06-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe("uploadedFromNow util", () => {
     it("returns an user friendly uploaded message", () => {
       const currentDate = new Date();

--- a/frontend/utilities/date_format/date_format.tests.ts
+++ b/frontend/utilities/date_format/date_format.tests.ts
@@ -4,6 +4,7 @@ import {
   addedFromNow,
   uploadedFromNow,
   monthDayTimeFormat,
+  timeAgo,
 } from ".";
 
 describe("date_format utilities", () => {
@@ -48,6 +49,45 @@ describe("date_format utilities", () => {
       date.setDate(date.getDate() - 2);
 
       expect(dateAgo(date)).toEqual("2 days ago");
+    });
+
+    const daysAgo = (n: number) =>
+      new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+
+    it("uses days below the month threshold", () => {
+      expect(dateAgo(daysAgo(5))).toEqual("5 days ago");
+      expect(dateAgo(daysAgo(29))).toEqual("29 days ago");
+      expect(dateAgo(daysAgo(30))).toEqual("30 days ago");
+      expect(dateAgo(daysAgo(40))).toEqual("40 days ago");
+      expect(dateAgo(daysAgo(60))).toEqual("60 days ago");
+      expect(dateAgo(daysAgo(89))).toEqual("89 days ago");
+    });
+
+    it("uses months at or beyond 90 days", () => {
+      expect(dateAgo(daysAgo(90))).toEqual("3 months ago");
+      expect(dateAgo(daysAgo(100))).toEqual("3 months ago");
+    });
+  });
+
+  describe("timeAgo util", () => {
+    const daysAgo = (n: number) =>
+      new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+
+    it("omits the `ago` suffix by default and adds it when requested", () => {
+      expect(timeAgo(daysAgo(40))).toEqual("40 days");
+      expect(timeAgo(daysAgo(40), { addSuffix: true })).toEqual("40 days ago");
+      expect(timeAgo(daysAgo(89), { addSuffix: true })).toEqual("89 days ago");
+    });
+
+    it("switches to months at 90 days", () => {
+      expect(timeAgo(daysAgo(90), { addSuffix: true })).toEqual("3 months ago");
+    });
+
+    // strict avoids the "about" prefix outside the day window.
+    it("supports the strict variant outside the window", () => {
+      expect(timeAgo(daysAgo(100), { addSuffix: true, strict: true })).toEqual(
+        "3 months ago"
+      );
     });
   });
 

--- a/frontend/utilities/date_format/index.ts
+++ b/frontend/utilities/date_format/index.ts
@@ -1,29 +1,73 @@
-import { format, formatDistanceToNow, isValid, parseISO } from "date-fns";
+import {
+  differenceInDays,
+  format,
+  formatDistanceToNow,
+  formatDistanceToNowStrict,
+  isValid,
+  parseISO,
+} from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
+
+/** Below this many days ago, relative timestamps are expressed in days rather
+ * than months (see issue #46965). */
+const DAYS_BEFORE_MONTHS = 90;
+
+interface ITimeAgoOptions {
+  addSuffix?: boolean;
+  includeSeconds?: boolean;
+  /** Base the out-of-window result on formatDistanceToNowStrict rather than
+   * formatDistanceToNow (e.g. "1 month" instead of "about 1 month"). */
+  strict?: boolean;
+}
+
+/** Relative "time ago" string that shows days (e.g. "45 days ago") for
+ * anything under 90 days old, switching to months only beyond that. This is
+ * the single source of truth for the day/month cutoff so it stays consistent
+ * everywhere; prefer it over calling date-fns' formatDistanceToNow directly.
+ *
+ * NOTE: Malformed dates will result in errors. This is expected "fail loudly"
+ * behavior. */
+export const timeAgo = (
+  date: Date,
+  {
+    addSuffix = false,
+    includeSeconds = false,
+    strict = false,
+  }: ITimeAgoOptions = {}
+): string => {
+  // date-fns switches to the month unit in the final seconds before day 30
+  // (it rounds), whereas differenceInDays truncates and reports 29 there, so
+  // 29 is the lower bound that reliably captures that last-day sliver.
+  const days = Math.abs(differenceInDays(new Date(), date));
+  if (days >= 29 && days < DAYS_BEFORE_MONTHS) {
+    return formatDistanceToNowStrict(date, { unit: "day", addSuffix });
+  }
+  if (strict) {
+    return formatDistanceToNowStrict(date, { addSuffix });
+  }
+  return formatDistanceToNow(date, { addSuffix, includeSeconds });
+};
 
 /** Utility to create a string from a date in this format:
   `Uploaded .... ago`
 */
 export const uploadedFromNow = (date: string) => {
-  // NOTE: Malformed dates will result in errors. This is expected "fail loudly" behavior.
-  return `Uploaded ${formatDistanceToNow(new Date(date), { addSuffix: true })}`;
+  return `Uploaded ${timeAgo(new Date(date), { addSuffix: true })}`;
 };
 
 /** Utility to create a string from a date in this format:
   `Added .... ago`
 */
 export const addedFromNow = (date: string) => {
-  // NOTE: Malformed dates will result in errors. This is expected "fail loudly" behavior.
-  return `Added ${formatDistanceToNow(new Date(date), { addSuffix: true })}`;
+  return `Added ${timeAgo(new Date(date), { addSuffix: true })}`;
 };
 
 /** Utility to create a string from a date in this format:
     `.... ago`
 */
 export const dateAgo = (date: string | Date) => {
-  // NOTE: Malformed dates will result in errors. This is expected "fail loudly" behavior.
   date = date instanceof Date ? date : new Date(date);
-  return `${formatDistanceToNow(date, { addSuffix: true })}`;
+  return `${timeAgo(date, { addSuffix: true })}`;
 };
 
 /**

--- a/frontend/utilities/helpers.tests.tsx
+++ b/frontend/utilities/helpers.tests.tsx
@@ -4,6 +4,7 @@ import helpers, {
   removeOSPrefix,
   compareVersions,
   willExpireWithinXDays,
+  humanLastSeen,
 } from "./helpers";
 
 describe("helpers utilities", () => {
@@ -76,6 +77,18 @@ describe("helpers utilities", () => {
 
       const fiftyDaysAgo = getPastDate(50);
       expect(willExpireWithinXDays(fiftyDaysAgo, 30)).toEqual(false);
+    });
+  });
+
+  describe("humanLastSeen function", () => {
+    it("uses days below the month threshold", () => {
+      expect(humanLastSeen(getPastDate(5))).toEqual("5 days ago");
+      expect(humanLastSeen(getPastDate(89))).toEqual("89 days ago");
+    });
+
+    it("uses months at or beyond 90 days", () => {
+      expect(humanLastSeen(getPastDate(90))).toEqual("3 months ago");
+      expect(humanLastSeen(getPastDate(100))).toEqual("3 months ago");
     });
   });
 

--- a/frontend/utilities/helpers.tests.tsx
+++ b/frontend/utilities/helpers.tests.tsx
@@ -81,6 +81,14 @@ describe("helpers utilities", () => {
   });
 
   describe("humanLastSeen function", () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date("2026-06-15T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it("uses days below the month threshold", () => {
       expect(humanLastSeen(getPastDate(5))).toEqual("5 days ago");
       expect(humanLastSeen(getPastDate(89))).toEqual("89 days ago");

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -13,7 +13,6 @@ import {
 } from "lodash";
 import md5 from "js-md5";
 import {
-  formatDistanceToNow,
   formatDuration,
   intlFormat,
   intervalToDuration,
@@ -22,6 +21,7 @@ import {
 } from "date-fns";
 
 import { QueryParams, buildQueryStringFromParams } from "utilities/url";
+import { timeAgo } from "utilities/date_format";
 import { IHost } from "interfaces/host";
 import { ILabel } from "interfaces/label";
 import { IPack } from "interfaces/pack";
@@ -578,14 +578,14 @@ export const humanHostLastSeen = (lastSeen: string): string => {
   if (lastSeen === "Unavailable") {
     return "Unavailable";
   }
-  return formatDistanceToNow(new Date(lastSeen), { addSuffix: true });
+  return timeAgo(new Date(lastSeen), { addSuffix: true });
 };
 
 export const humanHostEnrolled = (enrolled: string): string => {
   if (!enrolled || enrolled < INITIAL_FLEET_DATE) {
     return "Never";
   }
-  return formatDistanceToNow(new Date(enrolled), { addSuffix: true });
+  return timeAgo(new Date(enrolled), { addSuffix: true });
 };
 
 export const humanHostMemory = (bytes: number): string => {
@@ -599,7 +599,7 @@ export const humanHostDetailUpdated = (detailUpdated?: string): string => {
     return "unavailable";
   }
   try {
-    return formatDistanceToNow(new Date(detailUpdated), { addSuffix: true });
+    return timeAgo(new Date(detailUpdated), { addSuffix: true });
   } catch {
     return "unavailable";
   }
@@ -614,7 +614,7 @@ export const humanLastSeen = (lastSeen: string): string => {
     return "Unavailable";
   }
 
-  return formatDistanceToNow(new Date(lastSeen), { addSuffix: true });
+  return timeAgo(new Date(lastSeen), { addSuffix: true });
 };
 
 export const internationalTimeFormat = (date: number | Date): string => {
@@ -651,7 +651,7 @@ export const humanQueryLastRun = (lastRun: string): string => {
   }
 
   try {
-    return formatDistanceToNow(new Date(lastRun), { addSuffix: true });
+    return timeAgo(new Date(lastRun), { addSuffix: true });
   } catch {
     return "Unavailable";
   }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46965

Relative "time ago" timestamps switched to months at ~30 days, so a timestamp 45 days ago read "about 2 months ago" (even 89 days showed "3 months ago"). This centralizes the day/month cutoff in a new `timeAgo` helper and routes existing call sites through it, so anything under 90 days is shown in days.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relative “time ago” timestamps now keep values in **days** for items under **90 days**, switching to **months** later for more accurate wording.
  * Improved consistency of relative time labels across status modals, activity feeds, host details, and management screens (including “last updated,” “uploaded,” and “added” text).
* **Tests**
  * Added/updated coverage for the shared relative-time cutoff and formatting behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->