### PR TITLE
Move website workflows under the workflows folder in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -143,6 +143,11 @@ go.mod @fleetdm/go
 #/.github/ISSUE_TEMPLATE     @mikermcneil @sampfluger88 @lukeheath  # Covered in custom.js See https://github.com/fleetdm/fleet/pull/18668
 
 ##############################################################################################
+# 🚀 GitHub workflows
+##############################################################################################
+/.github/workflows/ @georgekarrv @sharon-fdm @lukeheath @lucasmrod @getvictor
+
+##############################################################################################
 # 🌐 GitHub workflows
 ##############################################################################################
 /.github/workflows/markdown-link-check-config.json @eashaw
@@ -151,11 +156,6 @@ go.mod @fleetdm/go
 /.github/workflows/test-vulnerability-dashboard-changes.yml @eashaw
 /.github/workflows/docs.yml @eashaw
 /.github/workflows/deploy-fleet-website.yml @eashaw
-
-##############################################################################################
-# 🚀 GitHub workflows
-##############################################################################################
-/.github/workflows/ @georgekarrv @sharon-fdm @lukeheath @lucasmrod @getvictor
 
 ##############################################################################################
 # 🤖 Claude Code configuration (agents, skills, rules, settings).


### PR DESCRIPTION
Changes:
- Moved the website-related GitHub workflows below the `/.github/workflows/` folder in CODEOWNERS. The last matching rule is applied, so changes to the website workflows currently require a review from one of the folder codeowners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized review rules for workflow-related changes to make the policy easier to find and maintain.
  * No product behavior or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->