### PR TITLE
Add host name row to host details OS settings modal

### DIFF
--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -12,6 +12,7 @@ import {
   MdmEnrollmentStatus,
   BootstrapPackageStatus,
   DiskEncryptionStatus,
+  HostNameSettingStatus,
 } from "./mdm";
 import { HostPlatform } from "./platform";
 
@@ -118,6 +119,11 @@ export type RecoveryLockPasswordStatus =
   | "pending"
   | "failed";
 
+export interface IHostMdmHostNameSetting {
+  status: HostNameSettingStatus;
+  detail: string;
+}
+
 // Prefer this over IMdmMacOsSettings, introduced MDM has expanded to non-mac platforms
 export interface IOSSettings {
   disk_encryption: {
@@ -129,6 +135,7 @@ export interface IOSSettings {
     detail: string;
     password_available: boolean;
   };
+  host_name?: IHostMdmHostNameSetting;
   managed_local_account?: {
     status: string | null;
     password_available: boolean;

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -263,6 +263,10 @@ export type RecoveryLockPasswordStatus =
   | "removing_enforcement"
   | "failed";
 
+// The host name template statuses are exactly the profile-delivery statuses, so
+// we alias MdmProfileStatus rather than re-declaring the same union.
+export type HostNameSettingStatus = MdmProfileStatus;
+
 export interface IMdmSSOResponse {
   url: string;
 }

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -800,6 +800,13 @@ const HostDetailsPage = ({
     return hostAPI.rotateRecoveryLockPassword(host.id);
   }, [host?.id]);
 
+  const resendHostNameTemplate = useCallback((): Promise<void> => {
+    if (!host?.id) {
+      return Promise.resolve();
+    }
+    return hostAPI.resendNameTemplate(host.id);
+  }, [host?.id]);
+
   const onChangeActivityTab = (tabIndex: number) => {
     setActiveActivityTab(tabIndex === 0 ? "past" : "upcoming");
     setActivityPage(0);
@@ -1738,12 +1745,14 @@ const HostDetailsPage = ({
                 isHostTeamAdmin ||
                 isHostTeamMaintainer
               }
+              canResendHostNameTemplate={canResendProfiles}
               platform={host.platform}
               hostMDMData={host.mdm}
               onClose={toggleOSSettingsModal}
               resendRequest={resendProfile}
               resendCertificateRequest={resendCertificate}
               rotateRecoveryLockPassword={rotateRecoveryLockPassword}
+              resendHostNameTemplate={resendHostNameTemplate}
               onProfileResent={refetchHostDetails}
             />
           )}

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
@@ -13,12 +13,15 @@ interface IOSSettingsModalProps {
   canResendProfiles?: boolean;
   /** controls showing the rotate action for the recovery lock password row. Defaults to `false` */
   canRotateRecoveryLockPassword?: boolean;
+  /** controls showing the resend action for the host name template row. Defaults to `false` */
+  canResendHostNameTemplate?: boolean;
   /** This request method will be called when a user clicks on the resend button.
    * This behaviour is dynamic based on the page this modal is rendered on
    * so we allow the request function to be passed in */
   resendRequest: (profileUUID: string) => Promise<void>;
   resendCertificateRequest?: (certificateTemplateId: number) => Promise<void>;
   rotateRecoveryLockPassword?: () => Promise<void>;
+  resendHostNameTemplate?: () => Promise<void>;
   onClose: () => void;
   /** handler that fires when a profile was reset. Requires `canResendProfiles` prop
    * to be `true`, otherwise has no effect.
@@ -33,10 +36,12 @@ const OSSettingsModal = ({
   hostMDMData,
   canResendProfiles = false,
   canRotateRecoveryLockPassword = false,
+  canResendHostNameTemplate = false,
   onClose,
   resendRequest,
   resendCertificateRequest,
   rotateRecoveryLockPassword,
+  resendHostNameTemplate,
   onProfileResent,
 }: IOSSettingsModalProps) => {
   // the caller should ensure that hostMDMData is not undefined and that platform is supported otherwise we will allow an empty modal will be rendered.
@@ -57,10 +62,12 @@ const OSSettingsModal = ({
       <OSSettingsTable
         canResendProfiles={canResendProfiles}
         canRotateRecoveryLockPassword={canRotateRecoveryLockPassword}
+        canResendHostNameTemplate={canResendHostNameTemplate}
         tableData={memoizedTableData ?? []}
         resendRequest={resendRequest}
         resendCertificateRequest={resendCertificateRequest}
         rotateRecoveryLockPassword={rotateRecoveryLockPassword}
+        resendHostNameTemplate={resendHostNameTemplate}
         onProfileResent={onProfileResent}
       />
       <div className="modal-cta-wrap">

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
@@ -6,6 +6,7 @@ import {
   FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID,
   ProfileOperationType,
 } from "interfaces/mdm";
+import { HOST_NAME_SYNTHETIC_PROFILE_UUID } from "pages/hosts/details/helpers";
 import OSSettingStatusCell from "./OSSettingStatusCell";
 
 describe("OS setting status cell", () => {
@@ -195,6 +196,97 @@ describe("OS setting status cell", () => {
       expect(
         screen.getByText(/The host is running the command/)
       ).toBeInTheDocument();
+    });
+  });
+
+  // Host name template synthetic row
+  describe("host name template row", () => {
+    it("displays 'Enforcing' for pending status", async () => {
+      const customRender = createCustomRenderer();
+
+      const { user } = customRender(
+        <OSSettingStatusCell
+          profileName="Host name"
+          status="pending"
+          operationType={null}
+          hostPlatform="darwin"
+          profileUUID={HOST_NAME_SYNTHETIC_PROFILE_UUID}
+        />
+      );
+
+      const statusText = screen.getByText("Enforcing");
+      expect(statusText).toBeInTheDocument();
+
+      await user.hover(statusText);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Fleet is enforcing this fleet's host name template/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("displays 'Verifying' for verifying status", () => {
+      render(
+        <OSSettingStatusCell
+          profileName="Host name"
+          status="verifying"
+          operationType={null}
+          hostPlatform="ios"
+          profileUUID={HOST_NAME_SYNTHETIC_PROFILE_UUID}
+        />
+      );
+
+      expect(screen.getByText("Verifying")).toBeInTheDocument();
+    });
+
+    it("displays 'Verified' for verified status", () => {
+      render(
+        <OSSettingStatusCell
+          profileName="Host name"
+          status="verified"
+          operationType={null}
+          hostPlatform="ipados"
+          profileUUID={HOST_NAME_SYNTHETIC_PROFILE_UUID}
+        />
+      );
+
+      expect(screen.getByText("Verified")).toBeInTheDocument();
+    });
+
+    it("displays 'Failed' and shows the profile detail in the tooltip", async () => {
+      const customRender = createCustomRenderer();
+
+      const detail =
+        "Host was renamed on the device and no longer matches the fleet's naming template.";
+      const profile = createMockHostMdmProfile({
+        profile_uuid: HOST_NAME_SYNTHETIC_PROFILE_UUID,
+        name: "Host name",
+        platform: "darwin",
+        operation_type: null,
+        status: "failed",
+        detail,
+      });
+
+      const { user } = customRender(
+        <OSSettingStatusCell
+          profileName="Host name"
+          status="failed"
+          operationType={null}
+          hostPlatform="darwin"
+          profileUUID={HOST_NAME_SYNTHETIC_PROFILE_UUID}
+          profile={profile}
+        />
+      );
+
+      const statusText = screen.getByText("Failed");
+      expect(statusText).toBeInTheDocument();
+
+      // With a null failed tooltip config, the cell falls through to the
+      // detail-based error tooltip (generateErrorTooltip).
+      await user.hover(statusText);
+      await waitFor(() => {
+        expect(screen.getByText(detail)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 
-import { REC_LOCK_SYNTHETIC_PROFILE_UUID } from "pages/hosts/details/helpers";
+import {
+  HOST_NAME_SYNTHETIC_PROFILE_UUID,
+  REC_LOCK_SYNTHETIC_PROFILE_UUID,
+} from "pages/hosts/details/helpers";
 
 import Icon from "components/Icon";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import {
   FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID,
+  HostNameSettingStatus,
   LinuxDiskEncryptionStatus,
   ProfileOperationType,
   ProfilePlatform,
@@ -20,6 +24,7 @@ import {
 import TooltipContent from "./components/Tooltip/TooltipContent";
 import generateErrorTooltip from "./errorTooltipHelpers";
 import {
+  HOST_NAME_DISPLAY_CONFIG,
   isDiskEncryptionProfile,
   LINUX_DISK_ENCRYPTION_DISPLAY_CONFIG,
   PROFILE_DISPLAY_CONFIG,
@@ -58,6 +63,8 @@ const OSSettingStatusCell = ({
       RECOVERY_LOCK_PASSWORD_DISPLAY_CONFIG[
         status as RecoveryLockPasswordStatus
       ];
+  } else if (profileUUID === HOST_NAME_SYNTHETIC_PROFILE_UUID) {
+    displayOption = HOST_NAME_DISPLAY_CONFIG[status as HostNameSettingStatus];
   }
 
   // Android host certificate templates.

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/helpers.ts
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/helpers.ts
@@ -1,5 +1,6 @@
 import {
   FLEET_FILEVAULT_PROFILE_DISPLAY_NAME,
+  HostNameSettingStatus,
   ProfileOperationType,
   RecoveryLockPasswordStatus,
 } from "interfaces/mdm";
@@ -172,6 +173,37 @@ export const LINUX_DISK_ENCRYPTION_DISPLAY_CONFIG: LinuxDiskEncryptionDisplayCon
     statusText: "Action required",
     iconName: "pending-outline",
     tooltip: TooltipInnerContentActionRequired as TooltipInnerContentFunc,
+  },
+};
+
+export const HOST_NAME_DISPLAY_CONFIG: Record<
+  HostNameSettingStatus,
+  ProfileDisplayOption
+> = {
+  pending: {
+    statusText: "Enforcing",
+    iconName: "pending-outline",
+    tooltip:
+      "Fleet is enforcing this fleet's host name template. The host will be renamed when it comes online.",
+  },
+  verifying: {
+    statusText: "Verifying",
+    iconName: "success-outline",
+    tooltip:
+      "The host acknowledged the MDM command to rename it. Fleet is verifying.",
+  },
+  verified: {
+    statusText: "Verified",
+    iconName: "success",
+    tooltip:
+      "The host was renamed to match this fleet's host name template. Fleet verified.",
+  },
+  // failed has no static tooltip so the cell falls back to the error-detail
+  // tooltip (drift message or Apple error) via generateErrorTooltip.
+  failed: {
+    statusText: "Failed",
+    iconName: "error",
+    tooltip: null,
   },
 };
 

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tests.tsx
@@ -1,9 +1,12 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { createMockHostMdmProfile } from "__mocks__/hostMock";
 
-import { REC_LOCK_SYNTHETIC_PROFILE_UUID } from "pages/hosts/details/helpers";
+import {
+  HOST_NAME_SYNTHETIC_PROFILE_UUID,
+  REC_LOCK_SYNTHETIC_PROFILE_UUID,
+} from "pages/hosts/details/helpers";
 
 import OSSettingsResendCell from "./OSSettingsResendCell";
 
@@ -108,5 +111,107 @@ describe("OSSettingsResendCell", () => {
     expect(
       screen.queryByRole("button", { name: "Rotate" })
     ).not.toBeInTheDocument();
+  });
+
+  describe("host name template row", () => {
+    it("renders a resend button when canResendHostNameTemplate is true and status is failed", () => {
+      render(
+        <OSSettingsResendCell
+          canResendProfiles={false}
+          canResendHostNameTemplate
+          profile={createMockHostMdmProfile({
+            profile_uuid: HOST_NAME_SYNTHETIC_PROFILE_UUID,
+            status: "failed",
+          })}
+          resendRequest={noop}
+          resendHostNameTemplate={noop}
+        />
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Resend" })
+      ).toBeInTheDocument();
+    });
+
+    it("renders a resend button when canResendHostNameTemplate is true and status is verified", () => {
+      render(
+        <OSSettingsResendCell
+          canResendProfiles={false}
+          canResendHostNameTemplate
+          profile={createMockHostMdmProfile({
+            profile_uuid: HOST_NAME_SYNTHETIC_PROFILE_UUID,
+            status: "verified",
+          })}
+          resendRequest={noop}
+          resendHostNameTemplate={noop}
+        />
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Resend" })
+      ).toBeInTheDocument();
+    });
+
+    it("does not render a resend button when status is pending", () => {
+      render(
+        <OSSettingsResendCell
+          canResendProfiles={false}
+          canResendHostNameTemplate
+          profile={createMockHostMdmProfile({
+            profile_uuid: HOST_NAME_SYNTHETIC_PROFILE_UUID,
+            status: "pending",
+          })}
+          resendRequest={noop}
+          resendHostNameTemplate={noop}
+        />
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Resend" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render a resend button when canResendHostNameTemplate is false (e.g. device user page)", () => {
+      render(
+        <OSSettingsResendCell
+          canResendProfiles={false}
+          canResendHostNameTemplate={false}
+          profile={createMockHostMdmProfile({
+            profile_uuid: HOST_NAME_SYNTHETIC_PROFILE_UUID,
+            status: "failed",
+          })}
+          resendRequest={noop}
+        />
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Resend" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("calls resendHostNameTemplate (not resendRequest) when clicked", async () => {
+      const resendHostNameTemplate = jest.fn(() => Promise.resolve());
+      const resendRequest = jest.fn(() => Promise.resolve());
+
+      render(
+        <OSSettingsResendCell
+          canResendProfiles={false}
+          canResendHostNameTemplate
+          profile={createMockHostMdmProfile({
+            profile_uuid: HOST_NAME_SYNTHETIC_PROFILE_UUID,
+            status: "failed",
+          })}
+          resendRequest={resendRequest}
+          resendHostNameTemplate={resendHostNameTemplate}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Resend" }));
+
+      await waitFor(() => {
+        expect(resendHostNameTemplate).toHaveBeenCalledTimes(1);
+      });
+      expect(resendRequest).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tsx
@@ -2,7 +2,10 @@ import React, { useState } from "react";
 import classnames from "classnames";
 import { noop } from "lodash";
 
-import { REC_LOCK_SYNTHETIC_PROFILE_UUID } from "pages/hosts/details/helpers";
+import {
+  HOST_NAME_SYNTHETIC_PROFILE_UUID,
+  REC_LOCK_SYNTHETIC_PROFILE_UUID,
+} from "pages/hosts/details/helpers";
 
 import { FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID } from "interfaces/mdm";
 import { getErrorReason } from "interfaces/errors";
@@ -70,20 +73,24 @@ const RotateButton = ({ isRotating, onClick }: IRotateButtonProps) => {
 interface IOSSettingsResendCellProps {
   canResendProfiles: boolean;
   canRotateRecoveryLockPassword?: boolean;
+  canResendHostNameTemplate?: boolean;
   profile: IHostMdmProfileWithAddedStatus;
   resendRequest: (profileUUID: string) => Promise<void>;
   resendCertificateRequest?: (certificateTemplateId: number) => Promise<void>;
   rotateRecoveryLockPassword?: () => Promise<void>;
+  resendHostNameTemplate?: () => Promise<void>;
   onProfileResent?: () => void;
 }
 
 const OSSettingsResendCell = ({
   canResendProfiles,
   canRotateRecoveryLockPassword = false,
+  canResendHostNameTemplate = false,
   profile,
   resendRequest,
   resendCertificateRequest,
   rotateRecoveryLockPassword,
+  resendHostNameTemplate,
   onProfileResent = noop,
 }: IOSSettingsResendCellProps) => {
   const [isResending, setIsResending] = useState(false);
@@ -131,14 +138,38 @@ const OSSettingsResendCell = ({
     setIsRotating(false);
   };
 
+  const onResendHostNameTemplate = async () => {
+    if (!resendHostNameTemplate) return;
+    setIsResending(true);
+    try {
+      await resendHostNameTemplate();
+      onProfileResent();
+    } catch (e) {
+      notify.error("Couldn't resend. Please try again.", { response: e });
+    }
+    setIsResending(false);
+  };
+
   const isFailed = profile.status === "failed";
   const isVerified = profile.status === "verified";
+  const isRecoveryLockRow =
+    profile.profile_uuid === REC_LOCK_SYNTHETIC_PROFILE_UUID;
+  const isHostNameRow =
+    profile.profile_uuid === HOST_NAME_SYNTHETIC_PROFILE_UUID;
+
+  // The host name row is a synthetic row resent through its own endpoint, so it
+  // must not go through the profile-resend path above.
   const showResendButton =
     canResendProfiles &&
     (isFailed || isVerified) &&
-    profile.profile_uuid !== REC_LOCK_SYNTHETIC_PROFILE_UUID;
+    !isRecoveryLockRow &&
+    !isHostNameRow;
   const showRotateButton =
     canRotateRecoveryLockPassword && (isFailed || isVerified);
+  // canResendHostNameTemplate is already pre-gated on the host name row by the
+  // caller, mirroring how showRotateButton relies on canRotateRecoveryLockPassword.
+  const showResendHostNameButton =
+    canResendHostNameTemplate && (isFailed || isVerified);
 
   return (
     <div className={baseClass}>
@@ -147,6 +178,12 @@ const OSSettingsResendCell = ({
       )}
       {showRotateButton && (
         <RotateButton isRotating={isRotating} onClick={onRotatePassword} />
+      )}
+      {showResendHostNameButton && (
+        <ResendButton
+          isResending={isResending}
+          onClick={onResendHostNameTemplate}
+        />
       )}
     </div>
   );

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTable.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTable.tsx
@@ -10,20 +10,24 @@ const baseClass = "os-settings-table";
 interface IOSSettingsTableProps {
   canResendProfiles: boolean;
   canRotateRecoveryLockPassword?: boolean;
+  canResendHostNameTemplate?: boolean;
   tableData: IHostMdmProfileWithAddedStatus[];
   resendRequest: (profileUUID: string) => Promise<void>;
   resendCertificateRequest?: (certificateTemplateId: number) => Promise<void>;
   rotateRecoveryLockPassword?: () => Promise<void>;
+  resendHostNameTemplate?: () => Promise<void>;
   onProfileResent: () => void;
 }
 
 const OSSettingsTable = ({
   canResendProfiles,
   canRotateRecoveryLockPassword = false,
+  canResendHostNameTemplate = false,
   tableData,
   resendRequest,
   resendCertificateRequest,
   rotateRecoveryLockPassword,
+  resendHostNameTemplate,
   onProfileResent,
 }: IOSSettingsTableProps) => {
   // useMemo prevents tooltip flashing during host data refetch
@@ -35,7 +39,9 @@ const OSSettingsTable = ({
         onProfileResent,
         resendCertificateRequest,
         canRotateRecoveryLockPassword,
-        rotateRecoveryLockPassword
+        rotateRecoveryLockPassword,
+        canResendHostNameTemplate,
+        resendHostNameTemplate
       ),
     [
       canResendProfiles,
@@ -43,6 +49,8 @@ const OSSettingsTable = ({
       onProfileResent,
       canRotateRecoveryLockPassword,
       rotateRecoveryLockPassword,
+      canResendHostNameTemplate,
+      resendHostNameTemplate,
       resendCertificateRequest,
     ]
   );

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tests.tsx
@@ -1,4 +1,4 @@
-import { IHostMdmData } from "interfaces/host";
+import { IHostMdmData, IHostMdmHostNameSetting } from "interfaces/host";
 import { HOST_NAME_SYNTHETIC_PROFILE_UUID } from "pages/hosts/details/helpers";
 
 import { generateTableData } from "./OSSettingsTableConfig";
@@ -20,8 +20,8 @@ const createMockHostMdmData = (
 });
 
 describe("generateTableData - host name row", () => {
-  const hostNameSetting = {
-    status: "pending" as const,
+  const hostNameSetting: IHostMdmHostNameSetting = {
+    status: "pending",
     detail: "",
   };
 
@@ -128,4 +128,31 @@ describe("generateTableData - host name row", () => {
     expect(rows).toHaveLength(2);
     expect(rows.map((r) => r.name)).toEqual(["Wi-Fi", "Host name"]);
   });
+
+  // The row is driven purely by the presence of os_settings.host_name and is
+  // team-agnostic: a host in "No team" (Unassigned) under a No-team template
+  // gets the object from the backend and therefore renders the row identically
+  // to a fleet host. The row generator cannot key on team — IHostMdmData
+  // carries no team field.
+  it.each(["darwin", "ios", "ipados"])(
+    "appends the host name row for No-team (Unassigned) %s hosts when os_settings.host_name is present",
+    (platform) => {
+      const mdmData = createMockHostMdmData({
+        os_settings: {
+          disk_encryption: { status: null, detail: "" },
+          certificates: [],
+          host_name: hostNameSetting,
+        },
+      });
+
+      const rows = generateTableData(mdmData, platform) ?? [];
+
+      const hostNameRow = rows.find(
+        (r) => r.profile_uuid === HOST_NAME_SYNTHETIC_PROFILE_UUID
+      );
+      expect(hostNameRow).toBeDefined();
+      expect(hostNameRow?.name).toBe("Host name");
+      expect(hostNameRow?.status).toBe("pending");
+    }
+  );
 });

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tests.tsx
@@ -1,0 +1,131 @@
+import { IHostMdmData } from "interfaces/host";
+import { HOST_NAME_SYNTHETIC_PROFILE_UUID } from "pages/hosts/details/helpers";
+
+import { generateTableData } from "./OSSettingsTableConfig";
+
+const createMockHostMdmData = (
+  overrides?: Partial<IHostMdmData>
+): IHostMdmData => ({
+  encryption_key_available: false,
+  enrollment_status: "On (manual)",
+  server_url: "https://example.com",
+  profiles: [],
+  device_status: "unlocked",
+  pending_action: "",
+  os_settings: {
+    disk_encryption: { status: null, detail: "" },
+    certificates: [],
+  },
+  ...overrides,
+});
+
+describe("generateTableData - host name row", () => {
+  const hostNameSetting = {
+    status: "pending" as const,
+    detail: "",
+  };
+
+  it.each(["darwin", "ios", "ipados"])(
+    "appends the host name row for %s hosts when os_settings.host_name is present",
+    (platform) => {
+      const mdmData = createMockHostMdmData({
+        os_settings: {
+          disk_encryption: { status: null, detail: "" },
+          certificates: [],
+          host_name: hostNameSetting,
+        },
+      });
+
+      const rows = generateTableData(mdmData, platform) ?? [];
+
+      const hostNameRow = rows.find(
+        (r) => r.profile_uuid === HOST_NAME_SYNTHETIC_PROFILE_UUID
+      );
+      expect(hostNameRow).toBeDefined();
+      expect(hostNameRow?.name).toBe("Host name");
+      expect(hostNameRow?.status).toBe("pending");
+    }
+  );
+
+  it.each(["darwin", "ios", "ipados"])(
+    "does not append the host name row for %s hosts when os_settings.host_name is omitted",
+    (platform) => {
+      const mdmData = createMockHostMdmData();
+
+      const rows = generateTableData(mdmData, platform) ?? [];
+
+      expect(
+        rows.find((r) => r.profile_uuid === HOST_NAME_SYNTHETIC_PROFILE_UUID)
+      ).toBeUndefined();
+    }
+  );
+
+  it.each(["darwin", "ios", "ipados"])(
+    "does not append the host name row for %s hosts that are not enrolled in MDM",
+    (platform) => {
+      const mdmData = createMockHostMdmData({
+        enrollment_status: "Off",
+        os_settings: {
+          disk_encryption: { status: null, detail: "" },
+          certificates: [],
+          host_name: hostNameSetting,
+        },
+      });
+
+      const rows = generateTableData(mdmData, platform) ?? [];
+
+      expect(
+        rows.find((r) => r.profile_uuid === HOST_NAME_SYNTHETIC_PROFILE_UUID)
+      ).toBeUndefined();
+    }
+  );
+
+  it("does not append the host name row for non-Apple platforms even if host_name is present", () => {
+    const mdmData = createMockHostMdmData({
+      os_settings: {
+        disk_encryption: { status: null, detail: "" },
+        certificates: [],
+        host_name: hostNameSetting,
+      },
+    });
+
+    const windowsRows = generateTableData(mdmData, "windows") ?? [];
+    const linuxRows = generateTableData(mdmData, "ubuntu") ?? [];
+
+    expect(
+      windowsRows.find(
+        (r) => r.profile_uuid === HOST_NAME_SYNTHETIC_PROFILE_UUID
+      )
+    ).toBeUndefined();
+    expect(
+      linuxRows.find((r) => r.profile_uuid === HOST_NAME_SYNTHETIC_PROFILE_UUID)
+    ).toBeUndefined();
+  });
+
+  it("keeps existing profiles alongside the host name row for ios hosts", () => {
+    const mdmData = createMockHostMdmData({
+      profiles: [
+        {
+          profile_uuid: "abc-123",
+          name: "Wi-Fi",
+          operation_type: "install",
+          platform: "ios",
+          status: "verified",
+          detail: "",
+          scope: "device",
+          managed_local_account: null,
+        },
+      ],
+      os_settings: {
+        disk_encryption: { status: null, detail: "" },
+        certificates: [],
+        host_name: hostNameSetting,
+      },
+    });
+
+    const rows = generateTableData(mdmData, "ios") ?? [];
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.name)).toEqual(["Wi-Fi", "Host name"]);
+  });
+});

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -12,6 +12,7 @@ import {
   isWindowsDiskEncryptionStatus,
   MdmDDMProfileStatus,
   MdmProfileStatus,
+  ProfilePlatform,
 } from "interfaces/mdm";
 import { isDDMProfile } from "services/entities/mdm";
 import { isAppleDevice, isIPadOrIPhone } from "interfaces/platform";
@@ -21,9 +22,11 @@ import OSSettingStatusCell from "./OSSettingStatusCell";
 import OSSettingsResendCell from "./OSSettingsResendCell";
 
 import {
+  generateHostNameSettingIfEligible,
   generateLinuxDiskEncryptionSetting,
   generateRecoveryLockPasswordSetting,
   generateWinDiskEncryptionSetting,
+  HOST_NAME_SYNTHETIC_PROFILE_UUID,
   REC_LOCK_SYNTHETIC_PROFILE_UUID,
 } from "../../helpers";
 
@@ -51,7 +54,9 @@ const generateTableConfig = (
   onProfileResent: () => void,
   resendCertificateRequest?: (certificateTemplateId: number) => Promise<void>,
   canRotateRecoveryLockPassword?: boolean,
-  rotateRecoveryLockPassword?: () => Promise<void>
+  rotateRecoveryLockPassword?: () => Promise<void>,
+  canResendHostNameTemplate?: boolean,
+  resendHostNameTemplate?: () => Promise<void>
 ): ITableColumnConfig[] => {
   return [
     {
@@ -110,6 +115,10 @@ const generateTableConfig = (
           cellProps.row.original.profile_uuid ===
           REC_LOCK_SYNTHETIC_PROFILE_UUID;
 
+        const isHostNameRow =
+          cellProps.row.original.profile_uuid ===
+          HOST_NAME_SYNTHETIC_PROFILE_UUID;
+
         return (
           <OSSettingsResendCell
             canResendProfiles={
@@ -121,10 +130,14 @@ const generateTableConfig = (
             canRotateRecoveryLockPassword={
               isRecoveryLockRow && canRotateRecoveryLockPassword
             }
+            canResendHostNameTemplate={
+              isHostNameRow && canResendHostNameTemplate
+            }
             profile={cellProps.row.original}
             resendRequest={resendRequest}
             resendCertificateRequest={resendCertificateRequest}
             rotateRecoveryLockPassword={rotateRecoveryLockPassword}
+            resendHostNameTemplate={resendHostNameTemplate}
             onProfileResent={onProfileResent}
           />
         );
@@ -216,6 +229,40 @@ const makeDarwinRows = ({
     ];
   }
 
+  const hostNameRow = generateHostNameSettingIfEligible(
+    "darwin",
+    enrollment_status,
+    os_settings
+  );
+  if (hostNameRow) {
+    rows = [...rows, hostNameRow];
+  }
+
+  return rows;
+};
+
+// iOS/iPadOS hosts don't surface disk-encryption or recovery-lock rows, but they
+// do get the synthetic "Host name" row when a template is enforced. They can also
+// have regular configuration profiles.
+const makeAppleMobileRows = (
+  { profiles, os_settings, enrollment_status }: IHostMdmData,
+  platform: ProfilePlatform
+) => {
+  const rows: IHostMdmProfileWithAddedStatus[] = profiles ? [...profiles] : [];
+
+  const hostNameRow = generateHostNameSettingIfEligible(
+    platform,
+    enrollment_status,
+    os_settings
+  );
+  if (hostNameRow) {
+    rows.push(hostNameRow);
+  }
+
+  if (rows.length === 0 && !profiles) {
+    return null;
+  }
+
   return rows;
 };
 
@@ -234,6 +281,7 @@ export const generateTableData = (
       return makeLinuxRows(hostMDMData);
     case "ios":
     case "ipados":
+      return makeAppleMobileRows(hostMDMData, platform);
     case "android":
       return hostMDMData.profiles;
     default:

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -111,6 +111,68 @@ describe("Host Summary section", () => {
     });
   });
 
+  describe("OS settings indicator", () => {
+    const osSettingsWithHostName = {
+      disk_encryption: { status: null, detail: "" },
+      certificates: [],
+      host_name: { status: "pending" as const, detail: "" },
+    };
+
+    it("renders the OS settings indicator for an enrolled darwin host whose only setting is the host name", () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+      const summaryData = {
+        ...createMockHostSummary({ platform: "darwin" }),
+        mdm: { enrollment_status: "On (manual)" },
+      };
+
+      render(
+        <HostSummary
+          summaryData={summaryData}
+          hostSettings={[]}
+          osSettings={osSettingsWithHostName}
+          toggleOSSettingsModal={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText("OS settings")).toBeInTheDocument();
+    });
+
+    it("does not render the OS settings indicator when the host is not enrolled in MDM", () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+      const summaryData = {
+        ...createMockHostSummary({ platform: "darwin" }),
+        mdm: { enrollment_status: "Off" },
+      };
+
+      render(
+        <HostSummary
+          summaryData={summaryData}
+          hostSettings={[]}
+          osSettings={osSettingsWithHostName}
+          toggleOSSettingsModal={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByText("OS settings")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Maintenance window data", () => {
     it("renders maintenance window data with timezone", async () => {
       const render = createCustomRenderer({

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -68,6 +68,10 @@ const HostSummary = ({
 
   const { status, platform, os_version, mdm } = summaryData;
 
+  // Derive a local copy so we can append the synthetic disk-encryption,
+  // recovery-lock, and host-name rows without mutating the hostSettings prop.
+  let derivedHostSettings = hostSettings;
+
   const isAndroidHost = isAndroid(platform);
   const isIosOrIpadosHost = isIPadOrIPhone(platform);
 
@@ -150,8 +154,8 @@ const HostSummary = ({
       osSettings.disk_encryption.status,
       osSettings.disk_encryption.detail
     );
-    hostSettings = hostSettings
-      ? [...hostSettings, winDiskEncryptionSetting]
+    derivedHostSettings = derivedHostSettings
+      ? [...derivedHostSettings, winDiskEncryptionSetting]
       : [winDiskEncryptionSetting];
   }
 
@@ -164,8 +168,8 @@ const HostSummary = ({
       osSettings.disk_encryption.status,
       osSettings.disk_encryption.detail
     );
-    hostSettings = hostSettings
-      ? [...hostSettings, linuxDiskEncryptionSetting]
+    derivedHostSettings = derivedHostSettings
+      ? [...derivedHostSettings, linuxDiskEncryptionSetting]
       : [linuxDiskEncryptionSetting];
   }
 
@@ -178,8 +182,8 @@ const HostSummary = ({
       osSettings.recovery_lock_password.status,
       osSettings.recovery_lock_password.detail
     );
-    hostSettings = hostSettings
-      ? [...hostSettings, recoveryLockSetting]
+    derivedHostSettings = derivedHostSettings
+      ? [...derivedHostSettings, recoveryLockSetting]
       : [recoveryLockSetting];
   }
 
@@ -193,8 +197,8 @@ const HostSummary = ({
     osSettings
   );
   if (hostNameSetting) {
-    hostSettings = hostSettings
-      ? [...hostSettings, hostNameSetting]
+    derivedHostSettings = derivedHostSettings
+      ? [...derivedHostSettings, hostNameSetting]
       : [hostNameSetting];
   }
 
@@ -222,14 +226,14 @@ const HostSummary = ({
       )}
       {isPremiumTier && renderHostTeam()}
       {isOsSettingsDisplayPlatform(platform, os_version) &&
-        hostSettings &&
-        hostSettings.length > 0 && (
+        derivedHostSettings &&
+        derivedHostSettings.length > 0 && (
           <DataSet
             className={`${baseClass}__os-settings`}
             title="OS settings"
             value={
               <OSSettingsIndicator
-                profiles={hostSettings}
+                profiles={derivedHostSettings}
                 onClick={toggleOSSettingsModal}
               />
             }

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -30,6 +30,7 @@ import OSSettingsIndicator from "./OSSettingsIndicator";
 import BootstrapPackageIndicator from "./BootstrapPackageIndicator/BootstrapPackageIndicator";
 
 import {
+  generateHostNameSettingIfEligible,
   generateLinuxDiskEncryptionSetting,
   generateRecoveryLockPasswordSetting,
   generateWinDiskEncryptionSetting,
@@ -180,6 +181,21 @@ const HostSummary = ({
     hostSettings = hostSettings
       ? [...hostSettings, recoveryLockSetting]
       : [recoveryLockSetting];
+  }
+
+  // The host name template row (macOS/iOS/iPadOS) is synthetic like the rows
+  // above, so it must be added here too — otherwise a host whose only OS setting
+  // is the host name wouldn't surface the "OS settings" indicator that opens the
+  // modal.
+  const hostNameSetting = generateHostNameSettingIfEligible(
+    platform,
+    mdm?.enrollment_status ?? null,
+    osSettings
+  );
+  if (hostNameSetting) {
+    hostSettings = hostSettings
+      ? [...hostSettings, hostNameSetting]
+      : [hostNameSetting];
   }
 
   return (

--- a/frontend/pages/hosts/details/helpers.ts
+++ b/frontend/pages/hosts/details/helpers.ts
@@ -2,10 +2,15 @@
 import {
   HostMdmDeviceStatus,
   HostMdmPendingAction,
+  IHostMdmHostNameSetting,
+  IOSSettings,
   RecoveryLockPasswordStatus,
 } from "interfaces/host";
 import {
   IHostMdmProfile,
+  isEnrolledInMdm,
+  MdmEnrollmentStatus,
+  ProfilePlatform,
   WindowsDiskEncryptionStatus,
   MdmProfileStatus,
   LinuxDiskEncryptionStatus,
@@ -88,6 +93,56 @@ export const generateRecoveryLockPasswordSetting = (
     scope: null,
     managed_local_account: null,
   };
+};
+
+export const HOST_NAME_SYNTHETIC_PROFILE_UUID = "host_name_dummy";
+
+/**
+ * Manually generates a setting for the host name template status. We need this
+ * as the host name template is enforced via a one-off MDM command, so it does
+ * not appear in the `profiles` attribute of the GET /hosts/:id API response.
+ */
+const generateHostNameSetting = (
+  hostName: IHostMdmHostNameSetting,
+  platform: ProfilePlatform
+): IHostMdmProfile => {
+  return {
+    profile_uuid: HOST_NAME_SYNTHETIC_PROFILE_UUID,
+    platform,
+    name: "Host name",
+    status: hostName.status,
+    detail: hostName.detail,
+    operation_type: null,
+    scope: null,
+    managed_local_account: null,
+  };
+};
+
+/** Platforms that can enforce a host name template (Apple only). */
+const HOST_NAME_TEMPLATE_PLATFORMS = ["darwin", "ios", "ipados"];
+
+/**
+ * Returns the synthetic "Host name" row when the host is an Apple host enrolled
+ * in MDM and enforcing a host name template, otherwise null. Centralizes the
+ * eligibility rule shared by the OS settings modal table (generateTableData)
+ * and the host summary OS-settings indicator so they can't drift apart.
+ */
+export const generateHostNameSettingIfEligible = (
+  platform: string,
+  enrollmentStatus: MdmEnrollmentStatus | null,
+  osSettings?: IOSSettings
+): IHostMdmProfile | null => {
+  if (
+    HOST_NAME_TEMPLATE_PLATFORMS.includes(platform) &&
+    isEnrolledInMdm(enrollmentStatus) &&
+    osSettings?.host_name?.status
+  ) {
+    return generateHostNameSetting(
+      osSettings.host_name,
+      platform as ProfilePlatform
+    );
+  }
+  return null;
 };
 
 export type HostMdmDeviceStatusUIState =

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -730,6 +730,12 @@ export default {
     );
   },
 
+  resendNameTemplate: (hostId: number): Promise<void> => {
+    const { HOST_RESEND_NAME_TEMPLATE } = endpoints;
+
+    return sendRequest("POST", HOST_RESEND_NAME_TEMPLATE(hostId));
+  },
+
   getHostSoftware: (
     params: IHostSoftwareQueryKey
   ): Promise<IGetHostSoftwareResponse> => {

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -103,6 +103,8 @@ export default {
     `/${API_VERSION}/fleet/hosts/${hostId}/configuration_profiles/${profileUUID}/resend`,
   HOST_RESEND_CERTIFICATE: (hostId: number, certificateTemplateId: number) =>
     `/${API_VERSION}/fleet/hosts/${hostId}/certificates/${certificateTemplateId}/resend`,
+  HOST_RESEND_NAME_TEMPLATE: (hostId: number) =>
+    `/${API_VERSION}/fleet/hosts/${hostId}/name_template/resend`,
   HOST_SOFTWARE: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/software`,
   HOST_SOFTWARE_PACKAGE_INSTALL: (hostId: number, softwareId: number) =>
     `/${API_VERSION}/fleet/hosts/${hostId}/software/${softwareId}/install`,


### PR DESCRIPTION
Fixes #48627

Surface the fleet's host name template enforcement per host in the OS settings modal for macOS/iOS/iPadOS hosts.

- Add HostNameSettingStatus type and os_settings.host_name to the host detail interfaces
- Render a synthetic "Host name" row (Enforcing/Verifying/Verified/ Failed) with tooltips; failed rows show the drift/Apple error detail. Omitted for ineligible hosts (no template, non-MDM, BYOD): backend omits the field and the client also gates on isEnrolledInMdm, matching the Recovery Lock treatment
- Append the row for darwin/ios/ipados; ios/ipados previously returned profiles directly
- Add a resend button on failed/verified rows wired to POST /hosts/{id}/name_template/resend via hostAPI.resendNameTemplate; permission mirrors canResendProfiles (admin/maintainer/technician) and matches the backend ActionResend authz. The row still renders on DeviceUserPage without the button

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility for host name template status in host details, including pending, verifying, verified, and failed states.
  * Introduced a new “Host name” row in OS settings for eligible Apple devices.
  * Added a “Resend” action for host name templates when enforcement fails or needs to be retried.

* **Bug Fixes**
  * OS settings indicators now appear correctly when host name is the only pending setting on enrolled devices.
  * Improved status text and tooltips so users can better understand template enforcement progress and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->