### PR TITLE
Docs: Add multiple custom packages for the same software title (#48402)

### DIFF
--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -25,7 +25,7 @@ SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader' AND version_comp
 
 ![Install software modal](../website/assets/images/articles/automatic-software-install-install-software-398x259@2x.png)
 
-> If a software title has more than one [custom package](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title), select which package to install. Fleet selects the package that was added first by default. Fleet installs the package on hosts within that package's label scope.
+> If a software title has more than one [custom package](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title), you can select which package to install. Fleet selects the package that was added first by default. Fleet installs the package on hosts within that package's label scope.
 
 Once the software is installed, Fleet will automatically refetch the host's vitals and update the software inventory.
 

--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -25,6 +25,8 @@ SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader' AND version_comp
 
 ![Install software modal](../website/assets/images/articles/automatic-software-install-install-software-398x259@2x.png)
 
+> If a software title has more than one [package](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title), select which package to install. Fleet selects the package that was added first by default. Fleet installs the package on hosts within that package's label scope.
+
 Once the software is installed, Fleet will automatically refetch the host's vitals and update the software inventory.
 
 Policy automation software installs are automatically attempted up to 3 total times. Each time the policy runs and fails, Fleet triggers the software install again, up to a total of 3 attempts. If the host passes the policy, the retry count resets.

--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -25,7 +25,7 @@ SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader' AND version_comp
 
 ![Install software modal](../website/assets/images/articles/automatic-software-install-install-software-398x259@2x.png)
 
-> If a software title has more than one [package](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title), select which package to install. Fleet selects the package that was added first by default. Fleet installs the package on hosts within that package's label scope.
+> If a software title has more than one [custom package](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title), select which package to install. Fleet selects the package that was added first by default. Fleet installs the package on hosts within that package's label scope.
 
 Once the software is installed, Fleet will automatically refetch the host's vitals and update the software inventory.
 

--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -88,11 +88,11 @@ Fleet also provides an `$UPGRADE_CODE` placeholder for MSIs. This placeholder is
 
 > Uninstall scripts do _not_ download the installer package to a host before running; if a .tar.gz archive includes an uninstall script, the contents of that script and any dependencies should be copied into the uninstall script text field rather than referred to by filename.
 
-## Add multiple packages to a software title
+## Add multiple packages to the same fleet
 
-You can add up to 10 custom packages to the same software title. This lets you support multiple architectures (for example, Arm and Intel builds) or run a staged rollout (a stable build for all hosts plus a newer build scoped to a test group) without creating separate fleets.
+You can add up to 10 custom packages of the same software to a fleet. This lets you support multiple architectures (for example, Arm and Intel builds) or run a staged rollout (a stable build for all hosts plus a newer build scoped to a test group) without creating separate fleets.
 
-To add another package to a title:
+To add another package to a software:
 
 * Navigate to the **Software** page, select a fleet, and select the **Library** tab.
 * Select the software.
@@ -105,9 +105,8 @@ Each package has its own [target labels](https://fleetdm.com/guides/managing-lab
 
 During [setup experience](https://fleetdm.com/guides/setup-experience), Fleet installs the package that was added first. Labels don't apply during setup experience.
 
-Fleet identifies packages by their contents, so you can add different builds of the same version. Uploading the exact same file again returns `Couldn't add. <file> package is already added (same SHA-256 hash).`
+Fleet identifies packages by their contents, so you can add different builds of the same version. Uploading the exact same file again is rejected.
 
-Adding an 11th package returns `Couldn't add. <title> already has 10 packages. Before adding, delete one you no longer use.`
 
 Script-only packages (`.sh` and `.ps1`) can also be added multiple times to the same title. They have no version, so Fleet tells them apart by file name, added date, labels, and hash.
 

--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -108,7 +108,7 @@ During [setup experience](https://fleetdm.com/guides/setup-experience), Fleet in
 Fleet identifies packages by their contents, so you can add different builds of the same version. Uploading the exact same file again is rejected.
 
 
-Script-only packages (`.sh` and `.ps1`) can also be added multiple times to the same software item. They have no version, so Fleet tells them apart by file name, added date, labels, and hash.
+Script-only packages (`.sh` and `.ps1`) can also be added multiple times to the same software item. Fleet uses the filename as a unique identifier to group multiple script-only packages into the same software.
 
 ## Install the package
 

--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -108,7 +108,7 @@ During [setup experience](https://fleetdm.com/guides/setup-experience), Fleet in
 Fleet identifies packages by their contents, so you can add different builds of the same version. Uploading the exact same file again is rejected.
 
 
-Script-only packages (`.sh` and `.ps1`) can also be added multiple times to the same title. They have no version, so Fleet tells them apart by file name, added date, labels, and hash.
+Script-only packages (`.sh` and `.ps1`) can also be added multiple times to the same software item. They have no version, so Fleet tells them apart by file name, added date, labels, and hash.
 
 ## Install the package
 

--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -95,7 +95,7 @@ You can add up to 10 custom packages to the same software title. This lets you s
 To add another package to a title:
 
 * Navigate to the **Software** page, select a fleet, and select the **Library** tab.
-* Select the software title.
+* Select the software.
 * In the **Library** section of the **Software details** page, select **Add package**.
 * Choose a file to upload, set the **Target**, and configure any advanced options.
 

--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -88,6 +88,29 @@ Fleet also provides an `$UPGRADE_CODE` placeholder for MSIs. This placeholder is
 
 > Uninstall scripts do _not_ download the installer package to a host before running; if a .tar.gz archive includes an uninstall script, the contents of that script and any dependencies should be copied into the uninstall script text field rather than referred to by filename.
 
+## Add multiple packages to a software title
+
+You can add up to 10 custom packages to the same software title. This lets you support multiple architectures (for example, Arm and Intel builds) or run a staged rollout (a stable build for all hosts plus a newer build scoped to a test group) without creating separate fleets.
+
+To add another package to a title:
+
+* Navigate to the **Software** page, select a fleet, and select the **Library** tab.
+* Select the software title.
+* In the **Library** section of the **Software details** page, select **Add package**.
+* Choose a file to upload, set the **Target**, and configure any advanced options.
+
+Each package has its own [target labels](https://fleetdm.com/guides/managing-labels-in-fleet), [self-service](https://fleetdm.com/guides/software-self-service) availability, categories, and advanced options. Scope each package to a distinct set of labels so that each host matches only one package.
+
+> If multiple packages target the same host, Fleet installs the one that was added first.
+
+During [setup experience](https://fleetdm.com/guides/setup-experience), Fleet installs the package that was added first. Labels don't apply during setup experience.
+
+Fleet identifies packages by their contents, so you can add different builds of the same version. Uploading the exact same file again returns `Couldn't add. <file> package is already added (same SHA-256 hash).`
+
+Adding an 11th package returns `Couldn't add. <title> already has 10 packages. Before adding, delete one you no longer use.`
+
+Script-only packages (`.sh` and `.ps1`) can also be added multiple times to the same title. They have no version, so Fleet tells them apart by file name, added date, labels, and hash.
+
 ## Install the package
 
 After a software package is added to a fleet, it can be installed on hosts via the UI.
@@ -109,7 +132,7 @@ Once the package is installed, Fleet will automatically refetch the host's vital
 
 * Navigate to the **Software** page, choose a fleet, and select the **Library** tab.
 * Select the software you want to edit.
-* On the **Software details** page select **Actions > Edit software** to edit the software's [self-service](https://fleetdm.com/guides/software-self-service) status, change its target to different sets of hosts, or edit advanced options like pre-install query, install script, post-install script, and uninstall script.
+* On the **Software details** page, select **Edit** next to a package in the **Library** section to edit that package's [self-service](https://fleetdm.com/guides/software-self-service) status, change its target to different sets of hosts, or edit advanced options like pre-install query, install script, post-install script, and uninstall script. Each package is edited separately.
 * Select **Actions > Edit appearance** to edit the software's icon and display name. The icon and display name can be edited for software that is available for install. The new icon and display name will appear on the software list and details pages for the fleet where the package is uploaded, as well as on **My device > Self-service**. If the display name is not set, then the default name (ingested by osquery) will be used.
 
 > Editing the advanced options cancels all pending installations and uninstallations for that package. Installs and uninstalls currently running on a host will complete, but results won't appear in Fleet. The software's host counts will be reset.
@@ -129,7 +152,7 @@ After a software package is installed on a host, it can be uninstalled on the ho
 
 * Navigate to the **Software** page, choose a fleet, and select the **Library** tab.
 * Select the software you want to delete.
-* On the **Software details** page, select the **Delete** icon next to the uploaded package file.
+* On the **Software details** page, select the **Delete** icon next to a package in the **Library** section to delete that package. If a title has more than one package, the remaining packages stay intact.
 
 > Deleting a software package from a fleet will cancel pending installs for hosts that are not in the middle of installing the software, but will not uninstall the software from hosts where it is already installed.
 

--- a/articles/software-self-service.md
+++ b/articles/software-self-service.md
@@ -30,6 +30,8 @@ You can also add the software and later make it available in self-service:
 
 If a software item isn't made available in self-service, end users will not see it in **Fleet Desktop > Self-service**. IT admins can still install, update, and uninstall the software from Fleet.
 
+> Self-service is set per [package](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title). When a title has more than one self-service package and a host matches more than one, Fleet installs the package that was added first.
+
 ## Manage self-service categories
 
 _Available in Fleet Premium_

--- a/articles/software-self-service.md
+++ b/articles/software-self-service.md
@@ -30,7 +30,7 @@ You can also add the software and later make it available in self-service:
 
 If a software item isn't made available in self-service, end users will not see it in **Fleet Desktop > Self-service**. IT admins can still install, update, and uninstall the software from Fleet.
 
-> Self-service is set per [package](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title). When a title has more than one self-service package and a host matches more than one, Fleet installs the package that was added first.
+> For [custom packages](https://fleetdm.com/guides/deploy-software-packages#add-multiple-packages-to-a-software-title), self-service is set per package. When a title has more than one self-service package and a host matches more than one, Fleet installs the package that was added first.
 
 ## Manage self-service categories
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48402 (story #28108)

Feature guide updates for [multiple custom packages for the same software title](https://github.com/fleetdm/fleet/issues/28108) (Fleet Premium, 4.90.0).

Docs-only PR against `docs-v4.90.0`, per Fleet convention that `docs/`/`articles/` changes ship separately from code.

## Changes

- **`articles/deploy-software-packages.md`** — new "Add multiple packages to a software title" section (up to 10 packages per title, per-package labels/self-service/categories, first-added precedence on overlap, setup-experience behavior, content-based dedupe, script-only support), plus per-package clarifications to "Edit the package" and "Delete the package".
- **`articles/automatic-software-install-in-fleet.md`** — note on the per-package "Select package" dropdown (defaults to first-added; installs within that package's label scope).
- **`articles/software-self-service.md`** — note that self-service is set per package and the first-added package wins on overlap.

## Related reference docs (already merged to `docs-v4.90.0`)

- REST API `packages[]` — #48265
- GitOps `*.package.yml` list form — #48544

Guide copy was cross-checked against both.

## No changes needed

- **Audit log** (`docs/Contributing/reference/audit-logs.md`) — same `added_software` activity, no new activity types.
- **Usage stats** (`articles/fleet-usage-statistics.md`) — no new usage stats.
- **Fleet-maintained apps guide** — FMA titles stay single-active/version-pinned and can't be mixed with custom packages, so multi-package content does not apply.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (docs render/links verified)

<!-- Docs-only PR: no changes file, no code/tests, no migrations, no config settings, no fleetd changes. -->
