### PR TITLE
Fleet UI: Policy details page labels/automations use TruncatedTextList

### DIFF
--- a/frontend/components/TruncatedTextList/TruncatedTextList.tests.tsx
+++ b/frontend/components/TruncatedTextList/TruncatedTextList.tests.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import TooltipWrapper from "components/TooltipWrapper";
+import TruncatedTextList from "./TruncatedTextList";
+
+// Mock TooltipWrapper so we can spy on which pieces of the row get wrapped
+// (and with what tipContent) without pulling in the real tooltip's layout
+// side effects.
+jest.mock("components/TooltipWrapper", () => ({
+  __esModule: true,
+  default: jest.fn(({ children }) => <>{children}</>),
+}));
+
+const mockedTooltipWrapper = (TooltipWrapper as unknown) as jest.Mock;
+
+// The component renders a hidden `__measure` layer that always contains
+// "+{items.length} more" for width probing — target only the visible row so
+// the measurement text can't false-positive our assertions.
+const getVisibleRow = (container: HTMLElement) =>
+  container.querySelector(".truncated-text-list__visible");
+
+// In jsdom `getBoundingClientRect().width` is 0 for every element, so the
+// internal measurement pass always concludes "the first item doesn't fit
+// alongside a +N more pill" and falls into the `truncatedFirstContent`
+// branch (visibleCount === 0). Both regressions guarded here live in that
+// branch, which makes it the right one to pin down.
+describe("TruncatedTextList — truncatedFirstContent edge cases", () => {
+  beforeEach(() => {
+    mockedTooltipWrapper.mockClear();
+  });
+
+  it("suppresses the '+N more' pill when items.length === 1", () => {
+    const { container } = render(<TruncatedTextList items={["Solo"]} />);
+
+    // Guards the "+0 more" regression: with a single item there is nothing
+    // to hide, so the visible row must not render the pill at all.
+    expect(getVisibleRow(container)).not.toHaveTextContent(/\+\d+ more/);
+    expect(mockedTooltipWrapper).not.toHaveBeenCalled();
+  });
+
+  it("still renders the '+N more' pill when items.length > 1", () => {
+    const { container } = render(
+      <TruncatedTextList items={["Solo", "Duet"]} />
+    );
+
+    expect(getVisibleRow(container)).toHaveTextContent("+1 more");
+  });
+
+  it("does not wrap the first item in a tooltip when truncateString leaves it unchanged", () => {
+    // 4 chars is well under the 30-char default truncatedFirstMaxChars, so
+    // truncateString returns the value verbatim → no hover tooltip needed.
+    render(<TruncatedTextList items={["Solo"]} />);
+
+    expect(mockedTooltipWrapper).not.toHaveBeenCalled();
+  });
+
+  it("wraps the first item in a tooltip only when truncateString actually shortened it", () => {
+    const longName =
+      "A very long name that definitely exceeds thirty characters";
+    render(<TruncatedTextList items={[longName]} />);
+
+    expect(mockedTooltipWrapper).toHaveBeenCalled();
+    expect(mockedTooltipWrapper.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ tipContent: longName })
+    );
+  });
+});

--- a/frontend/components/TruncatedTextList/TruncatedTextList.tsx
+++ b/frontend/components/TruncatedTextList/TruncatedTextList.tsx
@@ -58,30 +58,41 @@ const renderVisibleRow = ({
   onClick,
 }: IRenderVisibleRowParams) => {
   const truncatedFirst = truncateString(items[0] ?? "", truncatedFirstMaxChars);
+  const firstWasTruncated = truncatedFirst !== (items[0] ?? "");
 
   const truncatedFirstContent = (
     <>
-      <TooltipWrapper
-        tipContent={items[0]}
-        showArrow
-        underline={false}
-        position={tooltipPosition}
-        tipOffset={8}
-        fixedPositionStrategy
-      >
+      {firstWasTruncated ? (
+        <TooltipWrapper
+          tipContent={items[0]}
+          showArrow
+          underline={false}
+          position={tooltipPosition}
+          tipOffset={8}
+          fixedPositionStrategy
+        >
+          <span>{truncatedFirst}</span>
+        </TooltipWrapper>
+      ) : (
         <span>{truncatedFirst}</span>
-      </TooltipWrapper>
-      {separator}
-      <TooltipWrapper
-        tipContent={renderItemsList(items.slice(1))}
-        showArrow
-        underline={false}
-        position={tooltipPosition}
-        tipOffset={8}
-        fixedPositionStrategy
-      >
-        <span className={`${baseClass}__more`}>+{items.length - 1} more</span>
-      </TooltipWrapper>
+      )}
+      {items.length > 1 && (
+        <>
+          {separator}
+          <TooltipWrapper
+            tipContent={renderItemsList(items.slice(1))}
+            showArrow
+            underline={false}
+            position={tooltipPosition}
+            tipOffset={8}
+            fixedPositionStrategy
+          >
+            <span className={`${baseClass}__more`}>
+              +{items.length - 1} more
+            </span>
+          </TooltipWrapper>
+        </>
+      )}
     </>
   );
 

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -33,6 +33,7 @@ import PageDescription from "components/PageDescription";
 import Spinner from "components/Spinner";
 import TooltipWrapper from "components/TooltipWrapper";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
+import TruncatedTextList from "components/TruncatedTextList";
 import Avatar from "components/Avatar";
 import ShowQueryModal from "components/modals/ShowQueryModal";
 import { getTicketOrWebhookInfo } from "pages/policies/helpers";
@@ -276,17 +277,15 @@ const PolicyDetailsPage = ({
     const allLabels = [...(includeLabels ?? []), ...(excludeLabels ?? [])];
     if (!allLabels.length) return null;
 
-    const firstLabel = allLabels[0];
-    const moreLabels = allLabels.length - 1;
     return (
       <DataSet
         className={`${baseClass}__labels`}
         title="Labels"
         value={
-          <Button variant="link" onClick={openLabelModal}>
-            {firstLabel.name}
-            {moreLabels > 0 && ` + ${moreLabels} more`}
-          </Button>
+          <TruncatedTextList
+            items={allLabels.map((l) => l.name)}
+            onClick={openLabelModal}
+          />
         }
       />
     );
@@ -336,13 +335,14 @@ const PolicyDetailsPage = ({
     if (!automations.length) return emptyState;
 
     const firstAutomation = automations[0];
-    const moreCount = automations.length - 1;
     return (
       <DataSet
-        className={`${baseClass}__automations`}
+        className={`${baseClass}__automations${
+          automations.length > 1 ? ` ${baseClass}__automations--multi` : ""
+        }`}
         title="Automations"
         value={
-          <Button variant="link" onClick={openAutomationsModal}>
+          <>
             {firstAutomation.isSoftware ? (
               <SoftwareIcon
                 name={firstAutomation.iconName ?? firstAutomation.name}
@@ -362,9 +362,11 @@ const PolicyDetailsPage = ({
                 />
               )
             )}
-            {firstAutomation.name}
-            {moreCount > 0 && ` + ${moreCount} more`}
-          </Button>
+            <TruncatedTextList
+              items={automations.map((a) => a.name)}
+              onClick={openAutomationsModal}
+            />
+          </>
         }
       />
     );

--- a/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
@@ -62,10 +62,25 @@
     gap: $pad-xsmall;
   }
 
+  &__automations--multi {
+    // With more than one automation, floor the DataSet at 300px so
+    // TruncatedTextList has room to render before collapsing to a "+N more"
+    // pill; combined with `max-width` below and `flex-wrap` on __properties,
+    // the DataSet stays a fixed 300px and either fits inline or wraps
+    // cleanly to its own row.
+    min-width: 300px;
+  }
+
   &__automations {
+    // Cap the DataSet width so a long list doesn't push __properties to a
+    // second row when the first still has room — content beyond the cap
+    // falls into TruncatedTextList's "+N more" pill.
+    max-width: 300px;
+
     .software-icon,
     .graphic {
       margin-right: $pad-xsmall;
+      flex-shrink: 0;
     }
   }
 
@@ -90,7 +105,8 @@
   &__properties {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     justify-content: flex-start;
-    gap: $pad-xlarge;
+    gap: $pad-medium $pad-xlarge;
   }
 }


### PR DESCRIPTION
## Issue
Closes #38670

## Description
- UX: On the policy details page, the labels and automations rows previously rendered `<Button variant="link">{firstItem.name}{moreCount > 0 && ` + ${moreCount} more`}</Button>` — a single name plus a "+N more" counter, no truncation, and overflow spilled past the DataSet. Swap both to `TruncatedTextList`, which measures the container, fits as many items as it can, and collapses the rest into a hoverable "+N more" pill.
- Layout: `__properties` gains `flex-wrap` so a wide DataSet drops to a new row instead of overflowing the details card border. `__automations` is pinned to 300px (min + max), so a long list can't push `__properties` to a second row while the first still has room, and TruncatedTextList always has a bounded container to measure on first load. `__labels` hugs its content — no width floor, so a short label list doesn't leave 80px of empty gutter.
- Bug fix (`TruncatedTextList`): when `items.length === 1` and the container was too narrow to fit the first item alongside a "+N more" pill, the component fell into `truncatedFirstContent` and rendered "+0 more". Suppress the pill when there's nothing to hide.
- Bug fix (`TruncatedTextList`): the first item in `truncatedFirstContent` was always wrapped in a `TooltipWrapper`, so a short name that `truncateString` left unchanged still showed a redundant hover tooltip. Only wrap when truncation actually shortened the value.
- Tests: both `TruncatedTextList` bug fixes are pinned by new unit tests in `TruncatedTextList.tests.tsx`.

## Screenrecording
- Labels + automations rows at wide, medium, and narrow widths


https://github.com/user-attachments/assets/965c7364-62ae-4467-acdf-e5679ecee53c



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Labels and automation names now use a cleaner truncated list format, including full-item tooltips when text is cut off.
  * Clicking a label or automation opens the corresponding full list view.

* **Bug Fixes**
  * Single-item lists no longer show separators or “+N more” indicators.

* **Style**
  * Improved layout for multi-automation and properties sections, with better spacing and wrapping on narrower screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->