### PR TITLE
Update go to 1.26.5

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.26.4-trixie@sha256:0dcba0d95dbfb072e9917a106b9e07d7cc298097dc83e9307056ef1889de654d
+FROM --platform=linux/amd64 golang:1.26.5-trixie@sha256:8d5bf3ef8fd204fea2ea0dea4b46d4ecdabceb88b9b4cb86d2b323425add49c7
 LABEL maintainer="Fleet Developers"
 
 RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1056,17 +1056,25 @@ UPDATE_GO_MODS := \
 	./tools/snapshot/go.mod \
 	./tools/terraform/go.mod \
 	./third_party/vuln-check/go.mod \
+	./third_party/goval-dictionary/go.mod \
+	./tools/ci/apiparamcheck/go.mod \
 	./tools/ci/setboolcheck/go.mod \
 	./tools/github-manage/go.mod \
 	./tools/qacheck/go.mod \
-	./third_party/goval-dictionary/go.mod \
+	./tools/screencap/go.mod \
+	./tools/hangar/go.mod \
 	./tools/fleet-mcp/go.mod \
 	./tools/dibble/go.mod
 update-go:
 	@test $(version) || (echo "Mising 'version' argument, usage: 'make update-go version=1.24.4'" ; exit 1)
 	@for dockerfile in $(UPDATE_GO_DOCKERFILES) ; do \
 		go run ./tools/tuf/replace $$dockerfile "golang:.+-" "golang:$(version)-" ; \
-		echo "Please update sha256 in $$dockerfile" ; \
+		tag=$$(grep -oE 'golang:[^@[:space:]]+' $$dockerfile | head -n1) ; \
+		echo "Resolving index digest for $$tag ..." ; \
+		digest=$$(docker buildx imagetools inspect $$tag --format '{{.Manifest.Digest}}') ; \
+		test "$$digest" || (echo "Failed to resolve digest for $$tag" ; exit 1) ; \
+		go run ./tools/tuf/replace $$dockerfile "$$tag@sha256:[0-9a-f]+" "$$tag@$$digest" ; \
+		echo "* Updated $$dockerfile -> $$tag@$$digest" ; \
 	done
 	@for gomod in $(UPDATE_GO_MODS) ; do \
 		go run ./tools/tuf/replace $$gomod "(?m)^go .+$$" "go $(version)" ; \

--- a/Makefile
+++ b/Makefile
@@ -1066,7 +1066,7 @@ UPDATE_GO_MODS := \
 	./tools/fleet-mcp/go.mod \
 	./tools/dibble/go.mod
 update-go:
-	@test $(version) || (echo "Mising 'version' argument, usage: 'make update-go version=1.24.4'" ; exit 1)
+	@test $(version) || (echo "Missing 'version' argument, usage: 'make update-go version=1.24.4'" ; exit 1)
 	@for dockerfile in $(UPDATE_GO_DOCKERFILES) ; do \
 		go run ./tools/tuf/replace $$dockerfile "golang:.+-" "golang:$(version)-" ; \
 		tag=$$(grep -oE 'golang:[^@[:space:]]+' $$dockerfile | head -n1) ; \
@@ -1079,7 +1079,7 @@ update-go:
 	@for gomod in $(UPDATE_GO_MODS) ; do \
 		go run ./tools/tuf/replace $$gomod "(?m)^go .+$$" "go $(version)" ; \
 	done
-	@echo "* Updated go to $(version)" > changes/update-go-$(version)
-	@cp changes/update-go-$(version) orbit/changes/update-go-$(version)
+	@echo "- Updated Go to $(version)." > changes/update-go-$(version)
+	@echo "* Updated Go to $(version)." > orbit/changes/update-go-$(version)
 
 include ./tools/makefile-support/helpsystem-targets

--- a/changes/update-go-1.26.5
+++ b/changes/update-go-1.26.5
@@ -1,0 +1,1 @@
+* Updated go to 1.26.5

--- a/changes/update-go-1.26.5
+++ b/changes/update-go-1.26.5
@@ -1,1 +1,1 @@
-* Updated go to 1.26.5
+- Updated Go to 1.26.5.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/pubsub v1.50.1

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+FROM golang:1.26.5-alpine3.23@sha256:5e9acfbe29a783d9e2295bc88d30b7c3556e31c8bd21de10a887c4572f58dbd9
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git

--- a/orbit/changes/update-go-1.26.5
+++ b/orbit/changes/update-go-1.26.5
@@ -1,1 +1,1 @@
-* Updated go to 1.26.5
+* Updated Go to 1.26.5.

--- a/orbit/changes/update-go-1.26.5
+++ b/orbit/changes/update-go-1.26.5
@@ -1,0 +1,1 @@
+* Updated go to 1.26.5

--- a/third_party/goval-dictionary/go.mod
+++ b/third_party/goval-dictionary/go.mod
@@ -1,6 +1,6 @@
 module github.com/vulsio/goval-dictionary
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7

--- a/third_party/vuln-check/go.mod
+++ b/third_party/vuln-check/go.mod
@@ -9,7 +9,7 @@
 
 module github.com/fleetdm/fleet/v4/third_party/vuln-check
 
-go 1.26.4
+go 1.26.5
 
 require (
 	// NanoMDM - Apple MDM server (server/mdm/nanomdm/)

--- a/tools/ci/apiparamcheck/go.mod
+++ b/tools/ci/apiparamcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/ci/apiparamcheck
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/tools/ci/setboolcheck/go.mod
+++ b/tools/ci/setboolcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/ci/setboolcheck
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/tools/dibble/go.mod
+++ b/tools/dibble/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/dibble
 
-go 1.26.4
+go 1.26.5
 
 // The parent fleet module is included so we can enumerate every activity
 // type for the `dibble activities` seeder. Pinned to the local checkout via

--- a/tools/fleet-mcp/go.mod
+++ b/tools/fleet-mcp/go.mod
@@ -1,6 +1,6 @@
 module fleet-mcp
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/gorilla/websocket v1.5.1

--- a/tools/github-manage/go.mod
+++ b/tools/github-manage/go.mod
@@ -1,6 +1,6 @@
 module fleetdm/gm
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/tools/hangar/go.mod
+++ b/tools/hangar/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/tools/hangar
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+FROM golang:1.26.5-alpine3.23@sha256:5e9acfbe29a783d9e2295bc88d30b7c3556e31c8bd21de10a887c4572f58dbd9
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone --branch "${TAG}" --depth=1 --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git /go/fleet \

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.26.4
+go 1.26.5
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/qacheck/go.mod
+++ b/tools/qacheck/go.mod
@@ -1,6 +1,6 @@
 module qacheck
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed

--- a/tools/screencap/go.mod
+++ b/tools/screencap/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/tools/screencap
 
-go 1.25.7
+go 1.26.5
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Resolves #48988.

I ran `make update-go version=1.26.5`.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] QA'd all new/changed functionality manually

Fleet:
<img width="301" height="102" alt="Screenshot 2026-07-09 at 8 41 49 AM" src="https://github.com/user-attachments/assets/baf76ce7-6192-4506-a9db-52f5318939ee" />
fleetctl:
```
fleetctl --version
fleetctl - version orbit-v1.57.0-402-ge3d0c005dc
  branch:       48988-update-go-1.26.5
  revision:     e3d0c005dc6698c024ad47a124c99e4f264855a0
  build date:   2026-07-09
  build user:   lucas
  go version:   go1.26.5
```
Also verified orbit in Linux:
<img width="582" height="121" alt="Screenshot 2026-07-09 at 8 51 55 AM" src="https://github.com/user-attachments/assets/65672676-8010-45a1-8c28-9f9959e72134" />


## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project and all included tooling modules to Go 1.26.5.
  * Refreshed build images used by desktop Linux, load testing, and related utilities to the newer Go toolchain.
  * Updated change log entries to reflect the Go version bump.

* **Bug Fixes**
  * Improved the automation that refreshes Go-pinned Docker image references to resolve and apply correct digests, helping prevent broken build images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->