### PR TITLE
Policy status automation activities bug fixes

### DIFF
--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -46,6 +46,8 @@ export interface IPolicyAutomationActivity {
   host_display_name: string;
   status: PolicyAutomationActivityStatus;
   output: string | null;
+  pre_install_output: string | null;
+  post_install_output: string | null;
 }
 
 export interface IPolicy {

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -19,7 +19,10 @@ import { PLATFORM_DISPLAY_NAMES, Platform } from "interfaces/platform";
 import policiesAPI from "services/entities/policies";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { addGravatarUrlToResource } from "utilities/helpers";
-import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import {
+  DEFAULT_EMPTY_CELL_VALUE,
+  DOCUMENT_TITLE_SUFFIX,
+} from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
 import useTeamIdParam from "hooks/useTeamIdParam";
 
@@ -322,7 +325,7 @@ const PolicyDetailsPage = ({
       <DataSet
         className={`${baseClass}__automations`}
         title="Automations"
-        value="---"
+        value={DEFAULT_EMPTY_CELL_VALUE}
       />
     );
 

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -489,11 +489,7 @@ const PolicyDetailsPage = ({
           includeScopeLabel={labelModalData.includeScopeLabel}
           excludeLabels={labelModalData.excludeLabels}
           excludeScopeLabel={labelModalData.excludeScopeLabel}
-          onLabelClick={
-            canEditLabels
-              ? (labelId) => router.push(PATHS.LABEL_EDIT(labelId))
-              : undefined
-          }
+          getLabelPath={canEditLabels ? PATHS.LABEL_EDIT : undefined}
           onClose={() => setShowLabelModal(false)}
         />
       )}

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
@@ -17,6 +17,8 @@ const failedSoftwareActivity: IPolicyAutomationActivity = {
   host_display_name: "Rachael's MacBook Pro",
   status: "error",
   output: "Failed installer: Package name is Zoom Workplace",
+  pre_install_output: null,
+  post_install_output: null,
 };
 
 describe("PolicyAutomationActivityDetailsModal", () => {
@@ -61,6 +63,54 @@ describe("PolicyAutomationActivityDetailsModal", () => {
       screen.getByRole("button", { name: /reset policy/i })
     );
     expect(onResetPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders separate pre-install, install, and post-install output sections for software installs", () => {
+    render(
+      <PolicyAutomationActivityDetailsModal
+        activity={{
+          ...failedSoftwareActivity,
+          pre_install_output: "pre-install query returned no rows",
+          output: "install script exited 1",
+          post_install_output: "post-install verification failed",
+        }}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Pre-install query output")).toBeInTheDocument();
+    expect(
+      screen.getByText("pre-install query returned no rows")
+    ).toBeInTheDocument();
+    // The install-script section uses the "Details" label (shared with the modal
+    // title), so assert on its unique output value rather than the label.
+    expect(screen.getByText("install script exited 1")).toBeInTheDocument();
+    expect(screen.getByText("Post-install script output")).toBeInTheDocument();
+    expect(
+      screen.getByText("post-install verification failed")
+    ).toBeInTheDocument();
+  });
+
+  it("omits an install output section that is empty", () => {
+    render(
+      <PolicyAutomationActivityDetailsModal
+        activity={{
+          ...failedSoftwareActivity,
+          pre_install_output: "pre-install query failed",
+          output: null,
+          post_install_output: null,
+        }}
+        onCancel={jest.fn()}
+      />
+    );
+
+    // Only the stage that produced output is shown; empty sections (the
+    // install-script and post-install stages here) are omitted.
+    expect(screen.getByText("Pre-install query output")).toBeInTheDocument();
+    expect(screen.getByText("pre-install query failed")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Post-install script output")
+    ).not.toBeInTheDocument();
   });
 
   it("omits the details box when there is no output or error", () => {

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { ActivityType } from "interfaces/activity";
 import { IPolicyAutomationActivity } from "interfaces/policy";
 import PATHS from "router/paths";
 
@@ -34,6 +35,28 @@ const PolicyAutomationActivityDetailsModal = ({
 }: IPolicyAutomationActivityDetailsModalProps): JSX.Element => {
   const { status, created_at, host_id, host_display_name } = activity;
   const detailOutput = getDetailOutputText(activity);
+  const isSoftwareInstall = activity.type === ActivityType.InstalledSoftware;
+
+  // A code-style output block with a copy button. Renders nothing when empty.
+  const renderOutputSection = (label: string, value: string | null) =>
+    value ? (
+      <Textarea
+        key={label}
+        variant="code"
+        label={
+          <div className={`${baseClass}__details-label`}>
+            <span>{label}</span>
+            <CopyButton
+              copyText={value}
+              size="small"
+              ariaLabel={`Copy ${label.toLowerCase()}`}
+            />
+          </div>
+        }
+      >
+        {value}
+      </Textarea>
+    ) : null;
 
   return (
     <Modal title="Details" onExit={onCancel} className={baseClass}>
@@ -66,22 +89,20 @@ const PolicyAutomationActivityDetailsModal = ({
             </span>
           }
         />
-        {detailOutput && (
-          <Textarea
-            variant="code"
-            label={
-              <div className={`${baseClass}__details-label`}>
-                <span>Details</span>
-                <CopyButton
-                  copyText={detailOutput}
-                  size="small"
-                  ariaLabel="Copy details"
-                />
-              </div>
-            }
-          >
-            {detailOutput}
-          </Textarea>
+        {isSoftwareInstall ? (
+          <>
+            {renderOutputSection(
+              "Pre-install query output",
+              activity.pre_install_output
+            )}
+            {renderOutputSection("Details", activity.output)}
+            {renderOutputSection(
+              "Post-install script output",
+              activity.post_install_output
+            )}
+          </>
+        ) : (
+          renderOutputSection("Details", detailOutput || null)
         )}
         <div className="modal-cta-wrap">
           <Button onClick={onCancel}>Done</Button>

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -43,6 +43,8 @@ const mockActivity = (
   host_display_name: "Anna's MacBook Pro",
   status: "success",
   output: null,
+  pre_install_output: null,
+  post_install_output: null,
   ...overrides,
 });
 

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useContext, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { Row } from "react-table";
 import { AxiosError } from "axios";
 import classnames from "classnames";
 
+import { AppContext } from "context/app";
 import { notify } from "components/ToastNotification";
 import {
   IPolicy,
@@ -62,6 +63,12 @@ const PolicyAutomationsActivitiesTable = ({
 }: IPolicyAutomationsActivitiesTableProps): JSX.Element => {
   const { id: policyId } = policy;
   const queryClient = useQueryClient();
+  const { config } = useContext(AppContext);
+
+  const {
+    activity_expiry_enabled: activityExpiryEnabled,
+    activity_expiry_window: activityExpiryWindow,
+  } = config?.activity_expiry_settings ?? {};
 
   const [page, setPage] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
@@ -178,13 +185,15 @@ const PolicyAutomationsActivitiesTable = ({
         />
       );
     }
-    return (
-      <EmptyState
-        header="No automation runs"
-        info="When this policy's automations run, their results will appear here."
-      />
-    );
-  }, [isFiltered]);
+    const info =
+      activityExpiryEnabled && activityExpiryWindow
+        ? `Automation history is retained for ${activityExpiryWindow} ${pluralize(
+            activityExpiryWindow,
+            "day"
+          )}.`
+        : "Automation history will appear here.";
+    return <EmptyState header="No automation runs" info={info} />;
+  }, [isFiltered, activityExpiryEnabled, activityExpiryWindow]);
 
   const columnConfigs = useMemo(
     () => generateColumnConfigs(baseClass, setSelectedActivity),

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTableConfig.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTableConfig.tsx
@@ -94,7 +94,7 @@ const generateColumnConfigs = (
       return (
         <Button
           className={`${baseClass}__details-cell`}
-          variant="text-icon"
+          variant="inverse"
           onClick={() => onShowDetails(activity)}
         >
           <span className={`${baseClass}__details-text`}>

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/_styles.scss
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/_styles.scss
@@ -76,12 +76,23 @@
     text-align: left;
     font-weight: $regular;
 
-    // The whole row is clickable, so suppress the text-icon button's grey hover
-    // highlight over the Details cell.
+    // The whole row is clickable, so suppress the button's grey hover highlight
+    // over the Details cell. (The keyboard focus outline is left intact.)
     &:hover,
     &:focus,
     &:active {
       background-color: transparent;
+    }
+
+    // Keyboard focus draws a box via the button's `::after` outline, sized to
+    // the full button (`100%`), so in the fixed-height (40px) row it nearly
+    // fills the cell and bleeds into the adjacent rows. Inset it so the box
+    // floats inside the cell with clear space around both the text and the row
+    // dividers.
+    &.button:focus-visible::after {
+      inset: $pad-xsmall;
+      width: auto;
+      height: auto;
     }
 
     &.button > .children-wrapper {

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -69,5 +69,14 @@ export const getDetailOutputText = (
   if (activity.status === "error" && activity.details?.error_response) {
     return activity.details.error_response;
   }
-  return activity.output ?? "";
+  // For software installs, the install-script output is the primary preview, but
+  // a failure at the pre-install query or post-install script stage leaves it
+  // empty — fall back to those so the row still shows the failing stage's output.
+  // Other activity types have null pre/post output, so this is just `output`.
+  return (
+    activity.output ||
+    activity.post_install_output ||
+    activity.pre_install_output ||
+    ""
+  );
 };

--- a/frontend/pages/policies/details/components/PolicyLabelModal/PolicyLabelModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyLabelModal/PolicyLabelModal.tests.tsx
@@ -6,6 +6,16 @@ import { ILabelPolicy } from "interfaces/label";
 
 import PolicyLabelModal from "./PolicyLabelModal";
 
+// Render react-router's <Link> as a plain anchor so we can assert the href
+// without a surrounding <Router>. This mirrors the real behavior we care about:
+// labels render as real anchors (not buttons), which lets the browser open
+// them in a new tab via middle-click or cmd/ctrl-click.
+jest.mock("react-router", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
 const INCLUDE_LABELS: ILabelPolicy[] = [
   { id: 1, name: "Engineering" },
   { id: 2, name: "Design" },
@@ -13,7 +23,7 @@ const INCLUDE_LABELS: ILabelPolicy[] = [
 const EXCLUDE_LABELS: ILabelPolicy[] = [{ id: 3, name: "Servers" }];
 
 describe("PolicyLabelModal", () => {
-  it("renders only the include section, as plain text, when only include labels are provided and onLabelClick is absent", () => {
+  it("renders only the include section, as plain text, when only include labels are provided and getLabelPath is absent", () => {
     render(
       <PolicyLabelModal
         includeLabels={INCLUDE_LABELS}
@@ -27,9 +37,9 @@ describe("PolicyLabelModal", () => {
     expect(screen.getByText("Engineering")).toBeInTheDocument();
     expect(screen.getByText("Design")).toBeInTheDocument();
 
-    // Without onLabelClick, labels render as plain text rather than buttons.
+    // Without getLabelPath, labels render as plain text rather than links.
     expect(
-      screen.queryByRole("button", { name: "Engineering" })
+      screen.queryByRole("link", { name: "Engineering" })
     ).not.toBeInTheDocument();
 
     expect(
@@ -86,21 +96,21 @@ describe("PolicyLabelModal", () => {
     expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
   });
 
-  it("renders labels as clickable buttons and calls onLabelClick with the label id when onLabelClick is provided", async () => {
-    const user = userEvent.setup();
-    const onLabelClick = jest.fn();
+  it("renders labels as anchor links to the path from getLabelPath when it is provided", () => {
+    const getLabelPath = (labelId: number) => `/labels/${labelId}`;
     render(
       <PolicyLabelModal
         includeLabels={INCLUDE_LABELS}
         includeScopeLabel="have any"
-        onLabelClick={onLabelClick}
+        getLabelPath={getLabelPath}
         onClose={jest.fn()}
       />
     );
 
-    await user.click(screen.getByRole("button", { name: "Design" }));
-
-    expect(onLabelClick).toHaveBeenCalledWith(2);
+    // Real anchors (with href) are what make middle-click / cmd-click "open in
+    // new tab" work — a <button> would not.
+    const link = screen.getByRole("link", { name: "Design" });
+    expect(link).toHaveAttribute("href", "/labels/2");
   });
 
   it("calls onClose when the Done button is clicked", async () => {

--- a/frontend/pages/policies/details/components/PolicyLabelModal/PolicyLabelModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyLabelModal/PolicyLabelModal.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import React from "react";
+import { Link } from "react-router";
 
 import { ILabelPolicy } from "interfaces/label";
 import Modal from "components/Modal";
@@ -12,8 +13,11 @@ export interface IPolicyLabelModalProps {
   includeScopeLabel?: string;
   excludeLabels?: ILabelPolicy[];
   excludeScopeLabel?: string;
-  /** When provided, labels render as clickable links; otherwise as plain text. */
-  onLabelClick?: (labelId: number) => void;
+  /**
+   * When provided, labels render as links to this path; otherwise as plain
+   * text.
+   * */
+  getLabelPath?: (labelId: number) => string;
   onClose: () => void;
 }
 
@@ -22,7 +26,7 @@ const PolicyLabelModal = ({
   includeScopeLabel,
   excludeLabels,
   excludeScopeLabel,
-  onLabelClick,
+  getLabelPath,
   onClose,
 }: IPolicyLabelModalProps): JSX.Element => {
   return (
@@ -38,7 +42,7 @@ const PolicyLabelModal = ({
             labels={includeLabels}
             scopeLabel={includeScopeLabel}
             description="Policy targets hosts that"
-            onLabelClick={onLabelClick}
+            getLabelPath={getLabelPath}
           />
         )}
         {excludeLabels && excludeScopeLabel && (
@@ -46,7 +50,7 @@ const PolicyLabelModal = ({
             labels={excludeLabels}
             scopeLabel={excludeScopeLabel}
             description="Policy excludes hosts that"
-            onLabelClick={onLabelClick}
+            getLabelPath={getLabelPath}
           />
         )}
         <div className="modal-cta-wrap">
@@ -61,14 +65,14 @@ interface ILabelListProps {
   labels: ILabelPolicy[];
   scopeLabel: string;
   description: string;
-  onLabelClick?: (labelId: number) => void;
+  getLabelPath?: (labelId: number) => string;
 }
 
 const LabelList = ({
   labels,
   scopeLabel,
   description,
-  onLabelClick,
+  getLabelPath,
 }: ILabelListProps): JSX.Element => (
   <div className={`${baseClass}__section`}>
     <span>
@@ -77,10 +81,8 @@ const LabelList = ({
     <ul className={`${baseClass}__label-list`}>
       {labels.map((label) => (
         <li key={label.id} className={`${baseClass}__label-item`}>
-          {onLabelClick ? (
-            <Button variant="link" onClick={() => onLabelClick(label.id)}>
-              {label.name}
-            </Button>
+          {getLabelPath ? (
+            <Link to={getLabelPath(label.id)}>{label.name}</Link>
           ) : (
             <span>{label.name}</span>
           )}

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -1595,20 +1595,31 @@ const policyAutomationHostJoin = `
     JOIN  hosts               h   ON h.id            = ahp.host_id
     LEFT JOIN host_display_names hdn ON hdn.host_id  = ahp.host_id`
 
-// statusOutputCols renders the trailing "status, output" column pair that every
-// UNION branch must project after policyAutomationCols. Modeling it as a struct
+// statusOutputCols renders the trailing status/output columns that every UNION
+// branch must project after policyAutomationCols. Modeling it as a struct
 // (rather than a raw SQL fragment) makes the positional contract that UNION ALL
-// relies on impossible to break by hand: both columns are always present,
-// always aliased, and always in this order, so no branch can silently reorder
-// or drop one. status and output are SQL expressions; use "NULL" for output
-// when the branch has nothing to surface.
+// relies on impossible to break by hand: the columns are always present, always
+// aliased, and always in this order, so no branch can silently reorder or drop
+// one. All fields are SQL expressions. status and output are required; an empty
+// preInstallOutput/postInstallOutput is projected as NULL (only the
+// installed_software branch surfaces those).
 type statusOutputCols struct {
-	status string
-	output string
+	status            string
+	output            string
+	preInstallOutput  string
+	postInstallOutput string
 }
 
 func (c statusOutputCols) sql() string {
-	return fmt.Sprintf("%s AS status, %s AS output", c.status, c.output)
+	pre, post := c.preInstallOutput, c.postInstallOutput
+	if pre == "" {
+		pre = "NULL"
+	}
+	if post == "" {
+		post = "NULL"
+	}
+	return fmt.Sprintf("%s AS status, %s AS output, %s AS pre_install_output, %s AS post_install_output",
+		c.status, c.output, pre, post)
 }
 
 // policyAutomationNamedStatusCols projects the status/output pair for the named
@@ -1631,7 +1642,9 @@ type policyAutomationTaskBranch struct {
 	joins string
 	// errorCond and successCond are the WHERE fragments selecting failed and
 	// successful tasks respectively. They are wrapped in parentheses when
-	// applied, so internal OR/AND precedence is preserved.
+	// applied, so internal OR/AND precedence is preserved. Together they must
+	// partition the rows the branch surfaces: every row is matched by exactly one
+	// of them, and that must agree with statusCols.
 	errorCond   string
 	successCond string
 	// statusCols projects the status/output pair for this branch. The
@@ -1665,11 +1678,25 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
                 ON  hsi.host_id      = ahp.host_id
                 AND hsi.execution_id = ap.details->>'$.install_uuid'
                 AND hsi.policy_id    = ?`,
+		// Outcome comes from the recorded details.status (a historical snapshot),
+		// not the live host_software_installs status, which goes NULL once the row
+		// is removed. The activity is only written for a terminal install (see
+		// svc.NewActivity in orbit.go, gated on status != pending_install), and
+		// details.status has been recorded since the activity type was introduced,
+		// so in practice the only values are 'installed' and 'failed_install'.
+		// 'failed_install' is treated as the sole failure and anything else (an
+		// unexpected or empty status) as success, so errorCond and successCond are
+		// null-safe complements that exactly partition what statusCols reports.
 		errorCond:   "ap.details->>'$.status' = 'failed_install'",
-		successCond: "ap.details->>'$.status' = 'installed'",
+		successCond: "NOT (ap.details->>'$.status' <=> 'failed_install')",
+		// A software install can fail at the pre-install query, install script, or
+		// post-install script stage, so surface all three outputs; the modal shows
+		// them as separate sections.
 		statusCols: statusOutputCols{
-			status: "IF(ap.details->>'$.status' = 'installed', 'success', 'error')",
-			output: "hsi.install_script_output",
+			status:            "IF(ap.details->>'$.status' = 'failed_install', 'error', 'success')",
+			output:            "hsi.install_script_output",
+			preInstallOutput:  "hsi.pre_install_query_output",
+			postInstallOutput: "hsi.post_install_script_output",
 		},
 	},
 	{
@@ -1678,19 +1705,22 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
             INNER JOIN host_vpp_software_installs hvsi
                 ON  hvsi.host_id      = ahp.host_id
                 AND hvsi.command_uuid = ap.details->>'$.command_uuid'
-                AND hvsi.policy_id    = ?
-            LEFT JOIN nano_command_results ncr
-                ON  ncr.command_uuid = hvsi.command_uuid
-                AND ncr.id = (SELECT uuid FROM hosts WHERE id = ahp.host_id)`,
-		errorCond: "hvsi.verification_failed_at IS NOT NULL OR ncr.status IN ('Error', 'CommandFormatError')",
-		// verification_at IS NOT NULL is the canonical "installed" indicator: it
-		// is set by Fleet after the MDM command result is confirmed, independently
-		// of the nano_command_results row.
-		successCond: "hvsi.verification_at IS NOT NULL",
+                AND hvsi.policy_id    = ?`,
+		// Like installed_software, a VPP activity is only written in a terminal
+		// state — either on a command error (apple_mdm.go) or once the install is
+		// verified/timed out (setStatusForExpectedInstall in
+		// apple_mdm_cmd_results.go) — recording the outcome in details.status. Read
+		// that historical snapshot rather than the live hvsi.verification_* columns,
+		// which mutate over the install's lifetime and go NULL when the row is
+		// removed. 'failed_install' is the sole failure; everything else is a
+		// success. error and success conditions are null-safe complements that
+		// exactly partition what statusCols reports.
+		errorCond:   "ap.details->>'$.status' = 'failed_install'",
+		successCond: "NOT (ap.details->>'$.status' <=> 'failed_install')",
 		// VPP apps are installed via MDM command, not a script, so there is no
 		// script output to surface.
 		statusCols: statusOutputCols{
-			status: "IF(hvsi.verification_at IS NOT NULL, 'success', 'error')",
+			status: "IF(ap.details->>'$.status' = 'failed_install', 'error', 'success')",
 			output: "NULL",
 		},
 	},

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -2628,27 +2628,33 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 	}))
 
 	// ── installed_app_store_app (VPP) ─────────────────────────────────────────
+	// Outcome comes from the recorded details.status (a terminal snapshot), like
+	// installed_software — not the live hvsi.verification_* columns. To prove
+	// that, the live verification columns are set to the OPPOSITE of each row's
+	// details.status: the "success" row is marked verification_failed_at and the
+	// "failure" row verification_at. If the query read the live columns, the
+	// outcomes would flip and the assertions below would fail.
 	vppSuccessCmdUUID := "vpp-success-cmd-1"
 	vppFailureCmdUUID := "vpp-failure-cmd-1"
 	_, err = ds.writer(ctx).ExecContext(ctx,
-		`INSERT INTO host_vpp_software_installs (host_id, adam_id, command_uuid, policy_id, platform, verification_at)
+		`INSERT INTO host_vpp_software_installs (host_id, adam_id, command_uuid, policy_id, platform, verification_failed_at)
          VALUES (?, 'A001', ?, ?, 'darwin', NOW())`,
 		h1.ID, vppSuccessCmdUUID, policy.ID)
 	require.NoError(t, err)
 	_, err = ds.writer(ctx).ExecContext(ctx,
-		`INSERT INTO host_vpp_software_installs (host_id, adam_id, command_uuid, policy_id, platform, verification_failed_at)
+		`INSERT INTO host_vpp_software_installs (host_id, adam_id, command_uuid, policy_id, platform, verification_at)
          VALUES (?, 'A002', ?, ?, 'darwin', NOW())`,
 		h1.ID, vppFailureCmdUUID, policy.ID)
 	require.NoError(t, err)
 
 	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
 		name:    "installed_app_store_app",
-		details: map[string]any{"command_uuid": vppSuccessCmdUUID, "software_title": "My VPP App"},
+		details: map[string]any{"command_uuid": vppSuccessCmdUUID, "software_title": "My VPP App", "status": "installed"},
 		hostIDs: []uint{h1.ID},
 	}))
 	require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
 		name:    "installed_app_store_app",
-		details: map[string]any{"command_uuid": vppFailureCmdUUID, "software_title": "My VPP App"},
+		details: map[string]any{"command_uuid": vppFailureCmdUUID, "software_title": "My VPP App", "status": "failed_install"},
 		hostIDs: []uint{h1.ID},
 	}))
 
@@ -2779,8 +2785,10 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 			switch a.Type {
 			case "ran_script":
 				// Scripts always carry output; the script name comes through in
-				// the details blob.
+				// the details blob. Pre/post-install output is install-only.
 				require.NotNil(t, a.Output)
+				require.Nil(t, a.PreInstallOutput)
+				require.Nil(t, a.PostInstallOutput)
 				require.Equal(t, "my-script.sh", detailsValue(a, "script_name"))
 				if a.Status == "success" {
 					sawScriptSuccess = true
@@ -2790,21 +2798,30 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 					require.Equal(t, "script fail output", *a.Output)
 				}
 			case "installed_software":
-				// Software installs carry the install-script output; the software
+				// Software installs carry the install-script output plus the
+				// pre-install query and post-install script output; the software
 				// title comes through in the details blob.
 				require.NotNil(t, a.Output)
+				require.NotNil(t, a.PreInstallOutput)
+				require.NotNil(t, a.PostInstallOutput)
 				require.Equal(t, "My Software", detailsValue(a, "software_title"))
 				if a.Status == "success" {
 					sawSwSuccess = true
 					require.Equal(t, "install ok", *a.Output)
+					require.Equal(t, "pre ok", *a.PreInstallOutput)
+					require.Equal(t, "post ok", *a.PostInstallOutput)
 				} else {
 					sawSwFailure = true
 					require.Equal(t, "install fail", *a.Output)
+					require.Equal(t, "pre fail", *a.PreInstallOutput)
+					require.Equal(t, "post fail", *a.PostInstallOutput)
 				}
 			case "installed_app_store_app":
 				// VPP apps are installed via MDM command, so there is no output;
 				// the software title comes through in the details blob.
 				require.Nil(t, a.Output)
+				require.Nil(t, a.PreInstallOutput)
+				require.Nil(t, a.PostInstallOutput)
 				require.Equal(t, "My VPP App", detailsValue(a, "software_title"))
 				if a.Status == "success" {
 					sawVPPSuccess = true
@@ -2815,6 +2832,8 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 				// Named automation activities encode outcome in the type and have
 				// no output.
 				require.Nil(t, a.Output)
+				require.Nil(t, a.PreInstallOutput)
+				require.Nil(t, a.PostInstallOutput)
 				if strings.HasPrefix(a.Type, "failed_") {
 					sawNamedError = true
 					require.Equal(t, "error", a.Status)
@@ -2833,5 +2852,134 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 		require.True(t, sawVPPFailure, "expected a failed installed_app_store_app")
 		require.True(t, sawNamedError, "expected a failed named automation")
 		require.True(t, sawNamedSuccess, "expected a successful named automation")
+	})
+
+	t.Run("installed_software with an unrecorded status is treated as a success", func(t *testing.T) {
+		// Older installed_software activities can lack a recorded details.status
+		// (the field was added after the activity type, and back then the activity
+		// was only emitted on a successful install). 'failed_install' is the sole
+		// failure value, so a missing status is a success — and the reported status
+		// must agree with the filters: it appears under "All" and status=success,
+		// never under status=error.
+		execID := "sw-no-status-exec-1"
+		_, err := ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO host_software_installs
+                (host_id, execution_id, software_installer_id, install_script_exit_code,
+                 install_script_output, policy_id)
+             VALUES (?, ?, 1, 0, 'historical output', ?)`,
+			h1.ID, execID, policy.ID)
+		require.NoError(t, err)
+
+		// details intentionally omits "status".
+		require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+			name:    "installed_software",
+			details: map[string]any{"install_uuid": execID, "software_title": "My Software"},
+			hostIDs: []uint{h1.ID},
+		}))
+
+		find := func(as []*fleet.PolicyAutomationActivity) *fleet.PolicyAutomationActivity {
+			for _, a := range as {
+				if a.Type != "installed_software" || a.Details == nil {
+					continue
+				}
+				var m map[string]any
+				require.NoError(t, json.Unmarshal(*a.Details, &m))
+				if m["install_uuid"] == execID {
+					return a
+				}
+			}
+			return nil
+		}
+
+		all, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "")
+		require.NoError(t, err)
+		got := find(all)
+		require.NotNil(t, got, "unrecorded-status install must appear under All")
+		require.Equal(t, "success", got.Status, "a non-failed_install status is reported as a success")
+
+		success, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "success")
+		require.NoError(t, err)
+		require.NotNil(t, find(success), "a success shown under All must also appear under status=success")
+
+		errored, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(), "error")
+		require.NoError(t, err)
+		require.Nil(t, find(errored), "a success must not appear under status=error")
+	})
+
+	t.Run("status filters partition the feed for every activity type", func(t *testing.T) {
+		// A row is uniquely identified by (activity id, host id) — one activity
+		// linked to N hosts expands to N rows.
+		key := func(a *fleet.PolicyAutomationActivity) string {
+			return fmt.Sprintf("%d-%d", a.ID, a.HostID)
+		}
+		fetch := func(status string) map[string]*fleet.PolicyAutomationActivity {
+			acts, _, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter,
+				listOpts(fleet.ListOptions{PerPage: 1000}), status)
+			require.NoError(t, err)
+			m := make(map[string]*fleet.PolicyAutomationActivity, len(acts))
+			for _, a := range acts {
+				m[key(a)] = a
+			}
+			return m
+		}
+
+		all := fetch("")
+		errored := fetch("error")
+		success := fetch("success")
+
+		// error and success are disjoint and together reconstruct the full feed.
+		for k := range errored {
+			_, inSuccess := success[k]
+			require.False(t, inSuccess, "row %s appears under both status=error and status=success", k)
+		}
+		require.Equal(t, len(all), len(errored)+len(success),
+			"status=error and status=success must partition the unfiltered feed")
+
+		// Every row shown under All lands in exactly the filter matching its
+		// reported status — no type is dropped by either filter.
+		for k, a := range all {
+			_, inErr := errored[k]
+			_, inSucc := success[k]
+			require.True(t, inErr || inSucc,
+				"row %s (type %s, status %q) shown under All is missing from both filters",
+				k, a.Type, a.Status)
+			if a.Status == "error" {
+				require.True(t, inErr, "row %s (type %s) reports error but is absent from status=error", k, a.Type)
+			} else {
+				require.True(t, inSucc, "row %s (type %s) reports success but is absent from status=success", k, a.Type)
+			}
+		}
+
+		// Each task type is represented by both a success and a failure so the
+		// partition above is exercised for every branch, not just the named ones.
+		for _, typ := range []string{"ran_script", "installed_software", "installed_app_store_app"} {
+			var sawErr, sawSucc bool
+			for _, a := range all {
+				if a.Type != typ {
+					continue
+				}
+				if a.Status == "error" {
+					sawErr = true
+				} else {
+					sawSucc = true
+				}
+			}
+			require.True(t, sawErr, "expected at least one failed %s", typ)
+			require.True(t, sawSucc, "expected at least one successful %s", typ)
+		}
+		// Named automations: a failed_* type is an error, a ran_automation_* is a success.
+		var sawNamedErr, sawNamedSucc bool
+		for _, a := range all {
+			switch {
+			case strings.HasPrefix(a.Type, "failed_"):
+				sawNamedErr = true
+				require.Equal(t, "error", a.Status, "type %s", a.Type)
+			case strings.HasPrefix(a.Type, "ran_automation_"):
+				sawNamedSucc = true
+				require.Equal(t, "success", a.Status, "type %s", a.Type)
+			}
+		}
+		require.True(t, sawNamedErr, "expected a failed named automation")
+		require.True(t, sawNamedSucc, "expected a successful named automation")
 	})
 }

--- a/server/fleet/api_policies.go
+++ b/server/fleet/api_policies.go
@@ -303,6 +303,12 @@ type PolicyAutomationActivity struct {
 	// named automation and VPP (installed_app_store_app) activities, which carry
 	// no script output.
 	Output *string `json:"output" db:"output"`
+	// PreInstallOutput and PostInstallOutput are the pre-install query output and
+	// post-install script output for installed_software activities (a software
+	// install can fail at any of the three stages). They are null for every other
+	// activity type.
+	PreInstallOutput  *string `json:"pre_install_output" db:"pre_install_output"`
+	PostInstallOutput *string `json:"post_install_output" db:"post_install_output"`
 }
 
 // ListPolicyAutomationActivitiesRequest is the request type for


### PR DESCRIPTION
Relates to #38670 

Several fixes to the policy details page's "Automation runs" feed and the labels modal:
- Empty state: when activity expiry is enabled, show the configured
    retention window ("Automation history is retained for N days");
    otherwise show a generic "Automation history will appear here".
- Details column focus: replace the deprecated `text-icon` button variant
    with `inverse`, and inset the keyboard-focus outline so it no longer
    hugs the cell text or bleed into adjacent rows.
- Labels modal: render policy labels as react-router links (real anchors)
    instead of buttons, so they can be opened in a new tab via middle-click
    or cmd/ctrl-click.
- Status filtering: make the installed_software and VPP
    (installed_app_store_app) error/success conditions null-safe complements
    of the displayed status, so every row shown under "All" appears under
    exactly one of the status filters. Derive the VPP outcome from the
    historical details.status (activities are terminal-only) rather than the
    live verification columns, which mutate over the install's lifetime.
- Install output: surface the pre-install query output and post-install
    script output as separate sections in the activity details modal, and
    fall back to them in the grid preview when the install-script output is
    empty (e.g. a pre-install-stage failure).
- Add a datastore test asserting the status filters partition the feed
    (all = error ⊎ success) for every activity type.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Policy automation activity details now show separate pre-install and post-install outputs for software-install activities.
  * Policy label names can open directly as navigation links when label editing is available.
* **Bug Fixes**
  * Improved selection of which stage output to show when some install stages are missing.
  * Automation history empty-state messaging now reflects configured retention settings.
  * Status filtering for automation activity feeds is more consistent and complete.
* **Style**
  * Refined the activity table “Details” hover/focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->