### PR TITLE
Supress install all for all/undefined software category

### DIFF
--- a/changes/48485-hide-install-all-on-all-category
+++ b/changes/48485-hide-install-all-on-all-category
@@ -1,0 +1,1 @@
+- Hid the Self-service "Install all" button on the unfiltered "All" category so end users can't queue an install of the entire catalog in one click. The button still appears when a specific category is selected.

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -299,7 +299,10 @@ describe("SelfServiceCard", () => {
     expect(screen.queryByText("🔐 Security")).not.toBeInTheDocument();
   });
 
-  it("renders the install-all button enabled when 'All' is selected and items are eligible", () => {
+  it("does not render the install-all button on the unfiltered 'All' view even when items are eligible", () => {
+    // DEFAULT_QUERY_PARAMS has category_id: undefined, i.e. the "All" view.
+    // Install all is suppressed there so a single click can't queue the entire
+    // catalog — see #48485.
     const props = createTestProps({
       enhancedSoftware: [
         {
@@ -312,9 +315,9 @@ describe("SelfServiceCard", () => {
 
     render(<SelfServiceCard {...props} />);
 
-    const button = screen.getByRole("button", { name: /Install all/i });
-    expect(button).toBeInTheDocument();
-    expect(button).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: /Install all/i })
+    ).not.toBeInTheDocument();
   });
 
   it("renders the install-all button with the uninstalled count when a category is selected", async () => {
@@ -366,14 +369,27 @@ describe("SelfServiceCard", () => {
   // click only queues whatever's still eligible. The button stays enabled
   // whenever count > 0. See #47855.
   it("keeps the install-all button enabled when an item is in progress and there are still uninstalled items", async () => {
+    mockServer.use(
+      listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+    );
+    const browserPackage = createMockHostSoftwarePackage({
+      categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
+    });
     const props = createTestProps({
+      queryParams: { ...DEFAULT_QUERY_PARAMS, category_id: 1 },
       enhancedSoftware: [
         {
-          ...createMockDeviceSoftware({ name: "uninstalled-app" }),
+          ...createMockDeviceSoftware({
+            name: "uninstalled-app",
+            software_package: browserPackage,
+          }),
           ui_status: "uninstalled",
         },
         {
-          ...createMockDeviceSoftware({ name: "in-progress-app" }),
+          ...createMockDeviceSoftware({
+            name: "in-progress-app",
+            software_package: browserPackage,
+          }),
           ui_status: "installing",
         },
       ],
@@ -401,12 +417,22 @@ describe("SelfServiceCard", () => {
         }
       )
     );
+    mockServer.use(
+      listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+    );
+    const browserPackage = createMockHostSoftwarePackage({
+      categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
+    });
     const onInstallAllSuccess = jest.fn();
     const props = createTestProps({
       onInstallAllSuccess,
+      queryParams: { ...DEFAULT_QUERY_PARAMS, category_id: 1 },
       enhancedSoftware: [
         {
-          ...createMockDeviceSoftware({ name: "uninstalled-app" }),
+          ...createMockDeviceSoftware({
+            name: "uninstalled-app",
+            software_package: browserPackage,
+          }),
           ui_status: "uninstalled",
         },
       ],
@@ -417,7 +443,7 @@ describe("SelfServiceCard", () => {
     render(<SelfServiceCard {...props} />);
 
     await user.click(
-      screen.getByRole("button", { name: /Install all \(1\)/i })
+      await screen.findByRole("button", { name: /Install all \(1\)/i })
     );
     // The confirm button inside the modal is labeled "Install all" (no count).
     await user.click(
@@ -428,8 +454,8 @@ describe("SelfServiceCard", () => {
       expect(installAllCalled).toBe(true);
       expect(onInstallAllSuccess).toHaveBeenCalled();
     });
-    // "All" selected → no category_id should be on the query string.
-    expect(installAllUrl).not.toContain("category_id");
+    // A specific category is selected → its category_id is on the query string.
+    expect(installAllUrl).toContain("category_id=1");
   });
 
   it("does not render the install-all button on the mobile view", () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -250,21 +250,21 @@ const SelfServiceCard = ({
       })
     : softwareInSelectedCategory;
 
-  // The button is shown on desktop in the "All" filter and in any selected
-  // category. On
-  // "All", `categoryId` is undefined; the click posts to install_all without a
-  // category_id query param and the BE installs every eligible (uninstalled,
-  // not-in-progress) self-service item. Visibility, count, and disabled state
-  // are owned by InstallAllInCategoryButton — see #47855 for the full rules.
-  const installAllButton = !isMobileView ? (
-    <InstallAllInCategoryButton
-      uninstalledCount={uninstalledCount}
-      hasInProgressInCategory={hasInProgress}
-      deviceToken={deviceToken}
-      categoryId={queryParams.category_id}
-      onSuccess={() => onInstallAllSuccess?.()}
-    />
-  ) : null;
+  // The button is shown on desktop ONLY when a specific category is selected
+  // (`category_id` is defined). On the unfiltered "All" view we suppress it so a
+  // single click can't queue an install of the entire catalog — see #48485.
+  // Visibility beyond this (count / in-progress / disabled state) is owned by
+  // InstallAllInCategoryButton — see #47855 for the full rules.
+  const installAllButton =
+    !isMobileView && queryParams.category_id !== undefined ? (
+      <InstallAllInCategoryButton
+        uninstalledCount={uninstalledCount}
+        hasInProgressInCategory={hasInProgress}
+        deviceToken={deviceToken}
+        categoryId={queryParams.category_id}
+        onSuccess={() => onInstallAllSuccess?.()}
+      />
+    ) : null;
 
   if (isMobileView) {
     return (


### PR DESCRIPTION
**Related issue:** Resolves #49013

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the **Install all** button on the unfiltered **All** software view.
  * Kept **Install all** available when a specific category is selected.
  * Updated install-all behavior so the correct category is used when launching installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->