### PR TITLE
Fix invisible hover state in dark mode

### DIFF
--- a/changes/48531-dark-mode-hover-state
+++ b/changes/48531-dark-mode-hover-state
@@ -1,0 +1,1 @@
+- Fixed missing hover state on buttons and dropdowns inside cards in dark mode.

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -319,6 +319,15 @@ body.dark-mode .card .button--icon:hover {
   background-color: $core-fleet-white;
 }
 
+// A modal opened from inside a card inherits the .card hover above, which
+// matches the modal surface and hides it. Restore the normal inverse hover.
+body.dark-mode .modal__modal_container .button--inverse:hover,
+body.dark-mode .modal__modal_container .button--inverse-alert:hover,
+body.dark-mode .modal__modal_container .button--text-icon:hover,
+body.dark-mode .modal__modal_container .button--icon:hover {
+  background-color: $ui-fleet-black-5;
+}
+
 body.dark-mode .checkbox-unchecked-state {
   fill: $core-fleet-white;
   stroke: $ui-fleet-black-25;
@@ -328,6 +337,13 @@ body.dark-mode .checkbox-unchecked-state {
 // so !important is needed to override them in dark mode.
 body.dark-mode .react-select__control {
   background-color: $ui-fleet-black-5 !important;
+}
+
+// A "button" dropdown (e.g. software Actions) hardcodes its hover to
+// $ui-fleet-black-5, which matches the card surface and hides it. Darken to
+// $core-fleet-white on cards, same as the .card button rule above.
+body.dark-mode .card .dropdown-wrapper__button .react-select__control:hover {
+  background-color: $core-fleet-white !important;
 }
 
 // Legacy react-select v1 (Dropdown) uses SCSS-applied backgrounds.

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -319,8 +319,8 @@ body.dark-mode .card .button--icon:hover {
   background-color: $core-fleet-white;
 }
 
-// A modal opened from inside a card inherits the .card hover above, which
-// matches the modal surface and hides it. Restore the normal inverse hover.
+// A modal inside a card inherits the .card hover above, which matches the
+// modal surface and hides it. Restore the normal inverse hover.
 body.dark-mode .modal__modal_container .button--inverse:hover,
 body.dark-mode .modal__modal_container .button--inverse-alert:hover,
 body.dark-mode .modal__modal_container .button--text-icon:hover,
@@ -339,10 +339,11 @@ body.dark-mode .react-select__control {
   background-color: $ui-fleet-black-5 !important;
 }
 
-// A "button" dropdown (e.g. software Actions) hardcodes its hover to
-// $ui-fleet-black-5, which matches the card surface and hides it. Darken to
-// $core-fleet-white on cards, same as the .card button rule above.
-body.dark-mode .card .dropdown-wrapper__button .react-select__control:hover {
+// Button-style dropdowns hardcode their hover to $ui-fleet-black-5, which
+// matches the card surface. Darken to $core-fleet-white on cards, like the
+// .card button rule above. One selector per dropdown component.
+body.dark-mode .card .dropdown-wrapper__button .react-select__control:hover,
+body.dark-mode .card .actions-dropdown-select__control:hover {
   background-color: $core-fleet-white !important;
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48531

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
Checked all the places according to this list:
```
Rule 1 — modal secondary buttons (Cancel / Done / Clear all)
`body.dark-mode .modal__modal_container .button--inverse:hover, …`
Affects any modal opened from *inside a card* (the only modals where the card-leak made hover invisible). There are **4 such surfaces**, all reachable from the Dashboard or Self-service:

1. **Dashboard → the chart card (Hosts online / vulnerability exposure) → Settings cog → the Settings modal** — hover **Cancel** and **Clear all**. *(issue #48531)*
2. **Dashboard → Activity card → click any activity's details link** — the details modal's footer button (Done/Cancel). This is 12 different activity-detail modals (script details, software install/uninstall details, VPP install, MDM command, etc.).
3. **Dashboard on a fresh instance (fewer than 2 hosts) → "Welcome to Fleet" card → click a policy row** — the policy modal.
4. **Fleet Desktop "My device" → Self-service tab → "Install all" button** — the Install-all-in-category modal's Cancel.

## Rule 2 — button `DropdownWrapper` hover
`body.dark-mode .card .dropdown-wrapper__button .react-select__control:hover`
Exactly **1 place** in the whole app:

5. **Software → click a software title → title details page → the "Actions ▾" dropdown** at the top-right of the summary card. *(Admin/maintainer only — it's gated behind "can manage software".)*

## Rule 3 — `ActionsDropdown` hover
`body.dark-mode .card .actions-dropdown-select__control:hover`
Exactly **2 places**:

6. **Host details → Reports tab → each report card header → "Actions ▾"**. *(The confirmed repro.)*
7. **Fleet Desktop "My device" → Self-service tab → a software row → "More ▾"** dropdown.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dark-mode hover styling for buttons and dropdowns inside card components.
  * Restored the correct hover appearance for inverse buttons in modal containers.
  * Updated hover behavior for select-style dropdown controls so they match the card surface in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->