### PR TITLE
Docs: Python (.py) script-only package reconciliation (#48395)

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -342,7 +342,7 @@ agent_options:
 
 The `controls` section allows you to configure scripts and device management (MDM) features in Fleet.
 
-- `scripts` is a list of paths to macOS, Windows, or Linux scripts. Supports `path:` (single file) and `paths:` (glob pattern, filtered to `.sh` and `.ps1` files only). Filenames must not contain `*`, `?`, `[`, or `{` when using `path:`. See [`path:` vs `paths:`](#path-vs-paths-glob-patterns) for details.
+- `scripts` is a list of paths to macOS, Windows, or Linux scripts. Supports `path:` (single file) and `paths:` (glob pattern, filtered to `.sh`, `.py`, and `.ps1` files only). Filenames must not contain `*`, `?`, `[`, or `{` when using `path:`. See [`path:` vs `paths:`](#path-vs-paths-glob-patterns) for details.
 - `windows_enabled_and_configured` specifies whether or not to turn on Windows MDM features (default: `false`). Can only be configured for "All fleets" (`default.yml`).
 - `windows_entra_tenant_ids` is a list of Microsoft Entra tenant IDs to enable automatic (Autopilot) and manual enrollment by end users (**Settings** > **Accounts** > **Access work or school** on Windows). Can only be configured for "All fleets" (`default.yml`). Find your **Tenant ID**, on [**Microsoft Entra ID** > **Home**](https://entra.microsoft.com/#home).
 - `windows_entra_client_ids` is a list of Microsoft Entra application (client) IDs for the applications used to enroll Windows hosts via Microsoft Entra. Set this when you set up Entra enrollment: Microsoft Entra issues v2 access tokens whose audience is the application's client ID, so Fleet needs the client ID to authorize enrollment. Can only be configured for "All fleets" (`default.yml`). Find your **Application (client) ID** on [**Microsoft Entra ID** > **App registrations**](https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) > your MDM application > **Overview**.
@@ -362,7 +362,7 @@ controls:
     - path: ../lib/macos-script.sh
     - path: ../lib/windows-script.ps1
     - path: ../lib/linux-script.sh
-    - paths: ../lib/scripts/*.sh  # Glob pattern (filtered to .sh and .ps1 only)
+    - paths: ../lib/scripts/*.sh  # Glob pattern (filtered to .sh, .py, and .ps1 only)
   windows_enabled_and_configured: true
   windows_entra_tenant_ids:
     - 4e342a0d-ec1a-4353-bdeb-785542e0a8fb
@@ -720,7 +720,7 @@ If your server doesn't support ETags reliably, you can disable this behavior wit
 
 ##### Script-only
 
-Script-only packages (`.sh`, .`py`, and `.ps1` files) are referenced directly inline in the team YAML file. The file contents become the install script. Script packages do not support `install_script`, `uninstall_script`, `post_install_script`, `pre_install_query`, or automatic install (`install_software` in policies).
+Script-only packages (`.sh`, `.py`, and `.ps1` files) are referenced directly inline in the team YAML file. The file contents become the install script. Script packages do not support `install_script`, `uninstall_script`, `post_install_script`, `pre_install_query`, or automatic install (`install_software` in policies).
 
 `self_service`, `categories`, `labels`, and `icon` are specified inline in the team YAML file.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -11484,7 +11484,7 @@ Operating systems other than Windows, macOS, and Linux do not report vulnerabili
 
 _Available in Fleet Premium._
 
-Add a package (.pkg, .msi, .exe, .deb, .rpm, .tar.gz, .ipa) to install on Apple (macOS/iOS/iPadOS), Windows, or Linux hosts. Also supports adding a custom script (.sh, .ps1, .py) to run on Windows or Linux hosts.
+Add a package (.pkg, .msi, .exe, .deb, .rpm, .tar.gz, .ipa) to install on Apple (macOS/iOS/iPadOS), Windows, or Linux hosts. Also supports adding a custom script (.sh and .py for macOS and Linux, .ps1 for Windows).
 
 > You need to send a request of type `multipart/form-data`.
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48395 (story #41470)

Reconciles the `.py` script-only package reference docs against shipped behavior. The feature guide (#48116) and reference docs (#48113 YAML, #48115 REST API) are already merged to `docs-v4.90.0`; this fixes remaining `.py` inconsistencies found during the #48395 reconciliation.

Docs-only PR against `docs-v4.90.0`.

## Changes

- **`docs/REST API/rest-api.md`** — corrected the Add-package platform scoping: `.sh` and `.py` run on macOS and Linux, `.ps1` runs on Windows (was "Windows or Linux hosts," which omitted macOS and wrongly implied `.py` on Windows). Verified against `SoftwareInstallerPlatformFromExtension` and the Unix-like install-eligibility check in `ee/server/service/software_installers.go`.
- **`docs/Configuration/yaml-files.md`** — fixed a backtick typo in the Script-only heading (`` .`py` `` → `` `.py` ``) and added `.py` to the `controls.scripts` glob note (prose + example), matching the already-merged `scripts.md` statement that `.py` scripts are supported on macOS and Linux.

## No changes needed

- No new audit-log activity type — `docs/Contributing/reference/audit-logs.md` unchanged.
- No new usage-statistics toggle — `articles/fleet-usage-statistics.md` unchanged.
- Feature guide (`deploy-software-packages.md`, `scripts.md`, secrets doc) already merged via #48116.
- `python_packages` in `rest-api.md` is the osquery inventory source for installed pip packages — unrelated to `.py` packages, left as-is.

## Note

The script-only advanced-options wording (in `yaml-files.md` and `deploy-software-packages.md`) is corrected separately in the #42797 docs PR against `docs-v4.89.0`; it reaches 4.90 via the normal forward-merge.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (verified `.py` platform mapping and script-extension handling in `server/fleet/software_installer.go`, `server/fleet/scripts.go`, `pkg/spec/gitops.go`)

<!-- Docs-only PR: no changes file, no code/tests, no migrations, no config settings, no fleetd changes. -->
