### PR TITLE
Fix long certificate name overflow in delete certificate modal (#48948)

### DIFF
--- a/changes/48948-delete-cert-modal-overflow
+++ b/changes/48948-delete-cert-modal-overflow
@@ -1,0 +1,1 @@
+- Fixed long certificate names overflowing the delete certificate modal in Controls > OS settings > Certificates.

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/DeleteCertificateModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/DeleteCertificateModal/_styles.scss
@@ -1,2 +1,3 @@
-.delete-certificate-modal {
+.delete-cert-template-modal {
+  overflow-wrap: anywhere; // Prevent long certificate name overflow
 }


### PR DESCRIPTION
**Related issue:** Resolves #48948

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

## Testing

- [x] QA'd all new/changed functionality manually

## Notes

Long, unbroken certificate names overflowed the **Delete certificate** modal. Root cause: the modal's `baseClass` (`delete-cert-template-modal`) didn't match its stylesheet selector (`.delete-certificate-modal`), so no styling applied. Fixed the selector and added `overflow-wrap: anywhere`, matching the existing `DeleteSoftwareModal` pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long certificate names now wrap correctly in the delete certificate modal, preventing layout overflow in **Controls > OS settings > Certificates**.

* **Documentation**
  * Added a changelog entry describing the improved certificate modal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->