### PR TITLE
Frontend: document form validation rules and error copy register

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -107,6 +107,70 @@ Render software title names via `getDisplayedSoftwareName(name, display_name)` f
 ## Forms
 Cap free-text inputs' `maxLength` to the backend column length (check `server/datastore/mysql/schema.sql`, don't guess) via `inputOptions={{ maxLength: NAME_MAX_LENGTH }}` on `InputField`, using a local constant.
 
+## Validation
+
+See `frontend/docs/patterns.md#data-validation` for full rules and rationale. These describe target behavior; existing forms migrate one at a time as they're touched. A shared validation hook is planned to encode them.
+
+### Error timing
+- Never show a field's error before the user has interacted with it (typed into it, or blurred it while dirty).
+- On blur of an interacted-with field, validate that field and show its error inline. Don't modify other fields' errors.
+- On submit, show inline errors on every invalid field simultaneously, then return without submitting.
+- Autofill counts as user interaction — treat autofilled fields as touched.
+- On Edit forms, pre-filled invalid values don't show errors until interaction.
+
+### Error clearing
+- On focus (click-in) of an errored field, clear that field's error immediately — don't wait for a valid value.
+- Re-validate on blur. Never validate on keystroke.
+- Typing in one field never clears errors on other fields.
+- When a validation becomes irrelevant (e.g. conditional requirement removed by toggling a checkbox), clear the now-irrelevant error immediately.
+
+### Error priority
+Presence errors take priority over format errors. Show one error per field at a time; never stack.
+
+### Submit button state
+- Enabled by default — do not disable for empty required fields, currently-invalid values, unchanged Edit forms, or prior server errors.
+- Only disable while a submission is in flight.
+- If the user clicks submit with invalid data, the submit handler shows all inline errors and returns without submitting.
+
+### Server-side errors
+- Field-specific server errors: render inline on the field AND fire a toast. Submit stays enabled.
+- Global / cross-field server errors (e.g. `formatErrorResponse` `.base`): toast only.
+- Clear a server-set error on next focus of that field — same rule as client-side.
+- Backend field key → UI field key mapping stays local to the form until the API is normalized.
+
+### Optional and disabled fields
+- Empty optional fields: no error, submit enabled.
+- Optional fields with a format constraint (e.g. optional email): show inline error on invalid, but never disable submit.
+- Disabled fields skip validation entirely — never in an error state regardless of value.
+
+### In-flight submission
+- Submit button shows a spinner AND is disabled. Do not change the button's color/variant.
+- Disable form fields too, not just the button.
+- Guard the submit handler against double-submit; don't rely on the disabled button alone.
+- Cancel button stays enabled during submission and closes the modal. It does not abort the in-flight request.
+- Fire success toasts BEFORE navigation (see [Notifications](#notifications), #48088).
+- Closing a modal with unsaved changes silently discards them.
+
+### Input hygiene
+- Trim leading/trailing whitespace client-side before submitting; send the trimmed value.
+- Whitespace-only content in a required field counts as empty.
+- Match DB column max via `inputOptions.maxLength` on `InputField` (see [Forms](#forms) above). Native silent truncation is the default. Show an inline error only when the limit is awkward (e.g. a 48-char password).
+
+### Visual affordances
+- No visual indicator for required fields — no asterisk, no `(required)` suffix.
+- On error, `FormField` renders the error text in the field's label slot (replacing the label) with the `--error` modifier — red.
+- Input border is red while an error is showing, black (default) when clear. No green "valid" transition.
+- No inline error icon; text only.
+
+### Copy register
+- Grammar: `Verb + object + constraint`. Second-person imperative. Active voice. Present tense. One sentence per error.
+- Verb picks: `Enter`, `Choose`, `Select`, `Upload`.
+- Article discipline: `your` for the user's own data (`your email`); `a` for a value they're constructing (`a valid URL`, `a password`).
+- **No terminal periods** — the error renders where the label would be, and labels don't end in periods.
+- `Enter your email`, not `Email is required` / `Email field must be completed`.
+- Use "fleet" not "team" in error strings.
+- For non-fixable errors (server failure, timeout, network): use `<what happened>. <what to do>.` — two sentences, periods allowed. Example: `Couldn't save your changes. Try again in a few minutes.`
+
 ## Lists & rows
 User-typed free-text fields (`name`, `title`, `label`, `description`) inside an `UploadList` `ListItemComponent`, a `__row` flex container with sibling actions/badges, or a `TableContainer` open-text cell — wrap the value in `<TooltipTruncatedText value={...} />` and give the immediate parent `flex: 1; min-width: 0`.
 

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -113,7 +113,7 @@ Cap free-text inputs' `maxLength` to the backend column length (check `server/da
 
 Anti-defaults — the traps to avoid:
 - No visible required-field indicator (no `*`, no `(required)` suffix). Users discover requirements via post-interaction errors.
-- Submit button stays enabled with invalid fields. Only disable during in-flight submission. Handler shows errors and returns early.
+- Submit button stays enabled with invalid fields. Only disable during in-flight submission, or when the form is disabled by GitOps mode. Handler shows errors and returns early.
 - Field errors clear on **focus**, not on typing.
 - Re-validate on blur, never on keystroke.
 - Error text renders in the field's label slot via `FormField` (replaces the label). No separate error line below the input.

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -109,9 +109,7 @@ Cap free-text inputs' `maxLength` to the backend column length (check `server/da
 
 ## Validation
 
-**Read `frontend/docs/patterns.md#data-validation` before adding or editing form validation.** Fleet's rules diverge from common React defaults; the patterns doc is authoritative.
-
-Anti-defaults — the traps to avoid:
+**Read `frontend/docs/patterns.md#data-validation` before adding or editing form validation — that doc is authoritative.** Fleet diverges from what mainstream React libraries (Formik, react-hook-form, MUI, Ant Design) do by default on submit-button behavior, error timing, error position, and copy tone. Pattern-matching from another React app will land you in these specific mistakes:
 - No visible required-field indicator (no `*`, no `(required)` suffix). Users discover requirements via post-interaction errors.
 - Submit button stays enabled with invalid fields. Only disable during in-flight submission, or when the form is disabled by GitOps mode. Handler shows errors and returns early.
 - Field errors clear on **focus**, not on typing.

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -109,67 +109,16 @@ Cap free-text inputs' `maxLength` to the backend column length (check `server/da
 
 ## Validation
 
-See `frontend/docs/patterns.md#data-validation` for full rules and rationale. These describe target behavior; existing forms migrate one at a time as they're touched. A shared validation hook is planned to encode them.
+**Read `frontend/docs/patterns.md#data-validation` before adding or editing form validation.** Fleet's rules diverge from common React defaults; the patterns doc is authoritative.
 
-### Error timing
-- Never show a field's error before the user has interacted with it (typed into it, or blurred it while dirty).
-- On blur of an interacted-with field, validate that field and show its error inline. Don't modify other fields' errors.
-- On submit, show inline errors on every invalid field simultaneously, then return without submitting.
-- Autofill counts as user interaction — treat autofilled fields as touched.
-- On Edit forms, pre-filled invalid values don't show errors until interaction.
-
-### Error clearing
-- On focus (click-in) of an errored field, clear that field's error immediately — don't wait for a valid value.
-- Re-validate on blur. Never validate on keystroke.
-- Typing in one field never clears errors on other fields.
-- When a validation becomes irrelevant (e.g. conditional requirement removed by toggling a checkbox), clear the now-irrelevant error immediately.
-
-### Error priority
-Presence errors take priority over format errors. Show one error per field at a time; never stack.
-
-### Submit button state
-- Enabled by default — do not disable for empty required fields, currently-invalid values, unchanged Edit forms, or prior server errors.
-- Only disable while a submission is in flight.
-- If the user clicks submit with invalid data, the submit handler shows all inline errors and returns without submitting.
-
-### Server-side errors
-- Field-specific server errors: render inline on the field AND fire a toast. Submit stays enabled.
-- Global / cross-field server errors (e.g. `formatErrorResponse` `.base`): toast only.
-- Clear a server-set error on next focus of that field — same rule as client-side.
-- Backend field key → UI field key mapping stays local to the form until the API is normalized.
-
-### Optional and disabled fields
-- Empty optional fields: no error, submit enabled.
-- Optional fields with a format constraint (e.g. optional email): show inline error on invalid, but never disable submit.
-- Disabled fields skip validation entirely — never in an error state regardless of value.
-
-### In-flight submission
-- Submit button shows a spinner AND is disabled. Do not change the button's color/variant.
-- Disable form fields too, not just the button.
-- Guard the submit handler against double-submit; don't rely on the disabled button alone.
-- Cancel button stays enabled during submission and closes the modal. It does not abort the in-flight request.
-- Fire success toasts BEFORE navigation (see [Notifications](#notifications), #48088).
-- Closing a modal with unsaved changes silently discards them.
-
-### Input hygiene
-- Trim leading/trailing whitespace client-side before submitting; send the trimmed value.
-- Whitespace-only content in a required field counts as empty.
-- Match DB column max via `inputOptions.maxLength` on `InputField` (see [Forms](#forms) above). Native silent truncation is the default. Show an inline error only when the limit is awkward (e.g. a 48-char password).
-
-### Visual affordances
-- No visual indicator for required fields — no asterisk, no `(required)` suffix.
-- On error, `FormField` renders the error text in the field's label slot (replacing the label) with the `--error` modifier — red.
-- Input border is red while an error is showing, black (default) when clear. No green "valid" transition.
-- No inline error icon; text only.
-
-### Copy register
-- Grammar: `Verb + object + constraint`. Second-person imperative. Active voice. Present tense. One sentence per error.
-- Verb picks: `Enter`, `Choose`, `Select`, `Upload`.
-- Article discipline: `your` for the user's own data (`your email`); `a` for a value they're constructing (`a valid URL`, `a password`).
-- **No terminal periods** — the error renders where the label would be, and labels don't end in periods.
-- `Enter your email`, not `Email is required` / `Email field must be completed`.
-- Use "fleet" not "team" in error strings.
-- For non-fixable errors (server failure, timeout, network): use `<what happened>. <what to do>.` — two sentences, periods allowed. Example: `Couldn't save your changes. Try again in a few minutes.`
+Anti-defaults — the traps to avoid:
+- No visible required-field indicator (no `*`, no `(required)` suffix). Users discover requirements via post-interaction errors.
+- Submit button stays enabled with invalid fields. Only disable during in-flight submission. Handler shows errors and returns early.
+- Field errors clear on **focus**, not on typing.
+- Re-validate on blur, never on keystroke.
+- Error text renders in the field's label slot via `FormField` (replaces the label). No separate error line below the input.
+- Field-specific server errors: render inline AND fire a toast (long forms may scroll the field off-screen).
+- Copy: verb + object + constraint. `Enter your email`, not `Email is required`. No terminal periods.
 
 ## Lists & rows
 User-typed free-text fields (`name`, `title`, `label`, `description`) inside an `UploadList` `ListItemComponent`, a `__row` flex container with sibling actions/badges, or a `TableContainer` open-text cell — wrap the value in `<TooltipTruncatedText value={...} />` and give the immediate parent `flex: 1; min-width: 0`.

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -111,9 +111,9 @@ Cap free-text inputs' `maxLength` to the backend column length (check `server/da
 
 **Read `frontend/docs/patterns.md#data-validation` before adding or editing form validation — that doc is authoritative.** Fleet diverges from what mainstream React libraries (Formik, react-hook-form, MUI, Ant Design) do by default on submit-button behavior, error timing, error position, and copy tone. Pattern-matching from another React app will land you in these specific mistakes:
 - No visible required-field indicator (no `*`, no `(required)` suffix). Users discover requirements via post-interaction errors.
-- Submit button stays enabled with invalid fields. Only disable during in-flight submission, or when the form is disabled by GitOps mode. Handler shows errors and returns early.
+- Submit button stays enabled with invalid fields. Only disable during in-flight submission, or when the form is disabled by GitOps mode. On click, the handler runs client-side validation first — if invalid, it surfaces errors inline and returns without calling the API.
 - Field errors clear on **focus**, not on typing.
-- Re-validate on blur, never on keystroke.
+- Re-validate on blur of a dirty field, never on keystroke.
 - Error text renders in the field's label slot via `FormField` (replaces the label). No separate error line below the input.
 - Field-specific server errors: render inline AND fire a toast (long forms may scroll the field off-screen).
 - Copy: verb + object + constraint. `Enter your email`, not `Email is required`. No terminal periods.

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -116,7 +116,7 @@ Cap free-text inputs' `maxLength` to the backend column length (check `server/da
 - Re-validate on blur of a dirty field, never on keystroke.
 - Error text renders in the field's label slot via `FormField` (replaces the label). No separate error line below the input.
 - Field-specific server errors: render inline AND fire a toast (long forms may scroll the field off-screen).
-- Copy: verb + object + constraint. `Enter your email`, not `Email is required`. No terminal periods.
+- Copy: verb + object + constraint. `Enter your email`, not `Email is required`. No terminal periods on field errors (toasts for system/transport errors are the carve-out).
 
 ## Lists & rows
 User-typed free-text fields (`name`, `title`, `label`, `description`) inside an `UploadList` `ListItemComponent`, a `__row` flex container with sibling actions/badges, or a `TableContainer` open-text cell — wrap the value in `<TooltipTruncatedText value={...} />` and give the immediate parent `flex: 1; min-width: 0`.

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -109,7 +109,7 @@ Cap free-text inputs' `maxLength` to the backend column length (check `server/da
 
 ## Validation
 
-**Read `frontend/docs/patterns.md#data-validation` before adding or editing form validation — that doc is authoritative.** Fleet diverges from what mainstream React libraries (Formik, react-hook-form, MUI, Ant Design) do by default on submit-button behavior, error timing, error position, and copy tone. Pattern-matching from another React app will land you in these specific mistakes:
+**Read [frontend/docs/patterns.md#data-validation](../../frontend/docs/patterns.md#data-validation) before adding or editing form validation — that doc is authoritative.** Fleet diverges from what mainstream React libraries (Formik, react-hook-form, MUI, Ant Design) do by default on submit-button behavior, error timing, error position, and copy tone. Pattern-matching from another React app will land you in these specific mistakes:
 - No visible required-field indicator (no `*`, no `(required)` suffix). Users discover requirements via post-interaction errors.
 - Submit button stays enabled with invalid fields. Only disable during in-flight submission, or when the form is disabled by GitOps mode. On click, the handler runs client-side validation first — if invalid, it surfaces errors inline and returns without calling the API.
 - Field errors clear on **focus**, not on typing.

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -71,7 +71,7 @@ Use react-router, not `window.location` / `window.history`. Direct window mutati
 
 ## Notifications
 - Use `notify.success(msg)` / `notify.error(msg, { response })` / `notify.batch([...])` from `components/ToastNotification`.
-- **When showing a success toast and navigating, call `notify.success` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page (#48088).
+- **When showing a success toast and navigating, call `notify.success` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page.
 - Success toasts auto-dismiss after 5s by default; error toasts are sticky by default.
 
 ## XSS Prevention

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -318,84 +318,138 @@ export default PackComposerPage;
 When building a React-controlled form:
 - Use the native HTML `form` element to wrap the form.
 - Use a `Button` component with `type="submit"` for its submit button.
-- Write a submit handler, e.g. `handleSubmit`, that accepts an `evt:
-React.FormEvent<HTMLFormElement>` argument and, critically:
-  - calls `evt.preventDefault()` in its body. This prevents the HTML `form`'s default submit behavior from interfering with our custom
-handler's logic.
-  - does nothing (e.g., returns `null`) if the form is in an invalid state, preventing submission by any means.
-- Assign that handler to the `form`'s `onSubmit` property (*not* the submit button's `onClick`)
-- Disable the form's submit button when the form is in an invalid state. Redundancy with the submit handler returning `null` is good.
+- Write a submit handler, e.g. `handleSubmit`, that accepts an `evt: React.FormEvent<HTMLFormElement>` argument and, critically:
+  - calls `evt.preventDefault()` in its body. This prevents the HTML `form`'s default submit behavior from interfering with our custom handler's logic.
+  - runs `validate` against the full form, sets errors on every invalid field, and returns without submitting when any errors are present.
+- Assign that handler to the `form`'s `onSubmit` property (*not* the submit button's `onClick`).
+- Disable the submit button only while a submission is in flight. Do not disable it because required fields are empty or values are currently invalid — see [Submit button state](#submit-button-state).
 
 ### Data validation
 
+The rules below describe the target behavior. A shared validation hook is planned to encode them; until it lands, forms implement the rules directly and are migrated one at a time. New forms should follow these rules on day one.
+
 #### How to validate
 
-Forms should make use of a pure `validate` function whose input(s) correspond to form data (may include
-new and possibly former form data) and whose output is an object of formFieldName:errorMessage
-key-value pairs (`Record<string,string>`) e.g.
+Forms use a pure `validate` function whose input is the current form data and whose output is a `Record<string, string>` of `fieldName → errorMessage` pairs. Only invalid fields appear in the output.
 
 ```tsx
-const validate = (newFormData: IFormData) => {
-  const errors = {};
-  ...
-  return errors;
-}
-```
-
-The output of `validate` should be used by the calling handler to set a `formErrors`
-state.
-
-#### When to validate
-
-Form fields should *set only new errors* on blur and on save, and *set or remove* errors on change. This provides
-an "optimistic" user experience. The user is only told they have an error once they navigate
-away from a field or hit enter, actions which imply they are finished editing the field, while they are informed they have fixed
-an error as soon as possible, that is, as soon as they make the fixing change. e.g.
-
-```tsx
-const onInputChange = ({ name, value }: IInputFieldParseTarget) => {
-  const newFormData = { ...formData, [name]: value };
-  setFormData(newFormData);
-  const newErrs = validateFormData(newFormData);
-  // only set errors that are updates of existing errors
-  // new errors are only set onBlur
-  const errsToSet: Record<string, string> = {};
-  Object.keys(formErrors).forEach((k) => {
-    // @ts-ignore
-    if (newErrs[k]) {
-      // @ts-ignore
-      errsToSet[k] = newErrs[k];
-    }
-  });
-  setFormErrors(errsToSet);
-};
-
-```
-
-,
-
-```tsx
-const onInputBlur = () => {
-  setFormErrors(validateFormData(formData));
-};
-```
-
-, and
-
-```tsx
-const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
-  evt.preventDefault();
-  // return null if there are errors
-  const errs = validateFormData(formData);
-  if (Object.keys(errs).length > 0) {
-    setFormErrors(errs);
-    return;
+const validate = (formData: IFormData): Record<string, string> => {
+  const errors: Record<string, string> = {};
+  if (!formData.email.trim()) {
+    errors.email = "Enter your email";
+  } else if (!isValidEmail(formData.email)) {
+    errors.email = "Enter a valid email";
   }
-
-  ...
-  // continue with submit logic if no errors
-
+  return errors;
+};
 ```
+
+The output of `validate` is used by the calling handler to update a `formErrors` state that feeds each `InputField`'s `error` prop.
+
+#### When errors appear
+
+- Never show a field's error before the user has interacted with that field. A field becomes interacted-with when the user types into it or blurs it while it holds a value.
+- On blur of a field the user has interacted with, run validation and show the resulting error (if any) for that field only. Do not touch errors on other fields.
+- On submit, show inline errors on every invalid field simultaneously, then return without submitting.
+- Autofill counts as user interaction — treat autofilled fields as touched.
+- On an Edit form, pre-filled values that are invalid do not show errors until the user interacts with the field.
+
+#### When errors clear
+
+- On focus (click-in) of a field that has an error, clear that field's error immediately. Do not wait for the user to type a valid value.
+- Re-validate on blur, not on keystroke.
+- Typing in one field never clears errors on other fields. Clearing is per-field.
+- When a validation becomes irrelevant (e.g. a conditional requirement is removed by toggling a checkbox), clear the newly-irrelevant error immediately.
+
+#### Error priority
+
+- Presence errors take priority over format errors. If a field is both empty and format-invalid, show the presence error.
+- Show one error per field at a time. Never stack multiple errors on the same field.
+- Server-set errors follow the same "one at a time" rule.
+
+#### Submit button state
+
+- The submit button is enabled by default. Empty required fields, currently-invalid values, unchanged Edit forms, and prior server errors do not disable it.
+- The only reason to disable the submit button is an in-flight submission — see [In-flight and submission lifecycle](#in-flight-and-submission-lifecycle).
+- If the user clicks submit with invalid data, the submit handler shows all inline errors and returns without submitting. The button itself stays enabled so the click can surface the errors.
+- Do not gate on `isDirty` or "form has changes." A no-op re-save is allowed.
+
+#### Server-side errors
+
+- Field-specific server errors (e.g. "email already taken") render inline on the field via the same `error` prop as client-side errors, AND fire a toast with the error message. Submit stays enabled. The toast is intentional even when the inline error is visible — forms can be long enough that the errored field is scrolled off-screen after submission.
+- Cross-field or global server errors (e.g. `formatErrorResponse` `.base`) surface as a toast only. No inline surface.
+- When the user focuses a field that has a server-set error, clear it immediately — same rule as client-side.
+- Multiple field errors returned by the server: iterate the error map and set all inline. Prefer a single summary toast when there are many.
+- Backend field key → UI field key mapping stays local to the form. Do not centralize until the API is normalized.
+
+#### Conditional / dependent validation
+
+- Cross-field checks (e.g. password + confirmation match) run on blur of either field. The error attaches to the field that is invalid, not to both.
+- Fields that become required based on another field's state (e.g. password required when SSO is off) still follow the "no error until interacted with" rule. There is no visual indicator that a field is conditionally required.
+- When a condition changes such that an existing error no longer applies (e.g. SSO toggled on), clear the error immediately.
+- Client-side "at least one X must be selected" errors render inline on the selector's label, not as a toast. Server-side variants of the same error also fire a toast in addition to the inline surface.
+
+#### Optional and disabled fields
+
+- Empty optional fields never show an error.
+- An optional field that has a value with a format constraint (e.g. an optional email field) validates the format. On invalid, show an inline error, but do not disable submit.
+- Disabled fields skip validation entirely. A disabled field is never in an error state, regardless of its value.
+
+#### Input hygiene
+
+- Trim leading and trailing whitespace client-side before submitting. Send the trimmed value to the API.
+- Whitespace-only content in a required field counts as empty.
+- Cap free-text `maxLength` to the backend column length via `inputOptions={{ maxLength: N }}` on `InputField`. The native input silently truncates paste. See [Forms](#forms) in the top-level rules.
+- If the max length is unusual (e.g. a 48-character password), show an inline error on the field instead of relying on silent truncation.
+- Autofill counts as user interaction — treat autofilled fields as touched.
+
+#### In-flight and submission lifecycle
+
+- During submission, the submit button shows a spinner AND is disabled. Do not change the button's color/variant.
+- Form fields are disabled while a submission is in flight — the user cannot edit during the request.
+- The submit handler must guard against a second submission while one is in flight. Do not rely solely on the button being disabled.
+- The Cancel button remains enabled during submission and closes the modal immediately. It does not abort the in-flight request; the request completes in the background.
+- On success, fire the success toast BEFORE navigation (see [Notifications](../../.claude/rules/fleet-frontend.md#notifications) and #48088) and close the modal.
+- On failure, fields become editable again, the submit button re-enables immediately, and server errors surface per [Server-side errors](#server-side-errors).
+- Closing a modal with unsaved changes silently discards them. No confirmation dialog. (Exceptions like the SQL editor stay exceptions.)
+
+#### Visual affordances
+
+- There is no visual indicator for required fields. No asterisk, no `(required)` suffix. Users discover requirements through post-interaction errors.
+- On error, `FormField` renders the error text in the label slot, replacing the label text and applying the `--error` modifier (red).
+- Help text below the input is independent of error state. Do not duplicate error messages into help text.
+- The input border is red while an error is showing and returns to the default (black) when the error clears. There is no green "valid" transition.
+- No inline error icon. Text only.
+
+<!-- Design may iterate on error placement (e.g. moving the error text out of the label slot). Document any change here first. -->
+
+
+#### Error message copy register
+
+Every validation error follows a single grammar pattern:
+
+**Verb + object + constraint (if any).**
+
+- **Verb**: the action that fixes the error. `Enter`, `Choose`, `Select`, `Upload`.
+- **Object**: the thing being fixed. `your email`, `a valid URL`, `a password`.
+- **Constraint**: only when the rule isn't obvious. `with at least 8 characters`, `between 1 and 100`.
+
+Examples:
+- `Enter your email` — empty field
+- `Enter a valid email` — bad format
+- `Enter a password with at least 8 characters` — rule violation
+- `Choose an end date after the start date` — logical conflict
+- `Upload a file smaller than 5 MB` — limit
+
+Rules:
+- Second-person imperative, implied subject. Never `You must...` or `The user should...`.
+- Present tense, active voice. Not `must be completed`, not `was not provided`.
+- Article discipline: `your` for the user's own data (`your email`, `your name`); `a` for a value the user is constructing (`a valid URL`, `a password`).
+- One sentence per error. If it needs a second sentence, the constraint probably belongs in help text below the field, not in the error.
+- **No terminal periods.** The error renders in the label slot, and labels don't end with periods.
+- Use `fleet` not `team` in new copy. The codebase still uses `team_id` etc.; that stays. See [Terminology](../../.claude/rules/fleet-frontend.md#terminology).
+
+For errors the user can't fix by editing the field — server failures, timeouts, network errors — use a different register: **what happened + what to do**. Example: `Couldn't save your changes. Try again in a few minutes.` This is the one place where periods appear (two sentences).
 
 ## Tier modes
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -326,7 +326,7 @@ When building a React-controlled form:
 
 ### Data validation
 
-The rules below describe the target behavior. A shared validation hook is planned to encode them; until it lands, forms implement the rules directly and are migrated one at a time. New forms should follow these rules on day one.
+The rules below describe the target behavior. Existing forms implement the rules directly and are migrated one at a time. New forms should follow these rules on day one.
 
 #### How to validate
 
@@ -380,7 +380,6 @@ The output of `validate` is used by the calling handler to update a `formErrors`
 - Cross-field or global server errors (e.g. `formatErrorResponse` `.base`) surface as a toast only. No inline surface.
 - When the user focuses a field that has a server-set error, clear it immediately — same rule as client-side.
 - Multiple field errors returned by the server: iterate the error map and set all inline. Prefer a single summary toast when there are many.
-- Backend field key → UI field key mapping stays local to the form. Do not centralize until the API is normalized.
 
 #### Conditional / dependent validation
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -356,7 +356,7 @@ The output of `validate` is used by the calling handler to update a `formErrors`
 
 #### When errors clear
 
-- On focus (click-in) of a field that has an error, clear that field's error immediately. Do not wait for the user to type a valid value.
+- On focus (click-in) of a field that has an error, clear that field's error immediately — do not wait for the user to type a valid value. The error text replaces the field's label (see [Visual affordances](#visual-affordances)), so clearing on focus restores the label and lets the user see what they're editing.
 - Re-validate on blur, not on keystroke.
 - Typing in one field never clears errors on other fields. Clearing is per-field.
 - When a validation becomes irrelevant (e.g. a conditional requirement is removed by toggling a checkbox), clear the newly-irrelevant error immediately.
@@ -370,7 +370,7 @@ The output of `validate` is used by the calling handler to update a `formErrors`
 #### Submit button state
 
 - The submit button is enabled by default. Empty required fields, currently-invalid values, unchanged Edit forms, and prior server errors do not disable it.
-- The only reason to disable the submit button is an in-flight submission — see [In-flight and submission lifecycle](#in-flight-and-submission-lifecycle).
+- The only reasons to disable the submit button are an in-flight submission (see [In-flight and submission lifecycle](#in-flight-and-submission-lifecycle)) or the entire form being disabled by GitOps mode. GitOps-managed pages disable the form's fields and submit button together — users cannot save through the UI at all.
 - If the user clicks submit with invalid data, the submit handler shows all inline errors and returns without submitting. The button itself stays enabled so the click can surface the errors.
 - Do not gate on `isDirty` or "form has changes." A no-op re-save is allowed.
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -348,11 +348,12 @@ The output of `validate` is used by the calling handler to update a `formErrors`
 
 #### When errors appear
 
-- Never show a field's error before the user has interacted with that field. A field becomes interacted-with when the user types into it or blurs it while it holds a value.
-- On blur of a field the user has interacted with, run validation and show the resulting error (if any) for that field only. Do not touch errors on other fields.
+A field is **dirty** once the user has typed into it or the browser has autofilled it. It stays dirty for the session, even if the value returns to its initial state. Field errors gate on `dirty`. Form-level `isDirty` ("form has changes") is a separate concept — see [Submit button state](#submit-button-state).
+
+- Never show a field's error before the field is dirty.
+- On blur of a dirty field, run validation and show the resulting error (if any) for that field only. Do not touch errors on other fields.
 - On submit, show inline errors on every invalid field simultaneously, then return without submitting.
-- Autofill counts as user interaction — treat autofilled fields as touched.
-- On an Edit form, pre-filled values that are invalid do not show errors until the user interacts with the field.
+- On an Edit form, pre-filled values that are invalid do not show errors until the field is dirty.
 
 #### When errors clear
 
@@ -371,8 +372,8 @@ The output of `validate` is used by the calling handler to update a `formErrors`
 
 - The submit button is enabled by default. Empty required fields, currently-invalid values, unchanged Edit forms, and prior server errors do not disable it.
 - The only reasons to disable the submit button are an in-flight submission (see [In-flight and submission lifecycle](#in-flight-and-submission-lifecycle)) or the entire form being disabled by GitOps mode. GitOps-managed pages disable the form's fields and submit button together — users cannot save through the UI at all.
-- If the user clicks submit with invalid data, the submit handler shows all inline errors and returns without submitting. The button itself stays enabled so the click can surface the errors.
-- Do not gate on `isDirty` or "form has changes." A no-op re-save is allowed.
+- If the user clicks submit with invalid data, the submit handler shows all inline client-side errors and returns without calling the API. The button itself stays enabled so the click can surface the errors.
+- Do not gate on form-level `isDirty` ("form has changes"). A no-op re-save is allowed.
 
 #### Server-side errors
 
@@ -384,7 +385,7 @@ The output of `validate` is used by the calling handler to update a `formErrors`
 #### Conditional / dependent validation
 
 - Cross-field checks (e.g. password + confirmation match) run on blur of either field. The error attaches to the field that is invalid, not to both.
-- Fields that become required based on another field's state (e.g. password required when SSO is off) still follow the "no error until interacted with" rule. There is no visual indicator that a field is conditionally required.
+- Fields that become required based on another field's state (e.g. password required when SSO is off) still follow the "no error until dirty" rule. There is no visual indicator that a field is conditionally required.
 - When a condition changes such that an existing error no longer applies (e.g. SSO toggled on), clear the error immediately.
 - Client-side "at least one X must be selected" errors render inline on the selector's label, not as a toast. Server-side variants of the same error also fire a toast in addition to the inline surface.
 
@@ -400,15 +401,15 @@ The output of `validate` is used by the calling handler to update a `formErrors`
 - Whitespace-only content in a required field counts as empty.
 - Cap free-text `maxLength` to the backend column length via `inputOptions={{ maxLength: N }}` on `InputField`. The native input silently truncates paste. See [Forms](#forms) in the top-level rules.
 - If the max length is unusual (e.g. a 48-character password), show an inline error on the field instead of relying on silent truncation.
-- Autofill counts as user interaction — treat autofilled fields as touched.
 
 #### In-flight and submission lifecycle
 
 - During submission, the submit button shows a spinner AND is disabled. Do not change the button's color/variant.
 - Form fields are disabled while a submission is in flight — the user cannot edit during the request.
 - The submit handler must guard against a second submission while one is in flight. Do not rely solely on the button being disabled.
-- The Cancel button remains enabled during submission and closes the modal immediately. It does not abort the in-flight request; the request completes in the background.
-- On success, fire the success toast BEFORE navigation (see [Notifications](../../.claude/rules/fleet-frontend.md#notifications) and #48088) and close the modal.
+- The Cancel button remains enabled during submission and closes the modal immediately. It does not abort the in-flight request; the request completes in the background. We don't require abort because most call sites use plain Promises (not `useMutation`), and we don't want a confirmation dialog on Cancel — it adds friction to the common case for a rare one.
+- Because Cancel doesn't abort, the submission must be resilient to the modal being closed before the request resolves. Guard post-success side effects (toast, navigation, cache invalidation) so they don't fire against an unmounted component or a screen the user has already left. Failures on a closed modal are dropped silently — no toast, no re-open.
+- On success, close the modal and call `notify.success` before `router.push` / `router.replace`. This is a code-call order, not a visual order — `notify.success` defers toast creation by a tick, so calling it first lets the toast land on the destination page instead of getting wiped by its own navigation. See [Notifications](../../.claude/rules/fleet-frontend.md#notifications) and #48088.
 - On failure, fields become editable again, the submit button re-enables immediately, and server errors surface per [Server-side errors](#server-side-errors).
 - Closing a modal with unsaved changes silently discards them. No confirmation dialog. (Exceptions like the SQL editor stay exceptions.)
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -352,7 +352,7 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 
 - Never show a field's error before the field is dirty.
 - On blur of a dirty field, run validation and show the resulting error (if any) for that field only. Do not touch errors on other fields.
-- On submit, show inline errors on every invalid field simultaneously, then return without submitting. Submit is an explicit exception to the dirty gate — it marks all fields dirty, so pristine required fields surface their errors too.
+- On submit, validate every field regardless of dirty state, show inline errors on all invalid fields simultaneously, then return without submitting. Submit is a checkpoint that bypasses the dirty gate — pristine required fields surface their errors too.
 - On an Edit form, pre-filled values that are invalid do not show errors until the field is dirty.
 
 #### When errors clear

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -322,7 +322,7 @@ When building a React-controlled form:
   - calls `evt.preventDefault()` in its body. This prevents the HTML `form`'s default submit behavior from interfering with our custom handler's logic.
   - runs `validate` against the full form, sets errors on every invalid field, and returns without submitting when any errors are present.
 - Assign that handler to the `form`'s `onSubmit` property (*not* the submit button's `onClick`).
-- Disable the submit button only while a submission is in flight. Do not disable it because required fields are empty or values are currently invalid — see [Submit button state](#submit-button-state).
+- Disable the submit button only while a submission is in flight, or when the whole form is disabled by GitOps mode. Do not disable it because required fields are empty or values are currently invalid — see [Submit button state](#submit-button-state).
 
 ### Data validation
 
@@ -352,7 +352,7 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 
 - Never show a field's error before the field is dirty.
 - On blur of a dirty field, run validation and show the resulting error (if any) for that field only. Do not touch errors on other fields.
-- On submit, show inline errors on every invalid field simultaneously, then return without submitting.
+- On submit, show inline errors on every invalid field simultaneously, then return without submitting. Submit is an explicit exception to the dirty gate — it marks all fields dirty, so pristine required fields surface their errors too.
 - On an Edit form, pre-filled values that are invalid do not show errors until the field is dirty.
 
 #### When errors clear
@@ -399,7 +399,7 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 
 - Trim leading and trailing whitespace client-side before submitting. Send the trimmed value to the API.
 - Whitespace-only content in a required field counts as empty.
-- Cap free-text `maxLength` to the backend column length via `inputOptions={{ maxLength: N }}` on `InputField`. The native input silently truncates paste. See [Forms](#forms) in the top-level rules.
+- Cap free-text `maxLength` to the backend column length via `inputOptions={{ maxLength: N }}` on `InputField`. The native input silently truncates paste. See [Forms](../../.claude/rules/fleet-frontend.md#forms) in the top-level rules.
 - If the max length is unusual (e.g. a 48-character password), show an inline error on the field instead of relying on silent truncation.
 
 #### In-flight and submission lifecycle

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -1129,7 +1129,7 @@ Visible toasts are dismissed automatically on URL change.
 
 ```tsx
 // first notify
-notify.error("Something went wrong");
+notify.success("Package successfully added.");
 // then push
 router.push(newPath);
 ```

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -335,9 +335,10 @@ Forms use a pure `validate` function whose input is the current form data and wh
 ```tsx
 const validate = (formData: IFormData): Record<string, string> => {
   const errors: Record<string, string> = {};
-  if (!formData.email.trim()) {
+  const email = formData.email.trim();
+  if (!email) {
     errors.email = "Enter your email";
-  } else if (!isValidEmail(formData.email)) {
+  } else if (!isValidEmail(email)) {
     errors.email = "Enter a valid email";
   }
   return errors;
@@ -352,12 +353,12 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 
 - Never show a field's error before the field is dirty.
 - On blur of a dirty field, run validation and show the resulting error (if any) for that field only. Do not touch errors on other fields.
-- On submit, validate every field regardless of dirty state, show inline errors on all invalid fields simultaneously, then return without submitting. Submit is a checkpoint that bypasses the dirty gate — pristine required fields surface their errors too.
+- On submit, validate every field regardless of dirty state. If any are invalid, show all inline errors simultaneously and return without calling the API. Submit is a checkpoint that bypasses the dirty gate — pristine required fields surface their errors too.
 - On an Edit form, pre-filled values that are invalid do not show errors until the field is dirty.
 
 #### When errors clear
 
-- On focus (click-in) of a field that has an error, clear that field's error immediately — do not wait for the user to type a valid value. The error text replaces the field's label (see [Visual affordances](#visual-affordances)), so clearing on focus restores the label and lets the user see what they're editing.
+- On focus of a field that has an error (via click, tab, or programmatic focus), clear that field's error immediately — do not wait for the user to type a valid value. The error text replaces the field's label (see [Visual affordances](#visual-affordances)), so clearing on focus restores the label and lets the user see what they're editing.
 - Re-validate on blur, not on keystroke.
 - Typing in one field never clears errors on other fields. Clearing is per-field.
 - When a validation becomes irrelevant (e.g. a conditional requirement is removed by toggling a checkbox), clear the newly-irrelevant error immediately.
@@ -380,11 +381,11 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 - Field-specific server errors (e.g. "email already taken") render inline on the field via the same `error` prop as client-side errors, AND fire a toast with the error message. Submit stays enabled. The toast is intentional even when the inline error is visible — forms can be long enough that the errored field is scrolled off-screen after submission.
 - Cross-field or global server errors (e.g. `formatErrorResponse` `.base`) surface as a toast only. No inline surface.
 - When the user focuses a field that has a server-set error, clear it immediately — same rule as client-side.
-- Multiple field errors returned by the server: iterate the error map and set all inline. Prefer a single summary toast when there are many.
+- Multiple field errors returned by the server: iterate the error map and set all inline. Each field-specific error still gets its own toast per the rule above.
 
 #### Conditional / dependent validation
 
-- Cross-field checks (e.g. password + confirmation match) run on blur of the dependent/confirmation field only, and only when both fields are non-empty. If either is empty, skip the check — the empty field's own required-error covers it. On mismatch, attach the error to the field being blurred (the dependent/confirmation), consistent with the "blur validates that field only" rule.
+- Cross-field checks (e.g. password + confirmation match) run on blur of the dependent/confirmation field only, and only when both fields are non-empty. If either is empty, skip the check — the empty field's own required-error covers it. On mismatch, attach the error to the field being blurred (the dependent/confirmation), consistent with the "blur validates that field only" rule. Editing the source field after the mismatch error is set does not re-run the cross-field check; the error stays until the confirmation field is edited or re-blurred.
 - Fields that become required based on another field's state (e.g. password required when SSO is off) still follow the "no error until dirty" rule. There is no visual indicator that a field is conditionally required.
 - When a condition changes such that an existing error no longer applies (e.g. SSO toggled on), clear the error immediately.
 - Client-side "at least one X must be selected" errors render inline on the selector's label, not as a toast. Server-side variants of the same error also fire a toast in addition to the inline surface.
@@ -392,7 +393,7 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 #### Optional and disabled fields
 
 - Empty optional fields never show an error.
-- An optional field that has a value with a format constraint (e.g. an optional email field) validates the format. On invalid, show an inline error, but do not disable submit.
+- An optional field that has a value with a format constraint (e.g. an optional email field) validates the format on blur and shows an inline error on invalid. (Submit-button disable follows the general rule at [Submit button state](#submit-button-state) — the button stays enabled.)
 - Disabled fields skip validation entirely. A disabled field is never in an error state, regardless of its value.
 
 #### Input hygiene
@@ -443,10 +444,10 @@ Rules:
 - Present tense, active voice. Not `must be completed`, not `was not provided`.
 - Article discipline: `your` for the user's own data (`your email`, `your name`); `a` for a value the user is constructing (`a valid URL`, `a password`).
 - One sentence per error. If it needs a second sentence, the constraint probably belongs in help text below the field, not in the error.
-- **No terminal periods.** The error renders in the label slot, and labels don't end with periods.
+- **No terminal periods on field errors.** They render in the label slot, and labels don't end with periods. (System/transport errors in toasts — see below — are the one place periods appear.)
 - See [Terminology](../../.claude/rules/fleet-frontend.md#terminology) for `fleet` vs `team` and other renaming rules.
 
-For errors the user can't fix by editing the field — server failures, timeouts, network errors — use a different register: **what happened + what to do**. Example: `Couldn't save your changes. Try again in a few minutes.` This is the one place where periods appear (two sentences).
+System/transport errors (server failures, timeouts, network errors — things the user can't fix by editing a field) render as toasts, not inline, and use a different register: **what happened + what to do**. Example: `Couldn't save your changes. Try again in a few minutes.` This is the one place periods appear (two sentences). Field-specific server errors — e.g. `"email already taken"` per [Server-side errors](#server-side-errors) — stay in the verb + object register.
 
 ## Tier modes
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -326,7 +326,7 @@ When building a React-controlled form:
 
 ### Data validation
 
-The rules below describe the target behavior. Existing forms implement the rules directly and are migrated one at a time. New forms should follow these rules on day one.
+The rules below describe the target behavior. Not every existing form complies yet — they're migrated one at a time, without a wrapper or shim. New forms should follow these rules on day one.
 
 #### How to validate
 
@@ -384,7 +384,7 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 
 #### Conditional / dependent validation
 
-- Cross-field checks (e.g. password + confirmation match) run on blur only when both fields are non-empty. If either is empty, skip the check — the empty field's own required-error covers it. On mismatch, attach the error to the dependent/confirmation field, not the source.
+- Cross-field checks (e.g. password + confirmation match) run on blur of the dependent/confirmation field only, and only when both fields are non-empty. If either is empty, skip the check — the empty field's own required-error covers it. On mismatch, attach the error to the field being blurred (the dependent/confirmation), consistent with the "blur validates that field only" rule.
 - Fields that become required based on another field's state (e.g. password required when SSO is off) still follow the "no error until dirty" rule. There is no visual indicator that a field is conditionally required.
 - When a condition changes such that an existing error no longer applies (e.g. SSO toggled on), clear the error immediately.
 - Client-side "at least one X must be selected" errors render inline on the selector's label, not as a toast. Server-side variants of the same error also fire a toast in addition to the inline surface.
@@ -423,12 +423,9 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 
 <!-- Design may iterate on error placement (e.g. moving the error text out of the label slot). Document any change here first. -->
 
-
 #### Error message copy register
 
-Every validation error follows a single grammar pattern:
-
-**Verb + object + constraint (if any).**
+Every validation error follows a single grammar pattern: **verb + object + constraint (if any)**.
 
 - **Verb**: the action that fixes the error. `Enter`, `Choose`, `Select`, `Upload`.
 - **Object**: the thing being fixed. `your email`, `a valid URL`, `a password`.
@@ -447,7 +444,7 @@ Rules:
 - Article discipline: `your` for the user's own data (`your email`, `your name`); `a` for a value the user is constructing (`a valid URL`, `a password`).
 - One sentence per error. If it needs a second sentence, the constraint probably belongs in help text below the field, not in the error.
 - **No terminal periods.** The error renders in the label slot, and labels don't end with periods.
-- Use `fleet` not `team` in new copy. The codebase still uses `team_id` etc.; that stays. See [Terminology](../../.claude/rules/fleet-frontend.md#terminology).
+- See [Terminology](../../.claude/rules/fleet-frontend.md#terminology) for `fleet` vs `team` and other renaming rules.
 
 For errors the user can't fix by editing the field — server failures, timeouts, network errors — use a different register: **what happened + what to do**. Example: `Couldn't save your changes. Try again in a few minutes.` This is the one place where periods appear (two sentences).
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -384,7 +384,7 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 
 #### Conditional / dependent validation
 
-- Cross-field checks (e.g. password + confirmation match) run on blur of either field. The error attaches to the field that is invalid, not to both.
+- Cross-field checks (e.g. password + confirmation match) run on blur only when both fields are non-empty. If either is empty, skip the check — the empty field's own required-error covers it. On mismatch, attach the error to the dependent/confirmation field, not the source.
 - Fields that become required based on another field's state (e.g. password required when SSO is off) still follow the "no error until dirty" rule. There is no visual indicator that a field is conditionally required.
 - When a condition changes such that an existing error no longer applies (e.g. SSO toggled on), clear the error immediately.
 - Client-side "at least one X must be selected" errors render inline on the selector's label, not as a toast. Server-side variants of the same error also fire a toast in addition to the inline surface.
@@ -409,7 +409,7 @@ A field is **dirty** once the user has typed into it or the browser has autofill
 - The submit handler must guard against a second submission while one is in flight. Do not rely solely on the button being disabled.
 - The Cancel button remains enabled during submission and closes the modal immediately. It does not abort the in-flight request; the request completes in the background. We don't require abort because most call sites use plain Promises (not `useMutation`), and we don't want a confirmation dialog on Cancel — it adds friction to the common case for a rare one.
 - Because Cancel doesn't abort, the submission must be resilient to the modal being closed before the request resolves. Guard post-success side effects (toast, navigation, cache invalidation) so they don't fire against an unmounted component or a screen the user has already left. Failures on a closed modal are dropped silently — no toast, no re-open.
-- On success, close the modal and call `notify.success` before `router.push` / `router.replace`. This is a code-call order, not a visual order — `notify.success` defers toast creation by a tick, so calling it first lets the toast land on the destination page instead of getting wiped by its own navigation. See [Notifications](../../.claude/rules/fleet-frontend.md#notifications) and #48088.
+- On success, close the modal and call `notify.success` before `router.push` / `router.replace`. This is a code-call order, not a visual order — `notify.success` defers toast creation by a tick, so calling it first lets the toast land on the destination page instead of getting wiped by its own navigation. See [Notifications](../../.claude/rules/fleet-frontend.md#notifications).
 - On failure, fields become editable again, the submit button re-enables immediately, and server errors surface per [Server-side errors](#server-side-errors).
 - Closing a modal with unsaved changes silently discards them. No confirmation dialog. (Exceptions like the SQL editor stay exceptions.)
 
@@ -1125,7 +1125,7 @@ Use `notify.success(msg)` / `notify.error(msg, { response })` / `notify.batch([.
 `components/ToastNotification`. Success toasts auto-dismiss after 5s by default; error toasts are sticky by default.
 Visible toasts are dismissed automatically on URL change.
 
-**When showing a success toast and navigating, call `notify.success` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page (#48088).
+**When showing a success toast and navigating, call `notify.success` before `router.push` / `router.replace`** — the reverse order can break auto-dismiss on the destination page.
 
 ```tsx
 // first notify


### PR DESCRIPTION
## Issue
Docs-only. Kicks off the validation standardization workstream — target behavior for a forthcoming shared validation hook and per-form migrations.

## Description
- Extends `frontend/docs/patterns.md` "Data validation" with 10 subsections: error timing, clearing, priority, submit button state, server-side errors, conditional validation, optional/disabled fields, input hygiene, in-flight lifecycle, visual affordances, and copy register.
- Adds rules under a new "Validation" section in `.claude/rules/fleet-frontend.md`.
- Describes target behavior; upcoming work will be done for a shared validation hook that applies these new patterns as well as per-form migrations

## Screenrecording

## Testing
- [ ] Reviewed markdown rendering on GitHub for both files
- [ ] QA'd all new/changed functionality manually