### PR TITLE
Android enrollment debug logging

### DIFF
--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -192,6 +192,10 @@ func (r *profileReconciler) ReconcileProfiles(ctx context.Context, cursor string
 		bulkHostProfs = append(bulkHostProfs, bulkProfs...)
 	}
 
+	if hostCount > 0 {
+		r.Logger.InfoContext(ctx, "android profile reconciler processed hosts", "host_count", hostCount, "profile_count", len(bulkHostProfs))
+	}
+
 	if err := r.DS.BulkUpsertMDMAndroidHostProfiles(ctx, bulkHostProfs); err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "bulk upsert android host profiles")
 	}
@@ -442,6 +446,12 @@ func (r *profileReconciler) sendHostProfiles(
 				prof.IncludedInPolicyVersion = &v
 			}
 		}
+	}
+
+	if skip && !policyReq.PolicyVersion.Valid {
+		r.Logger.WarnContext(ctx, "android policy patch returned not-modified without a version; profiles will have nil IncludedInPolicyVersion",
+			"host_uuid", hostUUID, "policy_request_uuid", policyReq.RequestUUID, "status_code", policyReq.StatusCode,
+			"profile_count", len(bulkProfilesByUUID))
 	}
 	if patchPolicyReqFailed {
 		appendWithheld()

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -193,7 +193,7 @@ func (r *profileReconciler) ReconcileProfiles(ctx context.Context, cursor string
 	}
 
 	if hostCount > 0 {
-		r.Logger.InfoContext(ctx, "android profile reconciler processed hosts", "host_count", hostCount, "profile_count", len(bulkHostProfs))
+		r.Logger.DebugContext(ctx, "android profile reconciler processed hosts", "host_count", hostCount, "profile_count", len(bulkHostProfs))
 	}
 
 	if err := r.DS.BulkUpsertMDMAndroidHostProfiles(ctx, bulkHostProfs); err != nil {

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -1067,7 +1067,8 @@ func (svc *Service) getPolicyID(ctx context.Context, device *androidmanagement.D
 func (svc *Service) verifyDevicePolicy(ctx context.Context, hostUUID string, device *androidmanagement.Device) {
 	appliedPolicyVersion := device.AppliedPolicyVersion
 
-	svc.logger.DebugContext(ctx, "Verifying Android device policy", "host_uuid", hostUUID, "applied_policy_version", appliedPolicyVersion)
+	svc.logger.DebugContext(ctx, "Verifying Android device policy", "host_uuid", hostUUID, "applied_policy_version", appliedPolicyVersion,
+		"non_compliance_count", len(device.NonComplianceDetails))
 
 	// Get all host_mdm_android_profiles that are pending or failed due to non compliance reasons,
 	// and included_in_policy_version <= device.AppliedPolicyVersion. That way we can either fully
@@ -1079,6 +1080,9 @@ func (svc *Service) verifyDevicePolicy(ctx context.Context, hostUUID string, dev
 		svc.logger.ErrorContext(ctx, "error getting pending profiles", "err", err)
 		return
 	}
+
+	svc.logger.DebugContext(ctx, "pending install profiles for verification", "host_uuid", hostUUID,
+		"pending_count", len(pendingInstallProfiles), "applied_policy_version", appliedPolicyVersion)
 
 	// First case, if nonComplianceDetails is empty, verify all profiles that are pending or failed install, and remove the pending remove ones.
 	if len(device.NonComplianceDetails) == 0 {
@@ -1119,6 +1123,23 @@ func (svc *Service) verifyDevicePolicy(ctx context.Context, hostUUID string, dev
 					policyRequestUUID = *profile.PolicyRequestUUID
 				}
 			}
+		}
+
+		if policyRequestUUID == "" {
+			var nilPolicyReqCount, nilVersionCount int
+			for _, p := range pendingInstallProfiles {
+				if p.PolicyRequestUUID == nil {
+					nilPolicyReqCount++
+				}
+				if p.IncludedInPolicyVersion == nil {
+					nilVersionCount++
+				}
+			}
+			svc.logger.WarnContext(ctx, "no matching policy request UUID found for non-compliance verification",
+				"host_uuid", hostUUID, "applied_policy_version", appliedPolicyVersion,
+				"pending_profiles", len(pendingInstallProfiles),
+				"nil_policy_request_uuid", nilPolicyReqCount, "nil_included_in_policy_version", nilVersionCount,
+				"non_compliance_count", len(device.NonComplianceDetails))
 		}
 
 		// Iterate over all policy request uuids, fetch them and unmarshal the payload into the type.


### PR DESCRIPTION
## Testing

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android MDM device policy logging during profile reconciliation and verification, including host and profile counts.
  * Added clearer warnings when policy updates are skipped while returning an invalid policy version, preventing missing policy metadata from going unnoticed.
  * Enhanced verification diagnostics with more detail on pending/failed/non-compliant profiles and warnings when expected policy request details cannot be matched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->