### PR TITLE
Update Release QA template for current product groups

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -2,8 +2,8 @@
 name:  Release QA
 about: Checklist of required tests prior to release
 title: 'Release QA:'
-labels: '#g-mdm,#g-orchestration,#g-software,#g-security-compliance,:release'
-assignees: 'xpkoala,andreykizimenko,chrstphr84,Brajim20'
+labels: '#g-orchestration,#g-apple-at-work,#g-power-to-pc,#g-auto-patching,#g-security-compliance,:release'
+assignees: 'xpkoala,andreykizimenko,chrstphr84,Brajim20,marcusallen97,thisisjoegrant'
 
 ---
 
@@ -44,7 +44,6 @@ Smoke tests are limited to core functionality and serve as a pre-release final r
 - [ ] IdP Provisioning (SCIM)
 - [ ] GitOps and generate-gitops
 - [ ] Fleet Free
-- [ ] UI / UX
 
 <table>
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
@@ -156,21 +155,6 @@ Reference: https://fleetdm.com/pricing
 </td>
 </tr>
 
-<tr>
-<td>UI / UX</td>
-<td>Verify visual consistency and layout integrity across product group areas.</td>
-<td>
-
-Perform a quick visual scan of the UI and confirm:
-
-- No layout or alignment issues (misaligned, overlapping, or clipped elements).
-- Fonts, colors, and icons render correctly and match the design system.
-- UI components render correctly (buttons, inputs, tables).
-- No obvious visual regressions or broken UI states.
-
-</td>
-</tr>
-
 </table>
 
 ### Apple at Work
@@ -185,7 +169,6 @@ Perform a quick visual scan of the UI and confirm:
 - [ ] iOS/iPadOS
 - [ ] Token & Certificate Renewals
 - [ ] Fleet Free
-- [ ] UI / UX
 
 <table>
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
@@ -299,7 +282,7 @@ Run basic checks for the product group area while using a Fleet Free license.
 
 - Features documented as Free work normally:
    - Host enrollment
-   - Apple and Android MDM
+   - Apple MDM
    - Configuration profile delivery
    - APNs Certificate renewal
 - Premium features are correctly restricted or hidden:
@@ -309,21 +292,6 @@ Run basic checks for the product group area while using a Fleet Free license.
 - No UI, API, or workflow errors occur when using Free-only functionality.
 
 Reference: https://fleetdm.com/pricing
-
-</td>
-</tr>
-
-<tr>
-<td>UI / UX</td>
-<td>Verify visual consistency and layout integrity across product group areas.</td>
-<td>
-
-Perform a quick visual scan of the UI and confirm:
-
-- No layout or alignment issues (misaligned, overlapping, or clipped elements).
-- Fonts, colors, and icons render correctly and match the design system.
-- UI components render correctly (buttons, inputs, tables).
-- No obvious visual regressions or broken UI states.
 
 </td>
 </tr>
@@ -339,8 +307,8 @@ Perform a quick visual scan of the UI and confirm:
 - [ ] Disk encryption
 - [ ] OS updates
 - [ ] Setup Experience
+- [ ] Android
 - [ ] Fleet Free
-- [ ] UI / UX
 
 <table>
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
@@ -411,6 +379,20 @@ Perform a quick visual scan of the UI and confirm:
 </tr>
 
 <tr>
+<td>Android</td>
+<td>Verify enrollment, profiles, & software installs.</td>
+<td>
+
+1. Verify BYOD enrollment.
+2. Verify Profiles are delivered to host and applied.
+3. Verify apps install.
+4. Verify certificate delivery.
+5. Verify `Unenroll`.
+
+</td>
+</tr>
+
+<tr>
 <td>Fleet Free</td>
 <td>Verify that product group features behave correctly on Fleet Free.</td>
 <td>
@@ -420,6 +402,7 @@ Run basic checks for the product group area while using a Fleet Free license.
 - Features documented as Free work normally:
    - Host enrollment
    - Windows MDM
+   - Android MDM
    - Configuration profile delivery
 - Premium features are correctly restricted or hidden:
    - Automatic MDM migration
@@ -428,21 +411,6 @@ Run basic checks for the product group area while using a Fleet Free license.
 - No UI, API, or workflow errors occur when using Free-only functionality.
 
 Reference: https://fleetdm.com/pricing
-
-</td>
-</tr>
-
-<tr>
-<td>UI / UX</td>
-<td>Verify visual consistency and layout integrity across product group areas.</td>
-<td>
-
-Perform a quick visual scan of the UI and confirm:
-
-- No layout or alignment issues (misaligned, overlapping, or clipped elements).
-- Fonts, colors, and icons render correctly and match the design system.
-- UI components render correctly (buttons, inputs, tables).
-- No obvious visual regressions or broken UI states.
 
 </td>
 </tr>
@@ -458,7 +426,6 @@ Perform a quick visual scan of the UI and confirm:
 - [ ] Scripts
 - [ ] Software
 - [ ] Fleet Free
-- [ ] UI / UX
 
 <table>
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
@@ -552,21 +519,6 @@ Reference: https://fleetdm.com/pricing
 </td>
 </tr>
 
-<tr>
-<td>UI / UX</td>
-<td>Verify visual consistency and layout integrity across product group areas.</td>
-<td>
-
-Perform a quick visual scan of the UI and confirm:
-
-- No layout or alignment issues (misaligned, overlapping, or clipped elements).
-- Fonts, colors, and icons render correctly and match the design system.
-- UI components render correctly (buttons, inputs, tables).
-- No obvious visual regressions or broken UI states.
-
-</td>
-</tr>
-
 </table>
 
 ### Security & Compliance
@@ -575,10 +527,8 @@ Perform a quick visual scan of the UI and confirm:
 - [ ] Disk encryption (Linux)
 - [ ] Vulnerabilities
 - [ ] Certificate Authorities
-- [ ] Android
 - [ ] Lock & Wipe
 - [ ] Fleet Free
-- [ ] UI / UX
 
 <table>
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
@@ -620,20 +570,6 @@ Perform a quick visual scan of the UI and confirm:
 </tr>
 
 <tr>
-<td>Android</td>
-<td>Verify enrollment, profiles, & software installs.</td>
-<td>
-
-1. Verify BYOD enrollment.
-2. Verify Profiles are delivered to host and applied.
-3. Verify apps install.
-4. Verify certificate delivery.
-5. Verify `Unenroll`.
-
-</td>
-</tr>
-
-<tr>
 <td>Lock & Wipe</td>
 <td>Verify hosts can be locked & wiped.</td>
 <td>
@@ -663,21 +599,6 @@ Run basic checks for the product group area while using a Fleet Free license.
 - No UI, API, or workflow errors occur when using Free-only functionality.
 
 Reference: https://fleetdm.com/pricing
-
-</td>
-</tr>
-
-<tr>
-<td>UI / UX</td>
-<td>Verify visual consistency and layout integrity across product group areas.</td>
-<td>
-
-Perform a quick visual scan of the UI and confirm:
-
-- No layout or alignment issues (misaligned, overlapping, or clipped elements).
-- Fonts, colors, and icons render correctly and match the design system.
-- UI components render correctly (buttons, inputs, tables).
-- No obvious visual regressions or broken UI states.
 
 </td>
 </tr>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA — Release QA process/template maintenance

# Description

Updates the Release QA issue template (`.github/ISSUE_TEMPLATE/release-qa.md`) to reflect the current product groups and to tighten the smoke tests.

Changes:

- **Assignees:** added `marcusallen97` and `thisisjoegrant`.
- **Labels:** updated to the current product groups — `#g-mdm` → `#g-apple-at-work`, `#g-software` → `#g-auto-patching`, and added `#g-power-to-pc`. Reordered to match the section order in the template.
- **Android:** moved the Android checks (Progress checkbox + test steps) from **Security & Compliance** to **Power to PC**, which now owns them.
- **Fleet Free coverage:** added `Android MDM` to Power to PC's "works normally on Free" list (where Android now lives), and scoped Apple at Work's entry from "Apple and Android MDM" to "Apple MDM".
- **Removed the UI / UX check from all product groups.** It was too abstract to be actionable — smoke tests should focus on specific action items, and there was no clean way to integrate it as a concrete step. We rely on QA noticing visual issues as we go through the specific checks, so a separate catch-all check added no value and just took up space.

# Checklist for submitter

- [ ] QA'd all new/changed functionality manually

<sub>This is a change to the Release QA GitHub issue template only (markdown). No code, migrations, configuration, or fleetd/orbit changes — the remaining template checklist sections do not apply.</sub>
