### PR TITLE
Back-port missing 4.88.x fixes into 4.89.0 (#48652, #48916, #48808)

### DIFF
--- a/changes/48633-profile-reconcile-duplicate-host
+++ b/changes/48633-profile-reconcile-duplicate-host
@@ -1,0 +1,1 @@
+- Fixed an issue where a configuration profile could be enqueued multiple times for a single host.

--- a/changes/48805-byod-idp-enroll
+++ b/changes/48805-byod-idp-enroll
@@ -1,0 +1,1 @@
+* Fixed a bug where a user's BYOD selection was not persisted through IdP authentication

--- a/changes/48879-vpp-manual-byod-device-install
+++ b/changes/48879-vpp-manual-byod-device-install
@@ -1,0 +1,1 @@
+* Fixed a bug where installing App Store (VPP) or in-house apps on an iOS/iPadOS host enrolled with the manual (profile-driven) BYOD enrollment profile failed while trying to look up a VPP user. These device-channel hosts now install apps to the device, the same as company-owned manual enrollment; user-scoped licensing is reserved for Account-Driven User Enrollment.

--- a/ee/server/service/install_vpp_associate_test.go
+++ b/ee/server/service/install_vpp_associate_test.go
@@ -77,13 +77,24 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 		})
 	}
 
-	// Common datastore mock setup, parameterized by isPersonalEnrollment.
-	setupDS := func(t *testing.T, isPersonal bool) *mock.Store {
+	// Common datastore mock setup, parameterized by whether the host is enrolled
+	// via Account-Driven User Enrollment (ADUE). The routing decision keys off
+	// the host's primary nano_enrollments row (id = host UUID): ADUE devices
+	// enroll as "User Enrollment (Device)", every other device-channel
+	// enrollment (including manual-profile BYOD) is "Device". It does NOT key
+	// off host_mdm.is_personal_enrollment (see #48879), so this drives
+	// GetNanoMDMEnrollment rather than GetHostMDM.
+	setupDS := func(t *testing.T, isUserEnrollment bool) *mock.Store {
 		t.Helper()
 		ds := new(mock.Store)
-		ds.GetHostMDMFunc = func(_ context.Context, id uint) (*fleet.HostMDM, error) {
-			require.Equal(t, hostID, id)
-			return &fleet.HostMDM{HostID: id, Enrolled: true, IsPersonalEnrollment: isPersonal}, nil
+		ds.GetNanoMDMEnrollmentFunc = func(_ context.Context, id string) (*fleet.NanoEnrollment, error) {
+			require.Equal(t, hostUUID, id)
+			if isUserEnrollment {
+				return &fleet.NanoEnrollment{ID: hostUUID, DeviceID: hostUUID, Type: "User Enrollment (Device)", Enabled: true}, nil
+			}
+			// Device-channel enrollment (company-owned manual OR manual-profile
+			// BYOD): the primary row is type "Device".
+			return &fleet.NanoEnrollment{ID: hostUUID, DeviceID: hostUUID, Type: "Device", Enabled: true}, nil
 		}
 		ds.GetVPPTokenByTeamIDFunc = func(_ context.Context, _ *uint) (*fleet.VPPTokenDB, error) {
 			return &fleet.VPPTokenDB{ID: 99, Token: bearerToken, RenewDate: time.Now().Add(24 * time.Hour)}, nil
@@ -136,7 +147,7 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 		require.True(t, ds.InsertVPPClientUserFuncInvoked)
 	})
 
-	t.Run("non-personal enrollment keeps SerialNumbers", func(t *testing.T) {
+	t.Run("device-channel enrollment keeps SerialNumbers", func(t *testing.T) {
 		var capt captured
 		setupServer(t, &capt)
 
@@ -152,13 +163,51 @@ func TestInstallVPPAppPostValidation_AssociateAssetsRouting(t *testing.T) {
 			SerialNumbers []string `json:"serialNumbers"`
 		}
 		require.NoError(t, json.Unmarshal(capt.body, &got))
-		require.Equal(t, []string{hostSerial}, got.SerialNumbers, "manually-enrolled hosts must use serialNumbers")
-		require.Empty(t, got.ClientUserIds, "manually-enrolled hosts must not send clientUserIds")
+		require.Equal(t, []string{hostSerial}, got.SerialNumbers, "device-channel hosts must use serialNumbers")
+		require.Empty(t, got.ClientUserIds, "device-channel hosts must not send clientUserIds")
 
-		// User-provisioning datastore writes must NOT happen on the manual path.
+		// User-provisioning datastore writes must NOT happen on the device path.
 		require.False(t, ds.GetVPPClientUserFuncInvoked)
 		require.False(t, ds.InsertVPPClientUserFuncInvoked)
 		require.False(t, ds.GetHostManagedAppleIDFuncInvoked)
+	})
+
+	// Regression test for #48879: a manual-profile BYOD host carries
+	// host_mdm.is_personal_enrollment=1 but is a DEVICE-channel enrollment (its
+	// primary nano_enrollments row is type "Device", not "User Enrollment
+	// (Device)", and it has no Managed Apple ID). It must install device-scoped
+	// (serialNumbers), exactly like company-owned manual — and must NOT attempt
+	// user provisioning, which previously failed with errMissingManagedAppleID.
+	t.Run("manual-profile BYOD (personal flag, device channel) routes via serialNumbers", func(t *testing.T) {
+		var capt captured
+		setupServer(t, &capt)
+
+		// isUserEnrollment=false → the primary enrollment row is type "Device"
+		// even though this host would have is_personal_enrollment=1 in host_mdm.
+		ds := setupDS(t, false)
+		// Make it explicit that the Managed Apple ID is absent for this host, so a
+		// regression that re-introduces the user path would fail loudly here.
+		ds.GetHostManagedAppleIDFunc = func(_ context.Context, _ uint) (string, error) {
+			return "", nil
+		}
+		svc := &Service{ds: ds, logger: slog.New(slog.DiscardHandler)}
+
+		_, err := svc.InstallVPPAppPostValidation(context.Background(), host, vppApp, bearerToken, fleet.HostSoftwareInstallOptions{})
+		require.NoError(t, err)
+
+		require.NotEmpty(t, capt.body)
+		var got struct {
+			ClientUserIds []string `json:"clientUserIds"`
+			SerialNumbers []string `json:"serialNumbers"`
+		}
+		require.NoError(t, json.Unmarshal(capt.body, &got))
+		require.Equal(t, []string{hostSerial}, got.SerialNumbers, "manual-profile BYOD must use serialNumbers (device-scoped)")
+		require.Empty(t, got.ClientUserIds, "manual-profile BYOD must not send clientUserIds")
+
+		// The whole point of #48879: no VPP user lookup/registration for device-channel BYOD.
+		require.False(t, ds.GetHostManagedAppleIDFuncInvoked, "must not look up a Managed Apple ID for device-channel BYOD")
+		require.False(t, ds.GetVPPClientUserFuncInvoked)
+		require.False(t, ds.InsertVPPClientUserFuncInvoked)
 	})
 
 	t.Run("personal enrollment queries assignments by clientUserId", func(t *testing.T) {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -34,6 +34,7 @@ import (
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	maintained_apps "github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
+	nanomdm "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/worker"
@@ -1657,14 +1658,28 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 	// makes Fleet enter the AvailableCount check on every retry and produces
 	// false-positive "no available licenses" errors when the user is just
 	// adding their Nth (≤5) device under one Managed Apple ID.
-	hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
+	// Device-vs-user VPP licensing must key off the actual MDM enrollment
+	// channel, not host_mdm.is_personal_enrollment. is_personal_enrollment is
+	// set for BOTH Account-Driven User Enrollment (ADUE, user-scoped, backed by
+	// a Managed Apple ID) and manual-profile BYOD (device channel, no Managed
+	// Apple ID). Only ADUE gets user-scoped licensing; manual-profile BYOD
+	// installs device-scoped, exactly like company-owned manual enrollment.
+	//
+	// The host's primary nano_enrollments row (id = host UUID) tells us the
+	// channel: ADUE devices enroll as "User Enrollment (Device)", while every
+	// other device-channel enrollment (ADE, manual, manual-profile BYOD) is
+	// "Device". Note the "User" type is the separate macOS user channel and is
+	// NOT what we want here. This row exists from enrollment time, whereas the
+	// Managed Apple ID only arrives minutes later via TokenUpdate, so this is
+	// the correct, timing-robust signal. See #48879.
+	nanoEnroll, err := svc.ds.GetNanoMDMEnrollment(ctx, host.UUID)
 	if err != nil {
-		return "", ctxerr.Wrap(ctx, err, "looking up host MDM info for VPP install")
+		return "", ctxerr.Wrap(ctx, err, "looking up enrollment for VPP install")
 	}
-	isPersonal := hostMDM != nil && hostMDM.IsPersonalEnrollment
+	isUserEnrollment := nanoEnroll != nil && nanoEnroll.Type == nanomdm.EnrollType(nanomdm.UserEnrollmentDevice).String()
 
 	var clientUserID string
-	if isPersonal {
+	if isUserEnrollment {
 		// Token-selection policy (per #44009): use the team's default token —
 		// `GetVPPTokenByTeamID` already returns the first token for the team
 		// (existing behavior). Multi-location support is deferred unless a
@@ -1680,7 +1695,7 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 	}
 
 	assignmentFilter := &vpp.AssignmentFilter{AdamID: vppApp.AdamID}
-	if isPersonal {
+	if isUserEnrollment {
 		assignmentFilter.ClientUserID = clientUserID
 	} else {
 		assignmentFilter.SerialNumber = host.HardwareSerial
@@ -1735,7 +1750,7 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 		}
 
 		req := &vpp.AssociateAssetsRequest{Assets: assets}
-		if isPersonal {
+		if isUserEnrollment {
 			req.ClientUserIds = []string{clientUserID}
 		} else {
 			req.SerialNumbers = []string{host.HardwareSerial}

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -1402,16 +1402,26 @@ ORDER BY
 	ua.priority DESC, ua.created_at ASC
 `
 
+	// is_user_enrollment must reflect the actual MDM enrollment channel, NOT
+	// host_mdm.is_personal_enrollment: the latter is also set for
+	// manual-profile BYOD, which is device-channel and must install
+	// device-scoped like company-owned manual. Only Account-Driven User
+	// Enrollment (ADUE) is user-scoped, and its primary enrollment row
+	// (id = host UUID) has type 'User Enrollment (Device)' — every other
+	// device-channel enrollment is 'Device'. See #48879.
 	const getHostStmt = `
 SELECT
 	h.uuid,
 	h.team_id,
 	h.platform,
 	h.hardware_serial,
-	COALESCE(hm.is_personal_enrollment, 0) AS is_personal_enrollment
+	COALESCE((
+		SELECT 1 FROM nano_enrollments ne
+		WHERE ne.id = h.uuid AND ne.type = 'User Enrollment (Device)' AND ne.enabled = 1
+		LIMIT 1
+	), 0) AS is_user_enrollment
 FROM
 	hosts h
-	LEFT JOIN host_mdm hm ON hm.host_id = h.id
 WHERE
 	h.id = ?
 `
@@ -1439,11 +1449,11 @@ ORDER BY
 	}
 
 	var hostData struct {
-		UUID                 string `db:"uuid"`
-		TeamID               *uint  `db:"team_id"`
-		Platform             string `db:"platform"`
-		HardwareSerial       string `db:"hardware_serial"`
-		IsPersonalEnrollment bool   `db:"is_personal_enrollment"`
+		UUID             string `db:"uuid"`
+		TeamID           *uint  `db:"team_id"`
+		Platform         string `db:"platform"`
+		HardwareSerial   string `db:"hardware_serial"`
+		IsUserEnrollment bool   `db:"is_user_enrollment"`
 	}
 	if err := sqlx.GetContext(ctx, tx, &hostData, getHostStmt, hostID); err != nil {
 		return ctxerr.Wrap(ctx, err, "get host info for in-house install")
@@ -1546,7 +1556,7 @@ WHERE
 			HostPlatform:     hostData.Platform,
 			ManifestURL:      manifestURL,
 			Configuration:    cfg,
-			IsUserEnrollment: hostData.IsPersonalEnrollment,
+			IsUserEnrollment: hostData.IsUserEnrollment,
 		})
 		insValues = append(insValues, "(?, 'InstallApplication', ?, ?)")
 		insArgs = append(insArgs, p.ExecutionID, string(cmdBytes), mdm.CommandSubtypeNone)

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -46,7 +46,7 @@ func (ds *Datastore) listAppleMDMHostsForReconcileBatchTransaction(
 		WHERE
 			(h.platform = 'darwin' OR h.platform = 'ios' OR h.platform = 'ipados')
 			AND h.uuid > ?
-		ORDER BY h.uuid
+		ORDER BY h.uuid, h.id DESC
 		LIMIT ?
 	`
 
@@ -54,13 +54,43 @@ func (ds *Datastore) listAppleMDMHostsForReconcileBatchTransaction(
 	if err := sqlx.SelectContext(ctx, tx, &hosts, stmt, afterHostUUID, batchSize); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list apple mdm hosts for reconcile batch")
 	}
-	return hosts, nil
+
+	// In the rare case multiple hosts rows share the same UUID (e.g. from past bugs
+	// or DEP re-enrollment), this query can return more than one row per UUID.
+	// We dedupe in Go, keeping the highest host ID. The ORDER BY h.id DESC ensures
+	// that if a duplicate UUID lands on a page boundary, the highest-ID row is the
+	// one that makes it into the page.
+	return dedupeHostsByUUID(hosts), nil
+}
+
+// dedupeHostsByUUID collapses reconcile records that share a UUID down to one,
+// keeping the highest host ID, and preserving input order (the batch query
+// orders by UUID, which the cursor pagination relies on). If this tiebreaker
+// changes, update the ORDER BY in listAppleMDMHostsForReconcileBatchTransaction
+// to keep pagination deterministic across page boundaries.
+func dedupeHostsByUUID(hosts []*fleet.AppleHostReconcileInfo) []*fleet.AppleHostReconcileInfo {
+	seen := make(map[string]int, len(hosts))
+	deduped := make([]*fleet.AppleHostReconcileInfo, 0, len(hosts))
+	for _, h := range hosts {
+		if i, ok := seen[h.UUID]; ok {
+			if h.HostID > deduped[i].HostID {
+				deduped[i] = h
+			}
+			continue
+		}
+		seen[h.UUID] = len(deduped)
+		deduped = append(deduped, h)
+	}
+	return deduped
 }
 
 // GetAppleMDMHostForReconcile returns the Apple-MDM reconcile info for a
 // single host UUID, or (nil, nil) if the host is not enrolled or not an
-// Apple platform. Uses the same JOIN as listAppleMDMHostsForReconcileBatchTransaction
-// so per-host and per-batch reconcile paths see the same eligibility rules.
+// Apple platform. Uses the same JOINs as
+// listAppleMDMHostsForReconcileBatchTransaction so the per-host and per-batch
+// reconcile paths share eligibility rules, and when a UUID maps to more than
+// one hosts row it resolves the duplicate the same way the batch does: the
+// highest h.id wins.
 func (ds *Datastore) GetAppleMDMHostForReconcile(
 	ctx context.Context,
 	hostUUID string,
@@ -83,6 +113,7 @@ func (ds *Datastore) GetAppleMDMHostForReconcile(
 		WHERE
 			(h.platform = 'darwin' OR h.platform = 'ios' OR h.platform = 'ipados')
 			AND h.uuid = ?
+		ORDER BY h.id DESC
 		LIMIT 1
 	`
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -103,6 +103,7 @@ func TestMDMApple(t *testing.T) {
 		{"MDMAppleUpsertHostPersonalEnrollment", testMDMAppleUpsertHostPersonalEnrollment},
 		{"IngestMDMAppleDevicesFromDEPSyncIOSIPadOS", testIngestMDMAppleDevicesFromDEPSyncIOSIPadOS},
 		{"MDMAppleProfilesOnIOSIPadOS", testMDMAppleProfilesOnIOSIPadOS},
+		{"ReconcileAppleProfilesDuplicateHostUUID", testReconcileAppleProfilesDuplicateHostUUID},
 		{"GetEnrollmentIDsWithPendingMDMAppleCommands", testGetEnrollmentIDsWithPendingMDMAppleCommands},
 		{"MDMAppleBootstrapPackageWithS3", testMDMAppleBootstrapPackageWithS3},
 		{"GetAndUpdateABMToken", testMDMAppleGetAndUpdateABMToken},
@@ -7773,6 +7774,81 @@ func testMDMAppleProfilesOnIOSIPadOS(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, profiles, 1)
 	require.Equal(t, someProfile.Name, profiles[0].Name)
+}
+
+func testReconcileAppleProfilesDuplicateHostUUID(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	SetTestABMAssets(t, ds, "fleet")
+
+	// Two hosts rows that share one hardware UUID — the duplicate-enrollment
+	// state Fleet can land in (e.g. DEP re-enrollment) that the reconciler must
+	// tolerate. There is a single nano enrollment for the shared UUID.
+	const sharedUUID = "DUP-UUID-SHARED"
+	now := time.Now()
+	hLow := test.NewHost(t, ds, "dup-low", "1.1.1.1", "dup-key-low", sharedUUID, now)
+	hHigh := test.NewHost(t, ds, "dup-high", "1.1.1.2", "dup-key-high", sharedUUID, now)
+	require.Greater(t, hHigh.ID, hLow.ID)
+	nanoEnroll(t, ds, hHigh, false)
+
+	// Source dedup: the reconcile snapshot must surface the UUID exactly once,
+	// keeping the highest host id.
+	hosts, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 5000)
+	require.NoError(t, err)
+	var forUUID []*fleet.AppleHostReconcileInfo
+	for _, h := range hosts {
+		if h.UUID == sharedUUID {
+			forUUID = append(forUUID, h)
+		}
+	}
+	require.Len(t, forUUID, 1)
+	require.Equal(t, hHigh.ID, forUUID[0].HostID)
+
+	// Force the duplicate group across a batch boundary: with batchSize=1 the
+	// query returns a single row, and the h.id DESC tiebreak must make it the
+	// highest-id host rather than an arbitrary one.
+	boundaryHosts, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 1)
+	require.NoError(t, err)
+	require.Len(t, boundaryHosts, 1)
+	require.Equal(t, hHigh.ID, boundaryHosts[0].HostID)
+
+	// The per-host reconcile path resolves the same duplicate the same way:
+	// highest id wins, and multiple enrollment relationships don't multiply.
+	perHost, err := ds.GetAppleMDMHostForReconcile(ctx, sharedUUID)
+	require.NoError(t, err)
+	require.NotNil(t, perHost)
+	require.Equal(t, hHigh.ID, perHost.HostID)
+
+	// End to end: a global profile reconciles into a single clean enqueue. With
+	// the pre-fix behavior the duplicate host produced EnrollmentIDs=[uuid,
+	// uuid], the per-command INSERT collided on the nano_enrollment_queue PK,
+	// and the profile was reverted to a NULL status instead of Pending.
+	prof, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("dup-profile", "com.dup.profile", 0), nil)
+	require.NoError(t, err)
+
+	commander, _ := createMDMAppleCommanderAndStorage(t, ds)
+	mockKV := new(mock.AdvancedKVStore)
+	mockKV.MGetFunc = func(ctx context.Context, keys []string) (map[string]*string, error) {
+		return make(map[string]*string), nil
+	}
+	require.NoError(t, service.ReconcileAppleProfilesBatched(ctx, ds, commander, mockKV, ds.logger, 0))
+
+	var hostProf struct {
+		Status      *fleet.MDMDeliveryStatus `db:"status"`
+		CommandUUID string                   `db:"command_uuid"`
+	}
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &hostProf,
+		`SELECT status, command_uuid FROM host_mdm_apple_profiles WHERE host_uuid = ? AND profile_uuid = ?`,
+		sharedUUID, prof.ProfileUUID))
+	require.NotNil(t, hostProf.Status, "profile should not have been reverted to a NULL status by a failed enqueue")
+	require.Equal(t, fleet.MDMDeliveryPending, *hostProf.Status)
+	require.NotEmpty(t, hostProf.CommandUUID)
+
+	// The command enqueued to exactly one queue row for the shared UUID (not
+	// zero from a failed insert, not two from a duplicate insert).
+	var queueRowsForCmd int
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &queueRowsForCmd,
+		`SELECT COUNT(*) FROM nano_enrollment_queue WHERE id = ? AND command_uuid = ?`, sharedUUID, hostProf.CommandUUID))
+	require.Equal(t, 1, queueRowsForCmd)
 }
 
 func testGetEnrollmentIDsWithPendingMDMAppleCommands(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -3107,25 +3107,35 @@ func (ds *Datastore) nanoEnqueueVPPInstall(ctx context.Context, tx sqlx.ExtConte
 		return nil
 	}
 
+	// is_user_enrollment must reflect the actual MDM enrollment channel, NOT
+	// host_mdm.is_personal_enrollment: the latter is also set for
+	// manual-profile BYOD, which is device-channel and must install
+	// device-scoped like company-owned manual. Only Account-Driven User
+	// Enrollment (ADUE) is user-scoped, and its primary enrollment row
+	// (id = host UUID) has type 'User Enrollment (Device)' — every other
+	// device-channel enrollment is 'Device'. See #48879.
 	const getHostUUIDStmt = `
 SELECT
 	h.uuid,
 	h.platform,
 	h.team_id,
 	h.hardware_serial,
-	COALESCE(hm.is_personal_enrollment, 0) AS is_personal_enrollment
+	COALESCE((
+		SELECT 1 FROM nano_enrollments ne
+		WHERE ne.id = h.uuid AND ne.type = 'User Enrollment (Device)' AND ne.enabled = 1
+		LIMIT 1
+	), 0) AS is_user_enrollment
 FROM
 	hosts h
-	LEFT JOIN host_mdm hm ON hm.host_id = h.id
 WHERE
 	h.id = ?
 `
 	var hostData struct {
-		UUID                 string `db:"uuid"`
-		Platform             string `db:"platform"`
-		TeamID               *uint  `db:"team_id"`
-		HardwareSerial       string `db:"hardware_serial"`
-		IsPersonalEnrollment bool   `db:"is_personal_enrollment"`
+		UUID             string `db:"uuid"`
+		Platform         string `db:"platform"`
+		TeamID           *uint  `db:"team_id"`
+		HardwareSerial   string `db:"hardware_serial"`
+		IsUserEnrollment bool   `db:"is_user_enrollment"`
 	}
 	if err := sqlx.GetContext(ctx, tx, &hostData, getHostUUIDStmt, hostID); err != nil {
 		return ctxerr.Wrap(ctx, err, "get host info for vpp install")
@@ -3216,7 +3226,7 @@ WHERE
 			HostPlatform:     hostData.Platform,
 			ITunesStoreID:    p.AdamID,
 			Configuration:    cfg,
-			IsUserEnrollment: hostData.IsPersonalEnrollment,
+			IsUserEnrollment: hostData.IsUserEnrollment,
 		})
 		insValues = append(insValues, "(?, 'InstallApplication', ?, ?)")
 		insArgs = append(insArgs, p.ExecutionID, string(cmdBytes), mdm.CommandSubtypeNone)

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -50,6 +50,7 @@ func TestVPP(t *testing.T) {
 		{"VPPAppConfigDeletedOnTeamDelete", testVPPAppConfigDeletedOnTeamDelete},
 		{"VPPInstallEnqueuesConfigurationDict", testVPPInstallEnqueuesConfigurationDict},
 		{"VPPInstallOmitsConfigurationOnMacOS", testVPPInstallOmitsConfigurationOnMacOS},
+		{"VPPInstallEnrollmentChannelRouting", testVPPInstallEnrollmentChannelRouting},
 		{"MapAdamIDsPendingInstallVerification", testMapAdamIDsPendingInstallVerification},
 		{"MapAdamIDsRecentInstalls", testMapAdamIDsRecentInstalls},
 		{"MapAdamIDsRecentlyVerifiedInstalls", testMapAdamIDsRecentlyVerifiedInstalls},
@@ -3442,6 +3443,75 @@ func testVPPInstallOmitsConfigurationOnMacOS(t *testing.T, ds *Datastore) {
 	})
 	require.NotContains(t, commandXML, "<key>Configuration</key>", "macOS VPP install must not carry Configuration dict even when config row exists")
 	require.Contains(t, commandXML, "<key>iTunesStoreID</key>")
+}
+
+// testVPPInstallEnrollmentChannelRouting is the #48879 regression at the
+// enqueue layer. The InstallApplication command's IsUserEnrollment flag (which
+// omits ChangeManagementState, valid only on Apple's Account-Driven User
+// Enrollment channel) must be driven by the actual enrollment CHANNEL — the
+// host's primary nano_enrollments row (id = host UUID) being type
+// "User Enrollment (Device)" — NOT by host_mdm.is_personal_enrollment. A
+// manual-profile BYOD host has is_personal_enrollment=1 but is device-channel
+// (primary row type "Device"), so its command must include ChangeManagementState
+// exactly like company-owned manual.
+func testVPPInstallEnrollmentChannelRouting(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	test.CreateInsertGlobalVPPToken(t, ds)
+
+	const adamID = "77778888"
+	setupTestVPPApp(t, ds, adamID, fleet.IOSPlatform)
+	vppApp := &fleet.VPPApp{
+		Name:             "ChannelApp",
+		VPPAppTeam:       fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: adamID, Platform: fleet.IOSPlatform}},
+		BundleIdentifier: adamID,
+	}
+	_, err := ds.InsertVPPAppWithTeam(ctx, vppApp, nil)
+	require.NoError(t, err)
+
+	enqueueAndReadCommand := func(t *testing.T, host *fleet.Host, cmdUUID string) string {
+		require.NoError(t, ds.InsertHostVPPSoftwareInstall(ctx, host.ID, vppApp.VPPAppID, cmdUUID, "evt-"+cmdUUID, fleet.HostSoftwareInstallOptions{}))
+		var commandXML string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &commandXML, "SELECT command FROM nano_commands WHERE command_uuid = ?", cmdUUID)
+		})
+		return commandXML
+	}
+
+	t.Run("manual-profile BYOD (personal flag, device channel) includes ChangeManagementState", func(t *testing.T) {
+		host, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:       "byod-manual-ios",
+			UUID:           "byod-manual-uuid",
+			Platform:       string(fleet.IOSPlatform),
+			HardwareSerial: "BYOD-SERIAL",
+		})
+		require.NoError(t, err)
+		// Device-channel enrollment (primary row type "Device") ...
+		nanoEnroll(t, ds, host, false)
+		// ... but flagged personal in host_mdm, like a manual BYOD profile.
+		require.NoError(t, ds.SetOrUpdateMDMData(ctx, host.ID, false, true, "https://fleetdm.com", false, fleet.WellKnownMDMFleet, "", true))
+
+		commandXML := enqueueAndReadCommand(t, host, "byod-manual-cmd")
+		require.Contains(t, commandXML, "<key>ChangeManagementState</key>",
+			"manual-profile BYOD is device-channel and must include ChangeManagementState despite is_personal_enrollment=1 (#48879)")
+	})
+
+	t.Run("account-driven user enrollment omits ChangeManagementState", func(t *testing.T) {
+		host, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:       "adue-ios",
+			UUID:           "adue-uuid",
+			Platform:       string(fleet.IOSPlatform),
+			HardwareSerial: "ADUE-SERIAL",
+		})
+		require.NoError(t, err)
+		// Account-Driven User Enrollment: the primary enrollment row (id = host
+		// UUID) is type "User Enrollment (Device)".
+		nanoEnrollUserDevice(t, ds, host)
+		require.NoError(t, ds.SetOrUpdateMDMData(ctx, host.ID, false, true, "https://fleetdm.com", false, fleet.WellKnownMDMFleet, "", true))
+
+		commandXML := enqueueAndReadCommand(t, host, "adue-cmd")
+		require.NotContains(t, commandXML, "<key>ChangeManagementState</key>",
+			"account-driven user enrollment must omit ChangeManagementState")
+	})
 }
 
 func testHasVPPAppConfigurationChanged(t *testing.T, ds *Datastore) {

--- a/server/mdm/apple/reconcile.go
+++ b/server/mdm/apple/reconcile.go
@@ -603,6 +603,28 @@ func ExecuteReconcileBatch(
 		return nil, ctxerr.Wrap(ctx, err, "deleting profiles that didn't change")
 	}
 
+	// Defense in depth: the batch host query dedupes hosts by UUID at the
+	// source, but any caller could still hand us a target whose EnrollmentIDs
+	// contain the same ID twice (e.g. duplicate host rows sharing a UUID).
+	// That would make the per-command INSERT into nano_enrollment_queue collide
+	// on its (id, command_uuid) primary key and fail the whole enqueue, so
+	// collapse duplicates before we build commands.
+	var duplicateEnrollmentIDs int
+	for _, target := range installTargets {
+		var removed int
+		target.EnrollmentIDs, removed = dedupeEnrollmentIDs(target.EnrollmentIDs)
+		duplicateEnrollmentIDs += removed
+	}
+	for _, target := range removeTargets {
+		var removed int
+		target.EnrollmentIDs, removed = dedupeEnrollmentIDs(target.EnrollmentIDs)
+		duplicateEnrollmentIDs += removed
+	}
+	if duplicateEnrollmentIDs > 0 {
+		logger.WarnContext(ctx, "batched reconcile: removed duplicate enrollment IDs from command targets; likely duplicate host rows sharing a UUID",
+			"removed", duplicateEnrollmentIDs)
+	}
+
 	logger.DebugContext(ctx, "batched reconcile: before bulk upsert",
 		"host_profiles", len(hostProfiles),
 		"install_targets", len(installTargets),
@@ -670,6 +692,28 @@ func ExecuteReconcileBatch(
 	}
 
 	return enqueueResult.SucceededCmdUUIDs, nil
+}
+
+// dedupeEnrollmentIDs removes duplicate enrollment IDs, preserving first-seen
+// order, and reports how many it dropped. Duplicates would collide on the
+// nano_enrollment_queue (id, command_uuid) primary key when the command is
+// enqueued.
+func dedupeEnrollmentIDs(ids []string) ([]string, int) {
+	if len(ids) < 2 {
+		return ids, 0
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := ids[:0]
+	var removed int
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			removed++
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out, removed
 }
 
 // ReconcileProfilesForEnrollingHost is the per-host reconciler invoked

--- a/server/mdm/apple/reconcile_test.go
+++ b/server/mdm/apple/reconcile_test.go
@@ -1122,6 +1122,89 @@ func TestMDMAppleExecuteReconcileBatch(t *testing.T) {
 	})
 }
 
+func TestMDMAppleExecuteReconcileBatchDedupesEnrollmentIDs(t *testing.T) {
+	// Backstop: even if ComputeReconcileDeltas hands ExecuteReconcileBatch two
+	// payloads for the same profile+host UUID (as duplicate host rows sharing a
+	// UUID produce), the enrollment ID must reach the enqueue exactly once — a
+	// repeated ID collides on the nano_enrollment_queue (id, command_uuid) PK.
+	ctx := context.Background()
+	mdmStorage := &mdmmock.MDMAppleStore{}
+	ds := new(mock.Store)
+	kv := new(mock.AdvancedKVStore)
+	pushFactory, _ := newMockAPNSPushProviderFactory()
+	pusher := nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushFactory, stdlogfmt.New())
+	cmdr := NewMDMAppleCommander(mdmStorage, pusher)
+
+	const hostUUID = "DUP-UUID"
+	profUUID := "a" + uuid.NewString()
+	toInstall := []*fleet.MDMAppleProfilePayload{
+		{ProfileUUID: profUUID, ProfileIdentifier: "com.dup.profile", HostUUID: hostUUID, Scope: fleet.PayloadScopeSystem},
+		{ProfileUUID: profUUID, ProfileIdentifier: "com.dup.profile", HostUUID: hostUUID, Scope: fleet.PayloadScopeSystem},
+	}
+
+	kv.MGetFunc = func(ctx context.Context, keys []string) (map[string]*string, error) {
+		return map[string]*string{}, nil
+	}
+	ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]mobileconfig.Mobileconfig, error) {
+		return map[string]mobileconfig.Mobileconfig{profUUID: []byte("dup-content")}, nil
+	}
+	ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+		return &fleet.GroupedCertificateAuthorities{}, nil
+	}
+	ds.BulkDeleteMDMAppleHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMAppleProfilePayload) error {
+		return nil
+	}
+	ds.BulkUpsertMDMAppleHostProfilesFunc = func(ctx context.Context, payload []*fleet.MDMAppleBulkUpsertHostProfilePayload) error {
+		return nil
+	}
+
+	var mu sync.Mutex
+	var enqueuedIDs [][]string
+	mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+		mu.Lock()
+		enqueuedIDs = append(enqueuedIDs, append([]string(nil), id...))
+		mu.Unlock()
+		return nil, nil
+	}
+	mdmStorage.RetrievePushInfoFunc = func(ctx context.Context, tokens []string) (map[string]*mdm.Push, error) {
+		res := make(map[string]*mdm.Push, len(tokens))
+		for _, tok := range tokens {
+			res[tok] = &mdm.Push{Token: []byte(tok)}
+		}
+		return res, nil
+	}
+	mdmStorage.RetrievePushCertFunc = func(ctx context.Context, topic string) (*tls.Certificate, string, error) {
+		cert, err := tls.LoadX509KeyPair("../../service/testdata/server.pem", "../../service/testdata/server.key")
+		return &cert, "", err
+	}
+	mdmStorage.IsPushCertStaleFunc = func(ctx context.Context, topic string, staleToken string) (bool, error) {
+		return false, nil
+	}
+	mdmStorage.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName,
+		_ sqlx.QueryerContext,
+	) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+		certPEM, err := os.ReadFile("../../service/testdata/server.pem")
+		require.NoError(t, err)
+		keyPEM, err := os.ReadFile("../../service/testdata/server.key")
+		require.NoError(t, err)
+		return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+			fleet.MDMAssetCACert: {Value: certPEM},
+			fleet.MDMAssetCAKey:  {Value: keyPEM},
+		}, nil
+	}
+
+	appCfg := &fleet.AppConfig{}
+	appCfg.ServerSettings.ServerURL = "https://test.example.com"
+	appCfg.MDM.EnabledAndConfigured = true
+
+	succeeded, err := ExecuteReconcileBatch(ctx, ds, cmdr, kv, slog.New(slog.DiscardHandler), appCfg, 0, toInstall, nil)
+	require.NoError(t, err)
+	require.Len(t, succeeded, 1)
+
+	require.Len(t, enqueuedIDs, 1)
+	require.Equal(t, []string{hostUUID}, enqueuedIDs[0])
+}
+
 func TestMDMAppleExecuteReconcileBatchCAThrottle(t *testing.T) {
 	ctx := t.Context()
 	mdmStorage := &mdmmock.MDMAppleStore{}

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -264,6 +264,10 @@ func initiateOTAEnrollSSO(svc fleet.Service, w http.ResponseWriter, r *http.Requ
 	if r.URL.Query().Get("fully_managed") == "true" {
 		requestURL += "&fully_managed=true"
 	}
+	// Same with the byod modifier parameter for Apple enrollments
+	if r.URL.Query().Get("byod") == "true" {
+		requestURL += "&byod=true"
+	}
 	ssnID, ssnDurationSecs, idpURL, err := svc.InitiateMDMSSO(r.Context(), fleet.SSOInitiatorOTAEnroll, requestURL, "")
 	if err != nil {
 		return err

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -108,6 +108,76 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 	}
 }
 
+// ssoURLCaptureService captures the customOriginalURL passed to InitiateMDMSSO so
+// tests can assert which query parameters survive into the SAML round-trip.
+type ssoURLCaptureService struct {
+	fleet.Service
+	capturedOriginalURL string
+}
+
+func (s *ssoURLCaptureService) InitiateMDMSSO(_ context.Context, _, customOriginalURL, _ string) (string, int, string, error) {
+	s.capturedOriginalURL = customOriginalURL
+	return "session-id", 300, "https://idp.example.com/sso", nil
+}
+
+// The original URL is where the user lands after completing SAML auth, so any
+// enrollment query parameter (fully_managed, byod) must be threaded through it or
+// it is lost across the round-trip.
+func TestInitiateOTAEnrollSSOPersistsQueryParams(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		query        string
+		wantContains []string
+		wantExcludes []string
+	}{
+		{
+			name:         "byod true is persisted",
+			query:        "byod=true",
+			wantContains: []string{"&byod=true"},
+		},
+		{
+			name:         "byod absent is not added",
+			query:        "",
+			wantExcludes: []string{"byod"},
+		},
+		{
+			name:         "byod false is not persisted",
+			query:        "byod=false",
+			wantExcludes: []string{"byod"},
+		},
+		{
+			name:         "byod and fully_managed both persisted",
+			query:        "byod=true&fully_managed=true",
+			wantContains: []string{"&byod=true", "&fully_managed=true"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &ssoURLCaptureService{}
+			target := "/enroll?enroll_secret=foo"
+			if tc.query != "" {
+				target += "&" + tc.query
+			}
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			err := initiateOTAEnrollSSO(svc, rec, req, "foo")
+			require.NoError(t, err)
+
+			require.Contains(t, svc.capturedOriginalURL, "enroll_secret=foo")
+			for _, want := range tc.wantContains {
+				require.Contains(t, svc.capturedOriginalURL, want)
+			}
+			for _, exclude := range tc.wantExcludes {
+				require.NotContains(t, svc.capturedOriginalURL, exclude)
+			}
+
+			// The handler should redirect the browser to the IdP.
+			require.Equal(t, http.StatusSeeOther, rec.Code)
+			require.Equal(t, "https://idp.example.com/sso", rec.Header().Get("Location"))
+		})
+	}
+}
+
 func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 	if !hasBuildTag("full") {
 		t.Skip("This test requires running with -tags full")


### PR DESCRIPTION
This PR back-ports fixes that landed on the 4.88 patch RC branches (`rc-patch-fleet-v4.88.0` / `rc-patch-fleet-v4.88.1`) but were missing from `rc-minor-fleet-v4.89.0`.

**Related issue:** N/A — cherry-pick of already-merged, already-QA'd PRs.

## Cherry-picked commits

- Fix dupe profile enqueue bug (#48652)
- Fix VPP/in-house app install on manual-profile BYOD iOS hosts (#48916)
- Persist byod=true enroll param through IdP redirects (#48808)

These were the only 3 commits from the 4.88.x patch branches genuinely absent from 4.89.0. All other candidate commits were verified to already be present on 4.89.0 (merged via `main` under different SHAs) or were release-bookkeeping/migration-ordering commits that must not be back-ported. Migrations were confirmed already present and in-order on 4.89.0.

# Checklist for submitter

- [x] Changes file added for user-visible changes (carried over from the original PRs: `changes/48633-profile-reconcile-duplicate-host`, `changes/48879-vpp-manual-byod-device-install`, `changes/48805-byod-idp-enroll`).

## Testing

- [x] Added/updated automated tests (carried over from the original PRs).
- [x] QA'd all new/changed functionality manually (in the original PRs).

For unreleased bug fixes in a release candidate:

- [x] Confirmed that the fix is not expected to adversely impact load test results.

## Database migrations

- [x] No new migrations introduced by this PR — all referenced migrations already exist on 4.89.0 at their original timestamps, in order.
