### PR TITLE
Add missing space under Controls > Setup experience > Users > End user authentication

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -104,7 +104,7 @@ const EndUserAuthSection = ({
               helpText={
                 <span>
                   Prevents macOS users from editing{" "}
-                  <strong>Account Name</strong> and <strong>Full name</strong>
+                  <strong>Account Name</strong> and <strong>Full name</strong>{" "}
                   in Setup Assistant. These fields will be locked to IdP values.
                 </span>
               }


### PR DESCRIPTION
We missed a space under Controls > Setup experience > Users > End user authentication.

Before:

<img width="846" height="207" alt="Screenshot 2026-07-09 at 14 56 09" src="https://github.com/user-attachments/assets/ef0e0022-aba4-4087-84ad-6657af77ec93" />

After:

<img width="861" height="205" alt="Screenshot 2026-07-09 at 14 56 04" src="https://github.com/user-attachments/assets/8eeff380-4616-4621-b06c-88fc748329d0" />


# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the spacing in the “Lock end user info” help text so the highlighted field names now display more clearly in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->