### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2026.160",
+      "version": "1.2026.183",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '1.2026.160') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '1.2026.183') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2026.160_1781312926.dmg",
+      "installer_url": "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2026.183_1783607847.dmg",
       "install_script_ref": "61140545",
       "uninstall_script_ref": "34cffa61",
-      "sha256": "37e043abd3ffa592c4c2ba9ce8494bc3fa3b157ae4e6f7872a792ffd089edf07",
+      "sha256": "49b33cadd2ec659b76352384f7ebd332a7ec7029663365a9f720f4a251d3b8d1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.19367.0",
+      "version": "1.20186.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.19367.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.20186.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.19367.0/Claude-1a5be1fbf83d1832486e03a667557c18f0a0ec7a.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.20186.0/Claude-d7731e7f42fb72db87a6488ad8c1357b1cf971f7.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "fe8c810b0b8468fcadb871d5b66f1a6383394254f3c08c93dd645e1fbdac4cce",
+      "sha256": "34fe29eb3d7acc63fe8e7320986e8aee12304bb347e4d03beace6d7d6279ee4c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cleanmymac/darwin.json
+++ b/ee/maintained-apps/outputs/cleanmymac/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.5.4",
+      "version": "5.5.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5' AND version_compare(bundle_short_version, '5.5.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5' AND version_compare(bundle_short_version, '5.5.5') < 0);"
       },
-      "installer_url": "https://updates.cleanmymac.com/com.macpaw.cleanmymac5/releases/CleanMyMac5_50504.0.2605291449.zip",
+      "installer_url": "https://updates.cleanmymac.com/com.macpaw.cleanmymac5/releases/CleanMyMac5_50505.0.2607091048.zip",
       "install_script_ref": "fff893a1",
       "uninstall_script_ref": "f09da8a8",
-      "sha256": "b66d2f26ce4d1dc6819f1b4dd7e9f020f9f3b3527beaeb6406b9a41cac5b5020",
+      "sha256": "341e17067c39bd6fe2ec90adb51fd6dd94b43a2bbf571bff767e4b5325f69128",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cmake-app/darwin.json
+++ b/ee/maintained-apps/outputs/cmake-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.4",
+      "version": "4.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake' AND version_compare(bundle_short_version, '4.3.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake' AND version_compare(bundle_short_version, '4.4.0') < 0);"
       },
-      "installer_url": "https://cmake.org/files/v4.3/cmake-4.3.4-macos-universal.dmg",
+      "installer_url": "https://cmake.org/files/v4.4/cmake-4.4.0-macos-universal.dmg",
       "install_script_ref": "e8baa8ae",
       "uninstall_script_ref": "87ce57a8",
-      "sha256": "2aacd32eaaca88e2edcb29a892ff3d34db3f93ac09d9751aebef38e9ac80dd69",
+      "sha256": "86f4f074e21d3475ee52f706c13b4adc586a0d833c1a5df81ef5bc5b66c07801",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/deezer/darwin.json
+++ b/ee/maintained-apps/outputs/deezer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.1.270",
+      "version": "7.1.280",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop' AND version_compare(bundle_short_version, '7.1.270') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.deezer.deezer-desktop' AND version_compare(bundle_short_version, '7.1.280') < 0);"
       },
-      "installer_url": "https://www.deezer.com/desktop/download/artifact-darwin-x64-7.1.270",
+      "installer_url": "https://www.deezer.com/desktop/download/artifact-darwin-x64-7.1.280",
       "install_script_ref": "17993903",
       "uninstall_script_ref": "7a7ca836",
-      "sha256": "1713256fce054b97568db11ad160ea9cc682015651cff7385830987611188e06",
+      "sha256": "bd1e529c1f9f08818d435082e602ad09a9ad98bf6e8416e1d12e5695996708d0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dropbox/darwin.json
+++ b/ee/maintained-apps/outputs/dropbox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "258.4.3749",
+      "version": "260.4.2926",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox' AND version_compare(bundle_short_version, '258.4.3749') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox' AND version_compare(bundle_short_version, '260.4.2926') < 0);"
       },
-      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20258.4.3749.arm64.dmg",
+      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20260.4.2926.arm64.dmg",
       "install_script_ref": "1b6588b5",
       "uninstall_script_ref": "ef0b6a46",
-      "sha256": "ea96c12c0a0a7ea37070e5a69d92d415945bc490beaf43f348e33384efc6f0eb",
+      "sha256": "03b5507c71436f3a88657f70dc926059b76b8aa57495690e1fad70105f0f9b75",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.12",
+      "version": "1.2.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.13') < 0);"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.12/Hive-1.2.12-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.13/Hive-1.2.13-arm64.dmg",
       "install_script_ref": "6b39e7ad",
       "uninstall_script_ref": "78bb4e43",
-      "sha256": "91960040acb7d52fc5320a21fb216565de54e092ce8f369c40e8f5a4ff13d378",
+      "sha256": "973fc8f8a6b752b4297f0c4eaefd80f42b829c62e4dc11c55ef5c0d18a11d0f1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nextcloud-talk/darwin.json
+++ b/ee/maintained-apps/outputs/nextcloud-talk/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac' AND version_compare(bundle_short_version, '2.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac' AND version_compare(bundle_short_version, '2.2.1') < 0);"
       },
-      "installer_url": "https://github.com/nextcloud-releases/talk-desktop/releases/download/v2.2.0/Nextcloud.Talk-macos-universal.dmg",
+      "installer_url": "https://github.com/nextcloud-releases/talk-desktop/releases/download/v2.2.1/Nextcloud.Talk-macos-universal.dmg",
       "install_script_ref": "597512da",
       "uninstall_script_ref": "baa87dcf",
-      "sha256": "4d631867ebeb243033dc950aefbd3b2938fe81d08bd93f3377ef45da91c14900",
+      "sha256": "4e42c0c9d91e74b6e2eafa9dde4bd03645675c64877c5eb14c11773c23a027a2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17.16",
+      "version": "1.17.18",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.18') < 0);"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.16/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "727dc41e",
       "uninstall_script_ref": "ad62b190",
-      "sha256": "b67f477be00956a7bd9480281f92cb157b34467643fc2e2a875250d66f14c228",
+      "sha256": "b52c4dcc27a0b91e98270476aad34cee265bbbc5993ee4cbfb30e35340ffffb7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/windows.json
+++ b/ee/maintained-apps/outputs/prisma-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.33.2.46",
+      "version": "150.41.2.115",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '150.33.2.46') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '150.41.2.115') < 0);"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_150_33_2_46-150.33.2.46-1da7e04d.msi",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_150_41_2_115-150.41.2.115-af0d7600.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "84194ed8",
-      "sha256": "d8e18b46cc64488638c2ae77f8f9dfc3cbeeca9395809aae5efc15d67c7cf5e9",
+      "sha256": "78e7608185a133e1b034ecc847004eea3da407a7fa0bedf23e3448dde8e8f292",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.17.0",
+      "version": "8.18.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.17.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.18.0') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.17.0.zip",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.18.0.zip",
       "install_script_ref": "fac7f399",
       "uninstall_script_ref": "c0c94e32",
-      "sha256": "7aa9ca3c7d864c671cf08dd68a866c6bff3a41ac5f55851c6b62a3ca653b32da",
+      "sha256": "7b4d32118759054b2d44c0a4cde7ad4f50c1b4a0b6736a8929cde46c9295b815",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/superhuman/darwin.json
+++ b/ee/maintained-apps/outputs/superhuman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1041.0.15",
+      "version": "1041.0.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.16') < 0);"
       },
-      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.15-arm64-latest-mac.zip",
+      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.16-arm64-latest-mac.zip",
       "install_script_ref": "b7ebe5bf",
       "uninstall_script_ref": "1809183d",
-      "sha256": "dd6c39fba247d8ca5a74d87ef6dd9277657ae51673dba5468923ecf25e21b23e",
+      "sha256": "2b491a1fae1e717ca7f3049755e022ac23b06fa9b9ce8bd6f8d02b134560f5fd",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "46.6.1.35236",
+      "version": "46.6.1.35355",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.1.35236') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.1.35355') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "d105863f",

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.10.0",
+      "version": "1.10.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.10.1') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.10.0/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.10.1/Zed-aarch64.dmg",
       "install_script_ref": "ad597b79",
       "uninstall_script_ref": "2a2c7eb8",
-      "sha256": "ed414ec3276f42c6272958823e1b669ce9a63f929d067a0dd3b12f0bf8bd087e",
+      "sha256": "7fe05f335c249db08c893ddb064ad5387bf69fb21dc02e5969acadfa3ac28279",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed installer metadata for several maintained apps on macOS and Windows, including ChatGPT, Claude, CleanMyMac, CMake, Deezer, Dropbox, Hive, Nextcloud Talk, OpenCode Desktop, Prisma Access Browser, Signal, Superhuman, Webex, and Zed.
  * Bumped each entry to the latest available release and updated download links and checksums so installs stay current and verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->