### PR TITLE
Add GitOps support for macOS script-only packages in setup experience

### DIFF
--- a/changes/47629-gitops-scriptonly-macos-setup-experience
+++ b/changes/47629-gitops-scriptonly-macos-setup-experience
@@ -1,0 +1,1 @@
+- Added `setup_experience_platforms` on software packages in GitOps yaml so `.sh` script-only installers can be selected for the macOS setup experience declaratively, matching the per-platform UI selection. The list is authoritative on every batch apply and reconciles the cross-platform selection table.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1950,6 +1950,9 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 
 	setupSoftwareBySoftwareTitle := make(map[uint]struct{})
 	setupSoftwareByPlatformAndAppID := make(map[string]struct{})
+	// Emitted as setup_experience_platforms so a UI-set non-native selection
+	// round-trips through generate → apply unchanged.
+	crossPlatformSelectionsByTitleID := make(map[uint][]string)
 
 	// Fill in InstallDuringSetup for software, as that information is only available
 	// from the setup experience endpoint
@@ -1969,6 +1972,26 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			if appStoreApp != nil && appStoreApp.InstallDuringSetup != nil && *appStoreApp.InstallDuringSetup {
 				setupSoftwareByPlatformAndAppID[appStoreApp.FullyQualifiedName()] = struct{}{}
 			}
+		}
+	}
+
+	// A title returned by the per-platform setup experience listing whose
+	// native platform doesn't match the queried target is a cross-selection.
+	for _, crossTarget := range []string{"macos"} {
+		crossTitles, err := cmd.Client.GetSetupExperienceSoftware(crossTarget, teamID)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting %s setup software: %s\n", crossTarget, err)
+			return nil, err
+		}
+		for _, t := range crossTitles {
+			pkg := t.SoftwarePackage
+			if pkg == nil || pkg.Platform == "" {
+				continue
+			}
+			if pkg.Platform == fleet.CanonicalPlatform(crossTarget) {
+				continue
+			}
+			crossPlatformSelectionsByTitleID[t.ID] = append(crossPlatformSelectionsByTitleID[t.ID], crossTarget)
 		}
 	}
 
@@ -2276,6 +2299,9 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			}
 			if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
 				softwareSpec["setup_experience"] = true
+			}
+			if crosses, ok := crossPlatformSelectionsByTitleID[softwareTitle.ID]; ok && len(crosses) > 0 {
+				softwareSpec["setup_experience_platforms"] = crosses
 			}
 		} else {
 			platformAndAppID := softwareTitle.AppStoreApp.VPPAppID.String()

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3397,9 +3397,9 @@ func (svc *Service) softwareBatchUpload(
 		return
 	}
 
-	// GitOps is declarative: replace the cross-platform setup experience
-	// selections for this team on every apply, so removing the field on
-	// re-apply clears the corresponding rows.
+	// Reconcile cross-platform setup experience selections when the incoming
+	// batch mentions them. A batch that never touches setup_experience_platforms
+	// leaves the cross-table alone so UI-set selections aren't clobbered.
 	if err := svc.reconcileGitOpsSetupExperienceCrossInstallers(ctx, ptr.ValOrZero(teamID), softwareInstallers); err != nil {
 		batchErr = fmt.Errorf("reconciling cross-platform setup experience selections: %w", err)
 		return
@@ -3415,14 +3415,27 @@ func (svc *Service) softwareBatchUpload(
 var gitOpsCrossPlatformTargets = []string{"darwin"}
 
 // reconcileGitOpsSetupExperienceCrossInstallers replaces the
-// setup_experience_software_installers rows for the team from the incoming
-// payloads. Nil SetupExperiencePlatforms on a payload counts as no selection,
-// so a re-apply with the field removed clears the row.
+// setup_experience_software_installers rows for the team when the incoming
+// batch explicitly opts into cross-platform setup experience. Nil
+// SetupExperiencePlatforms across every payload means "no opinion" and the
+// cross-table is left alone — this preserves UI-set selections for callers
+// that never touch the field.
 func (svc *Service) reconcileGitOpsSetupExperienceCrossInstallers(
 	ctx context.Context,
 	teamID uint,
 	payloads []*fleet.UploadSoftwareInstallerPayload,
 ) error {
+	var anyOptIn bool
+	for _, p := range payloads {
+		if p != nil && p.SetupExperiencePlatforms != nil {
+			anyOptIn = true
+			break
+		}
+	}
+	if !anyOptIn {
+		return nil
+	}
+
 	type key struct{ filename, platform string }
 	perTarget := make(map[string][]key, len(gitOpsCrossPlatformTargets))
 	var allKeys []key

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2043,6 +2043,37 @@ func (svc *Service) GetSelfServiceUninstallScriptResult(ctx context.Context, hos
 	return scriptResult, nil
 }
 
+// normalizeSetupExperiencePlatforms canonicalizes, deduplicates, and
+// validates the incoming platforms against the extension's allowlist. Returns
+// an error on the first incompatible entry; empty input is legal.
+func normalizeSetupExperiencePlatforms(platforms []string, extension string) ([]string, error) {
+	allowed := fleet.AllowedSetupExperiencePlatformsForExtension(extension)
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		allowedSet[a] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(platforms))
+	out := make([]string, 0, len(platforms))
+	for _, raw := range platforms {
+		canonical := fleet.CanonicalPlatform(raw)
+		if canonical == "" {
+			continue
+		}
+		if _, ok := allowedSet[canonical]; !ok {
+			return nil, fmt.Errorf(
+				`platform %q is not a valid "setup_experience_platforms" value for a .%s package (allowed: %s)`,
+				raw, extension, strings.Join(allowed, ", "),
+			)
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		out = append(out, canonical)
+	}
+	return out, nil
+}
+
 func (svc *Service) storeSoftware(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) error {
 	// check if exists in the installer store
 	exists, err := svc.softwareInstallStore.Exists(ctx, payload.StorageID)
@@ -2821,24 +2852,25 @@ func (svc *Service) softwareBatchUpload(
 			// readers are collected in toBeClosedTFRs and will have their Close
 			// deferred after the join/wait of goroutines.
 			installer := &fleet.UploadSoftwareInstallerPayload{
-				TeamID:             teamID,
-				InstallScript:      p.InstallScript,
-				PreInstallQuery:    p.PreInstallQuery,
-				PostInstallScript:  p.PostInstallScript,
-				UninstallScript:    p.UninstallScript,
-				SelfService:        p.SelfService,
-				UserID:             userID,
-				URL:                p.URL,
-				InstallDuringSetup: p.InstallDuringSetup,
-				LabelsIncludeAny:   p.LabelsIncludeAny,
-				LabelsExcludeAny:   p.LabelsExcludeAny,
-				LabelsIncludeAll:   p.LabelsIncludeAll,
-				ValidatedLabels:    p.ValidatedLabels,
-				Categories:         p.Categories.Value,
-				DisplayName:        p.DisplayName,
-				RollbackVersion:    p.RollbackVersion,
-				AlwaysDownload:     p.AlwaysDownload,
-				Configuration:      p.Configuration,
+				TeamID:                   teamID,
+				InstallScript:            p.InstallScript,
+				PreInstallQuery:          p.PreInstallQuery,
+				PostInstallScript:        p.PostInstallScript,
+				UninstallScript:          p.UninstallScript,
+				SelfService:              p.SelfService,
+				UserID:                   userID,
+				URL:                      p.URL,
+				InstallDuringSetup:       p.InstallDuringSetup,
+				SetupExperiencePlatforms: p.SetupExperiencePlatforms,
+				LabelsIncludeAny:         p.LabelsIncludeAny,
+				LabelsExcludeAny:         p.LabelsExcludeAny,
+				LabelsIncludeAll:         p.LabelsIncludeAll,
+				ValidatedLabels:          p.ValidatedLabels,
+				Categories:               p.Categories.Value,
+				DisplayName:              p.DisplayName,
+				RollbackVersion:          p.RollbackVersion,
+				AlwaysDownload:           p.AlwaysDownload,
+				Configuration:            p.Configuration,
 			}
 
 			var extraInstallers []*fleet.UploadSoftwareInstallerPayload
@@ -3203,6 +3235,20 @@ func (svc *Service) softwareBatchUpload(
 				return errors.New(`Couldn't edit software. "setup_experience" cannot be used for macOS software if "macos_manual_agent_install" is enabled.`)
 			}
 
+			// Canonicalize and reject platforms incompatible with the
+			// installer's extension before the batch reaches the datastore.
+			if installer.SetupExperiencePlatforms != nil {
+				normalized, err := normalizeSetupExperiencePlatforms(*installer.SetupExperiencePlatforms, installer.Extension)
+				if err != nil {
+					return fmt.Errorf("Couldn't edit software. %s: %s", installer.Filename, err.Error())
+				}
+				installer.SetupExperiencePlatforms = &normalized
+
+				if slices.Contains(normalized, "darwin") && manualAgentInstall {
+					return errors.New(`Couldn't edit software. "setup_experience_platforms" cannot include "macos" if "macos_manual_agent_install" is enabled.`)
+				}
+			}
+
 			// Update $PACKAGE_ID/$UPGRADE_CODE in uninstall script
 			if err := preProcessUninstallScript(installer); err != nil {
 				return fmt.Errorf("processing uninstall script: %w", err)
@@ -3351,8 +3397,89 @@ func (svc *Service) softwareBatchUpload(
 		return
 	}
 
+	// GitOps is declarative: replace the cross-platform setup experience
+	// selections for this team on every apply, so removing the field on
+	// re-apply clears the corresponding rows.
+	if err := svc.reconcileGitOpsSetupExperienceCrossInstallers(ctx, ptr.ValOrZero(teamID), softwareInstallers); err != nil {
+		batchErr = fmt.Errorf("reconciling cross-platform setup experience selections: %w", err)
+		return
+	}
+
 	// Note: per @noahtalerman we don't want activity items for CLI actions
 	// anymore, so that's intentionally skipped.
+}
+
+// gitOpsCrossPlatformTargets is the set of non-native platforms whose
+// cross-table selections GitOps reconciles. Extend when a new cross-platform
+// combination becomes supported (also update AllowedSetupExperiencePlatformsForExtension).
+var gitOpsCrossPlatformTargets = []string{"darwin"}
+
+// reconcileGitOpsSetupExperienceCrossInstallers replaces the
+// setup_experience_software_installers rows for the team from the incoming
+// payloads. Nil SetupExperiencePlatforms on a payload counts as no selection,
+// so a re-apply with the field removed clears the row.
+func (svc *Service) reconcileGitOpsSetupExperienceCrossInstallers(
+	ctx context.Context,
+	teamID uint,
+	payloads []*fleet.UploadSoftwareInstallerPayload,
+) error {
+	type key struct{ filename, platform string }
+	perTarget := make(map[string][]key, len(gitOpsCrossPlatformTargets))
+	var allKeys []key
+	seenKey := make(map[key]struct{})
+	for _, p := range payloads {
+		if p == nil || p.SetupExperiencePlatforms == nil {
+			continue
+		}
+		for _, target := range *p.SetupExperiencePlatforms {
+			// An installer's own native platform is expressed via
+			// install_during_setup on the software_installers row; it does
+			// not belong in the cross-table.
+			if target == p.Platform {
+				continue
+			}
+			k := key{filename: p.Filename, platform: p.Platform}
+			perTarget[target] = append(perTarget[target], k)
+			if _, ok := seenKey[k]; !ok {
+				seenKey[k] = struct{}{}
+				allKeys = append(allKeys, k)
+			}
+		}
+	}
+
+	// (filename, platform) is uniquely constrained per team, so at most one
+	// row matches each pair.
+	idByKey := make(map[key]uint, len(allKeys))
+	if len(allKeys) > 0 {
+		filenames := make([]string, 0, len(allKeys))
+		platforms := make([]string, 0, len(allKeys))
+		for _, k := range allKeys {
+			filenames = append(filenames, k.filename)
+			platforms = append(platforms, k.platform)
+		}
+		rows, err := svc.ds.GetSoftwareInstallerIDsByTeamAndFilenamePlatform(ctx, teamID, filenames, platforms)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "look up installer ids for cross-platform reconcile")
+		}
+		for _, r := range rows {
+			idByKey[key{filename: r.Filename, platform: r.Platform}] = r.ID
+		}
+	}
+
+	// Call the datastore even for targets with no incoming selections so
+	// stale rows get cleared — that's what makes the apply declarative.
+	for _, target := range gitOpsCrossPlatformTargets {
+		var ids []uint
+		for _, k := range perTarget[target] {
+			if id, ok := idByKey[k]; ok {
+				ids = append(ids, id)
+			}
+		}
+		if err := svc.ds.SetSetupExperienceCrossInstallers(ctx, target, teamID, ids); err != nil {
+			return ctxerr.Wrap(ctx, err, "set cross-platform setup experience installers")
+		}
+	}
+	return nil
 }
 
 func (svc *Service) fillSoftwareInstallerPayloadFromExisting(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload, existing *fleet.ExistingSoftwareInstaller, sha256Hash string) error {

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -1843,3 +1843,44 @@ func TestParsePinnedVersion(t *testing.T) {
 		assert.Equalf(t, c.wantCaret, caret, "case %s", c.name)
 	}
 }
+
+func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		input     []string
+		extension string
+		want      []string
+		wantErr   string
+	}{
+		{name: "empty input", input: nil, extension: "sh", want: []string{}},
+		{name: "sh macos alias", input: []string{"macos"}, extension: "sh", want: []string{"darwin"}},
+		{name: "sh both platforms", input: []string{"macos", "linux"}, extension: "sh", want: []string{"darwin", "linux"}},
+		{name: "sh dedupe canonical", input: []string{"macos", "darwin", "macos"}, extension: "sh", want: []string{"darwin"}},
+		{name: "sh case + whitespace", input: []string{" MacOS ", "LINUX"}, extension: "sh", want: []string{"darwin", "linux"}},
+		{name: "pkg native only ok", input: []string{"macos"}, extension: "pkg", want: []string{"darwin"}},
+		{name: "pkg cross rejected", input: []string{"linux"}, extension: "pkg", wantErr: `platform "linux" is not a valid "setup_experience_platforms" value for a .pkg package`},
+		{name: "msi cross rejected", input: []string{"macos"}, extension: "msi", wantErr: `platform "macos" is not a valid "setup_experience_platforms" value for a .msi package`},
+		{name: "sh unsupported windows", input: []string{"windows"}, extension: "sh", wantErr: `platform "windows" is not a valid "setup_experience_platforms" value for a .sh package`},
+		{name: "empty string skipped", input: []string{""}, extension: "sh", want: []string{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := normalizeSetupExperiencePlatforms(c.input, c.extension)
+			if c.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			// nil vs empty-slice noise: compare both as normalized empty.
+			if len(c.want) == 0 {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Equal(t, c.want, got)
+		})
+	}
+}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -312,6 +312,7 @@ func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePac
 	packageLevel.LabelsExcludeAny = spec.LabelsExcludeAny
 	packageLevel.LabelsIncludeAll = spec.LabelsIncludeAll
 	packageLevel.InstallDuringSetup = spec.InstallDuringSetup
+	packageLevel.SetupExperiencePlatforms = spec.SetupExperiencePlatforms
 	packageLevel.SelfService = spec.SelfService
 	packageLevel.Configuration = spec.Configuration
 

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -1120,3 +1120,29 @@ func (ds *Datastore) CancelPendingSetupExperienceSteps(ctx context.Context, host
 	}
 	return nil
 }
+
+// SetSetupExperienceCrossInstallers replaces the setup_experience_software_installers
+// rows for (platform, teamID) with the given installer IDs. platform must be
+// canonical (e.g. "darwin"). An empty installerIDs slice clears the pair.
+func (ds *Datastore) SetSetupExperienceCrossInstallers(ctx context.Context, platform string, teamID uint, installerIDs []uint) error {
+	const stmtClear = `DELETE FROM setup_experience_software_installers WHERE platform = ? AND global_or_team_id = ?`
+	const stmtInsertTmpl = `INSERT IGNORE INTO setup_experience_software_installers (software_installer_id, platform, global_or_team_id) VALUES %s`
+
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		if _, err := tx.ExecContext(ctx, stmtClear, platform, teamID); err != nil {
+			return ctxerr.Wrap(ctx, err, "clearing setup experience cross-platform installers")
+		}
+		if len(installerIDs) == 0 {
+			return nil
+		}
+		rowPlaceholders := strings.Join(slices.Repeat([]string{"(?,?,?)"}, len(installerIDs)), ",")
+		args := make([]any, 0, len(installerIDs)*3)
+		for _, id := range installerIDs {
+			args = append(args, id, platform, teamID)
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(stmtInsertTmpl, rowPlaceholders), args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "inserting setup experience cross-platform installers")
+		}
+		return nil
+	})
+}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1139,6 +1139,42 @@ func (ds *Datastore) ValidateOrbitSoftwareInstallerAccess(ctx context.Context, h
 	return true, nil
 }
 
+// GetSoftwareInstallerIDsByTeamAndFilenamePlatform resolves installer IDs
+// from zipped (filename, platform) pairs on the given team. Only active
+// installers are returned; missing pairs are omitted rather than erroring,
+// so callers must handle a short result set.
+func (ds *Datastore) GetSoftwareInstallerIDsByTeamAndFilenamePlatform(
+	ctx context.Context, teamID uint, filenames []string, platforms []string,
+) ([]fleet.SoftwareInstallerLookupRow, error) {
+	if len(filenames) != len(platforms) {
+		return nil, ctxerr.New(ctx, "filenames and platforms slices must have the same length")
+	}
+	if len(filenames) == 0 {
+		return nil, nil
+	}
+	// sqlx.In can't expand tuple IN, so build the placeholders manually.
+	rowPlaceholders := strings.Join(slices.Repeat([]string{"(?,?)"}, len(filenames)), ",")
+	args := make([]any, 0, len(filenames)*2+1)
+	args = append(args, teamID)
+	for i := range filenames {
+		args = append(args, filenames[i], platforms[i])
+	}
+	stmt := fmt.Sprintf(`
+SELECT
+	id,
+	filename,
+	platform
+FROM software_installers
+WHERE global_or_team_id = ?
+	AND is_active = 1
+	AND (filename, platform) IN (%s)`, rowPlaceholders)
+	var rows []fleet.SoftwareInstallerLookupRow
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "look up installer ids by team and filename+platform")
+	}
+	return rows, nil
+}
+
 func (ds *Datastore) GetSoftwareInstallerMetadataByID(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
 	query := `
 SELECT

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2972,6 +2972,12 @@ type Datastore interface {
 	//
 
 	SetSetupExperienceSoftwareTitles(ctx context.Context, platform string, teamID uint, titleIDs []uint) error
+	// SetSetupExperienceCrossInstallers replaces the setup_experience_software_installers
+	// rows for (platform, teamID) with the given installer IDs.
+	SetSetupExperienceCrossInstallers(ctx context.Context, platform string, teamID uint, installerIDs []uint) error
+	// GetSoftwareInstallerIDsByTeamAndFilenamePlatform resolves installer IDs
+	// from zipped (filename, platform) pairs on the given team.
+	GetSoftwareInstallerIDsByTeamAndFilenamePlatform(ctx context.Context, teamID uint, filenames []string, platforms []string) ([]SoftwareInstallerLookupRow, error)
 	ListSetupExperienceSoftwareTitles(ctx context.Context, platform string, teamID uint, opts ListOptions) ([]SoftwareTitleListResult, int, *PaginationMetadata, error)
 
 	// SetHostAwaitingConfiguration sets a boolean indicating whether or not the given host is

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -611,10 +611,14 @@ type SoftwareInstallerPayload struct {
 	SelfService        bool     `json:"self_service"`
 	FleetMaintained    bool     `json:"-"`
 	Filename           string   `json:"-"`
-	InstallDuringSetup *bool    `json:"install_during_setup"` // if nil, do not change saved value, otherwise set it
-	LabelsIncludeAny   []string `json:"labels_include_any"`
-	LabelsExcludeAny   []string `json:"labels_exclude_any"`
-	LabelsIncludeAll   []string `json:"labels_include_all"`
+	InstallDuringSetup *bool `json:"install_during_setup"` // if nil, do not change saved value, otherwise set it
+	// SetupExperiencePlatforms carries non-native cross-platform setup
+	// experience selections. Nil means "no change"; an empty slice clears
+	// all cross-platform selections for this installer.
+	SetupExperiencePlatforms *[]string `json:"setup_experience_platforms,omitempty"`
+	LabelsIncludeAny         []string  `json:"labels_include_any"`
+	LabelsExcludeAny         []string  `json:"labels_exclude_any"`
+	LabelsIncludeAll         []string  `json:"labels_include_all"`
 	// ValidatedLabels is a struct that contains the validated labels for the
 	// software installer. It is nil if the labels have not been validated.
 	ValidatedLabels *LabelIdentsWithScope

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -586,10 +586,14 @@ type UploadSoftwareInstallerPayload struct {
 	UpgradeCode        string
 	UninstallScript    string
 	Extension          string
-	InstallDuringSetup *bool    // keep saved value if nil, otherwise set as indicated
-	LabelsIncludeAny   []string // names of "include any" labels
-	LabelsExcludeAny   []string // names of "exclude any" labels
-	LabelsIncludeAll   []string // names of "include all" labels
+	InstallDuringSetup *bool // keep saved value if nil, otherwise set as indicated
+	// SetupExperiencePlatforms carries non-native cross-platform setup
+	// experience selections. Nil means "no change"; an empty slice clears
+	// all cross-platform selections for this installer.
+	SetupExperiencePlatforms *[]string
+	LabelsIncludeAny         []string // names of "include any" labels
+	LabelsExcludeAny         []string // names of "exclude any" labels
+	LabelsIncludeAll         []string // names of "include all" labels
 	// ValidatedLabels is a struct that contains the validated labels for the software installer. It
 	// is nil if the labels have not been validated.
 	ValidatedLabels       *LabelIdentsWithScope
@@ -611,6 +615,14 @@ type UploadSoftwareInstallerPayload struct {
 	PatchQuery string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only).
 	Configuration []byte
+}
+
+// SoftwareInstallerLookupRow projects the columns needed to resolve an
+// installer's identity from its (filename, platform) natural key.
+type SoftwareInstallerLookupRow struct {
+	ID       uint   `db:"id"`
+	Filename string `db:"filename"`
+	Platform string `db:"platform"`
 }
 
 func (p UploadSoftwareInstallerPayload) UniqueIdentifier() string {
@@ -764,6 +776,39 @@ func IsScriptPackage(ext string) bool {
 	return ext == "sh" || ext == "ps1"
 }
 
+// CanonicalPlatform maps a user-friendly platform name to Fleet's canonical
+// form ("macos" → "darwin"); other inputs are lowercased/trimmed and returned
+// as-is. Callers must validate against their own allowlist.
+func CanonicalPlatform(p string) string {
+	p = strings.ToLower(strings.TrimSpace(p))
+	if p == "macos" {
+		return "darwin"
+	}
+	return p
+}
+
+// AllowedSetupExperiencePlatformsForExtension returns the canonical platform
+// names a package with the given extension may be selected for in the setup
+// experience. Cross-platform packages get more than one entry; others are
+// restricted to their native platform.
+func AllowedSetupExperiencePlatformsForExtension(ext string) []string {
+	ext = strings.TrimPrefix(strings.ToLower(ext), ".")
+	switch ext {
+	case "sh":
+		return []string{"darwin", "linux"}
+	case "pkg":
+		return []string{"darwin"}
+	case "msi", "exe", "ps1":
+		return []string{"windows"}
+	case "deb", "rpm", "tar.gz":
+		return []string{"linux"}
+	case "ipa":
+		return []string{"ios", "ipados"}
+	default:
+		return nil
+	}
+}
+
 // HostSoftwareWithInstaller represents the list of software installed on a
 // host with installer information if a matching installer exists. This is the
 // payload returned by the "Get host's (device's) software" endpoints.
@@ -875,8 +920,14 @@ type SoftwarePackageSpec struct {
 	LabelsIncludeAny   []string              `json:"labels_include_any"`
 	LabelsExcludeAny   []string              `json:"labels_exclude_any"`
 	LabelsIncludeAll   []string              `json:"labels_include_all"`
-	InstallDuringSetup optjson.Bool          `json:"setup_experience"`
-	Icon               TeamSpecSoftwareAsset `json:"icon"`
+	InstallDuringSetup optjson.Bool `json:"setup_experience"`
+	// SetupExperiencePlatforms selects the installer for the setup experience
+	// on non-native platforms. Additive with InstallDuringSetup: the native
+	// platform is controlled by that bool, this list feeds the
+	// setup_experience_software_installers cross-table. Only meaningful for
+	// packages whose file can run on more than one platform.
+	SetupExperiencePlatforms optjson.Slice[string] `json:"setup_experience_platforms,omitzero"`
+	Icon                     TeamSpecSoftwareAsset `json:"icon"`
 	// Configuration is the managed app configuration file path; only meaningful for .ipa packages.
 	Configuration TeamSpecSoftwareAsset `json:"configuration"`
 
@@ -916,7 +967,8 @@ func (spec SoftwarePackageSpec) ResolveSoftwarePackagePaths(baseDir string) Soft
 
 func (spec SoftwarePackageSpec) IncludesFieldsDisallowedInPackageFile() bool {
 	return len(spec.LabelsExcludeAny) > 0 || len(spec.LabelsIncludeAny) > 0 || len(spec.LabelsIncludeAll) > 0 ||
-		len(spec.Categories.Value) > 0 || spec.SelfService || spec.InstallDuringSetup.Valid
+		len(spec.Categories.Value) > 0 || spec.SelfService || spec.InstallDuringSetup.Valid ||
+		spec.SetupExperiencePlatforms.Set
 }
 
 func resolveApplyRelativePath(baseDir string, path string) string {
@@ -931,33 +983,35 @@ type MaintainedAppSpec struct {
 	Slug               string                `json:"slug"`
 	Version            string                `json:"version"`
 	SelfService        bool                  `json:"self_service"`
-	PreInstallQuery    TeamSpecSoftwareAsset `json:"pre_install_query"` //nolint:apiparamcheck // SQL precondition for install
-	InstallScript      TeamSpecSoftwareAsset `json:"install_script"`
-	PostInstallScript  TeamSpecSoftwareAsset `json:"post_install_script"`
-	UninstallScript    TeamSpecSoftwareAsset `json:"uninstall_script"`
-	LabelsIncludeAny   []string              `json:"labels_include_any"`
-	LabelsExcludeAny   []string              `json:"labels_exclude_any"`
-	LabelsIncludeAll   []string              `json:"labels_include_all"`
-	Categories         optjson.Slice[string] `json:"categories,omitzero"`
-	InstallDuringSetup optjson.Bool          `json:"setup_experience"`
-	Icon               TeamSpecSoftwareAsset `json:"icon"`
+	PreInstallQuery          TeamSpecSoftwareAsset `json:"pre_install_query"` //nolint:apiparamcheck // SQL precondition for install
+	InstallScript            TeamSpecSoftwareAsset `json:"install_script"`
+	PostInstallScript        TeamSpecSoftwareAsset `json:"post_install_script"`
+	UninstallScript          TeamSpecSoftwareAsset `json:"uninstall_script"`
+	LabelsIncludeAny         []string              `json:"labels_include_any"`
+	LabelsExcludeAny         []string              `json:"labels_exclude_any"`
+	LabelsIncludeAll         []string              `json:"labels_include_all"`
+	Categories               optjson.Slice[string] `json:"categories,omitzero"`
+	InstallDuringSetup       optjson.Bool          `json:"setup_experience"`
+	SetupExperiencePlatforms optjson.Slice[string] `json:"setup_experience_platforms,omitzero"`
+	Icon                     TeamSpecSoftwareAsset `json:"icon"`
 }
 
 func (spec MaintainedAppSpec) ToSoftwarePackageSpec() SoftwarePackageSpec {
 	return SoftwarePackageSpec{
-		Slug:               &spec.Slug,
-		Version:            spec.Version,
-		PreInstallQuery:    spec.PreInstallQuery,
-		InstallScript:      spec.InstallScript,
-		PostInstallScript:  spec.PostInstallScript,
-		UninstallScript:    spec.UninstallScript,
-		SelfService:        spec.SelfService,
-		LabelsIncludeAny:   spec.LabelsIncludeAny,
-		LabelsExcludeAny:   spec.LabelsExcludeAny,
-		LabelsIncludeAll:   spec.LabelsIncludeAll,
-		InstallDuringSetup: spec.InstallDuringSetup,
-		Icon:               spec.Icon,
-		Categories:         spec.Categories,
+		Slug:                     &spec.Slug,
+		Version:                  spec.Version,
+		PreInstallQuery:          spec.PreInstallQuery,
+		InstallScript:            spec.InstallScript,
+		PostInstallScript:        spec.PostInstallScript,
+		UninstallScript:          spec.UninstallScript,
+		SelfService:              spec.SelfService,
+		SetupExperiencePlatforms: spec.SetupExperiencePlatforms,
+		LabelsIncludeAny:         spec.LabelsIncludeAny,
+		LabelsExcludeAny:         spec.LabelsExcludeAny,
+		LabelsIncludeAll:         spec.LabelsIncludeAll,
+		InstallDuringSetup:       spec.InstallDuringSetup,
+		Icon:                     spec.Icon,
+		Categories:               spec.Categories,
 	}
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1736,6 +1736,10 @@ type ClearVPPAppAutoInstallPolicyStatusForHostsFunc func(ctx context.Context, vp
 
 type SetSetupExperienceSoftwareTitlesFunc func(ctx context.Context, platform string, teamID uint, titleIDs []uint) error
 
+type SetSetupExperienceCrossInstallersFunc func(ctx context.Context, platform string, teamID uint, installerIDs []uint) error
+
+type GetSoftwareInstallerIDsByTeamAndFilenamePlatformFunc func(ctx context.Context, teamID uint, filenames []string, platforms []string) ([]fleet.SoftwareInstallerLookupRow, error)
+
 type ListSetupExperienceSoftwareTitlesFunc func(ctx context.Context, platform string, teamID uint, opts fleet.ListOptions) ([]fleet.SoftwareTitleListResult, int, *fleet.PaginationMetadata, error)
 
 type SetHostAwaitingConfigurationFunc func(ctx context.Context, hostUUID string, inSetupExperience bool) error
@@ -4736,6 +4740,12 @@ type DataStore struct {
 
 	SetSetupExperienceSoftwareTitlesFunc        SetSetupExperienceSoftwareTitlesFunc
 	SetSetupExperienceSoftwareTitlesFuncInvoked bool
+
+	SetSetupExperienceCrossInstallersFunc        SetSetupExperienceCrossInstallersFunc
+	SetSetupExperienceCrossInstallersFuncInvoked bool
+
+	GetSoftwareInstallerIDsByTeamAndFilenamePlatformFunc        GetSoftwareInstallerIDsByTeamAndFilenamePlatformFunc
+	GetSoftwareInstallerIDsByTeamAndFilenamePlatformFuncInvoked bool
 
 	ListSetupExperienceSoftwareTitlesFunc        ListSetupExperienceSoftwareTitlesFunc
 	ListSetupExperienceSoftwareTitlesFuncInvoked bool
@@ -11378,6 +11388,20 @@ func (s *DataStore) SetSetupExperienceSoftwareTitles(ctx context.Context, platfo
 	s.SetSetupExperienceSoftwareTitlesFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetSetupExperienceSoftwareTitlesFunc(ctx, platform, teamID, titleIDs)
+}
+
+func (s *DataStore) SetSetupExperienceCrossInstallers(ctx context.Context, platform string, teamID uint, installerIDs []uint) error {
+	s.mu.Lock()
+	s.SetSetupExperienceCrossInstallersFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetSetupExperienceCrossInstallersFunc(ctx, platform, teamID, installerIDs)
+}
+
+func (s *DataStore) GetSoftwareInstallerIDsByTeamAndFilenamePlatform(ctx context.Context, teamID uint, filenames []string, platforms []string) ([]fleet.SoftwareInstallerLookupRow, error) {
+	s.mu.Lock()
+	s.GetSoftwareInstallerIDsByTeamAndFilenamePlatformFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetSoftwareInstallerIDsByTeamAndFilenamePlatformFunc(ctx, teamID, filenames, platforms)
 }
 
 func (s *DataStore) ListSetupExperienceSoftwareTitles(ctx context.Context, platform string, teamID uint, opts fleet.ListOptions) ([]fleet.SoftwareTitleListResult, int, *fleet.PaginationMetadata, error) {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1354,24 +1354,33 @@ func buildSoftwarePackagesPayload(specs []fleet.SoftwarePackageSpec, installDuri
 			}
 		}
 
+		// Pointer-to-slice preserves the tri-state: nil = no change, empty =
+		// clear all cross-platform selections, non-empty = replace.
+		var setupExperiencePlatforms *[]string
+		if si.SetupExperiencePlatforms.Set {
+			ps := append([]string(nil), si.SetupExperiencePlatforms.Value...)
+			setupExperiencePlatforms = &ps
+		}
+
 		softwarePayloads[i] = fleet.SoftwareInstallerPayload{
-			URL:                urlValue,
-			SelfService:        si.SelfService,
-			PreInstallQuery:    qc,
-			InstallScript:      string(ic),
-			PostInstallScript:  string(pc),
-			UninstallScript:    string(us),
-			InstallDuringSetup: installDuringSetup,
-			LabelsIncludeAny:   si.LabelsIncludeAny,
-			LabelsExcludeAny:   si.LabelsExcludeAny,
-			LabelsIncludeAll:   si.LabelsIncludeAll,
-			SHA256:             sha256Value,
-			Categories:         si.Categories,
-			DisplayName:        si.DisplayName,
-			IconPath:           si.Icon.Path,
-			IconHash:           iconHash,
-			AlwaysDownload:     si.AlwaysDownload,
-			Configuration:      cfg,
+			URL:                      urlValue,
+			SelfService:              si.SelfService,
+			PreInstallQuery:          qc,
+			InstallScript:            string(ic),
+			PostInstallScript:        string(pc),
+			UninstallScript:          string(us),
+			InstallDuringSetup:       installDuringSetup,
+			SetupExperiencePlatforms: setupExperiencePlatforms,
+			LabelsIncludeAny:         si.LabelsIncludeAny,
+			LabelsExcludeAny:         si.LabelsExcludeAny,
+			LabelsIncludeAll:         si.LabelsIncludeAll,
+			SHA256:                   sha256Value,
+			Categories:               si.Categories,
+			DisplayName:              si.DisplayName,
+			IconPath:                 si.Icon.Path,
+			IconHash:                 iconHash,
+			AlwaysDownload:           si.AlwaysDownload,
+			Configuration:            cfg,
 		}
 
 		if si.Slug != nil {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -17157,7 +17157,9 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploads() {
 	})
 	require.False(t, installDuringSetup, "linux not selected → install_during_setup should stay false")
 
-	// Re-apply without the field clears the row — declarative reconcile.
+	// Omitting the field on re-apply leaves the cross-table alone — the batch
+	// only reconciles when at least one payload opts in, so UI-set selections
+	// aren't clobbered by callers that don't know about the field.
 	crossPkgNoField := []*fleet.SoftwareInstallerPayload{
 		{URL: "script://cross-hello.sh", SHA256: hex.EncodeToString(crossHash[:]), InstallScript: crossScript},
 	}
@@ -17168,7 +17170,21 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploads() {
 		return sqlx.SelectContext(ctx, q, &crossRows,
 			`SELECT software_installer_id, platform FROM setup_experience_software_installers WHERE global_or_team_id = ?`, crossTeam.ID)
 	})
-	require.Empty(t, crossRows, "cross-table row should be cleared when field is omitted on re-apply")
+	require.Len(t, crossRows, 1, "omitting the field is a no-op; prior selection survives")
+
+	// Explicit empty list opts into reconcile with nothing selected → clears.
+	emptyPlatforms := []string{}
+	crossPkgEmpty := []*fleet.SoftwareInstallerPayload{
+		{URL: "script://cross-hello.sh", SHA256: hex.EncodeToString(crossHash[:]), InstallScript: crossScript, SetupExperiencePlatforms: &emptyPlatforms},
+	}
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: crossPkgEmpty}, http.StatusAccepted, &batchResp, "team_name", crossTeam.Name)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, crossTeam.Name, batchResp.RequestUUID)
+
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &crossRows,
+			`SELECT software_installer_id, platform FROM setup_experience_software_installers WHERE global_or_team_id = ?`, crossTeam.ID)
+	})
+	require.Empty(t, crossRows, "explicit empty list clears the cross-table row")
 
 	// Re-apply is idempotent.
 	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: crossPkg}, http.StatusAccepted, &batchResp, "team_name", crossTeam.Name)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -17117,6 +17117,102 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploads() {
 		return sqlx.GetContext(ctx, q, &storedURL, `SELECT url FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, &team.ID, "hello world.sh")
 	})
 	require.Empty(t, storedURL, "cache-hit re-apply must drop the placeholder url too")
+
+	// Fresh team so filename collisions from earlier assertions don't leak in.
+	crossTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "cross"})
+	require.NoError(t, err)
+
+	crossScript := "echo 'cross-platform hello'"
+	crossHash := sha256.Sum256([]byte(crossScript))
+	darwinOnly := []string{"macos"}
+	crossPkg := []*fleet.SoftwareInstallerPayload{
+		{
+			URL:                      "script://cross-hello.sh",
+			SHA256:                   hex.EncodeToString(crossHash[:]),
+			InstallScript:            crossScript,
+			SetupExperiencePlatforms: &darwinOnly,
+		},
+	}
+
+	// [macos] on a .sh (native=linux): cross-table row for darwin, install_during_setup stays off.
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: crossPkg}, http.StatusAccepted, &batchResp, "team_name", crossTeam.Name)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, crossTeam.Name, batchResp.RequestUUID)
+
+	var crossRows []struct {
+		SoftwareInstallerID uint   `db:"software_installer_id"`
+		Platform            string `db:"platform"`
+	}
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &crossRows,
+			`SELECT software_installer_id, platform FROM setup_experience_software_installers WHERE global_or_team_id = ?`, crossTeam.ID)
+	})
+	require.Len(t, crossRows, 1, "expected exactly one cross-platform selection")
+	require.Equal(t, "darwin", crossRows[0].Platform)
+	require.NotZero(t, crossRows[0].SoftwareInstallerID)
+
+	var installDuringSetup bool
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &installDuringSetup,
+			`SELECT install_during_setup FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, crossTeam.ID, "cross-hello.sh")
+	})
+	require.False(t, installDuringSetup, "linux not selected → install_during_setup should stay false")
+
+	// Re-apply without the field clears the row — declarative reconcile.
+	crossPkgNoField := []*fleet.SoftwareInstallerPayload{
+		{URL: "script://cross-hello.sh", SHA256: hex.EncodeToString(crossHash[:]), InstallScript: crossScript},
+	}
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: crossPkgNoField}, http.StatusAccepted, &batchResp, "team_name", crossTeam.Name)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, crossTeam.Name, batchResp.RequestUUID)
+
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &crossRows,
+			`SELECT software_installer_id, platform FROM setup_experience_software_installers WHERE global_or_team_id = ?`, crossTeam.ID)
+	})
+	require.Empty(t, crossRows, "cross-table row should be cleared when field is omitted on re-apply")
+
+	// Re-apply is idempotent.
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: crossPkg}, http.StatusAccepted, &batchResp, "team_name", crossTeam.Name)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, crossTeam.Name, batchResp.RequestUUID)
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &crossRows,
+			`SELECT software_installer_id, platform FROM setup_experience_software_installers WHERE global_or_team_id = ?`, crossTeam.ID)
+	})
+	require.Len(t, crossRows, 1, "cross-table row should be restored on re-apply")
+
+	// install_during_setup and SetupExperiencePlatforms are independent: the
+	// caller sets the native bool explicitly, list entries only feed the cross-table.
+	bothPlatforms := []string{"macos", "linux"}
+	crossPkgBoth := []*fleet.SoftwareInstallerPayload{
+		{
+			URL:                      "script://cross-hello.sh",
+			SHA256:                   hex.EncodeToString(crossHash[:]),
+			InstallScript:            crossScript,
+			SetupExperiencePlatforms: &bothPlatforms,
+			InstallDuringSetup:       new(true),
+		},
+	}
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: crossPkgBoth}, http.StatusAccepted, &batchResp, "team_name", crossTeam.Name)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, crossTeam.Name, batchResp.RequestUUID)
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &installDuringSetup,
+			`SELECT install_during_setup FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, crossTeam.ID, "cross-hello.sh")
+	})
+	require.True(t, installDuringSetup, "linux in list + install_during_setup=true → native selection on")
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &crossRows,
+			`SELECT software_installer_id, platform FROM setup_experience_software_installers WHERE global_or_team_id = ?`, crossTeam.ID)
+	})
+	require.Len(t, crossRows, 1, "darwin cross-row still present when [macos, linux] is selected")
+
+	// Extension/platform mismatch surfaces before any DB write, with the
+	// filename and allowed platforms in the error.
+	windows := []string{"windows"}
+	crossPkgBad := []*fleet.SoftwareInstallerPayload{
+		{URL: "script://cross-hello.sh", SHA256: hex.EncodeToString(crossHash[:]), InstallScript: crossScript, SetupExperiencePlatforms: &windows},
+	}
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: crossPkgBad}, http.StatusAccepted, &batchResp, "team_name", crossTeam.Name)
+	failure := waitBatchSetSoftwareInstallersFailed(t, &s.withServer, crossTeam.Name, batchResp.RequestUUID)
+	require.Contains(t, failure, `platform "windows" is not a valid "setup_experience_platforms" value for a .sh package`)
 }
 
 // 1. host reports software


### PR DESCRIPTION
**Related issue:** 

  # Summary

  Adds a `setup_experience_platforms` field to the GitOps software package spec so `.sh` script-only installers can be selected for macOS setup experience declaratively. Reconciles the cross-platform selection table on every batch apply.

  # Checklist for submitter

  If some of the following don't apply, delete the relevant line.

  - [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`. See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

  - [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  ## Testing

  - [x] Added/updated automated tests

  - [x] QA'd all new/changed functionality manually

  ## New Fleet configuration settings

  - [x] Verified that the setting is exported via `fleetctl generate-gitops`
  - [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
  - [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for choosing setup-experience platforms for software installers, including cross-platform script installers on macOS.
  * GitOps and batch uploads now preserve and apply platform-specific setup-experience selections.
* **Bug Fixes**
  * Improved validation so only compatible platform selections are accepted for each installer type.
  * Cleared and re-applied platform selections now behave consistently during updates.
* **Tests**
  * Added coverage for platform normalization, validation, and reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->