### PR TITLE
Android filter out empty enterprises

### DIFF
--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1474,7 +1474,7 @@ func queueManagedConfigResendJobs(ctx context.Context, tx sqlx.ExtContext, hostI
 
 	// Get the enterprise name from the DB.
 	var enterpriseID string
-	if err := sqlx.GetContext(ctx, tx, &enterpriseID, `SELECT enterprise_id FROM android_enterprises LIMIT 1`); err != nil {
+	if err := sqlx.GetContext(ctx, tx, &enterpriseID, `SELECT enterprise_id FROM android_enterprises WHERE enterprise_id != '' LIMIT 1`); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// No enterprise configured — nothing to do.
 			return nil


### PR DESCRIPTION
**Related issue:** Resolves #49004

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:
- [x] Confirmed that the fix is not expected to adversely impact load test results



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android managed-configuration resend processing by ignoring invalid empty enterprise IDs.
  * Prevented resend jobs from being queued when no valid enterprise ID is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->