### PR TITLE
Cherry-pick: Android config profiles resend on IdP changes

### DIFF
--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -606,7 +606,7 @@ func upsertAndroidHostMDMInfoDB(ctx context.Context, tx sqlx.ExtContext, serverU
 	return ctxerr.Wrap(ctx, err, "upsert host mdm info")
 }
 
-func (ds *Datastore) NewMDMAndroidConfigProfile(ctx context.Context, cp fleet.MDMAndroidConfigProfile) (*fleet.MDMAndroidConfigProfile, error) {
+func (ds *Datastore) NewMDMAndroidConfigProfile(ctx context.Context, cp fleet.MDMAndroidConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAndroidConfigProfile, error) {
 	profileUUID := fleet.MDMAndroidProfileUUIDPrefix + uuid.New().String()
 	insertProfileStmt := `
 INSERT INTO
@@ -675,6 +675,11 @@ INSERT INTO
 		}
 		if _, err := batchSetProfileLabelAssociationsDB(ctx, tx, labels, profsWithoutLabel, "android"); err != nil {
 			return ctxerr.Wrap(ctx, err, "inserting android profile label associations")
+		}
+		if _, err := batchSetProfileVariableAssociationsDB(ctx, tx, []fleet.MDMProfileUUIDFleetVariables{
+			{ProfileUUID: profileUUID, FleetVariables: usesFleetVars},
+		}, "android", false); err != nil {
+			return ctxerr.Wrap(ctx, err, "inserting android profile variable associations")
 		}
 
 		return nil
@@ -1724,6 +1729,7 @@ func (ds *Datastore) batchSetMDMAndroidProfiles(
 	tx sqlx.ExtContext,
 	tmID *uint,
 	profiles []*fleet.MDMAndroidConfigProfile,
+	profilesVariablesByIdentifier []fleet.MDMProfileIdentifierFleetVariables,
 ) (updatedDB bool, err error) {
 	if len(profiles) == 0 {
 		rowsAffected, err := ds.deleteAllAndroidProfiles(ctx, tx, tmID)
@@ -1858,7 +1864,7 @@ WHERE
 		})
 	}
 
-	didUpdateLabels, err := ds.batchSetLabelAndVariableAssociations(ctx, tx, "android", tmID, mappedIncomingProfiles, nil)
+	didUpdateLabels, err := ds.batchSetLabelAndVariableAssociations(ctx, tx, "android", tmID, mappedIncomingProfiles, profilesVariablesByIdentifier)
 	if err != nil {
 		return false, ctxerr.Wrap(ctx, err, "setting labels and variable associations")
 	}

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -795,7 +795,7 @@ func testNewMDMAndroidConfigProfile(t *testing.T, ds *Datastore) {
 	}
 
 	// Create the profile
-	result, err := ds.NewMDMAndroidConfigProfile(ctx, profile)
+	result, err := ds.NewMDMAndroidConfigProfile(ctx, profile, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.ProfileUUID)
 
@@ -805,7 +805,7 @@ func testNewMDMAndroidConfigProfile(t *testing.T, ds *Datastore) {
 		TeamID:  nil,
 		RawJSON: []byte(`{"hello2": "world2"}`),
 	}
-	result2, err := ds.NewMDMAndroidConfigProfile(ctx, profile2)
+	result2, err := ds.NewMDMAndroidConfigProfile(ctx, profile2, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, result2.ProfileUUID)
 
@@ -837,7 +837,7 @@ func testNewMDMAndroidConfigProfile(t *testing.T, ds *Datastore) {
 		TeamID:  nil,
 		RawJSON: []byte(`{"hello3": "world3"}`),
 	}
-	_, err = ds.NewMDMAndroidConfigProfile(ctx, androidProfile)
+	_, err = ds.NewMDMAndroidConfigProfile(ctx, androidProfile, nil)
 	require.ErrorContains(t, err, "already exists")
 
 	// Create that same conflicting android profile but on a different team
@@ -845,7 +845,7 @@ func testNewMDMAndroidConfigProfile(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.NotNil(t, team)
 	androidProfile.TeamID = ptr.Uint(team.ID)
-	otherTeamProfile, err := ds.NewMDMAndroidConfigProfile(ctx, androidProfile)
+	otherTeamProfile, err := ds.NewMDMAndroidConfigProfile(ctx, androidProfile, nil)
 	require.NoError(t, err)
 
 	// Verify we can GET the newly created profile
@@ -878,7 +878,7 @@ func testDeleteMDMAndroidConfigProfile(t *testing.T, ds *Datastore) {
 		RawJSON: []byte(`{"hello": "world"}`),
 	}
 
-	profile1, err = ds.NewMDMAndroidConfigProfile(ctx, *profile1)
+	profile1, err = ds.NewMDMAndroidConfigProfile(ctx, *profile1, nil)
 	require.NoError(t, err)
 	require.NotNil(t, profile1)
 
@@ -887,7 +887,7 @@ func testDeleteMDMAndroidConfigProfile(t *testing.T, ds *Datastore) {
 		TeamID:  nil,
 		RawJSON: []byte(`{"hello": "world"}`),
 	}
-	profile2, err = ds.NewMDMAndroidConfigProfile(ctx, *profile2)
+	profile2, err = ds.NewMDMAndroidConfigProfile(ctx, *profile2, nil)
 	require.NoError(t, err)
 	require.NotNil(t, profile2)
 
@@ -1157,17 +1157,17 @@ func testGetHostMDMAndroidProfiles(t *testing.T, ds *Datastore) {
 
 	// Create some profiles
 	profile1 := androidProfileForTest("profile1")
-	profile1, err = ds.NewMDMAndroidConfigProfile(ctx, *profile1)
+	profile1, err = ds.NewMDMAndroidConfigProfile(ctx, *profile1, nil)
 	require.NoError(t, err)
 	require.NotNil(t, profile1)
 
 	profile2 := androidProfileForTest("profile2")
-	profile2, err = ds.NewMDMAndroidConfigProfile(ctx, *profile2)
+	profile2, err = ds.NewMDMAndroidConfigProfile(ctx, *profile2, nil)
 	require.NoError(t, err)
 	require.NotNil(t, profile2)
 
 	profile3 := androidProfileForTest("profile3")
-	profile3, err = ds.NewMDMAndroidConfigProfile(ctx, *profile3)
+	profile3, err = ds.NewMDMAndroidConfigProfile(ctx, *profile3, nil)
 	require.NoError(t, err)
 	require.NotNil(t, profile3)
 
@@ -1360,13 +1360,13 @@ func testListMDMAndroidProfilesToSend(t *testing.T, ds *Datastore) {
 	tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "team"})
 	require.NoError(t, err)
 
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-1"))
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-1"), nil)
 	require.NoError(t, err)
-	p2, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-2"))
+	p2, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-2"), nil)
 	require.NoError(t, err)
 	tmP3 := androidProfileForTest("team-1")
 	tmP3.TeamID = &tm.ID
-	p3, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP3)
+	p3, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP3, nil)
 	require.NoError(t, err)
 
 	// all profiles use the same raw JSON, so they share the same checksum
@@ -1404,7 +1404,7 @@ func testListMDMAndroidProfilesToSend(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	lblIncAll2, err := ds.NewLabel(ctx, &fleet.Label{Name: "inclall-2", Query: "select 1"})
 	require.NoError(t, err)
-	p4, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-4", lblIncAll1, lblIncAll2))
+	p4, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-4", lblIncAll1, lblIncAll2), nil)
 	require.NoError(t, err)
 
 	// no change, host is not a member of both labels
@@ -1454,7 +1454,7 @@ func testListMDMAndroidProfilesToSend(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	lblIncAny2, err := ds.NewLabel(ctx, &fleet.Label{Name: "inclany-2", Query: "select 1"})
 	require.NoError(t, err)
-	p5, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-5", lblIncAny1, lblIncAny2))
+	p5, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-5", lblIncAny1, lblIncAny2), nil)
 	require.NoError(t, err)
 
 	// no change, host 0 not a member yet
@@ -1491,7 +1491,7 @@ func testListMDMAndroidProfilesToSend(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	lblExclAny2, err := ds.NewLabel(ctx, &fleet.Label{Name: "exclude-2", LabelMembershipType: fleet.LabelMembershipTypeManual})
 	require.NoError(t, err)
-	p6, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-6", lblExclAny1, lblExclAny2))
+	p6, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-6", lblExclAny1, lblExclAny2), nil)
 	require.NoError(t, err)
 
 	// no change, label membership was not updated after labels created
@@ -1673,13 +1673,13 @@ func testListMDMAndroidProfilesToSendWithExcludeAny(t *testing.T, ds *Datastore)
 	require.NoError(t, err)
 
 	// Dynamic exclude-any label
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-1", lblExclAny1))
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-1", lblExclAny1), nil)
 	require.NoError(t, err)
 	// Manual exclude-any label only
-	p2, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-2", lblExclAny2))
+	p2, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-2", lblExclAny2), nil)
 	require.NoError(t, err)
 	// Both manual and dynamic label exclusion
-	p3, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-3", lblExclAny1, lblExclAny2))
+	p3, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("no-team-3", lblExclAny1, lblExclAny2), nil)
 	require.NoError(t, err)
 
 	// all profiles use the same raw JSON, so they share the same checksum
@@ -1719,15 +1719,15 @@ func testListMDMAndroidProfilesToSendWithExcludeAny(t *testing.T, ds *Datastore)
 	tmP6.TeamID = &tm.ID
 
 	// Dynamic exclude-any label
-	p4, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP4)
+	p4, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP4, nil)
 	require.NoError(t, err)
 
 	// Manual exclude-any label only
-	p5, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP5)
+	p5, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP5, nil)
 	require.NoError(t, err)
 
 	// Both manual and dynamic label exclusion
-	p6, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP6)
+	p6, err := ds.NewMDMAndroidConfigProfile(ctx, *tmP6, nil)
 	require.NoError(t, err)
 
 	// p5 becomes immediately applicable to host 1 because it only has a manual label
@@ -1812,7 +1812,7 @@ func testListMDMAndroidProfilesToSendCursor(t *testing.T, ds *Datastore) {
 	})
 
 	// Add a profile so all 5 hosts have pending work.
-	_, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("cursor-test-profile"))
+	_, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("cursor-test-profile"), nil)
 	require.NoError(t, err)
 
 	// No cursor, no limit — returns all 5 hosts.
@@ -1901,10 +1901,10 @@ func testListMDMAndroidProfilesToSendWithCombinedLabels(t *testing.T, ds *Datast
 	require.NoError(t, err)
 
 	// include-all + exclude-any profile (requires both incl-all-1 and incl-all-2)
-	pCombinedAll, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("combined-incl-all", inclAllLbl, inclAllLbl2, exclLbl))
+	pCombinedAll, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("combined-incl-all", inclAllLbl, inclAllLbl2, exclLbl), nil)
 	require.NoError(t, err)
 	// include-any + exclude-any profile
-	pCombinedAny, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("combined-incl-any", inclAnyLbl, exclLbl))
+	pCombinedAny, err := ds.NewMDMAndroidConfigProfile(ctx, *androidProfileForTest("combined-incl-any", inclAnyLbl, exclLbl), nil)
 	require.NoError(t, err)
 
 	profChecksum := getAndroidProfileChecksum(t, ds, pCombinedAll.ProfileUUID)
@@ -1970,11 +1970,11 @@ func testGetMDMAndroidProfilesContents(t *testing.T, ds *Datastore) {
 	p3 := androidProfileForTest("p3")
 	p3.RawJSON = []byte(`{"v": 3}`)
 
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1)
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1, nil)
 	require.NoError(t, err)
-	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2)
+	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2, nil)
 	require.NoError(t, err)
-	p3, err = ds.NewMDMAndroidConfigProfile(ctx, *p3)
+	p3, err = ds.NewMDMAndroidConfigProfile(ctx, *p3, nil)
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -2049,7 +2049,7 @@ func testBulkUpsertMDMAndroidHostProfilesN(t *testing.T, ds *Datastore, batchSiz
 			// last profile is for a team
 			p.TeamID = &tm.ID
 		}
-		p, err := ds.NewMDMAndroidConfigProfile(ctx, *p)
+		p, err := ds.NewMDMAndroidConfigProfile(ctx, *p, nil)
 		require.NoError(t, err)
 		profiles[i] = p
 	}
@@ -2428,7 +2428,7 @@ func testListHostMDMAndroidProfilesPendingInstallWithVersion(t *testing.T, ds *D
 	profiles := make([]*fleet.MDMAndroidConfigProfile, 3)
 	for i := range profiles {
 		p := androidProfileForTest(fmt.Sprintf("profile-%d", i))
-		p, err := ds.NewMDMAndroidConfigProfile(ctx, *p)
+		p, err := ds.NewMDMAndroidConfigProfile(ctx, *p, nil)
 		require.NoError(t, err)
 		profiles[i] = p
 	}
@@ -2589,7 +2589,7 @@ func testBulkDeleteMDMAndroidHostProfiles(t *testing.T, ds *Datastore) {
 	profiles := make([]*fleet.MDMAndroidConfigProfile, 3)
 	for i := range profiles {
 		p := androidProfileForTest(fmt.Sprintf("profile-%d", i))
-		p, err := ds.NewMDMAndroidConfigProfile(ctx, *p)
+		p, err := ds.NewMDMAndroidConfigProfile(ctx, *p, nil)
 		require.NoError(t, err)
 		profiles[i] = p
 	}

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -607,7 +607,7 @@ func (ds *Datastore) BatchSetMDMProfiles(ctx context.Context, tmID *uint, macPro
 			return ctxerr.Wrap(ctx, err, "batch set apple declarations")
 		}
 
-		if updates.AndroidConfigProfile, err = ds.batchSetMDMAndroidProfiles(ctx, tx, tmID, androidProfiles); err != nil {
+		if updates.AndroidConfigProfile, err = ds.batchSetMDMAndroidProfiles(ctx, tx, tmID, androidProfiles, profilesVariablesByIdentifier); err != nil {
 			return ctxerr.Wrap(ctx, err, "batch set android profiles")
 		}
 

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -1650,7 +1650,7 @@ func testListMDMConfigProfiles(t *testing.T, ds *Datastore) {
 				{LabelName: labels[9].Name, LabelID: labels[9].ID},
 			}
 		}
-		_, err = ds.NewMDMAndroidConfigProfile(ctx, gcp)
+		_, err = ds.NewMDMAndroidConfigProfile(ctx, gcp, nil)
 		require.NoError(t, err)
 
 		gcp = fleet.MDMAndroidConfigProfile{ // H N and T
@@ -1664,7 +1664,7 @@ func testListMDMConfigProfiles(t *testing.T, ds *Datastore) {
 				{LabelName: labels[11].Name, LabelID: labels[11].ID},
 			}
 		}
-		_, err = ds.NewMDMAndroidConfigProfile(ctx, gcp)
+		_, err = ds.NewMDMAndroidConfigProfile(ctx, gcp, nil)
 		require.NoError(t, err)
 	}
 	// null label references to simulate profiles D, E and G being broken

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1381,7 +1381,29 @@ func triggerResendProfilesUsingVariables(ctx context.Context, tx sqlx.ExtContext
 		"affected_vars":          vars,
 	}
 
-	for _, query := range []string{appleUpdateStatusQuery, windowsUpdateStatusQuery, declarationUpdateStatusQuery} {
+	const androidUpdateStatusQuery = `
+	UPDATE
+		host_mdm_android_profiles hmap
+		JOIN hosts h
+			ON h.uuid = hmap.host_uuid
+		JOIN mdm_android_configuration_profiles macp
+			ON (macp.team_id = COALESCE(h.team_id, 0)) AND
+				 macp.profile_uuid = hmap.profile_uuid
+		JOIN mdm_configuration_profile_variables mcpv
+			ON mcpv.android_profile_uuid = macp.profile_uuid
+		JOIN fleet_variables fv
+			ON mcpv.fleet_variable_id = fv.id
+	SET
+		hmap.status = NULL,
+		hmap.detail = NULL
+	WHERE
+		h.id IN (:host_ids) AND
+		hmap.operation_type = :operation_type_install AND
+		hmap.status IS NOT NULL AND
+		fv.name IN (:affected_vars)
+`
+
+	for _, query := range []string{appleUpdateStatusQuery, windowsUpdateStatusQuery, declarationUpdateStatusQuery, androidUpdateStatusQuery} {
 		updateStmt, args, err := sqlx.Named(query, namedParams)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "prepare resend profiles replace names")

--- a/server/datastore/mysql/scim_test.go
+++ b/server/datastore/mysql/scim_test.go
@@ -2765,6 +2765,24 @@ func testTriggerResendCertTemplatesAndAppConfigs(t *testing.T, ds *Datastore) {
 		return err
 	})
 
+	// --- Android configuration profile resend ---
+
+	// Create an Android config profile with a variable.
+	androidProfile, err := ds.NewMDMAndroidConfigProfile(ctx, fleet.MDMAndroidConfigProfile{
+		TeamID:  new(uint), // team 0
+		Name:    "android-var-profile",
+		RawJSON: []byte(`{"screenCaptureDisabled": true, "shortSupportMessage": {"defaultMessage": "User $FLEET_VAR_HOST_END_USER_IDP_USERNAME"}}`),
+	}, []fleet.FleetVarName{fleet.FleetVarHostEndUserIDPUsername})
+	require.NoError(t, err)
+
+	// Create a host_mdm_android_profiles row in "verified" status.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO host_mdm_android_profiles (host_uuid, profile_uuid, profile_name, status, operation_type, checksum) VALUES (?, ?, 'android-var-profile', 'verified', 'install', 'abc123')`,
+			host.UUID, androidProfile.ProfileUUID)
+		return err
+	})
+
 	// --- Managed app config resend ---
 
 	// Create an android enterprise (required for job queuing).
@@ -2814,7 +2832,17 @@ func testTriggerResendCertTemplatesAndAppConfigs(t *testing.T, ds *Datastore) {
 	})
 	assert.Equal(t, string(fleet.CertificateTemplatePending), certStatus, "cert template should be reset to pending")
 
-	// (2) Assert a software_worker job was queued for the managed app config.
+	// (2) Assert android config profile was reset to pending (status = NULL).
+	var androidProfileStatus *string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q,
+			&androidProfileStatus,
+			`SELECT status FROM host_mdm_android_profiles WHERE host_uuid = ? AND profile_uuid = ?`,
+			host.UUID, androidProfile.ProfileUUID)
+	})
+	assert.Nil(t, androidProfileStatus, "android profile status should be reset to NULL (pending)")
+
+	// (3) Assert a software_worker job was queued for the managed app config.
 	type jobRow struct {
 		Name string          `db:"name"`
 		Args json.RawMessage `db:"args"`

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3136,7 +3136,7 @@ type Datastore interface {
 	AndroidDatastore
 
 	// NewMDMAndroidConfigProfile creates a new Android MDM config profile.
-	NewMDMAndroidConfigProfile(ctx context.Context, cp MDMAndroidConfigProfile) (*MDMAndroidConfigProfile, error)
+	NewMDMAndroidConfigProfile(ctx context.Context, cp MDMAndroidConfigProfile, usesFleetVars []FleetVarName) (*MDMAndroidConfigProfile, error)
 
 	// GetMDMAndroidConfigProfile returns the Android MDM profile corresponding
 	// to the specified profile uuid.

--- a/server/mdm/android/service/profiles_test.go
+++ b/server/mdm/android/service/profiles_test.go
@@ -180,7 +180,7 @@ func testHostsWithProfile(t *testing.T, ds fleet.Datastore, client *mock.Client,
 
 	// add an android profile
 	p1 := androidProfileForTest("p1")
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1)
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1, nil)
 	require.NoError(t, err)
 
 	// profile gets delivered to both hosts
@@ -221,11 +221,11 @@ func testHostsWithConflictProfile(t *testing.T, ds fleet.Datastore, client *mock
 
 	// add an android profile
 	p1 := androidProfileWithPayloadForTest("p1", `{"key1": "a"}`)
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1)
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1, nil)
 	require.NoError(t, err)
 	// add another one that overrides the first one
 	p2 := androidProfileWithPayloadForTest("p2", `{"key1": "b", "key2": "c"}`)
-	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2)
+	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2, nil)
 	require.NoError(t, err)
 
 	// profiles get delivered to both hosts, but p1 is failed
@@ -274,13 +274,13 @@ func testHostsWithMultiOverrideProfile(t *testing.T, ds fleet.Datastore, client 
 	// and insert in different order than the names to verify that name ordering
 	// is applied.
 	p3 := androidProfileWithPayloadForTest("p3", `{"key1": "c", "key2": "c", "key3": "c", "key4": "c"}`)
-	p3, err = ds.NewMDMAndroidConfigProfile(ctx, *p3)
+	p3, err = ds.NewMDMAndroidConfigProfile(ctx, *p3, nil)
 	require.NoError(t, err)
 	p1 := androidProfileWithPayloadForTest("p1", `{"key1": "a", "key2": "a"}`)
-	p1, err = ds.NewMDMAndroidConfigProfile(ctx, *p1)
+	p1, err = ds.NewMDMAndroidConfigProfile(ctx, *p1, nil)
 	require.NoError(t, err)
 	p2 := androidProfileWithPayloadForTest("p2", `{"key1": "b", "key2": "b", "key3": "b"}`)
-	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2)
+	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2, nil)
 	require.NoError(t, err)
 
 	// profiles get delivered to h1 only
@@ -321,7 +321,7 @@ func testHostsWithAPIFailures(t *testing.T, ds fleet.Datastore, client *mock.Cli
 
 	// add an android profile
 	p1 := androidProfileForTest("p1")
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1)
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1, nil)
 	require.NoError(t, err)
 
 	for i := range 3 {
@@ -357,7 +357,7 @@ func testHostsWithAPIFailures(t *testing.T, ds fleet.Datastore, client *mock.Cli
 
 	// add a new profile that "resets" the set of profiles to send, so will retry
 	p2 := androidProfileWithPayloadForTest("p2", `{"key1": "b"}`)
-	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2)
+	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2, nil)
 	require.NoError(t, err)
 
 	// and this time make it succeed
@@ -400,7 +400,7 @@ func testHostsWithAddRemoveUpdateProfiles(t *testing.T, ds fleet.Datastore, clie
 
 	// add a first android profile
 	p1 := androidProfileWithPayloadForTest("p1", `{"maximumTimeToLock": "1"}`)
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1)
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1, nil)
 	require.NoError(t, err)
 	p1Checksum := getAndroidProfileChecksum(t, ds, p1.ProfileUUID)
 
@@ -467,7 +467,7 @@ func testHostsWithAddRemoveUpdateProfiles(t *testing.T, ds fleet.Datastore, clie
 
 	// add a second android profile
 	p2 := androidProfileWithPayloadForTest("p2", `{"maximumTimeToLock": "4"}`)
-	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2)
+	p2, err = ds.NewMDMAndroidConfigProfile(ctx, *p2, nil)
 	require.NoError(t, err)
 	p2Checksum := getAndroidProfileChecksum(t, ds, p2.ProfileUUID)
 
@@ -582,19 +582,19 @@ func testHostsWithLabelProfiles(t *testing.T, ds fleet.Datastore, client *mock.C
 	// create profiles based on each label, and one with no label
 	pNoLabel := androidProfileWithPayloadForTest("pNoLabel", `{"maximumTimeToLock": "1"}`)
 	pNoLabel.TeamID = &tm.ID
-	pNoLabel, err = ds.NewMDMAndroidConfigProfile(ctx, *pNoLabel)
+	pNoLabel, err = ds.NewMDMAndroidConfigProfile(ctx, *pNoLabel, nil)
 	require.NoError(t, err)
 	pInclAny := androidProfileWithPayloadForTest("pInclAny", `{"maximumTimeToLock": "2"}`, linclAny)
 	pInclAny.TeamID = &tm.ID
-	pInclAny, err = ds.NewMDMAndroidConfigProfile(ctx, *pInclAny)
+	pInclAny, err = ds.NewMDMAndroidConfigProfile(ctx, *pInclAny, nil)
 	require.NoError(t, err)
 	pInclAll := androidProfileWithPayloadForTest("pInclAll", `{"maximumTimeToLock": "3"}`, linclAll)
 	pInclAll.TeamID = &tm.ID
-	pInclAll, err = ds.NewMDMAndroidConfigProfile(ctx, *pInclAll)
+	pInclAll, err = ds.NewMDMAndroidConfigProfile(ctx, *pInclAll, nil)
 	require.NoError(t, err)
 	pExclAny := androidProfileWithPayloadForTest("pExclAny", `{"maximumTimeToLock": "4"}`, lexclAny)
 	pExclAny.TeamID = &tm.ID
-	pExclAny, err = ds.NewMDMAndroidConfigProfile(ctx, *pExclAny)
+	pExclAny, err = ds.NewMDMAndroidConfigProfile(ctx, *pExclAny, nil)
 	require.NoError(t, err)
 
 	// mock and control the version number, and validate the expected MaximumTimeToLock value
@@ -1305,13 +1305,13 @@ func testONCWithheldUntilCertVerified(t *testing.T, ds fleet.Datastore, client *
 		}
 	}`, certTemplate.Name))
 	oncProfile.TeamID = &team.ID
-	oncProfile, err = ds.NewMDMAndroidConfigProfile(ctx, *oncProfile)
+	oncProfile, err = ds.NewMDMAndroidConfigProfile(ctx, *oncProfile, nil)
 	require.NoError(t, err)
 
 	// Create a non-ONC profile (should always be applied)
 	nonONCProfile := androidProfileForTest("camera-policy")
 	nonONCProfile.TeamID = &team.ID
-	nonONCProfile, err = ds.NewMDMAndroidConfigProfile(ctx, *nonONCProfile)
+	nonONCProfile, err = ds.NewMDMAndroidConfigProfile(ctx, *nonONCProfile, nil)
 	require.NoError(t, err)
 
 	// --- Phase 1: cert is pending, ONC should be withheld, non-ONC applied ---
@@ -1436,7 +1436,7 @@ func testUnresolvableFleetVarMarksProfileFailed(t *testing.T, ds fleet.Datastore
 
 	// Create a profile that references an IDP variable the host can't resolve.
 	p1 := androidProfileWithPayloadForTest("wifi-eap", `{"name": "$FLEET_VAR_HOST_END_USER_IDP_USERNAME"}`)
-	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1)
+	p1, err := ds.NewMDMAndroidConfigProfile(ctx, *p1, nil)
 	require.NoError(t, err)
 
 	// Reconcile — should NOT call AMAPI (no policy to patch) but should

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1894,7 +1894,7 @@ type MarkAllPendingAndroidVPPInstallsAsFailedFunc func(ctx context.Context) erro
 
 type MarkAllPendingVPPInstallsAsFailedForAndroidHostFunc func(ctx context.Context, hostID uint) (users []*fleet.User, activities []fleet.ActivityDetails, err error)
 
-type NewMDMAndroidConfigProfileFunc func(ctx context.Context, cp fleet.MDMAndroidConfigProfile) (*fleet.MDMAndroidConfigProfile, error)
+type NewMDMAndroidConfigProfileFunc func(ctx context.Context, cp fleet.MDMAndroidConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAndroidConfigProfile, error)
 
 type GetMDMAndroidConfigProfileFunc func(ctx context.Context, profileUUID string) (*fleet.MDMAndroidConfigProfile, error)
 
@@ -11863,11 +11863,11 @@ func (s *DataStore) MarkAllPendingVPPInstallsAsFailedForAndroidHost(ctx context.
 	return s.MarkAllPendingVPPInstallsAsFailedForAndroidHostFunc(ctx, hostID)
 }
 
-func (s *DataStore) NewMDMAndroidConfigProfile(ctx context.Context, cp fleet.MDMAndroidConfigProfile) (*fleet.MDMAndroidConfigProfile, error) {
+func (s *DataStore) NewMDMAndroidConfigProfile(ctx context.Context, cp fleet.MDMAndroidConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAndroidConfigProfile, error) {
 	s.mu.Lock()
 	s.NewMDMAndroidConfigProfileFuncInvoked = true
 	s.mu.Unlock()
-	return s.NewMDMAndroidConfigProfileFunc(ctx, cp)
+	return s.NewMDMAndroidConfigProfileFunc(ctx, cp, usesFleetVars)
 }
 
 func (s *DataStore) GetMDMAndroidConfigProfile(ctx context.Context, profileUUID string) (*fleet.MDMAndroidConfigProfile, error) {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1942,7 +1942,13 @@ func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint,
 	}
 	cp.LabelsExcludeAny = excludeLabels
 
-	newCP, err := svc.ds.NewMDMAndroidConfigProfile(ctx, cp)
+	foundVars := variables.Find(string(data))
+	varNames := make([]fleet.FleetVarName, 0, len(foundVars))
+	for _, v := range foundVars {
+		varNames = append(varNames, fleet.FleetVarName(v))
+	}
+
+	newCP, err := svc.ds.NewMDMAndroidConfigProfile(ctx, cp, varNames)
 	if err != nil {
 		var existsErr endpointer.ExistsErrorInterface
 		if errors.As(err, &existsErr) {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -3244,7 +3244,8 @@ func TestNewMDMProfilePremiumOnlyAndroid(t *testing.T) {
 	ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
 		return &fleet.GroupedCertificateAuthorities{}, nil
 	}
-	ds.NewMDMAndroidConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAndroidConfigProfile) (*fleet.MDMAndroidConfigProfile, error) {
+	ds.NewMDMAndroidConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAndroidConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAndroidConfigProfile, error) {
+		require.Empty(t, usesFleetVars)
 		return &fleet.MDMAndroidConfigProfile{}, nil
 	}
 	ds.BulkSetPendingMDMHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs []uint, profileUUIDs, hostUUIDs []string) (updates fleet.MDMProfilesUpdates, err error) {
@@ -3358,7 +3359,8 @@ func TestNewMDMAndroidConfigProfileLicense(t *testing.T) {
 		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
 			return &fleet.GroupedCertificateAuthorities{}, nil
 		}
-		ds.NewMDMAndroidConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAndroidConfigProfile) (*fleet.MDMAndroidConfigProfile, error) {
+		ds.NewMDMAndroidConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAndroidConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAndroidConfigProfile, error) {
+			require.Empty(t, usesFleetVars)
 			return &cp, nil
 		}
 		ds.BulkSetPendingMDMHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs []uint, profileUUIDs, hostUUIDs []string) (updates fleet.MDMProfilesUpdates, err error) {


### PR DESCRIPTION
Original issue: #49003
Original PR: https://github.com/fleetdm/fleet/pull/49068

## Testing
- [x] QA'd all new/changed functionality manually