### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.1.92.134",
+      "version": "150.1.92.139",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.134') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.139') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.134/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.139/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "4726e28a23da1b0b253efb63736efc9b20a580f26017f93f72ebdacf471c657a",
+      "sha256": "0e63b0614431c9ee276d7d8aa0f4a0afcb3741663ea60f47f7adf6d46167037c",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/figma/windows.json
+++ b/ee/maintained-apps/outputs/figma/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "126.6.12",
+      "version": "126.6.14",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.6.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.6.14') < 0);"
       },
-      "installer_url": "https://desktop.figma.com/win/build/Figma-126.6.12.exe",
+      "installer_url": "https://desktop.figma.com/win/build/Figma-126.6.14.exe",
       "install_script_ref": "442d71b3",
       "uninstall_script_ref": "e33afd6b",
-      "sha256": "371ddadf46485dd23b8b9f526988fbf2fa37e57ef1ee710e780961396cac14ca",
+      "sha256": "5e9fc18f0145ec914b9ec82f18264f680b77d32366948b33b3d7b16b2c7685b0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/kiro/windows.json
+++ b/ee/maintained-apps/outputs/kiro/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.89",
+      "version": "1.0.116",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services' AND version_compare(version, '1.0.89') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services' AND version_compare(version, '1.0.116') < 0);"
       },
-      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/1.0.89/kiro-ide-1.0.89-stable-win32-x64.exe",
+      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/1.0.116/kiro-ide-1.0.116-stable-win32-x64.exe",
       "install_script_ref": "c5bc3c21",
       "uninstall_script_ref": "afe8f2fa",
-      "sha256": "65b5325c887522dcf9179c181015b9777960d7c6fdcc9d593abd261dcd637e0e",
+      "sha256": "49eef30b675ee3d0fd74e822a96c1da196d570539a83c055087e264cf7b04f46",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.0.4078.48",
+      "version": "150.0.4078.65",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '150.0.4078.48') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '150.0.4078.65') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/6476e2cb-803c-4ed9-b91f-60caaa21dbfd/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/0870b5f5-cf08-4f24-8383-f362a669fcd8/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "94a406cdc1ab9c1c8ac8aa48b42d89e4e35cee68622cda718b301e5e3ed93b49",
+      "sha256": "037340dc31dc0d2dd6c0d7e7627064b3f34b03656d37a7cab499f4e8a1697882",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.1925",
+      "version": "1.4.1929",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1925') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1929') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1925/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1929/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "e835d68eb7c7ea1d8ee9d54fbae1240d268452043b7e9eaebbf693e89ff82a1d",
+      "sha256": "e37521b7a498cdd93c2794eebc11f11d45ac9e7b1182bafead44e87699734229",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ocenaudio/darwin.json
+++ b/ee/maintained-apps/outputs/ocenaudio/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.19.5",
+      "version": "3.20.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.19.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.20.0') < 0);"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg",
       "install_script_ref": "0c2240cf",

--- a/ee/maintained-apps/outputs/reqable/darwin.json
+++ b/ee/maintained-apps/outputs/reqable/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.6",
+      "version": "3.2.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.7') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.6/reqable-app-macos-arm64.dmg",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.7/reqable-app-macos-arm64.dmg",
       "install_script_ref": "5d84816f",
       "uninstall_script_ref": "3319d75e",
-      "sha256": "18635d9cdbf0742a0ca4225c294a04bf0fcba97a07b0861a55455e1c6a27496a",
+      "sha256": "9c6bc39c9a12dd329a380522677abba33f1d1bb296e4253d91c7d9b72cff6761",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/reqable/windows.json
+++ b/ee/maintained-apps/outputs/reqable/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.6",
+      "version": "3.2.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.7') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.6/reqable-app-windows-x86_64.exe",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.7/reqable-app-windows-x86_64.exe",
       "install_script_ref": "d2ffec58",
       "uninstall_script_ref": "b33fc442",
-      "sha256": "f3cce9a6203cd433437678083d2349e11361ed9365464039e764c6ec45aac84f",
+      "sha256": "9631a8d59820808d05ccc1a645b5a6aa99044c5df83489a7bcbb59c2dac747ac",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rocket-chat/darwin.json
+++ b/ee/maintained-apps/outputs/rocket-chat/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.15.2",
+      "version": "4.15.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.3') < 0);"
       },
-      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.2/rocketchat-4.15.2-mac.dmg",
+      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.3/rocketchat-4.15.3-mac.dmg",
       "install_script_ref": "8a2921c9",
       "uninstall_script_ref": "36b46743",
-      "sha256": "4c74d234fbda7711551aaecb6bfda12d76984c1a8123d2bab831f9e6e742ffc9",
+      "sha256": "2e8b7519c710227c806f8faa6777b16fe88a66e25fba81f7b42c9126d4d7c21b",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/session/darwin.json
+++ b/ee/maintained-apps/outputs/session/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.18.0",
+      "version": "1.18.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loki-project.messenger-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loki-project.messenger-desktop' AND version_compare(bundle_short_version, '1.18.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loki-project.messenger-desktop' AND version_compare(bundle_short_version, '1.18.1') < 0);"
       },
-      "installer_url": "https://github.com/session-foundation/session-desktop/releases/download/v1.18.0/session-desktop-mac-arm64-1.18.0.dmg",
+      "installer_url": "https://github.com/session-foundation/session-desktop/releases/download/v1.18.1/session-desktop-mac-arm64-1.18.1.dmg",
       "install_script_ref": "6dd0a6e0",
       "uninstall_script_ref": "406e17c9",
-      "sha256": "8b2fcaf4d9d559dfb9650d53613cc38dbbc1b2ad7b893c7ca9979ec6f0b7d3ff",
+      "sha256": "c07fd0d944de540f5e6a408cea351b82579edde28dd49ffa79ceabd82c134080",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/vivaldi/windows.json
+++ b/ee/maintained-apps/outputs/vivaldi/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.4033.57",
+      "version": "8.1.4087.48",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.0.4033.57') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.1.4087.48') < 0);"
       },
-      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.0.4033.57.x64.exe",
+      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.48.x64.exe",
       "install_script_ref": "d5d49757",
       "uninstall_script_ref": "4e1acf1b",
-      "sha256": "d12c511ebe3f99f15fee95933641b36dd49557e3f4fec756afc3dd02da11d141",
+      "sha256": "739376485a31813093e4379dd0983dba07911481eb058156503d141c7c82a787",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.07.01.09.21.01",
+      "version": "0.2026.07.08.17.54.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.01.09.21.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.08.17.54.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.01.09.21.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.08.17.54.stable_01/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "46.6.1.35236",
+      "version": "46.6.1.35355",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.1.35236') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.1.35355') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "d105863f",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance Updates**
  * Updated Windows releases for Brave Browser, Figma, Kiro, Microsoft Edge, Reqable, and Vivaldi.
  * Updated macOS releases for Notepad, Ocenaudio, Reqable, Rocket.Chat, Session, Warp, and Webex.
  * Refreshed download links, version detection, and verification data for applicable releases.
  * New versions are now recognized as current and available for installation through the app catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->